### PR TITLE
Fix doctests for swc_ecma_quote

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3781,6 +3781,7 @@ version = "0.44.4"
 dependencies = [
  "swc_atoms",
  "swc_common",
+ "swc_core",
  "swc_ecma_ast",
  "swc_ecma_quote_macros",
  "testing",

--- a/crates/swc_ecma_quote/Cargo.toml
+++ b/crates/swc_ecma_quote/Cargo.toml
@@ -18,4 +18,5 @@ swc_ecma_ast          = { version = "0.98.2", path = "../swc_ecma_ast" }
 swc_ecma_quote_macros = { version = "0.39.4", path = "../swc_ecma_quote_macros" }
 
 [dev-dependencies]
+swc_core = { path = "../swc_core", features = ["ecma_quote"] }
 testing = { version = "0.31.37", path = "../testing" }

--- a/crates/swc_ecma_quote_macros/src/ctxt.rs
+++ b/crates/swc_ecma_quote_macros/src/ctxt.rs
@@ -105,6 +105,7 @@ pub(super) fn prepare_vars(
                     "Ident" => VarPos::Ident,
                     "Expr" => VarPos::Expr,
                     "Pat" => VarPos::Pat,
+                    "Str" => VarPos::Str,
                     _ => panic!("Invalid type: {}", segment.ident),
                 }
             }


### PR DESCRIPTION
**Description:**

Fix errors from `cargo test -p swc_ecma_quote --doc` (part of `cargo test`).

**Related issue (if exists):**

I suspect this was broken by

- #5713
- #6797

although I wonder why this hasn’t been noticed—am I the first to try running `cargo test`?