### PR TITLE
add anther case in ExportNamedDeclaration comment

### DIFF
--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -129,6 +129,7 @@ impl Take for ExportAll {
 
 /// `export { foo } from 'mod'`
 /// `export { foo as bar } from 'mod'`
+/// `export { foo }`
 #[ast_node("ExportNamedDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]


### PR DESCRIPTION
when there is no source

**Description:**

add code example in ExportNamedDeclaration remind there is a case like below
```
export  { foo }
```

