### PR TITLE
perf(common): Fix perf bug of sourcemap for inputs with multi-byte chars

### DIFF
--- a/crates/swc/benches/minify.rs
+++ b/crates/swc/benches/minify.rs
@@ -46,7 +46,7 @@ fn bench_minify(b: &mut Bencher, filename: &str) {
                         module: Default::default(),
                         safari10: Default::default(),
                         toplevel: true,
-                        source_map: Default::default(),
+                        source_map: BoolOrDataConfig::from_bool(true),
                         output_path: Default::default(),
                         inline_sources_content: true,
                         emit_source_map_columns: true,
@@ -58,7 +58,7 @@ fn bench_minify(b: &mut Bencher, filename: &str) {
 
         let res = black_box(res);
 
-        assert_eq!(res.map, None);
+        // assert_eq!(res.map, None);
     })
 }
 
@@ -84,6 +84,7 @@ fn files_group(c: &mut Criterion) {
     bench_file("typescript");
     bench_file("victory");
     bench_file("vue");
+    // bench_file("large");
 }
 
 criterion_group!(benches, files_group);

--- a/crates/swc/benches/minify.rs
+++ b/crates/swc/benches/minify.rs
@@ -56,7 +56,7 @@ fn bench_minify(b: &mut Bencher, filename: &str) {
         })
         .unwrap();
 
-        let res = black_box(res);
+        black_box(res);
 
         // assert_eq!(res.map, None);
     })

--- a/crates/swc/scripts/instrument.sh
+++ b/crates/swc/scripts/instrument.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
-cargo profile instruments --release -t time --bench typescript --features tracing/release_max_level_info -- --bench $@
+export RUST_LOG=off
+
+cargo profile instruments --release -t time --bench minify --features tracing/release_max_level_info -- --bench $@
 # MINIFY=1 cargo profile instruments --release -t time --bench typescript --features concurrent,tracing/release_max_level_info $@

--- a/crates/swc_common/src/lib.rs
+++ b/crates/swc_common/src/lib.rs
@@ -32,7 +32,6 @@
 //!
 //! Use `fxhash` instead of `ahash` for `AHashMap` and `AHashSet`.
 #![deny(clippy::all)]
