### PR TITLE
perf(es/parser): Reduce memory operations

### DIFF
--- a/crates/swc_ecma_parser/benches/parser.rs
+++ b/crates/swc_ecma_parser/benches/parser.rs
@@ -26,69 +26,41 @@ fn bench_module(b: &mut Bencher, syntax: Syntax, src: &'static str) {
 }
 
 fn bench_files(c: &mut Criterion) {
-    c.bench_function("es/parser/colors", |b| {
-        // Copied from ratel-rust
-        bench_module(b, Default::default(), include_str!("../colors.js"))
-    });
+    let mut bench_file = |name: &str, src: &'static str| {
+        c.bench_function(name, |b| {
+            // Copied from ratel-rust
+            bench_module(b, Default::default(), src)
+        });
+    };
 
-    c.bench_function("es/parser/angular", |b| {
-        bench_module(
-            b,
-            Default::default(),
-            include_str!("./files/angular-1.2.5.js"),
-        )
-    });
+    bench_file("es/parser/colors", include_str!("../colors.js"));
+    bench_file(
+        "es/parser/angular",
+        include_str!("./files/angular-1.2.5.js"),
+    );
+    bench_file(
+        "es/parser/backbone",
+        include_str!("./files/backbone-1.1.0.js"),
+    );
+    bench_file("es/parser/jquery", include_str!("./files/jquery-1.9.1.js"));
+    bench_file(
+        "es/parser/jquery mobile",
+        include_str!("./files/jquery.mobile-1.4.2.js"),
+    );
 
-    c.bench_function("es/parser/backbone", |b| {
-        bench_module(
-            b,
-            Default::default(),
-            include_str!("./files/backbone-1.1.0.js"),
-        )
-    });
+    bench_file(
+        "es/parser/mootools",
+        include_str!("./files/mootools-1.4.5.js"),
+    );
 
-    c.bench_function("es/parser/jquery", |b| {
-        bench_module(
-            b,
-            Default::default(),
-            include_str!("./files/jquery-1.9.1.js"),
-        )
-    });
+    bench_file(
+        "es/parser/underscore",
+        include_str!("./files/underscore-1.5.2.js"),
+    );
 
-    c.bench_function("es/parser/jquery mobile", |b| {
-        bench_module(
-            b,
-            Default::default(),
-            include_str!("./files/jquery.mobile-1.4.2.js"),
-        )
-    });
-    c.bench_function("es/parser/mootools", |b| {
-        bench_module(
-            b,
-            Default::default(),
-            include_str!("./files/mootools-1.4.5.js"),
-        )
-    });
+    bench_file("es/parser/three", include_str!("./files/three-0.138.3.js"));
 
-    c.bench_function("es/parser/underscore", |b| {
-        bench_module(
-            b,
-            Default::default(),
-            include_str!("./files/underscore-1.5.2.js"),
-        )
-    });
-
-    c.bench_function("es/parser/three", |b| {
-        bench_module(
-            b,
-            Default::default(),
-            include_str!("./files/three-0.138.3.js"),
-        )
-    });
-
-    c.bench_function("es/parser/yui", |b| {
-        bench_module(b, Default::default(), include_str!("./files/yui-3.12.0.js"))
-    });
+    bench_file("es/parser/yui", include_str!("./files/yui-3.12.0.js"));
 }
 
 criterion_group!(benches, bench_files);

--- a/crates/swc_ecma_parser/scripts/instrument/bench.sh
+++ b/crates/swc_ecma_parser/scripts/instrument/bench.sh
@@ -4,4 +4,4 @@ set -eu
 export RUST_LOG=off
 export MIMALLOC_SHOW_STATS=1
 
-cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --features swc_common/parking_lot --bench parser -- --bench --color
+cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --features swc_common/parking_lot --bench parser -- $@

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -1166,22 +1166,22 @@ impl<'a, I: Input> Lexer<'a, I> {
         // Spec says "It is a Syntax Error if IdentifierPart contains a Unicode escape
         // sequence." TODO: check for escape
 
+        let separator = self.input.cur_pos();
+
         // Need to use `read_word` because '\uXXXX' sequences are allowed
         // here (don't ask).
         // let flags_start = self.cur_pos();
         let flags = {
             let atoms = self.atoms.clone();
             match self.cur() {
-                Some(c) if c.is_ident_start() => self
-                    .read_word_as_str_with(|s| atoms.borrow_mut().intern(s))
-                    .map(Some),
+                Some(c) if c.is_ident_start() => self.read_word_as_str_with(|s| {}).map(Some),
                 _ => Ok(None),
             }
         }?
         .map(|(value, _)| value)
         .unwrap_or_default();
 
-        Ok(Regex(content, flags))
+        Ok(Regex { separator })
     }
 
     fn read_shebang(&mut self) -> LexResult<Option<Atom>> {

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -108,7 +108,7 @@ impl<'a> From<&'a Token> for TokenType {
                         | Token::Str { .. }
                         | Token::Word(Word::Ident(..))
                         | Token::DollarLBrace
-                        | Token::Regex(..)
+                        | Token::Regex { .. }
                         | Token::BigInt { .. }
                         | Token::JSXText { .. }
                         | Token::RBrace

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -759,6 +759,8 @@ pub enum TokenContext {
     #[kind(is_expr, preserve_space)]
     Tpl {
         /// Start of a template literal.
+        ///
+        /// TODO(kdy1): Move this to a separate struct.
         start: BytePos,
     },
     #[kind(is_expr)]

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -1,6 +1,7 @@
 use std::{mem::take, ops::Range};
 
 use enum_kind::Kind;
+use swc_atoms::Atom;
 use swc_common::{BytePos, Span};
 use tracing::trace;
 
@@ -184,8 +185,11 @@ impl<I: Input> Tokens for Lexer<'_, I> {
     }
 
     #[inline]
-    fn text(&self, range: Range<BytePos>) -> &str {
-        self.input.slice(range.start, range.end)
+    fn text(&mut self, range: Range<BytePos>) -> Atom {
+        let pos = self.input.cur_pos();
+        let s = self.input.slice(range.start, range.end).into();
+        self.input.reset_to(pos);
+        s
     }
 }
 

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -52,9 +52,10 @@ enum TokenType {
     JSXTagStart,
     JSXTagEnd,
     Arrow,
-    // This is *encoded* (DoD) to reduce type size.
-    OtherBeforeExpr { can_have_trailing_comment: bool },
-    OtherNotBeforeExpr { can_have_trailing_comment: bool },
+    Other {
+        before_expr: bool,
+        can_have_trailing_comment: bool,
+    },
 }
 impl TokenType {
     #[inline]
@@ -75,8 +76,7 @@ impl TokenType {
 
             TokenType::BinOp(b) => b.before_expr(),
             TokenType::Keyword(k) => k.before_expr(),
-            TokenType::OtherBeforeExpr { .. } => true,
-            TokenType::OtherNotBeforeExpr { .. } => false,
+            TokenType::Other { before_expr, .. } => before_expr,
         }
     }
 }
@@ -99,8 +99,9 @@ impl<'a> From<&'a Token> for TokenType {
             Token::Arrow => TokenType::Arrow,
 
             Token::Word(Word::Keyword(k)) => TokenType::Keyword(k),
-            _ => {
-                let can_have_trailing_comment = matches!(
+            _ => TokenType::Other {
+                before_expr: t.before_expr(),
+                can_have_trailing_comment: matches!(
                     *t,
                     Token::Num { .. }
                         | Token::Str { .. }
@@ -110,18 +111,8 @@ impl<'a> From<&'a Token> for TokenType {
                         | Token::BigInt { .. }
                         | Token::JSXText { .. }
                         | Token::RBrace
-                );
-
-                if t.before_expr() {
-                    TokenType::OtherBeforeExpr {
-                        can_have_trailing_comment,
-                    }
-                } else {
-                    TokenType::OtherNotBeforeExpr {
-                        can_have_trailing_comment,
-                    }
-                }
-            }
+                ),
+            },
         }
     }
 }
