### PR TITLE
perf(es): Don't share `Globals`

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -569,7 +569,7 @@ jobs:
         env:
           SWC_FORCE_CONCURRENT: "1"
         run: |
-          cargo test -p swc --all-targets --features concurrent
+          cargo test -p swc --features concurrent
 
       - name: Install cargo-hack
         uses: baptiste0928/cargo-install@v1.1.0

--- a/crates/swc/benches/typescript.rs
+++ b/crates/swc/benches/typescript.rs
@@ -7,7 +7,9 @@ use std::{
 
 use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use swc::config::{Config, IsModule, JscConfig, Options, SourceMapsConfig};
-use swc_common::{errors::Handler, FileName, FilePathMapping, Mark, SourceFile, SourceMap};
+use swc_common::{
+    errors::Handler, FileName, FilePathMapping, Mark, SourceFile, SourceMap, GLOBALS,
+};
 use swc_ecma_ast::{EsVersion, Program};
 use swc_ecma_parser::{Syntax, TsConfig};
 use swc_ecma_transforms::{fixer, hygiene, resolver, typescript};
@@ -63,7 +65,7 @@ fn base_tr_group(c: &mut Criterion) {
 
 fn base_tr_fixer(b: &mut Bencher) {
     let c = mk();
-    c.run(|| {
+    GLOBALS.set(&Default::default(), || {
         let module = as_es(&c);
 
         b.iter(|| {
@@ -77,7 +79,7 @@ fn base_tr_fixer(b: &mut Bencher) {
 
 fn base_tr_resolver_and_hygiene(b: &mut Bencher) {
     let c = mk();
-    c.run(|| {
+    GLOBALS.set(&Default::default(), || {
         let module = as_es(&c);
 
         b.iter(|| {
@@ -97,7 +99,7 @@ fn base_tr_resolver_and_hygiene(b: &mut Bencher) {
 fn bench_codegen(b: &mut Bencher, _target: EsVersion) {
     let c = mk();
 
-    c.run(|| {
+    GLOBALS.set(&Default::default(), || {
         let module = as_es(&c);
 
         //TODO: Use target

--- a/crates/swc/tests/exec.rs
+++ b/crates/swc/tests/exec.rs
@@ -12,7 +12,7 @@ use swc::{
     config::{Config, JsMinifyOptions, JscConfig, ModuleConfig, Options, SourceMapsConfig},
     try_with_handler, BoolOrDataConfig, Compiler, HandlerOpts,
 };
-use swc_common::{errors::ColorConfig, SourceMap};
+use swc_common::{errors::ColorConfig, SourceMap, GLOBALS};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_parser::{EsConfig, Syntax, TsConfig};
 use swc_ecma_testing::{exec_node_js, JsExecOptions};
@@ -350,51 +350,53 @@ fn test_file_with_opts(
     let cm = Arc::new(SourceMap::default());
     let c = Compiler::new(cm.clone());
 
-    try_with_handler(
-        cm.clone(),
-        HandlerOpts {
-            color: ColorConfig::Always,
-            ..Default::default()
-        },
-        |handler| {
-            let fm = cm.load_file(entry).context("failed to load file")?;
+    GLOBALS.set(&Default::default(), || {
+        try_with_handler(
+            cm.clone(),
+            HandlerOpts {
+                color: ColorConfig::Always,
+                ..Default::default()
+            },
+            |handler| {
+                let fm = cm.load_file(entry).context("failed to load file")?;
 
-            let res = c
-                .process_js_file(fm, handler, opts)
-                .context("failed to process file")?;
+                let res = c
+                    .process_js_file(fm, handler, opts)
+                    .context("failed to process file")?;
 
-            println!(
-                "---- {} (#{}) ----\n{}",
-                ansi_term::Color::Green.bold().paint("Code"),
-                idx,
-                res.code
-            );
-            println!("external_helpers: {:?}", opts.config.jsc.external_helpers);
-            println!("target: {:?}", opts.config.jsc.target.unwrap());
+                println!(
+                    "---- {} (#{}) ----\n{}",
+                    ansi_term::Color::Green.bold().paint("Code"),
+                    idx,
+                    res.code
+                );
+                println!("external_helpers: {:?}", opts.config.jsc.external_helpers);
+                println!("target: {:?}", opts.config.jsc.target.unwrap());
 
-            let actual_stdout = stdout_of(
-                &res.code,
-                if entry.extension().unwrap() == "mjs" {
-                    NodeModuleType::Module
-                } else {
-                    NodeModuleType::CommonJs
-                },
-            )?;
+                let actual_stdout = stdout_of(
+                    &res.code,
+                    if entry.extension().unwrap() == "mjs" {
+                        NodeModuleType::Module
+                    } else {
+                        NodeModuleType::CommonJs
+                    },
+                )?;
 
-            assert_eq!(
-                expected_stdout,
-                actual_stdout,
-                "\n---- {} -----\n{}\n---- {} -----\n{:#?}",
-                ansi_term::Color::Red.paint("Actual"),
-                actual_stdout,
-                ansi_term::Color::Blue.paint("Options"),
-                opts
-            );
+                assert_eq!(
+                    expected_stdout,
+                    actual_stdout,
+                    "\n---- {} -----\n{}\n---- {} -----\n{:#?}",
+                    ansi_term::Color::Red.paint("Actual"),
+                    actual_stdout,
+                    ansi_term::Color::Blue.paint("Options"),
+                    opts
+                );
 
-            Ok(())
-        },
-    )
-    .with_context(|| format!("failed to compile with opts: {:#?}", opts))
+                Ok(())
+            },
+        )
+        .with_context(|| format!("failed to compile with opts: {:#?}", opts))
+    })
 }
 
 enum NodeModuleType {

--- a/crates/swc/tests/tsc-references/importTypeInJSDoc.1.normal.js
+++ b/crates/swc/tests/tsc-references/importTypeInJSDoc.1.normal.js
@@ -8,7 +8,7 @@
 //// [index.js]
 /**
  * @typedef {import("./externs")} Foo
- */ let a = /** @type {Foo} */ /** @type {*} */ undefined;
+ */ let a = /** @type {*} */ undefined;
 a = new Foo({
     doer: Foo.Bar
 });

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -67,7 +67,6 @@ pub const DUMMY_SP: Span = Span {
     ctxt: SyntaxContext::empty(),
 };
 
-#[derive(Default)]
 pub struct Globals {
     hygiene_data: Mutex<hygiene::HygieneData>,
     #[allow(unused)]
@@ -75,6 +74,12 @@ pub struct Globals {
 }
 
 const DUMMY_RESERVE: u32 = u32::MAX - 2_u32.pow(16);
+
+impl Default for Globals {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 impl Globals {
     pub fn new() -> Globals {

--- a/crates/swc_estree_compat/tests/convert.rs
+++ b/crates/swc_estree_compat/tests/convert.rs
@@ -14,7 +14,7 @@ use serde_json::{Number, Value};
 use swc::{config::IsModule, Compiler};
 use swc_common::{
     errors::{ColorConfig, Handler},
-    FileName, FilePathMapping, SourceMap,
+    FileName, FilePathMapping, SourceMap, GLOBALS,
 };
 use swc_ecma_parser::{EsConfig, Syntax};
 use swc_estree_compat::babelify::{Babelify, Context};
@@ -76,19 +76,21 @@ fn fixtures() -> Result<(), Error> {
                 ignore_message: Default::default(),
             },
             testfn: DynTestFn(Box::alloc().init(move || {
-                let syntax = if is_typescript {
-                    Syntax::Typescript(Default::default())
-                } else if is_jsx {
-                    Syntax::Es(EsConfig {
-                        jsx: true,
-                        ..Default::default()
-                    })
-                } else {
-                    Syntax::Es(EsConfig {
-                        ..Default::default()
-                    })
-                };
-                run_test(input, output, syntax, is_module);
+                GLOBALS.set(&Default::default(), || {
+                    let syntax = if is_typescript {
+                        Syntax::Typescript(Default::default())
+                    } else if is_jsx {
+                        Syntax::Es(EsConfig {
+                            jsx: true,
+                            ..Default::default()
+                        })
+                    } else {
+                        Syntax::Es(EsConfig {
+                            ..Default::default()
+                        })
+                    };
+                    run_test(input, output, syntax, is_module);
+                })
             })),
         })
     }

--- a/crates/swc_node_bundler/tests/fixture.rs
+++ b/crates/swc_node_bundler/tests/fixture.rs
@@ -10,7 +10,7 @@ use anyhow::Error;
 use swc::{config::SourceMapsConfig, resolver::environment_resolver};
 use swc_atoms::js_word;
 use swc_bundler::{BundleKind, Bundler, Config, ModuleRecord};
-use swc_common::{errors::HANDLER, FileName, Span, GLOBALS};
+use swc_common::{errors::HANDLER, FileName, Globals, Span, GLOBALS};
 use swc_ecma_ast::{
     Bool, EsVersion, Expr, Ident, KeyValueProp, Lit, MemberExpr, MemberProp, MetaPropExpr,
     MetaPropKind, PropName, Str,
@@ -51,8 +51,9 @@ fn pass(input_dir: PathBuf) {
     testing::run_test2(false, |cm, handler| {
         HANDLER.set(&handler, || {
             let compiler = Arc::new(swc::Compiler::new(cm.clone()));
+            let globals = Globals::new();
 
-            GLOBALS.set(compiler.globals(), || {
+            GLOBALS.set(&globals, || {
                 let loader = SwcLoader::new(
                     compiler.clone(),
                     swc::config::Options {
@@ -61,7 +62,7 @@ fn pass(input_dir: PathBuf) {
                     },
                 );
                 let mut bundler = Bundler::new(
-                    compiler.globals(),
+                    &globals,
                     cm.clone(),
                     &loader,
                     environment_resolver(TargetEnv::Node, Default::default(), false),


### PR DESCRIPTION
**Description:**

We don't need to share one instance of `Globals`.

---


# Investigation of test failure

Added log: 

```
  DEBUG  ===== Before pure =====
"use strict";
function _checkPrivateRedeclaration(obj, privateCollection) {
    if (privateCollection.has(obj)) {
        throw new TypeError("Cannot initialize the same private elements twice on an object");
    }
}
function _classApplyDescriptorGet(receiver, descriptor) {
    if (descriptor.get) {
        return descriptor.get.call(receiver);
    }
    return descriptor.value;
}
function _classExtractFieldDescriptor(receiver, privateMap, action) {
    if (!privateMap.has(receiver)) {
        throw new TypeError("attempted to " + action + " private field on non-instance");
    }
    return privateMap.get(receiver);
}
function _classPrivateFieldGet(receiver, privateMap) {
    var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "get");
    return _classApplyDescriptorGet(receiver, descriptor);
}
function _classPrivateFieldInit(obj, privateMap, value) {
    _checkPrivateRedeclaration(obj, privateMap);
    privateMap.set(obj, value);
}
var foo = "bar";
var _bar = new WeakMap();
class Foo {
    test() {
        return _classPrivateFieldGet(this, _bar);
    }
    constructor(){
        _classPrivateFieldInit(this, _bar, {
            writable: true,
            value: foo
        });
    }
}
const f = new Foo;
expect(f.test()).toBe(foo);
expect("bar" in f).toBe(false);

===== After pure =====
"use strict";
function _checkPrivateRedeclaration(obj, privateCollection) {
    if (privateCollection.has(obj)) {
        throw new TypeError("Cannot initialize the same private elements twice on an object");
    }
}
function _classApplyDescriptorGet(receiver, descriptor) {
    if (descriptor.get) {
        return descriptor.get.call(receiver);
    }
    return descriptor.value;
}
function _classExtractFieldDescriptor(receiver, privateMap, action) {
    if (!privateMap.has(receiver)) {
        throw new TypeError("attempted to " + action + " private field on non-instance");
    }
    return privateMap.get(receiver);
}
function _classPrivateFieldGet(receiver, privateMap) {
    var descriptor = _classExtractFieldDescriptor(receiver, privateMap, "get");
    return _classApplyDescriptorGet(receiver, descriptor);
}
function _classPrivateFieldInit(obj, privateMap, value) {}
var foo = "bar";
var _bar = new WeakMap();
class Foo {
    test() {
        return _classPrivateFieldGet(this, _bar);
    }
    constructor(){
        _classPrivateFieldInit(this, _bar, {
            writable: true,
            value: foo
        });
    }
}
const f = new Foo;
expect(f.test()).toBe(foo);
expect("bar" in f).toBe(false);
```

and I found

```

  DEBUG  ignore_return_value: Dropping a pure call, kind: "change"
    at crates/swc_ecma_minifier/src/compress/pure/misc.rs:662
    in visit_mut_fn_decl with id: _classPrivateFieldInit#5
    in apply pure optimizer
    in optimize with pass: 1
    in compress ast
    in minify
    in process_js_inner
    in process_js_with_custom_pass
    in process_js_file with fm: SourceFile(/Users/kdy1/projects/s/issues/crates/swc/tests/babel-exec/packages/babel-plugin-proposal-class-properties/test/fixtures/private/constructor-collision/exec.js)
    in test_file with idx: 12
```

too


So I think the `BytePos` for pure comment is wrong, due to misusage of `BytePos`