### PR TITLE
fix(swc/core): Stop doing require unnecessary packages (`@swc/core-darwin-universal`).

### DIFF
--- a/node-swc/src/binding.js
+++ b/node-swc/src/binding.js
@@ -102,15 +102,6 @@ switch (platform) {
     }
     break
   case 'darwin':
-    localFileExisted = existsSync(join(__dirname, 'swc.darwin-universal.node'))
-    try {
-      if (localFileExisted) {
-        nativeBinding = require('./swc.darwin-universal.node')
-      } else {
-        nativeBinding = require('@swc/core-darwin-universal')
-      }
-      break
-    } catch {}
     switch (arch) {
       case 'x64':
         localFileExisted = existsSync(join(__dirname, 'swc.darwin-x64.node'))


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
### Removed the part that requires a package that does not exist.
(Previously, this was enclosed in a try-catch and did not manifest itself as a clear error, but was problematic in the situation described in the issue below.)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

<br>

**BREAKING CHANGE:**

If `process.platform === 'darwin' && (process.arch !== 'x64' && process.arch !== 'arm64')`,
then Error "Unsupported architecture on macOS: (process.arch)" will be thrown.

Previously, **however**, the Error "Failed to load native binding" would have been thrown because `@swc/core-darwin-arm64` does not exist. In this point of view, Probably I can argue that this changes make error easy-to-understand.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

<br>

**Related issue (if exists):**
- ref #6901 