### PR TITLE
Fix feature used for plugin starter.

### DIFF
--- a/bindings/swc_cli/src/commands/plugin.rs
+++ b/bindings/swc_cli/src/commands/plugin.rs
@@ -164,7 +164,7 @@ lto = true
 
 [dependencies]
 serde = "1"
-swc_core = {{ version = "{}", features = ["plugin_transform"] }}
+swc_core = {{ version = "{}", features = ["ecma_plugin_transform"] }}
 
 # .cargo/config defines few alias to build plugin.
 # cargo build-wasi generates wasm-wasi32 binary


### PR DESCRIPTION
**Description:**

New plugins created with `swc plugin new` can't be compiled because the feature `plugin_transform` used by the plugin was recently removed (in fa8f7b00fc458c4ee2a74b431fb9004f67e54dde). This leads to errors like the following:

```
error: failed to select a version for `swc_core`.
    ... required by package `swc_plugin v0.1.0 (<redacted path>)`
versions that meet the requirements `0.50.*` are: 0.50.3, 0.50.2, 0.50.1, 0.50.0

the package `swc_plugin` depends on `swc_core`, with features: `plugin_transform` but `swc_core` does not have these features.


failed to select a version for `swc_core` which could resolve this conflict
```

This PR updates the template used for new plugins to depend on a proper feature name. I'm assuming it's supposed to be `ecma_plugin_transform` by default, but that is likely not applicable for all types of plugins and might need more work in the future. For now, this change fixes a currently-broken workflow for people new to the project.