### PR TITLE
perf(es/parser): Use SIMD for skipping whitespaces

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3729,6 +3729,7 @@ dependencies = [
  "either",
  "enum_kind",
  "lexical",
+ "memchr",
  "num-bigint",
  "pretty_assertions",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3731,6 +3731,7 @@ dependencies = [
  "lexical",
  "memchr",
  "num-bigint",
+ "once_cell",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -287,6 +287,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17febce684fd15d89027105661fec94afb475cb995fbc59d2865198446ba2eea"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2682,6 +2688,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6518fc26bced4d53678a22d6e423e9d8716377def84545fe328236e3af070e7f"
 
 [[package]]
+name = "safe_arch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3747,6 +3762,7 @@ dependencies = [
  "tracing",
  "typed-arena",
  "walkdir",
+ "wide",
 ]
 
 [[package]]
@@ -5488,6 +5504,16 @@ dependencies = [
  "either",
  "lazy_static",
  "libc",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b689b6c49d6549434bf944e6b0f39238cf63693cb7a147e9d887507fffa3b223"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -29,6 +29,7 @@ enum_kind      = { version = "0.2.1", path = "../enum_kind" }
 lexical        = { version = "6.1.0", features = ["power-of-two"] }
 memchr         = "2"
 num-bigint     = "0.4"
+once_cell      = "1"
 serde          = { version = "1", features = ["derive"] }
 smallvec       = "1.8.0"
 smartstring    = "1"

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -27,6 +27,7 @@ verify     = ["swc_ecma_visit"]
 either         = { version = "1.4" }
 enum_kind      = { version = "0.2.1", path = "../enum_kind" }
 lexical        = { version = "6.1.0", features = ["power-of-two"] }
+memchr         = "2"
 num-bigint     = "0.4"
 serde          = { version = "1", features = ["derive"] }
 smallvec       = "1.8.0"

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -39,6 +39,7 @@ swc_ecma_ast   = { version = "0.99.2", path = "../swc_ecma_ast" }
 swc_ecma_visit = { version = "0.85.2", path = "../swc_ecma_visit", optional = true }
 tracing        = "0.1.32"
 typed-arena    = "2.0.1"
+wide           = "0.7"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "arm")))'.dependencies]
 stacker = "0.1.15"

--- a/crates/swc_ecma_parser/scripts/instrument/bench.sh
+++ b/crates/swc_ecma_parser/scripts/instrument/bench.sh
@@ -4,4 +4,4 @@ set -eu
 export RUST_LOG=off
 export MIMALLOC_SHOW_STATS=1
 
-cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --features swc_common/parking_lot --bench parser -- --bench --color
+cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --features swc_common/parking_lot --bench parser -- --bench --color $@

--- a/crates/swc_ecma_parser/scripts/instrument/bench.sh
+++ b/crates/swc_ecma_parser/scripts/instrument/bench.sh
@@ -3,6 +3,5 @@ set -eu
 
 export RUST_LOG=off
 export MIMALLOC_SHOW_STATS=1
-export RUSTFLAGS="-C target-cpu=native"
 
 cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --features swc_common/parking_lot --bench parser -- --bench --color $@

--- a/crates/swc_ecma_parser/scripts/instrument/bench.sh
+++ b/crates/swc_ecma_parser/scripts/instrument/bench.sh
@@ -3,5 +3,6 @@ set -eu
 
 export RUST_LOG=off
 export MIMALLOC_SHOW_STATS=1
+export RUSTFLAGS="-C target-cpu=native"
 
 cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --features swc_common/parking_lot --bench parser -- --bench --color $@

--- a/crates/swc_ecma_parser/scripts/instrument/bench.sh
+++ b/crates/swc_ecma_parser/scripts/instrument/bench.sh
@@ -3,5 +3,6 @@ set -eu
 
 export RUST_LOG=off
 export MIMALLOC_SHOW_STATS=1
+export RUSTFLAGS='-C target-cpu=native'
 
 cargo profile instruments --release -t time --features tracing/release_max_level_info --features swc_common/concurrent --features swc_common/parking_lot --bench parser -- --bench --color $@

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -29,6 +29,7 @@ mod comments_buffer;
 pub mod input;
 mod jsx;
 mod number;
+mod simd;
 mod state;
 mod table;
 #[cfg(test)]

