### PR TITLE
perf(es/ast): Shrink only large variants

### DIFF
--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -172,8 +172,8 @@ pub enum Expr {
 
 bridge_from!(Expr, Box<CallExpr>, CallExpr);
 bridge_from!(Expr, Box<TaggedTpl>, TaggedTpl);
+bridge_from!(Expr, Box<ArrowExpr>, ArrowExpr);
 bridge_from!(Expr, Box<Tpl>, Tpl);
-bridge_from!(Expr, Box<MemberExpr>, MemberExpr);
 bridge_from!(Expr, Box<OptChainExpr>, OptChainExpr);
 
 impl Expr {

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -80,7 +80,7 @@ pub enum Expr {
     Cond(CondExpr),
 
     #[tag("CallExpression")]
-    Call(CallExpr),
+    Call(Box<CallExpr>),
 
     /// `new Cat()`
     #[tag("NewExpression")]
@@ -102,13 +102,13 @@ pub enum Expr {
     Lit(Lit),
 
     #[tag("TemplateLiteral")]
-    Tpl(Tpl),
+    Tpl(Box<Tpl>),
 
     #[tag("TaggedTemplateExpression")]
     TaggedTpl(Box<TaggedTpl>),
 
     #[tag("ArrowFunctionExpression")]
-    Arrow(ArrowExpr),
+    Arrow(Box<ArrowExpr>),
 
     #[tag("ClassExpression")]
     Class(ClassExpr),
@@ -140,7 +140,7 @@ pub enum Expr {
     JSXElement(Box<JSXElement>),
 
     #[tag("JSXFragment")]
-    JSXFragment(JSXFragment),
+    JSXFragment(Box<JSXFragment>),
 
     #[tag("TsTypeAssertion")]
     TsTypeAssertion(TsTypeAssertion),
@@ -164,7 +164,7 @@ pub enum Expr {
     PrivateName(PrivateName),
 
     #[tag("OptionalChainingExpression")]
-    OptChain(OptChainExpr),
+    OptChain(Box<OptChainExpr>),
 
     #[tag("Invalid")]
     Invalid(Invalid),
@@ -1409,12 +1409,12 @@ impl From<OptChainBase> for Expr {
                 callee,
                 args,
                 type_args,
-            }) => Self::Call(CallExpr {
+            }) => Self::Call(Box::new(CallExpr {
                 callee: Callee::Expr(callee),
                 args,
                 span,
                 type_args,
-            }),
+            })),
             OptChainBase::Member(member) => Self::Member(member),
         }
     }

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -105,7 +105,7 @@ pub enum Expr {
     Tpl(Tpl),
 
     #[tag("TaggedTemplateExpression")]
-    TaggedTpl(TaggedTpl),
+    TaggedTpl(Box<TaggedTpl>),
 
     #[tag("ArrowFunctionExpression")]
     Arrow(ArrowExpr),

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -170,6 +170,12 @@ pub enum Expr {
     Invalid(Invalid),
 }
 
+bridge_from!(Expr, Box<CallExpr>, CallExpr);
+bridge_from!(Expr, Box<TaggedTpl>, TaggedTpl);
+bridge_from!(Expr, Box<Tpl>, Tpl);
+bridge_from!(Expr, Box<MemberExpr>, MemberExpr);
+bridge_from!(Expr, Box<OptChainExpr>, OptChainExpr);
+
 impl Expr {
     /// Normalize parenthesized expressions.
     ///

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -172,6 +172,7 @@ pub enum Expr {
 
 bridge_from!(Expr, Box<CallExpr>, CallExpr);
 bridge_from!(Expr, Box<TaggedTpl>, TaggedTpl);
+bridge_from!(Expr, Box<JSXFragment>, JSXFragment);
 bridge_from!(Expr, Box<ArrowExpr>, ArrowExpr);
 bridge_from!(Expr, Box<Tpl>, Tpl);
 bridge_from!(Expr, Box<OptChainExpr>, OptChainExpr);

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -203,6 +203,12 @@ macro_rules! bridge_from {
             }
         }
     };
+
+    ($dst:ty, $bridge:ty, $($extra:ty),*) => {
+        $(
+            bridge_from!($dst, $bridge, $extra);
+        )*
+    };
 }
 
 macro_rules! bridge_expr_from {

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -89,7 +89,7 @@ pub enum Stmt {
     ForIn(ForInStmt),
 
     #[tag("ForOfStatement")]
-    ForOf(ForOfStmt),
+    ForOf(Box<ForOfStmt>),
 
     #[tag("ClassDeclaration")]
     #[tag("FunctionDeclaration")]

--- a/crates/swc_ecma_codegen/src/util.rs
+++ b/crates/swc_ecma_codegen/src/util.rs
@@ -100,7 +100,7 @@ impl StartsWithAlphaNum for Expr {
             Expr::Bin(BinExpr { ref left, .. }) | Expr::Cond(CondExpr { test: ref left, .. }) => {
                 left.starts_with_alpha_num()
             }
-            Expr::Call(CallExpr { callee: left, .. }) => left.starts_with_alpha_num(),
+            Expr::Call(c) => c.callee.starts_with_alpha_num(),
             Expr::Member(MemberExpr { obj: ref left, .. }) => left.starts_with_alpha_num(),
 
             Expr::Unary(UnaryExpr { op, .. }) => {
@@ -128,7 +128,7 @@ impl StartsWithAlphaNum for Expr {
 
             Expr::Tpl(_) | Expr::Array(_) | Expr::Object(_) | Expr::Paren(_) => false,
 
-            Expr::TaggedTpl(TaggedTpl { ref tag, .. }) => tag.starts_with_alpha_num(),
+            Expr::TaggedTpl(t) => t.tag.starts_with_alpha_num(),
 
             // it's empty
             Expr::JSXEmpty(..) => false,
@@ -144,15 +144,10 @@ impl StartsWithAlphaNum for Expr {
             | Expr::TsInstantiation(TsInstantiation { ref expr, .. })
             | Expr::TsSatisfies(TsSatisfiesExpr { ref expr, .. }) => expr.starts_with_alpha_num(),
 
-            Expr::OptChain(OptChainExpr {
-                base: OptChainBase::Member(MemberExpr { obj: expr, .. }),
-                ..
-            }) => expr.starts_with_alpha_num(),
-
-            Expr::OptChain(OptChainExpr {
-                base: OptChainBase::Call(OptCall { callee, .. }),
-                ..
-            }) => callee.starts_with_alpha_num(),
+            Expr::OptChain(o) => match &o.base {
+                OptChainBase::Member(o) => o.obj.starts_with_alpha_num(),
+                OptChainBase::Call(o) => o.callee.starts_with_alpha_num(),
+            },
 
             Expr::Invalid(..) => true,
         }

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -318,12 +318,12 @@ impl<I: Tokens> Parser<I> {
         }
 
         let args = self.parse_args(false)?;
-        Ok(Box::new(Expr::Call(CallExpr {
+        Ok(Box::new(Expr::Call(Box::new(CallExpr {
             span: span!(self, expr.span_lo()),
             callee: Callee::Expr(expr),
             args,
             type_args: None,
-        })))
+        }))))
     }
 
     fn parse_class_body(&mut self) -> PResult<Vec<ClassMember>> {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1031,19 +1031,19 @@ impl<I: Tokens> Parser<I> {
         &mut self,
         tag: Box<Expr>,
         type_params: Option<Box<TsTypeParamInstantiation>>,
-    ) -> PResult<TaggedTpl> {
+    ) -> PResult<Box<TaggedTpl>> {
         let tagged_tpl_start = tag.span_lo();
         trace_cur!(self, parse_tagged_tpl);
 
         let tpl = self.parse_tpl(true)?;
 
         let span = span!(self, tagged_tpl_start);
-        Ok(TaggedTpl {
+        Ok(Box::new(TaggedTpl {
             span,
             tag,
             type_params,
             tpl,
-        })
+        }))
     }
 
     pub(super) fn parse_tpl(&mut self, is_tagged_tpl: bool) -> PResult<Tpl> {
@@ -1292,11 +1292,11 @@ impl<I: Tokens> Parser<I> {
                             prop: MemberProp::Computed(prop),
                         };
                         let expr = if let Some(question_dot_token) = question_dot_token {
-                            Expr::OptChain(OptChainExpr {
+                            Expr::OptChain(Box::new(OptChainExpr {
                                 span,
                                 question_dot_token,
                                 base: OptChainBase::Member(expr),
-                            })
+                            }))
                         } else {
                             Expr::Member(expr)
                         };
@@ -1335,7 +1335,7 @@ impl<I: Tokens> Parser<I> {
                         syntax_error!(self, self.input.cur_span(), SyntaxError::SuperCallOptional)
                     }
                     Callee::Expr(callee) => Ok((
-                        Box::new(Expr::OptChain(OptChainExpr {
+                        Box::new(Expr::OptChain(Box::new(OptChainExpr {
                             span,
                             question_dot_token,
                             base: OptChainBase::Call(OptCall {
@@ -1344,18 +1344,18 @@ impl<I: Tokens> Parser<I> {
                                 args,
                                 type_args,
                             }),
-                        })),
+                        }))),
                         true,
                     )),
                 }
             } else {
                 Ok((
-                    Expr::Call(CallExpr {
+                    Expr::Call(Box::new(CallExpr {
                         span: span!(self, start),
                         callee: obj,
                         args,
                         type_args: None,
-                    })
+                    }))
                     .into(),
                     true,
                 ))
@@ -1432,11 +1432,11 @@ impl<I: Tokens> Parser<I> {
                     Callee::Expr(obj) => {
                         let expr = MemberExpr { span, obj, prop };
                         let expr = if let Some(question_dot_token) = question_dot_token {
-                            Expr::OptChain(OptChainExpr {
+                            Expr::OptChain(Box::new(OptChainExpr {
                                 span: span!(self, start),
                                 question_dot_token,
                                 base: OptChainBase::Member(expr),
-                            })
+                            }))
                         } else {
                             Expr::Member(expr)
                         };
@@ -1591,13 +1591,13 @@ impl<I: Tokens> Parser<I> {
             };
             let args = self.parse_args(is_import)?;
 
-            let call_expr = Box::new(Expr::Call(CallExpr {
+            let call_expr = Box::new(Expr::Call(Box::new(CallExpr {
                 span: span!(self, start),
 
                 callee,
                 args,
                 type_args,
-            }));
+            })));
 
             return self.parse_subscripts(Callee::Expr(call_expr), false, false);
         }
@@ -2007,12 +2007,12 @@ impl<I: Tokens> Parser<I> {
         import_span: Span,
     ) -> PResult<Box<Expr>> {
         let args = self.parse_args(true)?;
-        let import = Box::new(Expr::Call(CallExpr {
+        let import = Box::new(Expr::Call(Box::new(CallExpr {
             span: span!(self, start),
             callee: Callee::Import(Import { span: import_span }),
             args,
             type_args: Default::default(),
-        }));
+        })));
 
         self.parse_subscripts(Callee::Expr(import), true, false)
     }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -601,7 +601,7 @@ impl<I: Tokens> Parser<I> {
                         )
                     }
                     Expr::Member(MemberExpr { ref obj, .. }) => {
-                        if let Expr::OptChain(obj) = **obj {
+                        if let Expr::OptChain(obj) = &**obj {
                             syntax_error!(
                                 self,
                                 obj.question_dot_token,

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -905,7 +905,7 @@ impl<I: Tokens> Parser<I> {
                     return Ok(errorred_expr);
                 }
             }
-            return Ok(Box::new(Expr::Arrow(arrow_expr)));
+            return Ok(Box::new(Expr::Arrow(Box::new(arrow_expr))));
         } else {
             // If there's no arrow function, we have to check there's no
             // AssignProp in lhs to check against assignment in object literals
@@ -936,7 +936,7 @@ impl<I: Tokens> Parser<I> {
             .collect::<Result<Vec<_>, _>>()?;
         if let Some(async_span) = async_span {
             // It's a call expression
-            return Ok(Box::new(Expr::Call(CallExpr {
+            return Ok(Box::new(Expr::Call(Box::new(CallExpr {
                 span: span!(self, async_span.lo()),
                 callee: Callee::Expr(Box::new(Expr::Ident(Ident::new(
                     "async".into(),
@@ -944,7 +944,7 @@ impl<I: Tokens> Parser<I> {
                 )))),
                 args: expr_or_spreads,
                 type_args: None,
-            })));
+            }))));
         }
 
         // It was not head of arrow function.
@@ -1185,12 +1185,12 @@ impl<I: Tokens> Parser<I> {
                         let args = p.parse_args(is_dynamic_import)?;
 
                         Ok(Some((
-                            Box::new(Expr::Call(CallExpr {
+                            Box::new(Expr::Call(Box::new(CallExpr {
                                 span: span!(p, start),
                                 callee: mut_obj_opt.take().unwrap(),
                                 type_args: Some(type_args),
                                 args,
-                            })),
+                            }))),
                             true,
                         )))
                     } else if is!(p, '`') {

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -312,11 +312,8 @@ impl<I: Tokens> Parser<I> {
 
             if self.input.syntax().typescript() && op == op!("delete") {
                 match arg.unwrap_parens() {
-                    Expr::Member(..)
-                    | Expr::OptChain(OptChainExpr {
-                        base: OptChainBase::Member(..),
-                        ..
-                    }) => {}
+                    Expr::Member(..) => {}
+                    Expr::OptChain(o) if matches!(&o.base, OptChainBase::Member(..)) => {}
                     expr => {
                         self.emit_err(expr.span(), SyntaxError::TS2703);
                     }

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1122,13 +1122,13 @@ impl<'a, I: Tokens> Parser<I> {
                     body,
                 })
             }
-            ForHead::ForOf { left, right } => Stmt::ForOf(ForOfStmt {
+            ForHead::ForOf { left, right } => Stmt::ForOf(Box::new(ForOfStmt {
                 span,
                 await_token,
                 left,
                 right,
                 body,
-            }),
+            })),
         })
     }
 

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2659,7 +2659,7 @@ impl<I: Tokens> Parser<I> {
             let is_generator = false;
             let is_async = true;
             let body = p.parse_fn_body(true, false, true, params.is_simple_parameter_list())?;
-            Ok(Some(ArrowExpr {
+            Ok(Some(Box::new(ArrowExpr {
                 span: span!(p, start),
                 body,
                 is_async,
@@ -2667,7 +2667,7 @@ impl<I: Tokens> Parser<I> {
                 type_params: Some(type_params),
                 params,
                 return_type,
-            }))
+            })))
         })
     }
 

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2620,7 +2620,7 @@ impl<I: Tokens> Parser<I> {
     pub(super) fn try_parse_ts_generic_async_arrow_fn(
         &mut self,
         start: BytePos,
-    ) -> PResult<Option<ArrowExpr>> {
+    ) -> PResult<Option<Box<ArrowExpr>>> {
         if !cfg!(feature = "typescript") {
             return Ok(Default::default());
         }


### PR DESCRIPTION
**Description:**

This PR shrinks large variants of `Expr` and `Stmt` to make them into a cache line.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/7019.
 - Closes https://github.com/swc-project/swc/pull/7034.

---


cc @dsherret thank you for the idea!


This looks better than https://github.com/swc-project/swc/pull/7034
