### PR TITLE
ci(actions): skip benchmark on fork

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,8 +1,11 @@
 name: Benchmark
 
 on:
-  - push
-  - pull_request
+  pull_request:
+    types: ['opened', 'reopened', 'synchronize']
+  push:
+    branches:
+      - main
 
 env:
   RUST_LOG: "off"
@@ -11,7 +14,7 @@ jobs:
   binary-size:
     name: Binary size
     if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') }}
+      ${{ !contains(github.event.head_commit.message, 'chore: ') && github.repository_owner == 'swc-project' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +43,7 @@ jobs:
   benchmark:
     name: Performance regression check
     if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') }}
+      ${{ !contains(github.event.head_commit.message, 'chore: ') && github.repository_owner == 'swc-project' }}
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
Minor optimization for ci workflow: people can run ci on fork for various reasons (I do it for testing before PR) but running benchmark doesn't make sense lot as it is uncontrolled machine doesn't give reliable number anyway. 

PR changes flow to shortcurcuit those to not waste ci turnaround time for the fork.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
