### PR TITLE
mod(es/base): Move comments following the order of insertion in `fixer`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3844,6 +3844,7 @@ dependencies = [
  "better_scoped_tls",
  "bitflags",
  "criterion",
+ "indexmap",
  "once_cell",
  "phf",
  "rayon",

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -19,6 +19,7 @@ concurrent-renamer = ["rayon"]
 [dependencies]
 better_scoped_tls = { version = "0.1.0", path = "../better_scoped_tls" }
 bitflags          = "1"
+indexmap          = "1.6.1"
 once_cell         = "1.10.0"
 phf               = { version = "0.10", features = ["macros"] }
 rayon             = { version = "1", optional = true }

--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -1,4 +1,7 @@
-use rustc_hash::FxHashMap;
+use std::{hash::BuildHasherDefault, ops::RangeFull};
+
+use indexmap::IndexMap;
+use rustc_hash::FxHasher;
 use swc_atoms::js_word;
 use swc_common::{comments::Comments, util::take::Take, Span, Spanned};
 use swc_ecma_ast::*;
@@ -37,7 +40,7 @@ struct Fixer<'a> {
     ///
     /// Key is span of inner expression, and value is span of the paren
     /// expression.
-    span_map: FxHashMap<Span, Span>,
+    span_map: IndexMap<Span, Span, BuildHasherDefault<FxHasher>>,
 
     in_for_stmt_head: bool,
 
@@ -613,7 +616,7 @@ impl VisitMut for Fixer<'_> {
 
         n.visit_mut_children_with(self);
         if let Some(c) = self.comments {
-            for (to, from) in self.span_map.drain() {
+            for (to, from) in self.span_map.drain(RangeFull).rev() {
                 c.move_leading(from.lo, to.lo);
                 c.move_trailing(from.hi, to.hi);
             }
@@ -673,7 +676,7 @@ impl VisitMut for Fixer<'_> {
 
         n.visit_mut_children_with(self);
         if let Some(c) = self.comments {
-            for (to, from) in self.span_map.drain() {
+            for (to, from) in self.span_map.drain(RangeFull).rev() {
                 c.move_leading(from.lo, to.lo);
                 c.move_trailing(from.hi, to.hi);
             }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Or when encountering nested paren expr with comments, comments would be lost. Found this problem when testing #7096 

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
