### PR TITLE
chore(cli): Enable `preferUnplugged` by default for the plugins

### DIFF
--- a/bindings/swc_cli/src/commands/plugin.rs
+++ b/bindings/swc_cli/src/commands/plugin.rs
@@ -217,7 +217,8 @@ build-wasm32 = "build --target wasm32-unknown-unknown"
     "scripts": {{
         "prepublishOnly": "cargo {} --release"
     }},
-    "files": []
+    "files": [],
+    "preferUnplugged": true
 }}
 "#,
                 name, dist_output_path, build_alias


### PR DESCRIPTION
**Description:**

SWC plugin interface is not allowed when binary in .zip archive. (pnp environment)
Therefore, in order to easily support the yarn pnp environment, it is set to be installed as unplug by default.


**Related issue (if exists):**

- https://github.com/blitz-js/next-superjson-plugin/pull/61