### PR TITLE
build(cargo): dedupe indexmap with known version

### DIFF
--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -48,7 +48,7 @@ anyhow = "1"
 base64 = "0.13.0"
 dashmap = "5.1.0"
 either = "1"
-indexmap = { version = "1", features = ["serde"] }
+indexmap = { version = "1.6.1", features = ["serde"] }
 json_comments = "0.2.0"
 lru = "0.7.1"
 once_cell = "1.10.0"

--- a/crates/swc_bundler/Cargo.toml
+++ b/crates/swc_bundler/Cargo.toml
@@ -28,7 +28,7 @@ ahash                            = "0.7"
 anyhow                           = "1"
 crc                              = "2.1.0"
 dashmap                          = { version = "5.1.0", optional = true }
-indexmap                         = "1.6"
+indexmap                         = "1.6.1"
 is-macro                         = "0.2.0"
 once_cell                        = "1.10.0"
 parking_lot                      = "0.12.0"

--- a/crates/swc_config/Cargo.toml
+++ b/crates/swc_config/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.1.2"
 
 [dependencies]
 anyhow = "1"
-indexmap = "1"
+indexmap = "1.6.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 swc_config_macro = { version = "0.1.0", path = "../swc_config_macro" }

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -32,7 +32,7 @@ trace-ast = []
 ahash                            = "0.7.6"
 arrayvec                         = "0.7.2"
 backtrace                        = { version = "0.3.61", optional = true }
-indexmap                         = "1.7.0"
+indexmap                         = "1.6.1"
 num-bigint                       = "0.4.3"
 num_cpus                         = "1.13.1"
 once_cell                        = "1.10.0"

--- a/crates/swc_ecma_preset_env/Cargo.toml
+++ b/crates/swc_ecma_preset_env/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 ahash = "0.7.4"
 anyhow = "1"
 dashmap = "5.1.0"
-indexmap = "1.6.2"
+indexmap = "1.6.1"
 once_cell = "1.10.0"
 preset_env_base = { version = "0.3.2", path = "../preset_env_base" }
 semver = { version = "1.0.4", features = ["serde"] }

--- a/crates/swc_ecma_transforms_module/Cargo.toml
+++ b/crates/swc_ecma_transforms_module/Cargo.toml
@@ -17,7 +17,7 @@ Inflector = "0.11.4"
 ahash = "0.7.4"
 anyhow = "1.0.41"
 bitflags = "1"
-indexmap = "1.8.0"
+indexmap = "1.6.1"
 is-macro = "0.2.0"
 path-clean = "0.1.0"
 pathdiff = "0.2.0"
@@ -37,7 +37,7 @@ swc_ecma_visit = { version = "0.80.4", path = "../swc_ecma_visit" }
 tracing = "0.1.32"
 
 [dev-dependencies]
-indexmap = { version = "1", features = ["serde"] }
+indexmap = { version = "1.6.1", features = ["serde"] }
 serde_json = "1"
 swc_ecma_loader = { version = "0.41.4", path = "../swc_ecma_loader", features = [
   "node",

--- a/crates/swc_ecma_utils/Cargo.toml
+++ b/crates/swc_ecma_utils/Cargo.toml
@@ -20,7 +20,7 @@ bench = false
 concurrent = ["swc_common/concurrent", "rayon"]
 
 [dependencies]
-indexmap = "1"
+indexmap = "1.6.1"
 num_cpus = "1.13.1"
 once_cell = "1.10.0"
 rayon = {version = "1.5.1", optional = true}

--- a/crates/swc_fast_graph/Cargo.toml
+++ b/crates/swc_fast_graph/Cargo.toml
@@ -13,6 +13,6 @@ bench = false
 
 [dependencies]
 ahash      = "0.7.6"
-indexmap   = "1.7.0"
+indexmap   = "1.6.1"
 petgraph   = "0.6"
 swc_common = { version = "0.29.4", path = "../swc_common" }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

We are experiencing https://github.com/tkaitchuck/aHash/issues/95 when we try to bring some deps into next-swc. Looks like using indexmap 1.6.1 seems most straightforward way to avoid, I'd like to try this as first step. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
