### PR TITLE
perf(css): Optimize memory layout of ast types

### DIFF
--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -50,9 +50,9 @@ pub enum AtRulePrelude {
     #[tag("KeyframesName")]
     KeyframesPrelude(KeyframesName),
     #[tag("ImportPrelude")]
-    ImportPrelude(Box<ImportPrelude>),
+    ImportPrelude(ImportPrelude),
     #[tag("NamespacePrelude")]
-    NamespacePrelude(Box<NamespacePrelude>),
+    NamespacePrelude(NamespacePrelude),
     #[tag("MediaQueryList")]
     MediaPrelude(MediaQueryList),
     #[tag("SupportsCondition")]
@@ -125,9 +125,9 @@ pub enum KeyframeSelector {
 #[derive(Eq, Hash, EqIgnoreSpan)]
 pub struct ImportPrelude {
     pub span: Span,
-    pub href: ImportPreludeHref,
+    pub href: Box<ImportPreludeHref>,
     pub layer_name: Option<ImportPreludeLayerName>,
-    pub supports: Option<ImportPreludeSupportsType>,
+    pub supports: Option<Box<ImportPreludeSupportsType>>,
     pub media: Option<MediaQueryList>,
 }
 
@@ -163,7 +163,7 @@ pub enum ImportPreludeSupportsType {
 pub struct NamespacePrelude {
     pub span: Span,
     pub prefix: Option<Ident>,
-    pub uri: NamespacePreludeUri,
+    pub uri: Box<NamespacePreludeUri>,
 }
 
 #[ast_node]

--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -126,9 +126,9 @@ pub enum KeyframeSelector {
 pub struct ImportPrelude {
     pub span: Span,
     pub href: Box<ImportPreludeHref>,
-    pub layer_name: Option<ImportPreludeLayerName>,
+    pub layer_name: Option<Box<ImportPreludeLayerName>>,
     pub supports: Option<Box<ImportPreludeSupportsType>>,
-    pub media: Option<MediaQueryList>,
+    pub media: Option<Box<MediaQueryList>>,
 }
 
 #[ast_node]

--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -309,7 +309,7 @@ pub enum MediaInParens {
     MediaCondition(MediaCondition),
 
     #[tag("MediaFeature")]
-    Feature(MediaFeature),
+    Feature(Box<MediaFeature>),
     // TODO <general-enclosed>
 }
 

--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -155,7 +155,7 @@ pub enum ImportPreludeSupportsType {
     #[tag("SupportsCondition")]
     SupportsCondition(SupportsCondition),
     #[tag("Declaration")]
-    Declaration(Declaration),
+    Declaration(Box<Declaration>),
 }
 
 #[ast_node("NamespacePrelude")]
@@ -501,7 +501,7 @@ pub enum SupportsInParens {
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 pub enum SupportsFeature {
     #[tag("Declaration")]
-    Declaration(Declaration),
+    Declaration(Box<Declaration>),
     #[tag("Function")]
     Function(Function),
 }

--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -50,9 +50,9 @@ pub enum AtRulePrelude {
     #[tag("KeyframesName")]
     KeyframesPrelude(KeyframesName),
     #[tag("ImportPrelude")]
-    ImportPrelude(ImportPrelude),
+    ImportPrelude(Box<ImportPrelude>),
     #[tag("NamespacePrelude")]
-    NamespacePrelude(NamespacePrelude),
+    NamespacePrelude(Box<NamespacePrelude>),
     #[tag("MediaQueryList")]
     MediaPrelude(MediaQueryList),
     #[tag("SupportsCondition")]

--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -12,7 +12,7 @@ use crate::{
 pub struct AtRule {
     pub span: Span,
     pub name: AtRuleName,
-    pub prelude: Option<AtRulePrelude>,
+    pub prelude: Option<Box<AtRulePrelude>>,
     pub block: Option<SimpleBlock>,
 }
 

--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -357,7 +357,7 @@ pub enum MediaFeatureValue {
 pub struct MediaFeaturePlain {
     pub span: Span,
     pub name: MediaFeatureName,
-    pub value: MediaFeatureValue,
+    pub value: Box<MediaFeatureValue>,
 }
 
 #[ast_node("MediaFeatureBoolean")]
@@ -401,22 +401,22 @@ pub enum MediaFeatureRangeComparison {
 #[derive(Eq, Hash, EqIgnoreSpan)]
 pub struct MediaFeatureRange {
     pub span: Span,
-    pub left: MediaFeatureValue,
+    pub left: Box<MediaFeatureValue>,
     pub comparison: MediaFeatureRangeComparison,
-    pub right: MediaFeatureValue,
+    pub right: Box<MediaFeatureValue>,
 }
 
 #[ast_node("MediaFeatureRangeInterval")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 pub struct MediaFeatureRangeInterval {
     pub span: Span,
-    pub left: MediaFeatureValue,
+    pub left: Box<MediaFeatureValue>,
     #[serde(rename = "leftComparison")]
     pub left_comparison: MediaFeatureRangeComparison,
     pub name: MediaFeatureName,
     #[serde(rename = "rightComparison")]
     pub right_comparison: MediaFeatureRangeComparison,
-    pub right: MediaFeatureValue,
+    pub right: Box<MediaFeatureValue>,
 }
 
 #[ast_node("SupportsCondition")]

--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -447,7 +447,7 @@ pub enum SupportsConditionType {
 pub struct SupportsNot {
     pub span: Span,
     pub keyword: Option<Ident>,
-    pub condition: SupportsInParens,
+    pub condition: Box<SupportsInParens>,
 }
 
 impl EqIgnoreSpan for SupportsNot {
@@ -461,7 +461,7 @@ impl EqIgnoreSpan for SupportsNot {
 pub struct SupportsAnd {
     pub span: Span,
     pub keyword: Option<Ident>,
-    pub condition: SupportsInParens,
+    pub condition: Box<SupportsInParens>,
 }
 
 impl EqIgnoreSpan for SupportsAnd {
@@ -475,7 +475,7 @@ impl EqIgnoreSpan for SupportsAnd {
 pub struct SupportsOr {
     pub span: Span,
     pub keyword: Option<Ident>,
-    pub condition: SupportsInParens,
+    pub condition: Box<SupportsInParens>,
 }
 
 impl EqIgnoreSpan for SupportsOr {

--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -189,7 +189,7 @@ pub struct MediaQuery {
     pub modifier: Option<Ident>,
     pub media_type: Option<MediaType>,
     pub keyword: Option<Ident>,
-    pub condition: Option<MediaConditionType>,
+    pub condition: Option<Box<MediaConditionType>>,
 }
 
 impl EqIgnoreSpan for MediaQuery {

--- a/crates/swc_css_ast/src/base.rs
+++ b/crates/swc_css_ast/src/base.rs
@@ -18,7 +18,7 @@ pub struct Stylesheet {
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 pub enum Rule {
     #[tag("QualifiedRule")]
-    QualifiedRule(QualifiedRule),
+    QualifiedRule(Box<QualifiedRule>),
 
     #[tag("Tokens")]
     Invalid(Tokens),
@@ -54,7 +54,7 @@ pub enum StyleBlock {
     #[tag("Declaration")]
     Declaration(Box<Declaration>),
     #[tag("QualifiedRule")]
-    QualifiedRule(QualifiedRule),
+    QualifiedRule(Box<QualifiedRule>),
 }
 
 #[ast_node("SimpleBlock")]

--- a/crates/swc_css_ast/src/base.rs
+++ b/crates/swc_css_ast/src/base.rs
@@ -24,7 +24,7 @@ pub enum Rule {
     Invalid(Tokens),
 
     #[tag("AtRule")]
-    AtRule(AtRule),
+    AtRule(Box<AtRule>),
 }
 
 #[ast_node("QualifiedRule")]
@@ -50,7 +50,7 @@ pub enum StyleBlock {
     #[tag("ListOfComponentValues")]
     ListOfComponentValues(ListOfComponentValues),
     #[tag("AtRule")]
-    AtRule(AtRule),
+    AtRule(Box<AtRule>),
     #[tag("Declaration")]
     Declaration(Box<Declaration>),
     #[tag("QualifiedRule")]
@@ -151,7 +151,7 @@ pub enum DeclarationOrAtRule {
     #[tag("Declaration")]
     Declaration(Box<Declaration>),
     #[tag("AtRule")]
-    AtRule(AtRule),
+    AtRule(Box<AtRule>),
     // For recovery mode
     #[tag("ListOfComponentValues")]
     ListOfComponentValues(ListOfComponentValues),

--- a/crates/swc_css_ast/src/base.rs
+++ b/crates/swc_css_ast/src/base.rs
@@ -52,7 +52,7 @@ pub enum StyleBlock {
     #[tag("AtRule")]
     AtRule(AtRule),
     #[tag("Declaration")]
-    Declaration(Declaration),
+    Declaration(Box<Declaration>),
     #[tag("QualifiedRule")]
     QualifiedRule(QualifiedRule),
 }
@@ -149,7 +149,7 @@ pub enum ComponentValue {
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 pub enum DeclarationOrAtRule {
     #[tag("Declaration")]
-    Declaration(Declaration),
+    Declaration(Box<Declaration>),
     #[tag("AtRule")]
     AtRule(AtRule),
     // For recovery mode

--- a/crates/swc_css_ast/src/selector.rs
+++ b/crates/swc_css_ast/src/selector.rs
@@ -184,7 +184,7 @@ pub enum SubclassSelector {
     Class(ClassSelector),
 
     #[tag("AttributeSelector")]
-    Attribute(AttributeSelector),
+    Attribute(Box<AttributeSelector>),
 
     #[tag("PseudoClassSelector")]
     PseudoClass(PseudoClassSelector),
@@ -213,7 +213,7 @@ pub struct ClassSelector {
 #[derive(Eq, Hash, EqIgnoreSpan)]
 pub struct AttributeSelector {
     pub span: Span,
-    pub name: Box<WqName>,
+    pub name: WqName,
     pub matcher: Option<AttributeSelectorMatcher>,
     pub value: Option<AttributeSelectorValue>,
     pub modifier: Option<AttributeSelectorModifier>,

--- a/crates/swc_css_ast/src/selector.rs
+++ b/crates/swc_css_ast/src/selector.rs
@@ -89,7 +89,7 @@ pub struct CompoundSelector {
     pub span: Span,
     /// "&"
     pub nesting_selector: Option<NestingSelector>,
-    pub type_selector: Option<TypeSelector>,
+    pub type_selector: Option<Box<TypeSelector>>,
     pub subclass_selectors: Vec<SubclassSelector>,
 }
 
@@ -213,7 +213,7 @@ pub struct ClassSelector {
 #[derive(Eq, Hash, EqIgnoreSpan)]
 pub struct AttributeSelector {
     pub span: Span,
-    pub name: WqName,
+    pub name: Box<WqName>,
     pub matcher: Option<AttributeSelectorMatcher>,
     pub value: Option<AttributeSelectorValue>,
     pub modifier: Option<AttributeSelectorModifier>,

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -366,7 +366,7 @@ pub enum BinOp {
 pub struct Url {
     pub span: Span,
     pub name: Ident,
-    pub value: Option<UrlValue>,
+    pub value: Option<Box<UrlValue>>,
     pub modifiers: Option<Vec<UrlModifier>>,
 }
 

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -103,7 +103,7 @@ where
         }
 
         if n.block.is_some() {
-            match &n.prelude {
+            match n.prelude.as_deref() {
                 Some(AtRulePrelude::ListOfComponentValues(_)) | None => {}
                 _ => {
                     formatting_space!(self);
@@ -180,7 +180,7 @@ where
                 emit!(self, n)
             }
             AtRulePrelude::ImportPrelude(n) => {
-                match n.href {
+                match &*n.href {
                     ImportPreludeHref::Url(_) => {
                         space!(self);
                     }
@@ -197,7 +197,7 @@ where
                     Some(media_query)
                         if media_query.modifier.is_none() && media_query.media_type.is_none() =>
                     {
-                        match &media_query.condition {
+                        match media_query.condition.as_deref() {
                             Some(MediaConditionType::All(media_condition)) => !matches!(
                                 media_condition.conditions.get(0),
                                 Some(MediaConditionAllType::MediaInParens(_))
@@ -280,7 +280,7 @@ where
             emit!(self, layer_name);
 
             if self.config.minify && (n.supports.is_some() || n.media.is_some()) {
-                if let ImportPreludeLayerName::Ident(_) = layer_name {
+                if let ImportPreludeLayerName::Ident(_) = &**layer_name {
                     space!(self);
                 }
             }
@@ -697,7 +697,7 @@ where
     #[emitter]
     fn emit_namespace_prelude(&mut self, n: &NamespacePrelude) -> Result {
         let has_prefix = n.prefix.is_some();
-        let is_uri_url = match n.uri {
+        let is_uri_url = match &*n.uri {
             NamespacePreludeUri::Url(_) => true,
             NamespacePreludeUri::Str(_) => false,
         };

--- a/crates/swc_css_lints/src/lib.rs
+++ b/crates/swc_css_lints/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![feature(box_patterns)]
 
 mod config;
 mod dataset;

--- a/crates/swc_css_lints/src/rules/at_rule_no_unknown.rs
+++ b/crates/swc_css_lints/src/rules/at_rule_no_unknown.rs
@@ -40,7 +40,7 @@ struct AtRuleNoUnknown {
 impl Visit for AtRuleNoUnknown {
     fn visit_at_rule(&mut self, at_rule: &AtRule) {
         if let AtRuleName::Ident(Ident { value, .. }) = &at_rule.name {
-            if let Some(AtRulePrelude::ListOfComponentValues(_)) = at_rule.prelude {
+            if let Some(AtRulePrelude::ListOfComponentValues(_)) = at_rule.prelude.as_deref() {
                 if self.ignored.iter().all(|item| !item.is_match(&value)) {
                     let message = format!("Unexpected unknown at-rule \"@{}\".", &value);
 

--- a/crates/swc_css_lints/src/rules/declaration_no_important.rs
+++ b/crates/swc_css_lints/src/rules/declaration_no_important.rs
@@ -26,7 +26,7 @@ struct DeclarationNoImportant {
 
 impl Visit for DeclarationNoImportant {
     fn visit_at_rule(&mut self, keyframes_rule: &AtRule) {
-        if let Some(AtRulePrelude::KeyframesPrelude(_)) = keyframes_rule.prelude {
+        if let Some(AtRulePrelude::KeyframesPrelude(_)) = keyframes_rule.prelude.as_deref() {
             self.keyframe_rules.push(keyframes_rule.span);
 
             keyframes_rule.visit_children_with(self);

--- a/crates/swc_css_lints/src/rules/keyframe_declaration_no_important.rs
+++ b/crates/swc_css_lints/src/rules/keyframe_declaration_no_important.rs
@@ -23,7 +23,7 @@ struct KeyframeDeclarationNoImportant {
 
 impl Visit for KeyframeDeclarationNoImportant {
     fn visit_at_rule(&mut self, at_rule: &AtRule) {
-        if let Some(AtRulePrelude::KeyframesPrelude(_)) = at_rule.prelude {
+        if let Some(AtRulePrelude::KeyframesPrelude(_)) = at_rule.prelude.as_deref() {
             let old_value_in_keyframes_at_rule = self.in_keyframes_at_rule;
 
             self.in_keyframes_at_rule = true;

--- a/crates/swc_css_lints/src/rules/no_duplicate_at_import_rules.rs
+++ b/crates/swc_css_lints/src/rules/no_duplicate_at_import_rules.rs
@@ -34,7 +34,7 @@ struct NoDuplicateAtImportRules {
 
 impl Visit for NoDuplicateAtImportRules {
     fn visit_at_rule(&mut self, at_rule: &AtRule) {
-        if let Some(AtRulePrelude::ImportPrelude(_)) = at_rule.prelude {
+        if let Some(AtRulePrelude::ImportPrelude(_)) = at_rule.prelude.as_deref() {
             self.import_at_rules = Some(at_rule.clone());
 
             at_rule.visit_children_with(self);
@@ -44,11 +44,11 @@ impl Visit for NoDuplicateAtImportRules {
     }
 
     fn visit_import_prelude(&mut self, import_prelude: &ImportPrelude) {
-        let href = match &import_prelude.href {
+        let href = match &*import_prelude.href {
             ImportPreludeHref::Str(Str { value, .. }) => value,
             ImportPreludeHref::Url(Url {
                 value: Some(value), ..
-            }) => match value {
+            }) => match &**value {
                 UrlValue::Raw(UrlValueRaw { value, .. }) => value,
                 UrlValue::Str(Str { value, .. }) => value,
             },

--- a/crates/swc_css_lints/src/rules/no_invalid_position_at_import_rule.rs
+++ b/crates/swc_css_lints/src/rules/no_invalid_position_at_import_rule.rs
@@ -45,8 +45,8 @@ impl Visit for NoInvalidPositionAtImportRule {
             if seen
                 && matches!(
                     rule,
-                    Rule::AtRule(AtRule {
-                        prelude: Some(AtRulePrelude::ImportPrelude(_)),
+                    Rule::AtRule(box AtRule {
+                        prelude: Some(box AtRulePrelude::ImportPrelude(_)),
                         ..
                     })
                 )
@@ -57,17 +57,17 @@ impl Visit for NoInvalidPositionAtImportRule {
             // TODO improve me https://www.w3.org/TR/css-cascade-5/#layer-empty - @import and @namespace rules must be consecutive
             match rule {
                 Rule::AtRule(
-                    AtRule {
-                        prelude: Some(AtRulePrelude::CharsetPrelude(_)),
+                    box AtRule {
+                        prelude: Some(box AtRulePrelude::CharsetPrelude(_)),
                         ..
                     }
-                    | AtRule {
-                        prelude: Some(AtRulePrelude::ImportPrelude(_)),
+                    | box AtRule {
+                        prelude: Some(box AtRulePrelude::ImportPrelude(_)),
                         ..
                     },
                 ) => seen,
-                Rule::AtRule(AtRule {
-                    prelude: Some(AtRulePrelude::LayerPrelude(_)),
+                Rule::AtRule(box AtRule {
+                    prelude: Some(box AtRulePrelude::LayerPrelude(_)),
                     block,
                     ..
                 }) => match block {
@@ -75,7 +75,7 @@ impl Visit for NoInvalidPositionAtImportRule {
                     None => seen,
                     _ => true,
                 },
-                Rule::AtRule(AtRule { name, .. }) => {
+                Rule::AtRule(box AtRule { name, .. }) => {
                     let name = match name {
                         AtRuleName::DashedIdent(dashed_ident) => &dashed_ident.value,
                         AtRuleName::Ident(ident) => &ident.value,

--- a/crates/swc_css_minifier/src/compress/at_rule.rs
+++ b/crates/swc_css_minifier/src/compress/at_rule.rs
@@ -29,7 +29,7 @@ impl VisitMut for CompressAtRule {
                 }
             }
 
-            let new_value = match value {
+            let new_value = match &mut **value {
                 UrlValue::Str(Str { value, .. }) => value,
                 UrlValue::Raw(UrlValueRaw { value, .. }) => value,
             };
@@ -149,8 +149,8 @@ impl VisitMut for CompressAtRule {
 
         if !self.stylesheet_has_non_ascii_characters {
             match stylesheet.rules.get(0) {
-                Some(Rule::AtRule(AtRule {
-                    prelude: Some(AtRulePrelude::CharsetPrelude(Str { value, .. })),
+                Some(Rule::AtRule(box AtRule {
+                    prelude: Some(box AtRulePrelude::CharsetPrelude(Str { value, .. })),
                     ..
                 })) if value.as_ref().eq_ignore_ascii_case("utf-8") => {
                     stylesheet.rules.remove(0);

--- a/crates/swc_css_minifier/src/compressor/empty.rs
+++ b/crates/swc_css_minifier/src/compressor/empty.rs
@@ -6,8 +6,8 @@ use super::Compressor;
 impl Compressor {
     pub(super) fn compresss_empty_stylesheet(&self, stylesheet: &mut Stylesheet) {
         stylesheet.rules.retain(|rule| match rule {
-            Rule::QualifiedRule(QualifiedRule { block, .. }) if block.value.is_empty() => false,
-            Rule::AtRule(AtRule {
+            Rule::QualifiedRule(box QualifiedRule { block, .. }) if block.value.is_empty() => false,
+            Rule::AtRule(box AtRule {
                 name: AtRuleName::Ident(Ident { value, .. }),
                 block: Some(block),
                 ..
@@ -18,17 +18,19 @@ impl Compressor {
 
     pub(super) fn compresss_empty_simple_block(&self, simple_block: &mut SimpleBlock) {
         simple_block.value.retain(|rule| match rule {
-            ComponentValue::Rule(Rule::QualifiedRule(QualifiedRule { block, .. }))
-            | ComponentValue::Rule(Rule::AtRule(AtRule {
+            ComponentValue::Rule(Rule::QualifiedRule(box QualifiedRule { block, .. }))
+            | ComponentValue::Rule(Rule::AtRule(box AtRule {
                 block: Some(block), ..
             }))
-            | ComponentValue::StyleBlock(StyleBlock::QualifiedRule(QualifiedRule {
-                block, ..
+            | ComponentValue::StyleBlock(StyleBlock::QualifiedRule(box QualifiedRule {
+                block,
+                ..
             }))
-            | ComponentValue::StyleBlock(StyleBlock::AtRule(AtRule {
-                block: Some(block), ..
+            | ComponentValue::StyleBlock(StyleBlock::AtRule(box AtRule {
+                block: Some(block),
+                ..
             }))
-            | ComponentValue::DeclarationOrAtRule(DeclarationOrAtRule::AtRule(AtRule {
+            | ComponentValue::DeclarationOrAtRule(DeclarationOrAtRule::AtRule(box AtRule {
                 block: Some(block),
                 ..
             }))

--- a/crates/swc_css_minifier/src/compressor/keyframes.rs
+++ b/crates/swc_css_minifier/src/compressor/keyframes.rs
@@ -6,7 +6,7 @@ use super::Compressor;
 
 impl Compressor {
     pub(super) fn compress_keyframes_at_rule(&mut self, at_rule: &mut AtRule) {
-        match &at_rule.prelude {
+        match at_rule.prelude.as_deref() {
             Some(AtRulePrelude::KeyframesPrelude(KeyframesName::Str(string)))
                 if !matches!(
                     string.value.to_ascii_lowercase(),
@@ -18,13 +18,13 @@ impl Compressor {
                         | js_word!("none")
                 ) =>
             {
-                at_rule.prelude = Some(AtRulePrelude::KeyframesPrelude(
+                at_rule.prelude = Some(Box::new(AtRulePrelude::KeyframesPrelude(
                     KeyframesName::CustomIdent(CustomIdent {
                         span: string.span,
                         value: string.value.to_string().into(),
                         raw: None,
                     }),
-                ));
+                )));
             }
             _ => {}
         }

--- a/crates/swc_css_minifier/src/compressor/selector.rs
+++ b/crates/swc_css_minifier/src/compressor/selector.rs
@@ -253,7 +253,7 @@ impl Compressor {
         }
 
         if let Some(TypeSelector::Universal(UniversalSelector { prefix: None, .. })) =
-            &compound_selector.type_selector
+            compound_selector.type_selector.as_deref()
         {
             compound_selector.type_selector = None;
         }

--- a/crates/swc_css_minifier/src/compressor/url.rs
+++ b/crates/swc_css_minifier/src/compressor/url.rs
@@ -15,7 +15,7 @@ impl Compressor {
             }
         }
 
-        if let Some(UrlValue::Str(Str { value, span, .. })) = &url.value {
+        if let Some(UrlValue::Str(Str { value, span, .. })) = url.value.as_deref() {
             let mut escaped = String::new();
             let mut has_escaped = false;
 
@@ -43,13 +43,13 @@ impl Compressor {
                 }
             }
 
-            url.value = Some(UrlValue::Raw(UrlValueRaw {
+            url.value = Some(Box::new(UrlValue::Raw(UrlValueRaw {
                 span: *span,
                 value: escaped.into(),
                 before: None,
                 raw: None,
                 after: None,
-            }));
+            })));
         }
     }
 }

--- a/crates/swc_css_minifier/src/lib.rs
+++ b/crates/swc_css_minifier/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(box_patterns)]
 #![deny(clippy::all)]
 #![allow(clippy::match_like_matches_macro)]
 #![allow(clippy::needless_update)]

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -351,7 +351,7 @@ where
                         }
                     };
 
-                    let prelude = AtRulePrelude::ColorProfilePrelude(name);
+                    let prelude = Box::new(AtRulePrelude::ColorProfilePrelude(name));
 
                     parser.input.skip_ws();
 
@@ -366,7 +366,7 @@ where
                 "nest" => {
                     parser.input.skip_ws();
 
-                    let prelude = AtRulePrelude::NestPrelude(parser.parse()?);
+                    let prelude = Box::new(AtRulePrelude::NestPrelude(parser.parse()?));
 
                     parser.input.skip_ws();
 
@@ -384,7 +384,7 @@ where
                     let media = if !is!(parser, "{") {
                         let media_query_list = parser.parse()?;
 
-                        Some(AtRulePrelude::MediaPrelude(media_query_list))
+                        Some(Box::new(AtRulePrelude::MediaPrelude(media_query_list)))
                     } else {
                         None
                     };
@@ -396,7 +396,7 @@ where
                 "supports" => {
                     parser.input.skip_ws();
 
-                    let prelude = AtRulePrelude::SupportsPrelude(parser.parse()?);
+                    let prelude = Box::new(AtRulePrelude::SupportsPrelude(parser.parse()?));
 
                     parser.input.skip_ws();
 
@@ -478,13 +478,13 @@ where
 
                     parser.input.skip_ws();
 
-                    let prelude = AtRulePrelude::ImportPrelude(ImportPrelude {
+                    let prelude = Box::new(AtRulePrelude::ImportPrelude(ImportPrelude {
                         span: span!(parser, span.lo),
                         href,
                         layer_name,
                         supports,
                         media,
-                    });
+                    }));
 
                     if !is!(parser, ";") {
                         let span = parser.input.cur_span();
@@ -498,7 +498,7 @@ where
                 | "-ms-keyframes" => {
                     parser.input.skip_ws();
 
-                    let prelude = AtRulePrelude::KeyframesPrelude(parser.parse()?);
+                    let prelude = Box::new(AtRulePrelude::KeyframesPrelude(parser.parse()?));
 
                     parser.input.skip_ws();
 

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -51,7 +51,7 @@ where
             prelude: None,
             block: None,
         };
-        let parse_prelude = |parser: &mut Parser<I>| -> PResult<Option<AtRulePrelude>> {
+        let parse_prelude = |parser: &mut Parser<I>| -> PResult<Option<Box<AtRulePrelude>>> {
             match lowercased_name {
                 "viewport" | "-ms-viewport" | "-o-viewport" | "font-face" => {
                     parser.input.skip_ws();
@@ -85,7 +85,7 @@ where
                         return Err(Error::new(span, ErrorKind::Expected("';' token")));
                     }
 
-                    Ok(Some(prelude))
+                    Ok(Some(Box::new(prelude)))
                 }
                 "counter-style" => {
                     parser.input.skip_ws();
@@ -100,7 +100,7 @@ where
                         return Err(Error::new(span, ErrorKind::Expected("'{' token")));
                     }
 
-                    Ok(Some(prelude))
+                    Ok(Some(Box::new(prelude)))
                 }
                 "font-palette-values" => {
                     parser.input.skip_ws();
@@ -115,7 +115,7 @@ where
                         return Err(Error::new(span, ErrorKind::Expected("'{' token")));
                     }
 
-                    Ok(Some(prelude))
+                    Ok(Some(Box::new(prelude)))
                 }
                 "font-feature-values" => {
                     parser.input.skip_ws();
@@ -130,7 +130,7 @@ where
                         return Err(Error::new(span, ErrorKind::Expected("'{' token")));
                     }
 
-                    Ok(Some(prelude))
+                    Ok(Some(Box::new(prelude)))
                 }
                 "stylistic" | "historical-forms" | "styleset" | "character-variant" | "swash"
                 | "ornaments" | "annotation"

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -1255,11 +1255,11 @@ where
 
                 self.input.skip_ws();
 
-                condition_without_or = Some(MediaConditionType::WithoutOr(self.parse()?));
+                condition_without_or = Some(Box::new(MediaConditionType::WithoutOr(self.parse()?)));
             }
 
             let end_pos = if let Some(MediaConditionType::WithoutOr(condition_without_or)) =
-                &condition_without_or
+                condition_without_or.as_deref()
             {
                 condition_without_or.span.hi
             } else if let Some(MediaType::Ident(ident)) = &media_type {
@@ -1604,9 +1604,9 @@ where
                 if eat!(self, ")") {
                     return Ok(MediaFeature::Range(MediaFeatureRange {
                         span: span!(self, span.lo),
-                        left,
+                        left: Box::new(left),
                         comparison: left_comparison,
-                        right: center,
+                        right: Box::new(center),
                     }));
                 }
 
@@ -1675,7 +1675,7 @@ where
 
                 Ok(MediaFeature::RangeInterval(MediaFeatureRangeInterval {
                     span: span!(self, span.lo),
-                    left,
+                    left: Box::new(left),
                     left_comparison,
                     name,
                     right_comparison,

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -202,7 +202,7 @@ where
                         }
                     }
 
-                    Ok(prelude)
+                    Ok(Box::new(prelude))
                 }
                 "document" | "-moz-document" => {
                     parser.input.skip_ws();
@@ -236,7 +236,7 @@ where
                         return Err(Error::new(span, ErrorKind::Expected("'{' token")));
                     }
 
-                    Ok(Some(prelude))
+                    Ok(Some(Box::new(prelude)))
                 }
                 "page" => {
                     parser.input.skip_ws();
@@ -249,7 +249,7 @@ where
 
                     parser.input.skip_ws();
 
-                    Ok(prelude)
+                    Ok(Box::new(prelude))
                 }
                 "top-left-corner"
                 | "top-left"

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -697,19 +697,20 @@ where
 
                             let span = self.input.cur_span();
 
-                            let mut list_of_component_value = match at_rule.prelude {
+                            let mut list_of_component_value = match at_rule.prelude.as_deref_mut() {
                                 Some(AtRulePrelude::ListOfComponentValues(
                                     ref mut list_of_component_value,
                                 )) => list_of_component_value,
                                 _ => {
-                                    at_rule.prelude = Some(AtRulePrelude::ListOfComponentValues(
-                                        ListOfComponentValues {
-                                            span: span!(self, span.lo),
-                                            children: vec![],
-                                        },
-                                    ));
+                                    at_rule.prelude =
+                                        Some(Box::new(AtRulePrelude::ListOfComponentValues(
+                                            ListOfComponentValues {
+                                                span: span!(self, span.lo),
+                                                children: vec![],
+                                            },
+                                        )));
 
-                                    match at_rule.prelude {
+                                    match at_rule.prelude.as_deref_mut() {
                                         Some(AtRulePrelude::ListOfComponentValues(
                                             ref mut list_of_component_value,
                                         )) => list_of_component_value,
@@ -1239,7 +1240,7 @@ where
                 modifier: None,
                 media_type: None,
                 keyword: None,
-                condition: Some(MediaConditionType::All(condition)),
+                condition: Some(Box::new(MediaConditionType::All(condition))),
             })
         } else {
             let media_type = Some(self.parse()?);

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -202,7 +202,7 @@ where
                         }
                     }
 
-                    Ok(Box::new(prelude))
+                    Ok(prelude.map(Box::new))
                 }
                 "document" | "-moz-document" => {
                     parser.input.skip_ws();
@@ -249,7 +249,7 @@ where
 
                     parser.input.skip_ws();
 
-                    Ok(Box::new(prelude))
+                    Ok(prelude.map(Box::new))
                 }
                 "top-left-corner"
                 | "top-left"
@@ -286,7 +286,7 @@ where
                         return Err(Error::new(span, ErrorKind::Expected("'{' token")));
                     }
 
-                    Ok(Some(prelude))
+                    Ok(Some(Box::new(prelude)))
                 }
                 "namespace" => {
                     parser.input.skip_ws();
@@ -331,7 +331,7 @@ where
                         return Err(Error::new(span, ErrorKind::Expected("';' token")));
                     }
 
-                    Ok(Some(prelude))
+                    Ok(Some(Box::new(prelude)))
                 }
                 "color-profile" => {
                     parser.input.skip_ws();

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -406,7 +406,7 @@ where
                     parser.input.skip_ws();
 
                     let span = parser.input.cur_span();
-                    let href = match cur!(parser) {
+                    let href = Box::new(match cur!(parser) {
                         tok!("string") => ImportPreludeHref::Str(parser.parse()?),
                         tok!("url") => ImportPreludeHref::Url(parser.parse()?),
                         tok!("function") => ImportPreludeHref::Url(parser.parse()?),
@@ -416,7 +416,7 @@ where
                                 ErrorKind::Expected("string, url or function token"),
                             ))
                         }
-                    };
+                    });
 
                     parser.input.skip_ws();
 
@@ -426,7 +426,7 @@ where
 
                             parser.input.skip_ws();
 
-                            Some(name)
+                            Some(Box::new(name))
                         }
                         Token::Function { value, .. }
                             if *value.to_ascii_lowercase() == *"layer" =>
@@ -443,7 +443,7 @@ where
 
                             parser.input.skip_ws();
 
-                            Some(name)
+                            Some(Box::new(name))
                         }
                         _ => None,
                     };
@@ -465,7 +465,7 @@ where
 
                             expect!(parser, ")");
 
-                            Some(supports)
+                            Some(Box::new(supports))
                         }
                         _ => None,
                     };

--- a/crates/swc_css_parser/src/parser/at_rule.rs
+++ b/crates/swc_css_parser/src/parser/at_rule.rs
@@ -322,7 +322,7 @@ where
                     let prelude = AtRulePrelude::NamespacePrelude(NamespacePrelude {
                         span: span!(parser, span.lo),
                         prefix,
-                        uri,
+                        uri: Box::new(uri),
                     });
 
                     if !is!(parser, ";") {

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -2252,7 +2252,7 @@ where
                 self.input.skip_ws();
 
                 let value = match cur!(self) {
-                    tok!("string") => Some(UrlValue::Str(self.parse()?)),
+                    tok!("string") => Some(Box::new(UrlValue::Str(self.parse()?))),
                     _ => None,
                 };
 

--- a/crates/swc_css_parser/src/parser/value/mod.rs
+++ b/crates/swc_css_parser/src/parser/value/mod.rs
@@ -2211,7 +2211,7 @@ where
                     value: name,
                     raw: Some(raw_name),
                 };
-                let value = Some(UrlValue::Raw(UrlValueRaw {
+                let value = Some(Box::new(UrlValue::Raw(UrlValueRaw {
                     span: swc_common::Span::new(
                         span.lo + BytePos(name_length + 1),
                         span.hi - BytePos(1),
@@ -2221,7 +2221,7 @@ where
                     before: Some(before),
                     raw: Some(raw_value),
                     after: Some(after),
-                }));
+                })));
 
                 Ok(Url {
                     span: span!(self, span.lo),

--- a/crates/swc_css_prefixer/src/lib.rs
+++ b/crates/swc_css_prefixer/src/lib.rs
@@ -1,3 +1,6 @@
+#![feature(box_patterns)]
+#![allow(clippy::vec_box)]
+
 pub use self::prefixer::prefixer;
 
 pub mod options;

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -972,11 +972,11 @@ impl VisitMut for Prefixer {
                 );
 
                 if new_moz_prelude_with_previous != new_moz_prelude {
-                    let qualified_rule = QualifiedRule {
+                    let qualified_rule = Box::new(QualifiedRule {
                         span: DUMMY_SP,
                         prelude: new_moz_prelude_with_previous,
                         block: original_simple_block.clone(),
-                    };
+                    });
 
                     if self.simple_block.is_none() {
                         self.added_top_rules
@@ -1058,11 +1058,11 @@ impl VisitMut for Prefixer {
                 );
 
                 if new_ms_prelude_with_previous != new_ms_prelude {
-                    let qualified_rule = QualifiedRule {
+                    let qualified_rule = Box::new(QualifiedRule {
                         span: DUMMY_SP,
                         prelude: new_ms_prelude_with_previous,
                         block: original_simple_block.clone(),
-                    };
+                    });
 
                     if self.simple_block.is_none() {
                         self.added_top_rules
@@ -1430,12 +1430,12 @@ impl VisitMut for Prefixer {
                             let value: Option<Box<dyn Fn() -> Vec<ComponentValue>>> = $value;
 
                             if let Some(value) = value {
-                                self.added_declarations.push(Declaration {
+                                self.added_declarations.push(Box::new(Declaration {
                                     span: n.span,
                                     name,
                                     value: value(),
                                     important: n.important.clone(),
-                                });
+                                }));
                             } else {
                                 let new_value = match $prefix {
                                     Prefix::Webkit => webkit_value.clone(),
@@ -1444,12 +1444,12 @@ impl VisitMut for Prefixer {
                                     Prefix::Ms => ms_value.clone(),
                                 };
 
-                                self.added_declarations.push(Declaration {
+                                self.added_declarations.push(Box::new(Declaration {
                                     span: n.span,
                                     name,
                                     value: new_value,
                                     important: n.important.clone(),
-                                });
+                                }));
                             }
                         }
                     }

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -548,8 +548,8 @@ struct Prefixer {
     simple_block: Option<SimpleBlock>,
     rule_prefix: Option<Prefix>,
     added_top_rules: Vec<(Prefix, Rule)>,
-    added_at_rules: Vec<(Prefix, AtRule)>,
-    added_qualified_rules: Vec<(Prefix, QualifiedRule)>,
+    added_at_rules: Vec<(Prefix, Box<AtRule>)>,
+    added_qualified_rules: Vec<(Prefix, Box<QualifiedRule>)>,
     added_declarations: Vec<Declaration>,
 }
 
@@ -2546,7 +2546,7 @@ impl VisitMut for Prefixer {
                                 ..
                             } if value.as_ref().eq_ignore_ascii_case("direction"))
                 }) {
-                    Some(Declaration { value, .. }) => match value.get(0).as_deref() {
+                    Some(Declaration { value, .. }) => match value.get(0) {
                         Some(ComponentValue::Ident(Ident { value, .. }))
                             if value.as_ref().eq_ignore_ascii_case("rtl") =>
                         {

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -252,11 +252,11 @@ impl VisitMut for ImageSetFunctionReplacerOnLegacyVariant<'_> {
                     value: "url".into(),
                     raw: None,
                 },
-                value: Some(UrlValue::Str(Str {
+                value: Some(Box::new(UrlValue::Str(Str {
                     span: DUMMY_SP,
                     value: value.as_ref().into(),
                     raw: None,
-                })),
+                }))),
                 modifiers: Some(vec![]),
             })
         }
@@ -484,7 +484,7 @@ impl VisitMut for MediaFeatureResolutionReplacerOnLegacyVariant<'_> {
             value: resolution_value,
             unit: resolution_unit,
             ..
-        })) = &n.value
+        })) = &*n.value
         {
             let MediaFeatureName::Ident(Ident {
                 value: feature_name_value,
@@ -505,11 +505,11 @@ impl VisitMut for MediaFeatureResolutionReplacerOnLegacyVariant<'_> {
                     _ => resolution_value.value,
                 };
 
-                n.value = MediaFeatureValue::Number(Number {
+                n.value = Box::new(MediaFeatureValue::Number(Number {
                     span: resolution_value.span,
                     value: left,
                     raw: None,
-                });
+                }));
             }
         }
     }

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -755,7 +755,9 @@ impl VisitMut for Prefixer {
                         let supports_condition_type = SupportsConditionType::Or(SupportsOr {
                             span: DUMMY_SP,
                             keyword: None,
-                            condition: SupportsInParens::Feature(SupportsFeature::Declaration(n)),
+                            condition: Box::new(SupportsInParens::Feature(
+                                SupportsFeature::Declaration(n),
+                            )),
                         });
 
                         let need_skip =
@@ -901,11 +903,11 @@ impl VisitMut for Prefixer {
             }
 
             if !n.prelude.eq_ignore_span(&new_webkit_prelude) {
-                let qualified_rule = QualifiedRule {
+                let qualified_rule = Box::new(QualifiedRule {
                     span: DUMMY_SP,
                     prelude: new_webkit_prelude,
                     block: original_simple_block.clone(),
-                };
+                });
 
                 if self.simple_block.is_none() {
                     self.added_top_rules
@@ -1003,10 +1005,10 @@ impl VisitMut for Prefixer {
 
                 if self.simple_block.is_none() {
                     self.added_top_rules
-                        .push((Prefix::Moz, Rule::QualifiedRule(qualified_rule)));
+                        .push((Prefix::Moz, Rule::QualifiedRule(Box::new(qualified_rule))));
                 } else {
                     self.added_qualified_rules
-                        .push((Prefix::Moz, qualified_rule));
+                        .push((Prefix::Moz, Box::new(qualified_rule)));
                 }
             }
         }

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -2552,7 +2552,7 @@ impl VisitMut for Prefixer {
                                 ..
                             } if value.as_ref().eq_ignore_ascii_case("direction"))
                 }) {
-                    Some(Declaration { value, .. }) => match value.get(0) {
+                    Some(box Declaration { value, .. }) => match value.get(0) {
                         Some(ComponentValue::Ident(Ident { value, .. }))
                             if value.as_ref().eq_ignore_ascii_case("rtl") =>
                         {

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -1083,11 +1083,11 @@ impl VisitMut for Prefixer {
             }
 
             if !n.prelude.eq_ignore_span(&new_ms_prelude) {
-                let qualified_rule = QualifiedRule {
+                let qualified_rule = Box::new(QualifiedRule {
                     span: DUMMY_SP,
                     prelude: new_ms_prelude,
                     block: original_simple_block,
-                };
+                });
 
                 if self.simple_block.is_none() {
                     self.added_top_rules
@@ -1667,12 +1667,12 @@ impl VisitMut for Prefixer {
                     }
 
                     if n.value != old_spec_webkit_value {
-                        self.added_declarations.push(Declaration {
+                        self.added_declarations.push(Box::new(Declaration {
                             span: n.span,
                             name: n.name.clone(),
                             value: old_spec_webkit_value,
                             important: n.important.clone(),
-                        });
+                        }));
                     }
 
                     if should_prefix("-webkit-flex:display", self.env, false) {
@@ -3045,39 +3045,39 @@ impl VisitMut for Prefixer {
         }
 
         if n.value != webkit_value {
-            self.added_declarations.push(Declaration {
+            self.added_declarations.push(Box::new(Declaration {
                 span: n.span,
                 name: n.name.clone(),
                 value: webkit_value,
                 important: n.important.clone(),
-            });
+            }));
         }
 
         if n.value != moz_value {
-            self.added_declarations.push(Declaration {
+            self.added_declarations.push(Box::new(Declaration {
                 span: n.span,
                 name: n.name.clone(),
                 value: moz_value,
                 important: n.important.clone(),
-            });
+            }));
         }
 
         if n.value != o_value {
-            self.added_declarations.push(Declaration {
+            self.added_declarations.push(Box::new(Declaration {
                 span: n.span,
                 name: n.name.clone(),
                 value: o_value,
                 important: n.important.clone(),
-            });
+            }));
         }
 
         if n.value != ms_value {
-            self.added_declarations.push(Declaration {
+            self.added_declarations.push(Box::new(Declaration {
                 span: n.span,
                 name: n.name.clone(),
                 value: ms_value,
                 important: n.important.clone(),
-            });
+            }));
         }
     }
 }

--- a/crates/swc_css_prefixer/src/prefixer.rs
+++ b/crates/swc_css_prefixer/src/prefixer.rs
@@ -2541,12 +2541,12 @@ impl VisitMut for Prefixer {
 
             "writing-mode" if n.value.len() == 1 => {
                 let direction = match declarations.iter().rev().find(|declaration| {
-                    matches!(declaration, Declaration {
+                    matches!(&****declaration, Declaration {
                               name: DeclarationName::Ident(Ident { value, .. }),
                                 ..
                             } if value.as_ref().eq_ignore_ascii_case("direction"))
                 }) {
-                    Some(Declaration { value, .. }) => match value.get(0) {
+                    Some(Declaration { value, .. }) => match value.get(0).as_deref() {
                         Some(ComponentValue::Ident(Ident { value, .. }))
                             if value.as_ref().eq_ignore_ascii_case("rtl") =>
                         {

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -738,7 +738,7 @@ define!({
     pub struct MediaFeaturePlain {
         pub span: Span,
         pub name: MediaFeatureName,
-        pub value: MediaFeatureValue,
+        pub value: Box<MediaFeatureValue>,
     }
 
     pub struct MediaFeatureBoolean {
@@ -748,18 +748,18 @@ define!({
 
     pub struct MediaFeatureRange {
         pub span: Span,
-        pub left: MediaFeatureValue,
+        pub left: Box<MediaFeatureValue>,
         pub comparison: MediaFeatureRangeComparison,
-        pub right: MediaFeatureValue,
+        pub right: Box<MediaFeatureValue>,
     }
 
     pub struct MediaFeatureRangeInterval {
         pub span: Span,
-        pub left: MediaFeatureValue,
+        pub left: Box<MediaFeatureValue>,
         pub left_comparison: MediaFeatureRangeComparison,
         pub name: MediaFeatureName,
         pub right_comparison: MediaFeatureRangeComparison,
-        pub right: MediaFeatureValue,
+        pub right: Box<MediaFeatureValue>,
     }
 
     pub struct PageSelectorList {
@@ -798,19 +798,19 @@ define!({
     pub struct SupportsNot {
         pub span: Span,
         pub keyword: Option<Ident>,
-        pub condition: SupportsInParens,
+        pub condition: Box<SupportsInParens>,
     }
 
     pub struct SupportsAnd {
         pub span: Span,
         pub keyword: Option<Ident>,
-        pub condition: SupportsInParens,
+        pub condition: Box<SupportsInParens>,
     }
 
     pub struct SupportsOr {
         pub span: Span,
         pub keyword: Option<Ident>,
-        pub condition: SupportsInParens,
+        pub condition: Box<SupportsInParens>,
     }
 
     pub enum SupportsInParens {

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -258,7 +258,7 @@ define!({
     pub struct Url {
         pub span: Span,
         pub name: Ident,
-        pub value: Option<UrlValue>,
+        pub value: Option<Box<UrlValue>>,
         pub modifiers: Option<Vec<UrlModifier>>,
     }
 
@@ -392,7 +392,7 @@ define!({
     pub struct CompoundSelector {
         pub span: Span,
         pub nesting_selector: Option<NestingSelector>,
-        pub type_selector: Option<TypeSelector>,
+        pub type_selector: Option<Box<TypeSelector>>,
         pub subclass_selectors: Vec<SubclassSelector>,
     }
 
@@ -530,10 +530,10 @@ define!({
 
     pub struct ImportPrelude {
         pub span: Span,
-        pub href: ImportPreludeHref,
-        pub layer_name: Option<ImportPreludeLayerName>,
-        pub supports: Option<ImportPreludeSupportsType>,
-        pub media: Option<MediaQueryList>,
+        pub href: Box<ImportPreludeHref>,
+        pub layer_name: Option<Box<ImportPreludeLayerName>>,
+        pub supports: Option<Box<ImportPreludeSupportsType>>,
+        pub media: Option<Box<MediaQueryList>>,
     }
 
     pub enum ImportPreludeHref {
@@ -565,7 +565,7 @@ define!({
     pub struct AtRule {
         pub span: Span,
         pub name: AtRuleName,
-        pub prelude: Option<AtRulePrelude>,
+        pub prelude: Option<Box<AtRulePrelude>>,
         pub block: Option<SimpleBlock>,
     }
 
@@ -659,7 +659,7 @@ define!({
         pub modifier: Option<Ident>,
         pub media_type: Option<MediaType>,
         pub keyword: Option<Ident>,
-        pub condition: Option<MediaConditionType>,
+        pub condition: Option<Box<MediaConditionType>>,
     }
 
     pub enum MediaType {

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -130,14 +130,14 @@ define!({
 
     pub enum StyleBlock {
         ListOfComponentValues(ListOfComponentValues),
-        AtRule(AtRule),
-        Declaration(Declaration),
+        AtRule(Box<AtRule>),
+        Declaration(Box<Declaration>),
         QualifiedRule(QualifiedRule),
     }
 
     pub enum DeclarationOrAtRule {
-        Declaration(Declaration),
-        AtRule(AtRule),
+        Declaration(Box<Declaration>),
+        AtRule(Box<AtRule>),
         ListOfComponentValues(ListOfComponentValues),
     }
 
@@ -524,7 +524,7 @@ define!({
 
     pub enum Rule {
         QualifiedRule(QualifiedRule),
-        AtRule(AtRule),
+        AtRule(Box<AtRule>),
         Invalid(Tokens),
     }
 
@@ -548,7 +548,7 @@ define!({
 
     pub enum ImportPreludeSupportsType {
         SupportsCondition(SupportsCondition),
-        Declaration(Declaration),
+        Declaration(Box<Declaration>),
     }
 
     pub struct NamespacePrelude {
@@ -820,7 +820,7 @@ define!({
     }
 
     pub enum SupportsFeature {
-        Declaration(Declaration),
+        Declaration(Box<Declaration>),
         Function(Function),
     }
 

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -554,7 +554,7 @@ define!({
     pub struct NamespacePrelude {
         pub span: Span,
         pub prefix: Option<Ident>,
-        pub uri: NamespacePreludeUri,
+        pub uri: Box<NamespacePreludeUri>,
     }
 
     pub enum NamespacePreludeUri {

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -132,7 +132,7 @@ define!({
         ListOfComponentValues(ListOfComponentValues),
         AtRule(Box<AtRule>),
         Declaration(Box<Declaration>),
-        QualifiedRule(QualifiedRule),
+        QualifiedRule(Box<QualifiedRule>),
     }
 
     pub enum DeclarationOrAtRule {
@@ -434,7 +434,7 @@ define!({
     pub enum SubclassSelector {
         Id(IdSelector),
         Class(ClassSelector),
-        Attribute(AttributeSelector),
+        Attribute(Box<AttributeSelector>),
         PseudoClass(PseudoClassSelector),
         PseudoElement(PseudoElementSelector),
     }
@@ -523,7 +523,7 @@ define!({
     }
 
     pub enum Rule {
-        QualifiedRule(QualifiedRule),
+        QualifiedRule(Box<QualifiedRule>),
         AtRule(Box<AtRule>),
         Invalid(Tokens),
     }
@@ -714,7 +714,7 @@ define!({
 
     pub enum MediaInParens {
         MediaCondition(MediaCondition),
-        Feature(MediaFeature),
+        Feature(Box<MediaFeature>),
     }
 
     pub enum MediaFeature {

--- a/crates/swc_html_minifier/src/lib.rs
+++ b/crates/swc_html_minifier/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(clippy::all)]
 #![feature(box_patterns)]
+#![feature(box_syntax)]
 
 use std::cmp::Ordering;
 
@@ -1695,7 +1696,7 @@ impl Minifier<'_> {
                         swc_css_ast::Stylesheet {
                             span: Default::default(),
                             rules: vec![swc_css_ast::Rule::QualifiedRule(
-                                swc_css_ast::QualifiedRule {
+                                box swc_css_ast::QualifiedRule {
                                     span: Default::default(),
                                     prelude: swc_css_ast::QualifiedRulePrelude::SelectorList(
                                         swc_css_ast::SelectorList {
@@ -1723,14 +1724,14 @@ impl Minifier<'_> {
                 ) {
                     Ok(media_query_list) => swc_css_ast::Stylesheet {
                         span: Default::default(),
-                        rules: vec![swc_css_ast::Rule::AtRule(swc_css_ast::AtRule {
+                        rules: vec![swc_css_ast::Rule::AtRule(box swc_css_ast::AtRule {
                             span: Default::default(),
                             name: swc_css_ast::AtRuleName::Ident(swc_css_ast::Ident {
                                 span: Default::default(),
                                 value: "media".into(),
                                 raw: None,
                             }),
-                            prelude: Some(swc_css_ast::AtRulePrelude::MediaPrelude(
+                            prelude: Some(box swc_css_ast::AtRulePrelude::MediaPrelude(
                                 media_query_list,
                             )),
                             block: Some(swc_css_ast::SimpleBlock {
@@ -1793,8 +1794,9 @@ impl Minifier<'_> {
                 let swc_css_ast::Stylesheet { rules, .. } = &stylesheet;
 
                 // Because CSS is grammar free, protect for fails
-                if let Some(swc_css_ast::Rule::AtRule(swc_css_ast::AtRule { prelude, .. })) =
-                    rules.get(0)
+                if let Some(swc_css_ast::Rule::AtRule(box swc_css_ast::AtRule {
+                    prelude, ..
+                })) = rules.get(0)
                 {
                     swc_css_codegen::Emit::emit(&mut gen, &prelude).unwrap();
 

--- a/crates/swc_html_minifier/src/lib.rs
+++ b/crates/swc_html_minifier/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(clippy::all)]
+#![feature(box_patterns)]
 
 use std::cmp::Ordering;
 
@@ -1776,7 +1777,7 @@ impl Minifier<'_> {
                 let swc_css_ast::Stylesheet { rules, .. } = &stylesheet;
 
                 // Because CSS is grammar free, protect for fails
-                if let Some(swc_css_ast::Rule::QualifiedRule(swc_css_ast::QualifiedRule {
+                if let Some(swc_css_ast::Rule::QualifiedRule(box swc_css_ast::QualifiedRule {
                     block,
                     ..
                 })) = rules.get(0)


### PR DESCRIPTION
**Description:**

```
Benchmarking css/minify/libraries/bootstrap
Benchmarking css/minify/libraries/bootstrap: Warming up for 3.0000 s
Benchmarking css/minify/libraries/bootstrap: Collecting 10 samples in estimated 5.2997 s (825 iterations)
Benchmarking css/minify/libraries/bootstrap: Analyzing
css/minify/libraries/bootstrap
                        time:   [6.4418 ms 6.4475 ms 6.4558 ms]
                        change: [-21.738% -21.403% -21.047%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
```