### PR TITLE
perf: Using better `string cache`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,10 +31,6 @@
         "debug"
     ],
     "rust-analyzer.cargo.features": [
-    "cSpell.allowCompoundWords": true,
-    "cSpell.caseSensitive": true,
-    // "rust-analyzer.checkOnSave.command": "clippy",
-    "rust-analyzer.checkOnSave.features": [
         // We use this to make IDE faster
         "rust-analyzer",
         "rkyv-impl",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -31,6 +31,10 @@
         "debug"
     ],
     "rust-analyzer.cargo.features": [
+    "cSpell.allowCompoundWords": true,
+    "cSpell.caseSensitive": true,
+    // "rust-analyzer.checkOnSave.command": "clippy",
+    "rust-analyzer.checkOnSave.features": [
         // We use this to make IDE faster
         "rust-analyzer",
         "rkyv-impl",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,7 +241,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_json",
- "string_cache",
+ "string_cache 0.8.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "string_cache_codegen",
  "thiserror",
  "wasm-bindgen",
@@ -3027,6 +3027,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "string_cache"
+version = "0.8.4"
+source = "git+https://github.com/swc-project/string-cache?branch=swc#db382616e9a1bf71bff2004853c3ab88f85a2235"
+dependencies = [
+ "new_debug_unreachable",
+ "once_cell",
+ "phf_shared",
+ "precomputed-hash",
+ "serde",
+]
+
+[[package]]
 name = "string_cache_codegen"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3157,7 +3169,7 @@ dependencies = [
  "rkyv-test",
  "rustc-hash",
  "serde",
- "string_cache",
+ "string_cache 0.8.4 (git+https://github.com/swc-project/string-cache?branch=swc)",
  "string_cache_codegen",
  "triomphe",
 ]
@@ -3245,7 +3257,7 @@ dependencies = [
  "serde_json",
  "siphasher",
  "sourcemap",
- "string_cache",
+ "string_cache 0.8.4 (git+https://github.com/swc-project/string-cache?branch=swc)",
  "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",

--- a/crates/swc_atoms/Cargo.toml
+++ b/crates/swc_atoms/Cargo.toml
@@ -28,7 +28,7 @@ rkyv      = { package = "rkyv", version = "=0.7.37", optional = true }
 rkyv-latest  = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true }
 rustc-hash   = "1.1.0"
 serde        = "1"
-string_cache = "0.8.4"
+string_cache = { git = "https://github.com/swc-project/string-cache", branch = "swc" }
 triomphe     = "0.1.8"
 
 [build-dependencies]

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -71,7 +71,7 @@ rustc-hash           = "1.1.0"
 serde                = { version = "1.0.119", features = ["derive"] }
 siphasher            = "0.3.9"
 sourcemap            = { version = "6", optional = true }
-string_cache         = "0.8.4"
+string_cache         = { git = "https://github.com/swc-project/string-cache", branch = "swc" }
 swc_atoms            = { version = "0.4.32", path = "../swc_atoms" }
 swc_eq_ignore_macros = { version = "0.1.1", path = "../swc_eq_ignore_macros" }
 swc_visit            = { version = "0.5.4", path = "../swc_visit" }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
Using better string-cache
The latest `Mutex` implementation is faster than `parking_lot`, especially when locking contention is heavy, 
https://github.com/rust-lang/rust/pull/95035#issuecomment-1073966631, 
This could have a huge performance improvement when using swc in some parallel scenarios, like bundler.



**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