@@ -405,16 +396,10 @@ impl State {
         match self.token_type {
             Some(TokenType::Keyword(..)) => false,
             Some(TokenType::Semi) | Some(TokenType::LBrace) => true,
-            Some(
-                TokenType::OtherBeforeExpr {
-                    can_have_trailing_comment,
-                    ..
-                }
-                | TokenType::OtherNotBeforeExpr {
-                    can_have_trailing_comment,
-                    ..
-                },
-            ) => can_have_trailing_comment,
+            Some(TokenType::Other {
+                can_have_trailing_comment,
+                ..
+            }) => can_have_trailing_comment,
             _ => false,
         }
     }
@@ -708,7 +693,10 @@ impl TokenContexts {
         }
 
         if had_line_break {
-            if let Some(TokenType::OtherNotBeforeExpr { .. }) = prev {
+            if let Some(TokenType::Other {
+                before_expr: false, ..
+            }) = prev
+            {
                 return true;
             }
         }

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -1,4 +1,4 @@
-use std::mem::take;
+use std::{mem::take, ops::Range};
 
 use enum_kind::Kind;
 use swc_common::{BytePos, Span};
@@ -181,6 +181,11 @@ impl<I: Input> Tokens for Lexer<'_, I> {
 
     fn take_errors(&mut self) -> Vec<Error> {
         take(&mut self.errors.borrow_mut())
+    }
+
+    #[inline]
+    fn text(&self, range: Range<BytePos>) -> &str {
+        self.input.slice(range.start, range.end)
     }
 }
 

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1028,10 +1028,10 @@ impl<I: Tokens> Parser<I> {
                 let span = self.input.cur_span();
                 match bump!(self) {
                     Token::Template { cooked, .. } => match cooked {
-                        Ok(cooked) => (self.input.text(span.lo..span.hi).into(), Some(cooked)),
+                        Ok(cooked) => (self.input.text(span.lo..span.hi), Some(cooked)),
                         Err(err) => {
                             if is_tagged_tpl {
-                                (self.input.text(span.lo..span.hi).into(), None)
+                                (self.input.text(span.lo..span.hi), None)
                             } else {
                                 return Err(err);
                             }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1025,7 +1025,7 @@ impl<I: Tokens> Parser<I> {
 
         let (raw, cooked) = match *cur!(self, true)? {
             Token::Template { .. } => match bump!(self) {
-                Token::Template { raw, cooked, .. } => match cooked {
+                Token::Template { cooked, .. } => match cooked {
                     Ok(cooked) => (raw, Some(cooked)),
                     Err(err) => {
                         if is_tagged_tpl {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -327,9 +327,11 @@ impl<I: Tokens> Parser<I> {
                 }
 
                 // Regexp
-                Token::Regex(..) => match bump!(self) {
-                    Token::Regex(exp, flags) => {
+                Token::Regex { .. } => match bump!(self) {
+                    Token::Regex { separator } => {
                         let span = span!(self, start);
+                        let exp = self.input.text(span.lo..separator);
+                        let flags = self.input.text(separator..span.hi);
 
                         let mut flags_count = flags.chars().fold(
                             AHashMap::<char, usize>::default(),

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, mem, mem::take, rc::Rc};
+use std::{cell::RefCell, mem, mem::take, ops::Range, rc::Rc};
 
 use lexer::TokenContexts;
 use swc_common::{BytePos, Span};
@@ -44,6 +44,8 @@ pub trait Tokens: Clone + Iterator<Item = TokenAndSpan> {
     fn add_module_mode_error(&self, error: Error);
 
     fn take_errors(&mut self) -> Vec<Error>;
+
+    fn text(&self, range: Range<BytePos>) -> &str;
 }
 
 #[derive(Clone)]
@@ -428,6 +430,10 @@ impl<I: Tokens> Buffer<I> {
             .unwrap_or(self.prev_span);
 
         Span::new(data.lo, data.hi, data.ctxt)
+    }
+
+    pub fn text(&self, span: Range<BytePos>) -> &str {
+        self.iter.text(span)
     }
 
     /// Returns last byte position of previous token.

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -1,5 +1,6 @@
 use std::ops::Range;
 
+use swc_atoms::Atom;
 use swc_common::{BytePos, Span};
 
 use super::Parser;
@@ -44,7 +45,7 @@ pub trait Tokens: Clone + Iterator<Item = TokenAndSpan> {
 
     fn take_errors(&mut self) -> Vec<Error>;
 
-    fn text(&self, range: Range<BytePos>) -> &str;
+    fn text(&mut self, range: Range<BytePos>) -> Atom;
 }
 
 // #[derive(Clone)]

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -1,6 +1,5 @@
-use std::{cell::RefCell, mem, mem::take, ops::Range, rc::Rc};
+use std::ops::Range;
 
-use lexer::TokenContexts;
 use swc_common::{BytePos, Span};
 
 use super::Parser;
@@ -48,206 +47,207 @@ pub trait Tokens: Clone + Iterator<Item = TokenAndSpan> {
     fn text(&self, range: Range<BytePos>) -> &str;
 }
 
-#[derive(Clone)]
-pub struct TokensInput {
-    iter: <Vec<TokenAndSpan> as IntoIterator>::IntoIter,
-    ctx: Context,
-    syntax: Syntax,
-    start_pos: BytePos,
-    target: EsVersion,
-    token_ctx: TokenContexts,
-    errors: Rc<RefCell<Vec<Error>>>,
-    module_errors: Rc<RefCell<Vec<Error>>>,
-}
+// #[derive(Clone)]
+// pub struct TokensInput {
+//     iter: <Vec<TokenAndSpan> as IntoIterator>::IntoIter,
+//     ctx: Context,
+//     syntax: Syntax,
+//     start_pos: BytePos,
+//     target: EsVersion,
+//     token_ctx: TokenContexts,
+//     errors: Rc<RefCell<Vec<Error>>>,
+//     module_errors: Rc<RefCell<Vec<Error>>>,
+// }
 
-impl TokensInput {
-    pub fn new(tokens: Vec<TokenAndSpan>, ctx: Context, syntax: Syntax, target: EsVersion) -> Self {
-        let start_pos = tokens.first().map(|t| t.span.lo).unwrap_or(BytePos(0));
+// impl TokensInput {
+//     pub fn new(tokens: Vec<TokenAndSpan>, ctx: Context, syntax: Syntax,
+// target: EsVersion) -> Self {         let start_pos = tokens.first().map(|t|
+// t.span.lo).unwrap_or(BytePos(0));
 
-        TokensInput {
-            iter: tokens.into_iter(),
-            ctx,
-            syntax,
-            start_pos,
-            target,
-            token_ctx: Default::default(),
-            errors: Default::default(),
-            module_errors: Default::default(),
-        }
-    }
-}
+//         TokensInput {
+//             iter: tokens.into_iter(),
+//             ctx,
+//             syntax,
+//             start_pos,
+//             target,
+//             token_ctx: Default::default(),
+//             errors: Default::default(),
+//             module_errors: Default::default(),
+//         }
+//     }
+// }
 
-impl Iterator for TokensInput {
-    type Item = TokenAndSpan;
+// impl Iterator for TokensInput {
+//     type Item = TokenAndSpan;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
-    }
-}
+//     fn next(&mut self) -> Option<Self::Item> {
+//         self.iter.next()
+//     }
+// }
 
-impl Tokens for TokensInput {
-    fn set_ctx(&mut self, ctx: Context) {
-        if ctx.module && !self.module_errors.borrow().is_empty() {
-            let mut module_errors = self.module_errors.borrow_mut();
-            self.errors.borrow_mut().append(&mut *module_errors);
-        }
-        self.ctx = ctx;
-    }
+// impl Tokens for TokensInput {
+//     fn set_ctx(&mut self, ctx: Context) {
+//         if ctx.module && !self.module_errors.borrow().is_empty() {
+//             let mut module_errors = self.module_errors.borrow_mut();
+//             self.errors.borrow_mut().append(&mut *module_errors);
+//         }
+//         self.ctx = ctx;
+//     }
 
-    fn ctx(&self) -> Context {
-        self.ctx
-    }
+//     fn ctx(&self) -> Context {
+//         self.ctx
+//     }
 
-    fn syntax(&self) -> Syntax {
-        self.syntax
-    }
+//     fn syntax(&self) -> Syntax {
+//         self.syntax
+//     }
 
-    fn target(&self) -> EsVersion {
-        self.target
-    }
+//     fn target(&self) -> EsVersion {
+//         self.target
+//     }
 
-    fn start_pos(&self) -> BytePos {
-        self.start_pos
-    }
+//     fn start_pos(&self) -> BytePos {
+//         self.start_pos
+//     }
 
-    fn set_expr_allowed(&mut self, _: bool) {}
+//     fn set_expr_allowed(&mut self, _: bool) {}
 
-    fn token_context(&self) -> &TokenContexts {
-        &self.token_ctx
-    }
+//     fn token_context(&self) -> &TokenContexts {
+//         &self.token_ctx
+//     }
 
-    fn token_context_mut(&mut self) -> &mut TokenContexts {
-        &mut self.token_ctx
-    }
+//     fn token_context_mut(&mut self) -> &mut TokenContexts {
+//         &mut self.token_ctx
+//     }
 
-    fn set_token_context(&mut self, c: TokenContexts) {
-        self.token_ctx = c;
-    }
+//     fn set_token_context(&mut self, c: TokenContexts) {
+//         self.token_ctx = c;
+//     }
 
-    fn add_error(&self, error: Error) {
-        self.errors.borrow_mut().push(error);
-    }
+//     fn add_error(&self, error: Error) {
+//         self.errors.borrow_mut().push(error);
+//     }
 
-    fn add_module_mode_error(&self, error: Error) {
-        if self.ctx.module {
-            self.add_error(error);
-            return;
-        }
-        self.module_errors.borrow_mut().push(error);
-    }
+//     fn add_module_mode_error(&self, error: Error) {
+//         if self.ctx.module {
+//             self.add_error(error);
+//             return;
+//         }
+//         self.module_errors.borrow_mut().push(error);
+//     }
 
-    fn take_errors(&mut self) -> Vec<Error> {
-        take(&mut self.errors.borrow_mut())
-    }
-}
+//     fn take_errors(&mut self) -> Vec<Error> {
+//         take(&mut self.errors.borrow_mut())
+//     }
+// }
 
-/// Note: Lexer need access to parser's context to lex correctly.
-#[derive(Debug)]
-pub struct Capturing<I: Tokens> {
-    inner: I,
-    captured: Rc<RefCell<Vec<TokenAndSpan>>>,
-}
+// /// Note: Lexer need access to parser's context to lex correctly.
+// #[derive(Debug)]
+// pub struct Capturing<I: Tokens> {
+//     inner: I,
+//     captured: Rc<RefCell<Vec<TokenAndSpan>>>,
+// }
 
-impl<I: Tokens> Clone for Capturing<I> {
-    fn clone(&self) -> Self {
-        Capturing {
-            inner: self.inner.clone(),
-            captured: self.captured.clone(),
-        }
-    }
-}
+// impl<I: Tokens> Clone for Capturing<I> {
+//     fn clone(&self) -> Self {
+//         Capturing {
+//             inner: self.inner.clone(),
+//             captured: self.captured.clone(),
+//         }
+//     }
+// }
 
-impl<I: Tokens> Capturing<I> {
-    pub fn new(input: I) -> Self {
-        Capturing {
-            inner: input,
-            captured: Default::default(),
-        }
-    }
+// impl<I: Tokens> Capturing<I> {
+//     pub fn new(input: I) -> Self {
+//         Capturing {
+//             inner: input,
+//             captured: Default::default(),
+//         }
+//     }
 
-    /// Take captured tokens
-    pub fn take(&mut self) -> Vec<TokenAndSpan> {
-        mem::take(&mut *self.captured.borrow_mut())
-    }
-}
+//     /// Take captured tokens
+//     pub fn take(&mut self) -> Vec<TokenAndSpan> {
+//         mem::take(&mut *self.captured.borrow_mut())
+//     }
+// }
 
-impl<I: Tokens> Iterator for Capturing<I> {
-    type Item = TokenAndSpan;
+// impl<I: Tokens> Iterator for Capturing<I> {
+//     type Item = TokenAndSpan;
 
-    fn next(&mut self) -> Option<Self::Item> {
-        let next = self.inner.next();
+//     fn next(&mut self) -> Option<Self::Item> {
+//         let next = self.inner.next();
 
-        match next {
-            Some(ts) => {
-                let mut v = self.captured.borrow_mut();
+//         match next {
+//             Some(ts) => {
+//                 let mut v = self.captured.borrow_mut();
 
-                // remove tokens that could change due to backtracing
-                while let Some(last) = v.last() {
-                    if last.span.lo >= ts.span.lo {
-                        v.pop();
-                    } else {
-                        break;
-                    }
-                }
+//                 // remove tokens that could change due to backtracing
+//                 while let Some(last) = v.last() {
+//                     if last.span.lo >= ts.span.lo {
+//                         v.pop();
+//                     } else {
+//                         break;
+//                     }
+//                 }
 
-                v.push(ts.clone());
+//                 v.push(ts.clone());
 
-                Some(ts)
-            }
-            None => None,
-        }
-    }
-}
+//                 Some(ts)
+//             }
+//             None => None,
+//         }
+//     }
+// }
 
-impl<I: Tokens> Tokens for Capturing<I> {
-    fn set_ctx(&mut self, ctx: Context) {
-        self.inner.set_ctx(ctx)
-    }
+// impl<I: Tokens> Tokens for Capturing<I> {
+//     fn set_ctx(&mut self, ctx: Context) {
+//         self.inner.set_ctx(ctx)
+//     }
 
-    fn ctx(&self) -> Context {
-        self.inner.ctx()
-    }
+//     fn ctx(&self) -> Context {
+//         self.inner.ctx()
+//     }
 
-    fn syntax(&self) -> Syntax {
-        self.inner.syntax()
-    }
+//     fn syntax(&self) -> Syntax {
+//         self.inner.syntax()
+//     }
 
-    fn target(&self) -> EsVersion {
-        self.inner.target()
-    }
+//     fn target(&self) -> EsVersion {
+//         self.inner.target()
+//     }
 
-    fn start_pos(&self) -> BytePos {
-        self.inner.start_pos()
-    }
+//     fn start_pos(&self) -> BytePos {
+//         self.inner.start_pos()
+//     }
 
-    fn set_expr_allowed(&mut self, allow: bool) {
-        self.inner.set_expr_allowed(allow)
-    }
+//     fn set_expr_allowed(&mut self, allow: bool) {
+//         self.inner.set_expr_allowed(allow)
+//     }
 
-    fn token_context(&self) -> &TokenContexts {
-        self.inner.token_context()
-    }
+//     fn token_context(&self) -> &TokenContexts {
+//         self.inner.token_context()
+//     }
 
-    fn token_context_mut(&mut self) -> &mut TokenContexts {
-        self.inner.token_context_mut()
-    }
+//     fn token_context_mut(&mut self) -> &mut TokenContexts {
+//         self.inner.token_context_mut()
+//     }
 
-    fn set_token_context(&mut self, c: TokenContexts) {
-        self.inner.set_token_context(c)
-    }
+//     fn set_token_context(&mut self, c: TokenContexts) {
+//         self.inner.set_token_context(c)
+//     }
 
-    fn add_error(&self, error: Error) {
-        self.inner.add_error(error);
-    }
+//     fn add_error(&self, error: Error) {
+//         self.inner.add_error(error);
+//     }
 
-    fn add_module_mode_error(&self, error: Error) {
-        self.inner.add_module_mode_error(error)
-    }
+//     fn add_module_mode_error(&self, error: Error) {
+//         self.inner.add_module_mode_error(error)
+//     }
 
-    fn take_errors(&mut self) -> Vec<Error> {
-        self.inner.take_errors()
-    }
-}
+//     fn take_errors(&mut self) -> Vec<Error> {
+//         self.inner.take_errors()
+//     }
+// }
 
 /// This struct is responsible for managing current token and peeked token.
 #[derive(Clone)]

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -433,7 +433,7 @@ impl<I: Tokens> Buffer<I> {
         Span::new(data.lo, data.hi, data.ctxt)
     }
 
-    pub fn text(&self, span: Range<BytePos>) -> &str {
+    pub fn text(&mut self, span: Range<BytePos>) -> Atom {
         self.iter.text(span)
     }
 

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -7,7 +7,7 @@ use swc_atoms::{Atom, JsWord};
 use swc_common::{collections::AHashMap, comments::Comments, input::Input, BytePos, Span};
 use swc_ecma_ast::*;
 
-pub use self::input::{Capturing, Tokens, TokensInput};
+pub use self::input::Tokens;
 use self::{input::Buffer, util::ParseObject};
 use crate::{
     error::SyntaxError,

--- a/crates/swc_ecma_parser/src/token.rs
+++ b/crates/swc_ecma_parser/src/token.rs
@@ -603,7 +603,7 @@ impl Debug for Token {
             Semi => write!(f, ";")?,
             Comma => write!(f, ",")?,
             BackQuote => write!(f, "`")?,
-            Template { raw, .. } => write!(f, "template token ({})", raw)?,
+            Template { cooked, .. } => write!(f, "template token ({:?})", cooked)?,
             Colon => write!(f, ":")?,
             ColonColon => write!(f, "::")?,
             BinOp(op) => write!(f, "{}", BinaryOp::from(*op).as_str())?,

--- a/crates/swc_ecma_parser/src/token.rs
+++ b/crates/swc_ecma_parser/src/token.rs
@@ -71,7 +71,6 @@ pub enum Token {
     #[kind(starts_expr)]
     BackQuote,
     Template {
-        raw: Atom,
         cooked: LexResult<Atom>,
     },
     /// ':'

--- a/crates/swc_ecma_parser/src/token.rs
+++ b/crates/swc_ecma_parser/src/token.rs
@@ -9,7 +9,7 @@ use std::{
 use enum_kind::Kind;
 use num_bigint::BigInt as BigIntValue;
 use swc_atoms::{js_word, Atom, JsWord};
-use swc_common::{Span, Spanned};
+use swc_common::{BytePos, Span, Spanned};
 pub(crate) use swc_ecma_ast::AssignOp as AssignOpToken;
 use swc_ecma_ast::BinaryOp;
 
@@ -114,7 +114,10 @@ pub enum Token {
 
     /// Regexp literal.
     #[kind(starts_expr)]
-    Regex(Atom, Atom),
+    Regex {
+        /// The position of `/`
+        separator: BytePos,
+    },
 
     /// TODO: Make Num as enum and separate decimal, binary, ..etc
     #[kind(starts_expr)]
@@ -614,7 +617,7 @@ impl Debug for Token {
             MinusMinus => write!(f, "--")?,
             Tilde => write!(f, "~")?,
             Str { value, raw } => write!(f, "string literal ({}, {})", value, raw)?,
-            Regex(exp, flags) => write!(f, "regexp literal ({}, {})", exp, flags)?,
+            Regex { .. } => write!(f, "regexp literal")?,
             Num { value, raw, .. } => write!(f, "numeric literal ({}, {})", value, raw)?,
             BigInt { value, raw } => write!(f, "bigint literal ({}, {})", value, raw)?,
             JSXName { name } => write!(f, "jsx name ({})", name)?,


### PR DESCRIPTION
**Description:**

We don't need to store `Atom` in the `Token` for most cases. Because of the `Atom`s, the `Token` type is currently 48 bytes, but it's simply a waste. I drastically reduced the size of the `Token` type.

---

I'll post the performance difference after matching the current behavior.

---

cc @dsherret as this PR will change `Token` or lexer API a lot.