### PR TITLE
Use rkyv in strict mode

### DIFF
--- a/crates/swc_atoms/Cargo.toml
+++ b/crates/swc_atoms/Cargo.toml
@@ -22,10 +22,10 @@ rkyv-bytecheck-impl = ["__rkyv", "rkyv-latest"]
 [dependencies]
 bytecheck = { version = "0.6.9", optional = true }
 once_cell = "1"
-rkyv      = { package = "rkyv", version = "=0.7.37", optional = true }
+rkyv      = { package = "rkyv", version = "=0.7.37", optional = true, features = ["strict"] }
 # This is to avoid cargo version selection conflict between rkyv=0.7.37 and other versions, as it is strictly pinned
 # cannot be merged.
-rkyv-latest  = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true }
+rkyv-latest  = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true, features = ["strict"] }
 rustc-hash   = "1.1.0"
 serde        = "1"
 string_cache = "0.8.4"

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -63,10 +63,10 @@ new_debug_unreachable = "1.0.4"
 num-bigint            = "0.4"
 once_cell             = "1.10.0"
 parking_lot           = { version = "0.12.0", optional = true }
-rkyv                  = { version = "=0.7.37", optional = true }
+rkyv                  = { version = "=0.7.37", optional = true, features = ["strict"] }
 # This is to avoid cargo version selection conflict between rkyv=0.7.37 and other versions, as it is strictly pinned
 # cannot be merged.
-rkyv-latest          = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true }
+rkyv-latest          = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true, features = ["strict"] }
 rustc-hash           = "1.1.0"
 serde                = { version = "1.0.119", features = ["derive"] }
 siphasher            = "0.3.9"

--- a/crates/swc_common/src/errors/diagnostic.rs
+++ b/crates/swc_common/src/errors/diagnostic.rs
@@ -16,6 +16,17 @@ use rkyv_latest as rkyv;
 use super::{snippet::Style, Applicability, CodeSuggestion, Level, Substitution, SubstitutionPart};
 use crate::syntax_pos::{MultiSpan, Span};
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "diagnostic-serde",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(
+    any(feature = "rkyv-impl", feature = "rkyv-bytecheck-impl"),
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+pub struct Message(pub String, pub Style);
+
 #[must_use]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(
@@ -28,7 +39,7 @@ use crate::syntax_pos::{MultiSpan, Span};
 )]
 pub struct Diagnostic {
     pub level: Level,
-    pub message: Vec<(String, Style)>,
+    pub message: Vec<Message>,
     pub code: Option<DiagnosticId>,
     pub span: MultiSpan,
     pub children: Vec<SubDiagnostic>,
@@ -61,7 +72,7 @@ pub enum DiagnosticId {
 )]
 pub struct SubDiagnostic {
     pub level: Level,
-    pub message: Vec<(String, Style)>,
+    pub message: Vec<Message>,
     pub span: MultiSpan,
     pub render_span: Option<MultiSpan>,
 }
