### PR TITLE
perf(es/parser): Optimize memory layout

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/number.rs
+++ b/crates/swc_ecma_parser/src/lexer/number.rs
@@ -33,7 +33,7 @@ impl<'a, I: Input> Lexer<'a, I> {
     pub(super) fn read_number(
         &mut self,
         starts_with_dot: bool,
-    ) -> LexResult<Either<(f64, Atom), (BigIntValue, Atom)>> {
+    ) -> LexResult<Either<(f64, Atom), (Box<BigIntValue>, Atom)>> {
         debug_assert!(self.cur().is_some());
 
         if starts_with_dot {
@@ -63,7 +63,7 @@ impl<'a, I: Input> Lexer<'a, I> {
                 raw.push('n');
 
                 return Ok(Either::Right((
-                    s.into_value(),
+                    Box::new(s.into_value()),
                     self.atoms.borrow_mut().intern(raw),
                 )));
             }
@@ -227,7 +227,7 @@ impl<'a, I: Input> Lexer<'a, I> {
     /// Returns `Left(value)` or `Right(BigInt)`
     pub(super) fn read_radix_number<const RADIX: u8, const FORMAT: u128>(
         &mut self,
-    ) -> LexResult<Either<(f64, Atom), (BigIntValue, Atom)>> {
+    ) -> LexResult<Either<(f64, Atom), (Box<BigIntValue>, Atom)>> {
         debug_assert!(
             RADIX == 2 || RADIX == 8 || RADIX == 16,
             "radix should be one of 2, 8, 16, but got {}",
@@ -261,7 +261,7 @@ impl<'a, I: Input> Lexer<'a, I> {
                 buf.push('n');
 
                 return Ok(Either::Right((
-                    s.into_value(),
+                    Box::new(s.into_value()),
                     l.atoms.borrow_mut().intern(&**buf),
                 )));
             }
@@ -712,9 +712,11 @@ mod tests {
                 |l| l.read_number(false).unwrap().right().unwrap()
             ),
             (
-                "10000000000000000000000000000000000000000000000000000"
-                    .parse::<BigIntValue>()
-                    .unwrap(),
+                Box::new(
+                    "10000000000000000000000000000000000000000000000000000"
+                        .parse::<BigIntValue>()
+                        .unwrap()
+                ),
                 Atom::from("10000000000000000000000000000000000000000000000000000n")
             ),
         );

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -1,8 +1,6 @@
 use std::mem::take;
 
 use enum_kind::Kind;
-#[cfg(not(debug_assertions))]
-use smallvec::SmallVec;
 use swc_common::BytePos;
 use tracing::trace;
 
@@ -342,10 +340,7 @@ impl<'a, I: Input> Iterator for Lexer<'a, I> {
 
 impl State {
     pub fn new(syntax: Syntax, start_pos: BytePos) -> Self {
-        #[cfg(debug_assertions)]
         let context = TokenContexts(vec![TokenContext::BraceStmt]);
-        #[cfg(not(debug_assertions))]
-        let context = TokenContexts(SmallVec::from_slice(&[TokenContext::BraceStmt]));
 
         State {
             is_expr_allowed: true,
@@ -614,12 +609,7 @@ impl State {
 }
 
 #[derive(Clone, Default)]
-#[cfg(debug_assertions)]
 pub struct TokenContexts(pub(crate) Vec<TokenContext>);
-
-#[derive(Clone, Default)]
-#[cfg(not(debug_assertions))]
-pub struct TokenContexts(pub(crate) SmallVec<[TokenContext; 32]>);
 
 impl TokenContexts {
     /// Returns true if following `LBrace` token is `block statement` according

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1919,7 +1919,7 @@ impl<I: Tokens> Parser<I> {
             Token::BigInt { .. } => match bump!(self) {
                 Token::BigInt { value, raw } => Lit::BigInt(BigInt {
                     span: span!(self, start),
-                    value,
+                    value: *value,
                     raw: Some(raw),
                 }),
                 _ => unreachable!(),

--- a/crates/swc_ecma_parser/src/parser/object.rs
+++ b/crates/swc_ecma_parser/src/parser/object.rs
@@ -73,7 +73,7 @@ impl<I: Tokens> Parser<I> {
                 Token::BigInt { .. } => match bump!(p) {
                     Token::BigInt { value, raw } => PropName::BigInt(BigInt {
                         span: span!(p, start),
-                        value,
+                        value: *value,
                         raw: Some(raw),
                     }),
                     _ => unreachable!(),

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2762,12 +2762,8 @@ impl<I: Tokens> Parser<I> {
 
         let cloned = self.input.token_context().clone();
 
-        #[cfg(debug_assertions)]
         self.input
             .set_token_context(TokenContexts(vec![cloned.0[0]]));
-        #[cfg(not(debug_assertions))]
-        self.input
-            .set_token_context(TokenContexts(smallvec::smallvec![cloned.0[0]]));
         let res = op(self);
         self.input.set_token_context(cloned);
 

--- a/crates/swc_ecma_parser/src/token.rs
+++ b/crates/swc_ecma_parser/src/token.rs
@@ -126,7 +126,7 @@ pub enum Token {
 
     #[kind(starts_expr)]
     BigInt {
-        value: BigIntValue,
+        value: Box<BigIntValue>,
         raw: Atom,
     },
 


### PR DESCRIPTION
**Description:**

I boxed `BigIntValue` in `Token` type to make `TokenAndSpan` smaller and made the parser use `Vec` instead of `SmallVec` for token contexts.


## main

```
es/parser/colors        time:   [15.251 us 15.258 us 15.265 us]
es/parser/angular       time:   [7.8481 ms 7.8576 ms 7.8684 ms]
es/parser/backbone      time:   [1.1110 ms 1.1124 ms 1.1143 ms]
es/parser/jquery        time:   [6.1279 ms 6.1357 ms 6.1458 ms]
es/parser/jquery mobile time:   [9.6091 ms 9.6207 ms 9.6346 ms]
es/parser/mootools      time:   [4.6403 ms 4.6483 ms 4.6582 ms]
es/parser/underscore    time:   [949.03 us 949.69 us 950.50 us]
es/parser/three         time:   [27.706 ms 27.747 ms 27.795 ms]
es/parser/yui           time:   [4.6905 ms 4.6970 ms 4.7049 ms]
```


## new

```
es/parser/colors        time:   [14.922 us 14.932 us 14.942 us]
es/parser/angular       time:   [7.7169 ms 7.8253 ms 8.0080 ms]
es/parser/backbone      time:   [1.0840 ms 1.0890 ms 1.0952 ms]
es/parser/jquery        time:   [5.9651 ms 5.9697 ms 5.9754 ms]
es/parser/jquery mobile time:   [9.4014 ms 9.4340 ms 9.4724 ms]
es/parser/mootools      time:   [4.5028 ms 4.5124 ms 4.5255 ms]
es/parser/underscore    time:   [929.05 us 933.09 us 937.61 us]
es/parser/three         time:   [26.885 ms 26.926 ms 26.971 ms]
es/parser/yui           time:   [4.5731 ms 4.5855 ms 4.6022 ms]
```