### PR TITLE
fix: change process_js_with_custom_pass api

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -179,6 +179,9 @@ pub struct Options {
     #[serde(skip_deserializing, default)]
     pub top_level_mark: Option<Mark>,
 
+    #[serde(skip_deserializing, default)]
+    pub unresolved_mark: Option<Mark>,
+
     #[cfg(not(target_arch = "wasm32"))]
     #[serde(default = "default_cwd")]
     pub cwd: PathBuf,
@@ -338,7 +341,7 @@ impl Options {
             }
         });
 
-        let unresolved_mark = Mark::new();
+        let unresolved_mark = self.unresolved_mark.unwrap_or_else(Mark::new);
         let top_level_mark = self.top_level_mark.unwrap_or_else(Mark::new);
 
         let es_version = target.unwrap_or_default();


### PR DESCRIPTION
## Fix

Options missing unresolved_mark field

## Breaking Change

It's a breaking change I know but the usage of current implementation is hard to use, or maybe I did it wrong.
It's very easily to encounter lifetime limitation.

```rust
compiler.process_js_with_custom_pass(..., |_, comments| { build_pass(comments) });
-----------------------------------------------^^^^^^^ compile error
```

I believe this is a common pattern, `build_pass` should hold the comments' lifetime, but borrow checker would not allow this.

So I think maybe pass `comments` to it should be a better idea.

If anything wrong with my point of view, please tell me
