### PR TITLE
chore: update sourcemap -> 6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -158,12 +158,6 @@ checksum = "a4521f3e3d031370679b3b140beb36dfe4801b09ac77e30c61941f97df3ef28b"
 
 [[package]]
 name = "base64"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
-
-[[package]]
-name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
@@ -841,6 +835,12 @@ dependencies = [
  "num_cpus",
  "parking_lot",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "dbg-swc"
@@ -2553,7 +2553,7 @@ version = "0.11.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68cc60575865c7831548863cc02356512e3f1dc2f3f82cb837d7fc4cc8f3c97c"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",
@@ -2921,17 +2921,16 @@ dependencies = [
 
 [[package]]
 name = "sourcemap"
-version = "6.0.1"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e031f2463ecbdd5f34c950f89f5c1e1032f22c0f8e3dc4bdb2e8b6658cf61eb"
+checksum = "3562681c4e0890af6cd22f09a0eeed4afd855d5011cd5f9358c834b670932382"
 dependencies = [
- "base64 0.11.0",
+ "data-encoding",
  "if_chain",
- "lazy_static",
- "regex",
  "rustc_version 0.2.3",
  "serde",
  "serde_json",
+ "unicode-id",
  "url",
 ]
 
@@ -3125,7 +3124,7 @@ dependencies = [
  "ahash",
  "ansi_term",
  "anyhow",
- "base64 0.13.1",
+ "base64",
  "criterion",
  "dashmap",
  "either",
@@ -3568,7 +3567,7 @@ dependencies = [
 name = "swc_ecma_codegen"
 version = "0.129.15"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "criterion",
  "memchr",
  "num-bigint",
@@ -3993,7 +3992,7 @@ name = "swc_ecma_transforms_react"
 version = "0.160.21"
 dependencies = [
  "ahash",
- "base64 0.13.1",
+ "base64",
  "dashmap",
  "indexmap",
  "once_cell",
@@ -4024,7 +4023,7 @@ version = "0.119.14"
 dependencies = [
  "ansi_term",
  "anyhow",
- "base64 0.13.1",
+ "base64",
  "hex",
  "serde",
  "serde_json",

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -62,7 +62,7 @@ regex = "1"
 rustc-hash = "1.1.0"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sourcemap = "6"
+sourcemap = "6.2.2"
 swc_atoms = { version = "0.4.37", path = "../swc_atoms" }
 swc_cached = { version = "0.3.15", path = "../swc_cached" }
 swc_common = { version = "0.29.32", path = "../swc_common", features = [

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -70,7 +70,7 @@ rkyv-latest          = { package = "rkyv-test", version = "=0.7.38-test.2", opti
 rustc-hash           = "1.1.0"
 serde                = { version = "1.0.119", features = ["derive"] }
 siphasher            = "0.3.9"
-sourcemap            = { version = "6", optional = true }
+sourcemap            = { version = "6.2.2", optional = true }
 string_cache         = "0.8.4"
 swc_atoms            = { version = "0.4.37", path = "../swc_atoms" }
 swc_eq_ignore_macros = { version = "0.1.1", path = "../swc_eq_ignore_macros" }

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -18,7 +18,7 @@ num-bigint              = { version = "0.4", features = ["serde"] }
 once_cell               = "1.10.0"
 rustc-hash              = "1.1.0"
 serde                   = "1.0.127"
-sourcemap               = "6"
+sourcemap               = "6.2.2"
 swc_atoms               = { version = "0.4.37", path = "../swc_atoms" }
 swc_common              = { version = "0.29.32", path = "../swc_common" }
 swc_ecma_ast            = { version = "0.96.7", path = "../swc_ecma_ast" }

--- a/crates/swc_ecma_minifier/fuzz/Cargo.lock
+++ b/crates/swc_ecma_minifier/fuzz/Cargo.lock
@@ -122,12 +122,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
 name = "better_scoped_tls"
 version = "0.1.0"
 dependencies = [
@@ -242,13 +236,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "debug_unreachable"
-version = "0.1.1"
+name = "data-encoding"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a032eac705ca39214d169f83e3d3da290af06d8d1d344d1baad2fd002dca4b3"
-dependencies = [
- "unreachable",
-]
+checksum = "23d8666cb01533c39dde32bcbab8e227b4ed6679b2c925eba05feabea39508fb"
 
 [[package]]
 name = "derive_arbitrary"
@@ -856,6 +847,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "psm"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -863,6 +863,12 @@ checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radix_fmt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
 
 [[package]]
 name = "rand"
@@ -936,12 +942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0df32d82cedd1499386877b062ebe8721f806de80b08d183c70184ef17dd1d42"
 
 [[package]]
-name = "retain_mut"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -967,6 +967,12 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "ryu-js"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
 name = "scoped-tls"
@@ -1066,17 +1072,16 @@ checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
 
 [[package]]
 name = "sourcemap"
-version = "6.2.0"
+version = "6.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c46fdc1838ff49cf692226f5c2b0f5b7538f556863d0eca602984714667ac6e7"
+checksum = "3562681c4e0890af6cd22f09a0eeed4afd855d5011cd5f9358c834b670932382"
 dependencies = [
- "base64",
+ "data-encoding",
  "if_chain",
- "lazy_static",
- "regex",
  "rustc_version",
  "serde",
  "serde_json",
+ "unicode-id",
  "url",
 ]
 
@@ -1085,6 +1090,19 @@ name = "stable_deref_trait"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "stacker"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "winapi",
+]
 
 [[package]]
 name = "static_assertions"
@@ -1165,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "0.4.23"
+version = "0.4.37"
 dependencies = [
  "once_cell",
  "rustc-hash",
@@ -1189,7 +1207,7 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "0.29.10"
+version = "0.29.32"
 dependencies = [
  "ahash",
  "arbitrary",
@@ -1197,9 +1215,9 @@ dependencies = [
  "atty",
  "better_scoped_tls",
  "cfg-if",
- "debug_unreachable",
  "either",
  "from_variant",
+ "new_debug_unreachable",
  "num-bigint",
  "once_cell",
  "parking_lot",
@@ -1239,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "0.94.14"
+version = "0.96.7"
 dependencies = [
  "arbitrary",
  "bitflags",
@@ -1255,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "0.127.24"
+version = "0.129.15"
 dependencies = [
  "memchr",
  "num-bigint",
@@ -1283,7 +1301,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "0.159.47"
+version = "0.166.30"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -1292,9 +1310,10 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "parking_lot",
+ "radix_fmt",
  "regex",
- "retain_mut",
  "rustc-hash",
+ "ryu-js",
  "serde",
  "serde_json",
  "swc_atoms",
@@ -1306,6 +1325,7 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_optimization",
+ "swc_ecma_usage_analyzer",
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_timer",
@@ -1330,7 +1350,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "0.122.20"
+version = "0.124.12"
 dependencies = [
  "either",
  "enum_kind",
@@ -1338,6 +1358,7 @@ dependencies = [
  "num-bigint",
  "serde",
  "smallvec",
+ "stacker",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -1347,7 +1368,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "0.20.7"
+version = "0.20.8"
 dependencies = [
  "anyhow",
  "hex",
@@ -1357,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "0.111.34"
+version = "0.116.14"
 dependencies = [
  "better_scoped_tls",
  "bitflags",
@@ -1388,7 +1409,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.167.27"
+version = "0.172.27"
 dependencies = [
  "ahash",
  "dashmap",
@@ -1410,12 +1431,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_usage_analyzer"
+version = "0.3.10"
+dependencies = [
+ "ahash",
+ "indexmap",
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "swc_timer",
+ "tracing",
+]
+
+[[package]]
 name = "swc_ecma_utils"
-version = "0.105.25"
+version = "0.107.12"
 dependencies = [
  "indexmap",
  "num_cpus",
  "once_cell",
+ "rustc-hash",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -1426,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "0.80.14"
+version = "0.82.7"
 dependencies = [
  "num-bigint",
  "swc_atoms",
@@ -1448,7 +1486,7 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "0.13.10"
+version = "0.13.33"
 dependencies = [
  "anyhow",
  "miette",
@@ -1459,7 +1497,7 @@ dependencies = [
 
 [[package]]
 name = "swc_fast_graph"
-version = "0.17.11"
+version = "0.17.33"
 dependencies = [
  "ahash",
  "indexmap",
@@ -1479,14 +1517,14 @@ dependencies = [
 
 [[package]]
 name = "swc_timer"
-version = "0.17.10"
+version = "0.17.34"
 dependencies = [
  "tracing",
 ]
 
 [[package]]
 name = "swc_visit"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "either",
  "swc_visit_macros",
@@ -1494,7 +1532,7 @@ dependencies = [
 
 [[package]]
 name = "swc_visit_macros"
-version = "0.5.4"
+version = "0.5.5"
 dependencies = [
  "Inflector",
  "pmutil",
@@ -1536,7 +1574,7 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "0.31.10"
+version = "0.31.34"
 dependencies = [
  "ansi_term",
  "difference",
@@ -1749,15 +1787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
-name = "unreachable"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f2ae5ddb18e1c92664717616dd9549dde73f539f01bd7b77c2edb2446bdff91"
-dependencies = [
- "void",
-]
-
-[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1779,12 +1808,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasi"

--- a/crates/swc_ecma_transforms/Cargo.toml
+++ b/crates/swc_ecma_transforms/Cargo.toml
@@ -46,7 +46,7 @@ swc_ecma_visit                   = { version = "0.82.7", path = "../swc_ecma_vis
 
 [dev-dependencies]
 pretty_assertions           = "1.1"
-sourcemap                   = "6"
+sourcemap                   = "6.2.2"
 swc_ecma_codegen            = { version = "0.129.15", path = "../swc_ecma_codegen" }
 swc_ecma_parser             = { version = "0.124.12", path = "../swc_ecma_parser" }
 swc_ecma_transforms_testing = { version = "0.119.14", path = "../swc_ecma_transforms_testing" }

--- a/crates/swc_ecma_transforms_testing/Cargo.toml
+++ b/crates/swc_ecma_transforms_testing/Cargo.toml
@@ -19,7 +19,7 @@ hex = "0.4.3"
 serde = "1"
 serde_json = "1"
 sha-1 = "0.10"
-sourcemap = "6"
+sourcemap = "6.2.2"
 swc_common = { version = "0.29.32", path = "../swc_common", features = [
   "sourcemap",
 ] }


### PR DESCRIPTION
Updates the sourcemap crate. This is a follow up to the discussion in https://github.com/swc-project/swc/pull/6973.