### PR TITLE
fix(es): Remove `privateInObject` related setting

### DIFF
--- a/crates/swc/src/builder.rs
+++ b/crates/swc/src/builder.rs
@@ -17,7 +17,6 @@ use swc_ecma_minifier::option::{terser::TerserTopLevelOptions, MinifyOptions};
 use swc_ecma_parser::Syntax;
 use swc_ecma_transforms::{
     compat,
-    compat::es2022::private_in_object,
     feature::{enable_available_feature_from_es_version, FeatureFlag},
     fixer::{fixer, paren_remover},
     helpers, hygiene,
@@ -330,7 +329,6 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
                 paren_remover(comments.map(|v| v as &dyn Comments)),
                 self.fixer
             ),
-            Optional::new(private_in_object(), syntax.private_in_object()),
             compat_pass,
             // module / helper
             Optional::new(

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -1009,7 +1009,6 @@ impl Compiler {
                         decorators: true,
                         decorators_before_export: true,
                         import_assertions: true,
-                        private_in_object: true,
                         ..Default::default()
                     }),
                     IsModule::Bool(true),

--- a/crates/swc/tests/fixture/issues-6xxx/6373/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-6xxx/6373/input/.swcrc
@@ -1,0 +1,12 @@
+{
+    "jsc": {
+      "parser": {
+        "syntax": "ecmascript"
+      },
+      "target": "es5"
+    },
+    "module": {
+      "type": "es6"
+    },
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-6xxx/6373/input/input.js
+++ b/crates/swc/tests/fixture/issues-6xxx/6373/input/input.js
@@ -1,0 +1,1 @@
+class x { static #y = #y in x ; }

--- a/crates/swc/tests/fixture/issues-6xxx/6373/output/input.js
+++ b/crates/swc/tests/fixture/issues-6xxx/6373/output/input.js
@@ -1,10 +1,9 @@
 import _class_call_check from "@swc/helpers/src/_class_call_check.mjs";
-var _brand_check_y = new WeakSet(), _tmp;
 var x = function x() {
     "use strict";
     _class_call_check(this, x);
 };
 var _y = {
     writable: true,
-    value: (_tmp = _brand_check_y.has(x), _brand_check_y.add(x), _tmp)
+    value: x === x
 };

--- a/crates/swc/tests/fixture/issues-6xxx/6373/output/input.js
+++ b/crates/swc/tests/fixture/issues-6xxx/6373/output/input.js
@@ -1,0 +1,10 @@
+import _class_call_check from "@swc/helpers/src/_class_call_check.mjs";
+var _brand_check_y = new WeakSet(), _tmp;
+var x = function x() {
+    "use strict";
+    _class_call_check(this, x);
+};
+var _y = {
+    writable: true,
+    value: (_tmp = _brand_check_y.has(x), _brand_check_y.add(x), _tmp)
+};

--- a/crates/swc/tests/tsc-references/privateNameInInExpressionUnused.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameInInExpressionUnused.1.normal.js
@@ -1,10 +1,9 @@
 //// [privateNameInInExpressionUnused.ts]
-var _brand_check_brand = new WeakSet();
 class Foo {
     #unused;
-    #brand = void _brand_check_brand.add(this);
+    #brand;
     isFoo(v) {
         // This should count as using/reading '#brand'
-        return _brand_check_brand.has(v);
+        return #brand in v;
     }
 }

--- a/crates/swc/tests/tsc-references/privateNameInInExpressionUnused.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNameInInExpressionUnused.2.minified.js
@@ -1,2 +1,1 @@
 //// [privateNameInInExpressionUnused.ts]
-new WeakSet();

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -238,15 +238,6 @@ impl Syntax {
         }
     }
 
-    pub fn private_in_object(self) -> bool {
-        match self {
-            Syntax::Es(EsConfig {
-                private_in_object, ..
-            }) => private_in_object,
-            Syntax::Typescript(_) => true,
-        }
-    }
-
     pub(crate) fn allow_super_outside_method(self) -> bool {
         match self {
             Syntax::Es(EsConfig {
@@ -320,9 +311,6 @@ pub struct EsConfig {
     /// Stage 3.
     #[serde(default)]
     pub import_assertions: bool,
-
-    #[serde(default, rename = "privateInObject")]
-    pub private_in_object: bool,
 
     #[serde(default, rename = "allowSuperOutsideMethod")]
     pub allow_super_outside_method: bool,

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -487,7 +487,7 @@ impl<I: Tokens> Parser<I> {
             }
         }
 
-        if self.input.syntax().private_in_object() && eat!(self, '#') {
+        if eat!(self, '#') {
             let id = self.parse_ident_name()?;
             return Ok(Box::new(Expr::PrivateName(PrivateName {
                 span: span!(self, start),

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/c3731145e0e65d1d.js.stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/c3731145e0e65d1d.js.stderr
@@ -1,7 +1,6 @@
 
-  x Unexpected token `#`. Expected this, import, async, function, [ for array literal, { for object literal, @ for decorator, function, class, null, true, false, number, bigint, string, regexp, `
-  | for template literal, (, or an identifier
+  x Expected ident
    ,-[$DIR/tests/test262-parser/fail/c3731145e0e65d1d.js:1:1]
  1 | #=
-   : ^
+   :  ^
    `----

--- a/crates/swc_ecma_transforms_compat/tests/es2015_new_target.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_new_target.rs
@@ -2,7 +2,6 @@ use std::{fs::read_to_string, path::PathBuf};
 
 use serde::Deserialize;
 use swc_common::{chain, Mark};
-use swc_ecma_parser::{EsConfig, Syntax};
 use swc_ecma_transforms_base::pass::noop;
 use swc_ecma_transforms_compat::{
     es2015::{arrow, classes, new_target::new_target},
@@ -96,10 +95,7 @@ fn fixture(input: PathBuf) {
 
     let output = input.parent().unwrap().join("output.js");
     test_fixture(
-        Syntax::Es(EsConfig {
-            private_in_object: true,
-            ..Default::default()
-        }),
+        Default::default(),
         &|t| get_passes(t, &options.plugins),
         &input,
         &output,

--- a/crates/swc_ecma_transforms_compat/tests/es2022_private_in_object.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2022_private_in_object.rs
@@ -2,7 +2,6 @@ use std::path::PathBuf;
 
 use serde::Deserialize;
 use swc_common::chain;
-use swc_ecma_parser::{EsConfig, Syntax};
 use swc_ecma_transforms_base::pass::noop;
 use swc_ecma_transforms_compat::{
     es2015::classes,
@@ -32,10 +31,7 @@ fn fixture(input: PathBuf) {
 
     let output = parent.join("output.js");
     test_fixture(
-        Syntax::Es(EsConfig {
-            private_in_object: true,
-            ..Default::default()
-        }),
+        Default::default(),
         &|t| {
             let mut pass: Box<dyn Fold> = Box::new(noop());
 

--- a/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
@@ -236,7 +236,6 @@ fn identity(entry: PathBuf) {
                 decorators: true,
                 decorators_before_export: true,
                 export_default_from: true,
-                private_in_object: true,
                 import_assertions: true,
                 allow_super_outside_method: true,
                 ..Default::default()


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

private in object has already landed in ES2022 and there're many browsers supporting it, so related config can be removed. This won't be a break change for JS side as currently `serde` only checks extra fields in top level.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
closes #6373