### PR TITLE
perf(css/parser): Reduce clones and allocations

### DIFF
--- a/crates/swc_css_parser/benches/lexer.rs
+++ b/crates/swc_css_parser/benches/lexer.rs
@@ -20,18 +20,30 @@ fn bench_stylesheet(b: &mut Bencher, src: &'static str) {
     });
 }
 
+fn run(c: &mut Criterion, id: &str, src: &'static str) {
+    c.bench_function(&format!("css/parser/{}", id), |b| {
+        bench_stylesheet(b, src);
+    });
+}
+
 fn bench_files(c: &mut Criterion) {
-    c.bench_function("css/lexer/bootstrap_5_1_3", |b| {
-        bench_stylesheet(b, include_str!("./files/bootstrap_5_1_3.css"))
-    });
+    run(
+        c,
+        "bootstrap_5_1_3",
+        include_str!("./files/bootstrap_5_1_3.css"),
+    );
 
-    c.bench_function("css/lexer/foundation_6_7_4", |b| {
-        bench_stylesheet(b, include_str!("./files/foundation_6_7_4.css"))
-    });
+    run(
+        c,
+        "foundation_6_7_4",
+        include_str!("./files/foundation_6_7_4.css"),
+    );
 
-    c.bench_function("css/lexer/tailwind_3_1_1", |b| {
-        bench_stylesheet(b, include_str!("./files/tailwind_3_1_1.css"))
-    });
+    run(
+        c,
+        "tailwind_3_1_1",
+        include_str!("./files/tailwind_3_1_1.css"),
+    );
 }
 
 criterion_group!(benches, bench_files);

--- a/crates/swc_css_parser/benches/parser.rs
+++ b/crates/swc_css_parser/benches/parser.rs
@@ -21,18 +21,30 @@ fn bench_stylesheet(b: &mut Bencher, src: &'static str) {
     });
 }
 
+fn run(c: &mut Criterion, id: &str, src: &'static str) {
+    c.bench_function(&format!("css/parser/{}", id), |b| {
+        bench_stylesheet(b, src);
+    });
+}
+
 fn bench_files(c: &mut Criterion) {
-    c.bench_function("css/parser/bootstrap_5_1_3", |b| {
-        bench_stylesheet(b, include_str!("./files/bootstrap_5_1_3.css"))
-    });
+    run(
+        c,
+        "bootstrap_5_1_3",
+        include_str!("./files/bootstrap_5_1_3.css"),
+    );
 
-    c.bench_function("css/parser/foundation_6_7_4", |b| {
-        bench_stylesheet(b, include_str!("./files/foundation_6_7_4.css"))
-    });
+    run(
+        c,
+        "foundation_6_7_4",
+        include_str!("./files/foundation_6_7_4.css"),
+    );
 
-    c.bench_function("css/parser/tailwind_3_1_1", |b| {
-        bench_stylesheet(b, include_str!("./files/tailwind_3_1_1.css"))
-    });
+    run(
+        c,
+        "tailwind_3_1_1",
+        include_str!("./files/tailwind_3_1_1.css"),
+    );
 }
 
 criterion_group!(benches, bench_files);

--- a/crates/swc_css_parser/scripts/instruemnt/bench-parser.sh
+++ b/crates/swc_css_parser/scripts/instruemnt/bench-parser.sh
@@ -2,6 +2,6 @@
 set -eu
 
 export RUST_LOG=off
-export MIMALLOC_SHOW_STATS=1
+# export MIMALLOC_SHOW_STATS=1
 
 cargo profile instruments --release -t time --features swc_common/concurrent --bench parser -- $@

--- a/crates/swc_css_parser/scripts/instruemnt/bench-parser.sh
+++ b/crates/swc_css_parser/scripts/instruemnt/bench-parser.sh
@@ -4,4 +4,4 @@ set -eu
 export RUST_LOG=off
 export MIMALLOC_SHOW_STATS=1
 
-cargo profile instruments --release -t time --features swc_common/concurrent --bench parser -- --bench --color $@
+cargo profile instruments --release -t time --features swc_common/concurrent --bench parser -- $@

--- a/crates/swc_css_parser/src/parser/input.rs
+++ b/crates/swc_css_parser/src/parser/input.rs
@@ -219,16 +219,18 @@ pub enum InputType<'a> {
     ListOfComponentValues(&'a ListOfComponentValues),
 }
 
