### PR TITLE
Make `swc_css_parser` compile on stable rust

### DIFF
--- a/crates/swc_css_parser/src/lib.rs
+++ b/crates/swc_css_parser/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(box_patterns)]
-#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(unused_must_use)]
 #![deny(clippy::all)]
 #![allow(clippy::needless_return)]

--- a/crates/swc_css_parser/src/lib.rs
+++ b/crates/swc_css_parser/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(box_patterns)]
 #![deny(unused_must_use)]
 #![deny(clippy::all)]
 #![allow(clippy::needless_return)]

--- a/crates/swc_css_parser/src/parser/selectors/mod.rs
+++ b/crates/swc_css_parser/src/parser/selectors/mod.rs
@@ -1297,14 +1297,11 @@ where
                         n_value = if has_minus_sign { ident_value[1..].to_string() } else { ident_value.to_string() };
                     }
                     tok!("dimension") => {
-                        let dimension = match bump!(self) {
-                            Token::Dimension(box DimensionToken { value, raw_value, unit, .. }) => (value, raw_value, unit),
-                            _ => {
-                                unreachable!();
-                            }
-                        };
+                        let Token::Dimension(dimension) = bump!(self) else { unreachable!() };
+                        let DimensionToken { value, raw_value, unit, .. } = *dimension;
+                        // let dimension = (dimension.value, dimension.raw_value, dimension.unit);
 
-                        let n_char = dimension.2.chars().next();
+                        let n_char = unit.chars().next();
 
                         if n_char != Some('n') && n_char != Some('N') {
                             return Err(Error::new(
@@ -1313,9 +1310,9 @@ where
                             ));
                         }
 
-                        a = Some(dimension.0 as i32);
-                        a_raw = Some(dimension.1);
-                        n_value =  (*dimension.2).to_string();
+                        a = Some(value as i32);
+                        a_raw = Some(raw_value);
+                        n_value =  (*unit).to_string();
                     }
                     _ => {
                         return Err(Error::new(span, ErrorKind::InvalidAnPlusBMicrosyntax));

--- a/crates/swc_css_parser/src/parser/syntax/mod.rs
+++ b/crates/swc_css_parser/src/parser/syntax/mod.rs
@@ -661,6 +661,7 @@ where
             };
 
             match preserved_token {
+                // Optimization for step 6
                 Some(TokenAndSpan {
                     token: Token::Delim { value: '!', .. },
                     span,

--- a/crates/swc_css_parser/src/parser/syntax/mod.rs
+++ b/crates/swc_css_parser/src/parser/syntax/mod.rs
@@ -657,7 +657,7 @@ where
             let component_value = self.parse_as::<ComponentValue>()?;
             let preserved_token = match &component_value {
                 ComponentValue::PreservedToken(token_and_span) => {
-                    Some((&token_and_span.token, &token_and_span.span))
+                    Some((&token_and_span.token, token_and_span.span))
                 }
                 _ => None,
             };
@@ -679,7 +679,7 @@ where
                         last_whitespaces = (last_whitespaces.2, 0, 0);
                     }
 
-                    exclamation_point_span = Some(*span);
+                    exclamation_point_span = Some(span);
                 }
                 Some((Token::WhiteSpace { .. }, _)) => {
                     match (&exclamation_point_span, &important_ident) {
@@ -701,10 +701,8 @@ where
                     if exclamation_point_span.is_some()
                         && matches_eq_ignore_ascii_case!(value, js_word!("important")) =>
                 {
-                    important_ident = Some(TokenAndSpan {
-                        token: token.clone(),
-                        span: span.clone(),
-                    });
+                    let token = token.clone();
+                    important_ident = Some(TokenAndSpan { token, span });
                 }
                 _ => {
                     if let Err(err) = self.validate_declaration_value(&component_value) {

--- a/crates/swc_css_parser/src/parser/util.rs
+++ b/crates/swc_css_parser/src/parser/util.rs
@@ -376,74 +376,25 @@ where
         &mut self,
         component_value: &ComponentValue,
     ) -> PResult<()> {
-        match component_value {
-            ComponentValue::PreservedToken(box TokenAndSpan {
-                span,
-                token: Token::BadString { .. },
-            }) => {
-                return Err(Error::new(
-                    *span,
-                    ErrorKind::Unexpected("bad string in declaration value"),
-                ));
-            }
-            ComponentValue::PreservedToken(box TokenAndSpan {
-                span,
-                token: Token::BadUrl { .. },
-            }) => {
-                return Err(Error::new(
-                    *span,
-                    ErrorKind::Unexpected("bad url in declaration value"),
-                ));
-            }
-            ComponentValue::PreservedToken(box TokenAndSpan {
-                span,
-                token: Token::RParen,
-            }) => {
-                return Err(Error::new(
-                    *span,
-                    ErrorKind::Unexpected("')' in declaration value"),
-                ));
-            }
-            ComponentValue::PreservedToken(box TokenAndSpan {
-                span,
-                token: Token::RBracket,
-            }) => {
-                return Err(Error::new(
-                    *span,
-                    ErrorKind::Unexpected("']' in declaration value"),
-                ));
-            }
-            ComponentValue::PreservedToken(box TokenAndSpan {
-                span,
-                token: Token::RBrace,
-            }) => {
-                return Err(Error::new(
-                    *span,
-                    ErrorKind::Unexpected("'}' in declaration value"),
-                ));
-            }
-            ComponentValue::PreservedToken(box TokenAndSpan {
-                span,
-                token: Token::Semi,
-            }) => {
-                return Err(Error::new(
-                    *span,
-                    ErrorKind::Unexpected("';' in declaration value"),
-                ));
-            }
-            ComponentValue::PreservedToken(box TokenAndSpan {
-                span,
-                token: Token::Delim { value: '!' },
-            }) => {
-                return Err(Error::new(
-                    *span,
-                    ErrorKind::Unexpected("'!' in declaration value"),
-                ));
-            }
-            _ => {}
-        }
+        if let ComponentValue::PreservedToken(token_and_span) = component_value {
+            let span = &token_and_span.span;
+            let token = &token_and_span.token;
 
-        Ok(())
+            let result = match token {
+                Token::BadString { .. } => Err("bad string in declaration value"),
+                Token::BadUrl { .. } => Err("bad url in declaration value"),
+                Token::RParen => Err("')' in declaration value"),
+                Token::RBracket => Err("']' in declaration value"),
+                Token::RBrace => Err("'}' in declaration value"),
+                Token::Semi => Err("';' in declaration value"),
+                Token::Delim { value: '!' } => Err("'!' in declaration value"),
+                _ => Ok(()),
+            };
+
+            result.map_err(|err_message| Error::new(*span, ErrorKind::Unexpected(err_message)))
+        } else {
+            Ok(())
+        }
     }
 }
 

--- a/crates/swc_css_parser/src/parser/values_and_units/mod.rs
+++ b/crates/swc_css_parser/src/parser/values_and_units/mod.rs
@@ -2048,31 +2048,23 @@ where
         if !is!(self, Dimension) {
             return Err(Error::new(span, ErrorKind::Expected("dimension token")));
         }
-
-        let Token::Dimension(dimension) = bump!(self) else { unreachable!() };
-        let DimensionToken {
-            value,
-            raw_value,
-            raw_unit,
-            unit,
-            ..
-        } = *dimension;
+        let Token::Dimension(dim) = bump!(self) else { unreachable!() };
 
         // TODO validate
 
-        let unit_len = raw_unit.len() as u32;
+        let unit_len = dim.raw_unit.len() as u32;
 
         Ok(Length {
             span,
             value: Number {
                 span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
-                value,
-                raw: Some(raw_value),
+                value: dim.value,
+                raw: Some(dim.raw_value),
             },
             unit: Ident {
                 span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
-                value: unit.to_ascii_lowercase(),
-                raw: Some(raw_unit),
+                value: dim.unit.to_ascii_lowercase(),
+                raw: Some(dim.raw_unit),
             },
         })
     }
@@ -2088,36 +2080,28 @@ where
         if !is!(self, Dimension) {
             return Err(Error::new(span, ErrorKind::Expected("dimension token")));
         }
+        let Token::Dimension(dim) = bump!(self) else { unreachable!() };
 
-        let Token::Dimension(dimension) = bump!(self) else { unreachable!() };
-        let DimensionToken {
-            value,
-            raw_value,
-            raw_unit,
-            unit,
-            ..
-        } = *dimension;
-
-        if !is_angle_unit(&unit) {
+        if !is_angle_unit(&dim.unit) {
             return Err(Error::new(
                 span,
                 ErrorKind::Expected("'deg', 'grad', 'rad' or 'turn' units"),
             ));
         }
 
-        let unit_len = raw_unit.len() as u32;
+        let unit_len = dim.raw_unit.len() as u32;
 
         Ok(Angle {
             span,
             value: Number {
                 span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
-                value,
-                raw: Some(raw_value),
+                value: dim.value,
+                raw: Some(dim.raw_value),
             },
             unit: Ident {
                 span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
-                value: unit.to_ascii_lowercase(),
-                raw: Some(raw_unit),
+                value: dim.unit.to_ascii_lowercase(),
+                raw: Some(dim.raw_unit),
             },
         })
     }
@@ -2133,33 +2117,25 @@ where
         if !is!(self, Dimension) {
             return Err(Error::new(span, ErrorKind::Expected("dimension token")));
         }
+        let Token::Dimension(dim) = bump!(self) else { unreachable!() };
 
-        let Token::Dimension(dimension) = bump!(self) else { unreachable!() };
-        let DimensionToken {
-            value,
-            raw_value,
-            raw_unit,
-            unit,
-            ..
-        } = *dimension;
-
-        if !is_time_unit(&unit) {
+        if !is_time_unit(&dim.unit) {
             return Err(Error::new(span, ErrorKind::Expected("'s' or 'ms' units")));
         }
 
-        let unit_len = raw_unit.len() as u32;
+        let unit_len = dim.raw_unit.len() as u32;
 
         Ok(Time {
             span,
             value: Number {
                 span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
-                value,
-                raw: Some(raw_value),
+                value: dim.value,
+                raw: Some(dim.raw_value),
             },
             unit: Ident {
                 span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
-                value: unit.to_ascii_lowercase(),
-                raw: Some(raw_unit),
+                value: dim.unit.to_ascii_lowercase(),
+                raw: Some(dim.raw_unit),
             },
         })
     }
@@ -2176,32 +2152,25 @@ where
             return Err(Error::new(span, ErrorKind::Expected("dimension token")));
         }
 
-        let Token::Dimension(dimension) = bump!(self) else { unreachable!() };
-        let DimensionToken {
-            value,
-            raw_value,
-            raw_unit,
-            unit,
-            ..
-        } = *dimension;
+        let Token::Dimension(dim) = bump!(self) else { unreachable!() };
 
-        if !is_frequency_unit(&unit) {
+        if !is_frequency_unit(&dim.unit) {
             return Err(Error::new(span, ErrorKind::Expected("'Hz' or 'kHz' units")));
         }
 
-        let unit_len = raw_unit.len() as u32;
+        let unit_len = dim.raw_unit.len() as u32;
 
         Ok(Frequency {
             span,
             value: Number {
                 span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
-                value,
-                raw: Some(raw_value),
+                value: dim.value,
+                raw: Some(dim.raw_value),
             },
             unit: Ident {
                 span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
-                value: unit.to_ascii_lowercase(),
-                raw: Some(raw_unit),
+                value: dim.unit.to_ascii_lowercase(),
+                raw: Some(dim.raw_unit),
             },
         })
     }
@@ -2217,36 +2186,28 @@ where
         if !is!(self, Dimension) {
             return Err(Error::new(span, ErrorKind::Expected("dimension token")));
         }
+        let Token::Dimension(dim) = bump!(self) else { unreachable!() };
 
-        let Token::Dimension(dimension) = bump!(self) else { unreachable!() };
-        let DimensionToken {
-            value,
-            raw_value,
-            raw_unit,
-            unit,
-            ..
-        } = *dimension;
-
-        if !is_resolution_unit(&unit) {
+        if !is_resolution_unit(&dim.unit) {
             return Err(Error::new(
                 span,
                 ErrorKind::Expected("'dpi', 'dpcm', 'dppx' or 'x' units"),
             ));
         }
 
-        let unit_len = raw_unit.len() as u32;
+        let unit_len = dim.raw_unit.len() as u32;
 
         Ok(Resolution {
             span,
             value: Number {
                 span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
-                value,
-                raw: Some(raw_value),
+                value: dim.value,
+                raw: Some(dim.raw_value),
             },
             unit: Ident {
                 span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
-                value: unit.to_ascii_lowercase(),
-                raw: Some(raw_unit),
+                value: dim.unit.to_ascii_lowercase(),
+                raw: Some(dim.raw_unit),
             },
         })
     }
@@ -2262,33 +2223,25 @@ where
         if !is!(self, Dimension) {
             return Err(Error::new(span, ErrorKind::Expected("dimension token")));
         }
+        let Token::Dimension(dim) = bump!(self) else { unreachable!() };
 
-        let Token::Dimension(dimension) = bump!(self) else { unreachable!() };
-        let DimensionToken {
-            value,
-            raw_value,
-            raw_unit,
-            unit,
-            ..
-        } = *dimension;
-
-        if !is_flex_unit(&unit) {
+        if !is_flex_unit(&dim.unit) {
             return Err(Error::new(span, ErrorKind::Expected("'fr' unit")));
         }
 
-        let unit_len = raw_unit.len() as u32;
+        let unit_len = dim.raw_unit.len() as u32;
 
         Ok(Flex {
             span,
             value: Number {
                 span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
-                value,
-                raw: Some(raw_value),
+                value: dim.value,
+                raw: Some(dim.raw_value),
             },
             unit: Ident {
                 span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
-                value: unit.to_ascii_lowercase(),
-                raw: Some(raw_unit),
+                value: dim.unit.to_ascii_lowercase(),
+                raw: Some(dim.raw_unit),
             },
         })
     }
@@ -2304,29 +2257,21 @@ where
         if !is!(self, Dimension) {
             return Err(Error::new(span, ErrorKind::Expected("dimension token")));
         }
+        let Token::Dimension(dim) = bump!(self) else { unreachable!() };
 
-        let Token::Dimension(dimension) = bump!(self) else { unreachable!() };
-        let DimensionToken {
-            value,
-            unit,
-            raw_value,
-            raw_unit,
-            ..
-        } = *dimension;
-
-        let unit_len = raw_unit.len() as u32;
+        let unit_len = dim.raw_unit.len() as u32;
 
         Ok(UnknownDimension {
             span,
             value: Number {
                 span: Span::new(span.lo, span.hi - BytePos(unit_len), Default::default()),
-                value,
-                raw: Some(raw_value),
+                value: dim.value,
+                raw: Some(dim.raw_value),
             },
             unit: Ident {
                 span: Span::new(span.hi - BytePos(unit_len), span.hi, Default::default()),
-                value: unit.to_lowercase().into(),
-                raw: Some(raw_unit),
+                value: dim.unit.to_lowercase().into(),
+                raw: Some(dim.raw_unit),
             },
         })
     }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR removes usage of `#![feature(box_patterns)]` from `swc_css_parser`. It also removes `#![cfg_attr(docsrs, feature(doc_cfg))]`, but as far as I can see this feature was not actually being used in this crate. This is of course subjective, but IMO these changes actually improve the readability of the affected code. It certainly makes it shorter in most cases.

This allows `swc_css_parser` to be compiled using a stable rust compiler.

**Related issue (if exists):**

https://github.com/swc-project/swc/issues/6630

---

This PR only applies changes to the `swc_css_parser` crate as this the only crate (which does not already compile on stable) that I am personally interested in using, but I would be willing to go through the other swc crates and make similar changes to the other crates if you would be open to accepting such changes. It looks like swc's usage of unstable features are all pretty trivial and could easily be replaced.
