### PR TITLE
test(swc): Add Bazel tests

### DIFF
--- a/crates/swc/tests/projects.rs
+++ b/crates/swc/tests/projects.rs
@@ -1001,7 +1001,7 @@ fn bazel_support() {
             Ok(r) => {
                 assert!(r
                     .code
-                    .contains("const _moduleA = require(\"./modules/moduleA\");"),);
+                    .contains("const _moduleA = require(\"./modules/moduleA/index\");"),);
             }
             Err(out) => panic!("Failed to compile where it should not!\nErr:{:?}", out),
         }

--- a/crates/swc/tests/projects/bazel-support/.swcrc
+++ b/crates/swc/tests/projects/bazel-support/.swcrc
@@ -1,0 +1,16 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript"
+    },
+    "target": "es2021",
+    "baseUrl": "./src",
+    "paths": {
+      "@modules/*": ["./modules/*"]
+    }
+  },
+  "module": {
+    "type": "commonjs"
+  },
+  "sourceMaps": true
+}

--- a/crates/swc/tests/projects/bazel-support/modules/moduleA/index.ts
+++ b/crates/swc/tests/projects/bazel-support/modules/moduleA/index.ts
@@ -1,0 +1,6 @@
+import { moduleB } from "@modules/moduleB";
+
+export const moduleA = () => {
+  console.log("This is module A");
+  moduleB();
+};

--- a/crates/swc/tests/projects/bazel-support/modules/moduleB/index.ts
+++ b/crates/swc/tests/projects/bazel-support/modules/moduleB/index.ts
@@ -1,0 +1,1 @@
+export const moduleB = () => console.log("This is module B!");

--- a/crates/swc/tests/projects/bazel-support/src/index.ts
+++ b/crates/swc/tests/projects/bazel-support/src/index.ts
@@ -1,0 +1,3 @@
+import { moduleA } from "@modules/moduleA";
+
+moduleA();


### PR DESCRIPTION
Adds an integration test that simulates a Bazel environment using symbolic links to sources.

Related

- https://github.com/swc-project/swc/pull/6930