### PR TITLE
Ignore non_snake_case generated test names

### DIFF
--- a/crates/testing_macros/src/fixture.rs
+++ b/crates/testing_macros/src/fixture.rs
@@ -163,6 +163,7 @@ pub fn expand(callee: &Ident, attr: Config) -> Result<Vec<ItemFn>, Error> {
                 #[inline(never)]
                 #[ignore]
                 #[doc(hidden)]
+                #[allow(non_snake_case)]
                 fn test_ident() {
                     eprintln!("Input: {}", path_str);
 


### PR DESCRIPTION
Clippy is complaining about the `test_path__to__fixture` name casing generated by `testing::fixture`.