### PR TITLE
chore(ci): Lock old issues automatically

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,0 +1,27 @@
+name: "Lock Threads"
+
+on:
+  schedule:
+    # This runs twice a day: https://crontab.guru/#0_0,12_*_*_*
+    - cron: "0 0,12 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: lock
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'swc-project'
+    steps:
+      - uses: dessant/lock-threads@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          issue-inactive-days: 30
+          issue-comment: "This closed issue has been automatically locked because it had no new activity for a month. If you are running into a similar issue, please create a new issue with the steps to reproduce. Thank you."
+          pr-inactive-days: 30
+          log-output: true


### PR DESCRIPTION
**Description:**

Lefting a comment on an old issue does not help at all, so I'm adding an action to lock them.

**Related issue (if exists):**
