### PR TITLE
Support trailing commas in swcrc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1370,10 +1370,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "json_comments"
-version = "0.2.0"
+name = "jsonc-parser"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab25c689752fbb49903458495d3e71853229e262a2e6136325359e0705606483"
+checksum = "3a1853e40333206f9a685358046d13ab200169e3ee573019bddf0ede0dc29307"
+dependencies = [
+ "serde_json",
+]
 
 [[package]]
 name = "lazy_static"
@@ -2983,7 +2986,7 @@ dependencies = [
  "dashmap",
  "either",
  "indexmap",
- "json_comments",
+ "jsonc-parser",
  "lru",
  "napi",
  "napi-derive",

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -49,7 +49,7 @@ base64 = "0.13.0"
 dashmap = "5.1.0"
 either = "1"
 indexmap = { version = "1.6.1", features = ["serde"] }
-json_comments = "0.2.0"
+jsonc-parser = { version = "0.21.0", features = ["serde"] }
 lru = "0.7.1"
 once_cell = "1.10.0"
 parking_lot = "0.12.0"

--- a/crates/swc/src/config/jsonc.json
+++ b/crates/swc/src/config/jsonc.json
@@ -1,0 +1,5 @@
+{
+    "jsc": {
+      // comment & trailing comma
+    },
+}

--- a/crates/swc/src/config/tests.rs
+++ b/crates/swc/src/config/tests.rs
@@ -28,3 +28,9 @@ fn issue_1532() {
     let err = res.expect_err("should fail");
     assert!(err.to_string().contains("unknown variant `esnext`"));
 }
+
+#[test]
+fn jsonc() {
+    let rc = parse_swcrc(include_str!("jsonc.json")).expect("failed to parse");
+    dbg!(&rc);
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

As request in https://github.com/vercel/turbo/pull/2429, switches from json_comments to jsonc-parser to align dependencies with Turbopack. Used the same options as in Turbopack, which adds support for trailing commas but still requires properties to be quoted.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

No

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

No