+type SpanLike = (BytePos, BytePos);
+
 #[derive(Debug)]
 enum TokenOrBlock {
     Token(Box<TokenAndSpan>),
     Function(Box<(Span, JsWord, Atom)>),
-    LBracket(Box<Span>),
-    LParen(Box<Span>),
-    LBrace(Box<Span>),
-    RParen(Box<Span>),
-    RBracket(Box<Span>),
-    RBrace(Box<Span>),
+    LBracket(SpanLike),
+    LParen(SpanLike),
+    LBrace(SpanLike),
+    RParen(SpanLike),
+    RBracket(SpanLike),
+    RBrace(SpanLike),
 }
 
 impl<'a> Input<'a> {
@@ -288,11 +290,10 @@ impl<'a> Input<'a> {
                 let res = self.get_component_value(&function.value, deep + 1);
 
                 if res.is_none() {
-                    return Some(TokenOrBlock::RParen(Box::new(Span::new(
+                    return Some(TokenOrBlock::RParen((
                         function.span_hi() - BytePos(1),
                         function.span_hi(),
-                        Default::default(),
-                    ))));
+                    )));
                 }
 
                 res
@@ -300,9 +301,18 @@ impl<'a> Input<'a> {
             Some(ComponentValue::SimpleBlock(simple_block)) => {
                 if self.idx.len() - 1 == deep {
                     let close = match simple_block.name.token {
-                        Token::LBracket => TokenOrBlock::LBracket(Box::new(simple_block.name.span)),
-                        Token::LParen => TokenOrBlock::LParen(Box::new(simple_block.name.span)),
-                        Token::LBrace => TokenOrBlock::LBrace(Box::new(simple_block.name.span)),
+                        Token::LBracket => TokenOrBlock::LBracket((
+                            simple_block.name.span.lo,
+                            simple_block.name.span.hi,
+                        )),
+                        Token::LParen => TokenOrBlock::LParen((
+                            simple_block.name.span.lo,
+                            simple_block.name.span.hi,
+                        )),
+                        Token::LBrace => TokenOrBlock::LBrace((
+                            simple_block.name.span.lo,
+                            simple_block.name.span.hi,
+                        )),
                         _ => {
                             unreachable!();
                         }
@@ -320,9 +330,9 @@ impl<'a> Input<'a> {
                         Default::default(),
                     );
                     let close = match simple_block.name.token {
-                        Token::LBracket => TokenOrBlock::RBracket(Box::new(span)),
-                        Token::LParen => TokenOrBlock::RParen(Box::new(span)),
-                        Token::LBrace => TokenOrBlock::RBrace(Box::new(span)),
+                        Token::LBracket => TokenOrBlock::RBracket((span.lo, span.hi)),
+                        Token::LParen => TokenOrBlock::RParen((span.lo, span.hi)),
+                        Token::LBrace => TokenOrBlock::RBrace((span.lo, span.hi)),
                         _ => {
                             unreachable!();
                         }
@@ -377,27 +387,27 @@ impl<'a> Input<'a> {
                             },
                         },
                         TokenOrBlock::LBracket(span) => TokenAndSpan {
-                            span: *span,
+                            span: Span::new(span.0, span.1, Default::default()),
                             token: Token::LBracket,
                         },
                         TokenOrBlock::LBrace(span) => TokenAndSpan {
-                            span: *span,
+                            span: Span::new(span.0, span.1, Default::default()),
                             token: Token::LBrace,
                         },
                         TokenOrBlock::LParen(span) => TokenAndSpan {
-                            span: *span,
+                            span: Span::new(span.0, span.1, Default::default()),
                             token: Token::LParen,
                         },
                         TokenOrBlock::RBracket(span) => TokenAndSpan {
-                            span: *span,
+                            span: Span::new(span.0, span.1, Default::default()),
                             token: Token::RBracket,
                         },
                         TokenOrBlock::RBrace(span) => TokenAndSpan {
-                            span: *span,
+                            span: Span::new(span.0, span.1, Default::default()),
                             token: Token::RBrace,
                         },
                         TokenOrBlock::RParen(span) => TokenAndSpan {
-                            span: *span,
+                            span: Span::new(span.0, span.1, Default::default()),
                             token: Token::RParen,
                         },
                     },


### PR DESCRIPTION
**Description:**

 - We use `(BytePos, BytePos)` instead of `Box<Span>`.
 - We use `Cow` for `Input`.

**Related issue (if exists):**


---

<img width="1840" alt="image" src="https://user-images.githubusercontent.com/29931815/205927068-37c55dcd-8bb0-485f-afe0-1c0198b99c30.png">
