### PR TITLE
Remove mut from build_source_map_from

### DIFF
--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -498,7 +498,7 @@ impl Compiler {
 
                         self.cm
                             .build_source_map_with_config(
-                                &mut src_map_buf,
+                                &src_map_buf,
                                 orig,
                                 SwcSourceMapConfig {
                                     source_file_name,
@@ -523,7 +523,7 @@ impl Compiler {
 
                     self.cm
                         .build_source_map_with_config(
-                            &mut src_map_buf,
+                            &src_map_buf,
                             orig,
                             SwcSourceMapConfig {
                                 source_file_name,

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1124,7 +1124,7 @@ impl SourceMap {
     #[cfg_attr(docsrs, doc(cfg(feature = "sourcemap")))]
     pub fn build_source_map_from(
         &self,
-        mappings: &mut Vec<(BytePos, LineCol)>,
+        mappings: &Vec<(BytePos, LineCol)>,
         orig: Option<&sourcemap::SourceMap>,
     ) -> sourcemap::SourceMap {
         self.build_source_map_with_config(mappings, orig, DefaultSourceMapGenConfig)
@@ -1135,7 +1135,7 @@ impl SourceMap {
     #[cfg_attr(docsrs, doc(cfg(feature = "sourcemap")))]
     pub fn build_source_map_with_config(
         &self,
-        mappings: &mut Vec<(BytePos, LineCol)>,
+        mappings: &Vec<(BytePos, LineCol)>,
         orig: Option<&sourcemap::SourceMap>,
         config: impl SourceMapGenConfig,
     ) -> sourcemap::SourceMap {

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1115,7 +1115,7 @@ impl SourceMap {
     ///
     #[cfg(feature = "sourcemap")]
     #[cfg_attr(docsrs, doc(cfg(feature = "sourcemap")))]
-    pub fn build_source_map(&self, mappings: &mut Vec<(BytePos, LineCol)>) -> sourcemap::SourceMap {
+    pub fn build_source_map(&self, mappings: &[(BytePos, LineCol)]) -> sourcemap::SourceMap {
         self.build_source_map_from(mappings, None)
     }
 
@@ -1124,7 +1124,7 @@ impl SourceMap {
     #[cfg_attr(docsrs, doc(cfg(feature = "sourcemap")))]
     pub fn build_source_map_from(
         &self,
-        mappings: &Vec<(BytePos, LineCol)>,
+        mappings: &[(BytePos, LineCol)],
         orig: Option<&sourcemap::SourceMap>,
     ) -> sourcemap::SourceMap {
         self.build_source_map_with_config(mappings, orig, DefaultSourceMapGenConfig)
@@ -1135,7 +1135,7 @@ impl SourceMap {
     #[cfg_attr(docsrs, doc(cfg(feature = "sourcemap")))]
     pub fn build_source_map_with_config(
         &self,
-        mappings: &Vec<(BytePos, LineCol)>,
+        mappings: &[(BytePos, LineCol)],
         orig: Option<&sourcemap::SourceMap>,
         config: impl SourceMapGenConfig,
     ) -> sourcemap::SourceMap {


### PR DESCRIPTION

**Description:**

The `mappings` vector was required to be mutable, but the value is never mutated.

**BREAKING CHANGE:**

I don't believe so. Any code that passed in a mutable reference will still work without any changes.

**Related issue (if exists):**
