### PR TITLE
fix(es/react): Don't panic on `key` without a value

### DIFF
--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -533,10 +533,18 @@ where
                                             .value
                                             .and_then(jsx_attr_value_to_expr)
                                             .map(|expr| expr.as_arg());
-                                        assert_ne!(
-                                            key, None,
-                                            "value of property 'key' should not be empty"
-                                        );
+
+                                        if key.is_none() {
+                                            HANDLER.with(|handler| {
+                                                handler
+                                                    .struct_span_err(
+                                                        i.span,
+                                                        "The value of property 'key' should not \
+                                                         be empty",
+                                                    )
+                                                    .emit();
+                                            });
+                                        }
                                         continue;
                                     }
 

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-6939/input.js
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-6939/input.js
@@ -1,0 +1,1 @@
+const test = <div key></div>

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-6939/options.json
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-6939/options.json
@@ -1,0 +1,1 @@
+{ "runtime": "automatic" }

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-6939/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-6939/output.mjs
@@ -1,0 +1,2 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+const test = /*#__PURE__*/ _jsx("div", {});

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-6939/output.stderr
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-6939/output.stderr
@@ -1,0 +1,6 @@
+
+  x The value of property 'key' should not be empty
+   ,-[input.js:1:1]
+ 1 | const test = <div key></div>
+   :                   ^^^
+   `----


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6939.