### PR TITLE
fix(es/modules): Fix `jsc.paths` of `.ts` imports

### DIFF
--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -121,7 +121,7 @@ where
 
             if let Some(orig_ext) = orig_ext {
                 let use_orig = if let Some(ext) = p.extension() {
-                    ext == "ts" || ext == "tsx"
+                    (ext == "ts" || ext == "tsx") && p.is_file()
                 } else {
                     false
                 };

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -113,10 +113,22 @@ where
 {
     fn resolve_import(&self, base: &FileName, module_specifier: &str) -> Result<JsWord, Error> {
         fn to_specifier(target_path: &str, orig_ext: Option<&str>) -> JsWord {
-            let p = PathBuf::from(target_path);
+            let mut p = PathBuf::from(target_path);
 
             if cfg!(debug_assertions) {
                 trace!("to_specifier: orig_ext={:?}", orig_ext);
+            }
+
+            if let Some(orig_ext) = orig_ext {
+                let use_orig = if let Some(ext) = p.extension() {
+                    ext == "ts" || ext == "tsx"
+                } else {
+                    false
+                };
+
+                if use_orig {
+                    p.set_extension(orig_ext);
+                }
             }
 
             p.display().to_string().into()


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6432.

---

https://github.com/Nickersoft/swc-paths/blob/main/package.json

I verified that it's fixed by using `npm link`

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/29931815/201564384-464b6477-07dd-4a70-b994-7c9d09843fb0.png">