@@ -117,7 +128,7 @@ impl Diagnostic {
     pub fn new_with_code(level: Level, code: Option<DiagnosticId>, message: &str) -> Self {
         Diagnostic {
             level,
-            message: vec![(message.to_owned(), Style::NoStyle)],
+            message: vec![Message(message.to_owned(), Style::NoStyle)],
             code,
             span: MultiSpan::new(),
             children: vec![],
@@ -184,18 +195,18 @@ impl Diagnostic {
         expected_extra: &dyn fmt::Display,
         found_extra: &dyn fmt::Display,
     ) -> &mut Self {
-        let mut msg: Vec<_> = vec![(format!("expected {} `", label), Style::NoStyle)];
+        let mut msg: Vec<_> = vec![Message(format!("expected {} `", label), Style::NoStyle)];
         msg.extend(expected.0.iter().map(|x| match *x {
-            StringPart::Normal(ref s) => (s.to_owned(), Style::NoStyle),
-            StringPart::Highlighted(ref s) => (s.to_owned(), Style::Highlight),
+            StringPart::Normal(ref s) => Message(s.to_owned(), Style::NoStyle),
+            StringPart::Highlighted(ref s) => Message(s.to_owned(), Style::Highlight),
         }));
-        msg.push((format!("`{}\n", expected_extra), Style::NoStyle));
-        msg.push((format!("   found {} `", label), Style::NoStyle));
+        msg.push(Message(format!("`{}\n", expected_extra), Style::NoStyle));
+        msg.push(Message(format!("   found {} `", label), Style::NoStyle));
         msg.extend(found.0.iter().map(|x| match *x {
-            StringPart::Normal(ref s) => (s.to_owned(), Style::NoStyle),
-            StringPart::Highlighted(ref s) => (s.to_owned(), Style::Highlight),
+            StringPart::Normal(ref s) => Message(s.to_owned(), Style::NoStyle),
+            StringPart::Highlighted(ref s) => Message(s.to_owned(), Style::Highlight),
         }));
-        msg.push((format!("`{}", found_extra), Style::NoStyle));
+        msg.push(Message(format!("`{}", found_extra), Style::NoStyle));
 
         // For now, just attach these as notes
         self.highlighted_note(msg);
@@ -204,9 +215,9 @@ impl Diagnostic {
 
     pub fn note_trait_signature(&mut self, name: String, signature: String) -> &mut Self {
         self.highlighted_note(vec![
-            (format!("`{}` from trait: `", name), Style::NoStyle),
-            (signature, Style::Highlight),
-            ("`".to_string(), Style::NoStyle),
+            Message(format!("`{}` from trait: `", name), Style::NoStyle),
+            Message(signature, Style::Highlight),
+            Message("`".to_string(), Style::NoStyle),
         ]);
         self
     }
@@ -216,7 +227,7 @@ impl Diagnostic {
         self
     }
 
-    pub fn highlighted_note(&mut self, msg: Vec<(String, Style)>) -> &mut Self {
+    pub fn highlighted_note(&mut self, msg: Vec<Message>) -> &mut Self {
         self.sub_with_highlights(Level::Note, msg, MultiSpan::new(), None);
         self
     }
@@ -431,7 +442,7 @@ impl Diagnostic {
             .collect::<String>()
     }
 
-    pub fn styled_message(&self) -> &Vec<(String, Style)> {
+    pub fn styled_message(&self) -> &Vec<Message> {
         &self.message
     }
 
@@ -454,7 +465,7 @@ impl Diagnostic {
     ) {
         let sub = SubDiagnostic {
             level,
-            message: vec![(message.to_owned(), Style::NoStyle)],
+            message: vec![Message(message.to_owned(), Style::NoStyle)],
             span,
             render_span,
         };
@@ -466,7 +477,7 @@ impl Diagnostic {
     fn sub_with_highlights(
         &mut self,
         level: Level,
-        message: Vec<(String, Style)>,
+        message: Vec<Message>,
         span: MultiSpan,
         render_span: Option<MultiSpan>,
     ) {
@@ -488,7 +499,7 @@ impl SubDiagnostic {
             .collect::<String>()
     }
 
-    pub fn styled_message(&self) -> &Vec<(String, Style)> {
+    pub fn styled_message(&self) -> &Vec<Message> {
         &self.message
     }
 }

--- a/crates/swc_common/src/errors/emitter.rs
+++ b/crates/swc_common/src/errors/emitter.rs
@@ -23,6 +23,7 @@ use unicode_width;
 
 use self::Destination::*;
 use super::{
+    diagnostic::Message,
     snippet::{Annotation, AnnotationType, Line, MultilineAnnotation, Style, StyledString},
     styled_buffer::StyledBuffer,
     CodeSuggestion, DiagnosticBuilder, DiagnosticId, Level, SourceMapperDyn, SubDiagnostic,
@@ -842,7 +843,7 @@ impl EmitterWriter {
         if spans_updated {
             children.push(SubDiagnostic {
                 level: Level::Note,
-                message: vec![(
+                message: vec![Message(
                     "this error originates in a macro outside of the current crate (in Nightly \
                      builds, run with -Z external-macro-backtrace for more info)"
                         .to_string(),
@@ -859,7 +860,7 @@ impl EmitterWriter {
     fn msg_to_buffer(
         &self,
         buffer: &mut StyledBuffer,
-        msg: &[(String, Style)],
+        msg: &[Message],
         padding: usize,
         label: &str,
         override_style: Option<Style>,
@@ -912,7 +913,7 @@ impl EmitterWriter {
         //                see how it *looks* with
         //                very *weird* formats
         //                see?
-        for &(ref text, ref style) in msg.iter() {
+        for &Message(ref text, ref style) in msg.iter() {
             let lines = text.split('\n').collect::<Vec<_>>();
             if lines.len() > 1 {
                 for (i, line) in lines.iter().enumerate() {
@@ -932,7 +933,7 @@ impl EmitterWriter {
     fn emit_message_default(
         &mut self,
         msp: &MultiSpan,
-        msg: &[(String, Style)],
+        msg: &[Message],
         code: &Option<DiagnosticId>,
         level: Level,
         max_line_num_len: usize,
@@ -975,7 +976,7 @@ impl EmitterWriter {
             if !level_str.is_empty() {
                 buffer.append(0, ": ", header_style);
             }
-            for &(ref text, _) in msg.iter() {
+            for &Message(ref text, _) in msg.iter() {
                 buffer.append(0, text, header_style);
             }
         }
@@ -1212,7 +1213,7 @@ impl EmitterWriter {
             }
             self.msg_to_buffer(
                 &mut buffer,
-                &[(suggestion.msg.to_owned(), Style::NoStyle)],
+                &[Message(suggestion.msg.to_owned(), Style::NoStyle)],
                 max_line_num_len,
                 "suggestion",
                 Some(Style::HeaderMsg),
@@ -1332,7 +1333,7 @@ impl EmitterWriter {
     fn emit_messages_default(
         &mut self,
         level: Level,
-        message: &[(String, Style)],
+        message: &[Message],
         code: &Option<DiagnosticId>,
         span: &MultiSpan,
         children: &[SubDiagnostic],

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -478,8 +478,8 @@ impl SourceMap {
 
         if lo.file.start_pos != hi.file.start_pos {
             return Err(Box::new(SpanLinesError::DistinctSources(DistinctSources {
-                begin: (lo.file.name.clone(), lo.file.start_pos),
-                end: (hi.file.name.clone(), hi.file.start_pos),
+                begin: FilePos(lo.file.name.clone(), lo.file.start_pos),
+                end: FilePos(hi.file.name.clone(), hi.file.start_pos),
             })));
         }
         assert!(hi.line >= lo.line);
@@ -555,8 +555,8 @@ impl SourceMap {
         if local_begin.sf.start_pos != local_end.sf.start_pos {
             Err(Box::new(SpanSnippetError::DistinctSources(
                 DistinctSources {
-                    begin: (local_begin.sf.name.clone(), local_begin.sf.start_pos),
-                    end: (local_end.sf.name.clone(), local_end.sf.start_pos),
+                    begin: FilePos(local_begin.sf.name.clone(), local_begin.sf.start_pos),
+                    end: FilePos(local_end.sf.name.clone(), local_end.sf.start_pos),
                 },
             )))
         } else {

--- a/crates/swc_css_ast/Cargo.toml
+++ b/crates/swc_css_ast/Cargo.toml
@@ -21,7 +21,7 @@ rkyv-impl           = ["__rkyv", "rkyv", "swc_atoms/rkyv-impl", "swc_common/rkyv
 [dependencies]
 bytecheck   = { version = "0.6.9", optional = true }
 is-macro    = "0.2.0"
-rkyv        = { version = "=0.7.37", optional = true }
+rkyv        = { version = "=0.7.37", optional = true, features = ["strict"] }
 serde       = { version = "1.0.127", features = ["derive"] }
 string_enum = { version = "0.3.2", path = "../string_enum/" }
 swc_atoms   = { version = "0.4.32", path = "../swc_atoms" }

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -35,10 +35,10 @@ bitflags   = "1"
 bytecheck  = { version = "0.6.9", optional = true }
 is-macro   = "0.2.1"
 num-bigint = { version = "0.4", features = ["serde"] }
-rkyv       = { package = "rkyv", version = "=0.7.37", optional = true }
+rkyv       = { package = "rkyv", version = "=0.7.37", optional = true, features = ["strict"] }
 # This is to avoid cargo version selection conflict between rkyv=0.7.37 and other versions, as it is strictly pinned
 # cannot be merged.
-rkyv-latest = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true }
+rkyv-latest = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true, features = ["strict"] }
 scoped-tls  = "1.0.0"
 serde       = { version = "1.0.133", features = ["derive"] }
 string_enum = { version = "0.3.2", path = "../string_enum" }

--- a/crates/swc_html_ast/Cargo.toml
+++ b/crates/swc_html_ast/Cargo.toml
@@ -22,7 +22,7 @@ rkyv-impl = ["__rkyv", "rkyv", "swc_atoms/rkyv-impl", "swc_common/rkyv-impl"]
 [dependencies]
 bytecheck   = { version = "0.6.9", optional = true }
 is-macro    = "0.2.0"
-rkyv        = { version = "=0.7.37", optional = true }
+rkyv        = { version = "=0.7.37", optional = true, features = ["strict"] }
 serde       = { version = "1.0.127", features = ["derive"] }
 string_enum = { version = "0.3.2", path = "../string_enum/" }
 swc_atoms   = { version = "0.4.32", path = "../swc_atoms" }

--- a/crates/swc_plugin_proxy/Cargo.toml
+++ b/crates/swc_plugin_proxy/Cargo.toml
@@ -37,10 +37,10 @@ plugin-mode = ["__plugin_mode", "swc_common/plugin-base", "rkyv-impl"]
 
 [dependencies]
 better_scoped_tls = { version = "0.1.0", path = "../better_scoped_tls" }
-rkyv              = { package = "rkyv", version = "=0.7.37", optional = true }
+rkyv              = { package = "rkyv", version = "=0.7.37", optional = true, features = ["strict"] }
 # This is to avoid cargo version selection conflict between rkyv=0.7.37 and other versions, as it is strictly pinned
 # cannot be merged.
-rkyv-latest     = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true }
+rkyv-latest     = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true, features = ["strict"] }
 swc_common      = { version = "0.29.29", path = "../swc_common" }
 swc_ecma_ast    = { version = "0.96.3", path = "../swc_ecma_ast" }
 swc_trace_macro = { version = "0.1.2", path = "../swc_trace_macro" }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

*Note:* This PR turns on an rkyv feature that requires support from `wasmer`. I haven't done the work to push `strict` through `wasmer-types` yet.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

By default, rkyv data may change format across Rust compiler versions. Enabling the `strict` feature guarantees that the data format will not change over time.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Motivation:**

The end-to-end `plugins.compat.test.js` is failing on nightly.

**BREAKING CHANGE:**

Any rkyv-serialized data may change format. I'm not sure if SWC has an ABI or not, so this may not actually be considered a breaking change.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

https://github.com/rkyv/rkyv/issues/338