### PR TITLE
fix(es/minifier): Fix usage counter to fix infinite loop

### DIFF
--- a/crates/swc/tests/fixture/issues-6xxx/6729/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-6xxx/6729/input/.swcrc
@@ -15,6 +15,5 @@
     "module": {
         "type": "es6"
     },
-    "minify": true,
     "isModule": true
 }

--- a/crates/swc/tests/fixture/issues-6xxx/6729/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-6xxx/6729/input/.swcrc
@@ -8,7 +8,7 @@
         "target": "es2020",
         "loose": false,
         "minify": {
-            "compress": false,
+            "compress": true,
             "mangle": false
         }
     },

--- a/crates/swc/tests/fixture/issues-6xxx/6729/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-6xxx/6729/input/.swcrc
@@ -1,0 +1,20 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true,
+            "tsx": false
+        },
+        "target": "es2020",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": true,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-6xxx/6729/input/index.js
+++ b/crates/swc/tests/fixture/issues-6xxx/6729/input/index.js
@@ -1,0 +1,13 @@
+export async function foo() {
+    if (undefined_var_1) {
+        let replace;
+
+        if (undefined_var_2) {
+            replace = 1;
+        } else {
+            replace = 2;
+        }
+
+        await a({ replace })
+    }
+}

--- a/crates/swc/tests/fixture/issues-6xxx/6729/output/index.js
+++ b/crates/swc/tests/fixture/issues-6xxx/6729/output/index.js
@@ -1,0 +1,5 @@
+export async function foo() {
+    undefined_var_1 && await a({
+        replace: undefined_var_2 ? 1 : 2
+    });
+}

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -2444,15 +2444,6 @@ impl Visit for UsageCounter<'_> {
         }
     }
 
-    fn visit_super_prop_expr(&mut self, e: &SuperPropExpr) {
-        if let SuperProp::Computed(c) = &e.prop {
-            let old = self.in_lhs;
-            self.in_lhs = false;
-            c.expr.visit_with(self);
-            self.in_lhs = old;
-        }
-    }
-
     fn visit_pat(&mut self, p: &Pat) {
         let old = self.in_lhs;
         self.in_lhs = true;
@@ -2465,6 +2456,22 @@ impl Visit for UsageCounter<'_> {
         self.in_lhs = true;
         p.visit_children_with(self);
         self.in_lhs = old;
+    }
+
+    fn visit_prop_name(&mut self, p: &PropName) {
+        match p {
+            PropName::Computed(p) => p.visit_with(self),
+            _ => {}
+        }
+    }
+
+    fn visit_super_prop_expr(&mut self, e: &SuperPropExpr) {
+        if let SuperProp::Computed(c) = &e.prop {
+            let old = self.in_lhs;
+            self.in_lhs = false;
+            c.expr.visit_with(self);
+            self.in_lhs = old;
+        }
     }
 }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -2459,9 +2459,8 @@ impl Visit for UsageCounter<'_> {
     }
 
     fn visit_prop_name(&mut self, p: &PropName) {
-        match p {
-            PropName::Computed(p) => p.visit_with(self),
-            _ => {}
+        if let PropName::Computed(p) = p {
+            p.visit_with(self)
         }
     }
 

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -10412,7 +10412,7 @@ fn issue_6641() {
 fn issue_6728() {
     run_default_exec_test(
         r###"
-        export async function foo() {
+        async function foo() {
             if (undefined_var_1) {
               let replace;
             
@@ -10425,6 +10425,7 @@ fn issue_6728() {
               await a({ replace })
             }
         }
+        console.log('PASS')
         "###,
     )
 }

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -10407,3 +10407,24 @@ fn issue_6641() {
         "###,
     )
 }
+
+#[test]
+fn issue_6728() {
+    run_default_exec_test(
+        r###"
+        export async function foo() {
+            if (undefined_var_1) {
+              let replace;
+            
+              if (undefined_var_2) {
+                replace = 1;
+              } else {
+                replace = 2;
+              }
+            
+              await a({ replace })
+            }
+        }
+        "###,
+    )
+}


### PR DESCRIPTION
**Description:**

We skip non-computed property names while checking if we can inline an expression.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6729.