### PR TITLE
fix: visitBindingIdentifier should go through type annotations

### DIFF
--- a/node-swc/src/Visitor.ts
+++ b/node-swc/src/Visitor.ts
@@ -171,6 +171,7 @@ import {
   TsConstAssertion,
   Import,
   SuperPropExpression,
+  BindingIdentifier,
 } from "./types";
 
 export class Visitor {
@@ -1730,7 +1731,10 @@ export class Visitor {
     return node;
   }
 
-  visitBindingIdentifier(i: Identifier): Identifier {
+  visitBindingIdentifier(i: BindingIdentifier): BindingIdentifier {
+    if (i.typeAnnotation) {
+      i.typeAnnotation = this.visitTsTypeAnnotation(i.typeAnnotation);
+    }
     return this.visitIdentifier(i);
   }
 


### PR DESCRIPTION
**Description:**

`Visitor#visitBindingIdentifier()` currently doesn't go through type annotations, which makes customized visitor easy to overlook.

**BREAKING CHANGE:**

Changing the function type shouldn't break existing code because BindingIdentifier can be coerced to Identifier implicitly. Adding some specific typescript tests can better justify that, any suggestions about adding those?

**Related issue (if exists):**
n/a