### PR TITLE
Fix BytePos -> CharPos calculations

### DIFF
--- a/crates/swc/tests/fixture/sourcemap/issue-6552/input-map/input/.swcrc
+++ b/crates/swc/tests/fixture/sourcemap/issue-6552/input-map/input/.swcrc
@@ -1,0 +1,20 @@
+{
+    "sourceMaps": true,
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": false
+        },
+        "target": "es5",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "commonjs"
+    },
+    "minify": true,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/sourcemap/issue-6552/input-map/input/index.js
+++ b/crates/swc/tests/fixture/sourcemap/issue-6552/input-map/input/index.js
@@ -1,0 +1,4 @@
+const xxx = ', something';
+console.error(`❌ ${message}`);
+const bbb = '';
+//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJ4eHgiLCJjb25zb2xlIiwiZXJyb3IiLCJtZXNzYWdlIiwiYmJiIl0sInNvdXJjZXMiOlsidW5rbm93biJdLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCB4eHggPSAnLCBzb21ldGhpbmcnXG5jb25zb2xlLmVycm9yKGDinYwgJHttZXNzYWdlfWApO1xuXG5jb25zdCBiYmIgPSAnJ1xuIl0sIm1hcHBpbmdzIjoiQUFBQSxNQUFNQSxHQUFHLEdBQUcsYUFBWjtBQUNBQyxPQUFPLENBQUNDLEtBQVIsQ0FBZSxLQUFJQyxPQUFRLEVBQTNCO0FBRUEsTUFBTUMsR0FBRyxHQUFHLEVBQVoifQ==

--- a/crates/swc/tests/fixture/sourcemap/issue-6552/input-map/output/index.js
+++ b/crates/swc/tests/fixture/sourcemap/issue-6552/input-map/output/index.js
@@ -1,0 +1,1 @@
+"use strict";var xxx=", something";console.error("❌ ".concat(message));var bbb="";

--- a/crates/swc/tests/fixture/sourcemap/issue-6552/input-map/output/index.map
+++ b/crates/swc/tests/fixture/sourcemap/issue-6552/input-map/output/index.map
@@ -1,0 +1,17 @@
+{
+  "mappings": "AAAA,aAAA,IAAMA,IAAM,cACZC,QAAQC,KAAK,CAAC,AAAC,KAAY,OAARC,UACnB,IAAMC,IAAM",
+  "names": [
+    "xxx",
+    "console",
+    "error",
+    "message",
+    "bbb"
+  ],
+  "sources": [
+    "../../input/index.js"
+  ],
+  "sourcesContent": [
+    "const xxx = ', something';\nconsole.error(`❌ ${message}`);\nconst bbb = '';\n//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJ4eHgiLCJjb25zb2xlIiwiZXJyb3IiLCJtZXNzYWdlIiwiYmJiIl0sInNvdXJjZXMiOlsidW5rbm93biJdLCJzb3VyY2VzQ29udGVudCI6WyJjb25zdCB4eHggPSAnLCBzb21ldGhpbmcnXG5jb25zb2xlLmVycm9yKGDinYwgJHttZXNzYWdlfWApO1xuXG5jb25zdCBiYmIgPSAnJ1xuIl0sIm1hcHBpbmdzIjoiQUFBQSxNQUFNQSxHQUFHLEdBQUcsYUFBWjtBQUNBQyxPQUFPLENBQUNDLEtBQVIsQ0FBZSxLQUFJQyxPQUFRLEVBQTNCO0FBRUEsTUFBTUMsR0FBRyxHQUFHLEVBQVoifQ==\n"
+  ],
+  "version": 3
+}

--- a/crates/swc/tests/fixture/sourcemap/issue-6552/no-map/input/.swcrc
+++ b/crates/swc/tests/fixture/sourcemap/issue-6552/no-map/input/.swcrc
@@ -1,0 +1,20 @@
+{
+    "sourceMaps": true,
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": false
+        },
+        "target": "es5",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "commonjs"
+    },
+    "minify": true,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/sourcemap/issue-6552/no-map/input/index.js
+++ b/crates/swc/tests/fixture/sourcemap/issue-6552/no-map/input/index.js
@@ -1,0 +1,4 @@
+const xxx = ', something'
+console.error(`❌ ${message}`);
+
+const bbb = ''

--- a/crates/swc/tests/fixture/sourcemap/issue-6552/no-map/output/index.js
+++ b/crates/swc/tests/fixture/sourcemap/issue-6552/no-map/output/index.js
@@ -1,0 +1,1 @@
+"use strict";var xxx=", something";console.error("❌ ".concat(message));var bbb="";

