### PR TITLE
fix(bindings/cli): Rename --config to --config-json

### DIFF
--- a/bindings/swc_cli/src/commands/compile.rs
+++ b/bindings/swc_cli/src/commands/compile.rs
@@ -28,11 +28,11 @@ use crate::util::trace::init_trace;
 /// Configuration option for transform files.
 #[derive(Parser)]
 pub struct CompileOptions {
-    /// Experimental: provide additional configuration to override the .swcrc.
-    /// Can be used to provide experimental plugin configuration,
+    /// Experimental: provide an additional JSON config object to override the
+    /// .swcrc. Can be used to provide experimental plugin configuration,
     /// including plugin imports that are explicitly relative, starting with `.`
     /// or `..`
-    #[clap(long, value_parser = parse_config)]
+    #[clap(long = "config-json", value_parser = parse_config)]
     config: Option<Config>,
 
     /// Path to a .swcrc file to use


### PR DESCRIPTION

<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

`@swc/cli` uses a different format for `--config`, so use a different name.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

Experimental `--config` option has been renamed to `--config-json`.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):** https://github.com/swc-project/swc/issues/4017#issuecomment-1425273484
