### PR TITLE
perf(es/minifier): Optimize `MultiReplacer`

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -9,10 +9,7 @@ use swc_ecma_utils::{
 };
 use swc_ecma_visit::VisitMutWith;
 
-use super::{
-    util::{MultiReplacer, MultiReplacerMode},
-    Optimizer,
-};
+use super::{util::NormalMultiReplacer, Optimizer};
 #[cfg(feature = "debug")]
 use crate::debug::dump;
 use crate::{
@@ -323,16 +320,13 @@ where
     #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
     pub(super) fn inline_vars_in_node<N>(&mut self, n: &mut N, mut vars: FxHashMap<Id, Box<Expr>>)
     where
-        N: for<'aa> VisitMutWith<MultiReplacer<'aa>>,
+        N: for<'aa> VisitMutWith<NormalMultiReplacer<'aa>>,
     {
         trace_op!("inline: inline_vars_in_node");
 
-        n.visit_mut_with(&mut MultiReplacer::new(
-            &mut vars,
-            false,
-            MultiReplacerMode::Normal,
-            &mut self.changed,
-        ));
+        let mut v = NormalMultiReplacer::new(&mut vars);
+        n.visit_mut_with(&mut v);
+        self.changed |= v.changed;
     }
 
     /// Fully inlines iife.

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -276,8 +276,10 @@ impl Vars {
         }
 
         if !self.lits_for_cmp.is_empty() {
-            let mut v =
-                CloningMultiReplacer::new(&self.lits_for_cmp, MultiReplacerMode::OnlyCallee);
+            let mut v = CloningMultiReplacer::new(
+                &self.lits_for_cmp,
+                MultiReplacerMode::OnlyComparisonWithLit,
+            );
             n.visit_mut_with(&mut v);
             changed |= v.changed;
         }

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -20,9 +20,7 @@ use Value::Known;
 
 use self::{
     unused::PropertyAccessOpts,
-    util::{
-        extract_class_side_effect, CloningMultiReplacer, MultiReplacerMode, NormalMultiReplacer,
-    },
+    util::{extract_class_side_effect, CloningMultiReplacer, NormalMultiReplacer},
 };
 use super::util::{drop_invalid_stmts, is_fine_for_if_cons};
 #[cfg(feature = "debug")]
@@ -268,18 +266,12 @@ impl Vars {
         N: for<'aa> VisitMutWith<CloningMultiReplacer<'aa>>,
     {
         let mut changed = false;
-        if !self.simple_functions.is_empty() {
-            let mut v =
-                CloningMultiReplacer::new(&self.simple_functions, MultiReplacerMode::OnlyCallee);
-            n.visit_mut_with(&mut v);
-            changed |= v.changed;
-        }
-
-        if !self.lits_for_cmp.is_empty() {
-            let mut v = CloningMultiReplacer::new(
-                &self.lits_for_cmp,
-                MultiReplacerMode::OnlyComparisonWithLit,
-            );
+        if !self.simple_functions.is_empty() || !self.lits_for_cmp.is_empty() {
+            let mut v = CloningMultiReplacer {
+                lits_for_cmp: &self.lits_for_cmp,
+                simple_functions: &self.simple_functions,
+                changed: false,
+            };
             n.visit_mut_with(&mut v);
             changed |= v.changed;
         }

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -4,13 +4,13 @@ use rustc_hash::FxHashMap;
 use swc_atoms::js_word;
 use swc_common::{Span, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_transforms_base::perf::Parallel;
+use swc_ecma_transforms_base::perf::{Parallel, ParallelExt};
 use swc_ecma_utils::{ExprCtx, ExprExt};
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 use tracing::debug;
 
 use super::{Ctx, Optimizer};
-use crate::mode::Mode;
+use crate::{mode::Mode, HEAVY_TASK_PARALLELS};
 
 impl<'b, M> Optimizer<'b, M>
 where
@@ -238,6 +238,42 @@ impl VisitMut for CloningMultiReplacer<'_> {
             }
             _ => {}
         }
+    }
+
+    fn visit_mut_prop_or_spreads(&mut self, n: &mut Vec<PropOrSpread>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
+            n.visit_mut_with(v);
+        });
+    }
+
+    fn visit_mut_expr_or_spreads(&mut self, n: &mut Vec<ExprOrSpread>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
+            n.visit_mut_with(v);
+        });
+    }
+
+    fn visit_mut_opt_vec_expr_or_spreads(&mut self, n: &mut Vec<Option<ExprOrSpread>>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
+            n.visit_mut_with(v);
+        });
+    }
+
+    fn visit_mut_exprs(&mut self, n: &mut Vec<Box<Expr>>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
+            n.visit_mut_with(v);
+        });
+    }
+
+    fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
+            n.visit_mut_with(v);
+        });
+    }
+
+    fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
+            n.visit_mut_with(v);
+        });
     }
 }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -160,7 +160,7 @@ impl VisitMut for Remapper {
 #[derive(Clone, Copy)]
 pub(crate) struct CloningMultiReplacer<'a> {
     pub vars: &'a FxHashMap<Id, Box<Expr>>,
-    pub worked: bool,
+    pub changed: bool,
     pub mode: MultiReplacerMode,
 }
 
