### PR TITLE
fix(es): Preserve license comments by default

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -943,7 +943,7 @@ pub struct JsMinifyFormatOptions {
     #[serde(default)]
     pub braces: bool,
 
-    #[serde(default)]
+    #[serde(default = "default_comments")]
     pub comments: BoolOrDataConfig<JsMinifyCommentOption>,
 
     /// Not implemented yet.
@@ -1013,6 +1013,10 @@ pub struct JsMinifyFormatOptions {
     /// Not implemented yet.
     #[serde(default, alias = "wrap_func_args")]
     pub wrap_func_args: bool,
+}
+
+fn default_comments() -> BoolOrDataConfig<JsMinifyCommentOption> {
+    BoolOrDataConfig::from_obj(JsMinifyCommentOption::PreserveSomeComments)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
**Description:**



**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6677.