### PR TITLE
feat(es/minifier): Enable `reduce_funcs` by default

### DIFF
--- a/crates/swc_ecma_minifier/src/option/mod.rs
+++ b/crates/swc_ecma_minifier/src/option/mod.rs
@@ -257,7 +257,7 @@ pub struct CompressOptions {
     #[serde(alias = "pure_funcs")]
     pub pure_funcs: Vec<Box<Expr>>,
 
-    #[serde(default)]
+    #[serde(default = "true_by_default")]
     #[serde(alias = "reduce_funcs")]
     pub reduce_fns: bool,
     #[serde(default)]

--- a/crates/swc_ecma_minifier/src/option/terser.rs
+++ b/crates/swc_ecma_minifier/src/option/terser.rs
@@ -350,8 +350,7 @@ impl TerserCompressorOptions {
                     PureGetterOption::Str(v.split(',').map(From::from).collect())
                 }
             },
-            // TODO: Use self.defaults
-            reduce_fns: self.reduce_funcs.unwrap_or(false),
+            reduce_fns: self.reduce_funcs.unwrap_or(self.defaults),
             // TODO: Use self.defaults
             reduce_vars: self.reduce_vars.unwrap_or(false),
             sequences: self


### PR DESCRIPTION
**Description:**

This is to align with terser. There's no test change, though.
I'll merge this so we can see diff of real-world test cases when working on `reduce_fucs`.

**Related issue:**
