### PR TITLE
fix(cli): Windows stdin handle waits in an infinite loop

### DIFF
--- a/bindings/swc_cli/src/commands/compile.rs
+++ b/bindings/swc_cli/src/commands/compile.rs
@@ -347,34 +347,7 @@ impl CompileOptions {
     fn collect_inputs(&self) -> anyhow::Result<Vec<InputContext>> {
         let compiler = COMPILER.clone();
 
-        let stdin_input = collect_stdin_input();
-        if stdin_input.is_some() && !self.files.is_empty() {
-            anyhow::bail!("Cannot specify inputs from stdin and files at the same time");
-        }
-
-        if let Some(stdin_input) = stdin_input {
-            let options = self.build_transform_options(&self.filename.as_deref())?;
-
-            let fm = compiler.cm.new_source_file(
-                if options.filename.is_empty() {
-                    FileName::Anon
-                } else {
-                    FileName::Real(options.filename.clone().into())
-                },
-                stdin_input,
-            );
-
-            return Ok(vec![InputContext {
-                options,
-                fm,
-                compiler,
-                file_path: self
-                    .filename
-                    .clone()
-                    .unwrap_or_else(|| PathBuf::from("unknown")),
-                file_extension: self.out_file_extension.clone().into(),
-            }]);
-        } else if !self.files.is_empty() {
+        if !self.files.is_empty() {
             let included_extensions = if let Some(extensions) = &self.extensions {
                 extensions.clone()
             } else {
@@ -405,6 +378,35 @@ impl CompileOptions {
                     })
             })
             .collect::<anyhow::Result<Vec<InputContext>>>();
+        }
+
+        let stdin_input = collect_stdin_input();
+        if stdin_input.is_some() && !self.files.is_empty() {
+            anyhow::bail!("Cannot specify inputs from stdin and files at the same time");
+        }
+
+        if let Some(stdin_input) = stdin_input {
+            let options = self.build_transform_options(&self.filename.as_deref())?;
+
+            let fm = compiler.cm.new_source_file(
+                if options.filename.is_empty() {
+                    FileName::Anon
+                } else {
+                    FileName::Real(options.filename.clone().into())
+                },
+                stdin_input,
+            );
+
+            return Ok(vec![InputContext {
+                options,
+                fm,
+                compiler,
+                file_path: self
+                    .filename
+                    .clone()
+                    .unwrap_or_else(|| PathBuf::from("unknown")),
+                file_extension: self.out_file_extension.clone().into(),
+            }]);
         }
 
         anyhow::bail!("Input is empty");


### PR DESCRIPTION
Prevents the stdin handle from waiting in an infinite loop for the read stream to finish, when running in a process with a detached console on Windows. 

This is a [known issue](https://doc.rust-lang.org/std/io/fn.stdin.html#note-windows-portability-considerations) on Windows. To prevent this from happening, this change simply flips the order how inputs are parsed. Now, the files option is used first before using the stdin input as a fallback.

As a workaround in Bazel rules_swc, we forward the output of the null device to force the read stream to immediately finish on Windows. However, this workaround appears to cause a difference in argv quoting.

https://github.com/aspect-build/rules_swc/blob/e149dd5fc9e512d5b87b3d52a5aa8422c1a1a309/swc/private/swc.bzl#L194

Related 

- https://github.com/aspect-build/rules_swc/pull/187