### PR TITLE
refactor(es/parser): Make lexer not generic over `Input`

### DIFF
--- a/crates/swc/tests/serde.rs
+++ b/crates/swc/tests/serde.rs
@@ -1,13 +1,12 @@
 use std::path::Path;
 
-use swc_common::input::StringInput;
 use swc_ecma_ast::Module;
 use swc_ecma_parser::{lexer::Lexer, PResult, Parser, Syntax};
 use testing::NormalizedOutput;
 
 fn with_parser<F, Ret>(file_name: &str, f: F) -> Result<Ret, NormalizedOutput>
 where
-    F: FnOnce(&mut Parser<Lexer<StringInput>>) -> PResult<Ret>,
+    F: FnOnce(&mut Parser<Lexer>) -> PResult<Ret>,
 {
     ::testing::run_test(false, |cm, handler| {
         let fm = cm

--- a/crates/swc_ecma_codegen/tests/sourcemap.rs
+++ b/crates/swc_ecma_codegen/tests/sourcemap.rs
@@ -7,7 +7,7 @@ use sourcemap::SourceMap;
 use swc_common::{comments::SingleThreadedComments, source_map::SourceMapGenConfig};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_codegen::{self, text_writer::WriteJs, Emitter};
-use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, Parser, Syntax};
 use swc_ecma_testing::{exec_node_js, JsExecOptions};
 
 static IGNORED_PASS_TESTS: &[&str] = &[
@@ -306,7 +306,7 @@ fn identity(entry: PathBuf) {
             (&*fm).into(),
             Some(&comments),
         );
-        let mut parser: Parser<Lexer<StringInput>> = Parser::new_from(lexer);
+        let mut parser: Parser<Lexer> = Parser::new_from(lexer);
         let mut src_map = vec![];
 
         {

--- a/crates/swc_ecma_codegen/tests/test262.rs
+++ b/crates/swc_ecma_codegen/tests/test262.rs
@@ -9,7 +9,7 @@ use std::{
 use swc_common::comments::SingleThreadedComments;
 use swc_ecma_ast::EsVersion;
 use swc_ecma_codegen::{self, text_writer::WriteJs, Emitter};
-use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, Parser, Syntax};
 use testing::NormalizedOutput;
 
 const IGNORED_PASS_TESTS: &[&str] = &[
@@ -121,7 +121,7 @@ fn do_test(entry: &Path, minify: bool) {
             (&*src).into(),
             Some(&comments),
         );
-        let mut parser: Parser<Lexer<StringInput>> = Parser::new_from(lexer);
+        let mut parser: Parser<Lexer> = Parser::new_from(lexer);
 
         {
             let mut wr = Box::new(swc_ecma_codegen::text_writer::JsWriter::new(

--- a/crates/swc_ecma_dep_graph/src/lib.rs
+++ b/crates/swc_ecma_dep_graph/src/lib.rs
@@ -375,7 +375,7 @@ mod tests {
         comments::{Comment, CommentKind, SingleThreadedComments},
         BytePos, FileName, Span, SyntaxContext,
     };
-    use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
+    use swc_ecma_parser::{lexer::Lexer, Parser, Syntax, TsConfig};
 
     use super::*;
 
@@ -388,7 +388,7 @@ mod tests {
                 cm.new_source_file(FileName::Custom(file_name.to_string()), source.to_string());
 
             let comments = SingleThreadedComments::default();
-            let lexer: Lexer<StringInput<'_>> = Lexer::new(
+            let lexer: Lexer = Lexer::new(
                 Syntax::Typescript(TsConfig {
                     dts: file_name.ends_with(".d.ts"),
                     tsx: file_name.contains("tsx"),

--- a/crates/swc_ecma_parser/src/lexer/jsx.rs
+++ b/crates/swc_ecma_parser/src/lexer/jsx.rs
@@ -3,7 +3,7 @@ use swc_atoms::Atom;
 
 use super::*;
 
-impl<'a, I: Input> Lexer<'a, I> {
+impl<'a> Lexer<'a> {
     pub(super) fn read_jsx_token(&mut self) -> LexResult<Option<Token>> {
         debug_assert!(self.syntax.jsx());
 

--- a/crates/swc_ecma_parser/src/lexer/number.rs
+++ b/crates/swc_ecma_parser/src/lexer/number.rs
@@ -28,7 +28,7 @@ impl<const RADIX: u8> LazyBigInt<RADIX> {
     }
 }
 
-impl<'a, I: Input> Lexer<'a, I> {
+impl<'a> Lexer<'a> {
     /// Reads an integer, octal integer, or floating-point number
     pub(super) fn read_number(
         &mut self,
@@ -531,12 +531,12 @@ impl<'a, I: Input> Lexer<'a, I> {
 mod tests {
     use std::{f64::INFINITY, panic};
 
-    use super::{input::StringInput, *};
+    use super::*;
     use crate::EsConfig;
 
     fn lex<F, Ret>(s: &'static str, f: F) -> Ret
     where
-        F: FnOnce(&mut Lexer<'_, StringInput<'_>>) -> Ret,
+        F: FnOnce(&mut Lexer<'_>) -> Ret,
     {
         crate::with_test_sess(s, |_, input| {
             let mut l = Lexer::new(

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -120,7 +120,7 @@ impl<'a> From<&'a Token> for TokenType {
     }
 }
 
-impl<I: Input> Tokens for Lexer<'_, I> {
+impl Tokens for Lexer<'_> {
     #[inline]
     fn set_ctx(&mut self, ctx: Context) {
         if ctx.module && !self.module_errors.borrow().is_empty() {
@@ -192,7 +192,7 @@ impl<I: Input> Tokens for Lexer<'_, I> {
     }
 }
 
-impl<'a, I: Input> Iterator for Lexer<'a, I> {
+impl<'a> Iterator for Lexer<'a> {
     type Item = TokenAndSpan;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -797,7 +797,7 @@ pub(crate) fn with_lexer<F, Ret>(
     f: F,
 ) -> Result<Ret, ::testing::StdErr>
 where
-    F: FnOnce(&mut Lexer<'_, crate::lexer::input::StringInput<'_>>) -> Result<Ret, ()>,
+    F: FnOnce(&mut Lexer<'_>) -> Result<Ret, ()>,
 {
     crate::with_test_sess(s, |_, fm| {
         let mut l = Lexer::new(syntax, target, fm, None);

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -46,7 +46,7 @@ impl Raw {
 // pub const LINE_SEPARATOR: char = '\u{2028}';
 // pub const PARAGRAPH_SEPARATOR: char = '\u{2029}';
 
-impl<'a, I: Input> Lexer<'a, I> {
+impl<'a> Lexer<'a> {
     pub(super) fn span(&self, start: BytePos) -> Span {
         let end = self.last_pos();
         if cfg!(debug_assertions) && start > end {

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -405,7 +405,7 @@ pub fn with_file_parser<T>(
     target: EsVersion,
     comments: Option<&dyn Comments>,
     recovered_errors: &mut Vec<Error>,
-    op: impl for<'aa> FnOnce(&mut Parser<Lexer<SourceFileInput<'aa>>>) -> PResult<T>,
+    op: impl for<'aa> FnOnce(&mut Parser<Lexer>) -> PResult<T>,
 ) -> PResult<T> {
     let lexer = Lexer::new(syntax, target, SourceFileInput::from(fm), comments);
     let mut p = Parser::new_from(lexer);

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -4,7 +4,7 @@
 use std::ops::{Deref, DerefMut};
 
 use swc_atoms::{Atom, JsWord};
-use swc_common::{collections::AHashMap, comments::Comments, input::Input, BytePos, Span};
+use swc_common::{collections::AHashMap, comments::Comments, input::StringInput, BytePos, Span};
 use swc_ecma_ast::*;
 
 pub use self::input::{Capturing, Tokens, TokensInput};
@@ -58,8 +58,8 @@ struct State {
     trailing_commas: AHashMap<BytePos, Span>,
 }
 
-impl<'a, I: Input> Parser<Lexer<'a, I>> {
-    pub fn new(syntax: Syntax, input: I, comments: Option<&'a dyn Comments>) -> Self {
+impl<'a> Parser<Lexer<'a>> {
+    pub fn new(syntax: Syntax, input: StringInput<'a>, comments: Option<&'a dyn Comments>) -> Self {
         Self::new_from(Lexer::new(syntax, Default::default(), input, comments))
     }
 }
@@ -250,7 +250,7 @@ impl<I: Tokens> Parser<I> {
 #[cfg(test)]
 pub fn test_parser<F, Ret>(s: &'static str, syntax: Syntax, f: F) -> Ret
 where
-    F: FnOnce(&mut Parser<Lexer<crate::StringInput<'_>>>) -> Result<Ret, Error>,
+    F: FnOnce(&mut Parser<Lexer>) -> Result<Ret, Error>,
 {
     crate::with_test_sess(s, |handler, input| {
         let lexer = Lexer::new(syntax, EsVersion::Es2019, input, None);
@@ -277,7 +277,7 @@ where
 #[cfg(test)]
 pub fn test_parser_comment<F, Ret>(c: &dyn Comments, s: &'static str, syntax: Syntax, f: F) -> Ret
 where
-    F: FnOnce(&mut Parser<Lexer<crate::StringInput<'_>>>) -> Result<Ret, Error>,
+    F: FnOnce(&mut Parser<Lexer>) -> Result<Ret, Error>,
 {
     crate::with_test_sess(s, |handler, input| {
         let lexer = Lexer::new(syntax, EsVersion::Es2019, input, Some(&c));
@@ -296,7 +296,7 @@ where
 #[cfg(test)]
 pub fn bench_parser<F>(b: &mut Bencher, s: &'static str, syntax: Syntax, mut f: F)
 where
-    F: for<'a> FnMut(&'a mut Parser<Lexer<'a, crate::StringInput<'_>>>) -> PResult<()>,
+    F: for<'a> FnMut(&'a mut Parser<Lexer<'a>>) -> PResult<()>,
 {
     b.bytes = s.len() as u64;
 

--- a/crates/swc_ecma_parser/tests/errors.rs
+++ b/crates/swc_ecma_parser/tests/errors.rs
@@ -23,7 +23,7 @@ fn with_parser<F, Ret>(
     f: F,
 ) -> Result<Ret, ()>
 where
-    F: FnOnce(&mut Parser<Lexer<StringInput<'_>>>) -> PResult<Ret>,
+    F: FnOnce(&mut Parser<Lexer>) -> PResult<Ret>,
 {
     let fm = cm
         .load_file(file_name)

--- a/crates/swc_ecma_parser/tests/js.rs
+++ b/crates/swc_ecma_parser/tests/js.rs
@@ -8,7 +8,7 @@ use std::{
 
 use swc_common::{comments::SingleThreadedComments, FileName};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, EsConfig, PResult, Parser, StringInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, EsConfig, PResult, Parser, Syntax};
 use swc_ecma_visit::FoldWith;
 use testing::StdErr;
 
@@ -76,7 +76,7 @@ fn with_parser<F, Ret>(
     f: F,
 ) -> Result<Ret, StdErr>
 where
-    F: FnOnce(&mut Parser<Lexer<StringInput<'_>>>, &SingleThreadedComments) -> PResult<Ret>,
+    F: FnOnce(&mut Parser<Lexer>, &SingleThreadedComments) -> PResult<Ret>,
 {
     ::testing::run_test(treat_error_as_bug, |cm, handler| {
         if shift {

--- a/crates/swc_ecma_parser/tests/jsx.rs
+++ b/crates/swc_ecma_parser/tests/jsx.rs
@@ -6,7 +6,7 @@ use std::{
 use pretty_assertions::assert_eq;
 use swc_common::{errors::Handler, sync::Lrc, SourceMap};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, PResult, Parser, StringInput};
+use swc_ecma_parser::{lexer::Lexer, PResult, Parser};
 use swc_ecma_visit::{Fold, FoldWith};
 use testing::{run_test, StdErr};
 
@@ -21,7 +21,7 @@ fn with_parser<F, Ret>(
     f: F,
 ) -> Result<Ret, ()>
 where
-    F: FnOnce(&mut Parser<Lexer<StringInput<'_>>>) -> PResult<Ret>,
+    F: FnOnce(&mut Parser<Lexer>) -> PResult<Ret>,
 {
     let fm = cm
         .load_file(file_name)

--- a/crates/swc_ecma_parser/tests/span.rs
+++ b/crates/swc_ecma_parser/tests/span.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use swc_common::{comments::SingleThreadedComments, errors::Handler, Spanned};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, Syntax, TsConfig};
 use swc_ecma_visit::{Visit, VisitWith};
 
 #[testing::fixture("tests/span/**/*.js")]
@@ -39,7 +39,7 @@ fn span(entry: PathBuf) {
             (&*src).into(),
             Some(&comments),
         );
-        let mut parser: Parser<Lexer<StringInput>> = Parser::new_from(lexer);
+        let mut parser: Parser<Lexer> = Parser::new_from(lexer);
 
         {
             let module = parser

--- a/crates/swc_ecma_parser/tests/test262.rs
+++ b/crates/swc_ecma_parser/tests/test262.rs
@@ -11,7 +11,7 @@ use std::{
 
 use common::Normalizer;
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, PResult, Parser, StringInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, PResult, Parser, Syntax};
 use swc_ecma_visit::FoldWith;
 use test::{
     test_main, DynTestFn, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestName, TestType,
@@ -320,7 +320,7 @@ fn parse_module(file_name: &Path) -> Result<Module, NormalizedOutput> {
 
 fn with_parser<F, Ret>(file_name: &Path, f: F) -> Result<Ret, StdErr>
 where
-    F: FnOnce(&mut Parser<Lexer<StringInput<'_>>>) -> PResult<Ret>,
+    F: FnOnce(&mut Parser<Lexer>) -> PResult<Ret>,
 {
     ::testing::run_test(false, |cm, handler| {
         let fm = cm

--- a/crates/swc_ecma_parser/tests/typescript.rs
+++ b/crates/swc_ecma_parser/tests/typescript.rs
@@ -9,7 +9,7 @@ use std::{
 use pretty_assertions::assert_eq;
 use swc_common::{comments::SingleThreadedComments, FileName};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, PResult, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, PResult, Parser, Syntax, TsConfig};
 use swc_ecma_visit::FoldWith;
 use testing::StdErr;
 
@@ -224,7 +224,7 @@ fn with_parser<F, Ret>(
     f: F,
 ) -> Result<Ret, StdErr>
 where
-    F: FnOnce(&mut Parser<Lexer<StringInput<'_>>>, &SingleThreadedComments) -> PResult<Ret>,
+    F: FnOnce(&mut Parser<Lexer>, &SingleThreadedComments) -> PResult<Ret>,
 {
     let fname = file_name.display().to_string();
 

--- a/crates/swc_ecma_quote_macros/src/ret_type.rs
+++ b/crates/swc_ecma_quote_macros/src/ret_type.rs
@@ -50,7 +50,7 @@ pub(crate) fn parse_input_type(input_str: &str, ty: &Type) -> Result<BoxWrapper,
 
 fn parse<T>(
     input_str: &str,
-    op: &mut dyn FnMut(&mut Parser<Lexer<StringInput>>) -> PResult<T>,
+    op: &mut dyn FnMut(&mut Parser<Lexer>) -> PResult<T>,
 ) -> Result<BoxWrapper, Error>
 where
     T: ToCode,

--- a/crates/swc_ecma_transforms_base/src/tests.rs
+++ b/crates/swc_ecma_transforms_base/src/tests.rs
@@ -49,7 +49,7 @@ impl<'a> Tester<'a> {
         op: F,
     ) -> Result<T, ()>
     where
-        F: FnOnce(&mut Parser<Lexer<StringInput>>) -> Result<T, Error>,
+        F: FnOnce(&mut Parser<Lexer>) -> Result<T, Error>,
     {
         let fm = self
             .cm

--- a/crates/swc_ecma_transforms_base/tests/fixer_test262.rs
+++ b/crates/swc_ecma_transforms_base/tests/fixer_test262.rs
@@ -11,7 +11,7 @@ use std::{
 
 use swc_ecma_ast::*;
 use swc_ecma_codegen::{self, Emitter};
-use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax};
+use swc_ecma_parser::{lexer::Lexer, Parser, Syntax};
 use swc_ecma_transforms_base::fixer::fixer;
 use swc_ecma_utils::DropSpan;
 use swc_ecma_visit::{Fold, FoldWith, VisitMutWith};
@@ -165,7 +165,7 @@ fn identity_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                     let mut wr = Buf(Arc::new(RwLock::new(vec![])));
                     let mut wr2 = Buf(Arc::new(RwLock::new(vec![])));
 
-                    let mut parser: Parser<Lexer<StringInput>> =
+                    let mut parser: Parser<Lexer> =
                         Parser::new(Syntax::default(), (&*src).into(), None);
 
                     {
@@ -197,7 +197,7 @@ fn identity_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
 
                         // Parse source
 
-                        let mut e_parser: Parser<Lexer<StringInput>> =
+                        let mut e_parser: Parser<Lexer> =
                             Parser::new(Syntax::default(), (&*expected).into(), None);
 
                         if module {

--- a/crates/swc_ecma_transforms_testing/src/lib.rs
+++ b/crates/swc_ecma_transforms_testing/src/lib.rs
@@ -113,7 +113,7 @@ impl<'a> Tester<'a> {
         op: F,
     ) -> Result<T, ()>
     where
-        F: FnOnce(&mut Parser<Lexer<StringInput>>) -> Result<T, swc_ecma_parser::error::Error>,
+        F: FnOnce(&mut Parser<Lexer>) -> Result<T, swc_ecma_parser::error::Error>,
     {
         let fm = self
             .cm

--- a/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
@@ -7,7 +7,7 @@ use std::{
 use swc_common::{FileName, Mark};
 use swc_ecma_ast::*;
 use swc_ecma_codegen::{self, Emitter};
-use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, Syntax, TsConfig};
 use swc_ecma_transforms_base::{fixer::fixer, hygiene::hygiene, resolver};
 use swc_ecma_transforms_typescript::{strip, strip::strip_with_config};
 use swc_ecma_visit::{Fold, FoldWith};
@@ -172,7 +172,7 @@ fn identity(entry: PathBuf) {
         let src = cm.load_file(&entry).expect("failed to load file");
         println!("{}", src.src);
 
-        let mut parser: Parser<Lexer<StringInput>> = Parser::new(
+        let mut parser: Parser<Lexer> = Parser::new(
             Syntax::Typescript(TsConfig {
                 tsx: file_name.contains("tsx"),
                 decorators: true,
@@ -232,7 +232,7 @@ fn identity(entry: PathBuf) {
 
         let js_fm = cm.new_source_file(FileName::Anon, js_content.clone());
 
-        let mut parser: Parser<Lexer<StringInput>> = Parser::new(
+        let mut parser: Parser<Lexer> = Parser::new(
             Syntax::Es(EsConfig {
                 jsx: file_name.contains("tsx"),
                 decorators: true,


### PR DESCRIPTION
**Description:**

Currently, it uses `StringInput` as the input type, but I'll refactor it to use `String` or `Vec<u8>` directly to optimize it further.

**Related issue:**

 - https://github.com/swc-project/swc/discussions/6991