### PR TITLE
Upgrade `browserslist-rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,9 +216,9 @@ dependencies = [
 
 [[package]]
 name = "browserslist-rs"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c689fb4e42bd511c1927856b078d8a582690f5be196199d1c9005b9d4feae8c"
+checksum = "789a32c13ea5ef079e93f45951d46e5cc0488587beac6bfe716e4669b1cd98aa"
 dependencies = [
  "ahash",
  "anyhow",

--- a/crates/preset_env_base/Cargo.toml
+++ b/crates/preset_env_base/Cargo.toml
@@ -13,7 +13,7 @@ bench = false
 [dependencies]
 ahash = "0.7.4"
 anyhow = "1"
-browserslist-rs = "=0.11.0"
+browserslist-rs = "=0.12.1"
 dashmap = "5.1.0"
 from_variant = { version = "0.1.3", path = "../from_variant" }
 once_cell = "1.12.0"


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Upgrades the `browserslist-rs` dependency.

Importantly, `browserslist-rs` v0.12 marked Internet Explorer as dead:

https://github.com/browserslist/browserslist-rs/releases/tag/v0.12.0

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

Not sure if this is a breaking change, because browserslist queries are supposed to have different results over time. Most likely this PR could be considered a bug fix, because people expect the browserslist query to match the current spec and behavior.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

N/A.