-#![deny(unused)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::fmt::Debug;

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1194,7 +1194,6 @@ impl SourceMap {
         let mut prev_extra_bytes = 0;
         let mut ch_start = 0;
         let mut line_prev_extra_bytes = 0;
-        let mut prev_srcmap_line = 0;
         let mut line_ch_start = 0;
 
         for (pos, lc) in mappings.iter() {
@@ -1230,6 +1229,10 @@ impl SourceMap {
 
                     prev_extra_bytes = 0;
                     ch_start = 0;
+
+                    line_prev_extra_bytes = 0;
+                    line_ch_start = 0;
+
                     cur_file = Some(f.clone());
                     &f
                 }
@@ -1256,11 +1259,6 @@ impl SourceMap {
             }
 
             let mut line = a + 1; // Line numbers start at 1
-            if line != prev_srcmap_line {
-                prev_srcmap_line = line;
-                line_ch_start = 0;
-                line_prev_extra_bytes = 0;
-            }
 
             let linebpos = f.lines[a as usize];
             debug_assert!(

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1221,6 +1221,7 @@ impl SourceMap {
                         builder.set_source_contents(src_id, Some(&f.src));
                     }
 
+                    ch_start = 0;
                     cur_file = Some(f.clone());
                     &f
                 }

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1193,6 +1193,8 @@ impl SourceMap {
 
         let mut prev_extra_bytes = 0;
         let mut ch_start = 0;
+        let mut line_prev_extra_bytes = 0;
+        let mut line_ch_start = 0;
 
         for (pos, lc) in mappings.iter() {
             let pos = *pos;
@@ -1261,17 +1263,14 @@ impl SourceMap {
                 pos,
                 linebpos,
             );
+            // dbg!(prev_extra_bytes);
+            // dbg!(ch_start);
             let mut copied_prev_extra_bytes = prev_extra_bytes;
             let mut copied_ch_start = ch_start;
             let chpos =
                 pos.to_u32() - self.calc_extra_bytes(f, &mut prev_extra_bytes, &mut ch_start, pos);
-            let linechpos = linebpos.to_u32()
-                - self.calc_extra_bytes(
-                    f,
-                    &mut copied_prev_extra_bytes,
-                    &mut copied_ch_start,
-                    linebpos,
-                );
+            let linechpos = linebpos.to_u32() - self.calc_extra_bytes(f, &mut 0, &mut 0, linebpos);
+            // dbg!(chpos, linechpos);
 
             let mut col = max(chpos, linechpos) - min(chpos, linechpos);
 

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1194,6 +1194,7 @@ impl SourceMap {
         let mut prev_extra_bytes = 0;
         let mut ch_start = 0;
         let mut line_prev_extra_bytes = 0;
+        let mut prev_srcmap_line = 0;
         let mut line_ch_start = 0;
 
         for (pos, lc) in mappings.iter() {
@@ -1255,6 +1256,12 @@ impl SourceMap {
             }
 
             let mut line = a + 1; // Line numbers start at 1
+            if line != prev_srcmap_line {
+                prev_srcmap_line = line;
+                line_ch_start = 0;
+                line_prev_extra_bytes = 0;
+            }
+
             let linebpos = f.lines[a as usize];
             debug_assert!(
                 pos >= linebpos,
@@ -1263,14 +1270,15 @@ impl SourceMap {
                 pos,
                 linebpos,
             );
-            // dbg!(prev_extra_bytes);
-            // dbg!(ch_start);
-            let mut copied_prev_extra_bytes = prev_extra_bytes;
-            let mut copied_ch_start = ch_start;
             let chpos =
                 pos.to_u32() - self.calc_extra_bytes(f, &mut prev_extra_bytes, &mut ch_start, pos);
-            let linechpos = linebpos.to_u32() - self.calc_extra_bytes(f, &mut 0, &mut 0, linebpos);
-            // dbg!(chpos, linechpos);
+            let linechpos = linebpos.to_u32()
+                - self.calc_extra_bytes(
+                    f,
+                    &mut line_prev_extra_bytes,
+                    &mut line_ch_start,
+                    linebpos,
+                );
 
             let mut col = max(chpos, linechpos) - min(chpos, linechpos);
 

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -970,6 +970,11 @@ impl SourceMap {
         // The number of extra bytes due to multibyte chars in the SourceFile
         let mut total_extra_bytes = 0;
 
+        // Next file
+        if *start >= map.multibyte_chars.len() {
+            *start = 0;
+        }
+
         for (i, &mbc) in map.multibyte_chars[*start..].iter().enumerate() {
             debug!("{}-byte char at {:?}", mbc.bytes, mbc.pos);
             if mbc.pos < bpos {

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1183,6 +1183,8 @@ impl SourceMap {
 
         let mut prev_dst_line = u32::MAX;
 
+        let mut ch_start = 0;
+
         for (pos, lc) in mappings.iter() {
             let pos = *pos;
 
@@ -1248,8 +1250,10 @@ impl SourceMap {
                 pos,
                 linebpos,
             );
-            let chpos = pos.to_u32() - self.calc_extra_bytes(f, &mut 0, pos);
-            let linechpos = linebpos.to_u32() - self.calc_extra_bytes(f, &mut 0, linebpos);
+            let mut copied_ch_start = ch_start;
+            let chpos = pos.to_u32() - self.calc_extra_bytes(f, &mut ch_start, pos);
+            let linechpos =
+                linebpos.to_u32() - self.calc_extra_bytes(f, &mut copied_ch_start, linebpos);
 
             let mut col = max(chpos, linechpos) - min(chpos, linechpos);
 


### PR DESCRIPTION
**Description:**

This PR makes the source map generator cache the previous position instead of searching it from 0 every time.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6411.