### PR TITLE
fix(es/parser): fix infinite loop on jsx in js

### DIFF
--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -845,6 +845,10 @@ impl<'a, I: Tokens> Parser<I> {
 
             while !eat!(self, ';') {
                 bump!(self);
+
+                if let Some(Token::Error(_)) = self.input.cur() {
+                    break;
+                }
             }
         }
 

--- a/crates/swc_ecma_parser/tests/errors/jsx_in_js/input.js
+++ b/crates/swc_ecma_parser/tests/errors/jsx_in_js/input.js
@@ -1,0 +1,5 @@
+const a = (
+  <section>
+    <a href="/foo">foo</a>
+  </section>
+);

--- a/crates/swc_ecma_parser/tests/errors/jsx_in_js/input.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/errors/jsx_in_js/input.js.swc-stderr
@@ -1,0 +1,32 @@
+
+  x Unterminated regexp literal
+   ,-[$DIR/tests/errors/jsx_in_js/input.js:2:1]
+ 2 |   <section>
+ 3 |     <a href="/foo">foo</a>
+   :                        ^^^
+ 4 |   </section>
+   `----
+
+  x Expression expected
+   ,-[$DIR/tests/errors/jsx_in_js/input.js:1:1]
+ 1 | const a = (
+ 2 |   <section>
+   :   ^
+ 3 |     <a href="/foo">foo</a>
+   `----
+
+  x Expression expected
+   ,-[$DIR/tests/errors/jsx_in_js/input.js:2:1]
+ 2 |   <section>
+ 3 |     <a href="/foo">foo</a>
+   :     ^
+ 4 |   </section>
+   `----
+
+  x Expected a semicolon
+   ,-[$DIR/tests/errors/jsx_in_js/input.js:2:1]
+ 2 |   <section>
+ 3 |     <a href="/foo">foo</a>
+   :        ^^^^
+ 4 |   </section>
+   `----


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This fixes an infinite loop in the parser when it encountered an invalid token. This was easiest to reproduce by trying to parse JSX as JS.

I'm new to the swc codebase and I couldn't find places which a have a similar logic. So I opted to break out of the loop instead of modifying the `bump!` macro. Let me know if that is not the proper way to do it. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
no
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

Fixes #7189
