### PR TITLE
fix(es/plugin): Disable SIMD

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,9 @@
 rustdocflags = ["--cfg", "docsrs"]
 rustflags    = []
 
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-feature=+sse2"]
+
 [target.aarch64-apple-darwin]
 rustflags = []
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -89,7 +89,7 @@ checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
 name = "ast_node"
 version = "0.8.6"
 dependencies = [
- "darling",
+ "darling 0.13.1",
  "pmutil",
  "proc-macro2",
  "quote",
@@ -700,8 +700,18 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0d720b8683f8dd83c65155f0530560cba68cd2bf395f6513a483caee57ff7f4"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.13.1",
+ "darling_macro 0.13.1",
+]
+
+[[package]]
+name = "darling"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4529658bdda7fd6769b8614be250cdcfc3aeb0ee72fe66f9e41e5e5eb73eac02"
+dependencies = [
+ "darling_core 0.14.1",
+ "darling_macro 0.14.1",
 ]
 
 [[package]]
@@ -719,12 +729,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "649c91bc01e8b1eac09fb91e8dbc7d517684ca6be8ebc75bb9cafc894f9fdb6f"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72c41b3b7352feb3211a0d743dc5700a4e3b60f51bd2b368892d1e0f9a95f44b"
 dependencies = [
- "darling_core",
+ "darling_core 0.13.1",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
+dependencies = [
+ "darling_core 0.14.1",
  "quote",
  "syn",
 ]
@@ -901,20 +935,20 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.0.8"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6216d2c19a6fb5f29d1ada1dc7bc4367a8cbf0fa4af5cf12e07b5bbdde6b5b2c"
+checksum = "19be8061a06ab6f3a6cf21106c873578bf01bd42ad15e0311a9c76161cb1c753"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6451128aa6655d880755345d085494cf7561a6bee7c8dc821e5d77e6d267ecd4"
+checksum = "03e7b551eba279bf0fa88b83a46330168c1560a52a94f5126f892f0b364ab3e0"
 dependencies = [
- "darling",
+ "darling 0.14.1",
  "proc-macro2",
  "quote",
  "syn",
@@ -4234,6 +4268,7 @@ version = "0.77.12"
 dependencies = [
  "anyhow",
  "criterion",
+ "enumset",
  "once_cell",
  "parking_lot",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4250,6 +4250,8 @@ dependencies = [
  "tracing",
  "wasmer",
  "wasmer-cache",
+ "wasmer-compiler-cranelift",
+ "wasmer-engine-universal",
  "wasmer-wasi",
 ]
 

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -48,9 +48,11 @@ swc_common = { version = "0.29.8", path = "../swc_common", features = [
 swc_ecma_ast = { version = "0.94.11", path = "../swc_ecma_ast" }
 swc_plugin_proxy = { version = "0.22.11", path = "../swc_plugin_proxy" }
 
-tracing = "0.1.32"
-wasmer = { version = "2.3.0", default-features = false }
-wasmer-wasi = { version = "2.3.0", default-features = false }
+tracing                   = "0.1.32"
+wasmer                    = { version = "2.3.0", default-features = false }
+wasmer-compiler-cranelift = "2.3.0"
+wasmer-engine-universal   = "2.3.0"
+wasmer-wasi               = { version = "2.3.0", default-features = false }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 wasmer-cache = { version = "2.3.0", optional = true }

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -38,6 +38,7 @@ rkyv-impl = [
 
 [dependencies]
 anyhow = "1.0.42"
+enumset = "1.0.12"
 once_cell = "1.10.0"
 parking_lot = "0.12.0"
 serde = { version = "1.0.126", features = ["derive"] }

--- a/crates/swc_plugin_runner/src/cache.rs
+++ b/crates/swc_plugin_runner/src/cache.rs
@@ -31,7 +31,7 @@ compile_error!(
 /// however it is not gauranteed to be compatible across wasmer's
 /// internal changes.
 /// https://github.com/wasmerio/wasmer/issues/2781
-const MODULE_SERIALIZATION_VERSION: &str = "v3";
+const MODULE_SERIALIZATION_VERSION: &str = "v4";
 
 /// A shared instance to plugin's module bytecode cache.
 pub static PLUGIN_MODULE_CACHE: Lazy<PluginModuleCache> = Lazy::new(Default::default);

--- a/crates/swc_plugin_runner/src/cache.rs
+++ b/crates/swc_plugin_runner/src/cache.rs
@@ -238,7 +238,7 @@ impl PluginModuleCache {
 
 /// Creates an instnace of  [Store].
 ///
-/// This function exitsts because we need to disable simd.
+/// This function exists because we need to disable simd.
 fn new_store() -> Store {
     // Use empty enumset to disable simd.
     let target = Target::new(Triple::host(), EnumSet::new());

--- a/crates/swc_plugin_runner/src/cache.rs
+++ b/crates/swc_plugin_runner/src/cache.rs
@@ -149,7 +149,7 @@ impl PluginModuleCache {
             std::fs::read(&binary_path).context("Cannot read plugin from specified path")?;
         let module_bytes_hash = Hash::generate(&module_bytes);
 
-        let wasmer_store = Store::default();
+        let wasmer_store = new_store();
 
         let load_cold_wasm_bytes = || {
             let span = tracing::span!(
@@ -205,7 +205,7 @@ impl PluginModuleCache {
         //TODO: In native runtime we have to reconstruct module using raw bytes in
         // memory cache. requires https://github.com/wasmerio/wasmer/pull/2821
 
-        let wasmer_store = Store::default();
+        let wasmer_store = new_store();
         let module = Module::new(&wasmer_store, in_memory_module_bytes)?;
 
         Ok(module)
@@ -234,3 +234,8 @@ impl PluginModuleCache {
         }
     }
 }
+
+/// Creates an instnace of  [Store].
+///
+/// This function exitsts because we need to disable simd.
+fn new_store() -> Store {}

--- a/crates/swc_plugin_runner/src/cache.rs
+++ b/crates/swc_plugin_runner/src/cache.rs
@@ -4,12 +4,13 @@ use std::{
 };
 
 use anyhow::{Context, Error};
+use enumset::EnumSet;
 use parking_lot::Mutex;
 use swc_common::{
     collections::AHashMap,
     sync::{Lazy, OnceCell},
 };
-use wasmer::{BaseTunables, Module, Store};
+use wasmer::{BaseTunables, Engine, Module, Store, Target, Triple};
 #[cfg(all(not(target_arch = "wasm32"), feature = "filesystem_cache"))]
 use wasmer_cache::{Cache as WasmerCache, FileSystemCache, Hash};
 
@@ -239,8 +240,13 @@ impl PluginModuleCache {
 ///
 /// This function exitsts because we need to disable simd.
 fn new_store() -> Store {
+    // Use empty enumset to disable simd.
+    let target = Target::new(Triple::host(), EnumSet::new());
+
     let config = wasmer_compiler_cranelift::Cranelift::default();
-    let engine = wasmer_engine_universal::Universal::new(config).engine();
+    let engine = wasmer_engine_universal::Universal::new(config)
+        .target(target)
+        .engine();
     let tunables = BaseTunables::for_target(engine.target());
     Store::new_with_tunables(&engine, tunables)
 }

--- a/crates/swc_plugin_runner/src/cache.rs
+++ b/crates/swc_plugin_runner/src/cache.rs
@@ -9,7 +9,7 @@ use swc_common::{
     collections::AHashMap,
     sync::{Lazy, OnceCell},
 };
-use wasmer::{Module, Store};
+use wasmer::{BaseTunables, Module, Store};
 #[cfg(all(not(target_arch = "wasm32"), feature = "filesystem_cache"))]
 use wasmer_cache::{Cache as WasmerCache, FileSystemCache, Hash};
 
@@ -238,4 +238,9 @@ impl PluginModuleCache {
 /// Creates an instnace of  [Store].
 ///
 /// This function exitsts because we need to disable simd.
-fn new_store() -> Store {}
+fn new_store() -> Store {
+    let config = wasmer_compiler_cranelift::Cranelift::default();
+    let engine = wasmer_engine_universal::Universal::new(config).engine();
+    let tunables = BaseTunables::for_target(engine.target());
+    Store::new_with_tunables(&engine, tunables)
+}

--- a/crates/swc_plugin_runner/src/cache.rs
+++ b/crates/swc_plugin_runner/src/cache.rs
@@ -10,7 +10,7 @@ use swc_common::{
     collections::AHashMap,
     sync::{Lazy, OnceCell},
 };
-use wasmer::{BaseTunables, Engine, Module, Store, Target, Triple};
+use wasmer::{BaseTunables, CpuFeature, Engine, Module, Store, Target, Triple};
 #[cfg(all(not(target_arch = "wasm32"), feature = "filesystem_cache"))]
 use wasmer_cache::{Cache as WasmerCache, FileSystemCache, Hash};
 
@@ -241,7 +241,9 @@ impl PluginModuleCache {
 /// This function exists because we need to disable simd.
 fn new_store() -> Store {
     // Use empty enumset to disable simd.
-    let target = Target::new(Triple::host(), EnumSet::new());
+    let mut set = EnumSet::new();
+    set.insert(CpuFeature::SSE2);
+    let target = Target::new(Triple::host(), set);
 
     let config = wasmer_compiler_cranelift::Cranelift::default();
     let engine = wasmer_engine_universal::Universal::new(config)


### PR DESCRIPTION
**Description:**

This PR disables SIMD for all hosts because wasmer cache is not portable.

**Related issue:**