--- a/crates/swc_ecma_parser/src/lexer/simd.rs
+++ b/crates/swc_ecma_parser/src/lexer/simd.rs
@@ -1,0 +1,86 @@
+//! Lexer methods using portable-SIMD
+//! See:
+//!   * <https://github.com/rust-lang/portable-simd/blob/master/beginners-guide.md>
+//!   * <https://rapidjson.org/md_doc_internals.html#SkipwhitespaceWithSIMD>
+//!   * <https://lemire.me/blog/2017/01/20/how-quickly-can-you-remove-spaces-from-a-string>
+
+use std::simd::{Simd, SimdPartialEq, ToBitMask};
+
+const ELEMENTS: usize = 16;
+type SimdVec = Simd<u8, ELEMENTS>;
+
+#[derive(Debug)]
+pub struct SkipWhitespace {
+    /// Total offset
+    pub offset: usize,
+
+    /// Found multiline comment end '*/'?
+    pub found: bool,
+
+    /// Found newline inside the comment?
+    pub newline: bool,
+
+    lf: SimdVec,
+    cr: SimdVec,
+    space: SimdVec,
+    tab: SimdVec,
+}
+
+impl SkipWhitespace {
+    pub fn new(newline: bool) -> Self {
+        Self {
+            offset: 0,
+            found: false,
+            newline,
+            lf: SimdVec::splat(b'\n'),
+            cr: SimdVec::splat(b'\r'),
+            space: SimdVec::splat(b' '),
+            tab: SimdVec::splat(b'\t'),
+        }
+    }
+
+    pub fn simd(mut self, bytes: &[u8]) -> Self {
+        let (chunks, remainder) = bytes.as_chunks::<ELEMENTS>();
+
+        for chunk in chunks {
+            self.check_chunk(chunk);
+            if self.found {
+                return self;
+            }
+        }
+
+        if !remainder.is_empty() {
+            // Align the last chunk for avoiding the use of a scalar version
+            let mut chunk = [0; ELEMENTS];
+            let len = remainder.len();
+            chunk[..len].copy_from_slice(remainder);
+            self.check_chunk(&chunk);
+        }
+
+        self
+    }
+
+    fn check_chunk(&mut self, chunk: &[u8]) {
+        let s = SimdVec::from_slice(chunk);
+
+        let any_newline = s.simd_eq(self.lf) | s.simd_eq(self.cr);
+        let any_white = s.simd_eq(self.space) | s.simd_eq(self.tab) | any_newline;
+
+        let advance_by = (!any_white.to_bitmask()).trailing_zeros();
+
+        // If the advanced offset contains a newline
+        if !self.newline
+            && advance_by > 0
+            && any_newline.to_bitmask() & (1u16.checked_shl(advance_by).map_or(u16::MAX, |c| c - 1))
+                > 0
+        {
+            self.newline = true;
+        }
+
+        if (advance_by as usize) < ELEMENTS {
+            self.found = true;
+        }
+
+        self.offset += advance_by as usize;
+    }
+}

--- a/crates/swc_ecma_parser/src/lexer/simd.rs
+++ b/crates/swc_ecma_parser/src/lexer/simd.rs
@@ -1,5 +1,3 @@
-#![allow(unused)]
-
 //! Lexer methods using portable-SIMD
 //! See:
 //!   * <https://github.com/rust-lang/portable-simd/blob/master/beginners-guide.md>

