### PR TITLE
fix(swc): Remove import statement canonicalization

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1309,10 +1309,10 @@ impl ModuleConfig {
         available_features: FeatureFlag,
     ) -> Box<dyn swc_ecma_visit::Fold + 'cmt> {
         let base = match base {
-            FileName::Real(v) if !paths.is_empty() => {
-                FileName::Real(v.canonicalize().unwrap_or_else(|_| v.to_path_buf()))
+            FileName::Real(path) if !paths.is_empty() && !path.is_absolute() => {
+                FileName::Real(std::env::current_dir().unwrap().join(path))
             }
-            _ => base.clone(),
+            _ => base.to_owned(),
         };
 
         match config {


### PR DESCRIPTION
Fixes an issue where import statements to symbolic links (symlinks) are canonicalized in generated code and use the absolute form of the path with all intermediate components normalized and symbolic links resolved.

Import resolution was introduced in https://github.com/swc-project/swc/pull/1834.

However, resolving symbolic links in generated code is unnecessary. A JavaScript runtime (Node.js, Deno) will resolve import statements to symbolic links at runtime. 

The suggested solution introduces a new `match` guard to determine whether the path is relative and uses the current working directory as a base path. For example, the current working directory is already used as a base path for module resolution

https://github.com/swc-project/swc/blob/072bd130239579566d319a47156c570277cebb1b/crates/swc_ecma_transforms_module/src/path.rs#L276


Actual behavior (generated code, canonicalized import statement from a symbolic link)

```
const a = require("../../../src/modules/a");
```

Expected behavior

```
const a = require("./modules/a");
```

Related

- https://github.com/swc-project/swc/issues/4057
- https://github.com/aspect-build/rules_swc/issues/61
- https://github.com/aspect-build/rules_swc/issues/88