### PR TITLE
fix(es/typescript): Fix handling of non-uppercase JSX elements

### DIFF
--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -1629,7 +1629,7 @@ where
     fn visit_jsx_element_name(&mut self, n: &JSXElementName) {
         match n {
             JSXElementName::Ident(i) => {
-                if i.sym.starts_with(|c: char| c.is_ascii_uppercase()) {
+                if i.sym.starts_with(|c: char| !c.is_ascii_lowercase()) {
                     n.visit_children_with(self);
                 }
             }
@@ -2083,7 +2083,7 @@ where
     fn visit_mut_jsx_element_name(&mut self, n: &mut JSXElementName) {
         match n {
             JSXElementName::Ident(i) => {
-                if i.sym.starts_with(|c: char| c.is_ascii_uppercase()) {
+                if i.sym.starts_with(|c: char| !c.is_ascii_lowercase()) {
                     n.visit_mut_children_with(self);
                 }
             }

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-6923/input.tsx
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-6923/input.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import ReactDOM from "react-dom";
+import { _Component } from "./Component";
+
+const App = (
+    <div>
+        <_Component></_Component>
+        <p>Hello World</p>
+    </div>
+);
+ReactDOM.render(App, window.document.getElementById("react_root"));

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-6923/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-6923/output.js
@@ -1,0 +1,10 @@
+import ReactDOM from "react-dom";
+import { _Component } from "./Component";
+const App = <div>
+
+        <_Component></_Component>
+
+        <p>Hello World</p>
+
+    </div>;
+ReactDOM.render(App, window.document.getElementById("react_root"));


### PR DESCRIPTION
**Description:**



**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6923.