--- a/crates/swc_ecma_parser/src/lexer/simd.rs
+++ b/crates/swc_ecma_parser/src/lexer/simd.rs
@@ -1,3 +1,5 @@
+#![allow(unused)]
+
 //! Lexer methods using portable-SIMD
 //! See:
 //!   * <https://github.com/rust-lang/portable-simd/blob/master/beginners-guide.md>

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -48,6 +48,7 @@ impl Raw {
 // pub const PARAGRAPH_SEPARATOR: char = '\u{2029}';
 
 impl<'a> Lexer<'a> {
+    #[inline]
     pub(super) fn span(&self, start: BytePos) -> Span {
         let end = self.last_pos();
         if cfg!(debug_assertions) && start > end {
@@ -65,46 +66,55 @@ impl<'a> Lexer<'a> {
     }
 
     #[inline(always)]
+    #[inline]
     pub(super) fn bump(&mut self) {
         self.input.bump()
     }
 
     #[inline(always)]
+    #[inline]
     pub(super) fn is(&mut self, c: u8) -> bool {
         self.input.is_byte(c)
     }
 
     #[inline(always)]
+    #[inline]
     pub(super) fn is_str(&self, s: &str) -> bool {
         self.input.is_str(s)
     }
 
     #[inline(always)]
+    #[inline]
     pub(super) fn eat(&mut self, c: u8) -> bool {
         self.input.eat_byte(c)
     }
 
     #[inline(always)]
+    #[inline]
     pub(super) fn cur(&mut self) -> Option<char> {
         self.input.cur()
     }
 
     #[inline(always)]
+    #[inline]
     pub(super) fn peek(&mut self) -> Option<char> {
         self.input.peek()
     }
 
     #[inline(always)]
+    #[inline]
     pub(super) fn peek_ahead(&mut self) -> Option<char> {
         self.input.peek_ahead()
     }
 
     #[inline(always)]
+    #[inline]
     pub(super) fn cur_pos(&mut self) -> BytePos {
         self.input.cur_pos()
     }
 
     #[inline(always)]
+    #[inline]
     pub(super) fn last_pos(&self) -> BytePos {
         self.input.last_pos()
     }

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -12,9 +12,7 @@ use swc_common::{
 use swc_ecma_ast::Ident;
 use tracing::warn;
 
-use super::{
-    comments_buffer::BufferedComment, input::Input, simd::SkipWhitespace, Char, LexResult, Lexer,
-};
+use super::{comments_buffer::BufferedComment, input::Input, Char, LexResult, Lexer};
 use crate::{
     error::{Error, SyntaxError},
     lexer::comments_buffer::BufferedCommentKind,
@@ -200,7 +198,21 @@ impl<'a> Lexer<'a> {
             let skip = skip.simd(self.input.as_str().as_bytes());
             dbg!(skip.offset);
             self.input.bump_bytes(skip.offset);
+            // dbg!(skip.offset);
+            for _ in 0..skip.offset {
+                self.input.bump();
+            }
+            self.state.had_line_break |= skip.newline;
+    pub(super) fn skip_space(&mut self, lex_comments: bool) -> LexResult<()> {
+        // let skip = SkipWhitespace::new(false);
+        // let skip = skip.simd(self.input.as_str().as_bytes());
+        // // dbg!(skip.offset);
+        // for _ in 0..skip.offset {
+        //     self.input.bump();
+        // }
+        // self.state.had_line_break |= skip.newline;
 
+        loop {
             let cur_b = self.input.cur_as_ascii();
 
             if matches!(cur_b, Some(b'\n' | b'\r')) {

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -206,15 +206,15 @@ impl<'a> Lexer<'a> {
             }
             self.state.had_line_break |= skip.newline;
     pub(super) fn skip_space(&mut self, lex_comments: bool) -> LexResult<()> {
-        loop {
-            let skip = SkipWhitespace::new(false);
-            let skip = skip.simd(self.input.as_str().as_bytes());
-            // dbg!(skip.offset);
-            for _ in 0..skip.offset {
-                self.input.bump();
-            }
-            self.state.had_line_break |= skip.newline;
+        let skip = SkipWhitespace::new(false);
+        let skip = skip.simd(self.input.as_str().as_bytes());
+        // dbg!(skip.offset);
+        for _ in 0..skip.offset {
+            self.input.bump();
+        }
+        self.state.had_line_break |= skip.newline;
 
+        loop {
             let cur_b = self.input.cur_as_ascii();
 
             if matches!(cur_b, Some(b'\n' | b'\r')) {

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -12,9 +12,7 @@ use swc_common::{
 use swc_ecma_ast::Ident;
 use tracing::warn;
 
-use super::{
-    comments_buffer::BufferedComment, input::Input, simd::SkipWhitespace, Char, LexResult, Lexer,
-};
+use super::{comments_buffer::BufferedComment, input::Input, Char, LexResult, Lexer};
 use crate::{
     error::{Error, SyntaxError},
     lexer::comments_buffer::BufferedCommentKind,
@@ -50,7 +48,6 @@ impl Raw {
 // pub const PARAGRAPH_SEPARATOR: char = '\u{2029}';
 
 impl<'a> Lexer<'a> {
-    #[inline]
     pub(super) fn span(&self, start: BytePos) -> Span {
         let end = self.last_pos();
         if cfg!(debug_assertions) && start > end {
@@ -68,55 +65,46 @@ impl<'a> Lexer<'a> {
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn bump(&mut self) {
         self.input.bump()
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn is(&mut self, c: u8) -> bool {
         self.input.is_byte(c)
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn is_str(&self, s: &str) -> bool {
         self.input.is_str(s)
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn eat(&mut self, c: u8) -> bool {
         self.input.eat_byte(c)
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn cur(&mut self) -> Option<char> {
         self.input.cur()
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn peek(&mut self) -> Option<char> {
         self.input.peek()
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn peek_ahead(&mut self) -> Option<char> {
         self.input.peek_ahead()
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn cur_pos(&mut self) -> BytePos {
         self.input.cur_pos()
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn last_pos(&self) -> BytePos {
         self.input.last_pos()
     }
@@ -209,9 +197,8 @@ impl<'a> Lexer<'a> {
         let skip = SkipWhitespace::new(false);
         let skip = skip.simd(self.input.as_str().as_bytes());
         // dbg!(skip.offset);
-        for _ in 0..skip.offset {
-            self.input.bump();
-        }
+
+        self.input.bump_bytes(skip.offset);
         self.state.had_line_break |= skip.newline;
 
         loop {

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -27,14 +27,12 @@ use crate::{
 pub(super) struct Raw(pub Option<SmartString<LazyCompact>>);
 
 impl Raw {
-    #[inline]
     pub fn push_str(&mut self, s: &str) {
         if let Some(ref mut st) = self.0 {
             st.push_str(s)
         }
     }
 
-    #[inline]
     pub fn push(&mut self, c: char) {
         if let Some(ref mut st) = self.0 {
             st.push(c)
@@ -50,7 +48,6 @@ impl Raw {
 // pub const PARAGRAPH_SEPARATOR: char = '\u{2029}';
 
 impl<'a> Lexer<'a> {
-    #[inline]
     pub(super) fn span(&self, start: BytePos) -> Span {
         let end = self.last_pos();
         if cfg!(debug_assertions) && start > end {
@@ -68,55 +65,46 @@ impl<'a> Lexer<'a> {
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn bump(&mut self) {
         self.input.bump()
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn is(&mut self, c: u8) -> bool {
         self.input.is_byte(c)
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn is_str(&self, s: &str) -> bool {
         self.input.is_str(s)
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn eat(&mut self, c: u8) -> bool {
         self.input.eat_byte(c)
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn cur(&mut self) -> Option<char> {
         self.input.cur()
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn peek(&mut self) -> Option<char> {
         self.input.peek()
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn peek_ahead(&mut self) -> Option<char> {
         self.input.peek_ahead()
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn cur_pos(&mut self) -> BytePos {
         self.input.cur_pos()
     }
 
     #[inline(always)]
-    #[inline]
     pub(super) fn last_pos(&self) -> BytePos {
         self.input.last_pos()
     }
@@ -375,7 +363,7 @@ pub trait CharExt: Copy {
     /// Test whether a given character code starts an identifier.
     ///
     /// https://tc39.github.io/ecma262/#prod-IdentifierStart
-    #[inline]
+
     fn is_ident_start(self) -> bool {
         let c = match self.to_char() {
             Some(c) => c,
@@ -385,7 +373,7 @@ pub trait CharExt: Copy {
     }
 
     /// Test whether a given character is part of an identifier.
-    #[inline]
+
     fn is_ident_part(self) -> bool {
         let c = match self.to_char() {
             Some(c) => c,
@@ -395,7 +383,7 @@ pub trait CharExt: Copy {
     }
 
     /// See https://tc39.github.io/ecma262/#sec-line-terminators
-    #[inline]
+
     fn is_line_terminator(self) -> bool {
         let c = match self.to_char() {
             Some(c) => c,
@@ -405,7 +393,7 @@ pub trait CharExt: Copy {
     }
 
     /// See https://tc39.github.io/ecma262/#sec-literals-string-literals
-    #[inline]
+
     fn is_line_break(self) -> bool {
         let c = match self.to_char() {
             Some(c) => c,
@@ -415,7 +403,7 @@ pub trait CharExt: Copy {
     }
 
     /// See https://tc39.github.io/ecma262/#sec-white-space
-    #[inline]
+
     fn is_ws(self) -> bool {
         let c = match self.to_char() {
             Some(c) => c,

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -12,7 +12,9 @@ use swc_common::{
 use swc_ecma_ast::Ident;
 use tracing::warn;
 
-use super::{comments_buffer::BufferedComment, input::Input, Char, LexResult, Lexer};
+use super::{
+    comments_buffer::BufferedComment, input::Input, simd::SkipWhitespace, Char, LexResult, Lexer,
+};
 use crate::{
     error::{Error, SyntaxError},
     lexer::comments_buffer::BufferedCommentKind,
@@ -204,15 +206,15 @@ impl<'a> Lexer<'a> {
             }
             self.state.had_line_break |= skip.newline;
     pub(super) fn skip_space(&mut self, lex_comments: bool) -> LexResult<()> {
-        // let skip = SkipWhitespace::new(false);
-        // let skip = skip.simd(self.input.as_str().as_bytes());
-        // // dbg!(skip.offset);
-        // for _ in 0..skip.offset {
-        //     self.input.bump();
-        // }
-        // self.state.had_line_break |= skip.newline;
-
         loop {
+            let skip = SkipWhitespace::new(false);
+            let skip = skip.simd(self.input.as_str().as_bytes());
+            // dbg!(skip.offset);
+            for _ in 0..skip.offset {
+                self.input.bump();
+            }
+            self.state.had_line_break |= skip.newline;
+
             let cur_b = self.input.cur_as_ascii();
 
             if matches!(cur_b, Some(b'\n' | b'\r')) {

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -124,6 +124,8 @@
 #![allow(clippy::vec_box)]
 #![allow(clippy::wrong_self_convention)]
 #![allow(clippy::match_like_matches_macro)]
+#![feature(slice_as_chunks)]
+#![feature(portable_simd)]
 
 use error::Error;
 use lexer::Lexer;


### PR DESCRIPTION
**Description:**

I need to clean `StringInput` first.


**Related issue (if exists):**
