### PR TITLE
fix(es/plugin): Fix starter template main field (#6814)

### DIFF
--- a/bindings/swc_cli/src/commands/plugin.rs
+++ b/bindings/swc_cli/src/commands/plugin.rs
@@ -202,7 +202,7 @@ build-wasm32 = "build --target wasm32-unknown-unknown"
         .context("failed to write config toml file")?;
 
         // Create package.json for npm package publishing.
-        let dist_output_path = format!("target/{}/release/{}.wasm", build_target, name);
+        let dist_output_path = format!("target/{}/release/{}.wasm", build_target, name.replace("-", "_"));
         fs::write(
             &path.join("package.json"),
             format!(


### PR DESCRIPTION
**Description:**
Replace `-` with `_` in generated package.json `main` field to match what cargo names the output `.wasm` file. Allows swc-core to load the plugin at runtime.


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6814.