### PR TITLE
fix(es/modules): Hint nodejs for multiple `export *`

### DIFF
--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-7180/input.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-7180/input.js
@@ -1,0 +1,2 @@
+export * from "./fn.js";
+export * from "./fn2.js";

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-7180/module.json
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-7180/module.json
@@ -1,0 +1,3 @@
+{
+    "importInterop": "node"
+}

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-7180/output.amd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-7180/output.amd.js
@@ -1,0 +1,13 @@
+define([
+    "require",
+    "exports",
+    "./fn.js",
+    "./fn2.js"
+], function(require, exports, _fn, _fn2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    _export_star(_fn, exports);
+    _export_star(_fn2, exports);
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-7180/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-7180/output.cjs
@@ -1,0 +1,7 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+0 && __export(require("./fn.js")) && __export(require("./fn2.js"));
+_export_star(require("./fn.js"), exports);
+_export_star(require("./fn2.js"), exports);

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-7180/output.umd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-7180/output.umd.js
@@ -1,0 +1,16 @@
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("./fn.js"), require("./fn2.js"));
+    else if (typeof define === "function" && define.amd) define([
+        "exports",
+        "./fn.js",
+        "./fn2.js"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.input = {}, global.fnJs, global.fn2Js);
+})(this, function(exports, _fn, _fn2) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    _export_star(_fn, exports);
+    _export_star(_fn2, exports);
+});


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`cjs-module-lexer` detection is fragile. Redundant parentheses can cause detection failure.
Therefore, I replaced the sequence expression with a binary expression.

before:

```JavaScript 
0 && (__export(require("foo")), __export(require("bar")));
```

after this pull request

```JavaScript 
0 && __export(require("foo")) &&  __export(require("bar"));
```

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
- fix #7180 