### PR TITLE
Support aarch64 Linux with page sizes >= 16k

### DIFF
--- a/.github/workflows/publish-node.yml
+++ b/.github/workflows/publish-node.yml
@@ -88,6 +88,7 @@ jobs:
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-debian-aarch64
             build: >-
               set -e &&
+              export JEMALLOC_SYS_WITH_LG_PAGE=16 &&
               rustup target add aarch64-unknown-linux-gnu &&
               RUSTFLAGS='' cargo build --manifest-path ./bindings/swc_cli/Cargo.toml --release --features plugin --target aarch64-unknown-linux-gnu &&
               cp ./bindings/target/aarch64-unknown-linux-gnu/release/swc . && chmod +x ./swc &&
@@ -147,6 +148,7 @@ jobs:
             downloadTarget: aarch64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine
             build: >-
+              export JEMALLOC_SYS_WITH_LG_PAGE=16 &&
               rustup toolchain install $(cat ./rust-toolchain) &&
               rustup target add aarch64-unknown-linux-musl &&
               RUSTFLAGS='-C target-feature=+crt-static -C link-arg=-lgcc' cargo build --manifest-path ./bindings/swc_cli/Cargo.toml --release --features plugin --target aarch64-unknown-linux-musl &&


### PR DESCRIPTION
**Description:**

This adds support for aarch64 Linux with page sizes >= 16k, by compiling with jemalloc configured with largest possible page size.

It will still work for all other aarch64 Linux systems. To give you some confidence, I ran your Github actions in my fork, and compiled `1.5.1` release with this patch. You can grab the binaries and test for yourself!

https://github.com/maximbaz/swc/releases/tag/v1.5.1-1

I didn't touch Android as I don't have enough knowledge to confirm that this is needed for that platform or how to verify it.

**Related issue (if exists):**

Fixes https://github.com/swc-project/swc/issues/5967

I originally came to report this, because I wanted to fix Next.js swc plugin, which suffers from exactly the same issue and requires exactly the same fix. I can confirm that Next.js can finally be used on my aarch64 Linux machine with this patch.