### PR TITLE
perf(es/minifier): check whether a function is pure with O(1) cost

### DIFF
--- a/crates/swc_ecma_minifier/src/metadata/mod.rs
+++ b/crates/swc_ecma_minifier/src/metadata/mod.rs
@@ -17,7 +17,7 @@ struct EqIgnoreSpanExprRef<'a>(&'a Expr);
 
 impl<'a> PartialEq for EqIgnoreSpanExprRef<'a> {
     fn eq(&self, other: &Self) -> bool {
-        Ident::within_ignored_ctxt(|| self.0.eq_ignore_span(&other.0))
+        Ident::within_ignored_ctxt(|| self.0.eq_ignore_span(other.0))
     }
 }
 

--- a/crates/swc_ecma_minifier/src/metadata/mod.rs
+++ b/crates/swc_ecma_minifier/src/metadata/mod.rs
@@ -169,12 +169,6 @@ impl VisitMut for InfoMarker<'_> {
             n.span = n.span.apply_mark(self.marks.pure);
         } else if let Some(pure_fns) = &self.pure_funcs {
             if let Callee::Expr(e) = &n.callee {
-                println!("--pure_fns: {pure_fns:#?}");
-                println!("e: {e:#?}");
-                println!(
-                    "pure_fns.contains(&EqIgnoreSpanExprRef(e)): {:?}",
-                    pure_fns.contains(&HashEqIgnoreSpanExprRef(e))
-                );
                 // Check for pure_funcs
                 if pure_fns.contains(&HashEqIgnoreSpanExprRef(e)) {
                     n.span = n.span.apply_mark(self.marks.pure);

--- a/crates/swc_ecma_minifier/src/metadata/mod.rs
+++ b/crates/swc_ecma_minifier/src/metadata/mod.rs
@@ -31,7 +31,7 @@ pub(crate) fn info_marker<'a>(
     marks: Marks,
     // unresolved_mark: Mark,
 ) -> impl 'a + VisitMut {
-    let pure_fns = options.map(|options| {
+    let pure_funcs = options.map(|options| {
         options
             .pure_funcs
             .iter()
@@ -42,7 +42,7 @@ pub(crate) fn info_marker<'a>(
         options,
         comments,
         marks,
-        pure_fns,
+        pure_funcs,
         // unresolved_mark,
         state: Default::default(),
     }
@@ -55,8 +55,9 @@ struct State {
 }
 
 struct InfoMarker<'a> {
+    #[allow(dead_code)]
     options: Option<&'a CompressOptions>,
-    pure_fns: Option<FxHashSet<EqIgnoreSpanExprRef<'a>>>,
+    pure_funcs: Option<FxHashSet<EqIgnoreSpanExprRef<'a>>>,
     comments: Option<&'a dyn Comments>,
     marks: Marks,
     // unresolved_mark: Mark,
@@ -142,7 +143,7 @@ impl VisitMut for InfoMarker<'_> {
 
         if self.has_pure(n.span) {
             n.span = n.span.apply_mark(self.marks.pure);
-        } else if let Some(pure_fns) = &self.pure_fns {
+        } else if let Some(pure_fns) = &self.pure_funcs {
             if let Callee::Expr(e) = &n.callee {
                 // Check for pure_funcs
                 if pure_fns.contains(&EqIgnoreSpanExprRef(e)) {

--- a/crates/swc_ecma_minifier/src/metadata/tests.rs
+++ b/crates/swc_ecma_minifier/src/metadata/tests.rs
@@ -159,8 +159,6 @@
 //     assert_standalone("export default function f(module, exports) {}", 0);
 // }
 
-use std::hash::Hash;
-
 use rustc_hash::FxHashSet;
 use swc_common::{Mark, DUMMY_SP};
 use swc_ecma_utils::{member_expr, quote_expr};
@@ -171,7 +169,7 @@ use super::HashEqIgnoreSpanExprRef;
 fn test_hash_eq_ignore_span_expr_ref() {
     use swc_ecma_ast::*;
 
-    fn expr_ref<'a>(expr_ref: &'a Expr) -> HashEqIgnoreSpanExprRef<'a> {
+    fn expr_ref(expr_ref: &Expr) -> HashEqIgnoreSpanExprRef {
         HashEqIgnoreSpanExprRef(expr_ref)
     }
 
@@ -188,6 +186,7 @@ fn test_hash_eq_ignore_span_expr_ref() {
         let meaningful_null_expr = quote_expr!(meaningful_sp, null);
         let dummy_null_expr = quote_expr!(dummy_sp, null);
 
+        // Should equal ignoring span and syntax context
         assert_eq!(
             expr_ref(&meaningful_ident_expr),
             expr_ref(&dummy_ident_expr)
@@ -199,6 +198,7 @@ fn test_hash_eq_ignore_span_expr_ref() {
             expr_ref(&meaningful_null_expr),
         ]);
 
+        // Should produce the same hash value ignoring span and syntax context
         assert!(set.contains(&expr_ref(&dummy_ident_expr)));
         assert!(set.contains(&expr_ref(&dummy_member_expr)));
         assert!(set.contains(&expr_ref(&dummy_null_expr)));
@@ -207,6 +207,12 @@ fn test_hash_eq_ignore_span_expr_ref() {
         set.insert(expr_ref(&dummy_member_expr));
         set.insert(expr_ref(&dummy_null_expr));
         assert_eq!(set.len(), 3);
+
+        // Should not equal ignoring span and syntax context
+        let dummy_ident_expr = Expr::Ident(Ident::new("baz".into(), dummy_sp));
+        let dummy_member_expr = member_expr!(dummy_sp, baz.bar);
+        assert!(!set.contains(&expr_ref(&dummy_ident_expr)));
+        assert!(!set.contains(&expr_ref(&dummy_member_expr)));
 
         Ok(())
     })


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->


**Description:**

We might need to pass a giant pure function list to the SWC minifier as esbuild did [here](https://github.com/evanw/esbuild/blob/5fe21253ee75fb4c5ea395a0877b2a5ab51c3575/internal/config/globals.go).

The current implementation could slow the minifier.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
