### PR TITLE
feat(css/parser): use `Atom` for `raw` values

### DIFF
--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -1,6 +1,6 @@
 use is_macro::Is;
 use string_enum::StringEnum;
-use swc_atoms::JsWord;
+use swc_atoms::{Atom, JsWord};
 use swc_common::{ast_node, EqIgnoreSpan, Span};
 
 use crate::{
@@ -809,8 +809,7 @@ pub struct ExtensionName {
     pub span: Span,
     #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
     pub value: JsWord,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 impl EqIgnoreSpan for ExtensionName {

--- a/crates/swc_css_ast/src/selector.rs
+++ b/crates/swc_css_ast/src/selector.rs
@@ -401,8 +401,7 @@ pub struct CustomHighlightName {
     pub span: Span,
     #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
     pub value: JsWord,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 impl EqIgnoreSpan for CustomHighlightName {

--- a/crates/swc_css_ast/src/selector.rs
+++ b/crates/swc_css_ast/src/selector.rs
@@ -1,6 +1,6 @@
 use is_macro::Is;
 use string_enum::StringEnum;
-use swc_atoms::JsWord;
+use swc_atoms::{Atom, JsWord};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span};
 
 use crate::{Delimiter, Ident, ListOfComponentValues, Str, TokenAndSpan};
@@ -369,11 +369,9 @@ pub enum AnPlusB {
 pub struct AnPlusBNotation {
     pub span: Span,
     pub a: Option<i32>,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub a_raw: Option<JsWord>,
+    pub a_raw: Option<Atom>,
     pub b: Option<i32>,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub b_raw: Option<JsWord>,
+    pub b_raw: Option<Atom>,
 }
 
 #[ast_node("PseudoElementSelector")]

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -94,12 +94,10 @@ pub enum Token {
     Url {
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         name: JsWord,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw_name: JsWord,
+        raw_name: Atom,
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         value: JsWord,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw_value: JsWord,
+        raw_value: Atom,
     },
 
     BadUrl {

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -112,22 +112,19 @@ pub enum Token {
 
     Number {
         value: f64,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw: JsWord,
+        raw: Atom,
         #[serde(rename = "type")]
         type_flag: NumberType,
     },
 
     Percentage {
         value: f64,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw: JsWord,
+        raw: Atom,
     },
 
     Dimension {
         value: f64,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw_value: JsWord,
+        raw_value: Atom,
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         unit: JsWord,
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -76,8 +76,7 @@ pub enum Token {
         is_id: bool,
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         value: JsWord,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw: JsWord,
+        raw: Atom,
     },
 
     String {

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -106,10 +106,8 @@ pub enum Token {
     BadUrl {
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         name: JsWord,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw_name: JsWord,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw_value: JsWord,
+        raw_name: Atom,
+        raw_value: Atom,
     },
 
     Delim {

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -82,8 +82,7 @@ pub enum Token {
     String {
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         value: JsWord,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw: JsWord,
+        raw: Atom,
     },
 
     BadString {
@@ -197,8 +196,11 @@ impl Hash for Token {
         match self {
             Token::Ident { value, raw }
             | Token::Function { value, raw }
-            | Token::AtKeyword { value, raw }
-            | Token::String { value, raw } => {
+            | Token::AtKeyword { value, raw } => {
+                value.hash(state);
+                raw.hash(state);
+            }
+            Token::String { value, raw } => {
                 value.hash(state);
                 raw.hash(state);
             }

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -87,8 +87,7 @@ pub enum Token {
     },
 
     BadString {
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw_value: JsWord,
+        raw_value: Atom,
     },
 
     /// `url(value)`

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -5,7 +5,7 @@ use std::{
 
 use is_macro::Is;
 use serde::{Deserialize, Serialize};
-use swc_atoms::JsWord;
+use swc_atoms::{Atom, JsWord};
 use swc_common::{ast_node, EqIgnoreSpan, Span};
 
 #[ast_node("PreservedToken")]
@@ -145,8 +145,7 @@ pub enum Token {
 
     /// One or more whitespace.
     WhiteSpace {
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        value: JsWord,
+        value: Atom,
     },
 
     /// `<!--`

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -52,23 +52,20 @@ pub enum Token {
     Ident {
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         value: JsWord,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw: JsWord,
+        raw: Atom,
     },
 
     Function {
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         value: JsWord,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw: JsWord,
+        raw: Atom,
     },
 
     /// `@`
     AtKeyword {
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         value: JsWord,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw: JsWord,
+        raw: Atom,
     },
 
     /// `#`
@@ -127,8 +124,7 @@ pub enum Token {
         raw_value: Atom,
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         unit: JsWord,
-        #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-        raw_unit: JsWord,
+        raw_unit: Atom,
         #[serde(rename = "type")]
         type_flag: NumberType,
     },
@@ -193,11 +189,8 @@ impl Hash for Token {
         match self {
             Token::Ident { value, raw }
             | Token::Function { value, raw }
-            | Token::AtKeyword { value, raw } => {
-                value.hash(state);
-                raw.hash(state);
-            }
-            Token::String { value, raw } => {
+            | Token::AtKeyword { value, raw }
+            | Token::String { value, raw } => {
                 value.hash(state);
                 raw.hash(state);
             }

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -324,8 +324,7 @@ pub enum TimePercentage {
 pub struct Integer {
     pub span: Span,
     pub value: i64,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 impl EqIgnoreSpan for Integer {
@@ -338,8 +337,7 @@ impl EqIgnoreSpan for Integer {
 pub struct Number {
     pub span: Span,
     pub value: f64,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 impl Eq for Number {}

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -16,8 +16,7 @@ pub struct Ident {
     pub span: Span,
     #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
     pub value: JsWord,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 impl EqIgnoreSpan for Ident {
@@ -42,8 +41,7 @@ pub struct CustomIdent {
     pub span: Span,
     #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
     pub value: JsWord,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 impl EqIgnoreSpan for CustomIdent {
@@ -58,8 +56,7 @@ pub struct DashedIdent {
     pub span: Span,
     #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
     pub value: JsWord,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 impl EqIgnoreSpan for DashedIdent {
@@ -74,8 +71,7 @@ pub struct CustomPropertyName {
     pub span: Span,
     #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
     pub value: JsWord,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 impl EqIgnoreSpan for CustomPropertyName {

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -430,8 +430,7 @@ pub struct UrlValueRaw {
     pub span: Span,
     #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
     pub value: JsWord,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 #[ast_node]

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -164,8 +164,7 @@ pub struct HexColor {
     #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
     pub value: JsWord,
     /// Does **not** include `#`
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 #[ast_node]

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -91,8 +91,7 @@ pub struct Str {
     pub span: Span,
     #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
     pub value: JsWord,
-    #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
-    pub raw: Option<JsWord>,
+    pub raw: Option<Atom>,
 }
 
 impl EqIgnoreSpan for Str {

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -5,7 +5,7 @@ use std::{
 
 use is_macro::Is;
 use string_enum::StringEnum;
-use swc_atoms::JsWord;
+use swc_atoms::{Atom, JsWord};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span};
 
 use crate::Function;

--- a/crates/swc_css_codegen/src/lib.rs
+++ b/crates/swc_css_codegen/src/lib.rs
@@ -376,7 +376,7 @@ where
                     AtRuleName::Ident(swc_css_ast::Ident {
                         span: n.span,
                         value: js_word!("layer"),
-                        raw: Some(js_word!("layer"))
+                        raw: None
                     })
                 )
             }

--- a/crates/swc_css_minifier/src/compressor/mod.rs
+++ b/crates/swc_css_minifier/src/compressor/mod.rs
@@ -400,12 +400,20 @@ impl VisitMut for Compressor {
                 | Token::Function { value, .. }
                 | Token::AtKeyword { value, .. }
                 | Token::String { value, .. }
-                | Token::BadString {
-                    raw_value: value, ..
-                }
-                | Token::Dimension { unit: value, .. }
+                | Token::Url { value, .. }
                     if !contains_only_ascii_characters(value) =>
                 {
+                    self.need_utf8_at_rule = true;
+                }
+                Token::BadString {
+                    raw_value: value, ..
+                }
+                | Token::BadUrl {
+                    raw_value: value, ..
+                } if !contains_only_ascii_characters(value) => {
+                    self.need_utf8_at_rule = true;
+                }
+                Token::Dimension { unit: value, .. } if !contains_only_ascii_characters(value) => {
                     self.need_utf8_at_rule = true;
                 }
                 _ => {}

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -301,7 +301,7 @@ where
                             ..
                         } => {
                             *value = ident_sequence.0;
-                            *raw = Atom::new(&*ident_sequence.1);
+                            *raw = ident_sequence.1;
                         }
                         _ => {
                             unreachable!();
@@ -559,9 +559,9 @@ where
             // unit set initially to the empty string.
             let mut token = Token::Dimension {
                 value: number.0,
-                raw_value: number.1.into(),
+                raw_value: number.1,
                 unit: js_word!(""),
-                raw_unit: js_word!(""),
+                raw_unit: "".into(),
                 type_flag: number.2,
             };
 
@@ -592,7 +592,7 @@ where
 
             return Ok(Token::Percentage {
                 value: number.0,
-                raw: number.1.into(),
+                raw: number.1,
             });
         }
 
@@ -600,7 +600,7 @@ where
         // number, and return it.
         Ok(Token::Number {
             value: number.0,
-            raw: number.1.into(),
+            raw: number.1,
             type_flag: number.2,
         })
     }
@@ -779,7 +779,7 @@ where
 
     // This section describes how to consume a url token from a stream of code
     // points. It returns either a <url-token> or a <bad-url-token>.
-    fn read_url(&mut self, name: (JsWord, JsWord), before: String) -> LexResult<Token> {
+    fn read_url(&mut self, name: (JsWord, Atom), before: String) -> LexResult<Token> {
         // Initially create a <url-token> with its value set to the empty string.
         self.with_buf_and_raw_buf(|l, out, raw| {
             raw.push_str(&before);
@@ -805,9 +805,9 @@ where
                     Some(')') => {
                         return Ok(Token::Url {
                             name: name.0,
-                            raw_name: Atom::new(&*name.1),
+                            raw_name: name.1,
                             value: (&**out).into(),
-                            raw_value: Atom::new(&**raw),
+                            raw_value: (&**raw).into(),
                         });
                     }
 
@@ -818,7 +818,7 @@ where
 
                         return Ok(Token::Url {
                             name: name.0,
-                            raw_name: Atom::new(&*name.1),
+                            raw_name: name.1,
                             value: (&**out).into(),
                             raw_value: (&**raw).into(),
                         });
@@ -854,7 +854,7 @@ where
 
                                 return Ok(Token::Url {
                                     name: name.0,
-                                    raw_name: Atom::new(&*name.1),
+                                    raw_name: name.1,
                                     value: (&**out).into(),
                                     raw_value: (&**raw).into(),
                                 });
@@ -866,7 +866,7 @@ where
 
                                 return Ok(Token::Url {
                                     name: name.0,
-                                    raw_name: Atom::new(&*name.1),
+                                    raw_name: name.1,
                                     value: (&**out).into(),
                                     raw_value: (&**raw).into(),
                                 });
@@ -886,8 +886,8 @@ where
 
                         return Ok(Token::BadUrl {
                             name: name.0,
-                            raw_name: Atom::new(&*name.1),
-                            raw_value: Atom::new(&**raw),
+                            raw_name: name.1,
+                            raw_value: (&**raw).into(),
                         });
                     }
 
@@ -909,8 +909,8 @@ where
 
                         return Ok(Token::BadUrl {
                             name: name.0,
-                            raw_name: Atom::new(&*name.1),
-                            raw_value: Atom::new(&**raw),
+                            raw_name: name.1,
+                            raw_value: (&**raw).into(),
                         });
                     }
 
@@ -940,8 +940,8 @@ where
 
                             return Ok(Token::BadUrl {
                                 name: name.0,
-                                raw_name: Atom::new(&*name.1),
-                                raw_value: Atom::new(&**raw),
+                                raw_name: name.1,
+                                raw_value: (&**raw).into(),
                             });
                         }
                     }
@@ -1178,7 +1178,7 @@ where
     // This section describes how to consume an ident sequence from a stream of code
     // points. It returns a string containing the largest name that can be formed
     // from adjacent code points in the stream, starting from the first.
-    fn read_ident_sequence(&mut self) -> LexResult<(JsWord, JsWord)> {
+    fn read_ident_sequence(&mut self) -> LexResult<(JsWord, Atom)> {
         self.with_buf_and_raw_buf(|l, buf, raw| {
             // Let result initially be an empty string.
             // Done above
@@ -1219,10 +1219,9 @@ where
 
     // This section describes how to consume a number from a stream of code points.
     // It returns a numeric value, and a type which is either "integer" or "number".
-    fn read_number(&mut self) -> LexResult<(f64, String, NumberType)> {
-        let parsed =
+    fn read_number(&mut self) -> LexResult<(f64, Atom, NumberType)> {
+        let parsed: (Atom, NumberType) = self.with_buf(|l, out| {
             // Initially set type to "integer". Let repr be the empty string.
-            self.with_buf(|l, out| {
             let mut type_flag = NumberType::Integer;
 
             // If the next input code point is U+002B PLUS SIGN (+) or U+002D HYPHEN-MINUS
@@ -1324,7 +1323,7 @@ where
         })?;
 
         // Convert repr to a number, and set the value to the returned value.
-        let value = lexical::parse(&parsed.0).unwrap_or_else(|err| {
+        let value = lexical::parse(&*parsed.0).unwrap_or_else(|err| {
             unreachable!("failed to parse `{}` using lexical: {:?}", parsed.0, err)
         });
 

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -805,9 +805,9 @@ where
                     Some(')') => {
                         return Ok(Token::Url {
                             name: name.0,
-                            raw_name: name.1,
+                            raw_name: Atom::new(&*name.1),
                             value: (&**out).into(),
-                            raw_value: (&**raw).into(),
+                            raw_value: Atom::new(&**raw),
                         });
                     }
 
@@ -818,7 +818,7 @@ where
 
                         return Ok(Token::Url {
                             name: name.0,
-                            raw_name: name.1,
+                            raw_name: Atom::new(&*name.1),
                             value: (&**out).into(),
                             raw_value: (&**raw).into(),
                         });
@@ -854,7 +854,7 @@ where
 
                                 return Ok(Token::Url {
                                     name: name.0,
-                                    raw_name: name.1,
+                                    raw_name: Atom::new(&*name.1),
                                     value: (&**out).into(),
                                     raw_value: (&**raw).into(),
                                 });
@@ -866,7 +866,7 @@ where
 
                                 return Ok(Token::Url {
                                     name: name.0,
-                                    raw_name: name.1,
+                                    raw_name: Atom::new(&*name.1),
                                     value: (&**out).into(),
                                     raw_value: (&**raw).into(),
                                 });

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -886,8 +886,8 @@ where
 
                         return Ok(Token::BadUrl {
                             name: name.0,
-                            raw_name: name.1,
-                            raw_value: (&**raw).into(),
+                            raw_name: Atom::new(&*name.1),
+                            raw_value: Atom::new(&**raw),
                         });
                     }
 
@@ -909,8 +909,8 @@ where
 
                         return Ok(Token::BadUrl {
                             name: name.0,
-                            raw_name: name.1,
-                            raw_value: (&**raw).into(),
+                            raw_name: Atom::new(&*name.1),
+                            raw_value: Atom::new(&**raw),
                         });
                     }
 
@@ -940,8 +940,8 @@ where
 
                             return Ok(Token::BadUrl {
                                 name: name.0,
-                                raw_name: name.1,
-                                raw_value: (&**raw).into(),
+                                raw_name: Atom::new(&*name.1),
+                                raw_value: Atom::new(&**raw),
                             });
                         }
                     }

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -1,6 +1,6 @@
 use std::{cell::RefCell, char::REPLACEMENT_CHARACTER, rc::Rc};
 
-use swc_atoms::{js_word, JsWord};
+use swc_atoms::{js_word, Atom, JsWord};
 use swc_common::{input::Input, BytePos, Span};
 use swc_css_ast::{NumberType, Token, TokenAndSpan};
 
@@ -301,7 +301,7 @@ where
                             ..
                         } => {
                             *value = ident_sequence.0;
-                            *raw = ident_sequence.1;
+                            *raw = Atom::new(&*ident_sequence.1);
                         }
                         _ => {
                             unreachable!();

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -1,6 +1,6 @@
 use std::{fmt::Debug, mem::take};
 
-use swc_atoms::JsWord;
+use swc_atoms::{Atom, JsWord};
 use swc_common::{BytePos, Span, Spanned, SyntaxContext};
 use swc_css_ast::{ComponentValue, ListOfComponentValues, Token, TokenAndSpan};
 
@@ -222,7 +222,7 @@ pub enum InputType<'a> {
 #[derive(Debug)]
 pub enum TokenOrBlock {
     Token(TokenAndSpan),
-    Function(Span, JsWord, JsWord),
+    Function(Span, JsWord, Atom),
     LBracket(Span),
     LParen(Span),
     LBrace(Span),
@@ -280,7 +280,7 @@ impl<'a> Input<'a> {
                         function.name.value.clone(),
                         match &function.name.raw {
                             Some(raw) => raw.clone(),
-                            _ => function.name.value.clone(),
+                            _ => Atom::from(function.name.value.clone()),
                         },
                     ));
                 }

--- a/crates/swc_css_parser/src/parser/selectors/mod.rs
+++ b/crates/swc_css_parser/src/parser/selectors/mod.rs
@@ -1,3 +1,4 @@
+use swc_atoms::JsWord;
 use swc_common::{BytePos, Span, Spanned};
 use swc_css_ast::*;
 
@@ -629,7 +630,7 @@ where
                 Ident {
                     span,
                     value,
-                    raw: Some(raw),
+                    raw: Some(JsWord::from(&*raw)),
                 }
             }
             _ => {

--- a/crates/swc_css_parser/src/parser/selectors/mod.rs
+++ b/crates/swc_css_parser/src/parser/selectors/mod.rs
@@ -1,4 +1,3 @@
-use swc_atoms::JsWord;
 use swc_common::{BytePos, Span, Spanned};
 use swc_css_ast::*;
 
@@ -630,7 +629,7 @@ where
                 Ident {
                     span,
                     value,
-                    raw: Some(JsWord::from(&*raw)),
+                    raw: Some(raw),
                 }
             }
             _ => {

--- a/crates/swc_css_parser/src/parser/values_and_units/mod.rs
+++ b/crates/swc_css_parser/src/parser/values_and_units/mod.rs
@@ -2576,20 +2576,12 @@ where
                 Ok(UnknownDimension {
                     span,
                     value: Number {
-                        span: swc_common::Span::new(
-                            span.lo,
-                            span.hi - BytePos(unit_len),
-                            Default::default(),
-                        ),
+                        span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
                         value,
                         raw: Some(raw_value),
                     },
                     unit: Ident {
-                        span: swc_common::Span::new(
-                            span.hi - BytePos(unit_len),
-                            span.hi,
-                            Default::default(),
-                        ),
+                        span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
                         value: unit,
                         raw: Some(raw_unit),
                     },

--- a/crates/swc_css_parser/src/parser/values_and_units/mod.rs
+++ b/crates/swc_css_parser/src/parser/values_and_units/mod.rs
@@ -1,4 +1,3 @@
-use swc_atoms::JsWord;
 use swc_common::{BytePos, Span};
 use swc_css_ast::*;
 
@@ -2065,7 +2064,7 @@ where
             Token::Ident { value, raw } => {
                 match &*value.to_ascii_lowercase() {
                     "initial" | "inherit" | "unset" | "revert" | "default" => {
-                        return Err(Error::new(span, ErrorKind::InvalidCustomIdent(raw)));
+                        return Err(Error::new(span, ErrorKind::InvalidCustomIdent(value)));
                     }
                     _ => {}
                 }
@@ -2868,7 +2867,7 @@ where
                 let name = Ident {
                     span: Span::new(span.lo, span.lo + BytePos(name_length), Default::default()),
                     value: name,
-                    raw: Some(JsWord::from(&*raw_name)),
+                    raw: Some(raw_name),
                 };
                 let value = Some(Box::new(UrlValue::Raw(UrlValueRaw {
                     span: Span::new(

--- a/crates/swc_css_parser/src/parser/values_and_units/mod.rs
+++ b/crates/swc_css_parser/src/parser/values_and_units/mod.rs
@@ -1,3 +1,4 @@
+use swc_atoms::JsWord;
 use swc_common::{BytePos, Span};
 use swc_css_ast::*;
 
@@ -2865,16 +2866,12 @@ where
             } => {
                 let name_length = raw_name.len() as u32;
                 let name = Ident {
-                    span: swc_common::Span::new(
-                        span.lo,
-                        span.lo + BytePos(name_length),
-                        Default::default(),
-                    ),
+                    span: Span::new(span.lo, span.lo + BytePos(name_length), Default::default()),
                     value: name,
-                    raw: Some(raw_name),
+                    raw: Some(JsWord::from(&*raw_name)),
                 };
                 let value = Some(Box::new(UrlValue::Raw(UrlValueRaw {
-                    span: swc_common::Span::new(
+                    span: Span::new(
                         span.lo + BytePos(name_length + 1),
                         span.hi - BytePos(1),
                         Default::default(),

--- a/crates/swc_css_parser/src/parser/values_and_units/mod.rs
+++ b/crates/swc_css_parser/src/parser/values_and_units/mod.rs
@@ -2805,7 +2805,7 @@ where
         match bump!(self) {
             Token::Percentage { value, raw } => {
                 let value = Number {
-                    span: swc_common::Span::new(span.lo, span.hi - BytePos(1), Default::default()),
+                    span: Span::new(span.lo, span.hi - BytePos(1), Default::default()),
                     value,
                     raw: Some(raw),
                 };

--- a/crates/swc_css_parser/src/parser/values_and_units/mod.rs
+++ b/crates/swc_css_parser/src/parser/values_and_units/mod.rs
@@ -2250,20 +2250,12 @@ where
                 Ok(Length {
                     span,
                     value: Number {
-                        span: swc_common::Span::new(
-                            span.lo,
-                            span.hi - BytePos(unit_len),
-                            Default::default(),
-                        ),
+                        span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
                         value,
                         raw: Some(raw_value),
                     },
                     unit: Ident {
-                        span: swc_common::Span::new(
-                            span.hi - BytePos(unit_len),
-                            span.hi,
-                            Default::default(),
-                        ),
+                        span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
                         value: unit,
                         raw: Some(raw_unit),
                     },
@@ -2307,20 +2299,12 @@ where
                 Ok(Angle {
                     span,
                     value: Number {
-                        span: swc_common::Span::new(
-                            span.lo,
-                            span.hi - BytePos(unit_len),
-                            Default::default(),
-                        ),
+                        span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
                         value,
                         raw: Some(raw_value),
                     },
                     unit: Ident {
-                        span: swc_common::Span::new(
-                            span.hi - BytePos(unit_len),
-                            span.hi,
-                            Default::default(),
-                        ),
+                        span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
                         value: unit,
                         raw: Some(raw_unit),
                     },
@@ -2361,20 +2345,12 @@ where
                 Ok(Time {
                     span,
                     value: Number {
-                        span: swc_common::Span::new(
-                            span.lo,
-                            span.hi - BytePos(unit_len),
-                            Default::default(),
-                        ),
+                        span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
                         value,
                         raw: Some(raw_value),
                     },
                     unit: Ident {
-                        span: swc_common::Span::new(
-                            span.hi - BytePos(unit_len),
-                            span.hi,
-                            Default::default(),
-                        ),
+                        span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
                         value: unit,
                         raw: Some(raw_unit),
                     },
@@ -2415,20 +2391,12 @@ where
                 Ok(Frequency {
                     span,
                     value: Number {
-                        span: swc_common::Span::new(
-                            span.lo,
-                            span.hi - BytePos(unit_len),
-                            Default::default(),
-                        ),
+                        span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
                         value,
                         raw: Some(raw_value),
                     },
                     unit: Ident {
-                        span: swc_common::Span::new(
-                            span.hi - BytePos(unit_len),
-                            span.hi,
-                            Default::default(),
-                        ),
+                        span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
                         value: unit,
                         raw: Some(raw_unit),
                     },
@@ -2472,20 +2440,12 @@ where
                 Ok(Resolution {
                     span,
                     value: Number {
-                        span: swc_common::Span::new(
-                            span.lo,
-                            span.hi - BytePos(unit_len),
-                            Default::default(),
-                        ),
+                        span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
                         value,
                         raw: Some(raw_value),
                     },
                     unit: Ident {
-                        span: swc_common::Span::new(
-                            span.hi - BytePos(unit_len),
-                            span.hi,
-                            Default::default(),
-                        ),
+                        span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
                         value: unit,
                         raw: Some(raw_unit),
                     },
@@ -2526,20 +2486,12 @@ where
                 Ok(Flex {
                     span,
                     value: Number {
-                        span: swc_common::Span::new(
-                            span.lo,
-                            span.hi - BytePos(unit_len),
-                            Default::default(),
-                        ),
+                        span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
                         value,
                         raw: Some(raw_value),
                     },
                     unit: Ident {
-                        span: swc_common::Span::new(
-                            span.hi - BytePos(unit_len),
-                            span.hi,
-                            Default::default(),
-                        ),
+                        span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
                         value: unit,
                         raw: Some(raw_unit),
                     },

--- a/crates/swc_css_parser/tests/fixture/at-rule/container/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/container/span.rust-debug
@@ -1748,7 +1748,7 @@
     :                                                ^^^^^^^^^^^^
     `----
 
-  x Ident { value: Atom('--responsive' type=dynamic), raw: Atom('--responsive' type=dynamic) }
+  x Ident { value: Atom('--responsive' type=dynamic), raw: "--responsive" }
     ,-[$DIR/tests/fixture/at-rule/container/input.css:42:1]
  42 | @container card (inline-size > 30em) and style(--responsive: true) {
     :                                                ^^^^^^^^^^^^
@@ -1784,7 +1784,7 @@
     :                                                              ^^^^
     `----
 
-  x Ident { value: Atom('true' type=static), raw: Atom('true' type=static) }
+  x Ident { value: Atom('true' type=static), raw: "true" }
     ,-[$DIR/tests/fixture/at-rule/container/input.css:42:1]
  42 | @container card (inline-size > 30em) and style(--responsive: true) {
     :                                                              ^^^^
@@ -2015,7 +2015,7 @@
     :                                               ^^^^^^^^^^^^
     `----
 
-  x Ident { value: Atom('--responsive' type=dynamic), raw: Atom('--responsive' type=dynamic) }
+  x Ident { value: Atom('--responsive' type=dynamic), raw: "--responsive" }
     ,-[$DIR/tests/fixture/at-rule/container/input.css:46:1]
  46 | @container card (inline-size > 30em) or style(--responsive: true) {
     :                                               ^^^^^^^^^^^^
@@ -2051,7 +2051,7 @@
     :                                                             ^^^^
     `----
 
-  x Ident { value: Atom('true' type=static), raw: Atom('true' type=static) }
+  x Ident { value: Atom('true' type=static), raw: "true" }
     ,-[$DIR/tests/fixture/at-rule/container/input.css:46:1]
  46 | @container card (inline-size > 30em) or style(--responsive: true) {
     :                                                             ^^^^
@@ -5696,7 +5696,7 @@
      :                       ^^^^^^^^^^^^
      `----
 
-  x Ident { value: Atom('--responsive' type=dynamic), raw: Atom('--responsive' type=dynamic) }
+  x Ident { value: Atom('--responsive' type=dynamic), raw: "--responsive" }
      ,-[$DIR/tests/fixture/at-rule/container/input.css:113:1]
  113 | @container test style(--responsive: true) {
      :                       ^^^^^^^^^^^^
@@ -5732,7 +5732,7 @@
      :                                     ^^^^
      `----
 
-  x Ident { value: Atom('true' type=static), raw: Atom('true' type=static) }
+  x Ident { value: Atom('true' type=static), raw: "true" }
      ,-[$DIR/tests/fixture/at-rule/container/input.css:113:1]
  113 | @container test style(--responsive: true) {
      :                                     ^^^^
@@ -5913,7 +5913,7 @@
      :                  ^^^^^^^^^^^^
      `----
 
-  x Ident { value: Atom('--responsive' type=dynamic), raw: Atom('--responsive' type=dynamic) }
+  x Ident { value: Atom('--responsive' type=dynamic), raw: "--responsive" }
      ,-[$DIR/tests/fixture/at-rule/container/input.css:119:1]
  119 | @container style(--responsive: true) {
      :                  ^^^^^^^^^^^^
@@ -5949,7 +5949,7 @@
      :                                ^^^^
      `----
 
-  x Ident { value: Atom('true' type=static), raw: Atom('true' type=static) }
+  x Ident { value: Atom('true' type=static), raw: "true" }
      ,-[$DIR/tests/fixture/at-rule/container/input.css:119:1]
  119 | @container style(--responsive: true) {
      :                                ^^^^
@@ -6226,7 +6226,7 @@
      :                  ^^^^^^^^^^^^
      `----
 
-  x Ident { value: Atom('--responsive' type=dynamic), raw: Atom('--responsive' type=dynamic) }
+  x Ident { value: Atom('--responsive' type=dynamic), raw: "--responsive" }
      ,-[$DIR/tests/fixture/at-rule/container/input.css:126:5]
  126 | @container style(--responsive: true) {
      :                  ^^^^^^^^^^^^
@@ -6262,7 +6262,7 @@
      :                                ^^^^
      `----
 
-  x Ident { value: Atom('true' type=static), raw: Atom('true' type=static) }
+  x Ident { value: Atom('true' type=static), raw: "true" }
      ,-[$DIR/tests/fixture/at-rule/container/input.css:126:5]
  126 | @container style(--responsive: true) {
      :                                ^^^^

--- a/crates/swc_css_parser/tests/fixture/at-rule/container/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/container/span.rust-debug
@@ -1772,7 +1772,7 @@
     :                                                             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/container/input.css:42:1]
  42 | @container card (inline-size > 30em) and style(--responsive: true) {
     :                                                             ^
@@ -2039,7 +2039,7 @@
     :                                                            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/container/input.css:46:1]
  46 | @container card (inline-size > 30em) or style(--responsive: true) {
     :                                                            ^
@@ -5720,7 +5720,7 @@
      :                                    ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/container/input.css:113:1]
  113 | @container test style(--responsive: true) {
      :                                    ^
@@ -5937,7 +5937,7 @@
      :                               ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/container/input.css:119:1]
  119 | @container style(--responsive: true) {
      :                               ^
@@ -6250,7 +6250,7 @@
      :                               ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/container/input.css:126:5]
  126 | @container style(--responsive: true) {
      :                               ^

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
@@ -16788,7 +16788,7 @@
      :                    ^^^^^
      `----
 
-  x String { value: Atom('bar' type=inline), raw: Atom('"bar"' type=inline) }
+  x String { value: Atom('bar' type=inline), raw: "\"bar\"" }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:144:1]
  144 | @media (height foo("bar")) {}
      :                    ^^^^^

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
@@ -16470,7 +16470,7 @@
      :               ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:142:1]
  142 | @media (height << 600px) {}
      :               ^
@@ -16506,7 +16506,7 @@
      :                  ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:142:1]
  142 | @media (height << 600px) {}
      :                  ^
@@ -16620,7 +16620,7 @@
      :               ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:143:1]
  143 | @media (height foo bar) {}
      :               ^
@@ -16644,7 +16644,7 @@
      :                   ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:143:1]
  143 | @media (height foo bar) {}
      :                   ^
@@ -16758,7 +16758,7 @@
      :               ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:144:1]
  144 | @media (height foo("bar")) {}
      :               ^
@@ -16890,7 +16890,7 @@
      :               ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:145:1]
  145 | @media (height + 600px) {}
      :               ^
@@ -16914,7 +16914,7 @@
      :                 ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:145:1]
  145 | @media (height + 600px) {}
      :                 ^
@@ -17058,7 +17058,7 @@
      :                              ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:146:1]
  146 | @media screen and (min-width: ) {}
      :                              ^
@@ -17172,7 +17172,7 @@
      :                      ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:147:1]
  147 | @media (aspect-ratio: 12/) {}
      :                      ^

--- a/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/media/span.rust-debug
@@ -16458,7 +16458,7 @@
      :         ^^^^^^
      `----
 
-  x Ident { value: Atom('height' type=inline), raw: Atom('height' type=inline) }
+  x Ident { value: Atom('height' type=inline), raw: "height" }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:142:1]
  142 | @media (height << 600px) {}
      :         ^^^^^^
@@ -16518,7 +16518,7 @@
      :                   ^^^^^
      `----
 
-  x Dimension { value: 600.0, raw_value: Atom('600' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 600.0, raw_value: "600", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:142:1]
  142 | @media (height << 600px) {}
      :                   ^^^^^
@@ -16608,7 +16608,7 @@
      :         ^^^^^^
      `----
 
-  x Ident { value: Atom('height' type=inline), raw: Atom('height' type=inline) }
+  x Ident { value: Atom('height' type=inline), raw: "height" }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:143:1]
  143 | @media (height foo bar) {}
      :         ^^^^^^
@@ -16632,7 +16632,7 @@
      :                ^^^
      `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:143:1]
  143 | @media (height foo bar) {}
      :                ^^^
@@ -16656,7 +16656,7 @@
      :                    ^^^
      `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:143:1]
  143 | @media (height foo bar) {}
      :                    ^^^
@@ -16746,7 +16746,7 @@
      :         ^^^^^^
      `----
 
-  x Ident { value: Atom('height' type=inline), raw: Atom('height' type=inline) }
+  x Ident { value: Atom('height' type=inline), raw: "height" }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:144:1]
  144 | @media (height foo("bar")) {}
      :         ^^^^^^
@@ -16878,7 +16878,7 @@
      :         ^^^^^^
      `----
 
-  x Ident { value: Atom('height' type=inline), raw: Atom('height' type=inline) }
+  x Ident { value: Atom('height' type=inline), raw: "height" }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:145:1]
  145 | @media (height + 600px) {}
      :         ^^^^^^
@@ -16926,7 +16926,7 @@
      :                  ^^^^^
      `----
 
-  x Dimension { value: 600.0, raw_value: Atom('600' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 600.0, raw_value: "600", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:145:1]
  145 | @media (height + 600px) {}
      :                  ^^^^^
@@ -17034,7 +17034,7 @@
      :                    ^^^^^^^^^
      `----
 
-  x Ident { value: Atom('min-width' type=dynamic), raw: Atom('min-width' type=dynamic) }
+  x Ident { value: Atom('min-width' type=dynamic), raw: "min-width" }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:146:1]
  146 | @media screen and (min-width: ) {}
      :                    ^^^^^^^^^
@@ -17148,7 +17148,7 @@
      :         ^^^^^^^^^^^^
      `----
 
-  x Ident { value: Atom('aspect-ratio' type=dynamic), raw: Atom('aspect-ratio' type=dynamic) }
+  x Ident { value: Atom('aspect-ratio' type=dynamic), raw: "aspect-ratio" }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:147:1]
  147 | @media (aspect-ratio: 12/) {}
      :         ^^^^^^^^^^^^
@@ -17184,7 +17184,7 @@
      :                       ^^
      `----
 
-  x Number { value: 12.0, raw: Atom('12' type=inline), type_flag: Integer }
+  x Number { value: 12.0, raw: "12", type_flag: Integer }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:147:1]
  147 | @media (aspect-ratio: 12/) {}
      :                       ^^
@@ -17286,7 +17286,7 @@
      :             ^^^^^
      `----
 
-  x Dimension { value: 100.0, raw_value: Atom('100' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 100.0, raw_value: "100", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:148:1]
  148 | @media func(100px) {}
      :             ^^^^^
@@ -17394,7 +17394,7 @@
      :                        ^^^^^
      `----
 
-  x Dimension { value: 100.0, raw_value: Atom('100' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 100.0, raw_value: "100", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
      ,-[$DIR/tests/fixture/at-rule/media/input.css:149:1]
  149 | @media screen and func(100px) {}
      :                        ^^^^^

--- a/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
@@ -5546,7 +5546,7 @@
     :            ^^^^^
     `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:65:1]
  65 | @supports (ident "str") {
     :            ^^^^^
@@ -5759,7 +5759,7 @@
     :             ^^^^^
     `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:69:1]
  69 | @supports ((ident "str")) {
     :             ^^^^^
@@ -5966,7 +5966,7 @@
     :                ^^
     `----
 
-  x Number { value: 10.0, raw: Atom('10' type=inline), type_flag: Integer }
+  x Number { value: 10.0, raw: "10", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:73:1]
  73 | @supports func(10, 20, 40) {
     :                ^^
@@ -6002,7 +6002,7 @@
     :                    ^^
     `----
 
-  x Number { value: 20.0, raw: Atom('20' type=inline), type_flag: Integer }
+  x Number { value: 20.0, raw: "20", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:73:1]
  73 | @supports func(10, 20, 40) {
     :                    ^^
@@ -6038,7 +6038,7 @@
     :                        ^^
     `----
 
-  x Number { value: 40.0, raw: Atom('40' type=inline), type_flag: Integer }
+  x Number { value: 40.0, raw: "40", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:73:1]
  73 | @supports func(10, 20, 40) {
     :                        ^^
@@ -6227,7 +6227,7 @@
     :                 ^^
     `----
 
-  x Number { value: 10.0, raw: Atom('10' type=inline), type_flag: Integer }
+  x Number { value: 10.0, raw: "10", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:77:1]
  77 | @supports (func(10, 20, 40)) {
     :                 ^^
@@ -6263,7 +6263,7 @@
     :                     ^^
     `----
 
-  x Number { value: 20.0, raw: Atom('20' type=inline), type_flag: Integer }
+  x Number { value: 20.0, raw: "20", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:77:1]
  77 | @supports (func(10, 20, 40)) {
     :                     ^^
@@ -6299,7 +6299,7 @@
     :                         ^^
     `----
 
-  x Number { value: 40.0, raw: Atom('40' type=inline), type_flag: Integer }
+  x Number { value: 40.0, raw: "40", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:77:1]
  77 | @supports (func(10, 20, 40)) {
     :                         ^^
@@ -6500,7 +6500,7 @@
     :                       ^^
     `----
 
-  x Number { value: 10.0, raw: Atom('10' type=inline), type_flag: Integer }
+  x Number { value: 10.0, raw: "10", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:81:1]
  81 | @supports (   func(   10   ,   20   ,   40   )  ) {
     :                       ^^
@@ -6548,7 +6548,7 @@
     :                                ^^
     `----
 
-  x Number { value: 20.0, raw: Atom('20' type=inline), type_flag: Integer }
+  x Number { value: 20.0, raw: "20", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:81:1]
  81 | @supports (   func(   10   ,   20   ,   40   )  ) {
     :                                ^^
@@ -6596,7 +6596,7 @@
     :                                         ^^
     `----
 
-  x Number { value: 40.0, raw: Atom('40' type=inline), type_flag: Integer }
+  x Number { value: 40.0, raw: "40", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:81:1]
  81 | @supports (   func(   10   ,   20   ,   40   )  ) {
     :                                         ^^
@@ -6909,7 +6909,7 @@
     :                   ^^^^
     `----
 
-  x Ident { value: Atom('anim' type=inline), raw: Atom('anim' type=inline) }
+  x Ident { value: Atom('anim' type=inline), raw: "anim" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:86:5]
  86 | @-custom-keyframe anim {
     :                   ^^^^
@@ -6963,7 +6963,7 @@
     : ^^^^
     `----
 
-  x Ident { value: Atom('from' type=static), raw: Atom('from' type=static) }
+  x Ident { value: Atom('from' type=static), raw: "from" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:87:9]
  87 | from {
     : ^^^^
@@ -7019,7 +7019,7 @@
     : ^^^^^
     `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:88:13]
  88 | color: black;
     : ^^^^^
@@ -7055,7 +7055,7 @@
     :        ^^^^^
     `----
 
-  x Ident { value: Atom('black' type=inline), raw: Atom('black' type=inline) }
+  x Ident { value: Atom('black' type=inline), raw: "black" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:88:13]
  88 | color: black;
     :        ^^^^^
@@ -7103,7 +7103,7 @@
     : ^^
     `----
 
-  x Ident { value: Atom('to' type=static), raw: Atom('to' type=static) }
+  x Ident { value: Atom('to' type=static), raw: "to" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:90:9]
  90 | to {
     : ^^
@@ -7159,7 +7159,7 @@
     : ^^^^^
     `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:91:13]
  91 | color: white
     : ^^^^^
@@ -7195,7 +7195,7 @@
     :        ^^^^^
     `----
 
-  x Ident { value: Atom('white' type=inline), raw: Atom('white' type=inline) }
+  x Ident { value: Atom('white' type=inline), raw: "white" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:91:13]
  91 | color: white
     :        ^^^^^
@@ -7287,7 +7287,7 @@
     :            ^^^^^
     `----
 
-  x Ident { value: Atom('--var' type=inline), raw: Atom('--var' type=inline) }
+  x Ident { value: Atom('--var' type=inline), raw: "--var" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:96:1]
  96 | @supports (--var) {
     :            ^^^^^
@@ -7486,7 +7486,7 @@
      :                   ^^^^^
      `----
 
-  x Ident { value: Atom('green' type=inline), raw: Atom('green' type=inline) }
+  x Ident { value: Atom('green' type=inline), raw: "green" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:100:1]
  100 | @supports (--foo: green) {
      :                   ^^^^^
@@ -8903,7 +8903,7 @@
      :                   ^^^^
      `----
 
-  x Ident { value: Atom('anim' type=inline), raw: Atom('anim' type=inline) }
+  x Ident { value: Atom('anim' type=inline), raw: "anim" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:123:5]
  123 | @-custom-keyframe anim {
      :                   ^^^^
@@ -8957,7 +8957,7 @@
      : ^^^^
      `----
 
-  x Ident { value: Atom('from' type=static), raw: Atom('from' type=static) }
+  x Ident { value: Atom('from' type=static), raw: "from" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:124:9]
  124 | from {
      : ^^^^
@@ -9013,7 +9013,7 @@
      : ^^^^^
      `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:125:13]
  125 | color: black;
      : ^^^^^
@@ -9049,7 +9049,7 @@
      :        ^^^^^
      `----
 
-  x Ident { value: Atom('black' type=inline), raw: Atom('black' type=inline) }
+  x Ident { value: Atom('black' type=inline), raw: "black" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:125:13]
  125 | color: black;
      :        ^^^^^
@@ -9097,7 +9097,7 @@
      : ^^
      `----
 
-  x Ident { value: Atom('to' type=static), raw: Atom('to' type=static) }
+  x Ident { value: Atom('to' type=static), raw: "to" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:127:9]
  127 | to {
      : ^^
@@ -9153,7 +9153,7 @@
      : ^^^^^
      `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:128:13]
  128 | color: white
      : ^^^^^
@@ -9189,7 +9189,7 @@
      :        ^^^^^
      `----
 
-  x Ident { value: Atom('white' type=inline), raw: Atom('white' type=inline) }
+  x Ident { value: Atom('white' type=inline), raw: "white" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:128:13]
  128 | color: white
      :        ^^^^^
@@ -9919,7 +9919,7 @@
      :                            ^
      `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:145:1]
  145 | @supports (func("example": 1)) {
      :                            ^
@@ -10102,7 +10102,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('--var' type=inline), raw: Atom('--var' type=inline) }
+  x Ident { value: Atom('--var' type=inline), raw: "--var" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:149:1]
  149 | @supports (--var) {
      :            ^^^^^
@@ -10664,7 +10664,7 @@
      :                               ^
      `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:159:1]
  159 | @supports (   func("example": 1)   ) {
      :                               ^
@@ -10859,7 +10859,7 @@
      :               ^^^^^
      `----
 
-  x Ident { value: Atom('--var' type=inline), raw: Atom('--var' type=inline) }
+  x Ident { value: Atom('--var' type=inline), raw: "--var" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:163:1]
  163 | @supports (   --var   ) {
      :               ^^^^^
@@ -11066,7 +11066,7 @@
      :               ^^^^^
      `----
 
-  x Ident { value: Atom('--var' type=inline), raw: Atom('--var' type=inline) }
+  x Ident { value: Atom('--var' type=inline), raw: "--var" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:167:1]
  167 | @supports (   --var   "test"   ) {
      :               ^^^^^

--- a/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
@@ -4937,7 +4937,7 @@
     :                      ^^^^^^^^^^^
     `----
 
-  x String { value: Atom('.minwidth' type=dynamic), raw: Atom('".minwidth"' type=dynamic) }
+  x String { value: Atom('.minwidth' type=dynamic), raw: "\".minwidth\"" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:51:1]
  51 | @supports (--element(".minwidth")) {
     :                      ^^^^^^^^^^^
@@ -5570,7 +5570,7 @@
     :                  ^^^^^
     `----
 
-  x String { value: Atom('str' type=inline), raw: Atom('"str"' type=inline) }
+  x String { value: Atom('str' type=inline), raw: "\"str\"" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:65:1]
  65 | @supports (ident "str") {
     :                  ^^^^^
@@ -5783,7 +5783,7 @@
     :                   ^^^^^
     `----
 
-  x String { value: Atom('str' type=inline), raw: Atom('"str"' type=inline) }
+  x String { value: Atom('str' type=inline), raw: "\"str\"" }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:69:1]
  69 | @supports ((ident "str")) {
     :                   ^^^^^
@@ -9883,7 +9883,7 @@
      :                 ^^^^^^^^^
      `----
 
-  x String { value: Atom('example' type=inline), raw: Atom('"example"' type=dynamic) }
+  x String { value: Atom('example' type=inline), raw: "\"example\"" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:145:1]
  145 | @supports (func("example": 1)) {
      :                 ^^^^^^^^^
@@ -10628,7 +10628,7 @@
      :                    ^^^^^^^^^
      `----
 
-  x String { value: Atom('example' type=inline), raw: Atom('"example"' type=dynamic) }
+  x String { value: Atom('example' type=inline), raw: "\"example\"" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:159:1]
  159 | @supports (   func("example": 1)   ) {
      :                    ^^^^^^^^^
@@ -11090,7 +11090,7 @@
      :                       ^^^^^^
      `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:167:1]
  167 | @supports (   --var   "test"   ) {
      :                       ^^^^^^

--- a/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/supports/span.rust-debug
@@ -5558,7 +5558,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:65:1]
  65 | @supports (ident "str") {
     :                 ^
@@ -5771,7 +5771,7 @@
     :                  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:69:1]
  69 | @supports ((ident "str")) {
     :                  ^
@@ -5990,7 +5990,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:73:1]
  73 | @supports func(10, 20, 40) {
     :                   ^
@@ -6026,7 +6026,7 @@
     :                       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:73:1]
  73 | @supports func(10, 20, 40) {
     :                       ^
@@ -6251,7 +6251,7 @@
     :                    ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:77:1]
  77 | @supports (func(10, 20, 40)) {
     :                    ^
@@ -6287,7 +6287,7 @@
     :                        ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:77:1]
  77 | @supports (func(10, 20, 40)) {
     :                        ^
@@ -6488,7 +6488,7 @@
     :                    ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:81:1]
  81 | @supports (   func(   10   ,   20   ,   40   )  ) {
     :                    ^^^
@@ -6512,7 +6512,7 @@
     :                         ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:81:1]
  81 | @supports (   func(   10   ,   20   ,   40   )  ) {
     :                         ^^^
@@ -6536,7 +6536,7 @@
     :                             ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:81:1]
  81 | @supports (   func(   10   ,   20   ,   40   )  ) {
     :                             ^^^
@@ -6560,7 +6560,7 @@
     :                                  ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:81:1]
  81 | @supports (   func(   10   ,   20   ,   40   )  ) {
     :                                  ^^^
@@ -6584,7 +6584,7 @@
     :                                      ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:81:1]
  81 | @supports (   func(   10   ,   20   ,   40   )  ) {
     :                                      ^^^
@@ -6608,7 +6608,7 @@
     :                                           ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:81:1]
  81 | @supports (   func(   10   ,   20   ,   40   )  ) {
     :                                           ^^^
@@ -6897,7 +6897,7 @@
     :                  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:86:5]
  86 | @-custom-keyframe anim {
     :                  ^
@@ -6921,7 +6921,7 @@
     :                       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:86:5]
  86 | @-custom-keyframe anim {
     :                       ^
@@ -6951,8 +6951,7 @@
  87 | `->         from {
     `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:86:5]
  86 | ,-> @-custom-keyframe anim {
  87 | `->         from {
@@ -6976,7 +6975,7 @@
     :     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:87:9]
  87 | from {
     :     ^
@@ -7008,8 +7007,7 @@
  88 | `->             color: black;
     `----
 
-  x WhiteSpace { value: Atom('
-  |             ' type=dynamic) }
+  x WhiteSpace { value: "\n            " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:87:9]
  87 | ,-> from {
  88 | `->             color: black;
@@ -7045,7 +7043,7 @@
     :       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:88:13]
  88 | color: black;
     :       ^
@@ -7081,8 +7079,7 @@
  89 | `->         }
     `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:88:13]
  88 | ,-> color: black;
  89 | `->         }
@@ -7094,8 +7091,7 @@
  90 | `->         to {
     `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:89:9]
  89 | ,-> }
  90 | `->         to {
@@ -7119,7 +7115,7 @@
     :   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:90:9]
  90 | to {
     :   ^
@@ -7151,8 +7147,7 @@
  91 | `->             color: white
     `----
 
-  x WhiteSpace { value: Atom('
-  |             ' type=dynamic) }
+  x WhiteSpace { value: "\n            " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:90:9]
  90 | ,-> to {
  91 | `->             color: white
@@ -7188,7 +7183,7 @@
     :       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:91:13]
  91 | color: white
     :       ^
@@ -7212,8 +7207,7 @@
  92 | `->         }
     `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:91:13]
  91 | ,-> color: white
  92 | `->         }
@@ -7225,8 +7219,7 @@
  93 | `->     }
     `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
     ,-[$DIR/tests/fixture/at-rule/supports/input.css:92:9]
  92 | ,-> }
  93 | `->     }
@@ -8898,7 +8891,7 @@
      :                  ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:123:5]
  123 | @-custom-keyframe anim {
      :                  ^
@@ -8922,7 +8915,7 @@
      :                       ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:123:5]
  123 | @-custom-keyframe anim {
      :                       ^
@@ -8952,8 +8945,7 @@
  124 | `->         from {
      `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:123:5]
  123 | ,-> @-custom-keyframe anim {
  124 | `->         from {
@@ -8977,7 +8969,7 @@
      :     ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:124:9]
  124 | from {
      :     ^
@@ -9009,8 +9001,7 @@
  125 | `->             color: black;
      `----
 
-  x WhiteSpace { value: Atom('
-  |             ' type=dynamic) }
+  x WhiteSpace { value: "\n            " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:124:9]
  124 | ,-> from {
  125 | `->             color: black;
@@ -9046,7 +9037,7 @@
      :       ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:125:13]
  125 | color: black;
      :       ^
@@ -9082,8 +9073,7 @@
  126 | `->         }
      `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:125:13]
  125 | ,-> color: black;
  126 | `->         }
@@ -9095,8 +9085,7 @@
  127 | `->         to {
      `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:126:9]
  126 | ,-> }
  127 | `->         to {
@@ -9120,7 +9109,7 @@
      :   ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:127:9]
  127 | to {
      :   ^
@@ -9152,8 +9141,7 @@
  128 | `->             color: white
      `----
 
-  x WhiteSpace { value: Atom('
-  |             ' type=dynamic) }
+  x WhiteSpace { value: "\n            " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:127:9]
  127 | ,-> to {
  128 | `->             color: white
@@ -9189,7 +9177,7 @@
      :       ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:128:13]
  128 | color: white
      :       ^
@@ -9213,8 +9201,7 @@
  129 | `->         }
      `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:128:13]
  128 | ,-> color: white
  129 | `->         }
@@ -9226,8 +9213,7 @@
  130 | `->     }
      `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:129:9]
  129 | ,-> }
  130 | `->     }
@@ -9921,7 +9907,7 @@
      :                           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:145:1]
  145 | @supports (func("example": 1)) {
      :                           ^
@@ -10666,7 +10652,7 @@
      :                              ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:159:1]
  159 | @supports (   func("example": 1)   ) {
      :                              ^
@@ -10861,7 +10847,7 @@
      :            ^^^
      `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:163:1]
  163 | @supports (   --var   ) {
      :            ^^^
@@ -10885,7 +10871,7 @@
      :                    ^^^
      `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:163:1]
  163 | @supports (   --var   ) {
      :                    ^^^
@@ -11068,7 +11054,7 @@
      :            ^^^
      `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:167:1]
  167 | @supports (   --var   "test"   ) {
      :            ^^^
@@ -11092,7 +11078,7 @@
      :                    ^^^
      `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:167:1]
  167 | @supports (   --var   "test"   ) {
      :                    ^^^
@@ -11116,7 +11102,7 @@
      :                             ^^^
      `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
      ,-[$DIR/tests/fixture/at-rule/supports/input.css:167:1]
  167 | @supports (   --var   "test"   ) {
      :                             ^^^

--- a/crates/swc_css_parser/tests/fixture/at-rule/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/unknown/span.rust-debug
@@ -122,7 +122,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:2:1]
  2 | @unknown x y;
    :         ^
@@ -146,7 +146,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:2:1]
  2 | @unknown x y;
    :           ^
@@ -194,7 +194,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:3:1]
  3 | @unknown "blah";
    :         ^
@@ -242,7 +242,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:4:1]
  4 | @unknown \"blah\";
    :         ^
@@ -290,7 +290,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:5:1]
  5 | @unknown /*test*/;
    :         ^
@@ -326,7 +326,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:6:1]
  6 | @unknown /*test*/x/*test*/ y;
    :         ^
@@ -350,7 +350,7 @@
    :                           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:6:1]
  6 | @unknown /*test*/x/*test*/ y;
    :                           ^
@@ -398,7 +398,7 @@
    :         ^^
    `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:7:1]
  7 | @unknown  ;
    :         ^^
@@ -434,7 +434,7 @@
    :         ^^
    `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:8:1]
  8 | @unknown  x  y;
    :         ^^
@@ -458,7 +458,7 @@
    :            ^^
    `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:8:1]
  8 | @unknown  x  y;
    :            ^^
@@ -506,7 +506,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:10:1]
  10 | @unknown {}
     :         ^
@@ -554,7 +554,7 @@
     :          ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:11:1]
  11 | @\unknown {}
     :          ^
@@ -602,7 +602,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:12:1]
  12 | @unknown a b {}
     :         ^
@@ -626,7 +626,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:12:1]
  12 | @unknown a b {}
     :           ^
@@ -650,7 +650,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:12:1]
  12 | @unknown a b {}
     :             ^
@@ -698,7 +698,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:13:1]
  13 | @unknown {p:v}
     :         ^
@@ -782,7 +782,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:14:1]
  14 | @unknown x y {p:v}
     :         ^
@@ -806,7 +806,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:14:1]
  14 | @unknown x y {p:v}
     :           ^
@@ -830,7 +830,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:14:1]
  14 | @unknown x y {p:v}
     :             ^
@@ -914,7 +914,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:15:1]
  15 | @unknown x, y x(1) {p:v}
     :         ^
@@ -950,7 +950,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:15:1]
  15 | @unknown x, y x(1) {p:v}
     :            ^
@@ -974,7 +974,7 @@
     :              ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:15:1]
  15 | @unknown x, y x(1) {p:v}
     :              ^
@@ -1016,7 +1016,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:15:1]
  15 | @unknown x, y x(1) {p:v}
     :                   ^
@@ -1100,7 +1100,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:16:1]
  16 | @unknown x, y x(1+2) {p:v}
     :         ^
@@ -1136,7 +1136,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:16:1]
  16 | @unknown x, y x(1+2) {p:v}
     :            ^
@@ -1160,7 +1160,7 @@
     :              ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:16:1]
  16 | @unknown x, y x(1+2) {p:v}
     :              ^
@@ -1214,7 +1214,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:16:1]
  16 | @unknown x, y x(1+2) {p:v}
     :                     ^
@@ -1370,7 +1370,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:18:1]
  18 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}
     :         ^
@@ -1394,7 +1394,7 @@
     :                           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:18:1]
  18 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}
     :                           ^
@@ -1490,7 +1490,7 @@
     :         ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:20:1]
  20 | @unknown  {  p  :  v  }
     :         ^^
@@ -1514,7 +1514,7 @@
     :            ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:20:1]
  20 | @unknown  {  p  :  v  }
     :            ^^
@@ -1538,7 +1538,7 @@
     :               ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:20:1]
  20 | @unknown  {  p  :  v  }
     :               ^^
@@ -1562,7 +1562,7 @@
     :                  ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:20:1]
  20 | @unknown  {  p  :  v  }
     :                  ^^
@@ -1586,7 +1586,7 @@
     :                     ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:20:1]
  20 | @unknown  {  p  :  v  }
     :                     ^^
@@ -1622,7 +1622,7 @@
     :         ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :         ^^
@@ -1646,7 +1646,7 @@
     :            ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :            ^^
@@ -1670,7 +1670,7 @@
     :               ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :               ^^
@@ -1694,7 +1694,7 @@
     :                  ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :                  ^^
@@ -1718,7 +1718,7 @@
     :                     ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :                     ^^
@@ -1742,7 +1742,7 @@
     :                        ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :                        ^^
@@ -1766,7 +1766,7 @@
     :                           ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :                           ^^
@@ -1802,7 +1802,7 @@
     :         ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :         ^^
@@ -1826,7 +1826,7 @@
     :            ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :            ^^
@@ -1850,7 +1850,7 @@
     :               ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :               ^^
@@ -1874,7 +1874,7 @@
     :                  ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                  ^^
@@ -1904,7 +1904,7 @@
     :                      ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                      ^^
@@ -1928,7 +1928,7 @@
     :                         ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                         ^^
@@ -1952,7 +1952,7 @@
     :                            ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                            ^^
@@ -1976,7 +1976,7 @@
     :                               ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                               ^^
@@ -1988,7 +1988,7 @@
     :                                  ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                                  ^^
@@ -2012,7 +2012,7 @@
     :                                     ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                                     ^^
@@ -2036,7 +2036,7 @@
     :                                        ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                                        ^^
@@ -2060,7 +2060,7 @@
     :                                           ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                                           ^^
@@ -2084,7 +2084,7 @@
     :                                              ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                                              ^^
@@ -2120,7 +2120,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:24:1]
  24 | @unknown {s{p:v}}
     :         ^
@@ -2234,7 +2234,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:25:1]
  25 | @unknown x y {s{p:v}}
     :         ^
@@ -2258,7 +2258,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:25:1]
  25 | @unknown x y {s{p:v}}
     :           ^
@@ -2282,7 +2282,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:25:1]
  25 | @unknown x y {s{p:v}}
     :             ^
@@ -2396,7 +2396,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:26:1]
  26 | @unknown x, y f(1) {s{p:v}}
     :         ^
@@ -2432,7 +2432,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:26:1]
  26 | @unknown x, y f(1) {s{p:v}}
     :            ^
@@ -2456,7 +2456,7 @@
     :              ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:26:1]
  26 | @unknown x, y f(1) {s{p:v}}
     :              ^
@@ -2498,7 +2498,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:26:1]
  26 | @unknown x, y f(1) {s{p:v}}
     :                   ^
@@ -2612,7 +2612,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :         ^
@@ -2648,7 +2648,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :            ^
@@ -2672,7 +2672,7 @@
     :              ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :              ^
@@ -2726,7 +2726,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :                     ^
@@ -2840,7 +2840,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :         ^
@@ -2864,7 +2864,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :           ^
@@ -2900,7 +2900,7 @@
     :              ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :              ^
@@ -2930,7 +2930,7 @@
     :                ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                ^
@@ -2966,7 +2966,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                   ^
@@ -3002,7 +3002,7 @@
     :                      ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                      ^
@@ -3014,7 +3014,7 @@
     :                        ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                        ^
@@ -3050,7 +3050,7 @@
     :                           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                           ^
@@ -3080,7 +3080,7 @@
     :                             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                             ^
@@ -3116,7 +3116,7 @@
     :                                ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                                ^
@@ -3140,7 +3140,7 @@
     :                                  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                                  ^
@@ -3152,7 +3152,7 @@
     :                                    ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                                    ^
@@ -3290,7 +3290,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:30:1]
  30 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/s/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}/*test*/}
     :         ^
@@ -3314,7 +3314,7 @@
     :                           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:30:1]
  30 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/s/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}/*test*/}
     :                           ^
@@ -3440,7 +3440,7 @@
     :         ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :         ^^
@@ -3464,7 +3464,7 @@
     :            ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :            ^^
@@ -3488,7 +3488,7 @@
     :               ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :               ^^
@@ -3518,7 +3518,7 @@
     :                  ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :                  ^^
@@ -3542,7 +3542,7 @@
     :                     ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :                     ^^
@@ -3566,7 +3566,7 @@
     :                        ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :                        ^^
@@ -3590,7 +3590,7 @@
     :                           ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :                           ^^
@@ -3602,7 +3602,7 @@
     :                              ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :                              ^^
@@ -3638,7 +3638,7 @@
     :         ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :         ^^
@@ -3662,7 +3662,7 @@
     :            ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :            ^^
@@ -3686,7 +3686,7 @@
     :               ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :               ^^
@@ -3710,7 +3710,7 @@
     :                  ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :                  ^^
@@ -3734,7 +3734,7 @@
     :                     ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :                     ^^
@@ -3764,7 +3764,7 @@
     :                        ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :                        ^^
@@ -3788,7 +3788,7 @@
     :                           ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :                           ^^
@@ -3812,7 +3812,7 @@
     :                              ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :                              ^^
@@ -3836,7 +3836,7 @@
     :                                 ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :                                 ^^
@@ -3848,7 +3848,7 @@
     :                                    ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :                                    ^^
@@ -3884,7 +3884,7 @@
     :         ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :         ^^
@@ -3908,7 +3908,7 @@
     :            ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :            ^^
@@ -3932,7 +3932,7 @@
     :               ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :               ^^
@@ -3956,7 +3956,7 @@
     :                  ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                  ^^
@@ -3986,7 +3986,7 @@
     :                      ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                      ^^
@@ -4010,7 +4010,7 @@
     :                         ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                         ^^
@@ -4022,7 +4022,7 @@
     :                            ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                            ^^
@@ -4046,7 +4046,7 @@
     :                               ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                               ^^
@@ -4070,7 +4070,7 @@
     :                                  ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                                  ^^
@@ -4100,7 +4100,7 @@
     :                                     ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                                     ^^
@@ -4124,7 +4124,7 @@
     :                                        ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                                        ^^
@@ -4148,7 +4148,7 @@
     :                                           ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                                           ^^
@@ -4172,7 +4172,7 @@
     :                                              ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                                              ^^
@@ -4184,7 +4184,7 @@
     :                                                 ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                                                 ^^
@@ -4220,7 +4220,7 @@
     :         ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :         ^^
@@ -4244,7 +4244,7 @@
     :            ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :            ^^
@@ -4268,7 +4268,7 @@
     :               ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :               ^^
@@ -4292,7 +4292,7 @@
     :                  ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                  ^^
@@ -4322,7 +4322,7 @@
     :                      ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                      ^^
@@ -4346,7 +4346,7 @@
     :                         ^^^^
     `----
 
-  x WhiteSpace { value: Atom('    ' type=inline) }
+  x WhiteSpace { value: "    " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                         ^^^^
@@ -4370,7 +4370,7 @@
     :                              ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                              ^^
@@ -4382,7 +4382,7 @@
     :                                 ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                 ^^
@@ -4406,7 +4406,7 @@
     :                                    ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                    ^^
@@ -4430,7 +4430,7 @@
     :                                       ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                       ^^
@@ -4460,7 +4460,7 @@
     :                                          ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                          ^^
@@ -4484,7 +4484,7 @@
     :                                             ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                             ^^
@@ -4508,7 +4508,7 @@
     :                                                ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                                ^^
@@ -4532,7 +4532,7 @@
     :                                                   ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                                   ^^
@@ -4544,7 +4544,7 @@
     :                                                      ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                                      ^^
@@ -4584,7 +4584,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:37:1]
  37 | @unknown {
     :         ^
@@ -4610,8 +4610,7 @@
  38 | `->     --> {}
     `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:37:1]
  37 | ,-> @unknown {
  38 | `->     --> {}
@@ -4635,7 +4634,7 @@
     :    ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:38:5]
  38 | --> {}
     :    ^
@@ -4665,8 +4664,7 @@
  39 | `->     <!-- {}
     `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:38:5]
  38 | ,-> --> {}
  39 | `->     <!-- {}
@@ -4690,7 +4688,7 @@
     :     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:39:5]
  39 | <!-- {}
     :     ^
@@ -4721,8 +4719,7 @@
  40 | }
     `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:39:5]
  39 | <!-- {}
     :        ^
@@ -4761,7 +4758,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:42:1]
  42 | @unknown {
     :         ^
@@ -4786,8 +4783,7 @@
  43 | `->     @unknown {s{p:v}}
     `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:42:1]
  42 | ,-> @unknown {
  43 | `->     @unknown {s{p:v}}
@@ -4811,7 +4807,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:43:5]
  43 | @unknown {s{p:v}}
     :         ^
@@ -4908,8 +4904,7 @@
  44 | }
     `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:43:5]
  43 | @unknown {s{p:v}}
     :                  ^
@@ -4952,7 +4947,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:46:1]
  46 | @unknown {
     :         ^
@@ -4979,8 +4974,7 @@
  47 | `->     @unknown {s{p:v}}
     `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:46:1]
  46 | ,-> @unknown {
  47 | `->     @unknown {s{p:v}}
@@ -5004,7 +4998,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:47:5]
  47 | @unknown {s{p:v}}
     :         ^
@@ -5101,9 +5095,7 @@
  49 | `->     color: red;
     `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  |     ' type=dynamic) }
+  x WhiteSpace { value: "\n    \n    " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:47:5]
  47 | ,-> @unknown {s{p:v}}
  48 | |       
@@ -5140,7 +5132,7 @@
     :       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:49:5]
  49 | color: red;
     :       ^
@@ -5177,8 +5169,7 @@
  50 | }
     `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:49:5]
  49 | color: red;
     :            ^
@@ -5332,7 +5323,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:53:5]
  53 | @unknown {s{p:v}}
     :         ^
@@ -5446,7 +5437,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:58:1]
  58 | @unknown x ( a , b ) ;
     :         ^
@@ -5470,7 +5461,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:58:1]
  58 | @unknown x ( a , b ) ;
     :           ^
@@ -5500,7 +5491,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:58:1]
  58 | @unknown x ( a , b ) ;
     :             ^
@@ -5524,7 +5515,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:58:1]
  58 | @unknown x ( a , b ) ;
     :               ^
@@ -5548,7 +5539,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:58:1]
  58 | @unknown x ( a , b ) ;
     :                 ^
@@ -5572,7 +5563,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:58:1]
  58 | @unknown x ( a , b ) ;
     :                   ^
@@ -5584,7 +5575,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:58:1]
  58 | @unknown x ( a , b ) ;
     :                     ^
@@ -5620,7 +5611,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :         ^
@@ -5644,7 +5635,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :           ^
@@ -5674,7 +5665,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :             ^
@@ -5698,7 +5689,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :               ^
@@ -5722,7 +5713,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :                 ^
@@ -5746,7 +5737,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :                   ^
@@ -5758,7 +5749,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :                     ^
@@ -5782,7 +5773,7 @@
     :                       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :                       ^
@@ -5818,7 +5809,7 @@
     :                            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :                            ^
@@ -5842,7 +5833,7 @@
     :                                ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :                                ^
@@ -5878,7 +5869,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :         ^
@@ -5908,7 +5899,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :            ^
@@ -5944,7 +5935,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :               ^
@@ -5968,7 +5959,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :                 ^
@@ -5980,7 +5971,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :                   ^
@@ -6004,7 +5995,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :                     ^
@@ -6040,7 +6031,7 @@
     :                          ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :                          ^
@@ -6064,7 +6055,7 @@
     :                              ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :                              ^
@@ -6100,7 +6091,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:61:1]
  61 | @unknown x ( a + b ) ;
     :         ^
@@ -6124,7 +6115,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:61:1]
  61 | @unknown x ( a + b ) ;
     :           ^
@@ -6154,7 +6145,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:61:1]
  61 | @unknown x ( a + b ) ;
     :             ^
@@ -6178,7 +6169,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:61:1]
  61 | @unknown x ( a + b ) ;
     :               ^
@@ -6202,7 +6193,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:61:1]
  61 | @unknown x ( a + b ) ;
     :                 ^
@@ -6226,7 +6217,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:61:1]
  61 | @unknown x ( a + b ) ;
     :                   ^
@@ -6238,7 +6229,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:61:1]
  61 | @unknown x ( a + b ) ;
     :                     ^
@@ -6274,7 +6265,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:62:1]
  62 | @unknown x ( a - b ) ;
     :         ^
@@ -6298,7 +6289,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:62:1]
  62 | @unknown x ( a - b ) ;
     :           ^
@@ -6328,7 +6319,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:62:1]
  62 | @unknown x ( a - b ) ;
     :             ^
@@ -6352,7 +6343,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:62:1]
  62 | @unknown x ( a - b ) ;
     :               ^
@@ -6376,7 +6367,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:62:1]
  62 | @unknown x ( a - b ) ;
     :                 ^
@@ -6400,7 +6391,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:62:1]
  62 | @unknown x ( a - b ) ;
     :                   ^
@@ -6412,7 +6403,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:62:1]
  62 | @unknown x ( a - b ) ;
     :                     ^
@@ -6448,7 +6439,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:63:1]
  63 | @unknown x ( a * b ) ;
     :         ^
@@ -6472,7 +6463,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:63:1]
  63 | @unknown x ( a * b ) ;
     :           ^
@@ -6502,7 +6493,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:63:1]
  63 | @unknown x ( a * b ) ;
     :             ^
@@ -6526,7 +6517,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:63:1]
  63 | @unknown x ( a * b ) ;
     :               ^
@@ -6550,7 +6541,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:63:1]
  63 | @unknown x ( a * b ) ;
     :                 ^
@@ -6574,7 +6565,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:63:1]
  63 | @unknown x ( a * b ) ;
     :                   ^
@@ -6586,7 +6577,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:63:1]
  63 | @unknown x ( a * b ) ;
     :                     ^
@@ -6622,7 +6613,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:64:1]
  64 | @unknown x ( a / b ) ;
     :         ^
@@ -6646,7 +6637,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:64:1]
  64 | @unknown x ( a / b ) ;
     :           ^
@@ -6676,7 +6667,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:64:1]
  64 | @unknown x ( a / b ) ;
     :             ^
@@ -6700,7 +6691,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:64:1]
  64 | @unknown x ( a / b ) ;
     :               ^
@@ -6724,7 +6715,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:64:1]
  64 | @unknown x ( a / b ) ;
     :                 ^
@@ -6748,7 +6739,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:64:1]
  64 | @unknown x ( a / b ) ;
     :                   ^
@@ -6760,7 +6751,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:64:1]
  64 | @unknown x ( a / b ) ;
     :                     ^

--- a/crates/swc_css_parser/tests/fixture/at-rule/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/unknown/span.rust-debug
@@ -134,7 +134,7 @@
    :          ^
    `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:2:1]
  2 | @unknown x y;
    :          ^
@@ -158,7 +158,7 @@
    :            ^
    `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:2:1]
  2 | @unknown x y;
    :            ^
@@ -254,7 +254,7 @@
    :          ^^^^^^^^
    `----
 
-  x Ident { value: Atom('"blah"' type=inline), raw: Atom('\"blah\"' type=dynamic) }
+  x Ident { value: Atom('"blah"' type=inline), raw: "\\\"blah\\\"" }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:4:1]
  4 | @unknown \"blah\";
    :          ^^^^^^^^
@@ -338,7 +338,7 @@
    :                  ^
    `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:6:1]
  6 | @unknown /*test*/x/*test*/ y;
    :                  ^
@@ -362,7 +362,7 @@
    :                            ^
    `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:6:1]
  6 | @unknown /*test*/x/*test*/ y;
    :                            ^
@@ -446,7 +446,7 @@
    :           ^
    `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:8:1]
  8 | @unknown  x  y;
    :           ^
@@ -470,7 +470,7 @@
    :              ^
    `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:8:1]
  8 | @unknown  x  y;
    :              ^
@@ -614,7 +614,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:12:1]
  12 | @unknown a b {}
     :          ^
@@ -638,7 +638,7 @@
     :            ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:12:1]
  12 | @unknown a b {}
     :            ^
@@ -722,7 +722,7 @@
     :           ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:13:1]
  13 | @unknown {p:v}
     :           ^
@@ -746,7 +746,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:13:1]
  13 | @unknown {p:v}
     :             ^
@@ -794,7 +794,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:14:1]
  14 | @unknown x y {p:v}
     :          ^
@@ -818,7 +818,7 @@
     :            ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:14:1]
  14 | @unknown x y {p:v}
     :            ^
@@ -854,7 +854,7 @@
     :               ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:14:1]
  14 | @unknown x y {p:v}
     :               ^
@@ -878,7 +878,7 @@
     :                 ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:14:1]
  14 | @unknown x y {p:v}
     :                 ^
@@ -926,7 +926,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:15:1]
  15 | @unknown x, y x(1) {p:v}
     :          ^
@@ -962,7 +962,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:15:1]
  15 | @unknown x, y x(1) {p:v}
     :             ^
@@ -1004,7 +1004,7 @@
     :                 ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:15:1]
  15 | @unknown x, y x(1) {p:v}
     :                 ^
@@ -1040,7 +1040,7 @@
     :                     ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:15:1]
  15 | @unknown x, y x(1) {p:v}
     :                     ^
@@ -1064,7 +1064,7 @@
     :                       ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:15:1]
  15 | @unknown x, y x(1) {p:v}
     :                       ^
@@ -1112,7 +1112,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:16:1]
  16 | @unknown x, y x(1+2) {p:v}
     :          ^
@@ -1148,7 +1148,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:16:1]
  16 | @unknown x, y x(1+2) {p:v}
     :             ^
@@ -1190,7 +1190,7 @@
     :                 ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:16:1]
  16 | @unknown x, y x(1+2) {p:v}
     :                 ^
@@ -1202,7 +1202,7 @@
     :                  ^^
     `----
 
-  x Number { value: 2.0, raw: Atom('+2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "+2", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:16:1]
  16 | @unknown x, y x(1+2) {p:v}
     :                  ^^
@@ -1238,7 +1238,7 @@
     :                       ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:16:1]
  16 | @unknown x, y x(1+2) {p:v}
     :                       ^
@@ -1262,7 +1262,7 @@
     :                         ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:16:1]
  16 | @unknown x, y x(1+2) {p:v}
     :                         ^
@@ -1310,7 +1310,7 @@
     :                          ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:17:1]
  17 | @unknown/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}
     :                          ^
@@ -1334,7 +1334,7 @@
     :                                            ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:17:1]
  17 | @unknown/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}
     :                                            ^
@@ -1382,7 +1382,7 @@
     :                  ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:18:1]
  18 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}
     :                  ^
@@ -1406,7 +1406,7 @@
     :                            ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:18:1]
  18 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}
     :                            ^
@@ -1430,7 +1430,7 @@
     :                                              ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:18:1]
  18 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}
     :                                              ^
@@ -1454,7 +1454,7 @@
     :                                                                ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:18:1]
  18 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}
     :                                                                ^
@@ -1526,7 +1526,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:20:1]
  20 | @unknown  {  p  :  v  }
     :              ^
@@ -1574,7 +1574,7 @@
     :                    ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:20:1]
  20 | @unknown  {  p  :  v  }
     :                    ^
@@ -1634,7 +1634,7 @@
     :           ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :           ^
@@ -1658,7 +1658,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :              ^
@@ -1706,7 +1706,7 @@
     :                    ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :                    ^
@@ -1754,7 +1754,7 @@
     :                          ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:21:1]
  21 | @unknown  x  y  {  p  :  v  }
     :                          ^
@@ -1814,7 +1814,7 @@
     :           ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :           ^
@@ -1862,7 +1862,7 @@
     :                 ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                 ^
@@ -1916,7 +1916,7 @@
     :                        ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                        ^
@@ -1964,7 +1964,7 @@
     :                              ^
     `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                              ^
@@ -2024,7 +2024,7 @@
     :                                       ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                                       ^
@@ -2072,7 +2072,7 @@
     :                                             ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:22:1]
  22 | @unknown  x  ,  y  x(  1  +  2  )  {  p  :  v  }
     :                                             ^
@@ -2144,7 +2144,7 @@
     :           ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:24:1]
  24 | @unknown {s{p:v}}
     :           ^
@@ -2174,7 +2174,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:24:1]
  24 | @unknown {s{p:v}}
     :             ^
@@ -2198,7 +2198,7 @@
     :               ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:24:1]
  24 | @unknown {s{p:v}}
     :               ^
@@ -2246,7 +2246,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:25:1]
  25 | @unknown x y {s{p:v}}
     :          ^
@@ -2270,7 +2270,7 @@
     :            ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:25:1]
  25 | @unknown x y {s{p:v}}
     :            ^
@@ -2306,7 +2306,7 @@
     :               ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:25:1]
  25 | @unknown x y {s{p:v}}
     :               ^
@@ -2336,7 +2336,7 @@
     :                 ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:25:1]
  25 | @unknown x y {s{p:v}}
     :                 ^
@@ -2360,7 +2360,7 @@
     :                   ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:25:1]
  25 | @unknown x y {s{p:v}}
     :                   ^
@@ -2408,7 +2408,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:26:1]
  26 | @unknown x, y f(1) {s{p:v}}
     :          ^
@@ -2444,7 +2444,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:26:1]
  26 | @unknown x, y f(1) {s{p:v}}
     :             ^
@@ -2486,7 +2486,7 @@
     :                 ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:26:1]
  26 | @unknown x, y f(1) {s{p:v}}
     :                 ^
@@ -2522,7 +2522,7 @@
     :                     ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:26:1]
  26 | @unknown x, y f(1) {s{p:v}}
     :                     ^
@@ -2552,7 +2552,7 @@
     :                       ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:26:1]
  26 | @unknown x, y f(1) {s{p:v}}
     :                       ^
@@ -2576,7 +2576,7 @@
     :                         ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:26:1]
  26 | @unknown x, y f(1) {s{p:v}}
     :                         ^
@@ -2624,7 +2624,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :          ^
@@ -2660,7 +2660,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :             ^
@@ -2702,7 +2702,7 @@
     :                 ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :                 ^
@@ -2714,7 +2714,7 @@
     :                  ^^
     `----
 
-  x Number { value: 2.0, raw: Atom('+2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "+2", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :                  ^^
@@ -2750,7 +2750,7 @@
     :                       ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :                       ^
@@ -2780,7 +2780,7 @@
     :                         ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :                         ^
@@ -2804,7 +2804,7 @@
     :                           ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:27:1]
  27 | @unknown x, y f(1+2) {s{p:v}}
     :                           ^
@@ -2888,7 +2888,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :             ^
@@ -2942,7 +2942,7 @@
     :                 ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                 ^
@@ -2978,7 +2978,7 @@
     :                    ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                    ^
@@ -3038,7 +3038,7 @@
     :                          ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                          ^
@@ -3092,7 +3092,7 @@
     :                              ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                              ^
@@ -3128,7 +3128,7 @@
     :                                 ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:28:1]
  28 | @unknown { .a { p: v; } .b { p: v } }
     :                                 ^
@@ -3200,7 +3200,7 @@
     :                          ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:29:1]
  29 | @unknown/*test*/{/*test*/s/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}/*test*/}
     :                          ^
@@ -3230,7 +3230,7 @@
     :                                            ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:29:1]
  29 | @unknown/*test*/{/*test*/s/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}/*test*/}
     :                                            ^
@@ -3254,7 +3254,7 @@
     :                                                              ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:29:1]
  29 | @unknown/*test*/{/*test*/s/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}/*test*/}
     :                                                              ^
@@ -3302,7 +3302,7 @@
     :                  ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:30:1]
  30 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/s/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}/*test*/}
     :                  ^
@@ -3326,7 +3326,7 @@
     :                            ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:30:1]
  30 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/s/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}/*test*/}
     :                            ^
@@ -3350,7 +3350,7 @@
     :                                              ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:30:1]
  30 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/s/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}/*test*/}
     :                                              ^
@@ -3380,7 +3380,7 @@
     :                                                                ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:30:1]
  30 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/s/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}/*test*/}
     :                                                                ^
@@ -3404,7 +3404,7 @@
     :                                                                                  ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:30:1]
  30 | @unknown /*test*/x/*test*/ y/*test*/{/*test*/s/*test*/{/*test*/p/*test*/:/*test*/v/*test*/}/*test*/}
     :                                                                                  ^
@@ -3476,7 +3476,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :              ^
@@ -3530,7 +3530,7 @@
     :                    ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :                    ^
@@ -3578,7 +3578,7 @@
     :                          ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:32:1]
  32 | @unknown  {  s  {  p  :  v  }  }
     :                          ^
@@ -3650,7 +3650,7 @@
     :           ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :           ^
@@ -3674,7 +3674,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :              ^
@@ -3722,7 +3722,7 @@
     :                    ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :                    ^
@@ -3776,7 +3776,7 @@
     :                          ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :                          ^
@@ -3824,7 +3824,7 @@
     :                                ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:33:1]
  33 | @unknown  x  y  {  s  {  p  :  v  }  }
     :                                ^
@@ -3896,7 +3896,7 @@
     :           ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :           ^
@@ -3944,7 +3944,7 @@
     :                 ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                 ^
@@ -3998,7 +3998,7 @@
     :                        ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                        ^
@@ -4058,7 +4058,7 @@
     :                                 ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                                 ^
@@ -4112,7 +4112,7 @@
     :                                       ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                                       ^
@@ -4160,7 +4160,7 @@
     :                                             ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:34:1]
  34 | @unknown  x  ,  y  f(  1  )  {  s  {  p  :  v  }  }
     :                                             ^
@@ -4232,7 +4232,7 @@
     :           ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :           ^
@@ -4280,7 +4280,7 @@
     :                 ^
     `----
 
-  x Ident { value: Atom('y' type=inline), raw: Atom('y' type=inline) }
+  x Ident { value: Atom('y' type=inline), raw: "y" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                 ^
@@ -4334,7 +4334,7 @@
     :                        ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                        ^
@@ -4358,7 +4358,7 @@
     :                             ^
     `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                             ^
@@ -4418,7 +4418,7 @@
     :                                      ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                      ^
@@ -4472,7 +4472,7 @@
     :                                            ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                            ^
@@ -4520,7 +4520,7 @@
     :                                                  ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:35:1]
  35 | @unknown  x  ,  y  f(  1    2  )  {  s  {  p  :  v  }  }
     :                                                  ^
@@ -4795,7 +4795,7 @@
     : ^^^^^^^^
     `----
 
-  x AtKeyword { value: Atom('unknown' type=static), raw: Atom('unknown' type=static) }
+  x AtKeyword { value: Atom('unknown' type=static), raw: "unknown" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:43:5]
  43 | @unknown {s{p:v}}
     : ^^^^^^^^
@@ -4837,7 +4837,7 @@
     :           ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:43:5]
  43 | @unknown {s{p:v}}
     :           ^
@@ -4867,7 +4867,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:43:5]
  43 | @unknown {s{p:v}}
     :             ^
@@ -4891,7 +4891,7 @@
     :               ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:43:5]
  43 | @unknown {s{p:v}}
     :               ^
@@ -4986,7 +4986,7 @@
     : ^^^^^^^^
     `----
 
-  x AtKeyword { value: Atom('unknown' type=static), raw: Atom('unknown' type=static) }
+  x AtKeyword { value: Atom('unknown' type=static), raw: "unknown" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:47:5]
  47 | @unknown {s{p:v}}
     : ^^^^^^^^
@@ -5028,7 +5028,7 @@
     :           ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:47:5]
  47 | @unknown {s{p:v}}
     :           ^
@@ -5058,7 +5058,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:47:5]
  47 | @unknown {s{p:v}}
     :             ^
@@ -5082,7 +5082,7 @@
     :               ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:47:5]
  47 | @unknown {s{p:v}}
     :               ^
@@ -5108,7 +5108,7 @@
     : ^^^^^
     `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:49:5]
  49 | color: red;
     : ^^^^^
@@ -5144,7 +5144,7 @@
     :        ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:49:5]
  49 | color: red;
     :        ^^^
@@ -5347,7 +5347,7 @@
     :           ^
     `----
 
-  x Ident { value: Atom('s' type=static), raw: Atom('s' type=static) }
+  x Ident { value: Atom('s' type=static), raw: "s" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:53:5]
  53 | @unknown {s{p:v}}
     :           ^
@@ -5377,7 +5377,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:53:5]
  53 | @unknown {s{p:v}}
     :             ^
@@ -5401,7 +5401,7 @@
     :               ^
     `----
 
-  x Ident { value: Atom('v' type=inline), raw: Atom('v' type=inline) }
+  x Ident { value: Atom('v' type=inline), raw: "v" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:53:5]
  53 | @unknown {s{p:v}}
     :               ^
@@ -5449,7 +5449,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:58:1]
  58 | @unknown x ( a , b ) ;
     :          ^
@@ -5503,7 +5503,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:58:1]
  58 | @unknown x ( a , b ) ;
     :              ^
@@ -5551,7 +5551,7 @@
     :                  ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:58:1]
  58 | @unknown x ( a , b ) ;
     :                  ^
@@ -5623,7 +5623,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :          ^
@@ -5677,7 +5677,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :              ^
@@ -5725,7 +5725,7 @@
     :                  ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :                  ^
@@ -5785,7 +5785,7 @@
     :                        ^^^
     `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :                        ^^^
@@ -5821,7 +5821,7 @@
     :                             ^^^
     `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:59:1]
  59 | @unknown x ( a , b ) { foo: bar }
     :                             ^^^
@@ -5911,7 +5911,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :             ^
@@ -5947,7 +5947,7 @@
     :                ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :                ^
@@ -6007,7 +6007,7 @@
     :                      ^^^
     `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :                      ^^^
@@ -6043,7 +6043,7 @@
     :                           ^^^
     `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:60:1]
  60 | @unknown x( a, b ) { foo: bar }
     :                           ^^^
@@ -6103,7 +6103,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:61:1]
  61 | @unknown x ( a + b ) ;
     :          ^
@@ -6157,7 +6157,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:61:1]
  61 | @unknown x ( a + b ) ;
     :              ^
@@ -6205,7 +6205,7 @@
     :                  ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:61:1]
  61 | @unknown x ( a + b ) ;
     :                  ^
@@ -6277,7 +6277,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:62:1]
  62 | @unknown x ( a - b ) ;
     :          ^
@@ -6331,7 +6331,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:62:1]
  62 | @unknown x ( a - b ) ;
     :              ^
@@ -6379,7 +6379,7 @@
     :                  ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:62:1]
  62 | @unknown x ( a - b ) ;
     :                  ^
@@ -6451,7 +6451,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:63:1]
  63 | @unknown x ( a * b ) ;
     :          ^
@@ -6505,7 +6505,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:63:1]
  63 | @unknown x ( a * b ) ;
     :              ^
@@ -6553,7 +6553,7 @@
     :                  ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:63:1]
  63 | @unknown x ( a * b ) ;
     :                  ^
@@ -6625,7 +6625,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:64:1]
  64 | @unknown x ( a / b ) ;
     :          ^
@@ -6679,7 +6679,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:64:1]
  64 | @unknown x ( a / b ) ;
     :              ^
@@ -6727,7 +6727,7 @@
     :                  ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/at-rule/unknown/input.css:64:1]
  64 | @unknown x ( a / b ) ;
     :                  ^

--- a/crates/swc_css_parser/tests/fixture/at-rule/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/at-rule/unknown/span.rust-debug
@@ -206,7 +206,7 @@
    :          ^^^^^^
    `----
 
-  x String { value: Atom('blah' type=inline), raw: Atom('"blah"' type=inline) }
+  x String { value: Atom('blah' type=inline), raw: "\"blah\"" }
    ,-[$DIR/tests/fixture/at-rule/unknown/input.css:3:1]
  3 | @unknown "blah";
    :          ^^^^^^

--- a/crates/swc_css_parser/tests/fixture/csstree/1/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/csstree/1/span.rust-debug
@@ -2455,7 +2455,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/csstree/1/input.css:27:9]
  27 | --custom1: { something !important };
     :             ^
@@ -2479,7 +2479,7 @@
     :                       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/csstree/1/input.css:27:9]
  27 | --custom1: { something !important };
     :                       ^
@@ -2515,7 +2515,7 @@
     :                                  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/csstree/1/input.css:27:9]
  27 | --custom1: { something !important };
     :                                  ^

--- a/crates/swc_css_parser/tests/fixture/csstree/1/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/csstree/1/span.rust-debug
@@ -2467,7 +2467,7 @@
     :              ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('something' type=dynamic), raw: Atom('something' type=dynamic) }
+  x Ident { value: Atom('something' type=dynamic), raw: "something" }
     ,-[$DIR/tests/fixture/csstree/1/input.css:27:9]
  27 | --custom1: { something !important };
     :              ^^^^^^^^^
@@ -2503,7 +2503,7 @@
     :                         ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('important' type=static), raw: Atom('important' type=static) }
+  x Ident { value: Atom('important' type=static), raw: "important" }
     ,-[$DIR/tests/fixture/csstree/1/input.css:27:9]
  27 | --custom1: { something !important };
     :                         ^^^^^^^^^

--- a/crates/swc_css_parser/tests/fixture/dashed-ident/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/dashed-ident/span.rust-debug
@@ -120,7 +120,7 @@
    :               ^^^^
    `----
 
-  x Hash { is_id: false, value: Atom('06c' type=inline), raw: Atom('06c' type=inline) }
+  x Hash { is_id: false, value: Atom('06c' type=inline), raw: "06c" }
    ,-[$DIR/tests/fixture/dashed-ident/input.css:2:5]
  2 | --main-color: #06c;
    :               ^^^^
@@ -162,7 +162,7 @@
    :                 ^^^^
    `----
 
-  x Hash { is_id: false, value: Atom('006' type=inline), raw: Atom('006' type=inline) }
+  x Hash { is_id: false, value: Atom('006' type=inline), raw: "006" }
    ,-[$DIR/tests/fixture/dashed-ident/input.css:3:5]
  3 | --accent-color: #006;
    :                 ^^^^

--- a/crates/swc_css_parser/tests/fixture/dashed-ident/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/dashed-ident/span.rust-debug
@@ -267,7 +267,7 @@
    :             ^^^^
    `----
 
-  x Ident { value: Atom('blue' type=inline), raw: Atom('blue' type=inline) }
+  x Ident { value: Atom('blue' type=inline), raw: "blue" }
    ,-[$DIR/tests/fixture/dashed-ident/input.css:7:5]
  7 | --fg-color: blue;
    :             ^^^^

--- a/crates/swc_css_parser/tests/fixture/dashed-ident/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/dashed-ident/span.rust-debug
@@ -462,7 +462,7 @@
     :          ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/dashed-ident/input.css:14:1]
  14 | @--custom {}
     :          ^
@@ -510,7 +510,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/dashed-ident/input.css:15:1]
  15 | @--library1-custom {}
     :                   ^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/6s_VBuRPHbPiUrh1fWCR_Q/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/6s_VBuRPHbPiUrh1fWCR_Q/span.rust-debug
@@ -59,7 +59,7 @@
    :         ^^^^^^
    `----
 
-  x Ident { value: Atom('cl,ss' type=inline), raw: Atom('cl\,ss' type=inline) }
+  x Ident { value: Atom('cl,ss' type=inline), raw: "cl\\,ss" }
    ,-[$DIR/tests/fixture/esbuild/misc/6s_VBuRPHbPiUrh1fWCR_Q/input.css:1:1]
  1 | :pseudo(cl\,ss) {}
    :         ^^^^^^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/span.rust-debug
@@ -69,7 +69,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:2:1]
  2 | a: b;
    : ^
@@ -105,7 +105,7 @@
    :    ^
    `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
    ,-[$DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:2:1]
  2 | a: b;
    :    ^
@@ -143,7 +143,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('c' type=inline), raw: Atom('c' type=inline) }
+  x Ident { value: Atom('c' type=inline), raw: "c" }
    ,-[$DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:3:1]
  3 | c: d;
    : ^
@@ -179,7 +179,7 @@
    :    ^
    `----
 
-  x Ident { value: Atom('d' type=inline), raw: Atom('d' type=inline) }
+  x Ident { value: Atom('d' type=inline), raw: "d" }
    ,-[$DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:3:1]
  3 | c: d;
    :    ^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/span.rust-debug
@@ -56,8 +56,7 @@
  2 | a: b;
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:1:1]
  1 | @unknown{
    :          ^
@@ -94,7 +93,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:2:1]
  2 | a: b;
    :   ^
@@ -131,8 +130,7 @@
  3 | c: d;
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:2:1]
  2 | a: b;
    :      ^
@@ -169,7 +167,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:3:1]
  3 | c: d;
    :   ^
@@ -206,8 +204,7 @@
  4 | }
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/fixture/esbuild/misc/L0mEf41IMkWcP7NotllkAg/input.css:3:1]
  3 | c: d;
    :      ^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/MvD7ThpMVIxU3dzF71Gpcg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/MvD7ThpMVIxU3dzF71Gpcg/span.rust-debug
@@ -59,7 +59,7 @@
    :     ^
    `----
 
-  x Ident { value: Atom('c' type=inline), raw: Atom('c' type=inline) }
+  x Ident { value: Atom('c' type=inline), raw: "c" }
    ,-[$DIR/tests/fixture/esbuild/misc/MvD7ThpMVIxU3dzF71Gpcg/input.css:1:1]
  1 | ::b(c) {}
    :     ^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/SnMCumHJazvlgOXgmxJ9Jg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/SnMCumHJazvlgOXgmxJ9Jg/span.rust-debug
@@ -35,7 +35,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/esbuild/misc/SnMCumHJazvlgOXgmxJ9Jg/input.css:1:1]
  1 | @unknown x;
    :         ^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/SnMCumHJazvlgOXgmxJ9Jg/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/SnMCumHJazvlgOXgmxJ9Jg/span.rust-debug
@@ -47,7 +47,7 @@
    :          ^
    `----
 
-  x Ident { value: Atom('x' type=static), raw: Atom('x' type=static) }
+  x Ident { value: Atom('x' type=static), raw: "x" }
    ,-[$DIR/tests/fixture/esbuild/misc/SnMCumHJazvlgOXgmxJ9Jg/input.css:1:1]
  1 | @unknown x;
    :          ^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/WQWdwW4B4hm60AQgxTU08Q/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/WQWdwW4B4hm60AQgxTU08Q/span.rust-debug
@@ -83,7 +83,7 @@
    :      ^
    `----
 
-  x Ident { value: Atom('c' type=inline), raw: Atom('c' type=inline) }
+  x Ident { value: Atom('c' type=inline), raw: "c" }
    ,-[$DIR/tests/fixture/esbuild/misc/WQWdwW4B4hm60AQgxTU08Q/input.css:1:1]
  1 | a::b(c) {}
    :      ^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/_d22bZcPKDgNEKSyJ2NRsQ/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/_d22bZcPKDgNEKSyJ2NRsQ/span.rust-debug
@@ -71,7 +71,7 @@
    :      ^
    `----
 
-  x Ident { value: Atom('c' type=inline), raw: Atom('c' type=inline) }
+  x Ident { value: Atom('c' type=inline), raw: "c" }
    ,-[$DIR/tests/fixture/esbuild/misc/_d22bZcPKDgNEKSyJ2NRsQ/input.css:1:1]
  1 | *::b(c) {}
    :      ^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/_e6qpZBWfowEh1P3Wn3orA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/_e6qpZBWfowEh1P3Wn3orA/span.rust-debug
@@ -59,7 +59,7 @@
    :         ^^^^^^^
    `----
 
-  x Ident { value: Atom('class' type=static), raw: Atom('cl\61ss' type=inline) }
+  x Ident { value: Atom('class' type=static), raw: "cl\\61ss" }
    ,-[$DIR/tests/fixture/esbuild/misc/_e6qpZBWfowEh1P3Wn3orA/input.css:1:1]
  1 | :pseudo(cl\61ss) {}
    :         ^^^^^^^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/d1BWbOHfSbCE8-_qEz-luA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/d1BWbOHfSbCE8-_qEz-luA/span.rust-debug
@@ -95,7 +95,7 @@
    :      ^
    `----
 
-  x Ident { value: Atom('c' type=inline), raw: Atom('c' type=inline) }
+  x Ident { value: Atom('c' type=inline), raw: "c" }
    ,-[$DIR/tests/fixture/esbuild/misc/d1BWbOHfSbCE8-_qEz-luA/input.css:1:1]
  1 | a:b(:c) {}
    :      ^

--- a/crates/swc_css_parser/tests/fixture/esbuild/misc/pLQn9swtbpZ-CVZMGw0EwA/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/esbuild/misc/pLQn9swtbpZ-CVZMGw0EwA/span.rust-debug
@@ -59,7 +59,7 @@
    :         ^^^^^^^
    `----
 
-  x Ident { value: Atom('cl,ss' type=inline), raw: Atom('cl\2css' type=inline) }
+  x Ident { value: Atom('cl,ss' type=inline), raw: "cl\\2css" }
    ,-[$DIR/tests/fixture/esbuild/misc/pLQn9swtbpZ-CVZMGw0EwA/input.css:1:1]
  1 | :pseudo(cl\2css) {}
    :         ^^^^^^^

--- a/crates/swc_css_parser/tests/fixture/function/calc/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/function/calc/span.rust-debug
@@ -560,7 +560,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/function/calc/input.css:6:5]
  6 | --width: calc(10% + 30px);
    :                  ^
@@ -584,7 +584,7 @@
    :                    ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/function/calc/input.css:6:5]
  6 | --width: calc(10% + 30px);
    :                    ^

--- a/crates/swc_css_parser/tests/fixture/function/calc/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/function/calc/span.rust-debug
@@ -548,7 +548,7 @@
    :               ^^^
    `----
 
-  x Percentage { value: 10.0, raw: Atom('10' type=inline) }
+  x Percentage { value: 10.0, raw: "10" }
    ,-[$DIR/tests/fixture/function/calc/input.css:6:5]
  6 | --width: calc(10% + 30px);
    :               ^^^
@@ -596,7 +596,7 @@
    :                     ^^^^
    `----
 
-  x Dimension { value: 30.0, raw_value: Atom('30' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 30.0, raw_value: "30", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/fixture/function/calc/input.css:6:5]
  6 | --width: calc(10% + 30px);
    :                     ^^^^

--- a/crates/swc_css_parser/tests/fixture/rome/custom-properties/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/custom-properties/span.rust-debug
@@ -653,7 +653,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/rome/custom-properties/input.css:12:5]
  12 | --parentheses: ( );
     :                 ^
@@ -713,7 +713,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/rome/custom-properties/input.css:13:5]
  13 | --braces: { };
     :            ^
@@ -773,7 +773,7 @@
     :              ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/rome/custom-properties/input.css:14:5]
  14 | --brackets: [ ];
     :              ^
@@ -911,7 +911,7 @@
     :                                    ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/rome/custom-properties/input.css:17:5]
  17 | --at-keyword-unknown-block: @foobar {};
     :                                    ^
@@ -983,7 +983,7 @@
     :                                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/rome/custom-properties/input.css:18:5]
  18 | --at-keyword-known-block: @media {};
     :                                 ^

--- a/crates/swc_css_parser/tests/fixture/rome/custom-properties/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/custom-properties/span.rust-debug
@@ -311,7 +311,7 @@
    :         ^^^^
    `----
 
-  x Number { value: 1987.0, raw: Atom('1987' type=inline), type_flag: Integer }
+  x Number { value: 1987.0, raw: "1987", type_flag: Integer }
    ,-[$DIR/tests/fixture/rome/custom-properties/input.css:5:5]
  5 | --test: 1987;
    :         ^^^^
@@ -353,7 +353,7 @@
    :               ^^^
    `----
 
-  x Percentage { value: 25.0, raw: Atom('25' type=inline) }
+  x Percentage { value: 25.0, raw: "25" }
    ,-[$DIR/tests/fixture/rome/custom-properties/input.css:6:5]
  6 | --percentage: 25%;
    :               ^^^
@@ -395,7 +395,7 @@
    :           ^^
    `----
 
-  x Number { value: 37.0, raw: Atom('37' type=inline), type_flag: Integer }
+  x Number { value: 37.0, raw: "37", type_flag: Integer }
    ,-[$DIR/tests/fixture/rome/custom-properties/input.css:7:5]
  7 | --number: 37;
    :           ^^
@@ -437,7 +437,7 @@
    :           ^^^^
    `----
 
-  x Dimension { value: 12.0, raw_value: Atom('12' type=inline), unit: Atom('em' type=static), raw_unit: Atom('em' type=static), type_flag: Integer }
+  x Dimension { value: 12.0, raw_value: "12", unit: Atom('em' type=static), raw_unit: "em", type_flag: Integer }
    ,-[$DIR/tests/fixture/rome/custom-properties/input.css:8:5]
  8 | --length: 12em;
    :           ^^^^
@@ -479,7 +479,7 @@
    :         ^^^^
    `----
 
-  x Dimension { value: 75.0, raw_value: Atom('75' type=inline), unit: Atom('ms' type=static), raw_unit: Atom('ms' type=static), type_flag: Integer }
+  x Dimension { value: 75.0, raw_value: "75", unit: Atom('ms' type=static), raw_unit: "ms", type_flag: Integer }
    ,-[$DIR/tests/fixture/rome/custom-properties/input.css:9:5]
  9 | --time: 75ms;
    :         ^^^^
@@ -815,7 +815,7 @@
     :                       ^^^^^^^
     `----
 
-  x AtKeyword { value: Atom('foobar' type=inline), raw: Atom('foobar' type=inline) }
+  x AtKeyword { value: Atom('foobar' type=inline), raw: "foobar" }
     ,-[$DIR/tests/fixture/rome/custom-properties/input.css:15:5]
  15 | --at-keyword-unknown: @foobar;
     :                       ^^^^^^^
@@ -857,7 +857,7 @@
     :                     ^^^^^^
     `----
 
-  x AtKeyword { value: Atom('media' type=static), raw: Atom('media' type=static) }
+  x AtKeyword { value: Atom('media' type=static), raw: "media" }
     ,-[$DIR/tests/fixture/rome/custom-properties/input.css:16:5]
  16 | --at-keyword-known: @media;
     :                     ^^^^^^
@@ -899,7 +899,7 @@
     :                             ^^^^^^^
     `----
 
-  x AtKeyword { value: Atom('foobar' type=inline), raw: Atom('foobar' type=inline) }
+  x AtKeyword { value: Atom('foobar' type=inline), raw: "foobar" }
     ,-[$DIR/tests/fixture/rome/custom-properties/input.css:17:5]
  17 | --at-keyword-unknown-block: @foobar {};
     :                             ^^^^^^^
@@ -971,7 +971,7 @@
     :                           ^^^^^^
     `----
 
-  x AtKeyword { value: Atom('media' type=static), raw: Atom('media' type=static) }
+  x AtKeyword { value: Atom('media' type=static), raw: "media" }
     ,-[$DIR/tests/fixture/rome/custom-properties/input.css:18:5]
  18 | --at-keyword-known-block: @media {};
     :                           ^^^^^^

--- a/crates/swc_css_parser/tests/fixture/rome/custom-properties/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/custom-properties/span.rust-debug
@@ -185,7 +185,7 @@
    :        ^^^^^
    `----
 
-  x String { value: Atom('bar' type=inline), raw: Atom(''bar'' type=inline) }
+  x String { value: Atom('bar' type=inline), raw: "'bar'" }
    ,-[$DIR/tests/fixture/rome/custom-properties/input.css:2:5]
  2 | --foo: 'bar';
    :        ^^^^^
@@ -227,7 +227,7 @@
    :               ^^^^^
    `----
 
-  x String { value: Atom('foo' type=inline), raw: Atom('"foo"' type=inline) }
+  x String { value: Atom('foo' type=inline), raw: "\"foo\"" }
    ,-[$DIR/tests/fixture/rome/custom-properties/input.css:3:5]
  3 | --lore-ipsum: "foo";
    :               ^^^^^
@@ -269,7 +269,7 @@
    :          ^^^^^^^
    `----
 
-  x String { value: Atom('abort' type=inline), raw: Atom('"abort"' type=inline) }
+  x String { value: Atom('abort' type=inline), raw: "\"abort\"" }
    ,-[$DIR/tests/fixture/rome/custom-properties/input.css:4:5]
  4 | --FANCY: "abort";
    :          ^^^^^^^

--- a/crates/swc_css_parser/tests/fixture/rome/functions/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/functions/span.rust-debug
@@ -125,7 +125,7 @@
    :          ^^^
    `----
 
-  x Dimension { value: 2.0, raw_value: Atom('2' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 2.0, raw_value: "2", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/fixture/rome/functions/input.css:2:5]
  2 | --fancy: 2px;
    :          ^^^

--- a/crates/swc_css_parser/tests/fixture/rome/selectors/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/selectors/span.rust-debug
@@ -1431,7 +1431,7 @@
     :               ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/rome/selectors/input.css:38:1]
  38 | ::pseudo-elem(a, b) {
     :               ^
@@ -1467,7 +1467,7 @@
     :                  ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/rome/selectors/input.css:38:1]
  38 | ::pseudo-elem(a, b) {
     :                  ^

--- a/crates/swc_css_parser/tests/fixture/rome/selectors/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/rome/selectors/span.rust-debug
@@ -1455,7 +1455,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/rome/selectors/input.css:38:1]
  38 | ::pseudo-elem(a, b) {
     :                 ^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/has/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/has/span.rust-debug
@@ -2175,7 +2175,7 @@
     :           ^^^
     `----
 
-  x Ident { value: Atom('img' type=static), raw: Atom('img' type=static) }
+  x Ident { value: Atom('img' type=static), raw: "img" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:13:1]
  13 | a:has(<>  img, > img) {}
     :           ^^^
@@ -2379,7 +2379,7 @@
     :              ^^^
     `----
 
-  x Ident { value: Atom('img' type=static), raw: Atom('img' type=static) }
+  x Ident { value: Atom('img' type=static), raw: "img" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:14:1]
  14 | a:has(   <>  img, > img) {}
     :              ^^^
@@ -2631,7 +2631,7 @@
     :                  ^^^
     `----
 
-  x Ident { value: Atom('img' type=static), raw: Atom('img' type=static) }
+  x Ident { value: Atom('img' type=static), raw: "img" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:15:1]
  15 | a:has(> img, <>  img) {}
     :                  ^^^
@@ -2835,7 +2835,7 @@
     :                  ^^^
     `----
 
-  x Ident { value: Atom('img' type=static), raw: Atom('img' type=static) }
+  x Ident { value: Atom('img' type=static), raw: "img" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:16:1]
  16 | a:has(> img, <>  img   ) {}
     :                  ^^^
@@ -3051,7 +3051,7 @@
     :                     ^^^
     `----
 
-  x Ident { value: Atom('img' type=static), raw: Atom('img' type=static) }
+  x Ident { value: Atom('img' type=static), raw: "img" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:18:1]
  18 | a:has(> img,    <>  img   , > img) {}
     :                     ^^^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/has/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/has/span.rust-debug
@@ -2163,7 +2163,7 @@
     :         ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:13:1]
  13 | a:has(<>  img, > img) {}
     :         ^^
@@ -2331,7 +2331,7 @@
     :       ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:14:1]
  14 | a:has(   <>  img, > img) {}
     :       ^^^
@@ -2367,7 +2367,7 @@
     :            ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:14:1]
  14 | a:has(   <>  img, > img) {}
     :            ^^
@@ -2583,7 +2583,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:15:1]
  15 | a:has(> img, <>  img) {}
     :             ^
@@ -2619,7 +2619,7 @@
     :                ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:15:1]
  15 | a:has(> img, <>  img) {}
     :                ^^
@@ -2787,7 +2787,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:16:1]
  16 | a:has(> img, <>  img   ) {}
     :             ^
@@ -2823,7 +2823,7 @@
     :                ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:16:1]
  16 | a:has(> img, <>  img   ) {}
     :                ^^
@@ -2847,7 +2847,7 @@
     :                     ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:16:1]
  16 | a:has(> img, <>  img   ) {}
     :                     ^^^
@@ -3003,7 +3003,7 @@
     :             ^^^^
     `----
 
-  x WhiteSpace { value: Atom('    ' type=inline) }
+  x WhiteSpace { value: "    " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:18:1]
  18 | a:has(> img,    <>  img   , > img) {}
     :             ^^^^
@@ -3039,7 +3039,7 @@
     :                   ^^
     `----
 
-  x WhiteSpace { value: Atom('  ' type=inline) }
+  x WhiteSpace { value: "  " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:18:1]
  18 | a:has(> img,    <>  img   , > img) {}
     :                   ^^
@@ -3063,7 +3063,7 @@
     :                        ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/has/input.css:18:1]
  18 | a:has(> img,    <>  img   , > img) {}
     :                        ^^^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/is/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/is/span.rust-debug
@@ -4052,7 +4052,7 @@
     :      ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:25:1]
  25 | :is(a >< b, a > b, d > c) {}
     :      ^
@@ -4088,7 +4088,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:25:1]
  25 | :is(a >< b, a > b, d > c) {}
     :         ^
@@ -4328,7 +4328,7 @@
     :     ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:26:1]
  26 | :is(   a >< b, a > b, d > c) {}
     :     ^^^
@@ -4352,7 +4352,7 @@
     :         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:26:1]
  26 | :is(   a >< b, a > b, d > c) {}
     :         ^
@@ -4388,7 +4388,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:26:1]
  26 | :is(   a >< b, a > b, d > c) {}
     :            ^
@@ -4772,7 +4772,7 @@
     :                  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:27:1]
  27 | :is(a > b, d > c, a >< b) {}
     :                  ^
@@ -4796,7 +4796,7 @@
     :                    ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:27:1]
  27 | :is(a > b, d > c, a >< b) {}
     :                    ^
@@ -4832,7 +4832,7 @@
     :                       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:27:1]
  27 | :is(a > b, d > c, a >< b) {}
     :                       ^
@@ -5072,7 +5072,7 @@
     :                  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:28:1]
  28 | :is(a > b, d > c, a >< b   ) {}
     :                  ^
@@ -5096,7 +5096,7 @@
     :                    ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:28:1]
  28 | :is(a > b, d > c, a >< b   ) {}
     :                    ^
@@ -5132,7 +5132,7 @@
     :                       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:28:1]
  28 | :is(a > b, d > c, a >< b   ) {}
     :                       ^
@@ -5156,7 +5156,7 @@
     :                         ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:28:1]
  28 | :is(a > b, d > c, a >< b   ) {}
     :                         ^^^
@@ -5312,7 +5312,7 @@
     :           ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:29:1]
  29 | :is(a > b,   a >< b   ,  d > c) {}
     :           ^^^
@@ -5336,7 +5336,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:29:1]
  29 | :is(a > b,   a >< b   ,  d > c) {}
     :               ^
@@ -5372,7 +5372,7 @@
     :                  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:29:1]
  29 | :is(a > b,   a >< b   ,  d > c) {}
     :                  ^
@@ -5396,7 +5396,7 @@
     :                    ^^^
     `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:29:1]
  29 | :is(a > b,   a >< b   ,  d > c) {}
     :                    ^^^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/is/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/is/span.rust-debug
@@ -4040,7 +4040,7 @@
     :     ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:25:1]
  25 | :is(a >< b, a > b, d > c) {}
     :     ^
@@ -4100,7 +4100,7 @@
     :          ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:25:1]
  25 | :is(a >< b, a > b, d > c) {}
     :          ^
@@ -4340,7 +4340,7 @@
     :        ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:26:1]
  26 | :is(   a >< b, a > b, d > c) {}
     :        ^
@@ -4400,7 +4400,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:26:1]
  26 | :is(   a >< b, a > b, d > c) {}
     :             ^
@@ -4784,7 +4784,7 @@
     :                   ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:27:1]
  27 | :is(a > b, d > c, a >< b) {}
     :                   ^
@@ -4844,7 +4844,7 @@
     :                        ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:27:1]
  27 | :is(a > b, d > c, a >< b) {}
     :                        ^
@@ -5084,7 +5084,7 @@
     :                   ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:28:1]
  28 | :is(a > b, d > c, a >< b   ) {}
     :                   ^
@@ -5144,7 +5144,7 @@
     :                        ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:28:1]
  28 | :is(a > b, d > c, a >< b   ) {}
     :                        ^
@@ -5324,7 +5324,7 @@
     :              ^
     `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:29:1]
  29 | :is(a > b,   a >< b   ,  d > c) {}
     :              ^
@@ -5384,7 +5384,7 @@
     :                   ^
     `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/is/input.css:29:1]
  29 | :is(a > b,   a >< b   ,  d > c) {}
     :                   ^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/span.rust-debug
@@ -281,7 +281,7 @@
    :             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:4:1]
  4 | :unknown(foo bar) {}
    :             ^
@@ -389,7 +389,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:5:1]
  5 | :unknown(foo, bar) {}
    :              ^
@@ -593,7 +593,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:7:1]
  7 | :unknown((foo bar)) {}
    :              ^
@@ -725,7 +725,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:8:1]
  8 | :unknown(((foo bar))) {}
    :               ^
@@ -869,7 +869,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:9:1]
  9 | :unknown({foo: bar}) {}
    :               ^
@@ -1013,7 +1013,7 @@
     :                ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:10:1]
  10 | :unknown({{foo: bar}}) {}
     :                ^
@@ -1157,7 +1157,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:11:1]
  11 | :unknown({foo: bar !important}) {}
     :               ^
@@ -1181,7 +1181,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:11:1]
  11 | :unknown({foo: bar !important}) {}
     :                   ^
@@ -1385,7 +1385,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:13:1]
  13 | :unknown("string", foo) {}
     :                   ^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/span.rust-debug
@@ -197,7 +197,7 @@
    :          ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:3:1]
  3 | :unknown(foo) {}
    :          ^^^
@@ -269,7 +269,7 @@
    :          ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:4:1]
  4 | :unknown(foo bar) {}
    :          ^^^
@@ -293,7 +293,7 @@
    :              ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:4:1]
  4 | :unknown(foo bar) {}
    :              ^^^
@@ -365,7 +365,7 @@
    :          ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:5:1]
  5 | :unknown(foo, bar) {}
    :          ^^^
@@ -401,7 +401,7 @@
    :               ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:5:1]
  5 | :unknown(foo, bar) {}
    :               ^^^
@@ -485,7 +485,7 @@
    :           ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:6:1]
  6 | :unknown([foo]) {}
    :           ^^^
@@ -581,7 +581,7 @@
    :           ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:7:1]
  7 | :unknown((foo bar)) {}
    :           ^^^
@@ -605,7 +605,7 @@
    :               ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:7:1]
  7 | :unknown((foo bar)) {}
    :               ^^^
@@ -713,7 +713,7 @@
    :            ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:8:1]
  8 | :unknown(((foo bar))) {}
    :            ^^^
@@ -737,7 +737,7 @@
    :                ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:8:1]
  8 | :unknown(((foo bar))) {}
    :                ^^^
@@ -845,7 +845,7 @@
    :           ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:9:1]
  9 | :unknown({foo: bar}) {}
    :           ^^^
@@ -881,7 +881,7 @@
    :                ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:9:1]
  9 | :unknown({foo: bar}) {}
    :                ^^^
@@ -989,7 +989,7 @@
     :            ^^^
     `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:10:1]
  10 | :unknown({{foo: bar}}) {}
     :            ^^^
@@ -1025,7 +1025,7 @@
     :                 ^^^
     `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:10:1]
  10 | :unknown({{foo: bar}}) {}
     :                 ^^^
@@ -1133,7 +1133,7 @@
     :           ^^^
     `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:11:1]
  11 | :unknown({foo: bar !important}) {}
     :           ^^^
@@ -1169,7 +1169,7 @@
     :                ^^^
     `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:11:1]
  11 | :unknown({foo: bar !important}) {}
     :                ^^^
@@ -1205,7 +1205,7 @@
     :                     ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('important' type=static), raw: Atom('important' type=static) }
+  x Ident { value: Atom('important' type=static), raw: "important" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:11:1]
  11 | :unknown({foo: bar !important}) {}
     :                     ^^^^^^^^^
@@ -1397,7 +1397,7 @@
     :                    ^^^
     `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:13:1]
  13 | :unknown("string", foo) {}
     :                    ^^^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/span.rust-debug
@@ -1289,7 +1289,7 @@
     :          ^^^^^^^^
     `----
 
-  x String { value: Atom('string' type=static), raw: Atom('"string"' type=dynamic) }
+  x String { value: Atom('string' type=static), raw: "\"string\"" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:12:1]
  12 | :unknown("string") {}
     :          ^^^^^^^^
@@ -1361,7 +1361,7 @@
     :          ^^^^^^^^
     `----
 
-  x String { value: Atom('string' type=static), raw: Atom('"string"' type=dynamic) }
+  x String { value: Atom('string' type=static), raw: "\"string\"" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:13:1]
  13 | :unknown("string", foo) {}
     :          ^^^^^^^^
@@ -1469,7 +1469,7 @@
     :          ^^^^^^^^
     `----
 
-  x String { value: Atom('string' type=static), raw: Atom(''string'' type=dynamic) }
+  x String { value: Atom('string' type=static), raw: "'string'" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:14:1]
  14 | :unknown('string') {}
     :          ^^^^^^^^
@@ -1541,7 +1541,7 @@
     :          ^^^^^^^^^^^^
     `----
 
-  x Url { name: Atom('url' type=static), raw_name: Atom('url' type=static), value: Atom('foo.png' type=inline), raw_value: Atom('foo.png' type=inline) }
+  x Url { name: Atom('url' type=static), raw_name: "url", value: Atom('foo.png' type=inline), raw_value: "foo.png" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:15:1]
  15 | :unknown(url(foo.png)) {}
     :          ^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/where/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/where/span.rust-debug
@@ -3905,7 +3905,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/where/input.css:26:1]
  26 | h1:where(<> p) {}
     :            ^
@@ -4061,7 +4061,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/where/input.css:27:1]
  27 | h1:where(a, <> p) {}
     :            ^
@@ -4097,7 +4097,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/where/input.css:27:1]
  27 | h1:where(a, <> p) {}
     :               ^
@@ -4241,7 +4241,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/where/input.css:28:1]
  28 | h1:where(<> p,a) {}
     :            ^
@@ -4433,7 +4433,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/where/input.css:29:1]
  29 | h1:where(a, <> p,a) {}
     :            ^
@@ -4469,7 +4469,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-class/where/input.css:29:1]
  29 | h1:where(a, <> p,a) {}
     :               ^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/where/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/where/span.rust-debug
@@ -3917,7 +3917,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/where/input.css:26:1]
  26 | h1:where(<> p) {}
     :             ^
@@ -4109,7 +4109,7 @@
     :                ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/where/input.css:27:1]
  27 | h1:where(a, <> p) {}
     :                ^
@@ -4253,7 +4253,7 @@
     :             ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/where/input.css:28:1]
  28 | h1:where(<> p,a) {}
     :             ^
@@ -4481,7 +4481,7 @@
     :                ^
     `----
 
-  x Ident { value: Atom('p' type=static), raw: Atom('p' type=static) }
+  x Ident { value: Atom('p' type=static), raw: "p" }
     ,-[$DIR/tests/fixture/selector/pseudo-class/where/input.css:29:1]
  29 | h1:where(a, <> p,a) {}
     :                ^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/span.rust-debug
@@ -280,7 +280,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:4:1]
  4 | ::unknown(foo bar) {}
    :              ^
@@ -388,7 +388,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:5:1]
  5 | ::unknown(foo, bar) {}
    :               ^
@@ -592,7 +592,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:7:1]
  7 | ::unknown((foo bar)) {}
    :               ^
@@ -724,7 +724,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:8:1]
  8 | ::unknown(((foo bar))) {}
    :                ^
@@ -868,7 +868,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:9:1]
  9 | ::unknown({foo: bar}) {}
    :                ^
@@ -1012,7 +1012,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:10:1]
  10 | ::unknown({{foo: bar}}) {}
     :                 ^
@@ -1156,7 +1156,7 @@
     :                ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:11:1]
  11 | ::unknown({foo: bar !important}) {}
     :                ^
@@ -1180,7 +1180,7 @@
     :                    ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:11:1]
  11 | ::unknown({foo: bar !important}) {}
     :                    ^
@@ -1384,7 +1384,7 @@
     :                    ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:13:1]
  13 | ::unknown("string", foo) {}
     :                    ^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/span.rust-debug
@@ -196,7 +196,7 @@
    :           ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:3:1]
  3 | ::unknown(foo) {}
    :           ^^^
@@ -268,7 +268,7 @@
    :           ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:4:1]
  4 | ::unknown(foo bar) {}
    :           ^^^
@@ -292,7 +292,7 @@
    :               ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:4:1]
  4 | ::unknown(foo bar) {}
    :               ^^^
@@ -364,7 +364,7 @@
    :           ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:5:1]
  5 | ::unknown(foo, bar) {}
    :           ^^^
@@ -400,7 +400,7 @@
    :                ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:5:1]
  5 | ::unknown(foo, bar) {}
    :                ^^^
@@ -484,7 +484,7 @@
    :            ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:6:1]
  6 | ::unknown([foo]) {}
    :            ^^^
@@ -580,7 +580,7 @@
    :            ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:7:1]
  7 | ::unknown((foo bar)) {}
    :            ^^^
@@ -604,7 +604,7 @@
    :                ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:7:1]
  7 | ::unknown((foo bar)) {}
    :                ^^^
@@ -712,7 +712,7 @@
    :             ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:8:1]
  8 | ::unknown(((foo bar))) {}
    :             ^^^
@@ -736,7 +736,7 @@
    :                 ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:8:1]
  8 | ::unknown(((foo bar))) {}
    :                 ^^^
@@ -844,7 +844,7 @@
    :            ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:9:1]
  9 | ::unknown({foo: bar}) {}
    :            ^^^
@@ -880,7 +880,7 @@
    :                 ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:9:1]
  9 | ::unknown({foo: bar}) {}
    :                 ^^^
@@ -988,7 +988,7 @@
     :             ^^^
     `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:10:1]
  10 | ::unknown({{foo: bar}}) {}
     :             ^^^
@@ -1024,7 +1024,7 @@
     :                  ^^^
     `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:10:1]
  10 | ::unknown({{foo: bar}}) {}
     :                  ^^^
@@ -1132,7 +1132,7 @@
     :            ^^^
     `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:11:1]
  11 | ::unknown({foo: bar !important}) {}
     :            ^^^
@@ -1168,7 +1168,7 @@
     :                 ^^^
     `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:11:1]
  11 | ::unknown({foo: bar !important}) {}
     :                 ^^^
@@ -1204,7 +1204,7 @@
     :                      ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('important' type=static), raw: Atom('important' type=static) }
+  x Ident { value: Atom('important' type=static), raw: "important" }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:11:1]
  11 | ::unknown({foo: bar !important}) {}
     :                      ^^^^^^^^^
@@ -1396,7 +1396,7 @@
     :                     ^^^
     `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:13:1]
  13 | ::unknown("string", foo) {}
     :                     ^^^

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/span.rust-debug
@@ -1288,7 +1288,7 @@
     :           ^^^^^^^^
     `----
 
-  x String { value: Atom('string' type=static), raw: Atom('"string"' type=dynamic) }
+  x String { value: Atom('string' type=static), raw: "\"string\"" }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:12:1]
  12 | ::unknown("string") {}
     :           ^^^^^^^^
@@ -1360,7 +1360,7 @@
     :           ^^^^^^^^
     `----
 
-  x String { value: Atom('string' type=static), raw: Atom('"string"' type=dynamic) }
+  x String { value: Atom('string' type=static), raw: "\"string\"" }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:13:1]
  13 | ::unknown("string", foo) {}
     :           ^^^^^^^^
@@ -1468,7 +1468,7 @@
     :           ^^^^^^^^
     `----
 
-  x String { value: Atom('string' type=static), raw: Atom(''string'' type=dynamic) }
+  x String { value: Atom('string' type=static), raw: "'string'" }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:14:1]
  14 | ::unknown('string') {}
     :           ^^^^^^^^
@@ -1540,7 +1540,7 @@
     :           ^^^^^^^^^^^^
     `----
 
-  x Url { name: Atom('url' type=static), raw_name: Atom('url' type=static), value: Atom('foo.png' type=inline), raw_value: Atom('foo.png' type=inline) }
+  x Url { name: Atom('url' type=static), raw_name: "url", value: Atom('foo.png' type=inline), raw_value: "foo.png" }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:15:1]
  15 | ::unknown(url(foo.png)) {}
     :           ^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/fixture/style-block/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/style-block/span.rust-debug
@@ -3714,7 +3714,7 @@
     :       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/style-block/input.css:91:5]
  91 | @mixin mobile {
     :       ^
@@ -3738,7 +3738,7 @@
     :              ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/style-block/input.css:91:5]
  91 | @mixin mobile {
     :              ^
@@ -3763,8 +3763,7 @@
  92 | `->         height: 100px;
     `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
     ,-[$DIR/tests/fixture/style-block/input.css:91:5]
  91 | ,-> @mixin mobile {
  92 | `->         height: 100px;
@@ -3800,7 +3799,7 @@
     :        ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/style-block/input.css:92:9]
  92 | height: 100px;
     :        ^
@@ -3836,8 +3835,7 @@
  93 | `->     }
     `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
     ,-[$DIR/tests/fixture/style-block/input.css:92:9]
  92 | ,-> height: 100px;
  93 | `->     }
@@ -4065,7 +4063,7 @@
     :             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/style-block/input.css:98:1]
  98 | a { @unknown "a.css"; }
     :             ^
@@ -4185,7 +4183,7 @@
      :             ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/style-block/input.css:100:1]
  100 | a { @unknown foo {} }
      :             ^
@@ -4209,7 +4207,7 @@
      :                 ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/style-block/input.css:100:1]
  100 | a { @unknown foo {} }
      :                 ^
@@ -4444,8 +4442,7 @@
  107 | `->         width: 0;
      `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
      ,-[$DIR/tests/fixture/style-block/input.css:106:5]
  106 | ,-> --zero-size: {
  107 | `->         width: 0;
@@ -4481,7 +4478,7 @@
      :       ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/style-block/input.css:107:9]
  107 | width: 0;
      :       ^
@@ -4517,8 +4514,7 @@
  108 | `->         height: 0;
      `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
      ,-[$DIR/tests/fixture/style-block/input.css:107:9]
  107 | ,-> width: 0;
  108 | `->         height: 0;
@@ -4554,7 +4550,7 @@
      :        ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/style-block/input.css:108:9]
  108 | height: 0;
      :        ^
@@ -4590,8 +4586,7 @@
  109 | `->     };
      `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
      ,-[$DIR/tests/fixture/style-block/input.css:108:9]
  108 | ,-> height: 0;
  109 | `->     };
@@ -4664,8 +4659,7 @@
  111 | `->         width: 16px;
      `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
      ,-[$DIR/tests/fixture/style-block/input.css:110:5]
  110 | ,-> --small-icon: {
  111 | `->         width: 16px;
@@ -4701,7 +4695,7 @@
      :       ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/style-block/input.css:111:9]
  111 | width: 16px;
      :       ^
@@ -4737,8 +4731,7 @@
  112 | `->         height: 16px;
      `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
      ,-[$DIR/tests/fixture/style-block/input.css:111:9]
  111 | ,-> width: 16px;
  112 | `->         height: 16px;
@@ -4774,7 +4767,7 @@
      :        ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/fixture/style-block/input.css:112:9]
  112 | height: 16px;
      :        ^
@@ -4810,8 +4803,7 @@
  113 | `->     }
      `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
      ,-[$DIR/tests/fixture/style-block/input.css:112:9]
  112 | ,-> height: 16px;
  113 | `->     }

--- a/crates/swc_css_parser/tests/fixture/style-block/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/style-block/span.rust-debug
@@ -3726,7 +3726,7 @@
     :        ^^^^^^
     `----
 
-  x Ident { value: Atom('mobile' type=inline), raw: Atom('mobile' type=inline) }
+  x Ident { value: Atom('mobile' type=inline), raw: "mobile" }
     ,-[$DIR/tests/fixture/style-block/input.css:91:5]
  91 | @mixin mobile {
     :        ^^^^^^
@@ -3775,7 +3775,7 @@
     : ^^^^^^
     `----
 
-  x Ident { value: Atom('height' type=inline), raw: Atom('height' type=inline) }
+  x Ident { value: Atom('height' type=inline), raw: "height" }
     ,-[$DIR/tests/fixture/style-block/input.css:92:9]
  92 | height: 100px;
     : ^^^^^^
@@ -3811,7 +3811,7 @@
     :         ^^^^^
     `----
 
-  x Dimension { value: 100.0, raw_value: Atom('100' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 100.0, raw_value: "100", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
     ,-[$DIR/tests/fixture/style-block/input.css:92:9]
  92 | height: 100px;
     :         ^^^^^
@@ -4195,7 +4195,7 @@
      :              ^^^
      `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
      ,-[$DIR/tests/fixture/style-block/input.css:100:1]
  100 | a { @unknown foo {} }
      :              ^^^
@@ -4454,7 +4454,7 @@
      : ^^^^^
      `----
 
-  x Ident { value: Atom('width' type=inline), raw: Atom('width' type=inline) }
+  x Ident { value: Atom('width' type=inline), raw: "width" }
      ,-[$DIR/tests/fixture/style-block/input.css:107:9]
  107 | width: 0;
      : ^^^^^
@@ -4490,7 +4490,7 @@
      :        ^
      `----
 
-  x Number { value: 0.0, raw: Atom('0' type=inline), type_flag: Integer }
+  x Number { value: 0.0, raw: "0", type_flag: Integer }
      ,-[$DIR/tests/fixture/style-block/input.css:107:9]
  107 | width: 0;
      :        ^
@@ -4526,7 +4526,7 @@
      : ^^^^^^
      `----
 
-  x Ident { value: Atom('height' type=inline), raw: Atom('height' type=inline) }
+  x Ident { value: Atom('height' type=inline), raw: "height" }
      ,-[$DIR/tests/fixture/style-block/input.css:108:9]
  108 | height: 0;
      : ^^^^^^
@@ -4562,7 +4562,7 @@
      :         ^
      `----
 
-  x Number { value: 0.0, raw: Atom('0' type=inline), type_flag: Integer }
+  x Number { value: 0.0, raw: "0", type_flag: Integer }
      ,-[$DIR/tests/fixture/style-block/input.css:108:9]
  108 | height: 0;
      :         ^
@@ -4671,7 +4671,7 @@
      : ^^^^^
      `----
 
-  x Ident { value: Atom('width' type=inline), raw: Atom('width' type=inline) }
+  x Ident { value: Atom('width' type=inline), raw: "width" }
      ,-[$DIR/tests/fixture/style-block/input.css:111:9]
  111 | width: 16px;
      : ^^^^^
@@ -4707,7 +4707,7 @@
      :        ^^^^
      `----
 
-  x Dimension { value: 16.0, raw_value: Atom('16' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 16.0, raw_value: "16", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
      ,-[$DIR/tests/fixture/style-block/input.css:111:9]
  111 | width: 16px;
      :        ^^^^
@@ -4743,7 +4743,7 @@
      : ^^^^^^
      `----
 
-  x Ident { value: Atom('height' type=inline), raw: Atom('height' type=inline) }
+  x Ident { value: Atom('height' type=inline), raw: "height" }
      ,-[$DIR/tests/fixture/style-block/input.css:112:9]
  112 | height: 16px;
      : ^^^^^^
@@ -4779,7 +4779,7 @@
      :         ^^^^
      `----
 
-  x Dimension { value: 16.0, raw_value: Atom('16' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 16.0, raw_value: "16", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
      ,-[$DIR/tests/fixture/style-block/input.css:112:9]
  112 | height: 16px;
      :         ^^^^

--- a/crates/swc_css_parser/tests/fixture/style-block/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/style-block/span.rust-debug
@@ -4075,7 +4075,7 @@
     :              ^^^^^^^
     `----
 
-  x String { value: Atom('a.css' type=inline), raw: Atom('"a.css"' type=inline) }
+  x String { value: Atom('a.css' type=inline), raw: "\"a.css\"" }
     ,-[$DIR/tests/fixture/style-block/input.css:98:1]
  98 | a { @unknown "a.css"; }
     :              ^^^^^^^

--- a/crates/swc_css_parser/tests/fixture/styled-jsx/selector/1/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/styled-jsx/selector/1/span.rust-debug
@@ -74,7 +74,7 @@
    :          ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1]
  1 | :global(.foo + a) {
    :          ^^^
@@ -122,7 +122,7 @@
    :                ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1]
  1 | :global(.foo + a) {
    :                ^

--- a/crates/swc_css_parser/tests/fixture/styled-jsx/selector/1/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/styled-jsx/selector/1/span.rust-debug
@@ -86,7 +86,7 @@
    :             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1]
  1 | :global(.foo + a) {
    :             ^
@@ -110,7 +110,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/fixture/styled-jsx/selector/1/input.css:1:1]
  1 | :global(.foo + a) {
    :               ^

--- a/crates/swc_css_parser/tests/fixture/styled-jsx/selector/2/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/styled-jsx/selector/2/span.rust-debug
@@ -98,7 +98,7 @@
    :           ^^^^
    `----
 
-  x Ident { value: Atom('span' type=static), raw: Atom('span' type=static) }
+  x Ident { value: Atom('span' type=static), raw: "span" }
    ,-[$DIR/tests/fixture/styled-jsx/selector/2/input.css:1:1]
  1 | p :global(span:not(.test)) {
    :           ^^^^
@@ -122,7 +122,7 @@
    :                ^^^^
    `----
 
-  x Function { value: Atom('not' type=static), raw: Atom('not' type=static) }
+  x Function { value: Atom('not' type=static), raw: "not" }
    ,-[$DIR/tests/fixture/styled-jsx/selector/2/input.css:1:1]
  1 | p :global(span:not(.test)) {
    :                ^^^^
@@ -146,7 +146,7 @@
    :                     ^^^^
    `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
    ,-[$DIR/tests/fixture/styled-jsx/selector/2/input.css:1:1]
  1 | p :global(span:not(.test)) {
    :                     ^^^^

--- a/crates/swc_css_parser/tests/fixture/value/custom-property/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/custom-property/span.rust-debug
@@ -1171,7 +1171,7 @@
     :           ^^^^^^^^^^^^^^^^^^^^^^
     `----
 
-  x String { value: Atom('single quoted string' type=dynamic), raw: Atom(''single quoted string'' type=dynamic) }
+  x String { value: Atom('single quoted string' type=dynamic), raw: "'single quoted string'" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:24:5]
  24 | --string: 'single quoted string';
     :           ^^^^^^^^^^^^^^^^^^^^^^
@@ -1213,7 +1213,7 @@
     :           ^^^^^^^^^^^^^^^^^^^^^^
     `----
 
-  x String { value: Atom('double quoted string' type=dynamic), raw: Atom('"double quoted string"' type=dynamic) }
+  x String { value: Atom('double quoted string' type=dynamic), raw: "\"double quoted string\"" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:25:5]
  25 | --string: "double quoted string";
     :           ^^^^^^^^^^^^^^^^^^^^^^
@@ -1993,7 +1993,7 @@
     :             ^^^
     `----
 
-  x String { value: Atom('2' type=inline), raw: Atom('"2"' type=inline) }
+  x String { value: Atom('2' type=inline), raw: "\"2\"" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:38:5]
  38 | --JSON: [1, "2", {"three": {"a":1}}, [4]];
     :             ^^^
@@ -2047,7 +2047,7 @@
     :                   ^^^^^^^
     `----
 
-  x String { value: Atom('three' type=inline), raw: Atom('"three"' type=inline) }
+  x String { value: Atom('three' type=inline), raw: "\"three\"" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:38:5]
  38 | --JSON: [1, "2", {"three": {"a":1}}, [4]];
     :                   ^^^^^^^
@@ -2101,7 +2101,7 @@
     :                             ^^^
     `----
 
-  x String { value: Atom('a' type=static), raw: Atom('"a"' type=inline) }
+  x String { value: Atom('a' type=static), raw: "\"a\"" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:38:5]
  38 | --JSON: [1, "2", {"three": {"a":1}}, [4]];
     :                             ^^^

--- a/crates/swc_css_parser/tests/fixture/value/custom-property/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/custom-property/span.rust-debug
@@ -331,7 +331,7 @@
    :     ^^^^^
    `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
    ,-[$DIR/tests/fixture/value/custom-property/input.css:2:5]
  2 | ---:value;
    :     ^^^^^
@@ -373,7 +373,7 @@
    :             ^^^^^
    `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
    ,-[$DIR/tests/fixture/value/custom-property/input.css:4:5]
  4 | --important:value!important;
    :             ^^^^^
@@ -427,7 +427,7 @@
    :               ^^^^^
    `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
    ,-[$DIR/tests/fixture/value/custom-property/input.css:5:5]
  5 | --important1: value!important;
    :               ^^^^^
@@ -481,7 +481,7 @@
    :               ^^^^^
    `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
    ,-[$DIR/tests/fixture/value/custom-property/input.css:6:5]
  6 | --important2: value !important;
    :               ^^^^^
@@ -535,7 +535,7 @@
    :              ^^^^^
    `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
    ,-[$DIR/tests/fixture/value/custom-property/input.css:7:5]
  7 | --important3:value !important;
    :              ^^^^^
@@ -607,7 +607,7 @@
    :                    ^
    `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
    ,-[$DIR/tests/fixture/value/custom-property/input.css:8:5]
  8 | --important4: calc(1)!important;
    :                    ^
@@ -835,7 +835,7 @@
     :                 ^^^^^
     `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:16:5]
  16 | --no-whitespace:ident;
     :                 ^^^^^
@@ -877,7 +877,7 @@
     :           ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:17:5]
  17 | --number: 1;
     :           ^
@@ -919,7 +919,7 @@
     :         ^^^^^
     `----
 
-  x Dimension { value: 100.0, raw_value: Atom('100' type=inline), unit: Atom('vw' type=static), raw_unit: Atom('vw' type=static), type_flag: Integer }
+  x Dimension { value: 100.0, raw_value: "100", unit: Atom('vw' type=static), raw_unit: "vw", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:18:5]
  18 | --unit: 100vw;
     :         ^^^^^
@@ -1021,7 +1021,7 @@
     :                  ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:21:5]
  21 | --function: calc(1 + 1);
     :                  ^
@@ -1069,7 +1069,7 @@
     :                      ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:21:5]
  21 | --function: calc(1 + 1);
     :                      ^
@@ -1129,7 +1129,7 @@
     :                 ^^^^^^
     `----
 
-  x Ident { value: Atom('--unit' type=inline), raw: Atom('--unit' type=inline) }
+  x Ident { value: Atom('--unit' type=inline), raw: "--unit" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:22:5]
  22 | --variable: var(--unit);
     :                 ^^^^^^
@@ -1273,7 +1273,7 @@
     :                  ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:27:5]
  27 | --square-block: [1, 2, 3];
     :                  ^
@@ -1309,7 +1309,7 @@
     :                     ^
     `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:27:5]
  27 | --square-block: [1, 2, 3];
     :                     ^
@@ -1345,7 +1345,7 @@
     :                        ^
     `----
 
-  x Number { value: 3.0, raw: Atom('3' type=inline), type_flag: Integer }
+  x Number { value: 3.0, raw: "3", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:27:5]
  27 | --square-block: [1, 2, 3];
     :                        ^
@@ -1501,7 +1501,7 @@
     :                 ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:30:5]
  30 | --round-block: (1, 2, 3);
     :                 ^
@@ -1537,7 +1537,7 @@
     :                    ^
     `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:30:5]
  30 | --round-block: (1, 2, 3);
     :                    ^
@@ -1573,7 +1573,7 @@
     :                       ^
     `----
 
-  x Number { value: 3.0, raw: Atom('3' type=inline), type_flag: Integer }
+  x Number { value: 3.0, raw: "3", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:30:5]
  30 | --round-block: (1, 2, 3);
     :                       ^
@@ -1729,7 +1729,7 @@
     :                   ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:33:5]
  33 | --bracket-block: {1, 2, 3};
     :                   ^
@@ -1765,7 +1765,7 @@
     :                      ^
     `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:33:5]
  33 | --bracket-block: {1, 2, 3};
     :                      ^
@@ -1801,7 +1801,7 @@
     :                         ^
     `----
 
-  x Number { value: 3.0, raw: Atom('3' type=inline), type_flag: Integer }
+  x Number { value: 3.0, raw: "3", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:33:5]
  33 | --bracket-block: {1, 2, 3};
     :                         ^
@@ -1957,7 +1957,7 @@
     :          ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:38:5]
  38 | --JSON: [1, "2", {"three": {"a":1}}, [4]];
     :          ^
@@ -2125,7 +2125,7 @@
     :                                 ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:38:5]
  38 | --JSON: [1, "2", {"three": {"a":1}}, [4]];
     :                                 ^
@@ -2179,7 +2179,7 @@
     :                                       ^
     `----
 
-  x Number { value: 4.0, raw: Atom('4' type=inline), type_flag: Integer }
+  x Number { value: 4.0, raw: "4", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:38:5]
  38 | --JSON: [1, "2", {"three": {"a":1}}, [4]];
     :                                       ^
@@ -2239,7 +2239,7 @@
     :                        ^^^^
     `----
 
-  x Ident { value: Atom('rule' type=inline), raw: Atom('rule' type=inline) }
+  x Ident { value: Atom('rule' type=inline), raw: "rule" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:39:5]
  39 | --javascript: function(rule) { console.log(rule) };
     :                        ^^^^
@@ -2293,7 +2293,7 @@
     :                                ^^^^^^^
     `----
 
-  x Ident { value: Atom('console' type=inline), raw: Atom('console' type=inline) }
+  x Ident { value: Atom('console' type=inline), raw: "console" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:39:5]
  39 | --javascript: function(rule) { console.log(rule) };
     :                                ^^^^^^^
@@ -2335,7 +2335,7 @@
     :                                            ^^^^
     `----
 
-  x Ident { value: Atom('rule' type=inline), raw: Atom('rule' type=inline) }
+  x Ident { value: Atom('rule' type=inline), raw: "rule" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:39:5]
  39 | --javascript: function(rule) { console.log(rule) };
     :                                            ^^^^
@@ -2803,7 +2803,7 @@
     :                    ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('important' type=static), raw: Atom('important' type=static) }
+  x Ident { value: Atom('important' type=static), raw: "important" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:45:5]
  45 | --fake-important:{!important};
     :                    ^^^^^^^^^
@@ -3005,7 +3005,7 @@
     : ^^^^^
     `----
 
-  x Ident { value: Atom('width' type=inline), raw: Atom('width' type=inline) }
+  x Ident { value: Atom('width' type=inline), raw: "width" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:49:9]
  49 | width: 0;
     : ^^^^^
@@ -3041,7 +3041,7 @@
     :        ^
     `----
 
-  x Number { value: 0.0, raw: Atom('0' type=inline), type_flag: Integer }
+  x Number { value: 0.0, raw: "0", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:49:9]
  49 | width: 0;
     :        ^
@@ -3077,7 +3077,7 @@
     : ^^^^^^
     `----
 
-  x Ident { value: Atom('height' type=inline), raw: Atom('height' type=inline) }
+  x Ident { value: Atom('height' type=inline), raw: "height" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:50:9]
  50 | height: 0;
     : ^^^^^^
@@ -3113,7 +3113,7 @@
     :         ^
     `----
 
-  x Number { value: 0.0, raw: Atom('0' type=inline), type_flag: Integer }
+  x Number { value: 0.0, raw: "0", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:50:9]
  50 | height: 0;
     :         ^
@@ -3222,7 +3222,7 @@
     : ^^^^^
     `----
 
-  x Ident { value: Atom('width' type=inline), raw: Atom('width' type=inline) }
+  x Ident { value: Atom('width' type=inline), raw: "width" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:53:9]
  53 | width: 16px;
     : ^^^^^
@@ -3258,7 +3258,7 @@
     :        ^^^^
     `----
 
-  x Dimension { value: 16.0, raw_value: Atom('16' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 16.0, raw_value: "16", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:53:9]
  53 | width: 16px;
     :        ^^^^
@@ -3294,7 +3294,7 @@
     : ^^^^^^
     `----
 
-  x Ident { value: Atom('height' type=inline), raw: Atom('height' type=inline) }
+  x Ident { value: Atom('height' type=inline), raw: "height" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:54:9]
  54 | height: 16px;
     : ^^^^^^
@@ -3330,7 +3330,7 @@
     :         ^^^^
     `----
 
-  x Dimension { value: 16.0, raw_value: Atom('16' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 16.0, raw_value: "16", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:54:9]
  54 | height: 16px;
     :         ^^^^
@@ -3456,7 +3456,7 @@
     :           ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:59:1]
  59 | :root{--a:1}
     :           ^
@@ -3747,7 +3747,7 @@
     :         ^^^^^
     `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:66:5]
  66 | --var:  value;
     :         ^^^^^

--- a/crates/swc_css_parser/tests/fixture/value/custom-property/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/custom-property/span.rust-debug
@@ -961,7 +961,7 @@
     :          ^^^^
     `----
 
-  x Hash { is_id: false, value: Atom('06c' type=inline), raw: Atom('06c' type=inline) }
+  x Hash { is_id: false, value: Atom('06c' type=inline), raw: "06c" }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:19:5]
  19 | --color: #06c;
     :          ^^^^

--- a/crates/swc_css_parser/tests/fixture/value/custom-property/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/custom-property/span.rust-debug
@@ -1033,7 +1033,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:21:5]
  21 | --function: calc(1 + 1);
     :                   ^
@@ -1057,7 +1057,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:21:5]
  21 | --function: calc(1 + 1);
     :                     ^
@@ -1297,7 +1297,7 @@
     :                    ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:27:5]
  27 | --square-block: [1, 2, 3];
     :                    ^
@@ -1333,7 +1333,7 @@
     :                       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:27:5]
  27 | --square-block: [1, 2, 3];
     :                       ^
@@ -1525,7 +1525,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:30:5]
  30 | --round-block: (1, 2, 3);
     :                   ^
@@ -1561,7 +1561,7 @@
     :                      ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:30:5]
  30 | --round-block: (1, 2, 3);
     :                      ^
@@ -1753,7 +1753,7 @@
     :                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:33:5]
  33 | --bracket-block: {1, 2, 3};
     :                     ^
@@ -1789,7 +1789,7 @@
     :                        ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:33:5]
  33 | --bracket-block: {1, 2, 3};
     :                        ^
@@ -1981,7 +1981,7 @@
     :            ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:38:5]
  38 | --JSON: [1, "2", {"three": {"a":1}}, [4]];
     :            ^
@@ -2017,7 +2017,7 @@
     :                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:38:5]
  38 | --JSON: [1, "2", {"three": {"a":1}}, [4]];
     :                 ^
@@ -2071,7 +2071,7 @@
     :                           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:38:5]
  38 | --JSON: [1, "2", {"three": {"a":1}}, [4]];
     :                           ^
@@ -2149,7 +2149,7 @@
     :                                     ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:38:5]
  38 | --JSON: [1, "2", {"three": {"a":1}}, [4]];
     :                                     ^
@@ -2251,7 +2251,7 @@
     :                             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:39:5]
  39 | --javascript: function(rule) { console.log(rule) };
     :                             ^
@@ -2281,7 +2281,7 @@
     :                               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:39:5]
  39 | --javascript: function(rule) { console.log(rule) };
     :                               ^
@@ -2347,7 +2347,7 @@
     :                                                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:39:5]
  39 | --javascript: function(rule) { console.log(rule) };
     :                                                 ^
@@ -2993,8 +2993,7 @@
  49 | `->         width: 0;
     `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:48:5]
  48 | ,-> --zero-size: {
  49 | `->         width: 0;
@@ -3030,7 +3029,7 @@
     :       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:49:9]
  49 | width: 0;
     :       ^
@@ -3066,8 +3065,7 @@
  50 | `->         height: 0;
     `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:49:9]
  49 | ,-> width: 0;
  50 | `->         height: 0;
@@ -3103,7 +3101,7 @@
     :        ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:50:9]
  50 | height: 0;
     :        ^
@@ -3139,8 +3137,7 @@
  51 | `->     };
     `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:50:9]
  50 | ,-> height: 0;
  51 | `->     };
@@ -3213,8 +3210,7 @@
  53 | `->         width: 16px;
     `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:52:5]
  52 | ,-> --small-icon: {
  53 | `->         width: 16px;
@@ -3250,7 +3246,7 @@
     :       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:53:9]
  53 | width: 16px;
     :       ^
@@ -3286,8 +3282,7 @@
  54 | `->         height: 16px;
     `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:53:9]
  53 | ,-> width: 16px;
  54 | `->         height: 16px;
@@ -3323,7 +3318,7 @@
     :        ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:54:9]
  54 | height: 16px;
     :        ^
@@ -3359,8 +3354,7 @@
  55 | `->     }
     `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
     ,-[$DIR/tests/fixture/value/custom-property/input.css:54:9]
  54 | ,-> height: 16px;
  55 | `->     }

--- a/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
+++ b/crates/swc_css_parser/tests/fixture/value/url/span.rust-debug
@@ -1293,7 +1293,7 @@
     :        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 
-  x String { value: Atom('http://www.example.com/pinkish.gif' type=dynamic), raw: Atom('"http://www.example.com/pinkish.gif"' type=dynamic) }
+  x String { value: Atom('http://www.example.com/pinkish.gif' type=dynamic), raw: "\"http://www.example.com/pinkish.gif\"" }
     ,-[$DIR/tests/fixture/value/url/input.css:21:5]
  21 | --foo: "http://www.example.com/pinkish.gif";
     :        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/document/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/document/span.rust-debug
@@ -47,7 +47,7 @@
    :                  ^^^^
    `----
 
-  x Ident { value: Atom('http' type=inline), raw: Atom('http' type=inline) }
+  x Ident { value: Atom('http' type=inline), raw: "http" }
    ,-[$DIR/tests/recovery/at-rule/document/input.css:1:1]
  1 | @document domain(http://www.example.com/) {}
    :                  ^^^^
@@ -95,7 +95,7 @@
    :                         ^^^
    `----
 
-  x Ident { value: Atom('www' type=inline), raw: Atom('www' type=inline) }
+  x Ident { value: Atom('www' type=inline), raw: "www" }
    ,-[$DIR/tests/recovery/at-rule/document/input.css:1:1]
  1 | @document domain(http://www.example.com/) {}
    :                         ^^^
@@ -119,7 +119,7 @@
    :                             ^^^^^^^
    `----
 
-  x Ident { value: Atom('example' type=inline), raw: Atom('example' type=inline) }
+  x Ident { value: Atom('example' type=inline), raw: "example" }
    ,-[$DIR/tests/recovery/at-rule/document/input.css:1:1]
  1 | @document domain(http://www.example.com/) {}
    :                             ^^^^^^^
@@ -143,7 +143,7 @@
    :                                     ^^^
    `----
 
-  x Ident { value: Atom('com' type=inline), raw: Atom('com' type=inline) }
+  x Ident { value: Atom('com' type=inline), raw: "com" }
    ,-[$DIR/tests/recovery/at-rule/document/input.css:1:1]
  1 | @document domain(http://www.example.com/) {}
    :                                     ^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/extra-semi/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/extra-semi/span.rust-debug
@@ -75,9 +75,7 @@
  3 |     .color {
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/at-rule/extra-semi/input.css:1:1]
  1 | ,-> @import "x.css";;
  2 | `-> 
@@ -114,7 +112,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/extra-semi/input.css:3:1]
  3 | .color {
    :       ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/extra-semi/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/extra-semi/span.rust-debug
@@ -100,7 +100,7 @@
    :  ^^^^^
    `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
    ,-[$DIR/tests/recovery/at-rule/extra-semi/input.css:3:1]
  3 | .color {
    :  ^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/font-face/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/font-face/span.rust-debug
@@ -89,8 +89,7 @@
  3 | }
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/at-rule/font-face/input.css:2:5]
  2 | invalid
    :        ^
@@ -231,8 +230,7 @@
  11 | }
     `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
     ,-[$DIR/tests/recovery/at-rule/font-face/input.css:10:5]
  10 | 123
     :    ^
@@ -338,7 +336,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/font-face/input.css:17:1]
  17 | @font-face foo {}
     :           ^
@@ -362,7 +360,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/font-face/input.css:17:1]
  17 | @font-face foo {}
     :               ^
@@ -410,7 +408,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/font-face/input.css:19:1]
  19 | @font-face foo;
     :           ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/font-face/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/font-face/span.rust-debug
@@ -76,7 +76,7 @@
    : ^^^^^^^
    `----
 
-  x Ident { value: Atom('invalid' type=inline), raw: Atom('invalid' type=inline) }
+  x Ident { value: Atom('invalid' type=inline), raw: "invalid" }
    ,-[$DIR/tests/recovery/at-rule/font-face/input.css:2:5]
  2 | invalid
    : ^^^^^^^
@@ -147,7 +147,7 @@
    : ^^^^^^^
    `----
 
-  x Ident { value: Atom('invalid' type=inline), raw: Atom('invalid' type=inline) }
+  x Ident { value: Atom('invalid' type=inline), raw: "invalid" }
    ,-[$DIR/tests/recovery/at-rule/font-face/input.css:6:5]
  6 | invalid;
    : ^^^^^^^
@@ -217,7 +217,7 @@
     : ^^^
     `----
 
-  x Number { value: 123.0, raw: Atom('123' type=inline), type_flag: Integer }
+  x Number { value: 123.0, raw: "123", type_flag: Integer }
     ,-[$DIR/tests/recovery/at-rule/font-face/input.css:10:5]
  10 | 123
     : ^^^
@@ -288,7 +288,7 @@
     : ^^^
     `----
 
-  x Number { value: 123.0, raw: Atom('123' type=inline), type_flag: Integer }
+  x Number { value: 123.0, raw: "123", type_flag: Integer }
     ,-[$DIR/tests/recovery/at-rule/font-face/input.css:14:5]
  14 | 123;
     : ^^^
@@ -348,7 +348,7 @@
     :            ^^^
     `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
     ,-[$DIR/tests/recovery/at-rule/font-face/input.css:17:1]
  17 | @font-face foo {}
     :            ^^^
@@ -420,7 +420,7 @@
     :            ^^^
     `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
     ,-[$DIR/tests/recovery/at-rule/font-face/input.css:19:1]
  19 | @font-face foo;
     :            ^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/empty/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/empty/span.rust-debug
@@ -35,7 +35,7 @@
    :        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/empty/input.css:1:1]
  1 | @import ;
    :        ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/indent/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/indent/span.rust-debug
@@ -47,7 +47,7 @@
    :         ^^^^^^^
    `----
 
-  x Ident { value: Atom('foo-bar' type=inline), raw: Atom('foo-bar' type=inline) }
+  x Ident { value: Atom('foo-bar' type=inline), raw: "foo-bar" }
    ,-[$DIR/tests/recovery/at-rule/import/indent/input.css:1:1]
  1 | @import foo-bar;
    :         ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/indent/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/indent/span.rust-debug
@@ -35,7 +35,7 @@
    :        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/indent/input.css:1:1]
  1 | @import foo-bar;
    :        ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/invalid-layer/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/invalid-layer/span.rust-debug
@@ -96,7 +96,7 @@
    :                         ^^^^^^^^^
    `----
 
-  x String { value: Atom('invalid' type=inline), raw: Atom('"invalid"' type=dynamic) }
+  x String { value: Atom('invalid' type=inline), raw: "\"invalid\"" }
    ,-[$DIR/tests/recovery/at-rule/import/invalid-layer/input.css:2:1]
  2 | @import "foo.css" layer("invalid");
    :                         ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/invalid-layer/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/invalid-layer/span.rust-debug
@@ -174,7 +174,7 @@
    :                             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/invalid-layer/input.css:3:1]
  3 | @import "foo.css" layer(foo, bar);
    :                             ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/invalid-layer/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/invalid-layer/span.rust-debug
@@ -150,7 +150,7 @@
    :                         ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/recovery/at-rule/import/invalid-layer/input.css:3:1]
  3 | @import "foo.css" layer(foo, bar);
    :                         ^^^
@@ -186,7 +186,7 @@
    :                              ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/recovery/at-rule/import/invalid-layer/input.css:3:1]
  3 | @import "foo.css" layer(foo, bar);
    :                              ^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/invalid-supports/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/invalid-supports/span.rust-debug
@@ -71,7 +71,7 @@
    :                                    ^^^^^^^
    `----
 
-  x Ident { value: Atom('unknown' type=static), raw: Atom('unknown' type=static) }
+  x Ident { value: Atom('unknown' type=static), raw: "unknown" }
    ,-[$DIR/tests/recovery/at-rule/import/invalid-supports/input.css:1:1]
  1 | @import url("./test.css") supports(unknown);
    :                                    ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/no-semi/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/no-semi/span.rust-debug
@@ -65,7 +65,7 @@
    :             ^^^^^^^^^
    `----
 
-  x String { value: Atom('http://' type=inline), raw: Atom(''http://'' type=dynamic) }
+  x String { value: Atom('http://' type=inline), raw: "'http://'" }
    ,-[$DIR/tests/recovery/at-rule/import/no-semi/input.css:1:1]
  1 | @import url('http://') :root {}
    :             ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/no-semi/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/no-semi/span.rust-debug
@@ -35,7 +35,7 @@
    :        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/no-semi/input.css:1:1]
  1 | @import url('http://') :root {}
    :        ^
@@ -77,7 +77,7 @@
    :                       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/no-semi/input.css:1:1]
  1 | @import url('http://') :root {}
    :                       ^
@@ -113,7 +113,7 @@
    :                             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/no-semi/input.css:1:1]
  1 | @import url('http://') :root {}
    :                             ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/no-semi/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/no-semi/span.rust-debug
@@ -101,7 +101,7 @@
    :                         ^^^^
    `----
 
-  x Ident { value: Atom('root' type=inline), raw: Atom('root' type=inline) }
+  x Ident { value: Atom('root' type=inline), raw: "root" }
    ,-[$DIR/tests/recovery/at-rule/import/no-semi/input.css:1:1]
  1 | @import url('http://') :root {}
    :                         ^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/no-url/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/no-url/span.rust-debug
@@ -35,7 +35,7 @@
    :        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/no-url/input.css:1:1]
  1 | @import nourl(test);
    :        ^
@@ -101,7 +101,7 @@
    :        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/no-url/input.css:2:1]
  2 | @import 123;
    :        ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/no-url/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/no-url/span.rust-debug
@@ -65,7 +65,7 @@
    :               ^^^^
    `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
    ,-[$DIR/tests/recovery/at-rule/import/no-url/input.css:1:1]
  1 | @import nourl(test);
    :               ^^^^
@@ -113,7 +113,7 @@
    :         ^^^
    `----
 
-  x Number { value: 123.0, raw: Atom('123' type=inline), type_flag: Integer }
+  x Number { value: 123.0, raw: "123", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/import/no-url/input.css:2:1]
  2 | @import 123;
    :         ^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/unknown/span.rust-debug
@@ -35,7 +35,7 @@
    :        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/unknown/input.css:1:1]
  1 | @import url("./test.css") unknown(default) unknown(display: flex) unknown;
    :        ^
@@ -77,7 +77,7 @@
    :                          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/unknown/input.css:1:1]
  1 | @import url("./test.css") unknown(default) unknown(display: flex) unknown;
    :                          ^
@@ -119,7 +119,7 @@
    :                                           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/unknown/input.css:1:1]
  1 | @import url("./test.css") unknown(default) unknown(display: flex) unknown;
    :                                           ^
@@ -173,7 +173,7 @@
    :                                                            ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/unknown/input.css:1:1]
  1 | @import url("./test.css") unknown(default) unknown(display: flex) unknown;
    :                                                            ^
@@ -197,7 +197,7 @@
    :                                                                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/import/unknown/input.css:1:1]
  1 | @import url("./test.css") unknown(default) unknown(display: flex) unknown;
    :                                                                  ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/unknown/span.rust-debug
@@ -65,7 +65,7 @@
    :             ^^^^^^^^^^^^
    `----
 
-  x String { value: Atom('./test.css' type=dynamic), raw: Atom('"./test.css"' type=dynamic) }
+  x String { value: Atom('./test.css' type=dynamic), raw: "\"./test.css\"" }
    ,-[$DIR/tests/recovery/at-rule/import/unknown/input.css:1:1]
  1 | @import url("./test.css") unknown(default) unknown(display: flex) unknown;
    :             ^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/import/unknown/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/import/unknown/span.rust-debug
@@ -107,7 +107,7 @@
    :                                   ^^^^^^^
    `----
 
-  x Ident { value: Atom('default' type=static), raw: Atom('default' type=static) }
+  x Ident { value: Atom('default' type=static), raw: "default" }
    ,-[$DIR/tests/recovery/at-rule/import/unknown/input.css:1:1]
  1 | @import url("./test.css") unknown(default) unknown(display: flex) unknown;
    :                                   ^^^^^^^
@@ -149,7 +149,7 @@
    :                                                    ^^^^^^^
    `----
 
-  x Ident { value: Atom('display' type=static), raw: Atom('display' type=static) }
+  x Ident { value: Atom('display' type=static), raw: "display" }
    ,-[$DIR/tests/recovery/at-rule/import/unknown/input.css:1:1]
  1 | @import url("./test.css") unknown(default) unknown(display: flex) unknown;
    :                                                    ^^^^^^^
@@ -185,7 +185,7 @@
    :                                                             ^^^^
    `----
 
-  x Ident { value: Atom('flex' type=static), raw: Atom('flex' type=static) }
+  x Ident { value: Atom('flex' type=static), raw: "flex" }
    ,-[$DIR/tests/recovery/at-rule/import/unknown/input.css:1:1]
  1 | @import url("./test.css") unknown(default) unknown(display: flex) unknown;
    :                                                             ^^^^
@@ -209,7 +209,7 @@
    :                                                                   ^^^^^^^
    `----
 
-  x Ident { value: Atom('unknown' type=static), raw: Atom('unknown' type=static) }
+  x Ident { value: Atom('unknown' type=static), raw: "unknown" }
    ,-[$DIR/tests/recovery/at-rule/import/unknown/input.css:1:1]
  1 | @import url("./test.css") unknown(default) unknown(display: flex) unknown;
    :                                                                   ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-1/span.rust-debug
@@ -35,7 +35,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-1/input.css:1:1]
  1 | @keyframes None {}
    :           ^
@@ -59,7 +59,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-1/input.css:1:1]
  1 | @keyframes None {}
    :                ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-1/span.rust-debug
@@ -47,7 +47,7 @@
    :            ^^^^
    `----
 
-  x Ident { value: Atom('None' type=inline), raw: Atom('None' type=inline) }
+  x Ident { value: Atom('None' type=inline), raw: "None" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-1/input.css:1:1]
  1 | @keyframes None {}
    :            ^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-2/span.rust-debug
@@ -35,7 +35,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-2/input.css:1:1]
  1 | @keyframes inherit {}
    :           ^
@@ -59,7 +59,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-2/input.css:1:1]
  1 | @keyframes inherit {}
    :                   ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-2/span.rust-debug
@@ -47,7 +47,7 @@
    :            ^^^^^^^
    `----
 
-  x Ident { value: Atom('inherit' type=static), raw: Atom('inherit' type=static) }
+  x Ident { value: Atom('inherit' type=static), raw: "inherit" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-2/input.css:1:1]
  1 | @keyframes inherit {}
    :            ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-3/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-3/span.rust-debug
@@ -35,7 +35,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-3/input.css:1:1]
  1 | @keyframes unset {}
    :           ^
@@ -59,7 +59,7 @@
    :                 ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-3/input.css:1:1]
  1 | @keyframes unset {}
    :                 ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-3/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-3/span.rust-debug
@@ -47,7 +47,7 @@
    :            ^^^^^
    `----
 
-  x Ident { value: Atom('unset' type=static), raw: Atom('unset' type=static) }
+  x Ident { value: Atom('unset' type=static), raw: "unset" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-3/input.css:1:1]
  1 | @keyframes unset {}
    :            ^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-4/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-4/span.rust-debug
@@ -47,7 +47,7 @@
    :            ^^^^^^^
    `----
 
-  x Ident { value: Atom('default' type=static), raw: Atom('default' type=static) }
+  x Ident { value: Atom('default' type=static), raw: "default" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-4/input.css:1:1]
  1 | @keyframes default {}
    :            ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-4/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident-4/span.rust-debug
@@ -35,7 +35,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-4/input.css:1:1]
  1 | @keyframes default {}
    :           ^
@@ -59,7 +59,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident-4/input.css:1:1]
  1 | @keyframes default {}
    :                   ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident/span.rust-debug
@@ -35,7 +35,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident/input.css:1:1]
  1 | @keyframes initial {}
    :           ^
@@ -59,7 +59,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident/input.css:1:1]
  1 | @keyframes initial {}
    :                   ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/custom-ident/span.rust-debug
@@ -47,7 +47,7 @@
    :            ^^^^^^^
    `----
 
-  x Ident { value: Atom('initial' type=static), raw: Atom('initial' type=static) }
+  x Ident { value: Atom('initial' type=static), raw: "initial" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/custom-ident/input.css:1:1]
  1 | @keyframes initial {}
    :            ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/empty-name/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/empty-name/span.rust-debug
@@ -35,7 +35,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/empty-name/input.css:1:1]
  1 | @keyframes {}
    :           ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-broke-and-normal/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-broke-and-normal/span.rust-debug
@@ -105,7 +105,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-broke-and-normal/input.css:2:5]
  2 | 10 {
    :   ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-broke-and-normal/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-broke-and-normal/span.rust-debug
@@ -93,7 +93,7 @@
    : ^^
    `----
 
-  x Number { value: 10.0, raw: Atom('10' type=inline), type_flag: Integer }
+  x Number { value: 10.0, raw: "10", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-broke-and-normal/input.css:2:5]
  2 | 10 {
    : ^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/span.rust-debug
@@ -50,7 +50,7 @@
    :            ^^^^^^^
    `----
 
-  x Ident { value: Atom('initial' type=static), raw: Atom('initial' type=static) }
+  x Ident { value: Atom('initial' type=static), raw: "initial" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:1:1]
  1 | @keyframes initial {}
    :            ^^^^^^^
@@ -122,7 +122,7 @@
    :            ^^^^^^^
    `----
 
-  x Ident { value: Atom('inherit' type=static), raw: Atom('inherit' type=static) }
+  x Ident { value: Atom('inherit' type=static), raw: "inherit" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:2:1]
  2 | @keyframes inherit {}
    :            ^^^^^^^
@@ -194,7 +194,7 @@
    :            ^^^^^
    `----
 
-  x Ident { value: Atom('unset' type=static), raw: Atom('unset' type=static) }
+  x Ident { value: Atom('unset' type=static), raw: "unset" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:3:1]
  3 | @keyframes unset {}
    :            ^^^^^
@@ -266,7 +266,7 @@
    :            ^^^^
    `----
 
-  x Ident { value: Atom('none' type=static), raw: Atom('none' type=static) }
+  x Ident { value: Atom('none' type=static), raw: "none" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:4:1]
  4 | @keyframes none {}
    :            ^^^^
@@ -338,7 +338,7 @@
    :            ^^^^^^^
    `----
 
-  x Ident { value: Atom('iNiTiAl' type=inline), raw: Atom('iNiTiAl' type=inline) }
+  x Ident { value: Atom('iNiTiAl' type=inline), raw: "iNiTiAl" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:5:1]
  5 | @keyframes iNiTiAl {}
    :            ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/span.rust-debug
@@ -38,7 +38,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:1:1]
  1 | @keyframes initial {}
    :           ^
@@ -62,7 +62,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:1:1]
  1 | @keyframes initial {}
    :                   ^
@@ -110,7 +110,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:2:1]
  2 | @keyframes inherit {}
    :           ^
@@ -134,7 +134,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:2:1]
  2 | @keyframes inherit {}
    :                   ^
@@ -182,7 +182,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:3:1]
  3 | @keyframes unset {}
    :           ^
@@ -206,7 +206,7 @@
    :                 ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:3:1]
  3 | @keyframes unset {}
    :                 ^
@@ -254,7 +254,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:4:1]
  4 | @keyframes none {}
    :           ^
@@ -278,7 +278,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:4:1]
  4 | @keyframes none {}
    :                ^
@@ -326,7 +326,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:5:1]
  5 | @keyframes iNiTiAl {}
    :           ^
@@ -350,7 +350,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-css-wide-keywords/input.css:5:1]
  5 | @keyframes iNiTiAl {}
    :                   ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-keyword/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-keyword/span.rust-debug
@@ -85,7 +85,7 @@
    :     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-keyword/input.css:2:5]
  2 | form {}
    :     ^
@@ -166,7 +166,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-keyword/input.css:6:5]
  6 | ot {}
    :   ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-keyword/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-keyword/span.rust-debug
@@ -73,7 +73,7 @@
    : ^^^^
    `----
 
-  x Ident { value: Atom('form' type=static), raw: Atom('form' type=static) }
+  x Ident { value: Atom('form' type=static), raw: "form" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-keyword/input.css:2:5]
  2 | form {}
    : ^^^^
@@ -154,7 +154,7 @@
    : ^^
    `----
 
-  x Ident { value: Atom('ot' type=inline), raw: Atom('ot' type=inline) }
+  x Ident { value: Atom('ot' type=inline), raw: "ot" }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-keyword/input.css:6:5]
  6 | ot {}
    : ^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-number/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-number/span.rust-debug
@@ -77,7 +77,7 @@
    : ^^
    `----
 
-  x Number { value: 10.0, raw: Atom('10' type=inline), type_flag: Integer }
+  x Number { value: 10.0, raw: "10", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-number/input.css:2:5]
  2 | 10 {
    : ^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-number/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/keyframes/keyframe-number/span.rust-debug
@@ -89,7 +89,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/keyframes/keyframe-number/input.css:2:5]
  2 | 10 {
    :   ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/layer/block/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/layer/block/span.rust-debug
@@ -44,7 +44,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/layer/block/input.css:1:1]
  1 | @layer framework, override   ,    foo   {
    :       ^
@@ -80,7 +80,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/layer/block/input.css:1:1]
  1 | @layer framework, override   ,    foo   {
    :                  ^
@@ -104,7 +104,7 @@
    :                           ^^^
    `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
    ,-[$DIR/tests/recovery/at-rule/layer/block/input.css:1:1]
  1 | @layer framework, override   ,    foo   {
    :                           ^^^
@@ -128,7 +128,7 @@
    :                               ^^^^
    `----
 
-  x WhiteSpace { value: Atom('    ' type=inline) }
+  x WhiteSpace { value: "    " }
    ,-[$DIR/tests/recovery/at-rule/layer/block/input.css:1:1]
  1 | @layer framework, override   ,    foo   {
    :                               ^^^^
@@ -152,7 +152,7 @@
    :                                      ^^^
    `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
    ,-[$DIR/tests/recovery/at-rule/layer/block/input.css:1:1]
  1 | @layer framework, override   ,    foo   {
    :                                      ^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/layer/block/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/layer/block/span.rust-debug
@@ -56,7 +56,7 @@
    :        ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('framework' type=dynamic), raw: Atom('framework' type=dynamic) }
+  x Ident { value: Atom('framework' type=dynamic), raw: "framework" }
    ,-[$DIR/tests/recovery/at-rule/layer/block/input.css:1:1]
  1 | @layer framework, override   ,    foo   {
    :        ^^^^^^^^^
@@ -92,7 +92,7 @@
    :                   ^^^^^^^^
    `----
 
-  x Ident { value: Atom('override' type=static), raw: Atom('override' type=static) }
+  x Ident { value: Atom('override' type=static), raw: "override" }
    ,-[$DIR/tests/recovery/at-rule/layer/block/input.css:1:1]
  1 | @layer framework, override   ,    foo   {
    :                   ^^^^^^^^
@@ -140,7 +140,7 @@
    :                                   ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/recovery/at-rule/layer/block/input.css:1:1]
  1 | @layer framework, override   ,    foo   {
    :                                   ^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/layer/empty/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/layer/empty/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/layer/empty/input.css:1:1]
  1 | @layer ;
    :       ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/layer/string-name-block/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/layer/string-name-block/span.rust-debug
@@ -62,7 +62,7 @@
    :        ^^^^^^^^^^^
    `----
 
-  x String { value: Atom('framework' type=dynamic), raw: Atom('"framework"' type=dynamic) }
+  x String { value: Atom('framework' type=dynamic), raw: "\"framework\"" }
    ,-[$DIR/tests/recovery/at-rule/layer/string-name-block/input.css:1:1]
  1 | @layer "framework" {
    :        ^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/layer/string-name-block/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/layer/string-name-block/span.rust-debug
@@ -50,7 +50,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/layer/string-name-block/input.css:1:1]
  1 | @layer "framework" {
    :       ^
@@ -74,7 +74,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/layer/string-name-block/input.css:1:1]
  1 | @layer "framework" {
    :                   ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/layer/string-name-statement/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/layer/string-name-statement/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/layer/string-name-statement/input.css:1:1]
  1 | @layer "default";
    :       ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/layer/string-name-statement/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/layer/string-name-statement/span.rust-debug
@@ -47,7 +47,7 @@
    :        ^^^^^^^^^
    `----
 
-  x String { value: Atom('default' type=static), raw: Atom('"default"' type=dynamic) }
+  x String { value: Atom('default' type=static), raw: "\"default\"" }
    ,-[$DIR/tests/recovery/at-rule/layer/string-name-statement/input.css:1:1]
  1 | @layer "default";
    :        ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/condition-1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/condition-1/span.rust-debug
@@ -65,7 +65,7 @@
    :         ^^^^^^
    `----
 
-  x Ident { value: Atom('update' type=inline), raw: Atom('update' type=inline) }
+  x Ident { value: Atom('update' type=inline), raw: "update" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :         ^^^^^^
@@ -101,7 +101,7 @@
    :                 ^^^^
    `----
 
-  x Ident { value: Atom('slow' type=inline), raw: Atom('slow' type=inline) }
+  x Ident { value: Atom('slow' type=inline), raw: "slow" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                 ^^^^
@@ -125,7 +125,7 @@
    :                       ^^^
    `----
 
-  x Ident { value: Atom('and' type=static), raw: Atom('and' type=static) }
+  x Ident { value: Atom('and' type=static), raw: "and" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                       ^^^
@@ -167,7 +167,7 @@
    :                            ^^^^^
    `----
 
-  x Ident { value: Atom('hover' type=inline), raw: Atom('hover' type=inline) }
+  x Ident { value: Atom('hover' type=inline), raw: "hover" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                            ^^^^^
@@ -203,7 +203,7 @@
    :                                   ^^^^
    `----
 
-  x Ident { value: Atom('none' type=static), raw: Atom('none' type=static) }
+  x Ident { value: Atom('none' type=static), raw: "none" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                                   ^^^^
@@ -227,7 +227,7 @@
    :                                         ^^^^^^^
    `----
 
-  x Ident { value: Atom('unknown' type=static), raw: Atom('unknown' type=static) }
+  x Ident { value: Atom('unknown' type=static), raw: "unknown" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                                         ^^^^^^^
@@ -269,7 +269,7 @@
    :                                                  ^^^^^
    `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                                                  ^^^^^
@@ -305,7 +305,7 @@
    :                                                         ^
    `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                                                         ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/condition-1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/condition-1/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :       ^
@@ -89,7 +89,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                ^
@@ -113,7 +113,7 @@
    :                      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                      ^
@@ -137,7 +137,7 @@
    :                          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                          ^
@@ -191,7 +191,7 @@
    :                                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                                  ^
@@ -215,7 +215,7 @@
    :                                        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                                        ^
@@ -239,7 +239,7 @@
    :                                                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                                                ^
@@ -293,7 +293,7 @@
    :                                                        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                                                        ^
@@ -317,7 +317,7 @@
    :                                                           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-1/input.css:1:1]
  1 | @media (update: slow) and (hover: none) unknown (color: 1) {}
    :                                                           ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/condition-and-or/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/condition-and-or/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :       ^
@@ -59,7 +59,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :              ^
@@ -83,7 +83,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                  ^
@@ -137,7 +137,7 @@
    :                              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                              ^
@@ -161,7 +161,7 @@
    :                                     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                                     ^
@@ -185,7 +185,7 @@
    :                                        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                                        ^
@@ -239,7 +239,7 @@
    :                                                    ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                                                    ^
@@ -263,7 +263,7 @@
    :                                                            ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                                                            ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/condition-and-or/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/condition-and-or/span.rust-debug
@@ -47,7 +47,7 @@
    :        ^^^^^^
    `----
 
-  x Ident { value: Atom('screen' type=inline), raw: Atom('screen' type=inline) }
+  x Ident { value: Atom('screen' type=inline), raw: "screen" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :        ^^^^^^
@@ -71,7 +71,7 @@
    :               ^^^
    `----
 
-  x Ident { value: Atom('and' type=static), raw: Atom('and' type=static) }
+  x Ident { value: Atom('and' type=static), raw: "and" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :               ^^^
@@ -113,7 +113,7 @@
    :                    ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('min-width' type=dynamic), raw: Atom('min-width' type=dynamic) }
+  x Ident { value: Atom('min-width' type=dynamic), raw: "min-width" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                    ^^^^^^^^^
@@ -149,7 +149,7 @@
    :                               ^^^^^
    `----
 
-  x Dimension { value: 900.0, raw_value: Atom('900' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 900.0, raw_value: "900", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                               ^^^^^
@@ -173,7 +173,7 @@
    :                                      ^^
    `----
 
-  x Ident { value: Atom('or' type=static), raw: Atom('or' type=static) }
+  x Ident { value: Atom('or' type=static), raw: "or" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                                      ^^
@@ -215,7 +215,7 @@
    :                                          ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('min-width' type=dynamic), raw: Atom('min-width' type=dynamic) }
+  x Ident { value: Atom('min-width' type=dynamic), raw: "min-width" }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                                          ^^^^^^^^^
@@ -251,7 +251,7 @@
    :                                                     ^^^^^^
    `----
 
-  x Dimension { value: 1200.0, raw_value: Atom('1200' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 1200.0, raw_value: "1200", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/condition-and-or/input.css:1:1]
  1 | @media screen and (min-width: 900px) or (min-width: 1200px) {}
    :                                                     ^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/condition/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/condition/span.rust-debug
@@ -65,7 +65,7 @@
    :         ^^^^^^
    `----
 
-  x Ident { value: Atom('update' type=inline), raw: Atom('update' type=inline) }
+  x Ident { value: Atom('update' type=inline), raw: "update" }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :         ^^^^^^
@@ -101,7 +101,7 @@
    :                 ^^^^
    `----
 
-  x Ident { value: Atom('slow' type=inline), raw: Atom('slow' type=inline) }
+  x Ident { value: Atom('slow' type=inline), raw: "slow" }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :                 ^^^^
@@ -125,7 +125,7 @@
    :                       ^^^^^^^
    `----
 
-  x Ident { value: Atom('unknown' type=static), raw: Atom('unknown' type=static) }
+  x Ident { value: Atom('unknown' type=static), raw: "unknown" }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :                       ^^^^^^^
@@ -167,7 +167,7 @@
    :                                ^^^^^
    `----
 
-  x Ident { value: Atom('hover' type=inline), raw: Atom('hover' type=inline) }
+  x Ident { value: Atom('hover' type=inline), raw: "hover" }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :                                ^^^^^
@@ -203,7 +203,7 @@
    :                                       ^^^^
    `----
 
-  x Ident { value: Atom('none' type=static), raw: Atom('none' type=static) }
+  x Ident { value: Atom('none' type=static), raw: "none" }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :                                       ^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/condition/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/condition/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :       ^
@@ -89,7 +89,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :                ^
@@ -113,7 +113,7 @@
    :                      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :                      ^
@@ -137,7 +137,7 @@
    :                              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :                              ^
@@ -191,7 +191,7 @@
    :                                      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :                                      ^
@@ -215,7 +215,7 @@
    :                                            ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/condition/input.css:1:1]
  1 | @media (update: slow) unknown (hover: none) {}
    :                                            ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name-1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name-1/span.rust-debug
@@ -65,7 +65,7 @@
    :         ^^^^
    `----
 
-  x Dimension { value: 20.0, raw_value: Atom('20' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 20.0, raw_value: "20", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name-1/input.css:1:1]
  1 | @media (20px: 20px) {}
    :         ^^^^
@@ -101,7 +101,7 @@
    :               ^^^^
    `----
 
-  x Dimension { value: 20.0, raw_value: Atom('20' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 20.0, raw_value: "20", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name-1/input.css:1:1]
  1 | @media (20px: 20px) {}
    :               ^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name-1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name-1/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name-1/input.css:1:1]
  1 | @media (20px: 20px) {}
    :       ^
@@ -89,7 +89,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name-1/input.css:1:1]
  1 | @media (20px: 20px) {}
    :              ^
@@ -113,7 +113,7 @@
    :                    ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name-1/input.css:1:1]
  1 | @media (20px: 20px) {}
    :                    ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name-2/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name-2/input.css:1:1]
  1 | @media ("string") {}
    :       ^
@@ -77,7 +77,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name-2/input.css:1:1]
  1 | @media ("string") {}
    :                  ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name-2/span.rust-debug
@@ -65,7 +65,7 @@
    :         ^^^^^^^^
    `----
 
-  x String { value: Atom('string' type=static), raw: Atom('"string"' type=dynamic) }
+  x String { value: Atom('string' type=static), raw: "\"string\"" }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name-2/input.css:1:1]
  1 | @media ("string") {}
    :         ^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name/span.rust-debug
@@ -65,7 +65,7 @@
    :         ^^^^^^^^^^^
    `----
 
-  x String { value: Atom('min-width' type=dynamic), raw: Atom('"min-width"' type=dynamic) }
+  x String { value: Atom('min-width' type=dynamic), raw: "\"min-width\"" }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name/input.css:1:1]
  1 | @media ("min-width": 20px) {}
    :         ^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name/input.css:1:1]
  1 | @media ("min-width": 20px) {}
    :       ^
@@ -89,7 +89,7 @@
    :                     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name/input.css:1:1]
  1 | @media ("min-width": 20px) {}
    :                     ^
@@ -113,7 +113,7 @@
    :                           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name/input.css:1:1]
  1 | @media ("min-width": 20px) {}
    :                           ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-name/span.rust-debug
@@ -101,7 +101,7 @@
    :                      ^^^^
    `----
 
-  x Dimension { value: 20.0, raw_value: Atom('20' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 20.0, raw_value: "20", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-name/input.css:1:1]
  1 | @media ("min-width": 20px) {}
    :                      ^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-2/span.rust-debug
@@ -113,7 +113,7 @@
    :                 ^^^^^^^
    `----
 
-  x String { value: Atom('width' type=inline), raw: Atom('"width"' type=inline) }
+  x String { value: Atom('width' type=inline), raw: "\"width\"" }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-2/input.css:1:1]
  1 | @media (400px > "width" > 700px) {}
    :                 ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-2/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-2/input.css:1:1]
  1 | @media (400px > "width" > 700px) {}
    :       ^
@@ -77,7 +77,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-2/input.css:1:1]
  1 | @media (400px > "width" > 700px) {}
    :              ^
@@ -101,7 +101,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-2/input.css:1:1]
  1 | @media (400px > "width" > 700px) {}
    :                ^
@@ -125,7 +125,7 @@
    :                        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-2/input.css:1:1]
  1 | @media (400px > "width" > 700px) {}
    :                        ^
@@ -149,7 +149,7 @@
    :                          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-2/input.css:1:1]
  1 | @media (400px > "width" > 700px) {}
    :                          ^
@@ -173,7 +173,7 @@
    :                                 ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-2/input.css:1:1]
  1 | @media (400px > "width" > 700px) {}
    :                                 ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-2/span.rust-debug
@@ -65,7 +65,7 @@
    :         ^^^^^
    `----
 
-  x Dimension { value: 400.0, raw_value: Atom('400' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 400.0, raw_value: "400", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-2/input.css:1:1]
  1 | @media (400px > "width" > 700px) {}
    :         ^^^^^
@@ -161,7 +161,7 @@
    :                           ^^^^^
    `----
 
-  x Dimension { value: 700.0, raw_value: Atom('700' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 700.0, raw_value: "700", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-2/input.css:1:1]
  1 | @media (400px > "width" > 700px) {}
    :                           ^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-3/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-3/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :       ^
@@ -77,7 +77,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :              ^
@@ -101,7 +101,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :                ^
@@ -125,7 +125,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :                  ^
@@ -149,7 +149,7 @@
    :                        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :                        ^
@@ -173,7 +173,7 @@
    :                          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :                          ^
@@ -197,7 +197,7 @@
    :                            ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :                            ^
@@ -221,7 +221,7 @@
    :                                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :                                   ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-3/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-3/span.rust-debug
@@ -65,7 +65,7 @@
    :         ^^^^^
    `----
 
-  x Dimension { value: 400.0, raw_value: Atom('400' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 400.0, raw_value: "400", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :         ^^^^^
@@ -137,7 +137,7 @@
    :                   ^^^^^
    `----
 
-  x Ident { value: Atom('width' type=inline), raw: Atom('width' type=inline) }
+  x Ident { value: Atom('width' type=inline), raw: "width" }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :                   ^^^^^
@@ -209,7 +209,7 @@
    :                             ^^^^^
    `----
 
-  x Dimension { value: 700.0, raw_value: Atom('700' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 700.0, raw_value: "700", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-3/input.css:1:1]
  1 | @media (400px > = width > = 700px) {}
    :                             ^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-4/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-4/span.rust-debug
@@ -65,7 +65,7 @@
    :         ^^^^^
    `----
 
-  x Dimension { value: 400.0, raw_value: Atom('400' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 400.0, raw_value: "400", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-4/input.css:1:1]
  1 | @media (400px >= width ! 700px) {}
    :         ^^^^^
@@ -125,7 +125,7 @@
    :                  ^^^^^
    `----
 
-  x Ident { value: Atom('width' type=inline), raw: Atom('width' type=inline) }
+  x Ident { value: Atom('width' type=inline), raw: "width" }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-4/input.css:1:1]
  1 | @media (400px >= width ! 700px) {}
    :                  ^^^^^
@@ -173,7 +173,7 @@
    :                          ^^^^^
    `----
 
-  x Dimension { value: 700.0, raw_value: Atom('700' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 700.0, raw_value: "700", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-4/input.css:1:1]
  1 | @media (400px >= width ! 700px) {}
    :                          ^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-4/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-4/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-4/input.css:1:1]
  1 | @media (400px >= width ! 700px) {}
    :       ^
@@ -77,7 +77,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-4/input.css:1:1]
  1 | @media (400px >= width ! 700px) {}
    :              ^
@@ -113,7 +113,7 @@
    :                 ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-4/input.css:1:1]
  1 | @media (400px >= width ! 700px) {}
    :                 ^
@@ -137,7 +137,7 @@
    :                       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-4/input.css:1:1]
  1 | @media (400px >= width ! 700px) {}
    :                       ^
@@ -161,7 +161,7 @@
    :                         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-4/input.css:1:1]
  1 | @media (400px >= width ! 700px) {}
    :                         ^
@@ -185,7 +185,7 @@
    :                                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-4/input.css:1:1]
  1 | @media (400px >= width ! 700px) {}
    :                                ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-5/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-5/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-5/input.css:1:1]
  1 | @media (400px <= width >= 700px) {}
    :       ^
@@ -77,7 +77,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-5/input.css:1:1]
  1 | @media (400px <= width >= 700px) {}
    :              ^
@@ -113,7 +113,7 @@
    :                 ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-5/input.css:1:1]
  1 | @media (400px <= width >= 700px) {}
    :                 ^
@@ -137,7 +137,7 @@
    :                       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-5/input.css:1:1]
  1 | @media (400px <= width >= 700px) {}
    :                       ^
@@ -173,7 +173,7 @@
    :                          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-5/input.css:1:1]
  1 | @media (400px <= width >= 700px) {}
    :                          ^
@@ -197,7 +197,7 @@
    :                                 ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-5/input.css:1:1]
  1 | @media (400px <= width >= 700px) {}
    :                                 ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-5/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-5/span.rust-debug
@@ -65,7 +65,7 @@
    :         ^^^^^
    `----
 
-  x Dimension { value: 400.0, raw_value: Atom('400' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 400.0, raw_value: "400", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-5/input.css:1:1]
  1 | @media (400px <= width >= 700px) {}
    :         ^^^^^
@@ -125,7 +125,7 @@
    :                  ^^^^^
    `----
 
-  x Ident { value: Atom('width' type=inline), raw: Atom('width' type=inline) }
+  x Ident { value: Atom('width' type=inline), raw: "width" }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-5/input.css:1:1]
  1 | @media (400px <= width >= 700px) {}
    :                  ^^^^^
@@ -185,7 +185,7 @@
    :                           ^^^^^
    `----
 
-  x Dimension { value: 700.0, raw_value: Atom('700' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 700.0, raw_value: "700", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-5/input.css:1:1]
  1 | @media (400px <= width >= 700px) {}
    :                           ^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-6/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-6/span.rust-debug
@@ -65,7 +65,7 @@
    :         ^^^^^
    `----
 
-  x Dimension { value: 400.0, raw_value: Atom('400' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 400.0, raw_value: "400", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-6/input.css:1:1]
  1 | @media (400px >= width <= 700px) {}
    :         ^^^^^
@@ -125,7 +125,7 @@
    :                  ^^^^^
    `----
 
-  x Ident { value: Atom('width' type=inline), raw: Atom('width' type=inline) }
+  x Ident { value: Atom('width' type=inline), raw: "width" }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-6/input.css:1:1]
  1 | @media (400px >= width <= 700px) {}
    :                  ^^^^^
@@ -185,7 +185,7 @@
    :                           ^^^^^
    `----
 
-  x Dimension { value: 700.0, raw_value: Atom('700' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 700.0, raw_value: "700", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-6/input.css:1:1]
  1 | @media (400px >= width <= 700px) {}
    :                           ^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-6/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature-range-6/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-6/input.css:1:1]
  1 | @media (400px >= width <= 700px) {}
    :       ^
@@ -77,7 +77,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-6/input.css:1:1]
  1 | @media (400px >= width <= 700px) {}
    :              ^
@@ -113,7 +113,7 @@
    :                 ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-6/input.css:1:1]
  1 | @media (400px >= width <= 700px) {}
    :                 ^
@@ -137,7 +137,7 @@
    :                       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-6/input.css:1:1]
  1 | @media (400px >= width <= 700px) {}
    :                       ^
@@ -173,7 +173,7 @@
    :                          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-6/input.css:1:1]
  1 | @media (400px >= width <= 700px) {}
    :                          ^
@@ -197,7 +197,7 @@
    :                                 ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature-range-6/input.css:1:1]
  1 | @media (400px >= width <= 700px) {}
    :                                 ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature/span.rust-debug
@@ -35,7 +35,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature/input.css:1:1]
  1 | @media screen and {}
    :       ^
@@ -59,7 +59,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature/input.css:1:1]
  1 | @media screen and {}
    :              ^
@@ -83,7 +83,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/feature/input.css:1:1]
  1 | @media screen and {}
    :                  ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/feature/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/feature/span.rust-debug
@@ -47,7 +47,7 @@
    :        ^^^^^^
    `----
 
-  x Ident { value: Atom('screen' type=inline), raw: Atom('screen' type=inline) }
+  x Ident { value: Atom('screen' type=inline), raw: "screen" }
    ,-[$DIR/tests/recovery/at-rule/media/feature/input.css:1:1]
  1 | @media screen and {}
    :        ^^^^^^
@@ -71,7 +71,7 @@
    :               ^^^
    `----
 
-  x Ident { value: Atom('and' type=static), raw: Atom('and' type=static) }
+  x Ident { value: Atom('and' type=static), raw: "and" }
    ,-[$DIR/tests/recovery/at-rule/media/feature/input.css:1:1]
  1 | @media screen and {}
    :               ^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/invalid-nesting/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/invalid-nesting/span.rust-debug
@@ -149,7 +149,7 @@
    : ^^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('max-inline-size' type=dynamic), raw: Atom('max-inline-size' type=dynamic) }
+  x Ident { value: Atom('max-inline-size' type=dynamic), raw: "max-inline-size" }
    ,-[$DIR/tests/recovery/at-rule/media/invalid-nesting/input.css:2:5]
  2 | max-inline-size: 1024px;
    : ^^^^^^^^^^^^^^^
@@ -185,7 +185,7 @@
    :                  ^^^^^^
    `----
 
-  x Dimension { value: 1024.0, raw_value: Atom('1024' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 1024.0, raw_value: "1024", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/media/invalid-nesting/input.css:2:5]
  2 | max-inline-size: 1024px;
    :                  ^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/invalid-nesting/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/invalid-nesting/span.rust-debug
@@ -173,7 +173,7 @@
    :                 ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/invalid-nesting/input.css:2:5]
  2 | max-inline-size: 1024px;
    :                 ^
@@ -210,8 +210,7 @@
  3 | }
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/at-rule/media/invalid-nesting/input.css:2:5]
  2 | max-inline-size: 1024px;
    :                         ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/media-type/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/media-type/span.rust-debug
@@ -44,7 +44,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/media-type/input.css:1:1]
  1 | @media only layer {
    :       ^
@@ -68,7 +68,7 @@
    :            ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/media-type/input.css:1:1]
  1 | @media only layer {
    :            ^
@@ -92,7 +92,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/media-type/input.css:1:1]
  1 | @media only layer {
    :                  ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/media-type/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/media-type/span.rust-debug
@@ -56,7 +56,7 @@
    :        ^^^^
    `----
 
-  x Ident { value: Atom('only' type=static), raw: Atom('only' type=static) }
+  x Ident { value: Atom('only' type=static), raw: "only" }
    ,-[$DIR/tests/recovery/at-rule/media/media-type/input.css:1:1]
  1 | @media only layer {
    :        ^^^^
@@ -80,7 +80,7 @@
    :             ^^^^^
    `----
 
-  x Ident { value: Atom('layer' type=static), raw: Atom('layer' type=static) }
+  x Ident { value: Atom('layer' type=static), raw: "layer" }
    ,-[$DIR/tests/recovery/at-rule/media/media-type/input.css:1:1]
  1 | @media only layer {
    :             ^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/wrong-stylesheet/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/wrong-stylesheet/span.rust-debug
@@ -111,7 +111,7 @@
    : ^^^^^
    `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
    ,-[$DIR/tests/recovery/at-rule/media/wrong-stylesheet/input.css:2:5]
  2 | color: teal;
    : ^^^^^
@@ -147,7 +147,7 @@
    :        ^^^^
    `----
 
-  x Ident { value: Atom('teal' type=inline), raw: Atom('teal' type=inline) }
+  x Ident { value: Atom('teal' type=inline), raw: "teal" }
    ,-[$DIR/tests/recovery/at-rule/media/wrong-stylesheet/input.css:2:5]
  2 | color: teal;
    :        ^^^^
@@ -183,7 +183,7 @@
    : ^^^^
    `----
 
-  x Ident { value: Atom('main' type=static), raw: Atom('main' type=static) }
+  x Ident { value: Atom('main' type=static), raw: "main" }
    ,-[$DIR/tests/recovery/at-rule/media/wrong-stylesheet/input.css:3:5]
  3 | main {
    : ^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/media/wrong-stylesheet/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/media/wrong-stylesheet/span.rust-debug
@@ -135,7 +135,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/wrong-stylesheet/input.css:2:5]
  2 | color: teal;
    :       ^
@@ -171,8 +171,7 @@
  3 | `->     main {
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/at-rule/media/wrong-stylesheet/input.css:2:5]
  2 | ,-> color: teal;
  3 | `->     main {
@@ -196,7 +195,7 @@
    :     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/media/wrong-stylesheet/input.css:3:5]
  3 | main {
    :     ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/page/invalid-pseudo/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/page/invalid-pseudo/span.rust-debug
@@ -62,7 +62,7 @@
    :        ^^^^^^^
    `----
 
-  x Ident { value: Atom('unknown' type=static), raw: Atom('unknown' type=static) }
+  x Ident { value: Atom('unknown' type=static), raw: "unknown" }
    ,-[$DIR/tests/recovery/at-rule/page/invalid-pseudo/input.css:1:1]
  1 | @page :unknown {
    :        ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/page/invalid-pseudo/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/page/invalid-pseudo/span.rust-debug
@@ -38,7 +38,7 @@
    :      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/page/invalid-pseudo/input.css:1:1]
  1 | @page :unknown {
    :      ^
@@ -74,7 +74,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/page/invalid-pseudo/input.css:1:1]
  1 | @page :unknown {
    :               ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/page/no-space/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/page/no-space/span.rust-debug
@@ -41,7 +41,7 @@
    :      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/page/no-space/input.css:1:1]
  1 | @page Page: blank {
    :      ^
@@ -77,7 +77,7 @@
    :            ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/page/no-space/input.css:1:1]
  1 | @page Page: blank {
    :            ^
@@ -101,7 +101,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/page/no-space/input.css:1:1]
  1 | @page Page: blank {
    :                  ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/page/no-space/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/page/no-space/span.rust-debug
@@ -53,7 +53,7 @@
    :       ^^^^
    `----
 
-  x Ident { value: Atom('Page' type=inline), raw: Atom('Page' type=inline) }
+  x Ident { value: Atom('Page' type=inline), raw: "Page" }
    ,-[$DIR/tests/recovery/at-rule/page/no-space/input.css:1:1]
  1 | @page Page: blank {
    :       ^^^^
@@ -89,7 +89,7 @@
    :             ^^^^^
    `----
 
-  x Ident { value: Atom('blank' type=inline), raw: Atom('blank' type=inline) }
+  x Ident { value: Atom('blank' type=inline), raw: "blank" }
    ,-[$DIR/tests/recovery/at-rule/page/no-space/input.css:1:1]
  1 | @page Page: blank {
    :             ^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/page/without-page/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/page/without-page/span.rust-debug
@@ -79,7 +79,7 @@
    : ^^^^^^^
    `----
 
-  x Ident { value: Atom('content' type=static), raw: Atom('content' type=static) }
+  x Ident { value: Atom('content' type=static), raw: "content" }
    ,-[$DIR/tests/recovery/at-rule/page/without-page/input.css:2:5]
  2 | content: "foo";
    : ^^^^^^^
@@ -151,7 +151,7 @@
    : ^^^^^
    `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
    ,-[$DIR/tests/recovery/at-rule/page/without-page/input.css:3:5]
  3 | color: blue;
    : ^^^^^
@@ -187,7 +187,7 @@
    :        ^^^^
    `----
 
-  x Ident { value: Atom('blue' type=inline), raw: Atom('blue' type=inline) }
+  x Ident { value: Atom('blue' type=inline), raw: "blue" }
    ,-[$DIR/tests/recovery/at-rule/page/without-page/input.css:3:5]
  3 | color: blue;
    :        ^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/page/without-page/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/page/without-page/span.rust-debug
@@ -115,7 +115,7 @@
    :          ^^^^^
    `----
 
-  x String { value: Atom('foo' type=inline), raw: Atom('"foo"' type=inline) }
+  x String { value: Atom('foo' type=inline), raw: "\"foo\"" }
    ,-[$DIR/tests/recovery/at-rule/page/without-page/input.css:2:5]
  2 | content: "foo";
    :          ^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/page/without-page/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/page/without-page/span.rust-debug
@@ -41,7 +41,7 @@
    :          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/page/without-page/input.css:1:1]
  1 | @top-left {
    :          ^
@@ -67,8 +67,7 @@
  2 | `->     content: "foo";
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/at-rule/page/without-page/input.css:1:1]
  1 | ,-> @top-left {
  2 | `->     content: "foo";
@@ -104,7 +103,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/page/without-page/input.css:2:5]
  2 | content: "foo";
    :         ^
@@ -140,8 +139,7 @@
  3 | `->     color: blue;
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/at-rule/page/without-page/input.css:2:5]
  2 | ,-> content: "foo";
  3 | `->     color: blue;
@@ -177,7 +175,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/page/without-page/input.css:3:5]
  3 | color: blue;
    :       ^
@@ -214,8 +212,7 @@
  4 | }
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/at-rule/page/without-page/input.css:3:5]
  3 | color: blue;
    :             ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/supports/empty-in-parens/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/supports/empty-in-parens/span.rust-debug
@@ -38,7 +38,7 @@
    :          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/empty-in-parens/input.css:1:1]
  1 | @supports (      ) {
    :          ^
@@ -68,7 +68,7 @@
    :            ^^^^^^
    `----
 
-  x WhiteSpace { value: Atom('      ' type=inline) }
+  x WhiteSpace { value: "      " }
    ,-[$DIR/tests/recovery/at-rule/supports/empty-in-parens/input.css:1:1]
  1 | @supports (      ) {
    :            ^^^^^^
@@ -80,7 +80,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/empty-in-parens/input.css:1:1]
  1 | @supports (      ) {
    :                   ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/supports/no-parens/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/supports/no-parens/span.rust-debug
@@ -35,7 +35,7 @@
    :          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/no-parens/input.css:1:1]
  1 | @supports display: flex {}
    :          ^
@@ -71,7 +71,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/no-parens/input.css:1:1]
  1 | @supports display: flex {}
    :                   ^
@@ -95,7 +95,7 @@
    :                        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/no-parens/input.css:1:1]
  1 | @supports display: flex {}
    :                        ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/supports/no-parens/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/supports/no-parens/span.rust-debug
@@ -47,7 +47,7 @@
    :           ^^^^^^^
    `----
 
-  x Ident { value: Atom('display' type=static), raw: Atom('display' type=static) }
+  x Ident { value: Atom('display' type=static), raw: "display" }
    ,-[$DIR/tests/recovery/at-rule/supports/no-parens/input.css:1:1]
  1 | @supports display: flex {}
    :           ^^^^^^^
@@ -83,7 +83,7 @@
    :                    ^^^^
    `----
 
-  x Ident { value: Atom('flex' type=static), raw: Atom('flex' type=static) }
+  x Ident { value: Atom('flex' type=static), raw: "flex" }
    ,-[$DIR/tests/recovery/at-rule/supports/no-parens/input.css:1:1]
  1 | @supports display: flex {}
    :                    ^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/supports/non-standard-prelude/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/supports/non-standard-prelude/span.rust-debug
@@ -124,7 +124,7 @@
    :                                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:1:1]
  1 | @supports (--element(".minwidth", { "minWidth": 300 })) {
    :                                  ^
@@ -154,7 +154,7 @@
    :                                    ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:1:1]
  1 | @supports (--element(".minwidth", { "minWidth": 300 })) {
    :                                    ^
@@ -190,7 +190,7 @@
    :                                                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:1:1]
  1 | @supports (--element(".minwidth", { "minWidth": 300 })) {
    :                                                ^
@@ -214,7 +214,7 @@
    :                                                    ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:1:1]
  1 | @supports (--element(".minwidth", { "minWidth": 300 })) {
    :                                                    ^
@@ -385,7 +385,7 @@
    :          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:7:1]
  7 | @supports ({"example": 1}) {
    :          ^
@@ -457,7 +457,7 @@
    :                       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:7:1]
  7 | @supports ({"example": 1}) {
    :                       ^
@@ -481,7 +481,7 @@
    :                           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:7:1]
  7 | @supports ({"example": 1}) {
    :                           ^
@@ -634,7 +634,7 @@
     :          ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:11:1]
  11 | @supports (("example": 1)) {
     :          ^
@@ -706,7 +706,7 @@
     :                       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:11:1]
  11 | @supports (("example": 1)) {
     :                       ^
@@ -730,7 +730,7 @@
     :                           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:11:1]
  11 | @supports (("example": 1)) {
     :                           ^
@@ -883,7 +883,7 @@
     :          ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:15:1]
  15 | @supports ([]) {
     :          ^
@@ -931,7 +931,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:15:1]
  15 | @supports ([]) {
     :               ^
@@ -1084,7 +1084,7 @@
     :          ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:19:1]
  19 | @supports ([color: red]) {
     :          ^
@@ -1156,7 +1156,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:19:1]
  19 | @supports ([color: red]) {
     :                   ^
@@ -1180,7 +1180,7 @@
     :                         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:19:1]
  19 | @supports ([color: red]) {
     :                         ^
@@ -1333,7 +1333,7 @@
     :          ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:23:1]
  23 | @supports ([[[[[{ --func(color: { red }) }]]]]]) {
     :          ^
@@ -1471,7 +1471,7 @@
     :                  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:23:1]
  23 | @supports ([[[[[{ --func(color: { red }) }]]]]]) {
     :                  ^
@@ -1525,7 +1525,7 @@
     :                                ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:23:1]
  23 | @supports ([[[[[{ --func(color: { red }) }]]]]]) {
     :                                ^
@@ -1555,7 +1555,7 @@
     :                                  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:23:1]
  23 | @supports ([[[[[{ --func(color: { red }) }]]]]]) {
     :                                  ^
@@ -1579,7 +1579,7 @@
     :                                      ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:23:1]
  23 | @supports ([[[[[{ --func(color: { red }) }]]]]]) {
     :                                      ^
@@ -1591,7 +1591,7 @@
     :                                         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:23:1]
  23 | @supports ([[[[[{ --func(color: { red }) }]]]]]) {
     :                                         ^
@@ -1603,7 +1603,7 @@
     :                                                 ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:23:1]
  23 | @supports ([[[[[{ --func(color: { red }) }]]]]]) {
     :                                                 ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/supports/non-standard-prelude/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/supports/non-standard-prelude/span.rust-debug
@@ -202,7 +202,7 @@
    :                                                 ^^^
    `----
 
-  x Number { value: 300.0, raw: Atom('300' type=inline), type_flag: Integer }
+  x Number { value: 300.0, raw: "300", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:1:1]
  1 | @supports (--element(".minwidth", { "minWidth": 300 })) {
    :                                                 ^^^
@@ -469,7 +469,7 @@
    :                        ^
    `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:7:1]
  7 | @supports ({"example": 1}) {
    :                        ^
@@ -718,7 +718,7 @@
     :                        ^
     `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:11:1]
  11 | @supports (("example": 1)) {
     :                        ^
@@ -1132,7 +1132,7 @@
     :             ^^^^^
     `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:19:1]
  19 | @supports ([color: red]) {
     :             ^^^^^
@@ -1168,7 +1168,7 @@
     :                    ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:19:1]
  19 | @supports ([color: red]) {
     :                    ^^^
@@ -1501,7 +1501,7 @@
     :                          ^^^^^
     `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:23:1]
  23 | @supports ([[[[[{ --func(color: { red }) }]]]]]) {
     :                          ^^^^^
@@ -1567,7 +1567,7 @@
     :                                   ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:23:1]
  23 | @supports ([[[[[{ --func(color: { red }) }]]]]]) {
     :                                   ^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/supports/non-standard-prelude/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/supports/non-standard-prelude/span.rust-debug
@@ -100,7 +100,7 @@
    :                      ^^^^^^^^^^^
    `----
 
-  x String { value: Atom('.minwidth' type=dynamic), raw: Atom('".minwidth"' type=dynamic) }
+  x String { value: Atom('.minwidth' type=dynamic), raw: "\".minwidth\"" }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:1:1]
  1 | @supports (--element(".minwidth", { "minWidth": 300 })) {
    :                      ^^^^^^^^^^^
@@ -166,7 +166,7 @@
    :                                     ^^^^^^^^^^
    `----
 
-  x String { value: Atom('minWidth' type=dynamic), raw: Atom('"minWidth"' type=dynamic) }
+  x String { value: Atom('minWidth' type=dynamic), raw: "\"minWidth\"" }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:1:1]
  1 | @supports (--element(".minwidth", { "minWidth": 300 })) {
    :                                     ^^^^^^^^^^
@@ -433,7 +433,7 @@
    :             ^^^^^^^^^
    `----
 
-  x String { value: Atom('example' type=inline), raw: Atom('"example"' type=dynamic) }
+  x String { value: Atom('example' type=inline), raw: "\"example\"" }
    ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:7:1]
  7 | @supports ({"example": 1}) {
    :             ^^^^^^^^^
@@ -682,7 +682,7 @@
     :             ^^^^^^^^^
     `----
 
-  x String { value: Atom('example' type=inline), raw: Atom('"example"' type=dynamic) }
+  x String { value: Atom('example' type=inline), raw: "\"example\"" }
     ,-[$DIR/tests/recovery/at-rule/supports/non-standard-prelude/input.css:11:1]
  11 | @supports (("example": 1)) {
     :             ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/at-rule/supports/wrong-or-and/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/supports/wrong-or-and/span.rust-debug
@@ -35,7 +35,7 @@
    :          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :          ^
@@ -89,7 +89,7 @@
    :                                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                ^
@@ -113,7 +113,7 @@
    :                                       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                       ^
@@ -137,7 +137,7 @@
    :                                          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                          ^
@@ -191,7 +191,7 @@
    :                                                           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                                           ^
@@ -215,7 +215,7 @@
    :                                                                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                                                ^
@@ -239,7 +239,7 @@
    :                                                                    ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                                                    ^
@@ -293,7 +293,7 @@
    :                                                                                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                                                                ^
@@ -335,7 +335,7 @@
    :                                                                                               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                                                                               ^

--- a/crates/swc_css_parser/tests/recovery/at-rule/supports/wrong-or-and/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/at-rule/supports/wrong-or-and/span.rust-debug
@@ -65,7 +65,7 @@
    :            ^^^^^^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('transition-property' type=dynamic), raw: Atom('transition-property' type=dynamic) }
+  x Ident { value: Atom('transition-property' type=dynamic), raw: "transition-property" }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :            ^^^^^^^^^^^^^^^^^^^
@@ -101,7 +101,7 @@
    :                                 ^^^^^
    `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                 ^^^^^
@@ -125,7 +125,7 @@
    :                                        ^^
    `----
 
-  x Ident { value: Atom('or' type=static), raw: Atom('or' type=static) }
+  x Ident { value: Atom('or' type=static), raw: "or" }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                        ^^
@@ -167,7 +167,7 @@
    :                                            ^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('animation-name' type=static), raw: Atom('animation-name' type=static) }
+  x Ident { value: Atom('animation-name' type=static), raw: "animation-name" }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                            ^^^^^^^^^^^^^^
@@ -203,7 +203,7 @@
    :                                                            ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                                            ^^^
@@ -227,7 +227,7 @@
    :                                                                 ^^^
    `----
 
-  x Ident { value: Atom('and' type=static), raw: Atom('and' type=static) }
+  x Ident { value: Atom('and' type=static), raw: "and" }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                                                 ^^^
@@ -269,7 +269,7 @@
    :                                                                      ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('transform' type=static), raw: Atom('transform' type=static) }
+  x Ident { value: Atom('transform' type=static), raw: "transform" }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                                                      ^^^^^^^^^
@@ -323,7 +323,7 @@
    :                                                                                        ^^^^^
    `----
 
-  x Dimension { value: 10.0, raw_value: Atom('10' type=inline), unit: Atom('deg' type=static), raw_unit: Atom('deg' type=static), type_flag: Integer }
+  x Dimension { value: 10.0, raw_value: "10", unit: Atom('deg' type=static), raw_unit: "deg", type_flag: Integer }
    ,-[$DIR/tests/recovery/at-rule/supports/wrong-or-and/input.css:1:1]
  1 | @supports (transition-property: color) or (animation-name: foo) and (transform: rotate(10deg)) {}
    :                                                                                        ^^^^^

--- a/crates/swc_css_parser/tests/recovery/bad-url-token/double-quotes/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/bad-url-token/double-quotes/span.rust-debug
@@ -115,7 +115,7 @@
    :             ^^^^^^^^^^^^^^^
    `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('image".png' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "image\".png" }
    ,-[$DIR/tests/recovery/bad-url-token/double-quotes/input.css:2:5]
  2 | background: url(image".png);
    :             ^^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/bad-url-token/invalid-escape/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/bad-url-token/invalid-escape/span.rust-debug
@@ -115,8 +115,7 @@
  3 | `->     );
    `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('image.png\
-  |     ' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "image.png\\\n    " }
    ,-[$DIR/tests/recovery/bad-url-token/invalid-escape/input.css:2:5]
  2 | ,-> background: url(image.png\
  3 | `->     );

--- a/crates/swc_css_parser/tests/recovery/bad-url-token/left-parenthesis/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/bad-url-token/left-parenthesis/span.rust-debug
@@ -115,7 +115,7 @@
    :             ^^^^^^^^^^^^^^^
    `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('image(.png' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "image(.png" }
    ,-[$DIR/tests/recovery/bad-url-token/left-parenthesis/input.css:2:5]
  2 | background: url(image(.png);
    :             ^^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/bad-url-token/single-quotes/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/bad-url-token/single-quotes/span.rust-debug
@@ -115,7 +115,7 @@
    :             ^^^^^^^^^^^^^^^
    `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('image'.png' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "image'.png" }
    ,-[$DIR/tests/recovery/bad-url-token/single-quotes/input.css:2:5]
  2 | background: url(image'.png);
    :             ^^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/bad-url-token/whitespace-in-middle/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/bad-url-token/whitespace-in-middle/span.rust-debug
@@ -111,7 +111,7 @@
    :                   ^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('   ./image.jpg  a  ' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "   ./image.jpg  a  " }
    ,-[$DIR/tests/recovery/bad-url-token/whitespace-in-middle/input.css:2:5]
  2 | background-image: url(   ./image.jpg  a  );
    :                   ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/bad-url-token/whitespace/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/bad-url-token/whitespace/span.rust-debug
@@ -119,8 +119,7 @@
  3 | `->     png);
    `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('image.
-  |     png' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "image.\n    png" }
    ,-[$DIR/tests/recovery/bad-url-token/whitespace/input.css:2:5]
  2 | ,-> background: url(image.
  3 | `->     png);

--- a/crates/swc_css_parser/tests/recovery/cdo-and-cdc/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/cdo-and-cdc/span.rust-debug
@@ -69,7 +69,7 @@
    :      ^^^
    `----
 
-  x Number { value: 123.0, raw: Atom('123' type=inline), type_flag: Integer }
+  x Number { value: 123.0, raw: "123", type_flag: Integer }
    ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:1:1]
  1 | <!-- 123 -->
    :      ^^^
@@ -119,7 +119,7 @@
    : ^^^
    `----
 
-  x Ident { value: Atom('div' type=static), raw: Atom('div' type=static) }
+  x Ident { value: Atom('div' type=static), raw: "div" }
    ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:3:1]
  3 | div {
    : ^^^
@@ -249,7 +249,7 @@
    : ^^^^
    `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
    ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:7:1]
  7 | test
    : ^^^^
@@ -481,7 +481,7 @@
     : ^^^^
     `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:16:1]
  16 | test
     : ^^^^
@@ -533,7 +533,7 @@
     : ^^^^^
     `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:20:5]
  20 | color: blue;
     : ^^^^^
@@ -569,7 +569,7 @@
     :        ^^^^
     `----
 
-  x Ident { value: Atom('blue' type=inline), raw: Atom('blue' type=inline) }
+  x Ident { value: Atom('blue' type=inline), raw: "blue" }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:20:5]
  20 | color: blue;
     :        ^^^^
@@ -769,7 +769,7 @@
     : ^^^^
     `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:27:1]
  27 | test
     : ^^^^

--- a/crates/swc_css_parser/tests/recovery/cdo-and-cdc/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/cdo-and-cdc/span.rust-debug
@@ -81,7 +81,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:1:1]
  1 | <!-- 123 -->
    :         ^
@@ -106,9 +106,7 @@
  3 |     div {
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:1:1]
  1 | ,-> <!-- 123 -->
  2 | `-> 
@@ -133,7 +131,7 @@
    :    ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:3:1]
  3 | div {
    :    ^
@@ -238,9 +236,7 @@
  7 |     test
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:5:1]
  5 | ,-> <!--
  6 | `-> 
@@ -266,9 +262,7 @@
  9 |     -->
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:7:1]
  7 | ,-> test
  8 | `-> 
@@ -294,8 +288,7 @@
  10 | }
     `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:9:1]
   9 | -->
     :    ^
@@ -475,9 +468,7 @@
  16 |     test
     `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:14:1]
  14 | ,-> <!--
  15 | `-> 
@@ -503,9 +494,7 @@
  18 |     -->
     `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:16:1]
  16 | ,-> test
  17 | `-> 
@@ -531,9 +520,7 @@
  20 | `->     color: blue;
     `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n\n    " }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:18:1]
  18 | ,-> -->
  19 | |   
@@ -570,7 +557,7 @@
     :       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:20:5]
  20 | color: blue;
     :       ^
@@ -769,9 +756,7 @@
  27 |     test
     `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:25:1]
  25 | ,-> <!--
  26 | `-> 
@@ -797,9 +782,7 @@
  29 |     -->;
     `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
     ,-[$DIR/tests/recovery/cdo-and-cdc/input.css:27:1]
  27 | ,-> test
  28 | `-> 

--- a/crates/swc_css_parser/tests/recovery/comments/bad-comment-1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/comments/bad-comment-1/span.rust-debug
@@ -53,7 +53,7 @@
    :    ^^^^^^^
    `----
 
-  x Ident { value: Atom('comment' type=inline), raw: Atom('comment' type=inline) }
+  x Ident { value: Atom('comment' type=inline), raw: "comment" }
    ,-[$DIR/tests/recovery/comments/bad-comment-1/input.css:1:1]
  1 | // comment
    :    ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/comments/bad-comment-1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/comments/bad-comment-1/span.rust-debug
@@ -41,7 +41,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/comments/bad-comment-1/input.css:1:1]
  1 | // comment
    :   ^

--- a/crates/swc_css_parser/tests/recovery/comments/declaration/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/comments/declaration/span.rust-debug
@@ -136,7 +136,7 @@
    :           ^^^^^^
    `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
    ,-[$DIR/tests/recovery/comments/declaration/input.css:2:5]
  2 | prop: url("test") /* comment */   /* comment */
    :           ^^^^^^

--- a/crates/swc_css_parser/tests/recovery/comments/declaration/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/comments/declaration/span.rust-debug
@@ -148,7 +148,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/comments/declaration/input.css:2:5]
  2 | prop: url("test") /* comment */   /* comment */
    :                  ^
@@ -160,7 +160,7 @@
    :                                ^^^
    `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
    ,-[$DIR/tests/recovery/comments/declaration/input.css:2:5]
  2 | prop: url("test") /* comment */   /* comment */
    :                                ^^^
@@ -172,8 +172,7 @@
  3 | `->         /* comment */:
    `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
    ,-[$DIR/tests/recovery/comments/declaration/input.css:2:5]
  2 | ,-> prop: url("test") /* comment */   /* comment */
  3 | `->         /* comment */:

--- a/crates/swc_css_parser/tests/recovery/declaration/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/declaration/basic/span.rust-debug
@@ -407,7 +407,7 @@
     : ^^^^
     `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
     ,-[$DIR/tests/recovery/declaration/basic/input.css:12:5]
  12 | test;
     : ^^^^

--- a/crates/swc_css_parser/tests/recovery/declaration/important/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/declaration/important/span.rust-debug
@@ -137,7 +137,7 @@
    :             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/declaration/important/input.css:2:5]
  2 | color: white !!important;
    :             ^
@@ -266,7 +266,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/declaration/important/input.css:6:5]
  6 | color: red red red !important !important;
    :           ^
@@ -290,7 +290,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/declaration/important/input.css:6:5]
  6 | color: red red red !important !important;
    :               ^
@@ -314,7 +314,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/declaration/important/input.css:6:5]
  6 | color: red red red !important !important;
    :                   ^
@@ -467,7 +467,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:10:5]
  10 | color: red red red !important!important   ;
     :           ^
@@ -491,7 +491,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:10:5]
  10 | color: red red red !important!important   ;
     :               ^
@@ -515,7 +515,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:10:5]
  10 | color: red red red !important!important   ;
     :                   ^
@@ -668,7 +668,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:14:5]
  14 | color: red red red /* test*/ !important /*test*/ !important /*test*/ ;
     :           ^
@@ -692,7 +692,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:14:5]
  14 | color: red red red /* test*/ !important /*test*/ !important /*test*/ ;
     :               ^
@@ -716,7 +716,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:14:5]
  14 | color: red red red /* test*/ !important /*test*/ !important /*test*/ ;
     :                   ^
@@ -728,7 +728,7 @@
     :                             ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:14:5]
  14 | color: red red red /* test*/ !important /*test*/ !important /*test*/ ;
     :                             ^
@@ -881,7 +881,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:18:5]
  18 | color: red red red !important !important!important;
     :           ^
@@ -905,7 +905,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:18:5]
  18 | color: red red red !important !important!important;
     :               ^
@@ -929,7 +929,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:18:5]
  18 | color: red red red !important !important!important;
     :                   ^
@@ -965,7 +965,7 @@
     :                              ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:18:5]
  18 | color: red red red !important !important!important;
     :                              ^
@@ -1118,7 +1118,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:22:5]
  22 | color: red red red /* test */ ! /*test */ important /* test */ ! /* test */ important /* test */;
     :           ^
@@ -1142,7 +1142,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:22:5]
  22 | color: red red red /* test */ ! /*test */ important /* test */ ! /* test */ important /* test */;
     :               ^
@@ -1166,7 +1166,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:22:5]
  22 | color: red red red /* test */ ! /*test */ important /* test */ ! /* test */ important /* test */;
     :                   ^
@@ -1178,7 +1178,7 @@
     :                              ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:22:5]
  22 | color: red red red /* test */ ! /*test */ important /* test */ ! /* test */ important /* test */;
     :                              ^
@@ -1202,7 +1202,7 @@
     :                                ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:22:5]
  22 | color: red red red /* test */ ! /*test */ important /* test */ ! /* test */ important /* test */;
     :                                ^
@@ -1214,7 +1214,7 @@
     :                                          ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/declaration/important/input.css:22:5]
  22 | color: red red red /* test */ ! /*test */ important /* test */ ! /* test */ important /* test */;
     :                                          ^

--- a/crates/swc_css_parser/tests/recovery/declaration/important/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/declaration/important/span.rust-debug
@@ -125,7 +125,7 @@
    :        ^^^^^
    `----
 
-  x Ident { value: Atom('white' type=inline), raw: Atom('white' type=inline) }
+  x Ident { value: Atom('white' type=inline), raw: "white" }
    ,-[$DIR/tests/recovery/declaration/important/input.css:2:5]
  2 | color: white !!important;
    :        ^^^^^
@@ -254,7 +254,7 @@
    :        ^^^
    `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
    ,-[$DIR/tests/recovery/declaration/important/input.css:6:5]
  6 | color: red red red !important !important;
    :        ^^^
@@ -278,7 +278,7 @@
    :            ^^^
    `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
    ,-[$DIR/tests/recovery/declaration/important/input.css:6:5]
  6 | color: red red red !important !important;
    :            ^^^
@@ -302,7 +302,7 @@
    :                ^^^
    `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
    ,-[$DIR/tests/recovery/declaration/important/input.css:6:5]
  6 | color: red red red !important !important;
    :                ^^^
@@ -338,7 +338,7 @@
    :                     ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('important' type=static), raw: Atom('important' type=static) }
+  x Ident { value: Atom('important' type=static), raw: "important" }
    ,-[$DIR/tests/recovery/declaration/important/input.css:6:5]
  6 | color: red red red !important !important;
    :                     ^^^^^^^^^
@@ -455,7 +455,7 @@
     :        ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:10:5]
  10 | color: red red red !important!important   ;
     :        ^^^
@@ -479,7 +479,7 @@
     :            ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:10:5]
  10 | color: red red red !important!important   ;
     :            ^^^
@@ -503,7 +503,7 @@
     :                ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:10:5]
  10 | color: red red red !important!important   ;
     :                ^^^
@@ -539,7 +539,7 @@
     :                     ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('important' type=static), raw: Atom('important' type=static) }
+  x Ident { value: Atom('important' type=static), raw: "important" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:10:5]
  10 | color: red red red !important!important   ;
     :                     ^^^^^^^^^
@@ -656,7 +656,7 @@
     :        ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:14:5]
  14 | color: red red red /* test*/ !important /*test*/ !important /*test*/ ;
     :        ^^^
@@ -680,7 +680,7 @@
     :            ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:14:5]
  14 | color: red red red /* test*/ !important /*test*/ !important /*test*/ ;
     :            ^^^
@@ -704,7 +704,7 @@
     :                ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:14:5]
  14 | color: red red red /* test*/ !important /*test*/ !important /*test*/ ;
     :                ^^^
@@ -752,7 +752,7 @@
     :                               ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('important' type=static), raw: Atom('important' type=static) }
+  x Ident { value: Atom('important' type=static), raw: "important" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:14:5]
  14 | color: red red red /* test*/ !important /*test*/ !important /*test*/ ;
     :                               ^^^^^^^^^
@@ -869,7 +869,7 @@
     :        ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:18:5]
  18 | color: red red red !important !important!important;
     :        ^^^
@@ -893,7 +893,7 @@
     :            ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:18:5]
  18 | color: red red red !important !important!important;
     :            ^^^
@@ -917,7 +917,7 @@
     :                ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:18:5]
  18 | color: red red red !important !important!important;
     :                ^^^
@@ -953,7 +953,7 @@
     :                     ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('important' type=static), raw: Atom('important' type=static) }
+  x Ident { value: Atom('important' type=static), raw: "important" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:18:5]
  18 | color: red red red !important !important!important;
     :                     ^^^^^^^^^
@@ -989,7 +989,7 @@
     :                                ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('important' type=static), raw: Atom('important' type=static) }
+  x Ident { value: Atom('important' type=static), raw: "important" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:18:5]
  18 | color: red red red !important !important!important;
     :                                ^^^^^^^^^
@@ -1106,7 +1106,7 @@
     :        ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:22:5]
  22 | color: red red red /* test */ ! /*test */ important /* test */ ! /* test */ important /* test */;
     :        ^^^
@@ -1130,7 +1130,7 @@
     :            ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:22:5]
  22 | color: red red red /* test */ ! /*test */ important /* test */ ! /* test */ important /* test */;
     :            ^^^
@@ -1154,7 +1154,7 @@
     :                ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:22:5]
  22 | color: red red red /* test */ ! /*test */ important /* test */ ! /* test */ important /* test */;
     :                ^^^
@@ -1226,7 +1226,7 @@
     :                                           ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('important' type=static), raw: Atom('important' type=static) }
+  x Ident { value: Atom('important' type=static), raw: "important" }
     ,-[$DIR/tests/recovery/declaration/important/input.css:22:5]
  22 | color: red red red /* test */ ! /*test */ important /* test */ ! /* test */ important /* test */;
     :                                           ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/delim-token/at-sign/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/delim-token/at-sign/span.rust-debug
@@ -123,7 +123,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/delim-token/at-sign/input.css:2:5]
  2 | color: @ red;
    :         ^

--- a/crates/swc_css_parser/tests/recovery/delim-token/at-sign/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/delim-token/at-sign/span.rust-debug
@@ -135,7 +135,7 @@
    :          ^^^
    `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
    ,-[$DIR/tests/recovery/delim-token/at-sign/input.css:2:5]
  2 | color: @ red;
    :          ^^^

--- a/crates/swc_css_parser/tests/recovery/delim-token/minus/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/delim-token/minus/span.rust-debug
@@ -173,7 +173,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/delim-token/minus/input.css:3:5]
  3 | prop1: 1 - 2;
    :         ^
@@ -197,7 +197,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/delim-token/minus/input.css:3:5]
  3 | prop1: 1 - 2;
    :           ^
@@ -281,7 +281,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/delim-token/minus/input.css:4:5]
  4 | prop2: func(1 - 2);
    :              ^
@@ -305,7 +305,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/delim-token/minus/input.css:4:5]
  4 | prop2: func(1 - 2);
    :                ^

--- a/crates/swc_css_parser/tests/recovery/delim-token/minus/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/delim-token/minus/span.rust-debug
@@ -161,7 +161,7 @@
    :        ^
    `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
    ,-[$DIR/tests/recovery/delim-token/minus/input.css:3:5]
  3 | prop1: 1 - 2;
    :        ^
@@ -209,7 +209,7 @@
    :            ^
    `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
    ,-[$DIR/tests/recovery/delim-token/minus/input.css:3:5]
  3 | prop1: 1 - 2;
    :            ^
@@ -269,7 +269,7 @@
    :             ^
    `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
    ,-[$DIR/tests/recovery/delim-token/minus/input.css:4:5]
  4 | prop2: func(1 - 2);
    :             ^
@@ -317,7 +317,7 @@
    :                 ^
    `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
    ,-[$DIR/tests/recovery/delim-token/minus/input.css:4:5]
  4 | prop2: func(1 - 2);
    :                 ^

--- a/crates/swc_css_parser/tests/recovery/delim-token/plus/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/delim-token/plus/span.rust-debug
@@ -173,7 +173,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/delim-token/plus/input.css:3:5]
  3 | prop1: 1 + 2;
    :         ^
@@ -197,7 +197,7 @@
    :           ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/delim-token/plus/input.css:3:5]
  3 | prop1: 1 + 2;
    :           ^
@@ -281,7 +281,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/delim-token/plus/input.css:4:5]
  4 | prop2: func(1 + 2);
    :              ^
@@ -305,7 +305,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/delim-token/plus/input.css:4:5]
  4 | prop2: func(1 + 2);
    :                ^

--- a/crates/swc_css_parser/tests/recovery/delim-token/plus/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/delim-token/plus/span.rust-debug
@@ -161,7 +161,7 @@
    :        ^
    `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
    ,-[$DIR/tests/recovery/delim-token/plus/input.css:3:5]
  3 | prop1: 1 + 2;
    :        ^
@@ -209,7 +209,7 @@
    :            ^
    `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
    ,-[$DIR/tests/recovery/delim-token/plus/input.css:3:5]
  3 | prop1: 1 + 2;
    :            ^
@@ -269,7 +269,7 @@
    :             ^
    `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
    ,-[$DIR/tests/recovery/delim-token/plus/input.css:4:5]
  4 | prop2: func(1 + 2);
    :             ^
@@ -317,7 +317,7 @@
    :                 ^
    `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
    ,-[$DIR/tests/recovery/delim-token/plus/input.css:4:5]
  4 | prop2: func(1 + 2);
    :                 ^

--- a/crates/swc_css_parser/tests/recovery/function-token/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function-token/span.rust-debug
@@ -144,7 +144,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function-token/input.css:2:5]
  2 | prop: url("test") :
    :                  ^

--- a/crates/swc_css_parser/tests/recovery/function-token/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function-token/span.rust-debug
@@ -132,7 +132,7 @@
    :           ^^^^^^
    `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
    ,-[$DIR/tests/recovery/function-token/input.css:2:5]
  2 | prop: url("test") :
    :           ^^^^^^

--- a/crates/swc_css_parser/tests/recovery/function/bad-comment-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/bad-comment-2/span.rust-debug
@@ -131,10 +131,7 @@
  5 | `->     );
    `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('
-  |         /* test */
-  |         "test.png"
-  |     ' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "\n        /* test */\n        \"test.png\"\n    " }
    ,-[$DIR/tests/recovery/function/bad-comment-2/input.css:2:5]
  2 | ,-> background: url(
  3 | |           /* test */

--- a/crates/swc_css_parser/tests/recovery/function/bad-comment/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/bad-comment/span.rust-debug
@@ -131,10 +131,7 @@
  5 | `->     );
    `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('
-  |         /* test */
-  |         test.png
-  |     ' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "\n        /* test */\n        test.png\n    " }
    ,-[$DIR/tests/recovery/function/bad-comment/input.css:2:5]
  2 | ,-> background: url(
  3 | |           /* test */

--- a/crates/swc_css_parser/tests/recovery/function/base/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/base/span.rust-debug
@@ -153,7 +153,7 @@
    :            ^
    `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/base/input.css:2:5]
  2 | prop: func(1 + 2);
    :            ^
@@ -201,7 +201,7 @@
    :                ^
    `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/base/input.css:2:5]
  2 | prop: func(1 + 2);
    :                ^
@@ -261,7 +261,7 @@
    :            ^^^^^
    `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
    ,-[$DIR/tests/recovery/function/base/input.css:3:5]
  3 | prop: func(ident.ident);
    :            ^^^^^
@@ -285,7 +285,7 @@
    :                  ^^^^^
    `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
    ,-[$DIR/tests/recovery/function/base/input.css:3:5]
  3 | prop: func(ident.ident);
    :                  ^^^^^
@@ -357,7 +357,7 @@
    :                ^^^^^
    `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
    ,-[$DIR/tests/recovery/function/base/input.css:4:5]
  4 | prop: func3(   ident.ident   );
    :                ^^^^^
@@ -381,7 +381,7 @@
    :                      ^^^^^
    `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
    ,-[$DIR/tests/recovery/function/base/input.css:4:5]
  4 | prop: func3(   ident.ident   );
    :                      ^^^^^
@@ -675,7 +675,7 @@
    :              ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/recovery/function/base/input.css:7:5]
  7 | prop: func({ foo: bar });
    :              ^^^
@@ -711,7 +711,7 @@
    :                   ^^^
    `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
    ,-[$DIR/tests/recovery/function/base/input.css:7:5]
  7 | prop: func({ foo: bar });
    :                   ^^^

--- a/crates/swc_css_parser/tests/recovery/function/base/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/base/span.rust-debug
@@ -165,7 +165,7 @@
    :             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/base/input.css:2:5]
  2 | prop: func(1 + 2);
    :             ^
@@ -189,7 +189,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/base/input.css:2:5]
  2 | prop: func(1 + 2);
    :               ^
@@ -345,7 +345,7 @@
    :             ^^^
    `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
    ,-[$DIR/tests/recovery/function/base/input.css:4:5]
  4 | prop: func3(   ident.ident   );
    :             ^^^
@@ -393,7 +393,7 @@
    :                           ^^^
    `----
 
-  x WhiteSpace { value: Atom('   ' type=inline) }
+  x WhiteSpace { value: "   " }
    ,-[$DIR/tests/recovery/function/base/input.css:4:5]
  4 | prop: func3(   ident.ident   );
    :                           ^^^
@@ -663,7 +663,7 @@
    :             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/base/input.css:7:5]
  7 | prop: func({ foo: bar });
    :             ^
@@ -699,7 +699,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/base/input.css:7:5]
  7 | prop: func({ foo: bar });
    :                  ^
@@ -723,7 +723,7 @@
    :                      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/base/input.css:7:5]
  7 | prop: func({ foo: bar });
    :                      ^

--- a/crates/swc_css_parser/tests/recovery/function/calc/space/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/calc/space/span.rust-debug
@@ -123,7 +123,7 @@
    :             ^^^
    `----
 
-  x Dimension { value: 2.0, raw_value: Atom('2' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 2.0, raw_value: "2", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/calc/space/input.css:2:5]
  2 | width: calc(2px+1px);
    :             ^^^
@@ -135,7 +135,7 @@
    :                ^^^^
    `----
 
-  x Dimension { value: 1.0, raw_value: Atom('+1' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 1.0, raw_value: "+1", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/calc/space/input.css:2:5]
  2 | width: calc(2px+1px);
    :                ^^^^

--- a/crates/swc_css_parser/tests/recovery/function/rgb/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/rgb/span.rust-debug
@@ -271,7 +271,7 @@
    :                   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:4:5]
  4 | color: rgb("test", 100, 100);
    :                   ^
@@ -307,7 +307,7 @@
    :                        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:4:5]
  4 | color: rgb("test", 100, 100);
    :                        ^
@@ -409,7 +409,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:5:5]
  5 | color: rgb(100, "test", 100);
    :                ^
@@ -445,7 +445,7 @@
    :                        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:5:5]
  5 | color: rgb(100, "test", 100);
    :                        ^
@@ -547,7 +547,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:6:5]
  6 | color: rgb(100, 100, "test");
    :                ^
@@ -583,7 +583,7 @@
    :                     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:6:5]
  6 | color: rgb(100, 100, "test");
    :                     ^
@@ -685,7 +685,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:7:5]
  7 | color: rgb(100, 100, 100, "test");
    :                ^
@@ -721,7 +721,7 @@
    :                     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:7:5]
  7 | color: rgb(100, 100, 100, "test");
    :                     ^
@@ -757,7 +757,7 @@
    :                          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:7:5]
  7 | color: rgb(100, 100, 100, "test");
    :                          ^
@@ -847,7 +847,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:9:5]
  9 | color: rgb("test" 100 100);
    :                  ^
@@ -871,7 +871,7 @@
    :                      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/rgb/input.css:9:5]
  9 | color: rgb("test" 100 100);
    :                      ^
@@ -961,7 +961,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/function/rgb/input.css:10:5]
  10 | color: rgb(100 "test" 100);
     :               ^
@@ -985,7 +985,7 @@
     :                      ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/function/rgb/input.css:10:5]
  10 | color: rgb(100 "test" 100);
     :                      ^
@@ -1075,7 +1075,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/function/rgb/input.css:11:5]
  11 | color: rgb(100 100 "test");
     :               ^
@@ -1099,7 +1099,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/function/rgb/input.css:11:5]
  11 | color: rgb(100 100 "test");
     :                   ^
@@ -1189,7 +1189,7 @@
     :               ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/function/rgb/input.css:12:5]
  12 | color: rgb(100 100 100 / "test");
     :               ^
@@ -1213,7 +1213,7 @@
     :                   ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/function/rgb/input.css:12:5]
  12 | color: rgb(100 100 100 / "test");
     :                   ^
@@ -1237,7 +1237,7 @@
     :                       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/function/rgb/input.css:12:5]
  12 | color: rgb(100 100 100 / "test");
     :                       ^
@@ -1261,7 +1261,7 @@
     :                         ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/function/rgb/input.css:12:5]
  12 | color: rgb(100 100 100 / "test");
     :                         ^

--- a/crates/swc_css_parser/tests/recovery/function/rgb/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/rgb/span.rust-debug
@@ -283,7 +283,7 @@
    :                    ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:4:5]
  4 | color: rgb("test", 100, 100);
    :                    ^^^
@@ -319,7 +319,7 @@
    :                         ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:4:5]
  4 | color: rgb("test", 100, 100);
    :                         ^^^
@@ -385,7 +385,7 @@
    :            ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:5:5]
  5 | color: rgb(100, "test", 100);
    :            ^^^
@@ -457,7 +457,7 @@
    :                         ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:5:5]
  5 | color: rgb(100, "test", 100);
    :                         ^^^
@@ -523,7 +523,7 @@
    :            ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:6:5]
  6 | color: rgb(100, 100, "test");
    :            ^^^
@@ -559,7 +559,7 @@
    :                 ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:6:5]
  6 | color: rgb(100, 100, "test");
    :                 ^^^
@@ -661,7 +661,7 @@
    :            ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:7:5]
  7 | color: rgb(100, 100, 100, "test");
    :            ^^^
@@ -697,7 +697,7 @@
    :                 ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:7:5]
  7 | color: rgb(100, 100, 100, "test");
    :                 ^^^
@@ -733,7 +733,7 @@
    :                      ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:7:5]
  7 | color: rgb(100, 100, 100, "test");
    :                      ^^^
@@ -859,7 +859,7 @@
    :                   ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:9:5]
  9 | color: rgb("test" 100 100);
    :                   ^^^
@@ -883,7 +883,7 @@
    :                       ^^^
    `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/rgb/input.css:9:5]
  9 | color: rgb("test" 100 100);
    :                       ^^^
@@ -949,7 +949,7 @@
     :            ^^^
     `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
     ,-[$DIR/tests/recovery/function/rgb/input.css:10:5]
  10 | color: rgb(100 "test" 100);
     :            ^^^
@@ -997,7 +997,7 @@
     :                       ^^^
     `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
     ,-[$DIR/tests/recovery/function/rgb/input.css:10:5]
  10 | color: rgb(100 "test" 100);
     :                       ^^^
@@ -1063,7 +1063,7 @@
     :            ^^^
     `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
     ,-[$DIR/tests/recovery/function/rgb/input.css:11:5]
  11 | color: rgb(100 100 "test");
     :            ^^^
@@ -1087,7 +1087,7 @@
     :                ^^^
     `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
     ,-[$DIR/tests/recovery/function/rgb/input.css:11:5]
  11 | color: rgb(100 100 "test");
     :                ^^^
@@ -1177,7 +1177,7 @@
     :            ^^^
     `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
     ,-[$DIR/tests/recovery/function/rgb/input.css:12:5]
  12 | color: rgb(100 100 100 / "test");
     :            ^^^
@@ -1201,7 +1201,7 @@
     :                ^^^
     `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
     ,-[$DIR/tests/recovery/function/rgb/input.css:12:5]
  12 | color: rgb(100 100 100 / "test");
     :                ^^^
@@ -1225,7 +1225,7 @@
     :                    ^^^
     `----
 
-  x Number { value: 100.0, raw: Atom('100' type=inline), type_flag: Integer }
+  x Number { value: 100.0, raw: "100", type_flag: Integer }
     ,-[$DIR/tests/recovery/function/rgb/input.css:12:5]
  12 | color: rgb(100 100 100 / "test");
     :                    ^^^

--- a/crates/swc_css_parser/tests/recovery/function/rgb/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/rgb/span.rust-debug
@@ -181,7 +181,7 @@
    :            ^^^^^^
    `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
    ,-[$DIR/tests/recovery/function/rgb/input.css:2:5]
  2 | color: rgb("test");
    :            ^^^^^^
@@ -247,7 +247,7 @@
    :            ^^^^^^
    `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
    ,-[$DIR/tests/recovery/function/rgb/input.css:4:5]
  4 | color: rgb("test", 100, 100);
    :            ^^^^^^
@@ -421,7 +421,7 @@
    :                 ^^^^^^
    `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
    ,-[$DIR/tests/recovery/function/rgb/input.css:5:5]
  5 | color: rgb(100, "test", 100);
    :                 ^^^^^^
@@ -595,7 +595,7 @@
    :                      ^^^^^^
    `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
    ,-[$DIR/tests/recovery/function/rgb/input.css:6:5]
  6 | color: rgb(100, 100, "test");
    :                      ^^^^^^
@@ -769,7 +769,7 @@
    :                           ^^^^^^
    `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
    ,-[$DIR/tests/recovery/function/rgb/input.css:7:5]
  7 | color: rgb(100, 100, 100, "test");
    :                           ^^^^^^
@@ -835,7 +835,7 @@
    :            ^^^^^^
    `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
    ,-[$DIR/tests/recovery/function/rgb/input.css:9:5]
  9 | color: rgb("test" 100 100);
    :            ^^^^^^
@@ -973,7 +973,7 @@
     :                ^^^^^^
     `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
     ,-[$DIR/tests/recovery/function/rgb/input.css:10:5]
  10 | color: rgb(100 "test" 100);
     :                ^^^^^^
@@ -1111,7 +1111,7 @@
     :                    ^^^^^^
     `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
     ,-[$DIR/tests/recovery/function/rgb/input.css:11:5]
  11 | color: rgb(100 100 "test");
     :                    ^^^^^^
@@ -1273,7 +1273,7 @@
     :                          ^^^^^^
     `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
     ,-[$DIR/tests/recovery/function/rgb/input.css:12:5]
  12 | color: rgb(100 100 100 / "test");
     :                          ^^^^^^

--- a/crates/swc_css_parser/tests/recovery/function/unclosed-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/unclosed-2/span.rust-debug
@@ -147,7 +147,7 @@
    :                                 ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/unclosed-2/input.css:2:5]
  2 | grid-template-columns: repeat(4, [col-start] 12px
    :                                 ^
@@ -189,7 +189,7 @@
    :                                             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/function/unclosed-2/input.css:2:5]
  2 | grid-template-columns: repeat(4, [col-start] 12px
    :                                             ^
@@ -214,8 +214,7 @@
  3 | }
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/function/unclosed-2/input.css:2:5]
  2 | grid-template-columns: repeat(4, [col-start] 12px
    :                                                  ^
@@ -240,8 +239,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/function/unclosed-2/input.css:3:1]
  3 | }
    :  ^

--- a/crates/swc_css_parser/tests/recovery/function/unclosed-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/unclosed-2/span.rust-debug
@@ -123,7 +123,7 @@
    :                               ^
    `----
 
-  x Number { value: 4.0, raw: Atom('4' type=inline), type_flag: Integer }
+  x Number { value: 4.0, raw: "4", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/unclosed-2/input.css:2:5]
  2 | grid-template-columns: repeat(4, [col-start] 12px
    :                               ^
@@ -177,7 +177,7 @@
    :                                   ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('col-start' type=dynamic), raw: Atom('col-start' type=dynamic) }
+  x Ident { value: Atom('col-start' type=dynamic), raw: "col-start" }
    ,-[$DIR/tests/recovery/function/unclosed-2/input.css:2:5]
  2 | grid-template-columns: repeat(4, [col-start] 12px
    :                                   ^^^^^^^^^
@@ -201,7 +201,7 @@
    :                                              ^^^^
    `----
 
-  x Dimension { value: 12.0, raw_value: Atom('12' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 12.0, raw_value: "12", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/unclosed-2/input.css:2:5]
  2 | grid-template-columns: repeat(4, [col-start] 12px
    :                                              ^^^^

--- a/crates/swc_css_parser/tests/recovery/function/unclosed/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/unclosed/span.rust-debug
@@ -148,8 +148,7 @@
  3 | }
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/function/unclosed/input.css:2:5]
  2 | width: min(500px;
    :                  ^
@@ -174,8 +173,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/function/unclosed/input.css:3:1]
  3 | }
    :  ^

--- a/crates/swc_css_parser/tests/recovery/function/unclosed/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/function/unclosed/span.rust-debug
@@ -123,7 +123,7 @@
    :            ^^^^^
    `----
 
-  x Dimension { value: 500.0, raw_value: Atom('500' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 500.0, raw_value: "500", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/function/unclosed/input.css:2:5]
  2 | width: min(500px;
    :            ^^^^^

--- a/crates/swc_css_parser/tests/recovery/hacks/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/hacks/span.rust-debug
@@ -10531,7 +10531,7 @@
      : ^^^^^^^^^
      `----
 
-  x Hash { is_id: true, value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Hash { is_id: true, value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:160:5]
  160 | #property: value;
      : ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/hacks/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/hacks/span.rust-debug
@@ -889,7 +889,7 @@
     :                        ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/hacks/input.css:13:1]
  13 | .selector { (;property: value;); }
     :                        ^
@@ -1063,7 +1063,7 @@
     :                        ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/hacks/input.css:14:1]
  14 | .selector { [;property: value;]; }
     :                        ^
@@ -1135,7 +1135,7 @@
     :       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/hacks/input.css:16:1]
  16 | @media \\0 screen {}
     :       ^
@@ -1159,7 +1159,7 @@
     :           ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/hacks/input.css:16:1]
  16 | @media \\0 screen {}
     :           ^
@@ -1183,7 +1183,7 @@
     :                  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/hacks/input.css:16:1]
  16 | @media \\0 screen {}
     :                  ^
@@ -7897,7 +7897,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:104:5]
  104 | !property: value;
      :           ^
@@ -8089,7 +8089,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:108:5]
  108 | $property: value;
      :           ^
@@ -8281,7 +8281,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:112:5]
  112 | &property: value;
      :           ^
@@ -8473,7 +8473,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:116:5]
  116 | *property: value;
      :           ^
@@ -8665,7 +8665,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:120:5]
  120 | )property: value;
      :           ^
@@ -8857,7 +8857,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:124:5]
  124 | =property: value;
      :           ^
@@ -9049,7 +9049,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:128:5]
  128 | %property: value;
      :           ^
@@ -9241,7 +9241,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:132:5]
  132 | +property: value;
      :           ^
@@ -9469,7 +9469,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:136:5]
  136 | @property: value;
      :           ^
@@ -9607,7 +9607,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:140:5]
  140 | ,property: value;
      :           ^
@@ -9799,7 +9799,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:144:5]
  144 | .property: value;
      :           ^
@@ -9991,7 +9991,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:148:5]
  148 | /property: value;
      :           ^
@@ -10183,7 +10183,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:152:5]
  152 | `property: value;
      :           ^
@@ -10375,7 +10375,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:156:5]
  156 | ]property: value;
      :           ^
@@ -10555,7 +10555,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:160:5]
  160 | #property: value;
      :           ^
@@ -10747,7 +10747,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:164:5]
  164 | ~property: value;
      :           ^
@@ -10939,7 +10939,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:168:5]
  168 | ?property: value;
      :           ^
@@ -11131,7 +11131,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:172:5]
  172 | :property: value;
      :           ^
@@ -11323,7 +11323,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:176:5]
  176 | |property: value;
      :           ^
@@ -11503,7 +11503,7 @@
      :                            ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:180:1]
  180 | .selector { property: value !ie; }
      :                            ^
@@ -12859,7 +12859,7 @@
      :                        ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:204:1]
  204 | .selector { (;property: value;); }
      :                        ^
@@ -13033,7 +13033,7 @@
      :                        ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:205:1]
  205 | .selector { [;property: value;]; }
      :                        ^
@@ -14575,7 +14575,7 @@
      :                        ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:225:1]
  225 | .selector { (;property: value;); }
      :                        ^
@@ -14749,7 +14749,7 @@
      :                        ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:226:1]
  226 | .selector { [;property: value;]; }
      :                        ^
@@ -15907,7 +15907,7 @@
      :       ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:241:1]
  241 | @media \\0 screen {}
      :       ^
@@ -15931,7 +15931,7 @@
      :           ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:241:1]
  241 | @media \\0 screen {}
      :           ^
@@ -15955,7 +15955,7 @@
      :                  ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:241:1]
  241 | @media \\0 screen {}
      :                  ^
@@ -16093,7 +16093,7 @@
      :       ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:244:5]
  244 | *color : black;
      :       ^
@@ -16117,7 +16117,7 @@
      :         ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:244:5]
  244 | *color : black;
      :         ^
@@ -16315,7 +16315,7 @@
      :             ^
      `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
      ,-[$DIR/tests/recovery/hacks/input.css:247:5]
  247 | $(var)-size: 100%;
      :             ^

--- a/crates/swc_css_parser/tests/recovery/hacks/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/hacks/span.rust-debug
@@ -865,7 +865,7 @@
     :               ^^^^^^^^
     `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
     ,-[$DIR/tests/recovery/hacks/input.css:13:1]
  13 | .selector { (;property: value;); }
     :               ^^^^^^^^
@@ -901,7 +901,7 @@
     :                         ^^^^^
     `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
     ,-[$DIR/tests/recovery/hacks/input.css:13:1]
  13 | .selector { (;property: value;); }
     :                         ^^^^^
@@ -1039,7 +1039,7 @@
     :               ^^^^^^^^
     `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
     ,-[$DIR/tests/recovery/hacks/input.css:14:1]
  14 | .selector { [;property: value;]; }
     :               ^^^^^^^^
@@ -1075,7 +1075,7 @@
     :                         ^^^^^
     `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
     ,-[$DIR/tests/recovery/hacks/input.css:14:1]
  14 | .selector { [;property: value;]; }
     :                         ^^^^^
@@ -1147,7 +1147,7 @@
     :        ^^^
     `----
 
-  x Ident { value: Atom('\0' type=inline), raw: Atom('\\0' type=inline) }
+  x Ident { value: Atom('\0' type=inline), raw: "\\\\0" }
     ,-[$DIR/tests/recovery/hacks/input.css:16:1]
  16 | @media \\0 screen {}
     :        ^^^
@@ -1171,7 +1171,7 @@
     :            ^^^^^^
     `----
 
-  x Ident { value: Atom('screen' type=inline), raw: Atom('screen' type=inline) }
+  x Ident { value: Atom('screen' type=inline), raw: "screen" }
     ,-[$DIR/tests/recovery/hacks/input.css:16:1]
  16 | @media \\0 screen {}
     :            ^^^^^^
@@ -5107,7 +5107,7 @@
     :                 ^^^^^
     `----
 
-  x Ident { value: Atom('hover' type=inline), raw: Atom('hover' type=inline) }
+  x Ident { value: Atom('hover' type=inline), raw: "hover" }
     ,-[$DIR/tests/recovery/hacks/input.css:64:1]
  64 | _:-moz-tree-row(hover), .selector {}
     :                 ^^^^^
@@ -7873,7 +7873,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:104:5]
  104 | !property: value;
      :  ^^^^^^^^
@@ -7909,7 +7909,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:104:5]
  104 | !property: value;
      :            ^^^^^
@@ -8065,7 +8065,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:108:5]
  108 | $property: value;
      :  ^^^^^^^^
@@ -8101,7 +8101,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:108:5]
  108 | $property: value;
      :            ^^^^^
@@ -8257,7 +8257,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:112:5]
  112 | &property: value;
      :  ^^^^^^^^
@@ -8293,7 +8293,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:112:5]
  112 | &property: value;
      :            ^^^^^
@@ -8449,7 +8449,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:116:5]
  116 | *property: value;
      :  ^^^^^^^^
@@ -8485,7 +8485,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:116:5]
  116 | *property: value;
      :            ^^^^^
@@ -8641,7 +8641,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:120:5]
  120 | )property: value;
      :  ^^^^^^^^
@@ -8677,7 +8677,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:120:5]
  120 | )property: value;
      :            ^^^^^
@@ -8833,7 +8833,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:124:5]
  124 | =property: value;
      :  ^^^^^^^^
@@ -8869,7 +8869,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:124:5]
  124 | =property: value;
      :            ^^^^^
@@ -9025,7 +9025,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:128:5]
  128 | %property: value;
      :  ^^^^^^^^
@@ -9061,7 +9061,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:128:5]
  128 | %property: value;
      :            ^^^^^
@@ -9217,7 +9217,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:132:5]
  132 | +property: value;
      :  ^^^^^^^^
@@ -9253,7 +9253,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:132:5]
  132 | +property: value;
      :            ^^^^^
@@ -9481,7 +9481,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:136:5]
  136 | @property: value;
      :            ^^^^^
@@ -9583,7 +9583,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:140:5]
  140 | ,property: value;
      :  ^^^^^^^^
@@ -9619,7 +9619,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:140:5]
  140 | ,property: value;
      :            ^^^^^
@@ -9775,7 +9775,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:144:5]
  144 | .property: value;
      :  ^^^^^^^^
@@ -9811,7 +9811,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:144:5]
  144 | .property: value;
      :            ^^^^^
@@ -9967,7 +9967,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:148:5]
  148 | /property: value;
      :  ^^^^^^^^
@@ -10003,7 +10003,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:148:5]
  148 | /property: value;
      :            ^^^^^
@@ -10159,7 +10159,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:152:5]
  152 | `property: value;
      :  ^^^^^^^^
@@ -10195,7 +10195,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:152:5]
  152 | `property: value;
      :            ^^^^^
@@ -10351,7 +10351,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:156:5]
  156 | ]property: value;
      :  ^^^^^^^^
@@ -10387,7 +10387,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:156:5]
  156 | ]property: value;
      :            ^^^^^
@@ -10567,7 +10567,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:160:5]
  160 | #property: value;
      :            ^^^^^
@@ -10723,7 +10723,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:164:5]
  164 | ~property: value;
      :  ^^^^^^^^
@@ -10759,7 +10759,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:164:5]
  164 | ~property: value;
      :            ^^^^^
@@ -10915,7 +10915,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:168:5]
  168 | ?property: value;
      :  ^^^^^^^^
@@ -10951,7 +10951,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:168:5]
  168 | ?property: value;
      :            ^^^^^
@@ -11107,7 +11107,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:172:5]
  172 | :property: value;
      :  ^^^^^^^^
@@ -11143,7 +11143,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:172:5]
  172 | :property: value;
      :            ^^^^^
@@ -11299,7 +11299,7 @@
      :  ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:176:5]
  176 | |property: value;
      :  ^^^^^^^^
@@ -11335,7 +11335,7 @@
      :            ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:176:5]
  176 | |property: value;
      :            ^^^^^
@@ -11491,7 +11491,7 @@
      :                       ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:180:1]
  180 | .selector { property: value !ie; }
      :                       ^^^^^
@@ -11527,7 +11527,7 @@
      :                              ^^
      `----
 
-  x Ident { value: Atom('ie' type=inline), raw: Atom('ie' type=inline) }
+  x Ident { value: Atom('ie' type=inline), raw: "ie" }
      ,-[$DIR/tests/recovery/hacks/input.css:180:1]
  180 | .selector { property: value !ie; }
      :                              ^^
@@ -12835,7 +12835,7 @@
      :               ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:204:1]
  204 | .selector { (;property: value;); }
      :               ^^^^^^^^
@@ -12871,7 +12871,7 @@
      :                         ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:204:1]
  204 | .selector { (;property: value;); }
      :                         ^^^^^
@@ -13009,7 +13009,7 @@
      :               ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:205:1]
  205 | .selector { [;property: value;]; }
      :               ^^^^^^^^
@@ -13045,7 +13045,7 @@
      :                         ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:205:1]
  205 | .selector { [;property: value;]; }
      :                         ^^^^^
@@ -14551,7 +14551,7 @@
      :               ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:225:1]
  225 | .selector { (;property: value;); }
      :               ^^^^^^^^
@@ -14587,7 +14587,7 @@
      :                         ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:225:1]
  225 | .selector { (;property: value;); }
      :                         ^^^^^
@@ -14725,7 +14725,7 @@
      :               ^^^^^^^^
      `----
 
-  x Ident { value: Atom('property' type=static), raw: Atom('property' type=static) }
+  x Ident { value: Atom('property' type=static), raw: "property" }
      ,-[$DIR/tests/recovery/hacks/input.css:226:1]
  226 | .selector { [;property: value;]; }
      :               ^^^^^^^^
@@ -14761,7 +14761,7 @@
      :                         ^^^^^
      `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
      ,-[$DIR/tests/recovery/hacks/input.css:226:1]
  226 | .selector { [;property: value;]; }
      :                         ^^^^^
@@ -15919,7 +15919,7 @@
      :        ^^^
      `----
 
-  x Ident { value: Atom('\0' type=inline), raw: Atom('\\0' type=inline) }
+  x Ident { value: Atom('\0' type=inline), raw: "\\\\0" }
      ,-[$DIR/tests/recovery/hacks/input.css:241:1]
  241 | @media \\0 screen {}
      :        ^^^
@@ -15943,7 +15943,7 @@
      :            ^^^^^^
      `----
 
-  x Ident { value: Atom('screen' type=inline), raw: Atom('screen' type=inline) }
+  x Ident { value: Atom('screen' type=inline), raw: "screen" }
      ,-[$DIR/tests/recovery/hacks/input.css:241:1]
  241 | @media \\0 screen {}
      :            ^^^^^^
@@ -16081,7 +16081,7 @@
      :  ^^^^^
      `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
      ,-[$DIR/tests/recovery/hacks/input.css:244:5]
  244 | *color : black;
      :  ^^^^^
@@ -16129,7 +16129,7 @@
      :          ^^^^^
      `----
 
-  x Ident { value: Atom('black' type=inline), raw: Atom('black' type=inline) }
+  x Ident { value: Atom('black' type=inline), raw: "black" }
      ,-[$DIR/tests/recovery/hacks/input.css:244:5]
  244 | *color : black;
      :          ^^^^^
@@ -16279,7 +16279,7 @@
      :   ^^^
      `----
 
-  x Ident { value: Atom('var' type=static), raw: Atom('var' type=static) }
+  x Ident { value: Atom('var' type=static), raw: "var" }
      ,-[$DIR/tests/recovery/hacks/input.css:247:5]
  247 | $(var)-size: 100%;
      :   ^^^
@@ -16291,7 +16291,7 @@
      :       ^^^^^
      `----
 
-  x Ident { value: Atom('-size' type=inline), raw: Atom('-size' type=inline) }
+  x Ident { value: Atom('-size' type=inline), raw: "-size" }
      ,-[$DIR/tests/recovery/hacks/input.css:247:5]
  247 | $(var)-size: 100%;
      :       ^^^^^
@@ -16327,7 +16327,7 @@
      :              ^^^^
      `----
 
-  x Percentage { value: 100.0, raw: Atom('100' type=inline) }
+  x Percentage { value: 100.0, raw: "100" }
      ,-[$DIR/tests/recovery/hacks/input.css:247:5]
  247 | $(var)-size: 100%;
      :              ^^^^
@@ -16441,7 +16441,7 @@
      :    ^
      `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
      ,-[$DIR/tests/recovery/hacks/input.css:250:1]
  250 | a{*b:c}
      :    ^
@@ -16465,7 +16465,7 @@
      :      ^
      `----
 
-  x Ident { value: Atom('c' type=inline), raw: Atom('c' type=inline) }
+  x Ident { value: Atom('c' type=inline), raw: "c" }
      ,-[$DIR/tests/recovery/hacks/input.css:250:1]
  250 | a{*b:c}
      :      ^

--- a/crates/swc_css_parser/tests/recovery/ie-progid/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/ie-progid/span.rust-debug
@@ -229,7 +229,7 @@
    :                                                                 ^^^^^^^^^
    `----
 
-  x String { value: Atom('#4f4f4f' type=inline), raw: Atom(''#4f4f4f'' type=dynamic) }
+  x String { value: Atom('#4f4f4f' type=inline), raw: "'#4f4f4f'" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:2:5]
  2 | filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#4f4f4f',endColorstr='#292929',GradientType=0);
    :                                                                 ^^^^^^^^^
@@ -277,7 +277,7 @@
    :                                                                                       ^^^^^^^^^
    `----
 
-  x String { value: Atom('#292929' type=inline), raw: Atom(''#292929'' type=dynamic) }
+  x String { value: Atom('#292929' type=inline), raw: "'#292929'" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:2:5]
  2 | filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#4f4f4f',endColorstr='#292929',GradientType=0);
    :                                                                                       ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/ie-progid/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/ie-progid/span.rust-debug
@@ -115,7 +115,7 @@
    :        ^^^^^^
    `----
 
-  x Ident { value: Atom('progid' type=inline), raw: Atom('progid' type=inline) }
+  x Ident { value: Atom('progid' type=inline), raw: "progid" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:2:5]
  2 | filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#4f4f4f',endColorstr='#292929',GradientType=0);
    :        ^^^^^^
@@ -139,7 +139,7 @@
    :               ^^^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('DXImageTransform' type=dynamic), raw: Atom('DXImageTransform' type=dynamic) }
+  x Ident { value: Atom('DXImageTransform' type=dynamic), raw: "DXImageTransform" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:2:5]
  2 | filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#4f4f4f',endColorstr='#292929',GradientType=0);
    :               ^^^^^^^^^^^^^^^^
@@ -163,7 +163,7 @@
    :                                ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('Microsoft' type=dynamic), raw: Atom('Microsoft' type=dynamic) }
+  x Ident { value: Atom('Microsoft' type=dynamic), raw: "Microsoft" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:2:5]
  2 | filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#4f4f4f',endColorstr='#292929',GradientType=0);
    :                                ^^^^^^^^^
@@ -205,7 +205,7 @@
    :                                                   ^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('startColorstr' type=dynamic), raw: Atom('startColorstr' type=dynamic) }
+  x Ident { value: Atom('startColorstr' type=dynamic), raw: "startColorstr" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:2:5]
  2 | filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#4f4f4f',endColorstr='#292929',GradientType=0);
    :                                                   ^^^^^^^^^^^^^
@@ -253,7 +253,7 @@
    :                                                                           ^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('endColorstr' type=dynamic), raw: Atom('endColorstr' type=dynamic) }
+  x Ident { value: Atom('endColorstr' type=dynamic), raw: "endColorstr" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:2:5]
  2 | filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#4f4f4f',endColorstr='#292929',GradientType=0);
    :                                                                           ^^^^^^^^^^^
@@ -301,7 +301,7 @@
    :                                                                                                 ^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('GradientType' type=dynamic), raw: Atom('GradientType' type=dynamic) }
+  x Ident { value: Atom('GradientType' type=dynamic), raw: "GradientType" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:2:5]
  2 | filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#4f4f4f',endColorstr='#292929',GradientType=0);
    :                                                                                                 ^^^^^^^^^^^^
@@ -325,7 +325,7 @@
    :                                                                                                              ^
    `----
 
-  x Number { value: 0.0, raw: Atom('0' type=inline), type_flag: Integer }
+  x Number { value: 0.0, raw: "0", type_flag: Integer }
    ,-[$DIR/tests/recovery/ie-progid/input.css:2:5]
  2 | filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#4f4f4f',endColorstr='#292929',GradientType=0);
    :                                                                                                              ^
@@ -367,7 +367,7 @@
    :         ^^^^^^
    `----
 
-  x Ident { value: Atom('progid' type=inline), raw: Atom('progid' type=inline) }
+  x Ident { value: Atom('progid' type=inline), raw: "progid" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :         ^^^^^^
@@ -391,7 +391,7 @@
    :                ^^^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('DXImageTransform' type=dynamic), raw: Atom('DXImageTransform' type=dynamic) }
+  x Ident { value: Atom('DXImageTransform' type=dynamic), raw: "DXImageTransform" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :                ^^^^^^^^^^^^^^^^
@@ -415,7 +415,7 @@
    :                                 ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('Microsoft' type=dynamic), raw: Atom('Microsoft' type=dynamic) }
+  x Ident { value: Atom('Microsoft' type=dynamic), raw: "Microsoft" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :                                 ^^^^^^^^^
@@ -457,7 +457,7 @@
    :                                                ^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('pixelradius' type=dynamic), raw: Atom('pixelradius' type=dynamic) }
+  x Ident { value: Atom('pixelradius' type=dynamic), raw: "pixelradius" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :                                                ^^^^^^^^^^^
@@ -481,7 +481,7 @@
    :                                                            ^
    `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :                                                            ^
@@ -505,7 +505,7 @@
    :                                                               ^^^^^^
    `----
 
-  x Ident { value: Atom('progid' type=inline), raw: Atom('progid' type=inline) }
+  x Ident { value: Atom('progid' type=inline), raw: "progid" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :                                                               ^^^^^^
@@ -529,7 +529,7 @@
    :                                                                      ^^^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('DXImageTransform' type=dynamic), raw: Atom('DXImageTransform' type=dynamic) }
+  x Ident { value: Atom('DXImageTransform' type=dynamic), raw: "DXImageTransform" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :                                                                      ^^^^^^^^^^^^^^^^
@@ -553,7 +553,7 @@
    :                                                                                       ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('Microsoft' type=dynamic), raw: Atom('Microsoft' type=dynamic) }
+  x Ident { value: Atom('Microsoft' type=dynamic), raw: "Microsoft" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :                                                                                       ^^^^^^^^^
@@ -595,7 +595,7 @@
    :                                                                                                       ^^^^^^^^
    `----
 
-  x Ident { value: Atom('duration' type=dynamic), raw: Atom('duration' type=dynamic) }
+  x Ident { value: Atom('duration' type=dynamic), raw: "duration" }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :                                                                                                       ^^^^^^^^
@@ -619,7 +619,7 @@
    :                                                                                                                ^
    `----
 
-  x Number { value: 3.0, raw: Atom('3' type=inline), type_flag: Integer }
+  x Number { value: 3.0, raw: "3", type_flag: Integer }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :                                                                                                                ^

--- a/crates/swc_css_parser/tests/recovery/ie-progid/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/ie-progid/span.rust-debug
@@ -493,7 +493,7 @@
    :                                                              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/ie-progid/input.css:3:5]
  3 | filter: progid:DXImageTransform.Microsoft.Blur(pixelradius=2) progid:DXImageTransform.Microsoft.Wheel(duration=3);
    :                                                              ^

--- a/crates/swc_css_parser/tests/recovery/number/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/number/span.rust-debug
@@ -144,8 +144,7 @@
  3 | `->     prop1: 10px
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/number/input.css:2:5]
  2 | ,-> prop: 10.10px
  3 | `->     prop1: 10px
@@ -181,7 +180,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/number/input.css:3:5]
  3 | prop1: 10px
    :       ^
@@ -205,8 +204,7 @@
  4 | `->     prop2: 10
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/number/input.css:3:5]
  3 | ,-> prop1: 10px
  4 | `->     prop2: 10
@@ -242,7 +240,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/number/input.css:4:5]
  4 | prop2: 10
    :       ^
@@ -266,8 +264,7 @@
  5 | `->     prop3: 10.10
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/number/input.css:4:5]
  4 | ,-> prop2: 10
  5 | `->     prop3: 10.10
@@ -303,7 +300,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/number/input.css:5:5]
  5 | prop3: 10.10
    :       ^

--- a/crates/swc_css_parser/tests/recovery/number/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/number/span.rust-debug
@@ -132,7 +132,7 @@
    :       ^^^^^^^
    `----
 
-  x Dimension { value: 10.1, raw_value: Atom('10.10' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Number }
+  x Dimension { value: 10.1, raw_value: "10.10", unit: Atom('px' type=static), raw_unit: "px", type_flag: Number }
    ,-[$DIR/tests/recovery/number/input.css:2:5]
  2 | prop: 10.10px
    :       ^^^^^^^
@@ -156,7 +156,7 @@
    : ^^^^^
    `----
 
-  x Ident { value: Atom('prop1' type=inline), raw: Atom('prop1' type=inline) }
+  x Ident { value: Atom('prop1' type=inline), raw: "prop1" }
    ,-[$DIR/tests/recovery/number/input.css:3:5]
  3 | prop1: 10px
    : ^^^^^
@@ -192,7 +192,7 @@
    :        ^^^^
    `----
 
-  x Dimension { value: 10.0, raw_value: Atom('10' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 10.0, raw_value: "10", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/number/input.css:3:5]
  3 | prop1: 10px
    :        ^^^^
@@ -216,7 +216,7 @@
    : ^^^^^
    `----
 
-  x Ident { value: Atom('prop2' type=inline), raw: Atom('prop2' type=inline) }
+  x Ident { value: Atom('prop2' type=inline), raw: "prop2" }
    ,-[$DIR/tests/recovery/number/input.css:4:5]
  4 | prop2: 10
    : ^^^^^
@@ -252,7 +252,7 @@
    :        ^^
    `----
 
-  x Number { value: 10.0, raw: Atom('10' type=inline), type_flag: Integer }
+  x Number { value: 10.0, raw: "10", type_flag: Integer }
    ,-[$DIR/tests/recovery/number/input.css:4:5]
  4 | prop2: 10
    :        ^^
@@ -276,7 +276,7 @@
    : ^^^^^
    `----
 
-  x Ident { value: Atom('prop3' type=inline), raw: Atom('prop3' type=inline) }
+  x Ident { value: Atom('prop3' type=inline), raw: "prop3" }
    ,-[$DIR/tests/recovery/number/input.css:5:5]
  5 | prop3: 10.10
    : ^^^^^
@@ -312,7 +312,7 @@
    :        ^^^^^
    `----
 
-  x Number { value: 10.1, raw: Atom('10.10' type=inline), type_flag: Number }
+  x Number { value: 10.1, raw: "10.10", type_flag: Number }
    ,-[$DIR/tests/recovery/number/input.css:5:5]
  5 | prop3: 10.10
    :        ^^^^^

--- a/crates/swc_css_parser/tests/recovery/qualified-rule/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/qualified-rule/basic/span.rust-debug
@@ -56,7 +56,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/qualified-rule/basic/input.css:1:1]
  1 | // test
    :   ^
@@ -81,9 +81,7 @@
  3 |     a {
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/qualified-rule/basic/input.css:1:1]
  1 | ,-> // test
  2 | `-> 
@@ -108,7 +106,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/qualified-rule/basic/input.css:3:1]
  3 | a {
    :  ^

--- a/crates/swc_css_parser/tests/recovery/qualified-rule/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/qualified-rule/basic/span.rust-debug
@@ -68,7 +68,7 @@
    :    ^^^^
    `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
    ,-[$DIR/tests/recovery/qualified-rule/basic/input.css:1:1]
  1 | // test
    :    ^^^^
@@ -94,7 +94,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/recovery/qualified-rule/basic/input.css:3:1]
  3 | a {
    : ^

--- a/crates/swc_css_parser/tests/recovery/qualified-rule/double-slash-comment/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/qualified-rule/double-slash-comment/span.rust-debug
@@ -65,7 +65,7 @@
    :    ^^^^
    `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
    ,-[$DIR/tests/recovery/qualified-rule/double-slash-comment/input.css:1:1]
  1 | // test
    :    ^^^^
@@ -91,7 +91,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/recovery/qualified-rule/double-slash-comment/input.css:2:1]
  2 | a {
    : ^

--- a/crates/swc_css_parser/tests/recovery/qualified-rule/double-slash-comment/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/qualified-rule/double-slash-comment/span.rust-debug
@@ -53,7 +53,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/qualified-rule/double-slash-comment/input.css:1:1]
  1 | // test
    :   ^
@@ -78,8 +78,7 @@
  2 | a {
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/qualified-rule/double-slash-comment/input.css:1:1]
  1 | // test
    :        ^
@@ -104,7 +103,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/qualified-rule/double-slash-comment/input.css:2:1]
  2 | a {
    :  ^

--- a/crates/swc_css_parser/tests/recovery/rules/at-rule-in-middle/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/rules/at-rule-in-middle/span.rust-debug
@@ -198,7 +198,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/recovery/rules/at-rule-in-middle/input.css:5:1]
  5 | a { color: blue }
    : ^

--- a/crates/swc_css_parser/tests/recovery/rules/at-rule-in-middle/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/rules/at-rule-in-middle/span.rust-debug
@@ -185,9 +185,7 @@
  5 |     a { color: blue }
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/rules/at-rule-in-middle/input.css:3:1]
  3 | ,-> @media {};
  4 | `-> 
@@ -212,7 +210,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/at-rule-in-middle/input.css:5:1]
  5 | a { color: blue }
    :  ^

--- a/crates/swc_css_parser/tests/recovery/rules/at-rule-with-semi/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/rules/at-rule-with-semi/span.rust-debug
@@ -90,7 +90,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/recovery/rules/at-rule-with-semi/input.css:3:1]
  3 | a { color: red }
    : ^

--- a/crates/swc_css_parser/tests/recovery/rules/at-rule-with-semi/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/rules/at-rule-with-semi/span.rust-debug
@@ -77,9 +77,7 @@
  3 |     a { color: red }
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/rules/at-rule-with-semi/input.css:1:1]
  1 | ,-> @media {};
  2 | `-> 
@@ -104,7 +102,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/at-rule-with-semi/input.css:3:1]
  3 | a { color: red }
    :  ^

--- a/crates/swc_css_parser/tests/recovery/rules/unclosed-brackets/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/rules/unclosed-brackets/span.rust-debug
@@ -39,7 +39,7 @@
    :  ^^^^^
    `----
 
-  x Ident { value: Atom('class' type=static), raw: Atom('class' type=static) }
+  x Ident { value: Atom('class' type=static), raw: "class" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:1:1]
  1 | .class[attr= {
    :  ^^^^^
@@ -79,7 +79,7 @@
    :        ^^^^
    `----
 
-  x Ident { value: Atom('attr' type=inline), raw: Atom('attr' type=inline) }
+  x Ident { value: Atom('attr' type=inline), raw: "attr" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:1:1]
  1 | .class[attr= {
    :        ^^^^
@@ -175,7 +175,7 @@
    :  ^^^^^
    `----
 
-  x Ident { value: Atom('class' type=static), raw: Atom('class' type=static) }
+  x Ident { value: Atom('class' type=static), raw: "class" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:5:1]
  5 | .class { color: red }
    :  ^^^^^
@@ -229,7 +229,7 @@
    :          ^^^^^
    `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:5:1]
  5 | .class { color: red }
    :          ^^^^^
@@ -265,7 +265,7 @@
    :                 ^^^
    `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:5:1]
  5 | .class { color: red }
    :                 ^^^
@@ -315,7 +315,7 @@
    :  ^^^^^
    `----
 
-  x Ident { value: Atom('class' type=static), raw: Atom('class' type=static) }
+  x Ident { value: Atom('class' type=static), raw: "class" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:7:1]
  7 | .class { color: blue }
    :  ^^^^^
@@ -369,7 +369,7 @@
    :          ^^^^^
    `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:7:1]
  7 | .class { color: blue }
    :          ^^^^^
@@ -405,7 +405,7 @@
    :                 ^^^^
    `----
 
-  x Ident { value: Atom('blue' type=inline), raw: Atom('blue' type=inline) }
+  x Ident { value: Atom('blue' type=inline), raw: "blue" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:7:1]
  7 | .class { color: blue }
    :                 ^^^^

--- a/crates/swc_css_parser/tests/recovery/rules/unclosed-brackets/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/rules/unclosed-brackets/span.rust-debug
@@ -103,7 +103,7 @@
    :             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:1:1]
  1 | .class[attr= {
    :             ^
@@ -136,9 +136,7 @@
  3 |     }
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:1:1]
  1 | ,-> .class[attr= {
  2 | `-> 
@@ -152,9 +150,7 @@
  5 |     .class { color: red }
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:3:1]
  3 | ,-> }
  4 | `-> 
@@ -191,7 +187,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:5:1]
  5 | .class { color: red }
    :       ^
@@ -221,7 +217,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:5:1]
  5 | .class { color: red }
    :         ^
@@ -257,7 +253,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:5:1]
  5 | .class { color: red }
    :                ^
@@ -281,7 +277,7 @@
    :                    ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:5:1]
  5 | .class { color: red }
    :                    ^
@@ -294,9 +290,7 @@
  7 |     .class { color: blue }
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:5:1]
  5 | ,-> .class { color: red }
  6 | `-> 
@@ -333,7 +327,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:7:1]
  7 | .class { color: blue }
    :       ^
@@ -363,7 +357,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:7:1]
  7 | .class { color: blue }
    :         ^
@@ -399,7 +393,7 @@
    :                ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:7:1]
  7 | .class { color: blue }
    :                ^
@@ -423,7 +417,7 @@
    :                     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/unclosed-brackets/input.css:7:1]
  7 | .class { color: blue }
    :                     ^

--- a/crates/swc_css_parser/tests/recovery/rules/unclosed-curly/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/rules/unclosed-curly/span.rust-debug
@@ -28,7 +28,7 @@
    : ^^^^
    `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
    ,-[$DIR/tests/recovery/rules/unclosed-curly/input.css:1:1]
  1 | test};
    : ^^^^
@@ -78,7 +78,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/recovery/rules/unclosed-curly/input.css:3:1]
  3 | a { color: red }
    : ^

--- a/crates/swc_css_parser/tests/recovery/rules/unclosed-curly/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/rules/unclosed-curly/span.rust-debug
@@ -65,9 +65,7 @@
  3 |     a { color: red }
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/rules/unclosed-curly/input.css:1:1]
  1 | ,-> test};
  2 | `-> 
@@ -92,7 +90,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/rules/unclosed-curly/input.css:3:1]
  3 | a { color: red }
    :  ^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-1/span.rust-debug
@@ -41,7 +41,7 @@
    :  ^^^^
    `----
 
-  x Ident { value: Atom('href' type=static), raw: Atom('href' type=static) }
+  x Ident { value: Atom('href' type=static), raw: "href" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-1/input.css:1:1]
  1 | [href=] {}
    :  ^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-1/span.rust-debug
@@ -65,7 +65,7 @@
    :        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-1/input.css:1:1]
  1 | [href=] {}
    :        ^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-2/span.rust-debug
@@ -41,7 +41,7 @@
    :  ^^^^
    `----
 
-  x Ident { value: Atom('href' type=static), raw: Atom('href' type=static) }
+  x Ident { value: Atom('href' type=static), raw: "href" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-2/input.css:1:1]
  1 | [href#="test"] {}
    :  ^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-2/span.rust-debug
@@ -89,7 +89,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-2/input.css:1:1]
  1 | [href#="test"] {}
    :               ^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-2/span.rust-debug
@@ -77,7 +77,7 @@
    :        ^^^^^^
    `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-2/input.css:1:1]
  1 | [href#="test"] {}
    :        ^^^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-3/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-3/span.rust-debug
@@ -68,7 +68,7 @@
    :        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-3/input.css:1:1]
  1 | a[title * = "title" i ] {
    :        ^
@@ -92,7 +92,7 @@
    :          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-3/input.css:1:1]
  1 | a[title * = "title" i ] {
    :          ^
@@ -116,7 +116,7 @@
    :            ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-3/input.css:1:1]
  1 | a[title * = "title" i ] {
    :            ^
@@ -140,7 +140,7 @@
    :                    ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-3/input.css:1:1]
  1 | a[title * = "title" i ] {
    :                    ^
@@ -164,7 +164,7 @@
    :                      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-3/input.css:1:1]
  1 | a[title * = "title" i ] {
    :                      ^
@@ -176,7 +176,7 @@
    :                        ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-3/input.css:1:1]
  1 | a[title * = "title" i ] {
    :                        ^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-3/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-3/span.rust-debug
@@ -128,7 +128,7 @@
    :             ^^^^^^^
    `----
 
-  x String { value: Atom('title' type=static), raw: Atom('"title"' type=inline) }
+  x String { value: Atom('title' type=static), raw: "\"title\"" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-3/input.css:1:1]
  1 | a[title * = "title" i ] {
    :             ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-3/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-3/span.rust-debug
@@ -26,7 +26,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-3/input.css:1:1]
  1 | a[title * = "title" i ] {
    : ^
@@ -56,7 +56,7 @@
    :   ^^^^^
    `----
 
-  x Ident { value: Atom('title' type=static), raw: Atom('title' type=static) }
+  x Ident { value: Atom('title' type=static), raw: "title" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-3/input.css:1:1]
  1 | a[title * = "title" i ] {
    :   ^^^^^
@@ -152,7 +152,7 @@
    :                     ^
    `----
 
-  x Ident { value: Atom('i' type=static), raw: Atom('i' type=static) }
+  x Ident { value: Atom('i' type=static), raw: "i" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-3/input.css:1:1]
  1 | a[title * = "title" i ] {
    :                     ^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-4/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-4/span.rust-debug
@@ -26,7 +26,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-4/input.css:1:1]
  1 | a[title%="title"] {
    : ^
@@ -56,7 +56,7 @@
    :   ^^^^^
    `----
 
-  x Ident { value: Atom('title' type=static), raw: Atom('title' type=static) }
+  x Ident { value: Atom('title' type=static), raw: "title" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-4/input.css:1:1]
  1 | a[title%="title"] {
    :   ^^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-4/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-4/span.rust-debug
@@ -104,7 +104,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-4/input.css:1:1]
  1 | a[title%="title"] {
    :                  ^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-4/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher-4/span.rust-debug
@@ -92,7 +92,7 @@
    :          ^^^^^^^
    `----
 
-  x String { value: Atom('title' type=static), raw: Atom('"title"' type=inline) }
+  x String { value: Atom('title' type=static), raw: "\"title\"" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher-4/input.css:1:1]
  1 | a[title%="title"] {
    :          ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher/span.rust-debug
@@ -89,7 +89,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher/input.css:1:1]
  1 | [href==".org"] {}
    :               ^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher/span.rust-debug
@@ -77,7 +77,7 @@
    :        ^^^^^^
    `----
 
-  x String { value: Atom('.org' type=inline), raw: Atom('".org"' type=inline) }
+  x String { value: Atom('.org' type=inline), raw: "\".org\"" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher/input.css:1:1]
  1 | [href==".org"] {}
    :        ^^^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-matcher/span.rust-debug
@@ -41,7 +41,7 @@
    :  ^^^^
    `----
 
-  x Ident { value: Atom('href' type=static), raw: Atom('href' type=static) }
+  x Ident { value: Atom('href' type=static), raw: "href" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-matcher/input.css:1:1]
  1 | [href==".org"] {}
    :  ^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-modifier/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-modifier/span.rust-debug
@@ -65,7 +65,7 @@
    :       ^^^^^^
    `----
 
-  x String { value: Atom('test' type=inline), raw: Atom('"test"' type=inline) }
+  x String { value: Atom('test' type=inline), raw: "\"test\"" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-modifier/input.css:1:1]
  1 | [href="test" "z"] {}
    :       ^^^^^^
@@ -89,7 +89,7 @@
    :              ^^^
    `----
 
-  x String { value: Atom('z' type=inline), raw: Atom('"z"' type=inline) }
+  x String { value: Atom('z' type=inline), raw: "\"z\"" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-modifier/input.css:1:1]
  1 | [href="test" "z"] {}
    :              ^^^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-modifier/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-modifier/span.rust-debug
@@ -77,7 +77,7 @@
    :             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-modifier/input.css:1:1]
  1 | [href="test" "z"] {}
    :             ^
@@ -101,7 +101,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-modifier/input.css:1:1]
  1 | [href="test" "z"] {}
    :                  ^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-modifier/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/invalid-modifier/span.rust-debug
@@ -41,7 +41,7 @@
    :  ^^^^
    `----
 
-  x Ident { value: Atom('href' type=static), raw: Atom('href' type=static) }
+  x Ident { value: Atom('href' type=static), raw: "href" }
    ,-[$DIR/tests/recovery/selector/attribute/invalid-modifier/input.css:1:1]
  1 | [href="test" "z"] {}
    :  ^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/unclosed/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/unclosed/span.rust-debug
@@ -87,7 +87,7 @@
    :             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/attribute/unclosed/input.css:1:1]
  1 | .class[attr= {
    :             ^
@@ -120,9 +120,7 @@
  3 |     }
    `----
 
-  x WhiteSpace { value: Atom('
-  | 
-  | ' type=inline) }
+  x WhiteSpace { value: "\n\n" }
    ,-[$DIR/tests/recovery/selector/attribute/unclosed/input.css:1:1]
  1 | ,-> .class[attr= {
  2 | `-> 
@@ -135,8 +133,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/selector/attribute/unclosed/input.css:3:1]
  3 | }
    :  ^

--- a/crates/swc_css_parser/tests/recovery/selector/attribute/unclosed/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/attribute/unclosed/span.rust-debug
@@ -31,7 +31,7 @@
    :  ^^^^^
    `----
 
-  x Ident { value: Atom('class' type=static), raw: Atom('class' type=static) }
+  x Ident { value: Atom('class' type=static), raw: "class" }
    ,-[$DIR/tests/recovery/selector/attribute/unclosed/input.css:1:1]
  1 | .class[attr= {
    :  ^^^^^
@@ -63,7 +63,7 @@
    :        ^^^^
    `----
 
-  x Ident { value: Atom('attr' type=inline), raw: Atom('attr' type=inline) }
+  x Ident { value: Atom('attr' type=inline), raw: "attr" }
    ,-[$DIR/tests/recovery/selector/attribute/unclosed/input.css:1:1]
  1 | .class[attr= {
    :        ^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/combinator/only/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/combinator/only/span.rust-debug
@@ -38,7 +38,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/combinator/only/input.css:1:1]
  1 | > {
    :  ^

--- a/crates/swc_css_parser/tests/recovery/selector/combinator/two/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/combinator/two/span.rust-debug
@@ -23,7 +23,7 @@
    : ^^^^
    `----
 
-  x Ident { value: Atom('span' type=static), raw: Atom('span' type=static) }
+  x Ident { value: Atom('span' type=static), raw: "span" }
    ,-[$DIR/tests/recovery/selector/combinator/two/input.css:1:1]
  1 | span ~ + {}
    : ^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/combinator/two/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/combinator/two/span.rust-debug
@@ -35,7 +35,7 @@
    :     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/combinator/two/input.css:1:1]
  1 | span ~ + {}
    :     ^
@@ -59,7 +59,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/combinator/two/input.css:1:1]
  1 | span ~ + {}
    :       ^
@@ -83,7 +83,7 @@
    :         ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/combinator/two/input.css:1:1]
  1 | span ~ + {}
    :         ^

--- a/crates/swc_css_parser/tests/recovery/selector/id/invalid/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/id/invalid/span.rust-debug
@@ -38,7 +38,7 @@
    :      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/id/invalid/input.css:1:1]
  1 | #1234 {
    :      ^

--- a/crates/swc_css_parser/tests/recovery/selector/id/invalid/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/id/invalid/span.rust-debug
@@ -26,7 +26,7 @@
    : ^^^^^
    `----
 
-  x Hash { is_id: false, value: Atom('1234' type=inline), raw: Atom('1234' type=inline) }
+  x Hash { is_id: false, value: Atom('1234' type=inline), raw: "1234" }
    ,-[$DIR/tests/recovery/selector/id/invalid/input.css:1:1]
  1 | #1234 {
    : ^^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/list/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/list/span.rust-debug
@@ -35,7 +35,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/list/input.css:1:1]
  1 | , {
    :  ^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-class/an-plus-b/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-class/an-plus-b/span.rust-debug
@@ -59,7 +59,7 @@
    :            ^^^^^^^
    `----
 
-  x Ident { value: Atom('unknown' type=static), raw: Atom('unknown' type=static) }
+  x Ident { value: Atom('unknown' type=static), raw: "unknown" }
    ,-[$DIR/tests/recovery/selector/pseudo-class/an-plus-b/input.css:1:1]
  1 | :nth-child(unknown) {}
    :            ^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid-function/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid-function/span.rust-debug
@@ -68,7 +68,7 @@
    :             ^
    `----
 
-  x Number { value: 2.0, raw: Atom('2' type=inline), type_flag: Integer }
+  x Number { value: 2.0, raw: "2", type_flag: Integer }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid-function/input.css:1:1]
  1 | : nth-child(2) {
    :             ^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid-function/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid-function/span.rust-debug
@@ -38,7 +38,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid-function/input.css:1:1]
  1 | : nth-child(2) {
    :  ^
@@ -80,7 +80,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid-function/input.css:1:1]
  1 | : nth-child(2) {
    :               ^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid-ident/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid-ident/span.rust-debug
@@ -38,7 +38,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid-ident/input.css:1:1]
  1 | : first-child {
    :  ^
@@ -62,7 +62,7 @@
    :              ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid-ident/input.css:1:1]
  1 | : first-child {
    :              ^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid-ident/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid-ident/span.rust-debug
@@ -50,7 +50,7 @@
    :   ^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('first-child' type=static), raw: Atom('first-child' type=static) }
+  x Ident { value: Atom('first-child' type=static), raw: "first-child" }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid-ident/input.css:1:1]
  1 | : first-child {
    :   ^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid/span.rust-debug
@@ -26,7 +26,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid/input.css:1:1]
  1 | a: b {}
    : ^
@@ -62,7 +62,7 @@
    :    ^
    `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid/input.css:1:1]
  1 | a: b {}
    :    ^
@@ -112,7 +112,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid/input.css:3:1]
  3 | a: b {
    : ^
@@ -148,7 +148,7 @@
    :    ^
    `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid/input.css:3:1]
  3 | a: b {
    :    ^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-class/invalid/span.rust-debug
@@ -50,7 +50,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid/input.css:1:1]
  1 | a: b {}
    :   ^
@@ -74,7 +74,7 @@
    :     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid/input.css:1:1]
  1 | a: b {}
    :     ^
@@ -136,7 +136,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid/input.css:3:1]
  3 | a: b {
    :   ^
@@ -160,7 +160,7 @@
    :     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-class/invalid/input.css:3:1]
  3 | a: b {
    :     ^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-element/after/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-element/after/span.rust-debug
@@ -62,7 +62,7 @@
    :    ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/recovery/selector/pseudo-element/after/input.css:1:1]
  1 | :: foo {
    :    ^^^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-element/after/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-element/after/span.rust-debug
@@ -50,7 +50,7 @@
    :   ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-element/after/input.css:1:1]
  1 | :: foo {
    :   ^
@@ -74,7 +74,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-element/after/input.css:1:1]
  1 | :: foo {
    :       ^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-element/between/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-element/between/span.rust-debug
@@ -62,7 +62,7 @@
    :    ^^^
    `----
 
-  x Ident { value: Atom('foo' type=inline), raw: Atom('foo' type=inline) }
+  x Ident { value: Atom('foo' type=inline), raw: "foo" }
    ,-[$DIR/tests/recovery/selector/pseudo-element/between/input.css:1:1]
  1 | : :foo {
    :    ^^^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-element/between/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-element/between/span.rust-debug
@@ -38,7 +38,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-element/between/input.css:1:1]
  1 | : :foo {
    :  ^
@@ -74,7 +74,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-element/between/input.css:1:1]
  1 | : :foo {
    :       ^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-element/invalid/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-element/invalid/span.rust-debug
@@ -71,7 +71,7 @@
    :     ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/selector/pseudo-element/invalid/input.css:1:1]
  1 | a::1 {
    :     ^

--- a/crates/swc_css_parser/tests/recovery/selector/pseudo-element/invalid/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/selector/pseudo-element/invalid/span.rust-debug
@@ -23,7 +23,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('a' type=static), raw: Atom('a' type=static) }
+  x Ident { value: Atom('a' type=static), raw: "a" }
    ,-[$DIR/tests/recovery/selector/pseudo-element/invalid/input.css:1:1]
  1 | a::1 {
    : ^
@@ -59,7 +59,7 @@
    :    ^
    `----
 
-  x Number { value: 1.0, raw: Atom('1' type=inline), type_flag: Integer }
+  x Number { value: 1.0, raw: "1", type_flag: Integer }
    ,-[$DIR/tests/recovery/selector/pseudo-element/invalid/input.css:1:1]
  1 | a::1 {
    :    ^

--- a/crates/swc_css_parser/tests/recovery/simple-block/unclosed-in-function/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/simple-block/unclosed-in-function/span.rust-debug
@@ -165,7 +165,7 @@
    :                                   ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('col-start' type=dynamic), raw: Atom('col-start' type=dynamic) }
+  x Ident { value: Atom('col-start' type=dynamic), raw: "col-start" }
    ,-[$DIR/tests/recovery/simple-block/unclosed-in-function/input.css:2:5]
  2 | grid-template-columns: repeat(4, [col-start);
    :                                   ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/simple-block/unclosed-in-function/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/simple-block/unclosed-in-function/span.rust-debug
@@ -202,8 +202,7 @@
  3 | }
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/simple-block/unclosed-in-function/input.css:2:5]
  2 | grid-template-columns: repeat(4, [col-start);
    :                                              ^
@@ -228,8 +227,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/simple-block/unclosed-in-function/input.css:3:1]
  3 | }
    :  ^

--- a/crates/swc_css_parser/tests/recovery/style-blocks-contents/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/style-blocks-contents/basic/span.rust-debug
@@ -301,7 +301,7 @@
    : ^^^^^
    `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
    ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:5:9]
  5 | ident
    : ^^^^^
@@ -325,7 +325,7 @@
    : ^^^^^
    `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
    ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:6:9]
  6 | color: green;
    : ^^^^^
@@ -361,7 +361,7 @@
    :        ^^^^^
    `----
 
-  x Ident { value: Atom('green' type=inline), raw: Atom('green' type=inline) }
+  x Ident { value: Atom('green' type=inline), raw: "green" }
    ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:6:9]
  6 | color: green;
    :        ^^^^^
@@ -671,7 +671,7 @@
     : ^^^^^
     `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:13:13]
  13 | ident
     : ^^^^^
@@ -695,7 +695,7 @@
     : ^^^^^
     `----
 
-  x Ident { value: Atom('color' type=static), raw: Atom('color' type=static) }
+  x Ident { value: Atom('color' type=static), raw: "color" }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:14:13]
  14 | color: red
     : ^^^^^
@@ -731,7 +731,7 @@
     :        ^^^
     `----
 
-  x Ident { value: Atom('red' type=inline), raw: Atom('red' type=inline) }
+  x Ident { value: Atom('red' type=inline), raw: "red" }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:14:13]
  14 | color: red
     :        ^^^
@@ -1000,7 +1000,7 @@
     : ^^^^^
     `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:23:9]
  23 | ident;
     : ^^^^^
@@ -1350,7 +1350,7 @@
     : ^^^^^
     `----
 
-  x Ident { value: Atom('ident' type=inline), raw: Atom('ident' type=inline) }
+  x Ident { value: Atom('ident' type=inline), raw: "ident" }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:31:13]
  31 | ident;
     : ^^^^^
@@ -1560,7 +1560,7 @@
     :   ^^^^
     `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:39:5]
  39 | & test;
     :   ^^^^
@@ -1747,7 +1747,7 @@
     : ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('__ident__' type=dynamic), raw: Atom('__ident__' type=dynamic) }
+  x Ident { value: Atom('__ident__' type=dynamic), raw: "__ident__" }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:45:9]
  45 | __ident__
     : ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/style-blocks-contents/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/style-blocks-contents/basic/span.rust-debug
@@ -313,8 +313,7 @@
  6 | `->         color: green;
    `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: "\n        " }
    ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:5:9]
  5 | ,-> ident
  6 | `->         color: green;
@@ -350,7 +349,7 @@
    :       ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:6:9]
  6 | color: green;
    :       ^
@@ -684,8 +683,7 @@
  14 | `->             color: red
     `----
 
-  x WhiteSpace { value: Atom('
-  |             ' type=dynamic) }
+  x WhiteSpace { value: "\n            " }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:13:13]
  13 | ,-> ident
  14 | `->             color: red
@@ -721,7 +719,7 @@
     :       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:14:13]
  14 | color: red
     :       ^
@@ -745,8 +743,7 @@
  15 | `->         }
     `----
 
-  x WhiteSpace { value: Atom('
-  |         ' type=dynamic) }
+  x WhiteSpace { value: " \n        " }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:14:13]
  14 | ,-> color: red 
  15 | `->         }
@@ -1551,7 +1548,7 @@
     :  ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:39:5]
  39 | & test;
     :  ^
@@ -1762,8 +1759,7 @@
  46 | `->     }
     `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
     ,-[$DIR/tests/recovery/style-blocks-contents/basic/input.css:45:9]
  45 | ,-> __ident__
  46 | `->     }

--- a/crates/swc_css_parser/tests/recovery/style-blocks-contents/invalid-nested-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/style-blocks-contents/invalid-nested-2/span.rust-debug
@@ -156,7 +156,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/style-blocks-contents/invalid-nested-2/input.css:3:5]
  3 | & test;
    :  ^

--- a/crates/swc_css_parser/tests/recovery/style-blocks-contents/invalid-nested-2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/style-blocks-contents/invalid-nested-2/span.rust-debug
@@ -168,7 +168,7 @@
    :   ^^^^
    `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
    ,-[$DIR/tests/recovery/style-blocks-contents/invalid-nested-2/input.css:3:5]
  3 | & test;
    :   ^^^^

--- a/crates/swc_css_parser/tests/recovery/style-blocks-contents/invalid-nested/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/style-blocks-contents/invalid-nested/span.rust-debug
@@ -156,7 +156,7 @@
    :  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/style-blocks-contents/invalid-nested/input.css:3:5]
  3 | & test;
    :  ^

--- a/crates/swc_css_parser/tests/recovery/style-blocks-contents/invalid-nested/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/style-blocks-contents/invalid-nested/span.rust-debug
@@ -168,7 +168,7 @@
    :   ^^^^
    `----
 
-  x Ident { value: Atom('test' type=inline), raw: Atom('test' type=inline) }
+  x Ident { value: Atom('test' type=inline), raw: "test" }
    ,-[$DIR/tests/recovery/style-blocks-contents/invalid-nested/input.css:3:5]
  3 | & test;
    :   ^^^^

--- a/crates/swc_css_parser/tests/recovery/styled-jsx/1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/styled-jsx/1/span.rust-debug
@@ -350,7 +350,7 @@
    :                            ^^^^^^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('removed-214123-item' type=dynamic), raw: Atom('removed-214123-item' type=dynamic) }
+  x Ident { value: Atom('removed-214123-item' type=dynamic), raw: "removed-214123-item" }
    ,-[$DIR/tests/recovery/styled-jsx/1/input.css:7:1]
  7 | .removed-214123 :global(> .removed-214123-item) {
    :                            ^^^^^^^^^^^^^^^^^^^
@@ -492,7 +492,7 @@
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 
-  x Ident { value: Atom('__styled-jsx-placeholder__2' type=dynamic), raw: Atom('__styled-jsx-placeholder__2' type=dynamic) }
+  x Ident { value: Atom('__styled-jsx-placeholder__2' type=dynamic), raw: "__styled-jsx-placeholder__2" }
     ,-[$DIR/tests/recovery/styled-jsx/1/input.css:10:5]
  10 | flex-basis: __styled-jsx-placeholder__2%;
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -750,7 +750,7 @@
     :                            ^^^^^^^^^^^^^^^^^^^
     `----
 
-  x Ident { value: Atom('removed-214123-item' type=dynamic), raw: Atom('removed-214123-item' type=dynamic) }
+  x Ident { value: Atom('removed-214123-item' type=dynamic), raw: "removed-214123-item" }
     ,-[$DIR/tests/recovery/styled-jsx/1/input.css:15:5]
  15 | .removed-214123 :global(> .removed-214123-item) {
     :                            ^^^^^^^^^^^^^^^^^^^
@@ -805,7 +805,7 @@
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 
-  x Ident { value: Atom('__styled-jsx-placeholder__3' type=dynamic), raw: Atom('__styled-jsx-placeholder__3' type=dynamic) }
+  x Ident { value: Atom('__styled-jsx-placeholder__3' type=dynamic), raw: "__styled-jsx-placeholder__3" }
     ,-[$DIR/tests/recovery/styled-jsx/1/input.css:16:9]
  16 | flex-basis: __styled-jsx-placeholder__3%;
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1021,7 +1021,7 @@
     :                            ^^^^^^^^^^^^^^^^^^^
     `----
 
-  x Ident { value: Atom('removed-214123-item' type=dynamic), raw: Atom('removed-214123-item' type=dynamic) }
+  x Ident { value: Atom('removed-214123-item' type=dynamic), raw: "removed-214123-item" }
     ,-[$DIR/tests/recovery/styled-jsx/1/input.css:21:5]
  21 | .removed-214123 :global(> .removed-214123-item) {
     :                            ^^^^^^^^^^^^^^^^^^^
@@ -1076,7 +1076,7 @@
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 
-  x Ident { value: Atom('__styled-jsx-placeholder__4' type=dynamic), raw: Atom('__styled-jsx-placeholder__4' type=dynamic) }
+  x Ident { value: Atom('__styled-jsx-placeholder__4' type=dynamic), raw: "__styled-jsx-placeholder__4" }
     ,-[$DIR/tests/recovery/styled-jsx/1/input.css:22:9]
  22 | flex-basis: __styled-jsx-placeholder__4%;
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/styled-jsx/1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/styled-jsx/1/span.rust-debug
@@ -326,7 +326,7 @@
    :                          ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/styled-jsx/1/input.css:7:1]
  7 | .removed-214123 :global(> .removed-214123-item) {
    :                          ^
@@ -726,7 +726,7 @@
     :                          ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/styled-jsx/1/input.css:15:5]
  15 | .removed-214123 :global(> .removed-214123-item) {
     :                          ^
@@ -997,7 +997,7 @@
     :                          ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/styled-jsx/1/input.css:21:5]
  21 | .removed-214123 :global(> .removed-214123-item) {
     :                          ^

--- a/crates/swc_css_parser/tests/recovery/styled-jsx/2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/styled-jsx/2/span.rust-debug
@@ -104,7 +104,7 @@
    :             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/styled-jsx/2/input.css:1:1]
  1 | .a :global(> .b) {
    :             ^

--- a/crates/swc_css_parser/tests/recovery/styled-jsx/2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/styled-jsx/2/span.rust-debug
@@ -128,7 +128,7 @@
    :               ^
    `----
 
-  x Ident { value: Atom('b' type=static), raw: Atom('b' type=static) }
+  x Ident { value: Atom('b' type=static), raw: "b" }
    ,-[$DIR/tests/recovery/styled-jsx/2/input.css:1:1]
  1 | .a :global(> .b) {
    :               ^
@@ -183,7 +183,7 @@
    :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('__styled-jsx-placeholder__0' type=dynamic), raw: Atom('__styled-jsx-placeholder__0' type=dynamic) }
+  x Ident { value: Atom('__styled-jsx-placeholder__0' type=dynamic), raw: "__styled-jsx-placeholder__0" }
    ,-[$DIR/tests/recovery/styled-jsx/2/input.css:2:5]
  2 | flex-basis: __styled-jsx-placeholder__0%;
    :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/unicode-range/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/unicode-range/span.rust-debug
@@ -109,7 +109,7 @@
    :                ^
    `----
 
-  x Ident { value: Atom('U' type=inline), raw: Atom('U' type=inline) }
+  x Ident { value: Atom('U' type=inline), raw: "U" }
    ,-[$DIR/tests/recovery/unicode-range/input.css:2:5]
  2 | unicode-range: U+1Z1ee1-FFFFFF;
    :                ^
@@ -121,7 +121,7 @@
    :                 ^^^^^^^^^^^^^^
    `----
 
-  x Dimension { value: 1.0, raw_value: Atom('+1' type=inline), unit: Atom('Z1ee1-FFFFFF' type=dynamic), raw_unit: Atom('Z1ee1-FFFFFF' type=dynamic), type_flag: Integer }
+  x Dimension { value: 1.0, raw_value: "+1", unit: Atom('Z1ee1-FFFFFF' type=dynamic), raw_unit: "Z1ee1-FFFFFF", type_flag: Integer }
    ,-[$DIR/tests/recovery/unicode-range/input.css:2:5]
  2 | unicode-range: U+1Z1ee1-FFFFFF;
    :                 ^^^^^^^^^^^^^^
@@ -163,7 +163,7 @@
    :                ^
    `----
 
-  x Ident { value: Atom('U' type=inline), raw: Atom('U' type=inline) }
+  x Ident { value: Atom('U' type=inline), raw: "U" }
    ,-[$DIR/tests/recovery/unicode-range/input.css:3:5]
  3 | unicode-range: U+1e1ee1-FFZFFF;
    :                ^
@@ -175,7 +175,7 @@
    :                 ^^^^^^^^^^^^^^
    `----
 
-  x Dimension { value: 10.0, raw_value: Atom('+1e1' type=inline), unit: Atom('ee1-FFZFFF' type=dynamic), raw_unit: Atom('ee1-FFZFFF' type=dynamic), type_flag: Number }
+  x Dimension { value: 10.0, raw_value: "+1e1", unit: Atom('ee1-FFZFFF' type=dynamic), raw_unit: "ee1-FFZFFF", type_flag: Number }
    ,-[$DIR/tests/recovery/unicode-range/input.css:3:5]
  3 | unicode-range: U+1e1ee1-FFZFFF;
    :                 ^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/value/at-keyword/1/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/at-keyword/1/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^^^^^
    `----
 
-  x AtKeyword { value: Atom('x,' type=inline), raw: Atom('x\2c ' type=inline) }
+  x AtKeyword { value: Atom('x,' type=inline), raw: "x\\2c " }
    ,-[$DIR/tests/recovery/value/at-keyword/1/input.css:1:1]
  1 | a { value: @x\2c }
    :            ^^^^^^

--- a/crates/swc_css_parser/tests/recovery/value/at-keyword/2/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/at-keyword/2/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^^^
    `----
 
-  x AtKeyword { value: Atom(',x' type=inline), raw: Atom('\,x' type=inline) }
+  x AtKeyword { value: Atom(',x' type=inline), raw: "\\,x" }
    ,-[$DIR/tests/recovery/value/at-keyword/2/input.css:1:1]
  1 | a { value: @\,x }
    :            ^^^^

--- a/crates/swc_css_parser/tests/recovery/value/at-keyword/3/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/at-keyword/3/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^^^^^^^^^
    `----
 
-  x AtKeyword { value: Atom('keyword' type=inline), raw: Atom('k\65yword' type=dynamic) }
+  x AtKeyword { value: Atom('keyword' type=inline), raw: "k\\65yword" }
    ,-[$DIR/tests/recovery/value/at-keyword/3/input.css:1:1]
  1 | a { value: @k\65yword }
    :            ^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/value/at-keyword/4/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/at-keyword/4/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^^^^
    `----
 
-  x AtKeyword { value: Atom(',x' type=inline), raw: Atom('\2cx' type=inline) }
+  x AtKeyword { value: Atom(',x' type=inline), raw: "\\2cx" }
    ,-[$DIR/tests/recovery/value/at-keyword/4/input.css:1:1]
  1 | a { value: @\2cx }
    :            ^^^^^

--- a/crates/swc_css_parser/tests/recovery/value/at-keyword/5/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/at-keyword/5/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^^^
    `----
 
-  x AtKeyword { value: Atom('x,' type=inline), raw: Atom('x\,' type=inline) }
+  x AtKeyword { value: Atom('x,' type=inline), raw: "x\\," }
    ,-[$DIR/tests/recovery/value/at-keyword/5/input.css:1:1]
  1 | a { value: @x\, }
    :            ^^^^

--- a/crates/swc_css_parser/tests/recovery/value/at-keyword/6/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/at-keyword/6/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^^^^^^^^^
    `----
 
-  x AtKeyword { value: Atom('ھyword' type=inline), raw: Atom('\6beyword' type=dynamic) }
+  x AtKeyword { value: Atom('ھyword' type=inline), raw: "\\6beyword" }
    ,-[$DIR/tests/recovery/value/at-keyword/6/input.css:1:1]
  1 | a { value: @\6beyword }
    :            ^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/value/at-keyword/7/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/at-keyword/7/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^^^^^^^^^^
    `----
 
-  x AtKeyword { value: Atom('keyword' type=inline), raw: Atom('\6b eyword' type=dynamic) }
+  x AtKeyword { value: Atom('keyword' type=inline), raw: "\\6b eyword" }
    ,-[$DIR/tests/recovery/value/at-keyword/7/input.css:1:1]
  1 | a { value: @\6b eyword }
    :            ^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/value/custom-properties/exclamation/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/custom-properties/exclamation/span.rust-debug
@@ -570,7 +570,7 @@
     :        ^^^
     `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
     ,-[$DIR/tests/recovery/value/custom-properties/exclamation/input.css:15:5]
  15 | --foo: bar;
     :        ^^^
@@ -678,7 +678,7 @@
     :        ^^^
     `----
 
-  x Ident { value: Atom('bar' type=inline), raw: Atom('bar' type=inline) }
+  x Ident { value: Atom('bar' type=inline), raw: "bar" }
     ,-[$DIR/tests/recovery/value/custom-properties/exclamation/input.css:19:5]
  19 | --foo: bar;
     :        ^^^

--- a/crates/swc_css_parser/tests/recovery/value/custom-properties/only-dashed/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/custom-properties/only-dashed/span.rust-debug
@@ -91,7 +91,7 @@
    : ^^
    `----
 
-  x Ident { value: Atom('--' type=inline), raw: Atom('--' type=inline) }
+  x Ident { value: Atom('--' type=inline), raw: "--" }
    ,-[$DIR/tests/recovery/value/custom-properties/only-dashed/input.css:2:5]
  2 | --:value;
    : ^^
@@ -115,7 +115,7 @@
    :    ^^^^^
    `----
 
-  x Ident { value: Atom('value' type=inline), raw: Atom('value' type=inline) }
+  x Ident { value: Atom('value' type=inline), raw: "value" }
    ,-[$DIR/tests/recovery/value/custom-properties/only-dashed/input.css:2:5]
  2 | --:value;
    :    ^^^^^
@@ -232,7 +232,7 @@
    :                ^^
    `----
 
-  x Ident { value: Atom('--' type=inline), raw: Atom('--' type=inline) }
+  x Ident { value: Atom('--' type=inline), raw: "--" }
    ,-[$DIR/tests/recovery/value/custom-properties/only-dashed/input.css:6:5]
  6 | counter-reset: -- --a -a;
    :                ^^
@@ -256,7 +256,7 @@
    :                   ^^^
    `----
 
-  x Ident { value: Atom('--a' type=inline), raw: Atom('--a' type=inline) }
+  x Ident { value: Atom('--a' type=inline), raw: "--a" }
    ,-[$DIR/tests/recovery/value/custom-properties/only-dashed/input.css:6:5]
  6 | counter-reset: -- --a -a;
    :                   ^^^
@@ -280,7 +280,7 @@
    :                       ^^
    `----
 
-  x Ident { value: Atom('-a' type=inline), raw: Atom('-a' type=inline) }
+  x Ident { value: Atom('-a' type=inline), raw: "-a" }
    ,-[$DIR/tests/recovery/value/custom-properties/only-dashed/input.css:6:5]
  6 | counter-reset: -- --a -a;
    :                       ^^

--- a/crates/swc_css_parser/tests/recovery/value/custom-properties/only-dashed/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/custom-properties/only-dashed/span.rust-debug
@@ -244,7 +244,7 @@
    :                  ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/value/custom-properties/only-dashed/input.css:6:5]
  6 | counter-reset: -- --a -a;
    :                  ^
@@ -268,7 +268,7 @@
    :                      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/value/custom-properties/only-dashed/input.css:6:5]
  6 | counter-reset: -- --a -a;
    :                      ^

--- a/crates/swc_css_parser/tests/recovery/value/number/dot/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/number/dot/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^
    `----
 
-  x Number { value: 0.0, raw: Atom('0' type=inline), type_flag: Integer }
+  x Number { value: 0.0, raw: "0", type_flag: Integer }
    ,-[$DIR/tests/recovery/value/number/dot/input.css:1:1]
  1 | a { width: 0.; }
    :            ^

--- a/crates/swc_css_parser/tests/recovery/value/number/minus-dot/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/number/minus-dot/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^
    `----
 
-  x Number { value: -0.0, raw: Atom('-0' type=inline), type_flag: Integer }
+  x Number { value: -0.0, raw: "-0", type_flag: Integer }
    ,-[$DIR/tests/recovery/value/number/minus-dot/input.css:1:1]
  1 | a { width: -0.; }
    :            ^^

--- a/crates/swc_css_parser/tests/recovery/value/number/plus-dot/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/number/plus-dot/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^
    `----
 
-  x Number { value: 0.0, raw: Atom('+0' type=inline), type_flag: Integer }
+  x Number { value: 0.0, raw: "+0", type_flag: Integer }
    ,-[$DIR/tests/recovery/value/number/plus-dot/input.css:1:1]
  1 | a { width: +0.; }
    :            ^^

--- a/crates/swc_css_parser/tests/recovery/value/percentage/dot/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/percentage/dot/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^
    `----
 
-  x Number { value: 0.0, raw: Atom('0' type=inline), type_flag: Integer }
+  x Number { value: 0.0, raw: "0", type_flag: Integer }
    ,-[$DIR/tests/recovery/value/percentage/dot/input.css:1:1]
  1 | a { width: 0.%; }
    :            ^

--- a/crates/swc_css_parser/tests/recovery/value/percentage/minus/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/percentage/minus/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^
    `----
 
-  x Number { value: -0.0, raw: Atom('-0' type=inline), type_flag: Integer }
+  x Number { value: -0.0, raw: "-0", type_flag: Integer }
    ,-[$DIR/tests/recovery/value/percentage/minus/input.css:1:1]
  1 | a { width: -0.%; }
    :            ^^

--- a/crates/swc_css_parser/tests/recovery/value/percentage/plus/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/percentage/plus/span.rust-debug
@@ -107,7 +107,7 @@
    :            ^^
    `----
 
-  x Number { value: 0.0, raw: Atom('+0' type=inline), type_flag: Integer }
+  x Number { value: 0.0, raw: "+0", type_flag: Integer }
    ,-[$DIR/tests/recovery/value/percentage/plus/input.css:1:1]
  1 | a { width: +0.%; }
    :            ^^

--- a/crates/swc_css_parser/tests/recovery/value/quotes/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/quotes/span.rust-debug
@@ -148,8 +148,7 @@
  3 | `->     t";
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/value/quotes/input.css:2:5]
  2 | ,-> content: "tes
  3 | `->     t";

--- a/crates/swc_css_parser/tests/recovery/value/quotes/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/quotes/span.rust-debug
@@ -136,7 +136,7 @@
    :          ^^^^
    `----
 
-  x BadString { raw_value: Atom('"tes' type=inline) }
+  x BadString { raw_value: "\"tes" }
    ,-[$DIR/tests/recovery/value/quotes/input.css:2:5]
  2 | content: "tes
    :          ^^^^
@@ -172,7 +172,7 @@
    :  ^^
    `----
 
-  x BadString { raw_value: Atom('";' type=inline) }
+  x BadString { raw_value: "\";" }
    ,-[$DIR/tests/recovery/value/quotes/input.css:3:5]
  3 | t";
    :  ^^

--- a/crates/swc_css_parser/tests/recovery/value/quotes/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/quotes/span.rust-debug
@@ -160,7 +160,7 @@
    : ^
    `----
 
-  x Ident { value: Atom('t' type=inline), raw: Atom('t' type=inline) }
+  x Ident { value: Atom('t' type=inline), raw: "t" }
    ,-[$DIR/tests/recovery/value/quotes/input.css:3:5]
  3 | t";
    : ^

--- a/crates/swc_css_parser/tests/recovery/value/string/newline/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/string/newline/span.rust-debug
@@ -107,7 +107,7 @@
    :       ^
    `----
 
-  x BadString { raw_value: Atom('"' type=inline) }
+  x BadString { raw_value: "\"" }
    ,-[$DIR/tests/recovery/value/string/newline/input.css:2:5]
  2 | prop: "
    :       ^

--- a/crates/swc_css_parser/tests/recovery/value/url/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/url/basic/span.rust-debug
@@ -819,7 +819,7 @@
     :                       ^
     `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
     ,-[$DIR/tests/recovery/value/url/basic/input.css:17:5]
  17 | background: url("foo", "bar");
     :                       ^

--- a/crates/swc_css_parser/tests/recovery/value/url/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/url/basic/span.rust-debug
@@ -189,7 +189,7 @@
    :             ^^^^^^^^^^^^^^
    `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('var(--foo' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "var(--foo" }
    ,-[$DIR/tests/recovery/value/url/basic/input.css:3:5]
  3 | background: url(var(--foo));
    :             ^^^^^^^^^^^^^^
@@ -648,7 +648,7 @@
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('image.png param(var(--url' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "image.png param(var(--url" }
     ,-[$DIR/tests/recovery/value/url/basic/input.css:13:5]
  13 | background: url(image.png param(var(--url)));
     :             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/value/url/basic/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/url/basic/span.rust-debug
@@ -147,7 +147,7 @@
    :        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-  x String { value: Atom('http://www.example.com/pinkish.gif' type=dynamic), raw: Atom('"http://www.example.com/pinkish.gif"' type=dynamic) }
+  x String { value: Atom('http://www.example.com/pinkish.gif' type=dynamic), raw: "\"http://www.example.com/pinkish.gif\"" }
    ,-[$DIR/tests/recovery/value/url/basic/input.css:2:5]
  2 | --foo: "http://www.example.com/pinkish.gif";
    :        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -795,7 +795,7 @@
     :                 ^^^^^
     `----
 
-  x String { value: Atom('foo' type=inline), raw: Atom('"foo"' type=inline) }
+  x String { value: Atom('foo' type=inline), raw: "\"foo\"" }
     ,-[$DIR/tests/recovery/value/url/basic/input.css:17:5]
  17 | background: url("foo", "bar");
     :                 ^^^^^
@@ -831,7 +831,7 @@
     :                        ^^^^^
     `----
 
-  x String { value: Atom('bar' type=inline), raw: Atom('"bar"' type=inline) }
+  x String { value: Atom('bar' type=inline), raw: "\"bar\"" }
     ,-[$DIR/tests/recovery/value/url/basic/input.css:17:5]
  17 | background: url("foo", "bar");
     :                        ^^^^^

--- a/crates/swc_css_parser/tests/recovery/value/url/parenthesis/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/value/url/parenthesis/span.rust-debug
@@ -111,8 +111,7 @@
  3 | `-> }
    `----
 
-  x BadUrl { name: Atom('url' type=static), raw_name: Atom('url' type=static), raw_value: Atom('test\);
-  | }' type=dynamic) }
+  x BadUrl { name: Atom('url' type=static), raw_name: "url", raw_value: "test\\);\n}" }
    ,-[$DIR/tests/recovery/value/url/parenthesis/input.css:2:5]
  2 | ,-> background: url(test\);
  3 | `-> }

--- a/crates/swc_css_parser/tests/recovery/vercel/001/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/vercel/001/span.rust-debug
@@ -814,7 +814,7 @@
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
 
-  x Ident { value: Atom('__styled-jsx-placeholder__7' type=dynamic), raw: Atom('__styled-jsx-placeholder__7' type=dynamic) }
+  x Ident { value: Atom('__styled-jsx-placeholder__7' type=dynamic), raw: "__styled-jsx-placeholder__7" }
     ,-[$DIR/tests/recovery/vercel/001/input.css:14:5]
  14 | __styled-jsx-placeholder__7
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/vercel/001/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/vercel/001/span.rust-debug
@@ -827,8 +827,7 @@
  15 | }
     `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
     ,-[$DIR/tests/recovery/vercel/001/input.css:14:5]
  14 | __styled-jsx-placeholder__7
     :                            ^

--- a/crates/swc_css_parser/tests/recovery/vercel/002/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/vercel/002/span.rust-debug
@@ -267,7 +267,7 @@
    :                                             ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/vercel/002/input.css:4:5]
  4 | margin: 0 calc(__styled-jsx-placeholder__7vw - __styled-jsx-placeholder__7px);
    :                                             ^
@@ -291,7 +291,7 @@
    :                                               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/vercel/002/input.css:4:5]
  4 | margin: 0 calc(__styled-jsx-placeholder__7vw - __styled-jsx-placeholder__7px);
    :                                               ^

--- a/crates/swc_css_parser/tests/recovery/vercel/002/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/vercel/002/span.rust-debug
@@ -255,7 +255,7 @@
    :                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('__styled-jsx-placeholder__7vw' type=dynamic), raw: Atom('__styled-jsx-placeholder__7vw' type=dynamic) }
+  x Ident { value: Atom('__styled-jsx-placeholder__7vw' type=dynamic), raw: "__styled-jsx-placeholder__7vw" }
    ,-[$DIR/tests/recovery/vercel/002/input.css:4:5]
  4 | margin: 0 calc(__styled-jsx-placeholder__7vw - __styled-jsx-placeholder__7px);
    :                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -303,7 +303,7 @@
    :                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('__styled-jsx-placeholder__7px' type=dynamic), raw: Atom('__styled-jsx-placeholder__7px' type=dynamic) }
+  x Ident { value: Atom('__styled-jsx-placeholder__7px' type=dynamic), raw: "__styled-jsx-placeholder__7px" }
    ,-[$DIR/tests/recovery/vercel/002/input.css:4:5]
  4 | margin: 0 calc(__styled-jsx-placeholder__7vw - __styled-jsx-placeholder__7px);
    :                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/vercel/003/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/vercel/003/span.rust-debug
@@ -359,7 +359,7 @@
    :                      ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/vercel/003/input.css:7:1]
  7 | .geist-list :global(> .geist-list-item) {
    :                      ^

--- a/crates/swc_css_parser/tests/recovery/vercel/003/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/vercel/003/span.rust-debug
@@ -383,7 +383,7 @@
    :                        ^^^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('geist-list-item' type=dynamic), raw: Atom('geist-list-item' type=dynamic) }
+  x Ident { value: Atom('geist-list-item' type=dynamic), raw: "geist-list-item" }
    ,-[$DIR/tests/recovery/vercel/003/input.css:7:1]
  7 | .geist-list :global(> .geist-list-item) {
    :                        ^^^^^^^^^^^^^^^
@@ -525,7 +525,7 @@
     :             ^^^^^^^^^
     `----
 
-  x Ident { value: Atom('__ident__' type=dynamic), raw: Atom('__ident__' type=dynamic) }
+  x Ident { value: Atom('__ident__' type=dynamic), raw: "__ident__" }
     ,-[$DIR/tests/recovery/vercel/003/input.css:10:5]
  10 | flex-basis: __ident__%;
     :             ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/vercel/004/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/vercel/004/span.rust-debug
@@ -177,7 +177,7 @@
    : ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('__ident__' type=dynamic), raw: Atom('__ident__' type=dynamic) }
+  x Ident { value: Atom('__ident__' type=dynamic), raw: "__ident__" }
    ,-[$DIR/tests/recovery/vercel/004/input.css:3:5]
  3 | __ident__
    : ^^^^^^^^^
@@ -201,7 +201,7 @@
    : ^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('border-radius' type=dynamic), raw: Atom('border-radius' type=dynamic) }
+  x Ident { value: Atom('border-radius' type=dynamic), raw: "border-radius" }
    ,-[$DIR/tests/recovery/vercel/004/input.css:4:5]
  4 | border-radius: 7px;
    : ^^^^^^^^^^^^^
@@ -237,7 +237,7 @@
    :                ^^^
    `----
 
-  x Dimension { value: 7.0, raw_value: Atom('7' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 7.0, raw_value: "7", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/vercel/004/input.css:4:5]
  4 | border-radius: 7px;
    :                ^^^
@@ -359,7 +359,7 @@
    : ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('__ident__' type=dynamic), raw: Atom('__ident__' type=dynamic) }
+  x Ident { value: Atom('__ident__' type=dynamic), raw: "__ident__" }
    ,-[$DIR/tests/recovery/vercel/004/input.css:7:5]
  7 | __ident__
    : ^^^^^^^^^
@@ -383,7 +383,7 @@
    : ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('__ident__' type=dynamic), raw: Atom('__ident__' type=dynamic) }
+  x Ident { value: Atom('__ident__' type=dynamic), raw: "__ident__" }
    ,-[$DIR/tests/recovery/vercel/004/input.css:8:5]
  8 | __ident__
    : ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/vercel/004/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/vercel/004/span.rust-debug
@@ -189,8 +189,7 @@
  4 | `->     border-radius: 7px;
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/vercel/004/input.css:3:5]
  3 | ,-> __ident__
  4 | `->     border-radius: 7px;
@@ -226,7 +225,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/vercel/004/input.css:4:5]
  4 | border-radius: 7px;
    :               ^
@@ -372,8 +371,7 @@
  8 | `->     __ident__
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/vercel/004/input.css:7:5]
  7 | ,-> __ident__
  8 | `->     __ident__
@@ -398,8 +396,7 @@
  9 | }
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/vercel/004/input.css:8:5]
  8 | __ident__
    :          ^

--- a/crates/swc_css_parser/tests/recovery/vercel/005/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/vercel/005/span.rust-debug
@@ -117,7 +117,7 @@
    : ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('__ident__' type=dynamic), raw: Atom('__ident__' type=dynamic) }
+  x Ident { value: Atom('__ident__' type=dynamic), raw: "__ident__" }
    ,-[$DIR/tests/recovery/vercel/005/input.css:3:5]
  3 | __ident__
    : ^^^^^^^^^
@@ -141,7 +141,7 @@
    : ^^^^^^^^^^^^^
    `----
 
-  x Ident { value: Atom('border-radius' type=dynamic), raw: Atom('border-radius' type=dynamic) }
+  x Ident { value: Atom('border-radius' type=dynamic), raw: "border-radius" }
    ,-[$DIR/tests/recovery/vercel/005/input.css:4:5]
  4 | border-radius: 7px;
    : ^^^^^^^^^^^^^
@@ -177,7 +177,7 @@
    :                ^^^
    `----
 
-  x Dimension { value: 7.0, raw_value: Atom('7' type=inline), unit: Atom('px' type=static), raw_unit: Atom('px' type=static), type_flag: Integer }
+  x Dimension { value: 7.0, raw_value: "7", unit: Atom('px' type=static), raw_unit: "px", type_flag: Integer }
    ,-[$DIR/tests/recovery/vercel/005/input.css:4:5]
  4 | border-radius: 7px;
    :                ^^^
@@ -280,7 +280,7 @@
    : ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('__ident__' type=dynamic), raw: Atom('__ident__' type=dynamic) }
+  x Ident { value: Atom('__ident__' type=dynamic), raw: "__ident__" }
    ,-[$DIR/tests/recovery/vercel/005/input.css:7:5]
  7 | __ident__
    : ^^^^^^^^^
@@ -304,7 +304,7 @@
    : ^^^^^^^^^
    `----
 
-  x Ident { value: Atom('__ident__' type=dynamic), raw: Atom('__ident__' type=dynamic) }
+  x Ident { value: Atom('__ident__' type=dynamic), raw: "__ident__" }
    ,-[$DIR/tests/recovery/vercel/005/input.css:8:5]
  8 | __ident__
    : ^^^^^^^^^

--- a/crates/swc_css_parser/tests/recovery/vercel/005/span.rust-debug
+++ b/crates/swc_css_parser/tests/recovery/vercel/005/span.rust-debug
@@ -129,8 +129,7 @@
  4 | `->     border-radius: 7px;
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/vercel/005/input.css:3:5]
  3 | ,-> __ident__
  4 | `->     border-radius: 7px;
@@ -166,7 +165,7 @@
    :               ^
    `----
 
-  x WhiteSpace { value: Atom(' ' type=inline) }
+  x WhiteSpace { value: " " }
    ,-[$DIR/tests/recovery/vercel/005/input.css:4:5]
  4 | border-radius: 7px;
    :               ^
@@ -293,8 +292,7 @@
  8 | `->     __ident__
    `----
 
-  x WhiteSpace { value: Atom('
-  |     ' type=inline) }
+  x WhiteSpace { value: "\n    " }
    ,-[$DIR/tests/recovery/vercel/005/input.css:7:5]
  7 | ,-> __ident__
  8 | `->     __ident__
@@ -319,8 +317,7 @@
  9 | }
    `----
 
-  x WhiteSpace { value: Atom('
-  | ' type=inline) }
+  x WhiteSpace { value: "\n" }
    ,-[$DIR/tests/recovery/vercel/005/input.css:8:5]
  8 | __ident__
    :          ^

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -82,7 +82,7 @@ define!({
     pub struct Str {
         pub span: Span,
         pub value: JsWord,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub struct Integer {

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -2,7 +2,7 @@
 #![deny(clippy::all)]
 #![allow(clippy::ptr_arg)]
 
-use swc_atoms::JsWord;
+use swc_atoms::{Atom, JsWord};
 use swc_common::Span;
 use swc_css_ast::*;
 use swc_visit::define;

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -88,13 +88,13 @@ define!({
     pub struct Integer {
         pub span: Span,
         pub value: i64,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub struct Number {
         pub span: Span,
         pub value: f64,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub struct Declaration {
@@ -521,9 +521,9 @@ define!({
     pub struct AnPlusBNotation {
         pub span: Span,
         pub a: Option<i32>,
-        pub a_raw: Option<JsWord>,
+        pub a_raw: Option<Atom>,
         pub b: Option<i32>,
-        pub b_raw: Option<JsWord>,
+        pub b_raw: Option<Atom>,
     }
 
     pub struct PseudoElementSelector {

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -171,7 +171,7 @@ define!({
     pub struct HexColor {
         pub span: Span,
         pub value: JsWord,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub enum AlphaValue {

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -58,25 +58,25 @@ define!({
     pub struct Ident {
         pub span: Span,
         pub value: JsWord,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub struct CustomIdent {
         pub span: Span,
         pub value: JsWord,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub struct CustomPropertyName {
         pub span: Span,
         pub value: JsWord,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub struct DashedIdent {
         pub span: Span,
         pub value: JsWord,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub struct Str {
@@ -542,7 +542,7 @@ define!({
     pub struct CustomHighlightName {
         pub span: Span,
         pub value: JsWord,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub struct IdSelector {
@@ -993,7 +993,7 @@ define!({
     pub struct ExtensionName {
         pub span: Span,
         pub value: JsWord,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub struct CustomMediaQuery {

--- a/crates/swc_css_visit/src/lib.rs
+++ b/crates/swc_css_visit/src/lib.rs
@@ -288,7 +288,7 @@ define!({
     pub struct UrlValueRaw {
         pub span: Span,
         pub value: JsWord,
-        pub raw: Option<JsWord>,
+        pub raw: Option<Atom>,
     }
 
     pub enum UrlModifier {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Migrate to `Atom` for `raw`

Perf(lexer):

```
css/lexer/bootstrap_5_1_3                                                                            
                        time:   [5.6220 ms 5.6315 ms 5.6413 ms]
                        change: [-3.9771% -2.9640% -2.0043%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

css/lexer/foundation_6_7_4                                                                             
                        time:   [4.7299 ms 4.7514 ms 4.7772 ms]
                        change: [-19.648% -16.912% -14.210%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) high mild
  5 (5.00%) high severe

css/lexer/tailwind_3_1_1                                                                            
                        time:   [899.81 us 902.14 us 904.57 us]
                        change: [-6.3067% -5.8979% -5.4580%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe

```

`tailwind` lexered faster than `1ms` :star: 

**BREAKING CHANGE:**

Yes

**Related issue (if exists):**

No