### PR TITLE
refactor: process_js_with_custom_pass should accept comments as paramter

### DIFF
--- a/crates/binding_macros/src/wasm.rs
+++ b/crates/binding_macros/src/wasm.rs
@@ -327,6 +327,7 @@ macro_rules! build_transform_sync {
                               None,
                               handler,
                               &opts,
+                              Default::default(),
                               $before_pass,
                               $after_pass,
                           ), "failed to process js file"

--- a/crates/swc/tests/rust_api.rs
+++ b/crates/swc/tests/rust_api.rs
@@ -50,8 +50,9 @@ fn test_visit_mut() {
 
                 ..Default::default()
             },
-            |_, _| as_folder(PanicOnVisit),
-            |_, _| noop(),
+            SingleThreadedComments::default(),
+            |_| as_folder(PanicOnVisit),
+            |_| noop(),
         );
 
         assert_ne!(res.unwrap().code, "console.log(5 as const)");
@@ -101,11 +102,12 @@ fn shopify_1_check_filename() {
                 },
                 ..Default::default()
             },
-            |_, _: &SingleThreadedComments| {
+            SingleThreadedComments::default(),
+            |_| {
                 // Ensure comment API
                 noop()
             },
-            |_, _: &SingleThreadedComments| noop(),
+            |_| noop(),
         );
 
         if res.is_err() {
@@ -181,8 +183,15 @@ fn shopify_2_same_opt() {
             .into(),
         );
 
-        let res =
-            c.process_js_with_custom_pass(fm, None, &handler, &opts, |_, _| noop(), |_, _| noop());
+        let res = c.process_js_with_custom_pass(
+            fm,
+            None,
+            &handler,
+            &opts,
+            SingleThreadedComments::default(),
+            |_| noop(),
+            |_| noop(),
+        );
 
         if res.is_err() {
             return Err(());
@@ -243,8 +252,15 @@ fn shopify_3_reduce_defaults() {
             .into(),
         );
 
-        let res =
-            c.process_js_with_custom_pass(fm, None, &handler, &opts, |_, _| noop(), |_, _| noop());
+        let res = c.process_js_with_custom_pass(
+            fm,
+            None,
+            &handler,
+            &opts,
+            SingleThreadedComments::default(),
+            |_| noop(),
+            |_| noop(),
+        );
 
         if res.is_err() {
             return Err(());
@@ -300,8 +316,15 @@ fn shopify_4_reduce_more() {
             .into(),
         );
 
-        let res =
-            c.process_js_with_custom_pass(fm, None, &handler, &opts, |_, _| noop(), |_, _| noop());
+        let res = c.process_js_with_custom_pass(
+            fm,
+            None,
+            &handler,
+            &opts,
+            SingleThreadedComments::default(),
+            |_| noop(),
+            |_| noop(),
+        );
 
         if res.is_err() {
             return Err(());


### PR DESCRIPTION
**Description:**
[`process_js_with_custom_pass()`](https://github.com/swc-project/swc/blob/main/crates/swc/src/lib.rs#L851) should accept `comments` as parameter instead of using it internally, as user may pass an already parsed AST, and parse also need `comments` as parameter, so those `comments` should be the same.

**Breaking Change**
It's a breaking change, and I remember that next.js is using this API.
Also bindings/binding_core_wasm is using too.
Do I need to edit CHANGELOG, or if it can be done by `swc-bot`
