### PR TITLE
fix(bindings/node): Fix loading of `spack.config.js`

### DIFF
--- a/node-swc/src/spack.ts
+++ b/node-swc/src/spack.ts
@@ -4,12 +4,15 @@ import { Options } from "./types";
 
 export type BundleInput = BundleOptions | BundleOptions[];
 
+export const isLocalFile = /^\.{0,2}\//; // starts with '/' './' '../'
+
 export async function compileBundleOptions(config: BundleInput | string | undefined): Promise<BundleInput> {
     const f = config === undefined ? '.' : config;
 
     try {
-        const file = typeof f === 'string' ? f : path.resolve('spack.config.js');
-        let configFromFile: BundleInput = require(file);
+        const filepath = typeof f === 'string' ? f : 'spack.config.js';
+        const fileModule = isLocalFile.test(filepath) ? path.resolve(filepath) : filepath;
+        let configFromFile: BundleInput = require(fileModule);
         if ((configFromFile as any).default) {
             configFromFile = (configFromFile as any).default;
         }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
`spack` config file provided from CLI may not be properly imported with `require()`. Without a leading '/', './', or '../' to indicate a file, the module must either be a core module or be loaded from a node_modules folder, but spack.config.js is a local file.

**BREAKING CHANGE:**
N/A

**Related issue (if exists):**

ISSUE #3345