@@ -170,7 +170,7 @@ impl Parallel for CloningMultiReplacer<'_> {
     }
 
     fn merge(&mut self, other: Self) {
-        self.worked |= other.worked;
+        self.changed |= other.changed;
     }
 }
 
@@ -180,7 +180,7 @@ impl<'a> CloningMultiReplacer<'a> {
         CloningMultiReplacer {
             vars,
             mode,
-            worked: false,
+            changed: false,
         }
     }
 
@@ -205,7 +205,7 @@ impl<'a> CloningMultiReplacer<'a> {
         if let Expr::Ident(i) = e {
             if let Some(new) = self.var(&i.to_id()) {
                 debug!("multi-replacer: Replaced `{}`", i);
-                self.worked = true;
+                self.changed = true;
 
                 *e = *new;
             }
@@ -268,7 +268,7 @@ impl VisitMut for CloningMultiReplacer<'_> {
 
 pub(crate) struct NormalMultiReplacer<'a> {
     pub vars: &'a mut FxHashMap<Id, Box<Expr>>,
-    pub worked: bool,
+    pub changed: bool,
 }
 
 impl<'a> NormalMultiReplacer<'a> {
@@ -276,7 +276,7 @@ impl<'a> NormalMultiReplacer<'a> {
     pub fn new(vars: &'a mut FxHashMap<Id, Box<Expr>>) -> Self {
         NormalMultiReplacer {
             vars,
-            worked: false,
+            changed: false,
         }
     }
 
@@ -314,7 +314,7 @@ impl VisitMut for NormalMultiReplacer<'_> {
         if let Expr::Ident(i) = e {
             if let Some(new) = self.var(&i.to_id()) {
                 debug!("multi-replacer: Replaced `{}`", i);
-                self.worked = true;
+                self.changed = true;
 
                 *e = *new;
             }
@@ -340,7 +340,7 @@ impl VisitMut for NormalMultiReplacer<'_> {
         if let Prop::Shorthand(i) = p {
             if let Some(value) = self.var(&i.to_id()) {
                 debug!("multi-replacer: Replaced `{}` as shorthand", i);
-                self.worked = true;
+                self.changed = true;
 
                 *p = Prop::KeyValue(KeyValueProp {
                     key: PropName::Ident(Ident::new(

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -240,28 +240,6 @@ impl VisitMut for CloningMultiReplacer<'_> {
         }
     }
 
-    fn visit_mut_expr(&mut self, e: &mut Expr) {
-        if self.vars.is_empty() {
-            return;
-        }
-        e.visit_mut_children_with(self);
-
-        if self.vars.is_empty() {
-            return;
-        }
-
-        if matches!(self.mode, MultiReplacerMode::Normal) {
-            if let Expr::Ident(i) = e {
-                if let Some(new) = self.var(&i.to_id()) {
-                    debug!("multi-replacer: Replaced `{}`", i);
-                    *self.worked = true;
-
-                    *e = *new;
-                }
-            }
-        }
-    }
-
     fn visit_mut_module_items(&mut self, items: &mut Vec<ModuleItem>) {
         if self.vars.is_empty() {
             return;
@@ -274,27 +252,6 @@ impl VisitMut for CloningMultiReplacer<'_> {
             debug!("Dropping {:?}", keys);
         }
     }
-
-    fn visit_mut_prop(&mut self, p: &mut Prop) {
-        p.visit_mut_children_with(self);
-
-        if matches!(self.mode, MultiReplacerMode::Normal) {
-            if let Prop::Shorthand(i) = p {
-                if let Some(value) = self.var(&i.to_id()) {
-                    debug!("multi-replacer: Replaced `{}` as shorthand", i);
-                    *self.worked = true;
-
-                    *p = Prop::KeyValue(KeyValueProp {
-                        key: PropName::Ident(Ident::new(
-                            i.sym.clone(),
-                            i.span.with_ctxt(Default::default()),
-                        )),
-                        value,
-                    });
-                }
-            }
-        }
-    }
 }
 
 pub(crate) struct NormalMultiReplacer<'a> {
@@ -304,17 +261,10 @@ pub(crate) struct NormalMultiReplacer<'a> {
 
 impl<'a> NormalMultiReplacer<'a> {
     /// `worked` will be changed to `true` if any replacement is done
-    pub fn new(
-        vars: &'a mut FxHashMap<Id, Box<Expr>>,
-        clone: bool,
-        mode: MultiReplacerMode,
-        worked: &'a mut bool,
-    ) -> Self {
-        MultiReplacer {
+    pub fn new(vars: &'a mut FxHashMap<Id, Box<Expr>>) -> Self {
+        NormalMultiReplacer {
             vars,
-            clone,
-            mode,
-            worked,
+            worked: false,
         }
     }
 
@@ -338,49 +288,10 @@ impl<'a> NormalMultiReplacer<'a> {
             _ => Some(e),
         }
     }
-
-    fn check(&mut self, e: &mut Expr) {
-        if let Expr::Ident(i) = e {
-            if let Some(new) = self.var(&i.to_id()) {
-                debug!("multi-replacer: Replaced `{}`", i);
-                *self.worked = true;
-
-                *e = *new;
-            }
-        }
-    }
 }
 
 impl VisitMut for NormalMultiReplacer<'_> {
     noop_visit_mut_type!();
-
-    fn visit_mut_callee(&mut self, e: &mut Callee) {
-        e.visit_mut_children_with(self);
-
-        if matches!(self.mode, MultiReplacerMode::OnlyCallee) {
-            if let Callee::Expr(e) = e {
-                self.check(e);
-            }
-        }
-    }
-
-    fn visit_mut_bin_expr(&mut self, e: &mut BinExpr) {
-        e.visit_mut_children_with(self);
-
-        if let MultiReplacerMode::OnlyComparisonWithLit = self.mode {
-            match e.op {
-                op!("===") | op!("!==") | op!("==") | op!("!=") => {
-                    //
-                    if e.left.is_lit() {
-                        self.check(&mut e.right);
-                    } else if e.right.is_lit() {
-                        self.check(&mut e.left);
-                    }
-                }
-                _ => {}
-            }
-        }
-    }
 
     fn visit_mut_expr(&mut self, e: &mut Expr) {
         if self.vars.is_empty() {
@@ -392,14 +303,12 @@ impl VisitMut for NormalMultiReplacer<'_> {
             return;
         }
 
-        if matches!(self.mode, MultiReplacerMode::Normal) {
-            if let Expr::Ident(i) = e {
-                if let Some(new) = self.var(&i.to_id()) {
-                    debug!("multi-replacer: Replaced `{}`", i);
-                    *self.worked = true;
+        if let Expr::Ident(i) = e {
+            if let Some(new) = self.var(&i.to_id()) {
+                debug!("multi-replacer: Replaced `{}`", i);
+                self.worked = true;
 
-                    *e = *new;
-                }
+                *e = *new;
             }
         }
     }
@@ -420,20 +329,18 @@ impl VisitMut for NormalMultiReplacer<'_> {
     fn visit_mut_prop(&mut self, p: &mut Prop) {
         p.visit_mut_children_with(self);
 
-        if matches!(self.mode, MultiReplacerMode::Normal) {
-            if let Prop::Shorthand(i) = p {
-                if let Some(value) = self.var(&i.to_id()) {
-                    debug!("multi-replacer: Replaced `{}` as shorthand", i);
-                    *self.worked = true;
+        if let Prop::Shorthand(i) = p {
+            if let Some(value) = self.var(&i.to_id()) {
+                debug!("multi-replacer: Replaced `{}` as shorthand", i);
+                self.worked = true;
 
-                    *p = Prop::KeyValue(KeyValueProp {
-                        key: PropName::Ident(Ident::new(
-                            i.sym.clone(),
-                            i.span.with_ctxt(Default::default()),
-                        )),
-                        value,
-                    });
-                }
+                *p = Prop::KeyValue(KeyValueProp {
+                    key: PropName::Ident(Ident::new(
+                        i.sym.clone(),
+                        i.span.with_ctxt(Default::default()),
+                    )),
+                    value,
+                });
             }
         }
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -269,11 +269,7 @@ impl<'a> NormalMultiReplacer<'a> {
     }
 
     fn var(&mut self, i: &Id) -> Option<Box<Expr>> {
-        let mut e = if self.clone {
-            self.vars.get(i).cloned()?
-        } else {
-            self.vars.remove(i)?
-        };
+        let mut e = self.vars.remove(i)?;
 
         e.visit_mut_children_with(self);
 


### PR DESCRIPTION
**Description:**

This PR splits the `MultiReplacer` into two variants. The first one is the cloning version, and this is parallel. The other one is the non-cloning version, which is not parallel.