### PR TITLE
fix(es/compat): Fix the order of initialization for decorators on computed keys

### DIFF
--- a/crates/swc/tests/fixture/issues-5xxx/5189/1/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-5xxx/5189/1/input/.swcrc
@@ -1,0 +1,12 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true
+        },
+        "target": "es2020"
+    },
+    "module": {
+        "type": "commonjs"
+    }
+}

--- a/crates/swc/tests/fixture/issues-5xxx/5189/1/input/index.ts
+++ b/crates/swc/tests/fixture/issues-5xxx/5189/1/input/index.ts
@@ -1,0 +1,6 @@
+const sym = Symbol("sym");
+
+class Cls {
+    @Memoize()
+    [sym]() { }
+}

--- a/crates/swc/tests/fixture/issues-5xxx/5189/1/output/index.ts
+++ b/crates/swc/tests/fixture/issues-5xxx/5189/1/output/index.ts
@@ -1,0 +1,14 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+const _tsDecorate = require("@swc/helpers/lib/_ts_decorate.js").default;
+const sym = Symbol("sym");
+var _key;
+_key = sym;
+class Cls {
+    [_key]() {}
+}
+_tsDecorate([
+    Memoize()
+], Cls.prototype, _key, null);

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-only/issues/swc-node-210/output.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-only/issues/swc-node-210/output.ts
@@ -1,8 +1,8 @@
 var _key;
+_key = foo;
 class Foo {
     [_key]() {}
 }
-_key = foo;
 __decorate([
     dec
 ], Foo.prototype, _key, null);


### PR DESCRIPTION
**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/5189.