### PR TITLE
feat(plugin_runner): improve cache path

### DIFF
--- a/crates/swc_plugin_runner/src/cache.rs
+++ b/crates/swc_plugin_runner/src/cache.rs
@@ -80,7 +80,11 @@ fn create_filesystem_cache(filesystem_cache_root: &Option<String>) -> Option<Fil
 
     if let Some(root_path) = &mut root_path {
         root_path.push("plugins");
-        root_path.push(MODULE_SERIALIZATION_VERSION);
+        root_path.push(format!(
+            "{}_{}",
+            MODULE_SERIALIZATION_VERSION,
+            option_env!("CARGO_PKG_RUST_VERSION").unwrap_or("default")
+        ));
 
         return FileSystemCache::new(&root_path).ok();
     }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR is minor improvement, non breaking changes to cache path for the plugin. In short, it tries to combine rustc version if available to expand. `option_env!` supposed to embed build time rustc version. It'd be ideal if we could match between plugin's as well, but I doubt if we could before actually load plugin.