### PR TITLE
fix: Object spread operator is unnecessarily transformed when used with React

### DIFF
--- a/crates/swc/tests/vercel/loader-only/next-33291/2-classic/output/index.js
+++ b/crates/swc/tests/vercel/loader-only/next-33291/2-classic/output/index.js
@@ -1,3 +1,5 @@
+import _object_spread from "@swc/helpers/src/_object_spread.mjs";
+import _object_spread_props from "@swc/helpers/src/_object_spread_props.mjs";
 import _object_without_properties from "@swc/helpers/src/_object_without_properties.mjs";
 import Head from "next/head";
 import Image from "next/image";
@@ -50,9 +52,9 @@ export default function Home() {
         var href = _param.href, linkProps = _object_without_properties(_param, [
             "href"
         ]);
-        return React.createElement("link", Object.assign({
+        return React.createElement("link", _object_spread_props(_object_spread({
             href: href
-        }, linkProps, {
+        }, linkProps), {
             rel: "icon",
             key: href,
             __source: {

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -847,9 +847,7 @@ where
                     JSXAttrOrSpread::JSXAttr(a) => {
                         props.push(PropOrSpread::Prop(Box::new(self.attr_to_prop(a))))
                     }
-                    JSXAttrOrSpread::SpreadElement(e) => {
-                        props.push(PropOrSpread::Spread(e))
-                    }
+                    JSXAttrOrSpread::SpreadElement(e) => props.push(PropOrSpread::Spread(e)),
                 }
             }
 

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -849,8 +849,6 @@ where
                     }
                     JSXAttrOrSpread::SpreadElement(e) => {
                         props.push(PropOrSpread::Spread(e))
-                        // check!();
-                        // args.push(e.expr.as_arg());
                     }
                 }
             }
@@ -901,7 +899,6 @@ where
                     .into_iter()
                     .map(|a| match a {
                         JSXAttrOrSpread::JSXAttr(a) => a,
-                        // JSXAttrOrSpread::SpreadElement(s) => s,
                         _ => unreachable!(),
                     })
                     .map(|attr| {
@@ -914,53 +911,6 @@ where
                     .collect(),
             }))
         }
-
-        // if is_complex {
-        //     let mut args = vec![];
-        //     let mut cur_obj_props = vec![];
-        //     macro_rules! check {
-        //         () => {{
-        //             if args.is_empty() || !cur_obj_props.is_empty() {
-        //                 args.push(
-        //                     ObjectLit {
-        //                         span: DUMMY_SP,
-        //                         props: mem::take(&mut cur_obj_props),
-        //                     }
-        //                     .as_arg(),
-        //                 )
-        //             }
-        //         }};
-        //     }
-        //     for attr in attrs {
-        //         match attr {
-        //             JSXAttrOrSpread::JSXAttr(a) => {
-        //
-        // cur_obj_props.push(PropOrSpread::Prop(Box::new(self.
-        // attr_to_prop(a))))             }
-        //             JSXAttrOrSpread::SpreadElement(e) => {
-        //                 check!();
-        //                 args.push(e.expr.as_arg());
-        //             }
-        //         }
-        //     }
-        //     check!();
-
-        //     // calls `_extends` or `Object.assign`
-        //     Box::new(Expr::Call(CallExpr {
-        //         span: DUMMY_SP,
-        //         callee: {
-        //             if self.use_builtins {
-        //                 member_expr!(DUMMY_SP, Object.assign).as_callee()
-        //             } else {
-        //                 helper!(extends, "extends")
-        //             }
-        //         },
-        //         args,
-        //         type_args: None,
-        //     }))
-        // } else {
-
-        // }
     }
 
     fn attr_to_prop(&mut self, a: JSXAttr) -> Prop {

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -841,47 +841,59 @@ where
             .any(|a| matches!(*a, JSXAttrOrSpread::SpreadElement(..)));
 
         if is_complex {
-            let mut args = vec![];
-            let mut cur_obj_props = vec![];
-            macro_rules! check {
-                () => {{
-                    if args.is_empty() || !cur_obj_props.is_empty() {
-                        args.push(
-                            ObjectLit {
-                                span: DUMMY_SP,
-                                props: mem::take(&mut cur_obj_props),
-                            }
-                            .as_arg(),
-                        )
-                    }
-                }};
-            }
+            let mut props = vec![];
             for attr in attrs {
                 match attr {
                     JSXAttrOrSpread::JSXAttr(a) => {
-                        cur_obj_props.push(PropOrSpread::Prop(Box::new(self.attr_to_prop(a))))
+                        props.push(PropOrSpread::Prop(Box::new(self.attr_to_prop(a))))
                     }
                     JSXAttrOrSpread::SpreadElement(e) => {
-                        check!();
-                        args.push(e.expr.as_arg());
+                        props.push(PropOrSpread::Spread(e))
+                        // check!();
+                        // args.push(e.expr.as_arg());
                     }
                 }
             }
-            check!();
 
-            // calls `_extends` or `Object.assign`
-            Box::new(Expr::Call(CallExpr {
-                span: DUMMY_SP,
-                callee: {
-                    if self.use_builtins {
-                        member_expr!(DUMMY_SP, Object.assign).as_callee()
-                    } else {
-                        helper!(extends, "extends")
+            if self.use_builtins {
+                Box::new(Expr::Object(ObjectLit {
+                    span: DUMMY_SP,
+                    props,
+                }))
+            } else {
+                let mut args = vec![];
+                let mut cur_obj_props = vec![];
+                macro_rules! check {
+                    () => {{
+                        if args.is_empty() || !cur_obj_props.is_empty() {
+                            args.push(
+                                ObjectLit {
+                                    span: DUMMY_SP,
+                                    props: mem::take(&mut cur_obj_props),
+                                }
+                                .as_arg(),
+                            )
+                        }
+                    }};
+                }
+
+                for prop in props {
+                    match prop {
+                        PropOrSpread::Prop(p) => cur_obj_props.push(PropOrSpread::Prop(p)),
+                        PropOrSpread::Spread(s) => {
+                            check!();
+                            args.push(s.expr.as_arg());
+                        }
                     }
-                },
-                args,
-                type_args: None,
-            }))
+                }
+                check!();
+                Box::new(Expr::Call(CallExpr {
+                    span: DUMMY_SP,
+                    callee: helper!(extends, "extends"),
+                    args,
+                    type_args: None,
+                }))
+            }
         } else {
             Box::new(Expr::Object(ObjectLit {
                 span: DUMMY_SP,
@@ -889,6 +901,7 @@ where
                     .into_iter()
                     .map(|a| match a {
                         JSXAttrOrSpread::JSXAttr(a) => a,
+                        // JSXAttrOrSpread::SpreadElement(s) => s,
                         _ => unreachable!(),
                     })
                     .map(|attr| {
@@ -901,6 +914,53 @@ where
                     .collect(),
             }))
         }
+
+        // if is_complex {
+        //     let mut args = vec![];
+        //     let mut cur_obj_props = vec![];
+        //     macro_rules! check {
+        //         () => {{
+        //             if args.is_empty() || !cur_obj_props.is_empty() {
+        //                 args.push(
+        //                     ObjectLit {
+        //                         span: DUMMY_SP,
+        //                         props: mem::take(&mut cur_obj_props),
+        //                     }
+        //                     .as_arg(),
+        //                 )
+        //             }
+        //         }};
+        //     }
+        //     for attr in attrs {
+        //         match attr {
+        //             JSXAttrOrSpread::JSXAttr(a) => {
+        //
+        // cur_obj_props.push(PropOrSpread::Prop(Box::new(self.
+        // attr_to_prop(a))))             }
+        //             JSXAttrOrSpread::SpreadElement(e) => {
+        //                 check!();
+        //                 args.push(e.expr.as_arg());
+        //             }
+        //         }
+        //     }
+        //     check!();
+
+        //     // calls `_extends` or `Object.assign`
+        //     Box::new(Expr::Call(CallExpr {
+        //         span: DUMMY_SP,
+        //         callee: {
+        //             if self.use_builtins {
+        //                 member_expr!(DUMMY_SP, Object.assign).as_callee()
+        //             } else {
+        //                 helper!(extends, "extends")
+        //             }
+        //         },
+        //         args,
+        //         type_args: None,
+        //     }))
+        // } else {
+
+        // }
     }
 
     fn attr_to_prop(&mut self, a: JSXAttr) -> Prop {

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -19,9 +19,7 @@ use swc_config::merge::Merge;
 use swc_ecma_ast::*;
 use swc_ecma_parser::{parse_file_as_expr, Syntax};
 use swc_ecma_transforms_base::helper;
-use swc_ecma_utils::{
-    drop_span, prepend_stmt, private_ident, quote_ident, undefined, ExprFactory,
-};
+use swc_ecma_utils::{drop_span, prepend_stmt, private_ident, quote_ident, undefined, ExprFactory};
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
 use self::static_check::should_use_create_element;

--- a/crates/swc_ecma_transforms_react/src/jsx/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/tests.rs
@@ -1172,11 +1172,12 @@ test!(
         Mark::fresh(Mark::root())
     ),
     use_builtins_assignment,
-    r#"var div = <Component {...props} foo="bar" />"#,
+    r#"var div = <Component  {...props}  foo="bar"/>"#,
     r#"
-var div = React.createElement(Component, Object.assign({}, props, {
-  foo: "bar"
-}));
+    var div = React.createElement(Component, {
+        ...props,
+        foo: "bar"
+    });
 "#
 );
 


### PR DESCRIPTION
…th React

<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
fix Object spread operator is unnecessarily transformed when used with React
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
https://github.com/swc-project/swc/issues/7044