### PR TITLE
fix(es): Resolve plugin paths using config path as base

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -554,6 +554,7 @@ impl Options {
                 experimental.plugins,
                 transform_metadata_context,
                 Some(plugin_resolver),
+                cfg.config_filename,
                 comments,
                 source_map,
                 unresolved_mark,
@@ -587,6 +588,7 @@ impl Options {
             crate::plugin::plugins(
                 experimental.plugins,
                 transform_metadata_context,
+                None,
                 None,
                 comments,
                 source_map,
@@ -817,6 +819,23 @@ impl Rc {
 
         bail!(".swcrc exists but not matched")
     }
+
+    pub fn with_config_filename(self, config_filename: FileName) -> Self {
+        match self {
+            Rc::Single(mut c) => {
+                c.config_filename = Some(config_filename);
+                Rc::Single(c)
+            }
+            Rc::Multi(cs) => Rc::Multi(
+                cs.into_iter()
+                    .map(|mut c| {
+                        c.config_filename = Some(config_filename.clone());
+                        c
+                    })
+                    .collect(),
+            ),
+        }
+    }
 }
 
 /// A single object in the `.swcrc` file
@@ -862,6 +881,9 @@ pub struct Config {
 
     #[serde(rename = "$schema")]
     pub schema: Option<String>,
+
+    #[serde(skip)]
+    pub config_filename: Option<FileName>,
 }
 
 /// Second argument of `minify`.

--- a/crates/swc/src/config/tests.rs
+++ b/crates/swc/src/config/tests.rs
@@ -4,20 +4,21 @@ use crate::{parse_swcrc, Options};
 
 #[test]
 fn object() {
-    let rc = parse_swcrc(include_str!("object.json")).expect("failed to parse");
+    let rc = parse_swcrc(include_str!("object.json"), ".swcrc".into()).expect("failed to parse");
     dbg!(&rc);
 }
 
 #[test]
 fn array() {
-    let rc = parse_swcrc(include_str!("array.json")).expect("failed to parse");
+    let rc = parse_swcrc(include_str!("array.json"), ".swcrc".into()).expect("failed to parse");
 
     dbg!(&rc);
 }
 
 #[test]
 fn issue_4390() {
-    let rc = parse_swcrc(include_str!("issue-4390.json")).expect("failed to parse");
+    let rc =
+        parse_swcrc(include_str!("issue-4390.json"), ".swcrc".into()).expect("failed to parse");
     dbg!(&rc);
 }
 
@@ -31,6 +32,6 @@ fn issue_1532() {
 
 #[test]
 fn jsonc() {
-    let rc = parse_swcrc(include_str!("jsonc.json")).expect("failed to parse");
+    let rc = parse_swcrc(include_str!("jsonc.json"), ".swcrc".into()).expect("failed to parse");
     dbg!(&rc);
 }

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -32,6 +32,7 @@ pub fn plugins(
     configured_plugins: Option<Vec<PluginConfig>>,
     metadata_context: std::sync::Arc<swc_common::plugin::metadata::TransformPluginMetadataContext>,
     resolver: Option<CachingResolver<NodeModulesResolver>>,
+    resolve_base: Option<swc_common::FileName>,
     comments: Option<swc_common::comments::SingleThreadedComments>,
     source_map: std::sync::Arc<swc_common::SourceMap>,
     unresolved_mark: swc_common::Mark,
@@ -41,6 +42,7 @@ pub fn plugins(
             plugins: configured_plugins,
             metadata_context,
             resolver,
+            resolve_base,
             comments,
             source_map,
             unresolved_mark,
@@ -57,6 +59,7 @@ struct RustPlugins {
     plugins: Option<Vec<PluginConfig>>,
     metadata_context: std::sync::Arc<swc_common::plugin::metadata::TransformPluginMetadataContext>,
     resolver: Option<CachingResolver<NodeModulesResolver>>,
+    resolve_base: Option<swc_common::FileName>,
     comments: Option<swc_common::comments::SingleThreadedComments>,
     source_map: std::sync::Arc<swc_common::SourceMap>,
     unresolved_mark: swc_common::Mark,
@@ -115,7 +118,13 @@ impl RustPlugins {
                             .resolver
                             .as_ref()
                             .expect("filesystem_cache should provide resolver")
-                            .resolve(&FileName::Real(PathBuf::from(&p.0)), &p.0)?;
+                            .resolve(
+                                &self
+                                    .resolve_base
+                                    .as_ref()
+                                    .unwrap_or(&FileName::Real(PathBuf::from(&p.0))),
+                                &p.0,
+                            )?;
 
                         let path = if let FileName::Real(value) = resolved_path {
                             Arc::new(value)


### PR DESCRIPTION
**Description:**

This makes relative paths work for plugin references, they will be relative to the location of the config that imports the plugin.

Previously relative paths did not work, as the resolver attempted to resolve using the plugin path as the base and the target, resulting in mangled paths.


**Related issue (if exists):** https://github.com/aspect-build/rules_swc/pull/149