--- a/crates/swc/tests/fixture/sourcemap/issue-6552/no-map/output/index.map
+++ b/crates/swc/tests/fixture/sourcemap/issue-6552/no-map/output/index.map
@@ -1,0 +1,17 @@
+{
+  "mappings": "AAAA,aAAA,IAAMA,IAAM,cACZC,QAAQC,KAAK,CAAC,AAAC,KAAY,OAARC,UAEnB,IAAMC,IAAM",
+  "names": [
+    "xxx",
+    "console",
+    "error",
+    "message",
+    "bbb"
+  ],
+  "sources": [
+    "../../input/index.js"
+  ],
+  "sourcesContent": [
+    "const xxx = ', something'\nconsole.error(`❌ ${message}`);\n\nconst bbb = ''\n"
+  ],
+  "version": 3
+}

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1714,7 +1714,6 @@ mod tests {
         for c in input.chars() {
             let actual = bpos.to_u32() - sm.calc_utf16_offset(&file, bpos, &mut state);
 
-            dbg!(&bpos, &cpos, &state);
             assert_eq!(actual, cpos.to_u32());
 
             bpos = bpos + BytePos(c.len_utf8() as u32);

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1008,7 +1008,7 @@ impl SourceMap {
                     mbc.pos,
                     mbc.bytes
                 );
-                index = i;
+                index += 1;
             }
         } else {
             let range = 0..index;
@@ -1027,7 +1027,7 @@ impl SourceMap {
                     bpos,
                     mbc.pos,
                 );
-                index = i;
+                index -= 1;
             }
         }
 

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -737,6 +737,21 @@ pub struct MultiByteChar {
     pub bytes: u8,
 }
 
+impl MultiByteChar {
+    /// Computes the extra number of UTF-8 bytes necessary to encode a code
+    /// point, compared to UTF-16 encoding.
+    ///
+    /// 1, 2, and 3 UTF-8 bytes encode into 1 UTF-16 char, but 4 UTF-8 bytes
+    /// encode into 2.
+    pub fn byte_to_char_diff(&self) -> u8 {
+        if self.bytes == 4 {
+            2
+        } else {
+            self.bytes - 1
+        }
+    }
+}
+
 /// Identifies an offset of a non-narrow character in a SourceFile
 #[cfg_attr(
     any(feature = "rkyv-impl", feature = "rkyv-bytecheck-impl"),
@@ -1002,7 +1017,9 @@ pub trait Pos {
 ///  - Values larger than `u32::MAX - 2^16` are reserved for the comments.
 ///
 /// `u32::MAX` is special value used to generate source map entries.
-#[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Serialize, Deserialize)]
+#[derive(
+    Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Debug, Serialize, Deserialize, Default,
+)]
 #[serde(transparent)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(

--- a/crates/swc_estree_compat/src/babelify/mod.rs
+++ b/crates/swc_estree_compat/src/babelify/mod.rs
@@ -41,22 +41,7 @@ impl Context {
             return (None, None);
         }
 
-        // We rename this to feel more comfortable while doing math.
-        let start_offset = self.fm.start_pos;
-
-        let mut prev_extra_bytes = 0;
-        let mut ch_start = 0;
-
-        let start = span.lo.to_u32()
-            - start_offset.to_u32()
-            - self
-                .cm
-                .calc_utf16_offset(&self.fm, &mut prev_extra_bytes, &mut ch_start, span.lo);
-        let end = span.hi.to_u32()
-            - start_offset.to_u32()
-            - self
-                .cm
-                .calc_utf16_offset(&self.fm, &mut prev_extra_bytes, &mut ch_start, span.hi);
+        let (start, end) = self.cm.span_to_char_offset(&self.fm, span);
 
         (Some(start), Some(end))
     }

--- a/crates/swc_estree_compat/src/babelify/mod.rs
+++ b/crates/swc_estree_compat/src/babelify/mod.rs
@@ -4,7 +4,6 @@ use rayon::prelude::*;
 use serde::{de::DeserializeOwned, Serialize};
 use swc_common::{
     comments::{CommentKind, Comments},
-    source_map::Pos,
     sync::Lrc,
     BytePos, SourceFile, SourceMap, Span,
 };


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This fixes the BytePos -> CharPos calculation necessary for source maps. There were a few issues in the old code:

1. UTF-8 maps 1-3 bytes into 1 UTF-16 char, but 4 bytes into 2 UTF-16 chars
2. The starting offset was not recorded when we reach the end of the `multibyte_chars` iteration
3. The `mappings` can be unordered, meaning we need to restart UTF-16 offset calculation

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

Fixes #6552