### PR TITLE
fix(swc_core): Reexport `swc_css_compat` correctly

### DIFF
--- a/crates/swc_core/src/lib.rs
+++ b/crates/swc_core/src/lib.rs
@@ -187,7 +187,7 @@ pub mod css {
     #[cfg(feature = "css_compat")]
     #[cfg_attr(docsrs, doc(cfg(feature = "css_compat")))]
     pub mod compat {
-        pub use css_compat::*;
+        pub use swc_css_compat::*;
     }
 
     #[cfg(feature = "css_minifier")]


### PR DESCRIPTION
**Description:**


**Related issue (if exists):**
