### PR TITLE
fix(compress): fix usageCounter error

### DIFF
--- a/crates/swc_ecma_minifier/tests/fixture/issues/6729/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/6729/input.js
@@ -1,0 +1,13 @@
+export async function foo() {
+  if (undefined_var_1) {
+    let replace;
+
+    if (undefined_var_2) {
+      replace = 1;
+    } else {
+      replace = 2;
+    }
+
+    await a({ replace })
+  }
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/6729/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/6729/output.js
@@ -1,0 +1,5 @@
+export async function foo() {
+    undefined_var_1 && await a({
+        replace: undefined_var_2 ? 1 : 2
+    });
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fix #6729 

In

```javascript
( var bar, await a({ bar: foo ? 1 : 2 })  );
```

When merge sequence expr, there is a [loop](https://github.com/swc-project/swc/blob/main/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs#L911) and a usage [check](https://github.com/swc-project/swc/blob/9bdbe9dc9b5625acb5e85299e8a22729773bca8f/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs#L1966), it checks if `await a({ bar: foo ? 1 : 2 })` has usage of `bar`, if it is, re-iterate over this AST, otherwise break the loop.

But `UsageCounter` treats `bar` in object literal as used, so it never breaks the loop.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
#6729 