### PR TITLE
fix(swc_ecma_codegen): fix LineCol calculation of printed files

### DIFF
--- a/crates/swc/tests/source_map.rs
+++ b/crates/swc/tests/source_map.rs
@@ -16,6 +16,7 @@ use swc::{
     },
     Compiler,
 };
+use swc_ecma_parser::Syntax;
 use testing::{assert_eq, NormalizedOutput, StdErr, Tester};
 use walkdir::WalkDir;
 
@@ -425,4 +426,88 @@ fn issue_4578() {
         },
     )
     .unwrap();
+}
+
+#[test]
+fn issue_6694() {
+    Tester::new().print_errors(|cm, handler| {
+        let c = Compiler::new(cm.clone());
+        let fm = cm.new_source_file(
+            swc_common::FileName::Real("./app.js".into()),
+            r#"/**
+ * foo
+ * @param data foo
+ * @returns foo
+ */
+export const fixupRiskConfigData = (data: any): types.RiskConfigType => {
+  if (x) {
+    return 123;
+  } else {
+    return 456;
+  }
+};"#
+            .replace('\n', "\r\n"),
+        );
+        let result = c.process_js_file(
+            fm,
+            &handler,
+            &Options {
+                swcrc: false,
+                source_maps: Some(SourceMapsConfig::Bool(true)),
+                config: Config {
+                    jsc: JscConfig {
+                        target: Some(swc_ecma_ast::EsVersion::Es5),
+                        syntax: Some(Syntax::Typescript(Default::default())),
+                        ..Default::default()
+                    },
+                    is_module: IsModule::Bool(true),
+                    inline_sources_content: true.into(),
+                    emit_source_map_columns: true.into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+
+        fn line_col(needle: &str, haystack: &str) -> Option<(u32, u32)> {
+            let lines = haystack.lines().enumerate();
+            for (i, line) in lines {
+                if let Some(c) = line.find(needle) {
+                    return Some((i as _, c as _));
+                }
+            }
+
+            None
+        }
+
+        match result {
+            Ok(result) => {
+                assert!(result.map.is_some());
+                let map = result.map.unwrap();
+
+                let source_map = sourcemap::SourceMap::from_slice(map.as_bytes())
+                    .expect("failed to deserialize sourcemap");
+
+                // "export"
+                let export_line_col =
+                    line_col("export", &result.code).expect("failed to find `export`");
+                let token = source_map
+                    .lookup_token(export_line_col.0, export_line_col.1)
+                    .expect("failed to find token");
+                assert_eq!(token.get_src(), (5, 0));
+
+                // "if"
+                let if_line_col = line_col("if", &result.code).expect("failed to find `export`");
+                let token = source_map
+                    .lookup_token(if_line_col.0, export_line_col.1)
+                    .expect("failed to find token");
+                assert_eq!(token.get_src(), (6, 2));
+            }
+            Err(err) => {
+                panic!("Error: {:#?}", err);
+            }
+        }
+
+        Ok(())
+    });
 }

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -1220,7 +1220,10 @@ pub struct LineInfo {
 /// Used to create a `.map` file.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct LineCol {
+    /// Index of line, starting from 0.
     pub line: u32,
+
+    /// UTF-16 column in line, starting from 0.
     pub col: u32,
 }
 

--- a/crates/swc_common/src/syntax_pos/analyze_source_file.rs
+++ b/crates/swc_common/src/syntax_pos/analyze_source_file.rs
@@ -283,10 +283,28 @@ mod tests {
     );
 
     test!(
-        case: windows_crlf,
-        text: "012345678\r\nabcdef012345678\r\na",
+        case: unix_lf,
+        text: "/**\n * foo\n */\n012345678\nabcdef012345678\na",
         source_file_start_pos: 0,
-        lines: vec![0, 11, 28],
+        lines: vec![0, 4, 11, 15, 25, 41],
+        multi_byte_chars: vec![],
+        non_narrow_chars: vec![],
+    );
+
+    test!(
+        case: windows_cr,
+        text: "/**\r * foo\r */\r012345678\rabcdef012345678\ra",
+        source_file_start_pos: 0,
+        lines: vec![0, 4, 11, 15, 25, 41],
+        multi_byte_chars: vec![],
+        non_narrow_chars: vec![],
+    );
+
+    test!(
+        case: windows_crlf,
+        text: "/**\r\n * foo\r\n */\r\n012345678\r\nabcdef012345678\r\na",
+        source_file_start_pos: 0,
+        lines: vec![0, 5, 13, 18, 29, 46],
         multi_byte_chars: vec![],
         non_narrow_chars: vec![],
     );


### PR DESCRIPTION
**Description:**

There were several issues with the way we updated the current `LineCol` position during the printing of the generated file:

- We used `chars` and `char_indices` (UTF-32) instead of `encode_utf16` (UTF-16) chars.
  - JS uses UCS-2 (basically UTF-16) for its strings, and sourcemaps default to that implicitly.
- `\r` was incorrectly handled
  - it didn't add a `line_start`, only `\n` did
- `\r\n` was incorrectly handled
  - It was trying to let `\n` path handle the `line_start`, but it called `chars.next()` which ate the `\n` char.

I also took the opportunity to avoid the `Vec` allocations and reduced some code duplication.

See the [before](https://evanw.github.io/source-map-visualization/#ODEzAC8qKgogKiBmb28KICogQHBhcmFtIGRhdGEgZm9vCiAqIEByZXR1cm5zIGZvbwogKi8gZXhwb3J0IGNvbnN0IGZpeHVwUmlza0NvbmZpZ0RhdGEgPSAoZGF0YSk9PnsKICAgIGlmICh4KSB7CiAgICAgICAgcmV0dXJuIDEyMzsKICAgIH0gZWxzZSB7CiAgICAgICAgcmV0dXJuIDQ1NjsKICAgIH0KfTsKCi8vIyBzb3VyY2VNYXBwaW5nVVJMPWRhdGE6YXBwbGljYXRpb24vanNvbjtiYXNlNjQsZXlKMlpYSnphVzl1SWpvekxDSnpiM1Z5WTJWeklqcGJJbWx1Y0hWMExuUnpJbDBzSW5OdmRYSmpaWE5EYjI1MFpXNTBJanBiSWk4cUtseHlYRzRnS2lCbWIyOWNjbHh1SUNvZ1FIQmhjbUZ0SUdSaGRHRWdabTl2WEhKY2JpQXFJRUJ5WlhSMWNtNXpJR1p2YjF4eVhHNGdLaTljY2x4dVpYaHdiM0owSUdOdmJuTjBJR1pwZUhWd1VtbHphME52Ym1acFowUmhkR0VnUFNBb1pHRjBZVG9nWVc1NUtUb2dkSGx3WlhNdVVtbHphME52Ym1acFoxUjVjR1VnUFQ0Z2UxeHlYRzRnSUdsbUlDaDRLU0I3WEhKY2JpQWdJQ0J5WlhSMWNtNGdNVEl6TzF4eVhHNGdJSDBnWld4elpTQjdYSEpjYmlBZ0lDQnlaWFIxY200Z05EVTJPMXh5WEc0Z0lIMWNjbHh1ZlRzaVhTd2libUZ0WlhNaU9sc2labWw0ZFhCU2FYTnJRMjl1Wm1sblJHRjBZU0lzSW1SaGRHRWlMQ0o0SWwwc0ltMWhjSEJwYm1keklqb2lRVUZCUVN4dFJFRkpReXhIUVVORUxFOUJRVThzVFVGQlRVRXNjMEpCUVhOQ0xFTkJRVU5ETEU5QlFXOURPMGxCUTNSRkxFbEJRVWxETEVkQlFVYzdVVUZEVEN4UFFVRlBPMGxCUTFRc1QwRkJUenRSUVVOTUxFOUJRVTg3U1VGRFZDeERRVUZETzBGQlEwZ3NSVUZCUlNKOTQ0NAB7InZlcnNpb24iOjMsInNvdXJjZXMiOlsiaW5wdXQudHMiXSwic291cmNlc0NvbnRlbnQiOlsiLyoqXHJcbiAqIGZvb1xyXG4gKiBAcGFyYW0gZGF0YSBmb29cclxuICogQHJldHVybnMgZm9vXHJcbiAqL1xyXG5leHBvcnQgY29uc3QgZml4dXBSaXNrQ29uZmlnRGF0YSA9IChkYXRhOiBhbnkpOiB0eXBlcy5SaXNrQ29uZmlnVHlwZSA9PiB7XHJcbiAgaWYgKHgpIHtcclxuICAgIHJldHVybiAxMjM7XHJcbiAgfSBlbHNlIHtcclxuICAgIHJldHVybiA0NTY7XHJcbiAgfVxyXG59OyJdLCJuYW1lcyI6WyJmaXh1cFJpc2tDb25maWdEYXRhIiwiZGF0YSIsIngiXSwibWFwcGluZ3MiOiJBQUFBLG1EQUlDLEdBQ0QsT0FBTyxNQUFNQSxzQkFBc0IsQ0FBQ0MsT0FBb0M7SUFDdEUsSUFBSUMsR0FBRztRQUNMLE9BQU87SUFDVCxPQUFPO1FBQ0wsT0FBTztJQUNULENBQUM7QUFDSCxFQUFFIn0=) and [after](https://evanw.github.io/source-map-visualization/#ODIyAC8qKgogKiBmb28KICogQHBhcmFtIGRhdGEgZm9vCiAqIEByZXR1cm5zIGZvbwogKi8gZXhwb3J0IHZhciBmaXh1cFJpc2tDb25maWdEYXRhID0gZnVuY3Rpb24oZGF0YSkgewogICAgaWYgKHgpIHsKICAgICAgICByZXR1cm4gMTIzOwogICAgfSBlbHNlIHsKICAgICAgICByZXR1cm4gNDU2OwogICAgfQp9OwoKLy8jIHNvdXJjZU1hcHBpbmdVUkw9ZGF0YTphcHBsaWNhdGlvbi9qc29uO2Jhc2U2NCxleUoyWlhKemFXOXVJam96TENKemIzVnlZMlZ6SWpwYklpNHZZWEJ3TG1weklsMHNJbk52ZFhKalpYTkRiMjUwWlc1MElqcGJJaThxS2x4eVhHNGdLaUJtYjI5Y2NseHVJQ29nUUhCaGNtRnRJR1JoZEdFZ1ptOXZYSEpjYmlBcUlFQnlaWFIxY201eklHWnZiMXh5WEc0Z0tpOWNjbHh1Wlhod2IzSjBJR052Ym5OMElHWnBlSFZ3VW1semEwTnZibVpwWjBSaGRHRWdQU0FvWkdGMFlUb2dZVzU1S1RvZ2RIbHdaWE11VW1semEwTnZibVpwWjFSNWNHVWdQVDRnZTF4eVhHNGdJR2xtSUNoNEtTQjdYSEpjYmlBZ0lDQnlaWFIxY200Z01USXpPMXh5WEc0Z0lIMGdaV3h6WlNCN1hISmNiaUFnSUNCeVpYUjFjbTRnTkRVMk8xeHlYRzRnSUgxY2NseHVmVHNpWFN3aWJtRnRaWE1pT2xzaVptbDRkWEJTYVhOclEyOXVabWxuUkdGMFlTSXNJbVJoZEdFaUxDSjRJbDBzSW0xaGNIQnBibWR6SWpvaVFVRkJRVHM3T3p0RFFVbERMRWRCUTBRc1QwRkJUeXhKUVVGTlFTeHpRa0ZCYzBJc1UwRkJRME1zVFVGQmIwTTdTVUZEZEVVc1NVRkJTVU1zUjBGQlJ6dFJRVU5NTEU5QlFVODdTVUZEVkN4UFFVRlBPMUZCUTB3c1QwRkJUenRKUVVOVUxFTkJRVU03UVVGRFNDeEZRVUZGSW4wPTQ0NgB7InZlcnNpb24iOjMsInNvdXJjZXMiOlsiLi9hcHAuanMiXSwic291cmNlc0NvbnRlbnQiOlsiLyoqXHJcbiAqIGZvb1xyXG4gKiBAcGFyYW0gZGF0YSBmb29cclxuICogQHJldHVybnMgZm9vXHJcbiAqL1xyXG5leHBvcnQgY29uc3QgZml4dXBSaXNrQ29uZmlnRGF0YSA9IChkYXRhOiBhbnkpOiB0eXBlcy5SaXNrQ29uZmlnVHlwZSA9PiB7XHJcbiAgaWYgKHgpIHtcclxuICAgIHJldHVybiAxMjM7XHJcbiAgfSBlbHNlIHtcclxuICAgIHJldHVybiA0NTY7XHJcbiAgfVxyXG59OyJdLCJuYW1lcyI6WyJmaXh1cFJpc2tDb25maWdEYXRhIiwiZGF0YSIsIngiXSwibWFwcGluZ3MiOiJBQUFBOzs7O0NBSUMsR0FDRCxPQUFPLElBQU1BLHNCQUFzQixTQUFDQyxNQUFvQztJQUN0RSxJQUFJQyxHQUFHO1FBQ0wsT0FBTztJQUNULE9BQU87UUFDTCxPQUFPO0lBQ1QsQ0FBQztBQUNILEVBQUUifQ==)

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

Fixes https://github.com/swc-project/swc/issues/6694