### PR TITLE
fix(es/codegen): fix issue with typescript's mapped types output

### DIFF
--- a/crates/swc_ecma_codegen/src/typescript.rs
+++ b/crates/swc_ecma_codegen/src/typescript.rs
@@ -505,7 +505,7 @@ where
                 }
                 TruePlusMinus::Plus => {
                     punct!("+");
-                    punct!("/");
+                    punct!("?");
                 }
                 TruePlusMinus::Minus => {
                     punct!("-");

--- a/crates/swc_ecma_codegen/tests/fixture/issues/6616/input.ts
+++ b/crates/swc_ecma_codegen/tests/fixture/issues/6616/input.ts
@@ -1,0 +1,3 @@
+type Custom<A> = {
+    -readonly [P in keyof A]+?: A[P];
+};

--- a/crates/swc_ecma_codegen/tests/fixture/issues/6616/output.ts
+++ b/crates/swc_ecma_codegen/tests/fixture/issues/6616/output.ts
@@ -1,0 +1,3 @@
+type Custom<A> = {
+    -readonly [P in keyof A]+?: A[P];
+};


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

In some situations the code generated for mapped types would include a `/` instead of a `?`.

**BREAKING CHANGE:**

This is a small bug fix and shouldn't be breaking change.

**Related issue (if exists):**

fixes #6616