### PR TITLE
fix(es/minifier): Don't skip shorthand properties from sequential inliner

### DIFF
--- a/crates/swc/tests/tsc-references/objectLiteralShorthandPropertiesES6.2.minified.js
+++ b/crates/swc/tests/tsc-references/objectLiteralShorthandPropertiesES6.2.minified.js
@@ -1,8 +1,8 @@
 //// [objectLiteralShorthandPropertiesES6.ts]
-var b, c, x3 = {
+var x3 = {
     a: 0,
-    b,
-    c,
+    b: void 0,
+    c: void 0,
     d () {},
     x3,
     parent: x3

--- a/crates/swc_ecma_minifier/tests/TODO.txt
+++ b/crates/swc_ecma_minifier/tests/TODO.txt
@@ -70,7 +70,6 @@ collapse_vars/switch_case_1/input.js
 collapse_vars/toplevel_single_reference/input.js
 collapse_vars/undeclared/input.js
 collapse_vars/unused_orig/input.js
-conditionals/equality_conditionals_false/input.js
 conditionals/ifs_5/input.js
 conditionals/ifs_6/input.js
 conditionals/ifs_same_consequent/input.js

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -10898,3 +10898,36 @@ fn issue_6914_2() {
         false,
     );
 }
+
+#[test]
+fn issue_6914_3() {
+    run_exec_test(
+        r###"
+            console.log(function() {
+                return function() {
+                    let def = function() {
+                        return {
+                            id: 'fakeId',
+                            ui: 'something'
+                        };
+                    }();
+                    return {
+                        def,
+                        ui: function(def) {
+                            let uis = [];
+                            uis.push(def.ui);
+                            return uis;
+                        }(def)
+                    };
+                }();
+            }());
+        "###,
+        r###"
+        {
+            "inline": true,
+            "toplevel": true
+        }
+        "###,
+        false,
+    );
+}

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -10856,3 +10856,45 @@ fn issue_6914_1() {
     "###,
     );
 }
+
+#[test]
+fn issue_6914_2() {
+    run_exec_test(
+        r###"
+        console.log(doSomething())
+
+        function doSomething() {
+            return fabricateEvent()
+        }
+
+        function fabricateEvent() {
+            let def = createEventDef()
+
+            return {
+                def,
+                ui: compileEventUi(def),
+            }
+        }
+
+        function compileEventUi(def) {
+            let uis = []
+            uis.push(def.ui)
+            return uis
+        }
+
+        function createEventDef() {
+            return {
+                id: 'fakeId',
+                ui: 'something'
+            }
+        }
+        "###,
+        r###"
+        {
+            "inline": true,
+            "toplevel": true
+        }
+        "###,
+        false,
+    );
+}

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -10821,3 +10821,38 @@ fn issue_6903_3() {
         false,
     );
 }
+
+#[test]
+fn issue_6914() {
+    run_default_exec_test(
+        r###"
+        console.log(doSomething())
+
+        function doSomething() {
+        return fabricateEvent()
+        }
+
+        function fabricateEvent() {
+        let def = createEventDef()
+
+        return {
+            def,
+            ui: compileEventUi(def),
+        }
+        }
+
+        function compileEventUi(def) {
+        let uis = []
+        uis.push(def.ui)
+        return uis
+        }
+
+        function createEventDef() {
+        return {
+            id: 'fakeId',
+            ui: 'something'
+        }
+        }
+    ""###,
+    );
+}

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -10823,36 +10823,36 @@ fn issue_6903_3() {
 }
 
 #[test]
-fn issue_6914() {
+fn issue_6914_1() {
     run_default_exec_test(
         r###"
         console.log(doSomething())
 
         function doSomething() {
-        return fabricateEvent()
+            return fabricateEvent()
         }
 
         function fabricateEvent() {
-        let def = createEventDef()
+            let def = createEventDef()
 
-        return {
-            def,
-            ui: compileEventUi(def),
-        }
+            return {
+                def,
+                ui: compileEventUi(def),
+            }
         }
 
         function compileEventUi(def) {
-        let uis = []
-        uis.push(def.ui)
-        return uis
+            let uis = []
+            uis.push(def.ui)
+            return uis
         }
 
         function createEventDef() {
-        return {
-            id: 'fakeId',
-            ui: 'something'
+            return {
+                id: 'fakeId',
+                ui: 'something'
+            }
         }
-        }
-    ""###,
+    "###,
     );
 }

--- a/crates/swc_ecma_minifier/tests/passing.txt
+++ b/crates/swc_ecma_minifier/tests/passing.txt
@@ -288,6 +288,7 @@ conditionals/cond_9/input.js
 conditionals/condition_symbol_matches_consequent/input.js
 conditionals/delete_conditional_1/input.js
 conditionals/delete_conditional_2/input.js
+conditionals/equality_conditionals_false/input.js
 conditionals/equality_conditionals_true/input.js
 conditionals/ifs_1/input.js
 conditionals/ifs_2/input.js


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6914.