### PR TITLE
build(cargo): bump up swc_css_*

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3300,7 +3300,7 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "0.59.23"
+version = "0.59.24"
 dependencies = [
  "anyhow",
  "binding_macros",
@@ -3481,7 +3481,7 @@ dependencies = [
 
 [[package]]
 name = "swc_css_parser"
-version = "0.143.2"
+version = "0.143.3"
 dependencies = [
  "bitflags",
  "criterion",

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -6,7 +6,7 @@ edition       = "2021"
 license       = "Apache-2.0"
 name          = "swc_core"
 repository    = "https://github.com/swc-project/swc.git"
-version       = "0.59.23"
+version       = "0.59.24"
   [package.metadata.docs.rs]
   features = [
     "common_perf",
@@ -350,7 +350,7 @@ swc_css_ast                      = { optional = true, version = "0.134.2", path 
 swc_css_codegen                  = { optional = true, version = "0.144.2", path = "../swc_css_codegen" }
 swc_css_minifier                 = { optional = true, version = "0.109.2", path = "../swc_css_minifier" }
 swc_css_modules                  = { optional = true, version = "0.21.3", path = "../swc_css_modules" }
-swc_css_parser                   = { optional = true, version = "0.143.2", path = "../swc_css_parser" }
+swc_css_parser                   = { optional = true, version = "0.143.3", path = "../swc_css_parser" }
 swc_css_prefixer                 = { optional = true, version = "0.146.2", path = "../swc_css_prefixer" }
 swc_css_utils                    = { optional = true, version = "0.131.2", path = "../swc_css_utils/" }
 swc_css_visit                    = { optional = true, version = "0.133.2", path = "../swc_css_visit" }

--- a/crates/swc_css/Cargo.toml
+++ b/crates/swc_css/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
-authors = ["강동윤 <kdy1997.dev@gmail.com>"]
-description = "CSS apis for rust"
+authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
+description   = "CSS apis for rust"
 documentation = "https://rustdoc.swc.rs/swc_css/"
-edition = "2021"
-license = "Apache-2.0"
-name = "swc_css"
-repository = "https://github.com/swc-project/swc.git"
-version = "0.149.3"
+edition       = "2021"
+license       = "Apache-2.0"
+name          = "swc_css"
+repository    = "https://github.com/swc-project/swc.git"
+version       = "0.149.3"
 
-[package.metadata.docs.rs]
-all-features = true
-rustdoc-args = ["--cfg", "docsrs"]
+  [package.metadata.docs.rs]
+  all-features = true
+  rustdoc-args = ["--cfg", "docsrs"]
 
 [lib]
 bench = false
 
 [features]
-compat = ["swc_css_compat"]
+compat   = ["swc_css_compat"]
 minifier = ["swc_css_minifier"]
-modules = ["swc_css_modules"]
+modules  = ["swc_css_modules"]
 prefixer = ["swc_css_prefixer"]
 
 [dependencies]
-swc_css_ast = {version = "0.134.2", path = "../swc_css_ast"}
-swc_css_codegen = {version = "0.144.2", path = "../swc_css_codegen"}
-swc_css_compat = {version = "0.20.2", path = "../swc_css_compat", optional = true}
-swc_css_minifier = {version = "0.109.2", path = "../swc_css_minifier", optional = true}
-swc_css_modules = {version = "0.21.3", path = "../swc_css_modules", optional = true}
-swc_css_parser = {version = "0.143.2", path = "../swc_css_parser"}
-swc_css_prefixer = {version = "0.146.2", path = "../swc_css_prefixer", optional = true}
-swc_css_utils = {version = "0.131.2", path = "../swc_css_utils/"}
-swc_css_visit = {version = "0.133.2", path = "../swc_css_visit"}
+swc_css_ast      = { version = "0.134.2", path = "../swc_css_ast" }
+swc_css_codegen  = { version = "0.144.2", path = "../swc_css_codegen" }
+swc_css_compat   = { version = "0.20.2", path = "../swc_css_compat", optional = true }
+swc_css_minifier = { version = "0.109.2", path = "../swc_css_minifier", optional = true }
+swc_css_modules  = { version = "0.21.3", path = "../swc_css_modules", optional = true }
+swc_css_parser   = { version = "0.143.3", path = "../swc_css_parser" }
+swc_css_prefixer = { version = "0.146.2", path = "../swc_css_prefixer", optional = true }
+swc_css_utils    = { version = "0.131.2", path = "../swc_css_utils/" }
+swc_css_visit    = { version = "0.133.2", path = "../swc_css_visit" }

--- a/crates/swc_css_codegen/Cargo.toml
+++ b/crates/swc_css_codegen/Cargo.toml
@@ -27,6 +27,6 @@ swc_css_utils          = { version = "0.131.2", path = "../swc_css_utils" }
 swc_common = { version = "0.29.29", path = "../swc_common", features = [
   "sourcemap",
 ] }
-swc_css_parser = { version = "0.143.2", path = "../swc_css_parser" }
+swc_css_parser = { version = "0.143.3", path = "../swc_css_parser" }
 swc_css_visit = { version = "0.133.2", path = "../swc_css_visit" }
 testing = { version = "0.31.31", path = "../testing" }

--- a/crates/swc_css_compat/Cargo.toml
+++ b/crates/swc_css_compat/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
-authors = ["강동윤 <kdy1997.dev@gmail.com>"]
-description = "Port of stylis"
+authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
+description   = "Port of stylis"
 documentation = "https://rustdoc.swc.rs/swc_css_compat/"
-edition = "2021"
-include = ["Cargo.toml", "src/**/*.rs", "src/**/*.json", "data/**/*.json"]
-license = "Apache-2.0"
-name = "swc_css_compat"
-repository = "https://github.com/swc-project/swc.git"
-version = "0.20.2"
+edition       = "2021"
+include       = ["Cargo.toml", "src/**/*.rs", "src/**/*.json", "data/**/*.json"]
+license       = "Apache-2.0"
+name          = "swc_css_compat"
+repository    = "https://github.com/swc-project/swc.git"
+version       = "0.20.2"
 
 [lib]
 bench = false
 
 [dependencies]
-bitflags = "1.3.2"
-once_cell = "1.10.0"
-serde = {version = "1.0.118", features = ["derive"]}
-serde_json = "1.0.61"
-swc_atoms = {version = "0.4.32", path = "../swc_atoms"}
-swc_common = {version = "0.29.29", path = "../swc_common"}
-swc_css_ast = {version = "0.134.2", path = "../swc_css_ast"}
-swc_css_utils = {version = "0.131.2", path = "../swc_css_utils/"}
-swc_css_visit = {version = "0.133.2", path = "../swc_css_visit"}
+bitflags      = "1.3.2"
+once_cell     = "1.10.0"
+serde         = { version = "1.0.118", features = ["derive"] }
+serde_json    = "1.0.61"
+swc_atoms     = { version = "0.4.32", path = "../swc_atoms" }
+swc_common    = { version = "0.29.29", path = "../swc_common" }
+swc_css_ast   = { version = "0.134.2", path = "../swc_css_ast" }
+swc_css_utils = { version = "0.131.2", path = "../swc_css_utils/" }
+swc_css_visit = { version = "0.133.2", path = "../swc_css_visit" }
 
 [dev-dependencies]
-swc_css_codegen = {version = "0.144.2", path = "../swc_css_codegen"}
-swc_css_parser = {version = "0.143.2", path = "../swc_css_parser"}
-testing = {version = "0.31.31", path = "../testing"}
+swc_css_codegen = { version = "0.144.2", path = "../swc_css_codegen" }
+swc_css_parser  = { version = "0.143.3", path = "../swc_css_parser" }
+testing         = { version = "0.31.31", path = "../testing" }

--- a/crates/swc_css_lints/Cargo.toml
+++ b/crates/swc_css_lints/Cargo.toml
@@ -26,5 +26,5 @@ thiserror     = "1.0.30"
 
 [dev-dependencies]
 serde_json     = "1.0.79"
-swc_css_parser = { version = "0.143.2", path = "../swc_css_parser" }
+swc_css_parser = { version = "0.143.3", path = "../swc_css_parser" }
 testing        = { version = "0.31.31", path = "../testing" }

--- a/crates/swc_css_minifier/Cargo.toml
+++ b/crates/swc_css_minifier/Cargo.toml
@@ -23,7 +23,7 @@ swc_css_visit = { version = "0.133.2", path = "../swc_css_visit" }
 [dev-dependencies]
 criterion       = "0.3"
 swc_css_codegen = { version = "0.144.2", path = "../swc_css_codegen" }
-swc_css_parser  = { version = "0.143.2", path = "../swc_css_parser" }
+swc_css_parser  = { version = "0.143.3", path = "../swc_css_parser" }
 swc_node_base   = { version = "0.5.8", path = "../swc_node_base" }
 testing         = { version = "0.31.31", path = "../testing" }
 

--- a/crates/swc_css_modules/Cargo.toml
+++ b/crates/swc_css_modules/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-authors = ["강동윤 <kdy1997.dev@gmail.com>"]
-description = "CSS modules"
+authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
+description   = "CSS modules"
 documentation = "https://rustdoc.swc.rs/swc_css_modules/"
-edition = "2021"
-include = ["Cargo.toml", "src/**/*.rs"]
-license = "Apache-2.0"
-name = "swc_css_modules"
-repository = "https://github.com/swc-project/swc.git"
-version = "0.21.3"
+edition       = "2021"
+include       = ["Cargo.toml", "src/**/*.rs"]
+license       = "Apache-2.0"
+name          = "swc_css_modules"
+repository    = "https://github.com/swc-project/swc.git"
+version       = "0.21.3"
 
 [lib]
 bench = false
@@ -15,16 +15,16 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rustc-hash = "1.1.0"
-serde = {version = "1", features = ["derive"]}
-swc_atoms = {version = "0.4.32", path = "../swc_atoms"}
-swc_common = {version = "0.29.29", path = "../swc_common"}
-swc_css_ast = {version = "0.134.2", path = "../swc_css_ast"}
-swc_css_codegen = {version = "0.144.2", path = "../swc_css_codegen"}
-swc_css_parser = {version = "0.143.2", path = "../swc_css_parser"}
-swc_css_visit = {version = "0.133.2", path = "../swc_css_visit"}
+rustc-hash      = "1.1.0"
+serde           = { version = "1", features = ["derive"] }
+swc_atoms       = { version = "0.4.32", path = "../swc_atoms" }
+swc_common      = { version = "0.29.29", path = "../swc_common" }
+swc_css_ast     = { version = "0.134.2", path = "../swc_css_ast" }
+swc_css_codegen = { version = "0.144.2", path = "../swc_css_codegen" }
+swc_css_parser  = { version = "0.143.3", path = "../swc_css_parser" }
+swc_css_visit   = { version = "0.133.2", path = "../swc_css_visit" }
 
 [dev-dependencies]
-serde_json = "1"
-swc_css_compat = {version = "0.20.2", path = "../swc_css_compat"}
-testing = {version = "0.31.31", path = "../testing"}
+serde_json     = "1"
+swc_css_compat = { version = "0.20.2", path = "../swc_css_compat" }
+testing        = { version = "0.31.31", path = "../testing" }

--- a/crates/swc_css_parser/Cargo.toml
+++ b/crates/swc_css_parser/Cargo.toml
@@ -7,7 +7,7 @@ include       = ["Cargo.toml", "src/**/*.rs"]
 license       = "Apache-2.0"
 name          = "swc_css_parser"
 repository    = "https://github.com/swc-project/swc.git"
-version       = "0.143.2"
+version       = "0.143.3"
 
 [lib]
 bench = false
@@ -19,7 +19,7 @@ debug = []
 bitflags    = "1.2.1"
 lexical     = "6.1.0"
 serde       = "1.0.127"
-swc_atoms   = { version = "0.4.32", path = "../swc_atoms" }
+swc_atoms   = { version = "0.4.34", path = "../swc_atoms" }
 swc_common  = { version = "0.29.29", path = "../swc_common" }
 swc_css_ast = { version = "0.134.2", path = "../swc_css_ast" }
 

--- a/crates/swc_css_prefixer/Cargo.toml
+++ b/crates/swc_css_prefixer/Cargo.toml
@@ -1,29 +1,29 @@
 [package]
-authors = ["강동윤 <kdy1997.dev@gmail.com>"]
-description = "Port of stylis"
+authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
+description   = "Port of stylis"
 documentation = "https://rustdoc.swc.rs/swc_stylis/"
-edition = "2021"
-include = ["Cargo.toml", "src/**/*.rs", "src/**/*.json", "data/**/*.json"]
-license = "Apache-2.0"
-name = "swc_css_prefixer"
-repository = "https://github.com/swc-project/swc.git"
-version = "0.146.2"
+edition       = "2021"
+include       = ["Cargo.toml", "src/**/*.rs", "src/**/*.json", "data/**/*.json"]
+license       = "Apache-2.0"
+name          = "swc_css_prefixer"
+repository    = "https://github.com/swc-project/swc.git"
+version       = "0.146.2"
 
 [lib]
 bench = false
 
 [dependencies]
-once_cell = "1.10.0"
-preset_env_base = {version = "0.4.0", path = "../preset_env_base"}
-serde = {version = "1.0.118", features = ["derive"]}
-serde_json = "1.0.61"
-swc_atoms = {version = "0.4.32", path = "../swc_atoms"}
-swc_common = {version = "0.29.29", path = "../swc_common"}
-swc_css_ast = {version = "0.134.2", path = "../swc_css_ast"}
-swc_css_utils = {version = "0.131.2", path = "../swc_css_utils/"}
-swc_css_visit = {version = "0.133.2", path = "../swc_css_visit"}
+once_cell       = "1.10.0"
+preset_env_base = { version = "0.4.0", path = "../preset_env_base" }
+serde           = { version = "1.0.118", features = ["derive"] }
+serde_json      = "1.0.61"
+swc_atoms       = { version = "0.4.32", path = "../swc_atoms" }
+swc_common      = { version = "0.29.29", path = "../swc_common" }
+swc_css_ast     = { version = "0.134.2", path = "../swc_css_ast" }
+swc_css_utils   = { version = "0.131.2", path = "../swc_css_utils/" }
+swc_css_visit   = { version = "0.133.2", path = "../swc_css_visit" }
 
 [dev-dependencies]
-swc_css_codegen = {version = "0.144.2", path = "../swc_css_codegen"}
-swc_css_parser = {version = "0.143.2", path = "../swc_css_parser"}
-testing = {version = "0.31.31", path = "../testing"}
+swc_css_codegen = { version = "0.144.2", path = "../swc_css_codegen" }
+swc_css_parser  = { version = "0.143.3", path = "../swc_css_parser" }
+testing         = { version = "0.31.31", path = "../testing" }

--- a/crates/swc_html_minifier/Cargo.toml
+++ b/crates/swc_html_minifier/Cargo.toml
@@ -25,7 +25,7 @@ swc_common               = { version = "0.29.29", path = "../swc_common" }
 swc_css_ast              = { version = "0.134.2", path = "../swc_css_ast" }
 swc_css_codegen          = { version = "0.144.2", path = "../swc_css_codegen" }
 swc_css_minifier         = { version = "0.109.2", path = "../swc_css_minifier" }
-swc_css_parser           = { version = "0.143.2", path = "../swc_css_parser" }
+swc_css_parser           = { version = "0.143.3", path = "../swc_css_parser" }
 swc_ecma_ast             = { version = "0.96.3", path = "../swc_ecma_ast" }
 swc_ecma_codegen         = { version = "0.129.10", path = "../swc_ecma_codegen" }
 swc_ecma_minifier        = { version = "0.166.18", path = "../swc_ecma_minifier" }

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -63,7 +63,7 @@ swc_atoms = { version = "0.4.32", path = '../swc_atoms' }
 swc_css_ast = { version = "0.134.2", path = "../swc_css_ast", features = [
   "rkyv-impl",
 ] }
-swc_css_parser = { version = "0.143.2", path = "../swc_css_parser" }
+swc_css_parser = { version = "0.143.3", path = "../swc_css_parser" }
 swc_ecma_ast = { version = "0.96.3", path = "../swc_ecma_ast", features = [
   "rkyv-impl",
 ] }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Coming from internal report from @jridgewell 

```
swc_css_parser [v0.143.2](https://github.com/swc-project/swc/blob/29fee382249c9b91155d0d3c39d0df82bbd531c1/crates/swc_css_parser/Cargo.toml#L10) has a [js_word!(“first”)](https://github.com/swc-project/swc/blob/29fee382249c9b91155d0d3c39d0df82bbd531c1/crates/swc_css_parser/src/parser/at_rules/mod.rs#L2037)
The swc_css_parser v0.143.2 has a [hard dep](https://github.com/swc-project/swc/blob/29fee382249c9b91155d0d3c39d0df82bbd531c1/crates/swc_css_parser/Cargo.toml#L22) on swc_atoms v0.4.32
swc_atom [0.4.32](https://github.com/swc-project/swc/blob/1161360d5475e82e81aa1179557933d2748ae806/crates/swc_atoms/Cargo.toml#L10) does not include first in its [word list](https://github.com/swc-project/swc/blob/1161360d5475e82e81aa1179557933d2748ae806/crates/swc_atoms/words.txt#L1353-L1356)
```


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
