### PR TITLE
perf(atoms): Reduce size of `Atom`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,6 +2989,7 @@ dependencies = [
  "serde",
  "string_cache",
  "string_cache_codegen",
+ "triomphe",
 ]
 
 [[package]]
@@ -4671,6 +4672,16 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "triomphe"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1ee9bd9239c339d714d657fac840c6d2a4f9c45f4f9ec7b0975113458be78db"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
 ]
 
 [[package]]

--- a/crates/swc_atoms/Cargo.toml
+++ b/crates/swc_atoms/Cargo.toml
@@ -29,6 +29,7 @@ rkyv-latest  = { package = "rkyv-test", version = "=0.7.38-test.2", optional = t
 rustc-hash   = "1.1.0"
 serde        = "1"
 string_cache = "0.8.4"
+triomphe     = "0.1.8"
 
 [build-dependencies]
 string_cache_codegen = "0.5.2"

--- a/crates/swc_atoms/src/lib.rs
+++ b/crates/swc_atoms/src/lib.rs
@@ -20,13 +20,13 @@ use std::{
     hash::Hash,
     ops::Deref,
     rc::Rc,
-    sync::Arc,
 };
 
 #[cfg(feature = "rkyv-bytecheck-impl")]
 use rkyv_latest as rkyv;
 use rustc_hash::FxHashSet;
 use serde::Serializer;
+use triomphe::Arc;
 
 include!(concat!(env!("OUT_DIR"), "/js_word.rs"));
 
@@ -103,6 +103,16 @@ macro_rules! impl_from {
     };
 }
 
+macro_rules! impl_from_deref {
+    ($T:ty) => {
+        impl From<$T> for Atom {
+            fn from(s: $T) -> Self {
+                Atom::new(&*s)
+            }
+        }
+    };
+}
+
 impl PartialEq<str> for Atom {
     fn eq(&self, other: &str) -> bool {
         &*self.0 == other
@@ -111,16 +121,16 @@ impl PartialEq<str> for Atom {
 
 impl_eq!(&'_ str);
 impl_eq!(Box<str>);
-impl_eq!(Arc<str>);
+impl_eq!(std::sync::Arc<str>);
 impl_eq!(Rc<str>);
 impl_eq!(Cow<'_, str>);
 impl_eq!(String);
 impl_eq!(JsWord);
 
 impl_from!(&'_ str);
-impl_from!(Box<str>);
+impl_from_deref!(Box<str>);
 impl_from!(Arc<str>);
-impl_from!(Cow<'_, str>);
+impl_from_deref!(Cow<'_, str>);
 impl_from!(String);
 
 impl From<JsWord> for Atom {


### PR DESCRIPTION
**Description:**

This patch reduces the memory footprint

---

# ES parser comparison

## main

```

heap stats:    peak      total      freed    current       unit      count
  reserved:  512.1 MiB  512.1 MiB  256.0 MiB  256.1 MiB                        not all freed!
 committed:  512.1 MiB  512.1 MiB  256.0 MiB  256.1 MiB                        not all freed!
     reset:   13.2 MiB  775.2 MiB  896.9 MiB -121.7 MiB                        ok
   touched:      0          0       53.9 GiB  -53.9 GiB                        ok
  segments:     40        1.5 Ki     1.5 Ki       5                            not all freed!
-abandoned:      0          0          0          0                            ok
   -cached:      0          0          0          0                            ok
     pages:    2.0 Ki   956.6 Ki   956.5 Ki      28                            not all freed!
-abandoned:      0          0          0          0                            ok
 -extended:      0
 -noretire:      0
     mmaps:      0
   commits:      0
   threads:     10         10          0         10                            not all freed!
  searches:     0.0 avg
numa nodes:       1
   elapsed:      97.390 s
   process: user: 110.162 s, system: 0.846 s, faults: 0, rss: 351.0 MiB, commit: 512.1 MiB
```


## With this

```
heap stats:    peak      total      freed    current       unit      count
  reserved:  512.1 MiB  512.1 MiB  256.0 MiB  256.1 MiB                        not all freed!
 committed:  512.1 MiB  512.1 MiB  256.0 MiB  256.1 MiB                        not all freed!
     reset:   19.4 MiB  533.1 MiB  622.9 MiB  -89.7 MiB                        ok
   touched:      0          0       48.3 GiB  -48.3 GiB                        ok
  segments:     40        1.5 Ki     1.5 Ki       4                            not all freed!
-abandoned:      0          0          0          0                            ok
   -cached:      0          0          0          0                            ok
     pages:    1.9 Ki   852.7 Ki   852.7 Ki      28                            not all freed!
-abandoned:      0          0          0          0                            ok
 -extended:      0
 -noretire:      0
     mmaps:      0
   commits:      0
   threads:     10         10          0         10                            not all freed!
  searches:     0.0 avg
numa nodes:       1
   elapsed:      93.037 s
   process: user: 114.865 s, system: 1.098 s, faults: 0, rss: 348.0 MiB, commit: 512.1 MiB

```