### PR TITLE
fix(es/module): Fix `jsc.paths` on Windows

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1333,6 +1333,10 @@ impl ModuleConfig {
                     .unwrap_or_else(|_| path.to_path_buf()),
             ),
             _ => base.to_owned(),
+            FileName::Real(v) if !paths.is_empty() => {
+                FileName::Real(v.canonicalize().unwrap_or_else(|_| v.to_path_buf()))
+            }
+            _ => base.clone(),
         };
 
         match config {

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1327,12 +1327,6 @@ impl ModuleConfig {
         available_features: FeatureFlag,
     ) -> Box<dyn swc_ecma_visit::Fold + 'cmt> {
         let base = match base {
-            FileName::Real(path) if !paths.is_empty() && !path.is_absolute() => FileName::Real(
-                std::env::current_dir()
-                    .map(|v| v.join(path))
-                    .unwrap_or_else(|_| path.to_path_buf()),
-            ),
-            _ => base.to_owned(),
             FileName::Real(v) if !paths.is_empty() => {
                 FileName::Real(v.canonicalize().unwrap_or_else(|_| v.to_path_buf()))
             }

--- a/crates/swc/tests/fixture/issues-6xxx/6782/1/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-6xxx/6782/1/input/.swcrc
@@ -1,0 +1,24 @@
+{
+    "minify": true,
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true,
+            "dynamicImport": true
+        },
+        "target": "es2020",
+        "baseUrl": "./",
+        "paths": {
+            "@/config": [
+                "config"
+            ],
+            "@/config/*": [
+                "config/*"
+            ]
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "sourceMaps": true
+}

--- a/crates/swc/tests/fixture/issues-6xxx/6782/1/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-6xxx/6782/1/input/.swcrc
@@ -16,9 +16,5 @@
                 "config/*"
             ]
         }
-    },
-    "module": {
-        "type": "es6"
-    },
-    "sourceMaps": true
+    }
 }

--- a/crates/swc/tests/fixture/issues-6xxx/6782/1/input/config/index.ts
+++ b/crates/swc/tests/fixture/issues-6xxx/6782/1/input/config/index.ts
@@ -1,0 +1,1 @@
+export const config = () => console.log("\n\n--> all good!\n\n");

--- a/crates/swc/tests/fixture/issues-6xxx/6782/1/input/src/index.ts
+++ b/crates/swc/tests/fixture/issues-6xxx/6782/1/input/src/index.ts
@@ -1,0 +1,8 @@
+import { config } from "@/config";
+
+const main = () => config();
+
+main();
+
+// See https://github.com/swc-project/swc/issues/6782
+// See https://github.com/swc-project/swc/issues/6858

--- a/crates/swc/tests/fixture/issues-6xxx/6782/1/output/config/index.ts
+++ b/crates/swc/tests/fixture/issues-6xxx/6782/1/output/config/index.ts
@@ -1,0 +1,1 @@
+export const config=()=>console.log("\n\n--> all good!\n\n");

--- a/crates/swc/tests/fixture/issues-6xxx/6782/1/output/src/index.ts
+++ b/crates/swc/tests/fixture/issues-6xxx/6782/1/output/src/index.ts
@@ -1,0 +1,1 @@
+import{config}from"../config";const main=()=>config();main();

--- a/crates/swc/tests/fixture/issues-6xxx/6782/1/output/src/index.ts
+++ b/crates/swc/tests/fixture/issues-6xxx/6782/1/output/src/index.ts
@@ -1,1 +1,0 @@
-import{config}from"../config";const main=()=>config();main();

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -116,7 +116,7 @@ where
             let mut p = PathBuf::from(target_path);
 
             if cfg!(debug_assertions) {
-                trace!("to_specifier: orig_ext={:?}", orig_ext);
+                trace!("to_specifier({target_path}): orig_ext={:?}", orig_ext);
             }
 
             if let Some(orig_ext) = orig_ext {


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Reverts https://github.com/swc-project/swc/pull/6716.
 - Closes https://github.com/swc-project/swc/issues/6782.
