### PR TITLE
fix(es/typescript): Treat export default declarations as declarations

### DIFF
--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -365,8 +365,6 @@ struct DeclInfo {
     /// when setting `has_concrete` for `foo`, it must also be set for
     /// `bar`.
     maybe_dependency: Option<Ident>,
-
-    has_another_decl: bool,
 }
 
 impl<C> Strip<C>
@@ -2087,15 +2085,10 @@ where
                 let entry = self.scope.referenced_idents.get(&local.to_id());
                 !matches!(
                     entry,
-                    Some(
-                        &DeclInfo {
-                            has_concrete: false,
-                            ..
-                        } | &DeclInfo {
-                            has_another_decl: true,
-                            ..
-                        }
-                    )
+                    Some(&DeclInfo {
+                        has_concrete: false,
+                        ..
+                    })
                 )
             }
         });

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -365,6 +365,8 @@ struct DeclInfo {
     /// when setting `has_concrete` for `foo`, it must also be set for
     /// `bar`.
     maybe_dependency: Option<Ident>,
+
+    has_another_decl: bool,
 }
 
 impl<C> Strip<C>
@@ -2068,10 +2070,15 @@ where
                 let entry = self.scope.referenced_idents.get(&local.to_id());
                 !matches!(
                     entry,
-                    Some(&DeclInfo {
-                        has_concrete: false,
-                        ..
-                    })
+                    Some(
+                        &DeclInfo {
+                            has_concrete: false,
+                            ..
+                        } | &DeclInfo {
+                            has_another_decl: true,
+                            ..
+                        }
+                    )
                 )
             }
         });

--- a/crates/swc_ecma_transforms_typescript/src/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip.rs
@@ -1583,6 +1583,23 @@ where
         self.non_top_level = old;
     }
 
+    fn visit_default_decl(&mut self, decl: &DefaultDecl) {
+        decl.visit_children_with(self);
+        match decl {
+            DefaultDecl::Class(d) => {
+                if let Some(id) = &d.ident {
+                    self.store(id.sym.clone(), id.span.ctxt, true);
+                }
+            }
+            DefaultDecl::Fn(d) => {
+                if let Some(id) = &d.ident {
+                    self.store(id.sym.clone(), id.span.ctxt, true);
+                }
+            }
+            _ => {}
+        }
+    }
+
     fn visit_expr(&mut self, n: &Expr) {
         let old = self.in_var_pat;
         self.in_var_pat = false;

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-6953/1/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-6953/1/input.ts
@@ -1,0 +1,15 @@
+import { Scope } from "../../scopes";
+import {
+    AnyNode,
+    TSUnknownKeywordTypeAnnotation,
+    tsUnknownKeywordTypeAnnotation,
+} from "@internal/ast";
+
+export default function TSUnknownKeywordTypeAnnotation(
+    node: AnyNode,
+    scope: Scope,
+) {
+    node = tsUnknownKeywordTypeAnnotation.assert(node);
+    scope;
+    throw new Error("unimplemented");
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-6953/1/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-6953/1/output.js
@@ -1,0 +1,6 @@
+import { tsUnknownKeywordTypeAnnotation } from "@internal/ast";
+export default function TSUnknownKeywordTypeAnnotation(node, scope) {
+    node = tsUnknownKeywordTypeAnnotation.assert(node);
+    scope;
+    throw new Error("unimplemented");
+}


### PR DESCRIPTION
**Description:**

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/6953.