### PR TITLE
fix(css/parser): avoid skipping extra whitespaces

### DIFF
--- a/crates/swc_css_parser/src/parser/macros.rs
+++ b/crates/swc_css_parser/src/parser/macros.rs
@@ -43,28 +43,6 @@ macro_rules! tok_pat {
     };
 }
 
-macro_rules! can_ignore_ws {
-    ("{") => {
-        true
-    };
-    ("}") => {
-        true
-    };
-    ("(") => {
-        true
-    };
-    (")") => {
-        true
-    };
-    (":") => {
-        true
-    };
-
-    ($tt:tt) => {
-        false
-    };
-}
-
 macro_rules! cur {
     ($parser:expr) => {
         match $parser.input.cur() {
@@ -182,10 +160,6 @@ macro_rules! eat {
 
 macro_rules! expect {
     ($parser:expr, $tt:tt) => {
-        if can_ignore_ws!($tt) {
-            $parser.input.skip_ws()
-        }
-
         if !eat!($parser, $tt) {
             let span = $parser.input.cur_span();
             return Err(crate::error::Error::new(


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Avoid skipping whitespaces in `[`/`(`/`{` because:
- it is invalid, whitespaces can allowed and can be disallowed based on context, we can't apply this logic for any CSS context
- we already skip whitespaces where it is necessary (no failed tests)
- avoid extra actions

**BREAKING CHANGE:**

No

**Related issue (if exists):**

No