### PR TITLE
[WIP] feat(swc/parser): multiple nesting selector

### DIFF
--- a/crates/swc_css_parser/tests/fixture/selector/nesting/input.css
+++ b/crates/swc_css_parser/tests/fixture/selector/nesting/input.css
@@ -37,11 +37,22 @@ table.colortable {
     & { padding: 2ch; }
 }
 
-/* TODO fix me */
-/*.foo {*/
-/*    color: blue;*/
-/*    && { padding: 2ch; }*/
-/*}*/
+.foo {
+    color: blue;
+    && { padding: 2ch; }
+}
+
+.foo {
+    color: blue;
+    &&&& { padding: 2ch; }
+    &&&& > p {
+          font-size: .9rem;
+    }
+
+    & > figcaption {
+        &&&& { padding: 2ch; }
+    }
+}
 
 .error, #test {
     &:hover > .baz { color: red; }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Allow to parse:
```css
.foo {
  color: blue;
  && { padding: 2ch; }
}
```

Ref: https://www.w3.org/TR/css-nesting-1/#nesting

**BREAKING CHANGE:**

Maybe

**Related issue (if exists):**

@tabatkins Hello and sorry for ping, we need your advice and help here. In spec we have:

> The [nesting selector](https://www.w3.org/TR/css-nesting-1/#nesting-selector) is allowed anywhere in a [compound selector](https://www.w3.org/TR/selectors-4/#compound), even before a [type selector](https://www.w3.org/TR/selectors-4/#type-selector), violating the normal restrictions on ordering within a compound selector.

But if you look at https://www.w3.org/TR/selectors-4/#grammar 

Compound selector contains a lot of other selectors, so based on the condition above, we can get (and it looks weird):
```
.class {
   &div#id:pseudo-class&::pseudo-element& { }
}
```

So can you provide syntax of `<compound-selector>` with `<nesting-selector>` to fully undestand syntax and will be great to have it in spec too, thank you