### PR TITLE
fix(es/typescript): Ignore jsx element names

### DIFF
--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -2067,6 +2067,19 @@ where
         }
     }
 
+    fn visit_mut_jsx_element_name(&mut self, n: &mut JSXElementName) {
+        match n {
+            JSXElementName::Ident(i) => {
+                if i.sym.starts_with(|c: char| c.is_ascii_uppercase()) {
+                    n.visit_mut_children_with(self);
+                }
+            }
+            _ => {
+                n.visit_mut_children_with(self);
+            }
+        }
+    }
+
     fn visit_mut_module(&mut self, module: &mut Module) {
         let was_module = module
             .body

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/next-45561/1/input.tsx
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/next-45561/1/input.tsx
@@ -1,0 +1,18 @@
+import path, { dirname } from "node:path";
+
+export default function IndexPage(props: { abc: string }) {
+    return (
+        <div>
+            abc: {props.abc}
+            <svg viewBox="0 -85 600 600"></svg>
+        </div>
+    );
+}
+
+export function getServerSideProps() {
+    return {
+        props: {
+            abc: dirname("/abc/def"),
+        },
+    };
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/next-45561/1/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/next-45561/1/output.js
@@ -1,0 +1,17 @@
+import { dirname } from "node:path";
+export default function IndexPage(props) {
+    return <div>
+
+            abc: {props.abc}
+
+            <svg viewBox="0 -85 600 600"></svg>
+
+        </div>;
+}
+export function getServerSideProps() {
+    return {
+        props: {
+            abc: dirname("/abc/def")
+        }
+    };
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/next-45561/2/input.tsx
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/next-45561/2/input.tsx
@@ -1,4 +1,4 @@
-import path from "node:path";
+import path, { dirname } from "node:path";
 
 export default function IndexPage(props: { abc: string }) {
     return (
@@ -13,4 +13,12 @@ export default function IndexPage(props: { abc: string }) {
             </svg>
         </div>
     );
+}
+
+export function getServerSideProps() {
+    return {
+        props: {
+            abc: dirname("/abc/def"),
+        },
+    };
 }

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/next-45561/2/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/next-45561/2/output.js
@@ -1,0 +1,21 @@
+import { dirname } from "node:path";
+export default function IndexPage(props) {
+    return <div>
+
+            abc: {props.abc}
+
+            <svg viewBox="0 -85 600 600">
+
+                <path fillRule="evenodd" d="M513 256.5C513 398.161 398.161 513 256.5 513C114.839 513 0 398.161 0 256.5C0 114.839 114.839 0 256.5 0C398.161 0 513 114.839 513 256.5ZM211.146 305.243L369.885 145L412 185.878L253.26 346.122L211.146 387L101 275.811L143.115 234.932L211.146 305.243Z" fill="#fff"/>
+
+            </svg>
+
+        </div>;
+}
+export function getServerSideProps() {
+    return {
+        props: {
+            abc: dirname("/abc/def")
+        }
+    };
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/next-45561/input.tsx
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/next-45561/input.tsx
@@ -1,0 +1,16 @@
+import path from "node:path";
+
+export default function IndexPage(props: { abc: string }) {
+    return (
+        <div>
+            abc: {props.abc}
+            <svg viewBox="0 -85 600 600">
+                <path
+                    fillRule="evenodd"
+                    d="M513 256.5C513 398.161 398.161 513 256.5 513C114.839 513 0 398.161 0 256.5C0 114.839 114.839 0 256.5 0C398.161 0 513 114.839 513 256.5ZM211.146 305.243L369.885 145L412 185.878L253.26 346.122L211.146 387L101 275.811L143.115 234.932L211.146 305.243Z"
+                    fill="#fff"
+                />
+            </svg>
+        </div>
+    );
+}


### PR DESCRIPTION
**Description:**


**Related issue:**

 - https://github.com/vercel/next.js/issues/45561.