### PR TITLE
fix(es/minifier): Don't drop op-assignments

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -2038,7 +2038,7 @@ where
                     }
                     Mergable::Expr(a) => {
                         if can_remove {
-                            if let Expr::Assign(e) = a {
+                            if let Expr::Assign(e @ AssignExpr { op: op!("="), .. }) = a {
                                 report_change!(
                                     "sequences: Dropping assignment as we are going to drop the \
                                      variable declaration. ({})",
@@ -2060,6 +2060,9 @@ where
             Expr::Assign(b @ AssignExpr { op: op!("="), .. }) => {
                 if let Some(b_left) = b.left.as_ident() {
                     if b_left.to_id() == left_id.to_id() {
+                        report_change!("sequences: Merged assignment into another assignment");
+                        self.changed = true;
+
                         let mut a_expr = take_a!(true);
                         let a_expr = self.ignore_return_value(&mut a_expr);
 
@@ -2077,6 +2080,11 @@ where
                 if let Some(b_left) = b.left.as_ident() {
                     if b_left.to_id() == left_id.to_id() {
                         if let Some(bin_op) = b.op.to_update() {
+                            report_change!(
+                                "sequences: Merged assignment into another (op) assignment"
+                            );
+                            self.changed = true;
+
                             b.op = op!("=");
 
                             let to = take_a!(true);


### PR DESCRIPTION
**Description:**

Op-assignments should not be dropped, and we add `report_change` to those modifications.

**Related issue:**
