### PR TITLE
fix: properly handle CSS animation on CSS Modules

### DIFF
--- a/crates/swc_atoms/words.txt
+++ b/crates/swc_atoms/words.txt
@@ -984,6 +984,7 @@ background-position-x
 background-position-y
 background-repeat
 background-size
+backwards
 base
 baseFrequency
 baseProfile
@@ -1068,6 +1069,7 @@ border-top-right-radius
 border-top-style
 border-top-width
 border-width
+both
 bottom
 bottom-center
 bottom-left
@@ -1405,6 +1407,7 @@ forestgreen
 form
 formaction
 format
+forwards
 fr
 frame
 frameset
@@ -1505,6 +1508,7 @@ inactivecaptiontext
 indianred
 indigo
 infer
+infinite
 infinity
 infobackground
 infotext
@@ -1971,6 +1975,7 @@ patternUnits
 patterncontentunits
 patterntransform
 patternunits
+paused
 pc
 peachpuff
 perspective
@@ -2094,6 +2099,7 @@ ruby-merge
 ruby-position
 ruby-text
 run-in
+running
 s
 saddlebrown
 salmon

--- a/crates/swc_css_modules/tests/fixture/modules/animation/source.compiled.css
+++ b/crates/swc_css_modules/tests/fixture/modules/animation/source.compiled.css
@@ -1,0 +1,33 @@
+.__local__a {
+  animation: 3s ease __local__animationName;
+}
+.__local__b {
+  animation: 3s cubic-bezier(0.075, 0.82, 0.165, 1) __local__ease;
+}
+.__local__c {
+  animation: 3s ease-in-out 10 __local__infinite;
+}
+@keyframes __local__animationName {
+  0% {
+    background: white;
+  }
+  100% {
+    background: red;
+  }
+}
+@keyframes __local__ease {
+  0% {
+    background: white;
+  }
+  100% {
+    background: red;
+  }
+}
+@keyframes __local__infinite {
+  0% {
+    background: white;
+  }
+  100% {
+    background: red;
+  }
+}

--- a/crates/swc_css_modules/tests/fixture/modules/animation/source.css
+++ b/crates/swc_css_modules/tests/fixture/modules/animation/source.css
@@ -1,0 +1,38 @@
+.a {
+  animation: 3s ease animationName;
+}
+
+.b {
+  animation: 3s cubic-bezier(0.075, 0.82, 0.165, 1) ease;
+}
+
+.c {
+  animation: 3s ease-in-out 10 infinite;
+}
+
+@keyframes animationName {
+  0% {
+    background: white;
+  }
+  100% {
+    background: red;
+  }
+}
+
+@keyframes ease {
+  0% {
+    background: white;
+  }
+  100% {
+    background: red;
+  }
+}
+
+@keyframes infinite {
+  0% {
+    background: white;
+  }
+  100% {
+    background: red;
+  }
+}

--- a/crates/swc_css_modules/tests/fixture/modules/animation/source.transform.json
+++ b/crates/swc_css_modules/tests/fixture/modules/animation/source.transform.json
@@ -1,0 +1,38 @@
+{
+  "b": [
+    {
+      "type": "local",
+      "name": "__local__b"
+    }
+  ],
+  "a": [
+    {
+      "type": "local",
+      "name": "__local__a"
+    }
+  ],
+  "infinite": [
+    {
+      "type": "local",
+      "name": "__local__infinite"
+    }
+  ],
+  "c": [
+    {
+      "type": "local",
+      "name": "__local__c"
+    }
+  ],
+  "animationName": [
+    {
+      "type": "local",
+      "name": "__local__animationName"
+    }
+  ],
+  "ease": [
+    {
+      "type": "local",
+      "name": "__local__ease"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

In the current implementation of `swc_css_modules`, any first identifier in `animation` properties are transformed as the local identifier.

Current behaviour:
```css
/* this */
.a {
  animation: 3s ease animationName;
}

/* will be transformed like this: */
.__local__a {
  animation: 3s __local__ease animationName;
}
```

Expected behaviour:
```css
/* this */
.a {
  animation: 3s ease animationName;
}

/* should be transformed like this: */
.__local__a {
  animation: 3s ease __local__animationName;
}
```

This pull request will fix this.


FYI: https://developer.mozilla.org/en-US/docs/Web/CSS/animation

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
