### PR TITLE
fix(css/minifier): don't touch `@supports`

### DIFF
--- a/crates/swc_css_minifier/src/compressor/mod.rs
+++ b/crates/swc_css_minifier/src/compressor/mod.rs
@@ -213,7 +213,11 @@ impl VisitMut for Compressor {
             ..self.ctx
         }));
 
-        self.compress_calc_sum(n);
+        // Don't touch `@supports`, it can be used to check a browser's support for one
+        // or more specific CSS features
+        if !self.in_supports_conidition {
+            self.compress_calc_sum(n);
+        }
     }
 
     fn visit_mut_component_value(&mut self, n: &mut ComponentValue) {

--- a/crates/swc_css_minifier/tests/fixture/compress-calc/supports-condition/input.css
+++ b/crates/swc_css_minifier/tests/fixture/compress-calc/supports-condition/input.css
@@ -21,3 +21,9 @@
         background: red;
     }
 }
+
+@supports (width: calc(100px * sqrt(9))) {
+    div {
+        background: red;
+    }
+}

--- a/crates/swc_css_minifier/tests/fixture/compress-calc/supports-condition/output.min.css
+++ b/crates/swc_css_minifier/tests/fixture/compress-calc/supports-condition/output.min.css
@@ -1,1 +1,1 @@
-@supports(width:200px){div{background:red}}@supports(width:200px){div{background:red}}@supports(width:0){div{background:red}}@supports(width:0){div{background:red}}
+@supports(width:calc(100px + 100px)){div{background:red}}@supports(width:calc(100px + 100px)){div{background:red}}@supports(width:calc(0px*100)){div{background:red}}@supports(width:calc(0px + 0px)){div{background:red}}@supports(width:calc(100px*sqrt(9))){div{background:red}}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Don't tocuh `@supports`, because it can be used for check a support of `calc`, so

```css
// Will not work in old browser
@supports (width: calc(100px + 100px)) {
    div {
        background: red;
    }
}
```

will be

```css
// Will work in odl browser
@supports (width: 200px) {
   div {
        background: red;
    }
}
```

But some styles can be used for old browser (and verca vise), this is definitely not the expected behavior

**BREAKING CHANGE:**

No

**Related issue (if exists):**

No