### PR TITLE
feat(es/minifier): Increase default pass limit to 3

### DIFF
--- a/crates/swc_ecma_minifier/src/option/mod.rs
+++ b/crates/swc_ecma_minifier/src/option/mod.rs
@@ -354,7 +354,7 @@ const fn true_by_default() -> bool {
 }
 
 const fn default_passes() -> usize {
-    2
+    3
 }
 
 const fn three_by_default() -> u8 {


### PR DESCRIPTION
**Description:**

I'll update this PR once the profiling is done.

---

## Real world

### 2 passes

```
Total
  swc: 34766013 bytes
  terser: 34976318 bytes
  Size ratio: 0.9939872172937129
swc produced smaller or equal output for 987 files out of 1029 files, 95.92%
Total (gzipped)
  swc: 9226153 bytes
  terser: 9256225 bytes
  Size ratio: 0.9967511593549206
swc produced smaller or equal output for 948 files out of 1029 files, 92.13%
```

### 3 passes

```
Total
  swc: 34755358 bytes
  terser: 34976318 bytes
  Size ratio: 0.9936825825977451
swc produced smaller or equal output for 989 files out of 1029 files, 96.11%
Total (gzipped)
  swc: 9220253 bytes
  terser: 9256225 bytes
  Size ratio: 0.996113750476031
swc produced smaller or equal output for 959 files out of 1029 files, 93.20%
```


## Libraries


### 2 passes

```
File: ./benches/full/antd.js
  458632
File: ./benches/full/d3.js
   87716
File: ./benches/full/echarts.js
  321880
File: ./benches/full/jquery.js
   30926
File: ./benches/full/lodash.js
   25177
File: ./benches/full/moment.js
   18691
File: ./benches/full/react.js
    8265
File: ./benches/full/terser.js
  122468
File: ./benches/full/three.js
  158484
File: ./benches/full/typescript.js
  815297
File: ./benches/full/victory.js
  158559
File: ./benches/full/vue.js
   42860
```

### 3 passes

```
File: ./benches/full/antd.js
  458222
File: ./benches/full/d3.js
   87623
File: ./benches/full/echarts.js
  320716
File: ./benches/full/jquery.js
   30919
File: ./benches/full/lodash.js
   25150
File: ./benches/full/moment.js
   18675
File: ./benches/full/react.js
    8231
File: ./benches/full/terser.js
  122410
File: ./benches/full/three.js
  158139
File: ./benches/full/typescript.js
  810818
File: ./benches/full/victory.js
  158234
File: ./benches/full/vue.js
   42769
```

## Performance (libraries, 2 passes)

## Performance (libraries, 3 passes)

## Performance (libraries, 2 pass + DCE)