### PR TITLE
fix(es/minifier): Preserve `this` of tagged template literals

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -2587,7 +2587,10 @@ where
     /// We don't optimize [Tpl] contained in [TaggedTpl].
     #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
     fn visit_mut_tagged_tpl(&mut self, n: &mut TaggedTpl) {
-        n.tag.visit_mut_with(self);
+        n.tag.visit_mut_with(&mut *self.with_ctx(Ctx {
+            is_this_aware_callee: true,
+            ..self.ctx
+        }));
 
         n.tpl.exprs.visit_mut_with(self);
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -2263,6 +2263,10 @@ where
             .enumerate()
             .identify_last()
             .filter_map(|(last, (idx, expr))| {
+                #[cfg(feature = "debug")]
+                let _span =
+                    tracing::span!(tracing::Level::ERROR, "seq_expr_with_children").entered();
+
                 expr.visit_mut_with(&mut *self.with_ctx(ctx));
                 let is_injected_zero = match &**expr {
                     Expr::Lit(Lit::Num(v)) => v.span.is_dummy(),

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -2269,6 +2269,9 @@ where
                     _ => false,
                 };
 
+                #[cfg(feature = "debug")]
+                let _span = tracing::span!(tracing::Level::ERROR, "seq_expr").entered();
+
                 let can_remove = !last
                     && (idx != 0
                         || !is_injected_zero

--- a/crates/swc_ecma_minifier/tests/fixture/issues/6146/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/6146/input.js
@@ -1,0 +1,6 @@
+let o = {
+    f() {
+        assert.ok(this !== o);
+    }
+};
+(1, o.f)``;

--- a/crates/swc_ecma_minifier/tests/fixture/issues/6146/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/6146/output.js
@@ -3,4 +3,4 @@ let o = {
         assert.ok(this !== o);
     }
 };
-(o.f)``;
+(0, o.f)``;

--- a/crates/swc_ecma_minifier/tests/fixture/issues/6146/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/6146/output.js
@@ -1,0 +1,6 @@
+let o = {
+    f () {
+        assert.ok(this !== o);
+    }
+};
+(o.f)``;

--- a/crates/swc_ecma_minifier/tests/fixture/issues/vercel/007/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/vercel/007/output.js
@@ -9,7 +9,7 @@ import _JSXStyle from "styled-jsx/style";
                 top ? "column" : "column-reverse"
             ]
         ]
-    ]), _JSXStyle.dynamic([
+    ]), Sidebar, _JSXStyle.dynamic([
         [
             "4507deac72c40d6c",
             [

--- a/crates/swc_ecma_minifier/tests/terser/compress/template_string/tagged_call_with_invalid_escape_2/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/template_string/tagged_call_with_invalid_escape_2/output.js
@@ -1,3 +1,3 @@
 console.log(({
     y: ()=>String.raw
-}).y()`\4321\u\x`), console.log(String.raw`\4321\u\x`);
+}).y()`\4321\u\x`), console.log((0, String.raw)`\4321\u\x`);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -1584,19 +1584,6 @@ impl VisitMut for SimplifyExpr {
         self.is_modifying = old;
     }
 
-    fn visit_mut_tagged_tpl(&mut self, n: &mut TaggedTpl) {
-        let check_this = !matches!(&*n.tag, Expr::Ident(..) | Expr::Member(..));
-
-        n.visit_mut_children_with(self);
-
-        if check_this && matches!(&*n.tag, Expr::Member(..)) {
-            n.tag = Box::new(Expr::Seq(SeqExpr {
-                span: DUMMY_SP,
-                exprs: vec![0.into(), n.tag.take()],
-            }));
-        }
-    }
-
     fn visit_mut_with_stmt(&mut self, n: &mut WithStmt) {
         n.obj.visit_mut_with(self);
     }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -1504,7 +1504,9 @@ impl VisitMut for SimplifyExpr {
                     }
                 }
 
-                Expr::Lit(..) | Expr::Ident(..) if self.in_callee => {
+                Expr::Lit(..) | Expr::Ident(..)
+                    if self.in_callee && !expr.may_have_side_effects(&self.expr_ctx) =>
+                {
                     if exprs.is_empty() {
                         self.changed = true;
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -1584,6 +1584,19 @@ impl VisitMut for SimplifyExpr {
         self.is_modifying = old;
     }
 
+    fn visit_mut_tagged_tpl(&mut self, n: &mut TaggedTpl) {
+        let check_this = !matches!(&*n.tag, Expr::Ident(..) | Expr::Member(..));
+
+        n.visit_mut_children_with(self);
+
+        if check_this && matches!(&*n.tag, Expr::Member(..)) {
+            n.tag = Box::new(Expr::Seq(SeqExpr {
+                span: DUMMY_SP,
+                exprs: vec![0.into(), n.tag.take()],
+            }));
+        }
+    }
+
     fn visit_mut_with_stmt(&mut self, n: &mut WithStmt) {
         n.obj.visit_mut_with(self);
     }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -1584,6 +1584,18 @@ impl VisitMut for SimplifyExpr {
         self.is_modifying = old;
     }
 
+    fn visit_mut_tagged_tpl(&mut self, n: &mut TaggedTpl) {
+        let old = self.in_callee;
+        self.in_callee = true;
+
+        n.tag.visit_mut_with(self);
+
+        self.in_callee = false;
+        n.tpl.visit_mut_with(self);
+
+        self.in_callee = old;
+    }
+
     fn visit_mut_with_stmt(&mut self, n: &mut WithStmt) {
         n.obj.visit_mut_with(self);
     }


### PR DESCRIPTION
**Description:**

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6146