### PR TITLE
chore(ci): Fix benchmark action

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -43,7 +43,7 @@ jobs:
   benchmark:
     name: Performance regression check
     if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') && github.repository_owner == 'swc-project' }}
+      ${{ !contains(github.event.head_commit.message, 'chore: ') && github.repository_owner == 'swc-project' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-large
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -44,7 +44,7 @@ jobs:
     name: Performance regression check
     if: >-
       ${{ !contains(github.event.head_commit.message, 'chore: ') && github.repository_owner == 'swc-project' }}
-    runs-on: macos-latest
+    runs-on: ubuntu-large
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -2,7 +2,7 @@ name: Benchmark
 
 on:
   pull_request:
-    types: ['opened', 'reopened', 'synchronize']
+    types: ["opened", "reopened", "synchronize"]
   push:
     branches:
       - main
@@ -77,7 +77,7 @@ jobs:
           yarn
 
       - name: Run benchmark
-        run: cargo bench --workspace --exclude swc_plugin --features plugin_transform_schema_vtest --features rkyv-impl -- --output-format bencher | tee output.txt
+        run: cargo bench --workspace --exclude swc_plugin --features plugin_transform_schema_vtest --features rkyv-impl -- --output-format bencher --sample-size 10 | tee output.txt
 
       - name: Download previous benchmark results
         run: mkdir raw-data && curl -o raw-data/benchmark-data.json https://raw.githubusercontent.com/swc-project/raw-data/gh-pages/benchmark-data.json


### PR DESCRIPTION
**Description:**

It's broken due to 6-hour time limit of GitHub actions. To fix it, this PR changes the machine type to `ubuntu-large`.