### PR TITLE
fix(node-swc): Add missing `const_to_let` to the type

### DIFF
--- a/node-swc/src/types.ts
+++ b/node-swc/src/types.ts
@@ -343,6 +343,7 @@ export interface TerserCompressOptions {
 
   unused?: boolean,
 
+  const_to_let?: boolean
 
   module?: boolean,
 }


### PR DESCRIPTION
**Description:**

https://github.com/swc-project/swc/blob/a5efa8af503c3e570b36248b7a05bfa393c82f0b/crates/swc_ecma_minifier/src/option/terser.rs#L243-L244

SWC has `const_to_let`, but it is missing in the type.

**BREAKING CHANGE:**

**Related issue (if exists):**