### PR TITLE
feat(bindings/cli): Add --plugin and --cache-root

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -70,9 +70,9 @@ use swc_ecma_transforms_compat::es2015::regenerator;
 use swc_ecma_transforms_optimization::{inline_globals2, GlobalExprMap};
 use swc_ecma_visit::{Fold, VisitMutWith};
 
+pub use crate::plugin::PluginConfig;
 use crate::{
-    builder::PassBuilder, dropped_comments_preserver::dropped_comments_preserver,
-    plugin::PluginConfig, SwcImportResolver,
+    builder::PassBuilder, dropped_comments_preserver::dropped_comments_preserver, SwcImportResolver,
 };
 
 #[cfg(test)]

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -25,7 +25,7 @@ use swc_ecma_visit::{noop_fold_type, Fold};
 /// plugin's entrypoint function.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
-pub struct PluginConfig(String, serde_json::Value);
+pub struct PluginConfig(pub String, pub serde_json::Value);
 
 #[cfg(any(feature = "plugin", feature = "plugin-bytecheck"))]
 pub fn plugins(


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

- Add `--plugin` CLI option that takes a `plugin/path={"config":"object"}` formatted argument and adds the plugin to the `jsc.experimental.plugins` list (can be used multiple times). If the plugin path is explicitly relative (starts with `./` or `../`), then it is converted to an absolute path using the current working directory as the base.
- Add a `--cache-root` CLI option that sets `jsc.experimental.cacheRoot`

This is an alternative to https://github.com/swc-project/swc/pull/6800 that works better for `rules_swc` and is more straightforward.

**Related issue (if exists):** https://github.com/aspect-build/rules_swc/pull/149
