### PR TITLE
fix(bindings/node): Treat `.cts` and `.mts` as input by default

### DIFF
--- a/node-swc/src/index.ts
+++ b/node-swc/src/index.ts
@@ -466,7 +466,9 @@ export const DEFAULT_EXTENSIONS = Object.freeze([
   ".es",
   ".mjs",
   ".ts",
-  ".tsx"
+  ".tsx",
+  ".cts",
+  ".mts"
 ]);
 
 function toBuffer(t: any): Buffer {


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6958.