### PR TITLE
refactor(preset_env_base): remove serde-serialize from bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -217,8 +217,7 @@ dependencies = [
 [[package]]
 name = "browserslist-rs"
 version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c689fb4e42bd511c1927856b078d8a582690f5be196199d1c9005b9d4feae8c"
+source = "git+https://github.com/kwonoj/browserslist-rs?rev=bd47b8e17c937d15ed75fe9c3522ef0ac94ffcd9#bd47b8e17c937d15ed75fe9c3522ef0ac94ffcd9"
 dependencies = [
  "ahash",
  "anyhow",
@@ -4924,8 +4923,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
  "cfg-if 1.0.0",
- "serde",
- "serde_json",
  "wasm-bindgen-macro",
 ]
 

--- a/crates/preset_env_base/Cargo.toml
+++ b/crates/preset_env_base/Cargo.toml
@@ -1,23 +1,24 @@
 [package]
-authors = ["강동윤 <kdy1997.dev@gmail.com>"]
-description = "Common logic for targetting vairous browsers"
+authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
+description   = "Common logic for targetting vairous browsers"
 documentation = "https://rustdoc.swc.rs/preset_env_base/"
-edition = "2021"
-license = "Apache-2.0"
-name = "preset_env_base"
-version = "0.3.2"
+edition       = "2021"
+license       = "Apache-2.0"
+name          = "preset_env_base"
+version       = "0.3.2"
 
 [lib]
 bench = false
 
 [dependencies]
-ahash = "0.7.4"
+ahash  = "0.7.4"
 anyhow = "1"
-browserslist-rs = "=0.11.0"
-dashmap = "5.1.0"
-from_variant = { version = "0.1.3", path = "../from_variant" }
-once_cell = "1.12.0"
-semver = { version = "1.0.4", features = ["serde"] }
-serde = { version = "1", features = ["derive"] }
-st-map = "0.1.2"
-tracing = { version = "0.1.32" }
+# https://github.com/browserslist/browserslist-rs/pull/13
+browserslist-rs = { git = "https://github.com/kwonoj/browserslist-rs", rev = "bd47b8e17c937d15ed75fe9c3522ef0ac94ffcd9" }
+dashmap         = "5.1.0"
+from_variant    = { version = "0.1.3", path = "../from_variant" }
+once_cell       = "1.12.0"
+semver          = { version = "1.0.4", features = ["serde"] }
+serde           = { version = "1", features = ["derive"] }
+st-map          = "0.1.2"
+tracing         = { version = "0.1.32" }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Same as https://github.com/swc-project/swc/pull/6462, but for the transitive dep browserslist-rs. There is an open PR targeting the latest version of browserslist (0.12), but we are currently using 0.11 so use a commit https://github.com/kwonoj/browserslist-rs/commit/bd47b8e17c937d15ed75fe9c3522ef0ac94ffcd9#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R58 to safely remove features for now, and then later try to bump up version separately to avoid regressions.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
