### PR TITLE
fix(es/codegen): Ensure 'readonly' modified included when emitting TsIndexSignature

### DIFF
--- a/crates/swc_ecma_codegen/src/typescript.rs
+++ b/crates/swc_ecma_codegen/src/typescript.rs
@@ -297,6 +297,11 @@ where
     fn emit_ts_index_signature(&mut self, n: &TsIndexSignature) -> Result {
         self.emit_leading_comments_of_span(n.span(), false)?;
 
+        if n.readonly {
+            keyword!("readonly");
+            formatting_space!();
+        }
+
         punct!("[");
         self.emit_list(n.span, Some(&n.params), ListFormat::Parameters)?;
         punct!("]");

--- a/crates/swc_ecma_codegen/tests/fixture/issues/6171/input.ts
+++ b/crates/swc_ecma_codegen/tests/fixture/issues/6171/input.ts
@@ -1,0 +1,6 @@
+type ReadonlyDict = {
+    readonly [key: string]: string;
+};
+type Dict = {
+    [key: string]: string;
+};

--- a/crates/swc_ecma_codegen/tests/fixture/issues/6171/output.ts
+++ b/crates/swc_ecma_codegen/tests/fixture/issues/6171/output.ts
@@ -1,0 +1,6 @@
+type ReadonlyDict = {
+    readonly [key: string]: string;
+};
+type Dict = {
+    [key: string]: string;
+};


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This change updates `swc_ecma_codegen` so that it emits a `readonly` modified on index signatures when appropriate.

**BREAKING CHANGE:**

This is a minor bug fix and people shouldn't have been relying on the current behaviour.

**Related issue (if exists):**

Closes #6171