### PR TITLE
ci(actions): scope pr trigger type

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,8 +1,11 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
+  push:
+    branches:
+      - main
 
 env:
   CI: 1


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Curious if we're interested in having reduced scope to trigger pr workflow? currently it is wide, runs all CI workflow for the commit / pr both when new commit's being updated in pull request. `synchronize` supposed to do the work for the pr, while we keep main branch push behavior as is.

ref: https://github.com/vercel/next.js/blob/canary/.github/workflows/build_test_deploy.yml#L3-L5

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
