### PR TITLE
feat(css/parser): normalize keyframe selector

### DIFF
--- a/crates/swc_css_minifier/src/compressor/keyframes.rs
+++ b/crates/swc_css_minifier/src/compressor/keyframes.rs
@@ -34,7 +34,7 @@ impl Compressor {
 
     pub(super) fn compress_keyframe_selector(&mut self, keyframe_selector: &mut KeyframeSelector) {
         match keyframe_selector {
-            KeyframeSelector::Ident(i) if i.value.eq_ignore_ascii_case(&js_word!("from")) => {
+            KeyframeSelector::Ident(i) if i.value == js_word!("from") => {
                 *keyframe_selector = KeyframeSelector::Percentage(Percentage {
                     span: i.span,
                     value: Number {

--- a/crates/swc_css_parser/src/parser/at_rules/mod.rs
+++ b/crates/swc_css_parser/src/parser/at_rules/mod.rs
@@ -896,10 +896,11 @@ where
     fn parse(&mut self) -> PResult<KeyframeSelector> {
         match cur!(self) {
             tok!("ident") => {
-                let ident: Ident = self.parse()?;
-                let normalized_ident_value = ident.value.to_ascii_lowercase();
+                let mut ident: Ident = self.parse()?;
 
-                if &*normalized_ident_value != "from" && &*normalized_ident_value != "to" {
+                ident.value = ident.value.to_ascii_lowercase();
+
+                if ident.value != js_word!("from") && ident.value != js_word!("to") {
                     return Err(Error::new(
                         ident.span,
                         ErrorKind::Expected("'from' or 'to' idents"),

--- a/crates/swc_css_parser/tests/fixture/at-rule/keyframe/output.json
+++ b/crates/swc_css_parser/tests/fixture/at-rule/keyframe/output.json
@@ -1513,7 +1513,7 @@
                   "end": 686,
                   "ctxt": 0
                 },
-                "value": "fRoM",
+                "value": "from",
                 "raw": "fRoM"
               }
             ],
@@ -1611,7 +1611,7 @@
                   "end": 737,
                   "ctxt": 0
                 },
-                "value": "tO",
+                "value": "to",
                 "raw": "tO"
               }
             ],


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Normalize `from`/`to` for keyframes selector

**BREAKING CHANGE:**

No

**Related issue (if exists):**

No