### PR TITLE
(perf) bump "string-cache" crate for per-bucket mutex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3041,9 +3041,9 @@ checksum = "213701ba3370744dcd1a12960caa4843b3d68b4d1c0a5d575e0d65b2ee9d16c0"
 
 [[package]]
 name = "string_cache"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "213494b7a2b503146286049378ce02b482200519accc31872ee8be91fa820a08"
+checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
 dependencies = [
  "new_debug_unreachable",
  "once_cell",

--- a/crates/swc_atoms/Cargo.toml
+++ b/crates/swc_atoms/Cargo.toml
@@ -28,7 +28,7 @@ rkyv      = { package = "rkyv", version = "=0.7.37", optional = true }
 rkyv-latest  = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true }
 rustc-hash   = "1.1.0"
 serde        = "1"
-string_cache = "0.8.4"
+string_cache = "0.8.7"
 triomphe     = "0.1.8"
 
 [build-dependencies]

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -71,7 +71,7 @@ rustc-hash           = "1.1.0"
 serde                = { version = "1.0.119", features = ["derive"] }
 siphasher            = "0.3.9"
 sourcemap            = { version = "6", optional = true }
-string_cache         = "0.8.4"
+string_cache         = "0.8.7"
 swc_atoms            = { version = "0.4.38", path = "../swc_atoms" }
 swc_eq_ignore_macros = { version = "0.1.1", path = "../swc_eq_ignore_macros" }
 swc_visit            = { version = "0.5.4", path = "../swc_visit" }


### PR DESCRIPTION

**Description:**

Bump the "string-cache" crate to 0.8.5, which includes [this PR](https://github.com/servo/string-cache/commit/b473a4ad3be989166031f56976f7ce54ae79ac05).
Internally, it now locks on each individual bucket within the DYNAMIC_SET struct, rather than locking on the whole data structure.
Parallel performance should improve.

**BREAKING CHANGE:**


**Related issue (if exists):**
