### PR TITLE
refactor: unnecessary `GLOBALS.set` and `GLOBALS.with`

### DIFF
--- a/crates/swc_ecma_transforms_base/src/perf.rs
+++ b/crates/swc_ecma_transforms_base/src/perf.rs
@@ -1,6 +1,6 @@
+#[cfg(feature = "concurrent")]
 use rayon::prelude::{IntoParallelIterator, ParallelIterator};
 use swc_common::util::move_map::MoveMap;
-#[cfg(feature = "concurrent")]
 use swc_ecma_ast::*;
 pub use swc_ecma_utils::parallel::*;
 use swc_ecma_visit::{Fold, FoldWith, Visit, VisitMut, VisitMutWith, VisitWith};


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
1. `GLOBALS.with` will panic if inner is not set, the `GLOBALS.with` and reset with `GLOBALS.set` seems a little redundant. 
2. Also it would cause panic when you only use `dce` visitor with feature `concurrent_minifier` enable.
![image](https://user-images.githubusercontent.com/17974631/211997294-51bccab0-c56c-49cf-8696-5e73a576ac9c.png)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
