### PR TITLE
feat(plugin/runner): Update `wasmer` to `v3`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -232,7 +232,7 @@ jobs:
             os: ubuntu-latest
             runner: ubuntu-latest
             check: |
-              cargo hack check --feature-powerset --no-dev-deps --exclude-features debug --exclude-features plugin --exclude-features plugin_transform_schema_v1 --exclude-features plugin_transform_schema_vtest --exclude-features plugin-bytecheck
+              cargo hack check --feature-powerset --no-dev-deps --exclude-features debug --exclude-features plugin --exclude-features plugin_transform_schema_v1 --exclude-features plugin_transform_schema_vtest --exclude-features plugin-bytecheck --exclude-features plugin_transform_host_js --exclude-features plugin_transform_host_native
           - crate: swc
             os: windows-latest
             runner: windows-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,6 +68,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "any_ascii"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
+
+[[package]]
 name = "anyhow"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -102,7 +108,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
+
+[[package]]
+name = "atomic-polyfill"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
+dependencies = [
+ "critical-section",
 ]
 
 [[package]]
@@ -125,7 +151,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -142,10 +168,10 @@ checksum = "321629d8ba6513061f26707241fa9bc89524ff1cd7a915a97ef0c62c666ce1b6"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide 0.4.4",
- "object 0.27.1",
+ "object",
  "rustc-demangle",
 ]
 
@@ -168,10 +194,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+
+[[package]]
 name = "better_scoped_tls"
 version = "0.1.0"
 dependencies = [
  "scoped-tls",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -208,7 +249,7 @@ dependencies = [
  "arrayref",
  "arrayvec",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "constant_time_eq",
  "digest",
 ]
@@ -282,7 +323,7 @@ checksum = "13e576ebe98e605500b3c8041bb888e966653577172df6dd97398714eb30b9bf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -293,9 +334,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cast"
@@ -311,12 +355,6 @@ name = "cc"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
-
-[[package]]
-name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
@@ -373,11 +411,11 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd1122e63869df2cb309f449da1ad54a7c6dfeb7c7e6ccd8e0825d9eb93bb72"
 dependencies = [
- "heck",
+ "heck 0.4.0",
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -410,7 +448,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen",
 ]
 
@@ -458,6 +496,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cooked-waker"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147be55d677052dabc6b22252d5dd0fd4c29c8c27aa4f2fbef0f94aa003b406f"
+
+[[package]]
 name = "copyless"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -486,7 +530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab4b310cff9117ec16d05970743c20df3eaddafd461829f2758e76a8de2863a9"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "scopeguard",
  "windows-sys 0.33.0",
@@ -503,62 +547,86 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38faa2a16616c8e78a18d37b4726b98bfd2de192f2fdc8a39ddf568a408a0f75"
+checksum = "2a2ab4512dfd3a6f4be184403a195f76e81a8a9f9e6c898e19d2dc3ce20e0115"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26f192472a3ba23860afd07d2b0217dc628f21fcc72617aa1336d98e1671f33b"
+checksum = "98b022ed2a5913a38839dfbafe6cf135342661293b08049843362df4301261dc"
 dependencies = [
+ "arrayvec",
+ "bumpalo",
  "cranelift-bforest",
  "cranelift-codegen-meta",
  "cranelift-codegen-shared",
+ "cranelift-egraph",
  "cranelift-entity",
+ "cranelift-isle",
  "gimli",
  "log",
- "regalloc",
+ "regalloc2",
  "smallvec",
  "target-lexicon",
 ]
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f32ddb89e9b89d3d9b36a5b7d7ea3261c98235a76ac95ba46826b8ec40b1a24"
+checksum = "639307b45434ad112a98f8300c0f0ab085cbefcd767efcdef9ef19d4c0756e74"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fd0d9f288cc1b42d9333b7a776b17e278fc888c28e6a0f09b5573d45a150bc"
+checksum = "278e52e29c53fcf32431ef08406c295699a70306d05a0715c5b1bf50e33a9ab7"
+
+[[package]]
+name = "cranelift-egraph"
+version = "0.91.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "624b54323b06e675293939311943ba82d323bb340468ce1889be5da7932c8d73"
+dependencies = [
+ "cranelift-entity",
+ "fxhash",
+ "hashbrown 0.12.3",
+ "indexmap",
+ "log",
+ "smallvec",
+]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3bfe172b83167604601faf9dc60453e0d0a93415b57a9c4d1a7ae6849185cf"
+checksum = "9a59bcbca89c3f1b70b93ab3cbba5e5e0cbf3e63dadb23c7525cb142e21a9d4c"
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.82.3"
+version = "0.91.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a006e3e32d80ce0e4ba7f1f9ddf66066d052a8c884a110b91d05404d6ce26dce"
+checksum = "0d70abacb8cfef3dc8ff7e8836e9c1d70f7967dfdac824a4cd5e30223415aca6"
 dependencies = [
  "cranelift-codegen",
  "log",
  "smallvec",
  "target-lexicon",
 ]
+
+[[package]]
+name = "cranelift-isle"
+version = "0.91.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "393bc73c451830ff8dbb3a07f61843d6cb41a084f9996319917c0b291ed785bb"
 
 [[package]]
 name = "crc"
@@ -581,7 +649,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -621,12 +689,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6548a0ad5d2549e111e1f6a11a6c2e2d00ce6a3dafe22948d67c2b443f775e52"
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2dd04ddaf88237dc3b8d8f9a3c1004b506b54b3313403944054d23c0870c521"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -636,7 +710,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -648,7 +722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "01a9af1f4c2ef74bb8aa1f7e19706bc72d03598c8a570bb5de72243c7a9d9d5a"
 dependencies = [
  "autocfg",
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "memoffset 0.7.1",
  "scopeguard",
@@ -660,7 +734,7 @@ version = "0.8.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb766fa798726286dbbb842f174001dab8abc7b627a1dd86e0b7222a95d929f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -708,7 +782,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc0a48a9b826acdf4028595adc9db92caea352f7af011a3034acd172a52a0aa"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -741,7 +815,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -758,7 +832,7 @@ checksum = "a08a6e2fcc370a089ad3b4aaf54db3b1b4cee38ddabce5896b33eb693275f470"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -781,7 +855,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -792,7 +866,7 @@ checksum = "ddfc69c5bfcbd2fc09a0f38451d2daf0e372e367986a83906d1b0dbc88134fb5"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -801,7 +875,7 @@ version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0834a35a3fce649144119e18da2a4d8ed12ef3862f47183fd46f625d072d96c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "num_cpus",
  "parking_lot",
 ]
@@ -835,6 +909,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -842,7 +927,7 @@ checksum = "b24629208e87a2d8b396ff43b15c4afb0a69cea3fbbaa9ed9b92b7c02f0aed73"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -880,6 +965,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -903,7 +1008,7 @@ version = "0.8.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9852635589dc9f9ea1b6fe9f05b50ef208c85c834a562f0c6abb1c475736ec2b"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -932,7 +1037,7 @@ checksum = "c134c37760b27a871ba422106eedbb8247da973a09e82558bf26d619c882b159"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -943,7 +1048,7 @@ checksum = "b13f1e69590421890f90448c3cd5f554746a31adc6dc0dac406ec6901db8dc25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -964,7 +1069,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1001,6 +1106,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a407cfaa3385c4ae6b23e84623d48c2798d06e3e6a1878f7f59f17b3f86499"
 dependencies = [
  "instant",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cbc844cecaee9d4443931972e1289c8ff485cb4cc2767cb03ca139ed6885153"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1056,7 +1173,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1066,46 +1183,87 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
-name = "futures-channel"
-version = "0.3.25"
+name = "futures"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ba265a92256105f45b719605a571ffe2d1f0fea3807304b522c1d778f79eed"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04909a7a7e4633ae6c4a9ab280aeb86da1236243a77b694a49eacd659a4bd3ac"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00f5fb52a06bdcadeb54e8d3671f8888a39697dcb0b81b23b55174030427f4eb"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.13",
+]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39c15cf1a4aa79df40f1bb462fb39676d0ad9e366c2a33b590d7c66f4f81fcf9"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
 
 [[package]]
 name = "futures-task"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffb393ac5d9a6eaa9d3fdf37ae2776656b706e200c8e16b1bdb227f5198e6ea"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
 
 [[package]]
 name = "futures-util"
-version = "0.3.25"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "197676987abd2f9cadff84926f410af1c183608d36641465df73ae8211dc65d6"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -1114,12 +1272,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "generational-arena"
-version = "0.2.8"
+name = "fxhash"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d3b771574f62d0548cee0ad9057857e9fc25d7a3335f140c84f6acd0bf601"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
- "cfg-if 0.1.10",
+ "byteorder",
 ]
 
 [[package]]
@@ -1138,7 +1296,7 @@ version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "libc",
  "wasi",
@@ -1154,7 +1312,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1200,6 +1358,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1210,11 +1377,33 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.0"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c21d40587b92fa6a6c6e3c1bdbf87d75511db5672f9c93175574b3a00df1758"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db04bc24a18b9ea980628ecf00e6c0264f3c1426dac36c00cb49b6fbad8b0743"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version 0.4.0",
+ "spin 0.9.8",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "heck"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -1306,6 +1495,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1788965e61b367cd03a62950836d5cd41560c3577d90e40e0819373194d1661c"
+dependencies = [
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1343,6 +1545,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
 name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1371,7 +1579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
 dependencies = [
  "autocfg",
- "hashbrown 0.12.0",
+ "hashbrown 0.12.3",
  "rayon",
  "serde",
 ]
@@ -1382,7 +1590,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1411,7 +1619,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1530,6 +1738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lexical-sort"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c09e4591611e231daf4d4c685a66cb0410cc1e502027a20ae55f2bb9e997207a"
+dependencies = [
+ "any_ascii",
+]
+
+[[package]]
 name = "lexical-util"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1571,7 +1788,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efbc0f03f9a775e9f6aed295c6a1ba2253c5757a9e03d55c6caa46a681abcddd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "winapi",
 ]
 
@@ -1582,6 +1799,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9272ab7b96c9046fbc5bc56c06c117cb639fe2d509df0c421cad82d2915cf369"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linked_hash_set"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47186c6da4d81ca383c7c47c1bfc80f4b95f4720514d860a5407aaf4233f9588"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -1605,28 +1837,7 @@ version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
- "cfg-if 1.0.0",
-]
-
-[[package]]
-name = "loupe"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b6a72dfa44fe15b5e76b94307eeb2ff995a8c5b283b55008940c02e0c5b634d"
-dependencies = [
- "indexmap",
- "loupe-derive",
- "rustversion",
-]
-
-[[package]]
-name = "loupe-derive"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fbfc88337168279f2e9ae06e157cfed4efd3316e14dc96ed074d4f2e6c5952"
-dependencies = [
- "quote",
- "syn",
+ "cfg-if",
 ]
 
 [[package]]
@@ -1664,9 +1875,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "memmap2"
-version = "0.5.0"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4647a11b578fead29cdbb34d4adef8dd3dc35b876c9c6d5240d83f205abfe96e"
+checksum = "83faa42c0a078c393f6b29d5db232d8be22776a891f8f56e5284faee4a20b327"
 dependencies = [
  "libc",
 ]
@@ -1717,7 +1928,7 @@ checksum = "c547b28d4f52cae473fb5a30ca087ed7fc5d1bac150bd6dfd9ec0a4562303aa3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1814,7 +2025,7 @@ dependencies = [
  "napi-derive-backend",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1828,7 +2039,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1909,7 +2120,7 @@ checksum = "c03e3201148714c580c5cf1ef68b1ed4039203068193197834a43503164b8237"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1919,10 +2130,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a870300c30d4224cb16022a4660fd8084d6cb4d29618563c3016b50cc757d1e7"
 dependencies = [
  "ntest_proc_macro_helper",
- "proc-macro-crate",
+ "proc-macro-crate 0.1.5",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -1967,6 +2178,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+dependencies = [
+ "proc-macro-crate 1.3.1",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,18 +2213,6 @@ version = "0.27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67ac1d3f9a1d3616fd9a60c8d74296f22406a238b6a72f5cc1e6f314df4ffbf9"
 dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "object"
-version = "0.28.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
-dependencies = [
- "crc32fast",
- "hashbrown 0.11.2",
- "indexmap",
  "memchr",
 ]
 
@@ -2015,7 +2235,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
- "cfg-if 1.0.0",
+ "cfg-if",
  "foreign-types",
  "libc",
  "once_cell",
@@ -2031,7 +2251,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2093,7 +2313,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
@@ -2160,7 +2380,7 @@ dependencies = [
  "proc-macro-hack",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2170,6 +2390,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
 dependencies = [
  "siphasher",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2226,7 +2466,7 @@ checksum = "3894e5d549cccbe44afecf72922f277f603cd4bb0219c8342631ef18fffbe004"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2279,6 +2519,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2287,7 +2537,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "version_check",
 ]
 
@@ -2310,9 +2560,9 @@ checksum = "dc375e1527247fe1a97d8b7156678dfe7c1af2fc075c9a4db3690ecd2a148068"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
 ]
@@ -2343,14 +2593,25 @@ checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffade02495f22453cd593159ea2f59827aae7f53fa8323f756799b670881dcf8"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
 dependencies = [
  "proc-macro2",
 ]
@@ -2423,13 +2684,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "regalloc"
-version = "0.0.34"
+name = "redox_users"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62446b1d3ebf980bdc68837700af1d77b37bc430e524bf95319c6eada2a4cc02"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
+name = "regalloc2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300d4fbfb40c1c66a78ba3ddd41c1110247cf52f97b87d0f2fc9209bd49b030c"
+dependencies = [
+ "fxhash",
  "log",
- "rustc-hash",
+ "slice-group-by",
  "smallvec",
 ]
 
@@ -2510,6 +2783,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "ipnet",
  "js-sys",
@@ -2519,17 +2793,36 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -2539,7 +2832,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c30f1d45d9aa61cbc8cd1eb87705470892289bb2d01943e7803b873a57404dc3"
 dependencies = [
  "bytecheck",
- "hashbrown 0.12.0",
+ "hashbrown 0.12.3",
+ "indexmap",
  "ptr_meta",
  "rend 0.4.0",
  "rkyv_derive",
@@ -2553,7 +2847,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddf47bca568385a5121422d265f8ea7ca2c8816141e29fd415498eabb150f14e"
 dependencies = [
  "bytecheck",
- "hashbrown 0.12.0",
+ "hashbrown 0.12.3",
  "ptr_meta",
  "rend 0.3.6",
  "rkyv_derive_test",
@@ -2568,7 +2862,7 @@ checksum = "ff26ed6c7c4dfc2aa9480b86a60e3c7233543a270a680e10758a507c5a4ce476"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2579,7 +2873,7 @@ checksum = "e573710463b17b3cc3c5de19cc12118a788392b056ff097c6ee700920a4545ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2624,6 +2918,27 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.20.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fff78fc74d175294f4e83b28343315ffcfb114b156f0185e9741cb5570f50e2f"
+dependencies = [
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
+dependencies = [
+ "base64 0.21.0",
 ]
 
 [[package]]
@@ -2680,6 +2995,16 @@ name = "scratch"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8132065adcfd6e02db789d9285a0deb2f3fcb04002865ab67d5fb103533898"
+
+[[package]]
+name = "sct"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "seahash"
@@ -2755,15 +3080,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfc50e8183eeeb6178dcb167ae34a8051d63535023ae38b5d8d12beae193d37b"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "serde_cbor"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2781,7 +3097,7 @@ checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2808,12 +3124,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
+dependencies = [
+ "indexmap",
+ "ryu",
+ "serde",
+ "yaml-rust",
+]
+
+[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "028f48d513f9678cda28f6e4064755b3fbb2af6acd672f2c209b62323f7aea0f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -2830,7 +3158,18 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+dependencies = [
+ "cfg-if",
  "cpufeatures",
  "digest",
 ]
@@ -2842,6 +3181,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900fba806f70c630b0a382d0d825e17a0f19fcd059a2ade1ff237bcddf446b31"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2858,6 +3215,12 @@ checksum = "4614a76b2a8be0058caa9dbbaf66d988527d86d003c11a94fbd335d7661edcef"
 dependencies = [
  "autocfg",
 ]
+
+[[package]]
+name = "slice-group-by"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03b634d87b960ab1a38c4fe143b508576f075e7c978bfad18217645ebfdfa2ec"
 
 [[package]]
 name = "smallvec"
@@ -2909,6 +3272,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "st-map"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2931,7 +3309,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
 dependencies = [
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "psm",
  "winapi",
@@ -2955,7 +3333,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -2988,7 +3366,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_derive",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3004,7 +3382,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "sha1 0.6.0",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3048,7 +3426,7 @@ dependencies = [
  "quote",
  "serde",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3230,7 +3608,7 @@ dependencies = [
  "atty",
  "better_scoped_tls",
  "bytecheck",
- "cfg-if 1.0.0",
+ "cfg-if",
  "criterion",
  "either",
  "from_variant",
@@ -3274,7 +3652,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3326,8 +3704,6 @@ dependencies = [
  "swc_trace_macro",
  "testing",
  "vergen",
- "wasmer",
- "wasmer-wasi",
 ]
 
 [[package]]
@@ -3384,7 +3760,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3569,7 +3945,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3761,7 +4137,7 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -3875,7 +4251,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4109,7 +4485,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4231,7 +4607,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4309,7 +4685,7 @@ dependencies = [
  "pmutil",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4384,7 +4760,7 @@ version = "0.9.11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4426,8 +4802,7 @@ dependencies = [
  "wasmer",
  "wasmer-cache",
  "wasmer-compiler-cranelift",
- "wasmer-engine-universal",
- "wasmer-wasi",
+ "wasmer-wasix",
 ]
 
 [[package]]
@@ -4448,7 +4823,7 @@ version = "0.1.2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4468,7 +4843,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4516,7 +4891,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "swc_macros_common",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4555,10 +4930,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-lexicon"
-version = "0.12.2"
+name = "syn"
+version = "2.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9bffcddbc2458fa3e6058414599e3c838a022abae82e5c67b4f7f80298d5bff"
+checksum = "4c9da457c5285ac1f936ebd076af6dac17a61cfe7826f2076b4d015cf47bc8ec"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae9980cab1db3fceee2f6c6f643d5d8de2997c58ee8d25fb0cc8a9e9e7348e5"
 
 [[package]]
 name = "tempfile"
@@ -4566,11 +4952,21 @@ version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "fastrand",
  "redox_syscall",
  "rustix",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "term_size"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4129646ca0ed8f45d09b929036bafad5377103edd06e50bf574b353d2b08d9"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4590,6 +4986,15 @@ checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4621,7 +5026,7 @@ dependencies = [
  "quote",
  "regex",
  "relative-path",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4646,22 +5051,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.32"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.32"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.13",
 ]
 
 [[package]]
@@ -4750,7 +5155,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "standback",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4800,8 +5205,21 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.42.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4812,6 +5230,17 @@ checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
 dependencies = [
  "native-tls",
  "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43ee83903113e03984cb9e5cebe6c04a5116269e900e3ddba8f068a62adda59"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
 ]
 
 [[package]]
@@ -4838,6 +5267,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ab8ed2edee10b50132aed5f331333428b011c99402b5a534154ed15746f9622"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "239410c8609e8125456927e6707163a3b1fdb40561e4b803bc041f466ccfdc13"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4849,7 +5295,7 @@ version = "0.1.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "log",
  "pin-project-lite",
  "tracing-attributes",
@@ -4864,7 +5310,7 @@ checksum = "4017f8f45139870ca7e672686113917c71c7a6e02d4924eda67186083c03081a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -4935,6 +5381,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf81ac59edc17cc8697ff311e8f5ef2d99fcbd9817b34cec66f90b6c3dfd987"
 
 [[package]]
+name = "unicase"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50f37be617794602aabbeee0be4f259dc1778fabe05e2d67ee8f79326d5cb4f6"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4983,6 +5438,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
+name = "unicode-xid"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f962df74c8c05a667b5ee8bcf162993134c104e96440b663c8daa176dc772d8c"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
 name = "url"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4991,7 +5458,14 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8db7427f936968176eaa7cdf81b7f98b980b18495ec28f1b5791ac3bfe3eea9"
 
 [[package]]
 name = "valuable"
@@ -5012,7 +5486,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffa80ed519f45995741e70664d4abcf147d2a47b8c7ea0a4aa495548ef9474f"
 dependencies = [
  "anyhow",
- "cfg-if 1.0.0",
+ "cfg-if",
  "enum-iterator 1.1.3",
  "getset",
  "rustversion",
@@ -5025,6 +5499,154 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virtual-fs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66ecfcab24d1c4722afb076d89f21a49299fc9b34e36726114413012b48f795c"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "bytes",
+ "derivative",
+ "filetime",
+ "fs_extra",
+ "getrandom",
+ "indexmap",
+ "lazy_static",
+ "libc",
+ "pin-project-lite",
+ "slab",
+ "thiserror",
+ "tokio",
+ "tracing",
+ "webc",
+]
+
+[[package]]
+name = "virtual-net"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e043eb813b35633445d602acf13df921a8a1ac8833818fb8f891e2f6223fedd7"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "libc",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "wai-bindgen-gen-core"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa3dc41b510811122b3088197234c27e08fcad63ef936306dd8e11e2803876c"
+dependencies = [
+ "anyhow",
+ "wai-parser",
+]
+
+[[package]]
+name = "wai-bindgen-gen-rust"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bc05e8380515c4337c40ef03b2ff233e391315b178a320de8640703d522efe"
+dependencies = [
+ "heck 0.3.3",
+ "wai-bindgen-gen-core",
+]
+
+[[package]]
+name = "wai-bindgen-gen-rust-wasm"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f35ce5e74086fac87f3a7bd50f643f00fe3559adb75c88521ecaa01c8a6199"
+dependencies = [
+ "heck 0.3.3",
+ "wai-bindgen-gen-core",
+ "wai-bindgen-gen-rust",
+]
+
+[[package]]
+name = "wai-bindgen-gen-wasmer"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f61484185d8c520a86d5a7f7f8265f446617c2f9774b2e20a52de19b6e53432"
+dependencies = [
+ "heck 0.3.3",
+ "wai-bindgen-gen-core",
+ "wai-bindgen-gen-rust",
+]
+
+[[package]]
+name = "wai-bindgen-rust"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e5601c6f448c063e83a5e931b8fefcdf7e01ada424ad42372c948d2e3d67741"
+dependencies = [
+ "bitflags",
+ "wai-bindgen-rust-impl",
+]
+
+[[package]]
+name = "wai-bindgen-rust-impl"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeb5c1170246de8425a3e123e7ef260dc05ba2b522a1d369fe2315376efea4"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.107",
+ "wai-bindgen-gen-core",
+ "wai-bindgen-gen-rust-wasm",
+]
+
+[[package]]
+name = "wai-bindgen-wasmer"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e20321fa5e7f7affba9ba727dbb3f4e0168656af4f1aa78306203ad2d9a0bba7"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "once_cell",
+ "thiserror",
+ "tracing",
+ "wai-bindgen-wasmer-impl",
+ "wasmer",
+]
+
+[[package]]
+name = "wai-bindgen-wasmer-impl"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b3488ed88d4dd0e3bf85bad4e27dac6cb31aae5d122a5dda2424803c8dc863a"
+dependencies = [
+ "proc-macro2",
+ "syn 1.0.107",
+ "wai-bindgen-gen-core",
+ "wai-bindgen-gen-wasmer",
+]
+
+[[package]]
+name = "wai-parser"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bd0acb6d70885ea0c343749019ba74f015f64a9d30542e66db69b49b7e28186"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "pulldown-cmark",
+ "unicode-normalization",
+ "unicode-xid",
+]
+
+[[package]]
+name = "waker-fn"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -5059,7 +5681,7 @@ version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 
@@ -5074,8 +5696,31 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-downcast"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dac026d43bcca6e7ce1c0956ba68f59edf6403e8e930a5d891be72c31a44340"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "wasm-bindgen-downcast-macros",
+]
+
+[[package]]
+name = "wasm-bindgen-downcast-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5020cfa87c7cecefef118055d44e3c1fc122c7ec25701d528ee458a0b45f38f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.107",
 ]
 
 [[package]]
@@ -5084,7 +5729,7 @@ version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -5108,7 +5753,7 @@ checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.107",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -5121,25 +5766,25 @@ checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
 
 [[package]]
 name = "wasmer"
-version = "2.3.0"
+version = "3.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8d8361c9d006ea3d7797de7bd6b1492ffd0f91a22430cfda6c1658ad57bedf"
+checksum = "ad0f668c7708f75c74f0d97bcc7269c0bd523d3cf5a4d3db66365eb8092e2e1f"
 dependencies = [
- "cfg-if 1.0.0",
+ "bytes",
+ "cfg-if",
+ "derivative",
  "indexmap",
  "js-sys",
- "loupe",
  "more-asserts",
+ "serde",
+ "serde-wasm-bindgen",
  "target-lexicon",
  "thiserror",
  "wasm-bindgen",
- "wasmer-artifact",
+ "wasm-bindgen-downcast",
  "wasmer-compiler",
  "wasmer-compiler-cranelift",
  "wasmer-derive",
- "wasmer-engine",
- "wasmer-engine-dylib",
- "wasmer-engine-universal",
  "wasmer-types",
  "wasmer-vm",
  "wasmparser",
@@ -5148,23 +5793,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmer-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aaf9428c29c1d8ad2ac0e45889ba8a568a835e33fd058964e5e500f2f7ce325"
-dependencies = [
- "enumset",
- "loupe",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
 name = "wasmer-cache"
-version = "2.3.0"
+version = "3.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0def391ee1631deac5ac1e6ce919c07a5ccb936ad0fd44708cdc2365c49561a4"
+checksum = "35fb2759671bcaedbd51754f75709903ed5f73e68300cab329b2f064b98a5f2f"
 dependencies = [
  "blake3",
  "hex",
@@ -5174,33 +5806,38 @@ dependencies = [
 
 [[package]]
 name = "wasmer-compiler"
-version = "2.3.0"
+version = "3.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67a6cd866aed456656db2cfea96c18baabbd33f676578482b85c51e1ee19d2c"
+checksum = "9d880f91d020ba406020e150a70c68413bd970867f1c47cb1ab407e8cba688c9"
 dependencies = [
+ "backtrace",
+ "cfg-if",
+ "enum-iterator 0.7.0",
  "enumset",
- "loupe",
- "rkyv",
- "serde",
- "serde_bytes",
+ "lazy_static",
+ "leb128",
+ "memmap2",
+ "more-asserts",
+ "region",
+ "rustc-demangle",
  "smallvec",
- "target-lexicon",
  "thiserror",
  "wasmer-types",
+ "wasmer-vm",
  "wasmparser",
+ "winapi",
 ]
 
 [[package]]
 name = "wasmer-compiler-cranelift"
-version = "2.3.0"
+version = "3.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48be2f9f6495f08649e4f8b946a2cbbe119faf5a654aa1457f9504a99d23dae0"
+checksum = "7b051cdd601f46de3ba76b44bb5ff850f47df3040d56e2dc8e21a95480a47eed"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
  "cranelift-frontend",
  "gimli",
- "loupe",
  "more-asserts",
  "rayon",
  "smallvec",
@@ -5212,204 +5849,139 @@ dependencies = [
 
 [[package]]
 name = "wasmer-derive"
-version = "2.3.0"
+version = "3.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e50405cc2a2f74ff574584710a5f2c1d5c93744acce2ca0866084739284b51"
+checksum = "23df3f21f629e45da8b9fe1d4266ba3e4af356ac4c22f71071a240563ba55a24"
 dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "wasmer-engine"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f98f010978c244db431b392aeab0661df7ea0822343334f8f2a920763548e45"
-dependencies = [
- "backtrace",
- "enumset",
- "lazy_static",
- "loupe",
- "memmap2",
- "more-asserts",
- "rustc-demangle",
- "serde",
- "serde_bytes",
- "target-lexicon",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
- "wasmer-vm",
-]
-
-[[package]]
-name = "wasmer-engine-dylib"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad0358af9c154724587731175553805648d9acb8f6657880d165e378672b7e53"
-dependencies = [
- "cfg-if 1.0.0",
- "enum-iterator 0.7.0",
- "enumset",
- "leb128",
- "libloading",
- "loupe",
- "object 0.28.4",
- "rkyv",
- "serde",
- "tempfile",
- "tracing",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-object",
- "wasmer-types",
- "wasmer-vm",
- "which",
-]
-
-[[package]]
-name = "wasmer-engine-universal"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "440dc3d93c9ca47865a4f4edd037ea81bf983b5796b59b3d712d844b32dbef15"
-dependencies = [
- "cfg-if 1.0.0",
- "enumset",
- "leb128",
- "loupe",
- "region",
- "rkyv",
- "wasmer-compiler",
- "wasmer-engine",
- "wasmer-engine-universal-artifact",
- "wasmer-types",
- "wasmer-vm",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-engine-universal-artifact"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68f1db3f54152657eb6e86c44b66525ff7801dad8328fe677da48dd06af9ad41"
-dependencies = [
- "enum-iterator 0.7.0",
- "enumset",
- "loupe",
- "rkyv",
- "thiserror",
- "wasmer-artifact",
- "wasmer-compiler",
- "wasmer-types",
-]
-
-[[package]]
-name = "wasmer-object"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d831335ff3a44ecf451303f6f891175c642488036b92ceceb24ac8623a8fa8b"
-dependencies = [
- "object 0.28.4",
- "thiserror",
- "wasmer-compiler",
- "wasmer-types",
+ "syn 1.0.107",
 ]
 
 [[package]]
 name = "wasmer-types"
-version = "2.3.0"
+version = "3.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39df01ea05dc0a9bab67e054c7cb01521e53b35a7bb90bd02eca564ed0b2667f"
+checksum = "fa69c0da907df0110d0276273db3e730186b1378f01c111e41c93068142bcc54"
 dependencies = [
- "backtrace",
+ "bytecheck",
  "enum-iterator 0.7.0",
+ "enumset",
  "indexmap",
- "loupe",
  "more-asserts",
  "rkyv",
- "serde",
+ "target-lexicon",
  "thiserror",
-]
-
-[[package]]
-name = "wasmer-vfs"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9302eae3edc53cb540c2d681e7f16d8274918c1ce207591f04fed351649e97c0"
-dependencies = [
- "libc",
- "slab",
- "thiserror",
- "tracing",
 ]
 
 [[package]]
 name = "wasmer-vm"
-version = "2.3.0"
+version = "3.2.0-beta.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d965fa61f4dc4cdb35a54daaf7ecec3563fbb94154a6c35433f879466247dd"
+checksum = "e5bd65399be53ddcb647c323ec73b827890cebf04e853ab01e989425a347b23a"
 dependencies = [
  "backtrace",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "corosensei",
+ "derivative",
  "enum-iterator 0.7.0",
  "indexmap",
  "lazy_static",
  "libc",
- "loupe",
  "mach",
  "memoffset 0.6.5",
  "more-asserts",
  "region",
- "rkyv",
  "scopeguard",
- "serde",
  "thiserror",
- "wasmer-artifact",
  "wasmer-types",
  "winapi",
 ]
 
 [[package]]
-name = "wasmer-wasi"
-version = "2.3.0"
+name = "wasmer-wasix"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fadbe31e3c1b6f3e398ad172b169152ae1a743ae6efd5f9ffb34019983319d99"
+checksum = "c808ba4a46d03a76a8ed53c15e7f49b42532d272aa814776659d2e21ab920309"
 dependencies = [
- "cfg-if 1.0.0",
- "generational-arena",
+ "anyhow",
+ "async-trait",
+ "bincode",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "cooked-waker",
+ "derivative",
+ "futures",
  "getrandom",
+ "heapless",
+ "hex",
+ "http",
+ "lazy_static",
  "libc",
+ "linked_hash_set",
+ "once_cell",
+ "pin-project",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_yaml",
+ "sha2",
+ "shellexpand",
+ "term_size",
+ "termios",
  "thiserror",
+ "tokio",
  "tracing",
+ "urlencoding",
+ "virtual-fs",
+ "virtual-net",
+ "wai-bindgen-wasmer",
+ "waker-fn",
  "wasm-bindgen",
  "wasmer",
- "wasmer-vfs",
- "wasmer-wasi-types",
+ "wasmer-types",
+ "wasmer-wasix-types",
+ "webc",
+ "weezl",
  "winapi",
 ]
 
 [[package]]
-name = "wasmer-wasi-types"
-version = "2.3.0"
+name = "wasmer-wasix-types"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22dc83aadbdf97388de3211cb6f105374f245a3cf2a5c65a16776e7a087a8468"
+checksum = "79992bb1b873535e16afa77455eed58b922aa4c8b30d591f103ac038b01537de"
 dependencies = [
+ "anyhow",
+ "bitflags",
  "byteorder",
+ "cfg-if",
+ "num_enum",
  "time 0.2.27",
+ "wai-bindgen-gen-core",
+ "wai-bindgen-gen-rust",
+ "wai-bindgen-gen-rust-wasm",
+ "wai-bindgen-rust",
+ "wai-parser",
+ "wasmer",
+ "wasmer-derive",
  "wasmer-types",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.83.0"
+version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718ed7c55c2add6548cca3ddd6383d738cd73b892df400e96b9aa876f0141d7a"
+checksum = "f2ea896273ea99b15132414be1da01ab0d8836415083298ecaffbe308eaac87a"
+dependencies = [
+ "indexmap",
+ "url",
+]
 
 [[package]]
 name = "wast"
@@ -5442,15 +6014,55 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.2.5"
+name = "webc"
+version = "5.0.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c4fb54e6113b6a8772ee41c3404fb0301ac79604489467e0a9ce1f3e97c24ae"
+checksum = "418bfd8fc298ce60295203a6960d53af48c8e10c5a021a5e7db8bc06c4830148"
 dependencies = [
- "either",
- "lazy_static",
- "libc",
+ "anyhow",
+ "base64 0.21.0",
+ "byteorder",
+ "bytes",
+ "indexmap",
+ "leb128",
+ "lexical-sort",
+ "memmap2",
+ "once_cell",
+ "path-clean",
+ "rand",
+ "serde",
+ "serde_cbor",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "url",
+ "walkdir",
 ]
+
+[[package]]
+name = "webpki"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.22.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c71e40d7d2c34a5106301fb632274ca37242cd0c9d3e64dbece371a40a2d87"
+dependencies = [
+ "webpki",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "winapi"
@@ -5515,12 +6127,12 @@ version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.1",
  "windows_aarch64_msvc 0.42.1",
  "windows_i686_gnu 0.42.1",
  "windows_i686_msvc 0.42.1",
  "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.1",
  "windows_x86_64_msvc 0.42.1",
 ]
 
@@ -5530,7 +6142,16 @@ version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.42.1",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.0",
 ]
 
 [[package]]
@@ -5539,13 +6160,28 @@ version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e2522491fbfcd58cc84d47aeb2958948c4b8982e9a2d8a2a35bbaed431390e7"
 dependencies = [
- "windows_aarch64_gnullvm",
+ "windows_aarch64_gnullvm 0.42.1",
  "windows_aarch64_msvc 0.42.1",
  "windows_i686_gnu 0.42.1",
  "windows_i686_msvc 0.42.1",
  "windows_x86_64_gnu 0.42.1",
- "windows_x86_64_gnullvm",
+ "windows_x86_64_gnullvm 0.42.1",
  "windows_x86_64_msvc 0.42.1",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -5553,6 +6189,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -5573,6 +6215,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5589,6 +6237,12 @@ name = "windows_i686_gnu"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -5609,6 +6263,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5627,10 +6287,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -5651,12 +6323,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]

--- a/bindings/binding_core_node/Cargo.toml
+++ b/bindings/binding_core_node/Cargo.toml
@@ -56,7 +56,7 @@ tracing-chrome = "0.5.0"
 tracing-futures = "0.2.5"
 tracing-subscriber = { version = "0.3.9", features = ["env-filter"] }
 
-swc_core = { version = "0.74.0", features = [
+swc_core = { version = "0.74.6", features = [
   "allocator_node",
   "ecma_ast",
   "ecma_ast_serde",

--- a/bindings/binding_core_wasm/Cargo.toml
+++ b/bindings/binding_core_wasm/Cargo.toml
@@ -17,13 +17,26 @@ default = ["swc_v1"]
 swc_v1  = []
 swc_v2  = []
 # This feature exists to allow cargo operations
-plugin = ["swc_core/plugin_transform_host_js"]
+# [TODO]: this is disabled due to signature mismatch between host_native and host_js,
+# which causes build errors like
+# .call(&mut self.store, ptr.0, ptr.1)
+#   |                  ^^^^ the trait `NativeWasmTypeInto` is not implemented for `u32`
+#   |
+#   = help: the following other types implement trait `NativeWasmTypeInto`:
+#             f32
+#             f64
+#             i32
+#             i64
+#             u128
+plugin = [
+  #"swc_core/plugin_transform_host_js"
+]
 
 [dependencies]
 anyhow = "1.0.66"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.4.5"
-swc_core = { version = "0.74.0", features = [
+swc_core = { version = "0.74.6", features = [
   "ecma_ast_serde",
   "common_perf",
   "binding_macro_wasm",

--- a/bindings/swc_cli/Cargo.toml
+++ b/bindings/swc_cli/Cargo.toml
@@ -27,7 +27,7 @@ relative-path = "1.6.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["unbounded_depth"] }
 sourcemap = "6.2.2"
-swc_core = { version = "0.74.0", features = [
+swc_core = { version = "0.74.6", features = [
   "trace_macro",
   "common_concurrent",
   "base_concurrent",

--- a/crates/binding_macros/src/wasm.rs
+++ b/crates/binding_macros/src/wasm.rs
@@ -307,7 +307,9 @@ macro_rules! build_transform_sync {
 
         let c = $crate::wasm::compiler();
 
-        #[cfg(feature = "plugin")]
+        //[TODO]: refer binding_core_wasm/Cargo.toml,
+        //disables via renaming feature to arbitary name
+        #[cfg(feature = "__plugin")]
         {
             if experimental_plugin_bytes_resolver.is_object() {
                 use $crate::wasm::js_sys::{Array, Object, Uint8Array};

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -46,6 +46,11 @@ plugin_transform_schema_vtest = [
   "swc_plugin_runner/plugin_transform_schema_vtest",
 ]
 
+plugin_transform_host_js = ["swc_plugin_runner/plugin_transform_host_js"]
+plugin_transform_host_native = [
+  "swc_plugin_runner/plugin_transform_host_native",
+]
+
 [dependencies]
 ahash        = "0.7.4"
 anyhow       = "1"

--- a/crates/swc_atoms/Cargo.toml
+++ b/crates/swc_atoms/Cargo.toml
@@ -22,14 +22,18 @@ rkyv-bytecheck-impl = ["__rkyv", "rkyv-latest"]
 [dependencies]
 bytecheck = { version = "0.6.9", optional = true }
 once_cell = "1"
-rkyv      = { package = "rkyv", version = "=0.7.40", optional = true }
+rkyv = { package = "rkyv", version = "=0.7.40", optional = true, features = [
+  "strict",
+] }
 # This is to avoid cargo version selection conflict between rkyv=0.7.40 and other versions, as it is strictly pinned
 # cannot be merged.
-rkyv-latest  = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true }
-rustc-hash   = "1.1.0"
-serde        = "1"
+rkyv-latest = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true, features = [
+  "strict",
+] }
+rustc-hash = "1.1.0"
+serde = "1"
 string_cache = "0.8.7"
-triomphe     = "0.1.8"
+triomphe = "0.1.8"
 
 [build-dependencies]
 string_cache_codegen = "0.5.2"

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -60,7 +60,7 @@ new_debug_unreachable = "1.0.4"
 num-bigint            = "0.4"
 once_cell             = "1.10.0"
 parking_lot           = { version = "0.12.0", optional = true }
-rkyv                  = { version = "=0.7.40", optional = true }
+rkyv                  = { version = "=0.7.40", optional = true, features = ["strict"] }
 # This is to avoid cargo version selection conflict between rkyv=0.7.40 and other versions, as it is strictly pinned
 # cannot be merged.
 rkyv-latest   = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true }

--- a/crates/swc_common/src/errors/diagnostic.rs
+++ b/crates/swc_common/src/errors/diagnostic.rs
@@ -16,6 +16,17 @@ use rkyv_latest as rkyv;
 use super::{snippet::Style, Applicability, CodeSuggestion, Level, Substitution, SubstitutionPart};
 use crate::syntax_pos::{MultiSpan, Span};
 
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "diagnostic-serde",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(
+    any(feature = "rkyv-impl", feature = "rkyv-bytecheck-impl"),
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+pub struct Message(pub String, pub Style);
+
 #[must_use]
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 #[cfg_attr(
@@ -28,7 +39,7 @@ use crate::syntax_pos::{MultiSpan, Span};
 )]
 pub struct Diagnostic {
     pub level: Level,
-    pub message: Vec<(String, Style)>,
+    pub message: Vec<Message>,
     pub code: Option<DiagnosticId>,
     pub span: MultiSpan,
     pub children: Vec<SubDiagnostic>,
@@ -61,7 +72,7 @@ pub enum DiagnosticId {
 )]
 pub struct SubDiagnostic {
     pub level: Level,
-    pub message: Vec<(String, Style)>,
+    pub message: Vec<Message>,
     pub span: MultiSpan,
     pub render_span: Option<MultiSpan>,
 }
@@ -117,7 +128,7 @@ impl Diagnostic {
     pub fn new_with_code(level: Level, code: Option<DiagnosticId>, message: &str) -> Self {
         Diagnostic {
             level,
-            message: vec![(message.to_owned(), Style::NoStyle)],
+            message: vec![Message(message.to_owned(), Style::NoStyle)],
             code,
             span: MultiSpan::new(),
             children: vec![],
@@ -184,18 +195,18 @@ impl Diagnostic {
         expected_extra: &dyn fmt::Display,
         found_extra: &dyn fmt::Display,
     ) -> &mut Self {
-        let mut msg: Vec<_> = vec![(format!("expected {} `", label), Style::NoStyle)];
+        let mut msg: Vec<_> = vec![Message(format!("expected {} `", label), Style::NoStyle)];
         msg.extend(expected.0.iter().map(|x| match *x {
-            StringPart::Normal(ref s) => (s.to_owned(), Style::NoStyle),
-            StringPart::Highlighted(ref s) => (s.to_owned(), Style::Highlight),
+            StringPart::Normal(ref s) => Message(s.to_owned(), Style::NoStyle),
+            StringPart::Highlighted(ref s) => Message(s.to_owned(), Style::Highlight),
         }));
-        msg.push((format!("`{}\n", expected_extra), Style::NoStyle));
-        msg.push((format!("   found {} `", label), Style::NoStyle));
+        msg.push(Message(format!("`{}\n", expected_extra), Style::NoStyle));
+        msg.push(Message(format!("   found {} `", label), Style::NoStyle));
         msg.extend(found.0.iter().map(|x| match *x {
-            StringPart::Normal(ref s) => (s.to_owned(), Style::NoStyle),
-            StringPart::Highlighted(ref s) => (s.to_owned(), Style::Highlight),
+            StringPart::Normal(ref s) => Message(s.to_owned(), Style::NoStyle),
+            StringPart::Highlighted(ref s) => Message(s.to_owned(), Style::Highlight),
         }));
-        msg.push((format!("`{}", found_extra), Style::NoStyle));
+        msg.push(Message(format!("`{}", found_extra), Style::NoStyle));
 
         // For now, just attach these as notes
         self.highlighted_note(msg);
@@ -204,9 +215,9 @@ impl Diagnostic {
 
     pub fn note_trait_signature(&mut self, name: String, signature: String) -> &mut Self {
         self.highlighted_note(vec![
-            (format!("`{}` from trait: `", name), Style::NoStyle),
-            (signature, Style::Highlight),
-            ("`".to_string(), Style::NoStyle),
+            Message(format!("`{}` from trait: `", name), Style::NoStyle),
+            Message(signature, Style::Highlight),
+            Message("`".to_string(), Style::NoStyle),
         ]);
         self
     }
@@ -216,7 +227,7 @@ impl Diagnostic {
         self
     }
 
-    pub fn highlighted_note(&mut self, msg: Vec<(String, Style)>) -> &mut Self {
+    pub fn highlighted_note(&mut self, msg: Vec<Message>) -> &mut Self {
         self.sub_with_highlights(Level::Note, msg, MultiSpan::new(), None);
         self
     }
@@ -431,7 +442,7 @@ impl Diagnostic {
             .collect::<String>()
     }
 
-    pub fn styled_message(&self) -> &Vec<(String, Style)> {
+    pub fn styled_message(&self) -> &Vec<Message> {
         &self.message
     }
 
@@ -454,7 +465,7 @@ impl Diagnostic {
     ) {
         let sub = SubDiagnostic {
             level,
-            message: vec![(message.to_owned(), Style::NoStyle)],
+            message: vec![Message(message.to_owned(), Style::NoStyle)],
             span,
             render_span,
         };
@@ -466,7 +477,7 @@ impl Diagnostic {
     fn sub_with_highlights(
         &mut self,
         level: Level,
-        message: Vec<(String, Style)>,
+        message: Vec<Message>,
         span: MultiSpan,
         render_span: Option<MultiSpan>,
     ) {
@@ -488,7 +499,7 @@ impl SubDiagnostic {
             .collect::<String>()
     }
 
-    pub fn styled_message(&self) -> &Vec<(String, Style)> {
+    pub fn styled_message(&self) -> &Vec<Message> {
         &self.message
     }
 }

--- a/crates/swc_common/src/errors/emitter.rs
+++ b/crates/swc_common/src/errors/emitter.rs
@@ -23,6 +23,7 @@ use unicode_width;
 
 use self::Destination::*;
 use super::{
+    diagnostic::Message,
     snippet::{Annotation, AnnotationType, Line, MultilineAnnotation, Style, StyledString},
     styled_buffer::StyledBuffer,
     CodeSuggestion, DiagnosticBuilder, DiagnosticId, Level, SourceMapperDyn, SubDiagnostic,
@@ -842,7 +843,7 @@ impl EmitterWriter {
         if spans_updated {
             children.push(SubDiagnostic {
                 level: Level::Note,
-                message: vec![(
+                message: vec![Message(
                     "this error originates in a macro outside of the current crate (in Nightly \
                      builds, run with -Z external-macro-backtrace for more info)"
                         .to_string(),
@@ -859,7 +860,7 @@ impl EmitterWriter {
     fn msg_to_buffer(
         &self,
         buffer: &mut StyledBuffer,
-        msg: &[(String, Style)],
+        msg: &[Message],
         padding: usize,
         label: &str,
         override_style: Option<Style>,
@@ -912,7 +913,7 @@ impl EmitterWriter {
         //                see how it *looks* with
         //                very *weird* formats
         //                see?
-        for (text, style) in msg.iter() {
+        for &Message(ref text, ref style) in msg.iter() {
             let lines = text.split('\n').collect::<Vec<_>>();
             if lines.len() > 1 {
                 for (i, line) in lines.iter().enumerate() {
@@ -932,7 +933,7 @@ impl EmitterWriter {
     fn emit_message_default(
         &mut self,
         msp: &MultiSpan,
-        msg: &[(String, Style)],
+        msg: &[Message],
         code: &Option<DiagnosticId>,
         level: Level,
         max_line_num_len: usize,
@@ -975,7 +976,7 @@ impl EmitterWriter {
             if !level_str.is_empty() {
                 buffer.append(0, ": ", header_style);
             }
-            for (text, _) in msg.iter() {
+            for &Message(ref text, _) in msg.iter() {
                 buffer.append(0, text, header_style);
             }
         }
@@ -1212,7 +1213,7 @@ impl EmitterWriter {
             }
             self.msg_to_buffer(
                 &mut buffer,
-                &[(suggestion.msg.to_owned(), Style::NoStyle)],
+                &[Message(suggestion.msg.to_owned(), Style::NoStyle)],
                 max_line_num_len,
                 "suggestion",
                 Some(Style::HeaderMsg),
@@ -1332,7 +1333,7 @@ impl EmitterWriter {
     fn emit_messages_default(
         &mut self,
         level: Level,
-        message: &[(String, Style)],
+        message: &[Message],
         code: &Option<DiagnosticId>,
         span: &MultiSpan,
         children: &[SubDiagnostic],

--- a/crates/swc_common/src/errors/emitter.rs
+++ b/crates/swc_common/src/errors/emitter.rs
@@ -913,7 +913,7 @@ impl EmitterWriter {
         //                see how it *looks* with
         //                very *weird* formats
         //                see?
-        for &Message(ref text, ref style) in msg.iter() {
+        for Message(text, ref style) in msg.iter() {
             let lines = text.split('\n').collect::<Vec<_>>();
             if lines.len() > 1 {
                 for (i, line) in lines.iter().enumerate() {
@@ -976,7 +976,7 @@ impl EmitterWriter {
             if !level_str.is_empty() {
                 buffer.append(0, ": ", header_style);
             }
-            for &Message(ref text, _) in msg.iter() {
+            for Message(text, _) in msg.iter() {
                 buffer.append(0, text, header_style);
             }
         }

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -488,8 +488,8 @@ impl SourceMap {
 
         if lo.file.start_pos != hi.file.start_pos {
             return Err(Box::new(SpanLinesError::DistinctSources(DistinctSources {
-                begin: (lo.file.name.clone(), lo.file.start_pos),
-                end: (hi.file.name.clone(), hi.file.start_pos),
+                begin: FilePos(lo.file.name.clone(), lo.file.start_pos),
+                end: FilePos(hi.file.name.clone(), hi.file.start_pos),
             })));
         }
         assert!(hi.line >= lo.line);
@@ -565,8 +565,8 @@ impl SourceMap {
         if local_begin.sf.start_pos != local_end.sf.start_pos {
             Err(Box::new(SpanSnippetError::DistinctSources(
                 DistinctSources {
-                    begin: (local_begin.sf.name.clone(), local_begin.sf.start_pos),
-                    end: (local_end.sf.name.clone(), local_end.sf.start_pos),
+                    begin: FilePos(local_begin.sf.name.clone(), local_begin.sf.start_pos),
+                    end: FilePos(local_end.sf.name.clone(), local_end.sf.start_pos),
                 },
             )))
         } else {

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -312,6 +312,17 @@ impl FileName {
     }
 }
 
+#[derive(Clone, Debug, Default, Hash, PartialEq, Eq)]
+#[cfg_attr(
+    feature = "diagnostic-serde",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+#[cfg_attr(
+    any(feature = "rkyv-impl", feature = "rkyv-bytecheck-impl"),
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+pub struct PrimarySpanLabel(pub Span, pub String);
+
 /// A collection of spans. Spans have two orthogonal attributes:
 ///
 /// - they can be *primary spans*. In this case they are the locus of the error,
@@ -329,7 +340,7 @@ impl FileName {
 )]
 pub struct MultiSpan {
     primary_spans: Vec<Span>,
-    span_labels: Vec<(Span, String)>,
+    span_labels: Vec<PrimarySpanLabel>,
 }
 
 extern "C" {
@@ -633,7 +644,7 @@ impl MultiSpan {
     }
 
     pub fn push_span_label(&mut self, span: Span, label: String) {
-        self.span_labels.push((span, label));
+        self.span_labels.push(PrimarySpanLabel(span, label));
     }
 
     /// Selects the first primary span (if any)
@@ -689,7 +700,7 @@ impl MultiSpan {
         let mut span_labels = self
             .span_labels
             .iter()
-            .map(|&(span, ref label)| SpanLabel {
+            .map(|&PrimarySpanLabel(span, ref label)| SpanLabel {
                 span,
                 is_primary: is_primary(span),
                 label: Some(label.clone()),
@@ -1301,9 +1312,16 @@ pub enum SpanSnippetError {
     any(feature = "rkyv-impl", feature = "rkyv-bytecheck-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
+pub struct FilePos(pub FileName, pub BytePos);
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+#[cfg_attr(
+    any(feature = "rkyv-impl", feature = "rkyv-bytecheck-impl"),
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
 pub struct DistinctSources {
-    pub begin: (FileName, BytePos),
-    pub end: (FileName, BytePos),
+    pub begin: FilePos,
+    pub end: FilePos,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -295,15 +295,15 @@ __plugin_transform_host_bytecheck = [
 
 # Internal flags to control plugin environment
 __plugin_transform_env_native = [
+  "swc/plugin_transform_host_native",
   "swc_plugin_runner/filesystem_cache",
-  "wasmer/default",
-  "wasmer-wasi/default",
+  "swc_plugin_runner/plugin_transform_host_native",
 ]
 
 __plugin_transform_env_js = [
+  "swc/plugin_transform_host_js",
   "swc_plugin_runner/memory_cache",
-  "wasmer/js-default",
-  "wasmer-wasi/js-default",
+  "swc_plugin_runner/plugin_transform_host_js",
 ]
 
 # Do not use: testing purpose only
@@ -337,9 +337,7 @@ __visit = ["__ecma", "swc_ecma_visit"]
 
 [dependencies]
 # 3rd party dependencies
-once_cell   = { optional = true, version = "1.13.0" }
-wasmer      = { optional = true, version = "2.3.0", default-features = false }
-wasmer-wasi = { optional = true, version = "2.3.0", default-features = false }
+once_cell = { optional = true, version = "1.13.0" }
 
 # swc_* dependencies
 binding_macros                   = { optional = true, version = "0.48.6", path = "../binding_macros" }
@@ -350,6 +348,7 @@ swc_cached                       = { optional = true, version = "0.3.15", path =
 swc_common                       = { optional = true, version = "0.30.5", path = "../swc_common" }
 swc_css_ast                      = { optional = true, version = "0.136.6", path = "../swc_css_ast" }
 swc_css_codegen                  = { optional = true, version = "0.146.6", path = "../swc_css_codegen" }
+swc_css_compat                   = { optional = true, version = "0.22.7", path = "../swc_css_compat" }
 swc_css_minifier                 = { optional = true, version = "0.111.6", path = "../swc_css_minifier" }
 swc_css_modules                  = { optional = true, version = "0.24.1", path = "../swc_css_modules" }
 swc_css_parser                   = { optional = true, version = "0.145.6", path = "../swc_css_parser" }
@@ -383,8 +382,7 @@ swc_plugin_proxy                 = { optional = true, version = "0.31.5", path =
 swc_trace_macro                  = { optional = true, version = "0.1.2", path = "../swc_trace_macro" }
 testing                          = { optional = true, version = "0.32.5", path = "../testing" }
 # TODO: eventually swc_plugin_runner needs to remove default features
-swc_css_compat    = { version = "0.22.7", path = "../swc_css_compat", optional = true }
-swc_plugin_runner = { optional = true, version = "0.93.8", path = "../swc_plugin_runner", default-features = false }
+swc_plugin_runner = { optional = true, version = "0.93.7", path = "../swc_plugin_runner", default-features = false }
 
 [build-dependencies]
 vergen = { version = "7.3.2", default-features = false, features = ["cargo"] }

--- a/crates/swc_core/tests/fixture/stub_wasm/Cargo.toml
+++ b/crates/swc_core/tests/fixture/stub_wasm/Cargo.toml
@@ -24,7 +24,9 @@ swc_core = { path = "../../../../swc_core", features = [
   "binding_macro_wasm",
   "ecma_transforms",
   "ecma_visit",
-  "plugin_transform_host_js",
+  # Disabled for now, until resolve type mismatches. Refer bindings/binding_core_wasm/Cargo.toml
+  # for the detail.
+  # "plugin_transform_host_js",
 ] }
 tracing = { version = "0.1.37", features = ["max_level_off"] }
 wasm-bindgen = { version = "0.2.82", features = ["enable-interning"] }

--- a/crates/swc_core/tests/integration.rs
+++ b/crates/swc_core/tests/integration.rs
@@ -29,7 +29,7 @@ fn build_fixture_binary(dir: &Path, target: Option<&str>) -> Result<(), Error> {
 }
 
 #[test]
-fn swc_core_napi_integartion_build() -> Result<(), Error> {
+fn swc_core_napi_integration_build() -> Result<(), Error> {
     build_fixture_binary(
         &PathBuf::from(env::var("CARGO_MANIFEST_DIR")?)
             .join("tests")
@@ -40,7 +40,7 @@ fn swc_core_napi_integartion_build() -> Result<(), Error> {
 }
 
 #[test]
-fn swc_core_wasm_integartion_build() -> Result<(), Error> {
+fn swc_core_wasm_integration_build() -> Result<(), Error> {
     build_fixture_binary(
         &PathBuf::from(env::var("CARGO_MANIFEST_DIR")?)
             .join("tests")

--- a/crates/swc_css_ast/Cargo.toml
+++ b/crates/swc_css_ast/Cargo.toml
@@ -21,7 +21,7 @@ serde-impl          = ["serde"]
 [dependencies]
 bytecheck = { version = "0.6.9", optional = true }
 is-macro  = "0.2.0"
-rkyv      = { version = "=0.7.40", optional = true }
+rkyv      = { version = "=0.7.40", optional = true, features = ["strict"] }
 serde     = { version = "1.0.127", features = ["derive"], optional = true }
 
 string_enum = { version = "0.4.0", path = "../string_enum/" }

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -25,6 +25,14 @@ impl Take for TokenAndSpan {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, EqIgnoreSpan, Hash)]
+#[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    any(feature = "rkyv-impl", feature = "rkyv-bytecheck-impl"),
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+pub struct UrlKeyValue(pub Atom, pub Atom);
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(
     feature = "rkyv",
@@ -114,7 +122,7 @@ pub enum Token {
         #[cfg_attr(feature = "rkyv", with(swc_atoms::EncodeJsWord))]
         value: JsWord,
         /// Name and value
-        raw: Box<(Atom, Atom)>,
+        raw: Box<UrlKeyValue>,
     },
     BadUrl {
         raw: Atom,

--- a/crates/swc_css_parser/src/lexer/mod.rs
+++ b/crates/swc_css_parser/src/lexer/mod.rs
@@ -2,7 +2,9 @@ use std::{cell::RefCell, char::REPLACEMENT_CHARACTER, rc::Rc};
 
 use swc_atoms::{js_word, Atom, JsWord};
 use swc_common::{input::Input, BytePos, Span};
-use swc_css_ast::{matches_eq_ignore_ascii_case, DimensionToken, NumberType, Token, TokenAndSpan};
+use swc_css_ast::{
+    matches_eq_ignore_ascii_case, DimensionToken, NumberType, Token, TokenAndSpan, UrlKeyValue,
+};
 
 use crate::{
     error::{Error, ErrorKind},
@@ -755,7 +757,7 @@ where
                     Some(')') => {
                         return Ok(Token::Url {
                             value: (&**out).into(),
-                            raw: Box::new((name.1, (&**raw).into())),
+                            raw: Box::new(UrlKeyValue(name.1, (&**raw).into())),
                         });
                     }
 
@@ -766,7 +768,7 @@ where
 
                         return Ok(Token::Url {
                             value: (&**out).into(),
-                            raw: Box::new((name.1, (&**raw).into())),
+                            raw: Box::new(UrlKeyValue(name.1, (&**raw).into())),
                         });
                     }
 
@@ -800,7 +802,7 @@ where
 
                                 return Ok(Token::Url {
                                     value: (&**out).into(),
-                                    raw: Box::new((name.1, (&**raw).into())),
+                                    raw: Box::new(UrlKeyValue(name.1, (&**raw).into())),
                                 });
                             }
                             None => {
@@ -810,7 +812,7 @@ where
 
                                 return Ok(Token::Url {
                                     value: (&**out).into(),
-                                    raw: Box::new((name.1, (&**raw).into())),
+                                    raw: Box::new(UrlKeyValue(name.1, (&**raw).into())),
                                 });
                             }
                             _ => {}

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/span.swc-stderr
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-class/unknown/span.swc-stderr
@@ -2037,7 +2037,7 @@
  16 | :unknown({!}) {}
     `----
 
-  x Url { value: Atom('foo.png' type=inline), raw: ("url", "foo.png") }
+  x Url { value: Atom('foo.png' type=inline), raw: UrlKeyValue("url", "foo.png") }
     ,-[$DIR/tests/fixture/selector/pseudo-class/unknown/input.css:14:1]
  14 | :unknown('string') {}
  15 | :unknown(url(foo.png)) {}

--- a/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/span.swc-stderr
+++ b/crates/swc_css_parser/tests/fixture/selector/pseudo-element/unknown/span.swc-stderr
@@ -2036,7 +2036,7 @@
  16 | ::unknown({!}) {}
     `----
 
-  x Url { value: Atom('foo.png' type=inline), raw: ("url", "foo.png") }
+  x Url { value: Atom('foo.png' type=inline), raw: UrlKeyValue("url", "foo.png") }
     ,-[$DIR/tests/fixture/selector/pseudo-element/unknown/input.css:14:1]
  14 | ::unknown('string') {}
  15 | ::unknown(url(foo.png)) {}

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -31,18 +31,22 @@ rkyv-bytecheck-impl = [
 serde-impl = ["serde"]
 
 [dependencies]
-arbitrary  = { version = "1", optional = true, features = ["derive"] }
-bitflags   = "1"
-bytecheck  = { version = "0.6.9", optional = true }
-is-macro   = "0.2.1"
+arbitrary = { version = "1", optional = true, features = ["derive"] }
+bitflags = "1"
+bytecheck = { version = "0.6.9", optional = true }
+is-macro = "0.2.1"
 num-bigint = { version = "0.4", features = ["serde"] }
-rkyv       = { package = "rkyv", version = "=0.7.40", optional = true }
+rkyv = { package = "rkyv", version = "=0.7.40", optional = true, features = [
+  "strict",
+] }
 # This is to avoid cargo version selection conflict between rkyv=0.7.40 and other versions, as it is strictly pinned
 # cannot be merged.
-rkyv-latest = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true }
-scoped-tls  = "1.0.0"
-serde       = { version = "1.0.133", features = ["derive"], optional = true }
-unicode-id  = "0.3"
+rkyv-latest = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true, features = [
+  "strict",
+] }
+scoped-tls = "1.0.0"
+serde = { version = "1.0.133", features = ["derive"], optional = true }
+unicode-id = "0.3"
 
 string_enum = { version = "0.4.0", path = "../string_enum" }
 swc_atoms   = { version = "0.4.43", path = "../swc_atoms" }

--- a/crates/swc_html_ast/Cargo.toml
+++ b/crates/swc_html_ast/Cargo.toml
@@ -23,7 +23,7 @@ serde-impl          = ["serde"]
 [dependencies]
 bytecheck = { version = "0.6.9", optional = true }
 is-macro  = "0.2.0"
-rkyv      = { version = "=0.7.40", optional = true }
+rkyv      = { version = "=0.7.40", optional = true, features = ["strict"] }
 serde     = { version = "1.0.127", features = ["derive"], optional = true }
 
 string_enum = { version = "0.4.0", path = "../string_enum/" }

--- a/crates/swc_plugin/src/allocation.rs
+++ b/crates/swc_plugin/src/allocation.rs
@@ -1,3 +1,5 @@
+use std::alloc::{alloc as global_alloc, dealloc as global_dealloc, Layout};
+
 /// Allocate bytes that won't be dropped by the allocator.
 /// Return the pointer to the leaked allocation so the host can write to it.
 ///
@@ -31,5 +33,46 @@ pub extern "C" fn __alloc(size: i32) -> *mut u8 {
 pub extern "C" fn __free(ptr: *mut u8, size: i32) -> i32 {
     let data = unsafe { Vec::from_raw_parts(ptr, size as usize, size as usize) };
     std::mem::drop(data);
-    0
+    0 as _
+}
+
+/// Allocates memory area of specified size and returns its address.
+/// Returns 0 if supplied size is too long.
+/// [TODO]: This is for the experiment to alloc memory with specified layout instead of
+/// manually creating vec![] and forget it. This is not used yet.
+#[doc(hidden)]
+#[cfg(all(target_arch = "wasm32", feature = "layout_alloc"))]
+#[no_mangle]
+#[inline(always)]
+pub unsafe fn __alloc(size: usize) -> usize {
+    let layout = match Layout::from_size_align(size as usize, std::mem::align_of::<u8>()) {
+        Ok(layout) => layout,
+        // in this case a err may occur only in a case of too long allocated size,
+        // so just return 0
+        Err(_) => return 0 as _,
+    };
+
+    unsafe { global_alloc(layout) as _ }
+}
+
+/// Deallocates memory area for provided memory pointer and size.
+/// Does nothing if supplied size is too long.
+/// [TODO]: This is for the experiment to free memory with specified layout with explicit
+/// dealloc instead of dropping it. This is not used yet.
+#[doc(hidden)]
+#[cfg(all(target_arch = "wasm32", feature = "layout_alloc"))]
+#[no_mangle]
+#[inline(always)]
+pub unsafe fn __free(ptr: *mut u8, size: usize) {
+    let layout = match Layout::from_size_align(size as usize, std::mem::align_of::<u8>()) {
+        Ok(layout) => layout,
+        // in this case a err may occur only in a case of too long allocated size,
+        // so just done nothing
+        Err(_) => return 0 as _,
+    };
+
+    unsafe {
+        global_dealloc(ptr, layout);
+    }
+    0 as _
 }

--- a/crates/swc_plugin_proxy/Cargo.toml
+++ b/crates/swc_plugin_proxy/Cargo.toml
@@ -37,7 +37,9 @@ plugin-mode = ["__plugin_mode", "swc_common/plugin-base", "rkyv-impl"]
 
 [dependencies]
 
-rkyv = { package = "rkyv", version = "=0.7.40", optional = true }
+rkyv = { package = "rkyv", version = "=0.7.40", optional = true, features = [
+  "strict",
+] }
 # This is to avoid cargo version selection conflict between rkyv=0.7.40 and other versions, as it is strictly pinned
 # cannot be merged.
 rkyv-latest = { package = "rkyv-test", version = "=0.7.38-test.2", optional = true }

--- a/crates/swc_plugin_runner/Cargo.toml
+++ b/crates/swc_plugin_runner/Cargo.toml
@@ -12,9 +12,19 @@ version       = "0.93.8"
 bench = false
 
 [features]
-default = ["filesystem_cache"]
+default = ["filesystem_cache", "plugin_transform_host_native"]
+plugin_transform_host_js = [
+  "wasmer/js-default",
+  "wasmer-wasix/js-default",
+  "wasmer-compiler-cranelift/wasm",
+]
+plugin_transform_host_native = [
+  "wasmer/default",
+  "wasmer-wasix/default",
+  "wasmer-compiler-cranelift/default",
+]
 # Supports a cache allow to store compiled bytecode into filesystem location.
-# This feature implies in-memory cache enabled always.
+# This feature implies in-memory cache support, but not via `memory_cache` feature.
 filesystem_cache = ["wasmer-cache"]
 # Supports a cache allow to store wasm module in-memory. This avoids recompilation
 # to the same module in a single procress lifecycle.
@@ -36,15 +46,15 @@ rkyv-bytecheck-impl = [
 rkyv-impl = ["__rkyv", "swc_common/plugin-rt", "swc_plugin_proxy/plugin-rt"]
 
 [dependencies]
-anyhow      = "1.0.42"
-enumset     = "1.0.12"
-once_cell   = "1.10.0"
-parking_lot = "0.12.0"
-serde       = { version = "1.0.126", features = ["derive"] }
-serde_json  = "1.0.64"
-tracing     = "0.1.32"
-wasmer      = { version = "2.3.0", default-features = false }
-wasmer-wasi = { version = "2.3.0", default-features = false }
+anyhow       = "1.0.42"
+enumset      = "1.0.12"
+once_cell    = "1.10.0"
+parking_lot  = "0.12.0"
+serde        = { version = "1.0.126", features = ["derive"] }
+serde_json   = "1.0.64"
+tracing      = "0.1.32"
+wasmer       = { version = "3.2.0-beta.2", default-features = false }
+wasmer-wasix = { version = "0.2", default-features = false }
 
 swc_common = { version = "0.30.5", path = "../swc_common", features = [
   "concurrent",
@@ -53,16 +63,12 @@ swc_css_ast = { version = "0.136.6", path = "../swc_css_ast", optional = true }
 swc_ecma_ast = { version = "0.102.5", path = "../swc_ecma_ast", optional = true }
 swc_plugin_proxy = { version = "0.31.5", path = "../swc_plugin_proxy" }
 
-
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-wasmer-cache              = { version = "2.3.0", optional = true }
-wasmer-compiler-cranelift = { version = "2.3.0" }
-wasmer-engine-universal   = { version = "2.3.0" }
+wasmer-cache              = { version = "3.2.0-beta.2", optional = true }
+wasmer-compiler-cranelift = { version = "3.2.0-beta.2", default-features = false }
 
 [dev-dependencies]
-criterion   = "0.3"
-wasmer      = "2.3.0"
-wasmer-wasi = "2.3.0"
+criterion = "0.3"
 
 swc_atoms = { version = "0.4.43", path = '../swc_atoms' }
 swc_css_ast = { version = "0.136.6", path = "../swc_css_ast", features = [

--- a/crates/swc_plugin_runner/src/host_environment.rs
+++ b/crates/swc_plugin_runner/src/host_environment.rs
@@ -1,25 +1,22 @@
-use wasmer::{LazyInit, Memory};
+use wasmer::Memory;
 
 /// An external environment state imported (declared in host, injected into
 /// guest) fn can access. This'll allow host to read from updated state from
 /// guest.
 ///
-/// This is `base` environment exposes guest's memory space only. For other
+/// This is `base` environment exposes nothing. For other
 /// calls requires additional data to be set in the host, separate
 /// hostenvironments are declared. Refer `CommentsHostEnvironment` for an
 /// example.
 ///
 /// ref: https://docs.wasmer.io/integrations/examples/host-functions#declaring-the-data
-#[derive(wasmer::WasmerEnv, Clone)]
+#[derive(Clone)]
 pub struct BaseHostEnvironment {
-    #[wasmer(export)]
-    pub memory: wasmer::LazyInit<Memory>,
+    pub memory: Option<Memory>,
 }
 
 impl BaseHostEnvironment {
     pub fn new() -> BaseHostEnvironment {
-        BaseHostEnvironment {
-            memory: LazyInit::new(),
-        }
+        BaseHostEnvironment { memory: None }
     }
 }

--- a/crates/swc_plugin_runner/src/imported_fn/comments.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/comments.rs
@@ -7,20 +7,18 @@ use swc_common::{
     BytePos,
 };
 use swc_plugin_proxy::COMMENTS;
-use wasmer::{LazyInit, Memory, NativeFunc};
+use wasmer::{AsStoreMut, FunctionEnvMut, Memory, TypedFunction};
 
 use crate::memory_interop::{allocate_return_values_into_guest, copy_bytes_into_host};
 
 /// External environment state for imported (declared in host, injected into
 /// guest) fn for comments proxy.
-#[derive(wasmer::WasmerEnv, Clone)]
+#[derive(Clone)]
 pub struct CommentHostEnvironment {
-    #[wasmer(export)]
-    pub memory: wasmer::LazyInit<Memory>,
+    pub memory: Option<Memory>,
     /// Attached imported fn `__alloc` to the hostenvironment to allow any other
     /// imported fn can allocate guest's memory space from host runtime.
-    #[wasmer(export(name = "__alloc"))]
-    pub alloc_guest_memory: LazyInit<NativeFunc<u32, u32>>,
+    pub alloc_guest_memory: Option<TypedFunction<u32, u32>>,
     /// A buffer to `Comment`, or `Vec<Comment>` plugin need to pass to the host
     /// to perform mutable comment operations like `add_leading, or
     /// add_leading_comments`. This is vec to serialized bytes, doesn't
@@ -32,8 +30,8 @@ pub struct CommentHostEnvironment {
 impl CommentHostEnvironment {
     pub fn new(mutable_comment_buffer: &Arc<Mutex<Vec<u8>>>) -> CommentHostEnvironment {
         CommentHostEnvironment {
-            memory: LazyInit::default(),
-            alloc_guest_memory: LazyInit::default(),
+            memory: None,
+            alloc_guest_memory: None,
             mutable_comment_buffer: mutable_comment_buffer.clone(),
         }
     }
@@ -42,11 +40,18 @@ impl CommentHostEnvironment {
 /// Copy given serialized byte into host's comment buffer, subsequent proxy call
 /// in the host can read it.
 #[tracing::instrument(level = "info", skip_all)]
-pub fn copy_comment_to_host_env(env: &CommentHostEnvironment, bytes_ptr: u32, bytes_ptr_len: u32) {
-    if let Some(memory) = env.memory_ref() {
-        (*env.mutable_comment_buffer.lock()) =
-            copy_bytes_into_host(memory, bytes_ptr, bytes_ptr_len);
-    }
+pub fn copy_comment_to_host_env(
+    mut env: FunctionEnvMut<CommentHostEnvironment>,
+    bytes_ptr: i32,
+    bytes_ptr_len: i32,
+) {
+    let memory = env
+        .data()
+        .memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+    (*env.data_mut().mutable_comment_buffer.lock()) =
+        copy_bytes_into_host(&memory.view(&env), bytes_ptr, bytes_ptr_len);
 }
 
 /// Utility fn to unwrap necessary values for the comments fn operation when fn
@@ -88,31 +93,42 @@ where
 /// Utility fn to unwrap necessary values for the comments, as well as host
 /// environment's state.
 #[tracing::instrument(level = "info", skip_all)]
-fn unwrap_comments_storage_with_env<F, R>(env: &CommentHostEnvironment, f: F, default: R) -> R
+fn unwrap_comments_storage_with_env<F, R>(
+    env: &FunctionEnvMut<CommentHostEnvironment>,
+    f: F,
+    default: R,
+) -> R
 where
-    F: FnOnce(&SingleThreadedComments, &Memory, &NativeFunc<u32, u32>) -> R,
+    F: FnOnce(&SingleThreadedComments, &Memory, &TypedFunction<u32, u32>) -> R,
 {
-    if let Some(memory) = env.memory_ref() {
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            return unwrap_comments_storage_or_default(
-                |comments| f(comments, memory, alloc_guest_memory),
-                default,
-            );
-        }
-    }
-    default
+    let memory = env
+        .data()
+        .memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
+    let alloc_guest_memory = env
+        .data()
+        .alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
+
+    return unwrap_comments_storage_or_default(
+        |comments| f(comments, memory, alloc_guest_memory),
+        default,
+    );
 }
 
 /// Common logics for add_*_comment/comments.
 #[tracing::instrument(level = "info", skip_all)]
-fn add_comments_inner<F>(env: &CommentHostEnvironment, byte_pos: u32, f: F)
+fn add_comments_inner<F>(mut env: FunctionEnvMut<CommentHostEnvironment>, byte_pos: u32, f: F)
 where
     F: FnOnce(&SingleThreadedComments, BytePos, PluginSerializedBytes),
 {
     unwrap_comments_storage(|comments| {
         let byte_pos = BytePos(byte_pos);
         // PluginCommentProxy in the guest should've copied buffer already
-        let comment_byte = &mut (*env.mutable_comment_buffer.lock());
+        let comment_byte = &mut (*env.data_mut().mutable_comment_buffer.lock());
         let serialized = PluginSerializedBytes::from_slice(comment_byte);
 
         f(comments, byte_pos, serialized);
@@ -123,7 +139,7 @@ where
     });
 }
 
-pub fn add_leading_comment_proxy(env: &CommentHostEnvironment, byte_pos: u32) {
+pub fn add_leading_comment_proxy(env: FunctionEnvMut<CommentHostEnvironment>, byte_pos: u32) {
     add_comments_inner(env, byte_pos, |comments, byte_pos, serialized| {
         comments.add_leading(
             byte_pos,
@@ -135,7 +151,7 @@ pub fn add_leading_comment_proxy(env: &CommentHostEnvironment, byte_pos: u32) {
 }
 
 #[tracing::instrument(level = "info", skip_all)]
-pub fn add_leading_comments_proxy(env: &CommentHostEnvironment, byte_pos: u32) {
+pub fn add_leading_comments_proxy(env: FunctionEnvMut<CommentHostEnvironment>, byte_pos: u32) {
     add_comments_inner(env, byte_pos, |comments, byte_pos, serialized| {
         comments.add_leading_comments(
             byte_pos,
@@ -160,13 +176,22 @@ pub fn move_leading_comments_proxy(from_byte_pos: u32, to_byte_pos: u32) {
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn take_leading_comments_proxy(
-    env: &CommentHostEnvironment,
+    mut env: FunctionEnvMut<CommentHostEnvironment>,
     byte_pos: u32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    unwrap_comments_storage_with_env(
-        env,
-        |comments, memory, alloc_guest_memory| {
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
+
+    return unwrap_comments_storage_or_default(
+        |comments| {
             let leading_comments = comments.take_leading(BytePos(byte_pos));
             if let Some(leading_comments) = leading_comments {
                 let serialized_leading_comments_vec_bytes =
@@ -175,6 +200,7 @@ pub fn take_leading_comments_proxy(
 
                 allocate_return_values_into_guest(
                     memory,
+                    &mut env.as_store_mut(),
                     alloc_guest_memory,
                     allocated_ret_ptr,
                     &serialized_leading_comments_vec_bytes,
@@ -185,7 +211,7 @@ pub fn take_leading_comments_proxy(
             }
         },
         0,
-    )
+    );
 }
 
 /// Ask to get leading_comments from currently scoped comments held by
@@ -195,13 +221,22 @@ pub fn take_leading_comments_proxy(
 /// Allocated results should be read through CommentsPtr.
 #[tracing::instrument(level = "info", skip_all)]
 pub fn get_leading_comments_proxy(
-    env: &CommentHostEnvironment,
+    mut env: FunctionEnvMut<CommentHostEnvironment>,
     byte_pos: u32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    unwrap_comments_storage_with_env(
-        env,
-        |comments, memory, alloc_guest_memory| {
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
+
+    return unwrap_comments_storage_or_default(
+        |comments| {
             let leading_comments = comments.get_leading(BytePos(byte_pos));
             if let Some(leading_comments) = leading_comments {
                 let serialized_leading_comments_vec_bytes =
@@ -210,6 +245,7 @@ pub fn get_leading_comments_proxy(
 
                 allocate_return_values_into_guest(
                     memory,
+                    &mut env.as_store_mut(),
                     alloc_guest_memory,
                     allocated_ret_ptr,
                     &serialized_leading_comments_vec_bytes,
@@ -220,11 +256,11 @@ pub fn get_leading_comments_proxy(
             }
         },
         0,
-    )
+    );
 }
 
 #[tracing::instrument(level = "info", skip_all)]
-pub fn add_trailing_comment_proxy(env: &CommentHostEnvironment, byte_pos: u32) {
+pub fn add_trailing_comment_proxy(env: FunctionEnvMut<CommentHostEnvironment>, byte_pos: u32) {
     add_comments_inner(env, byte_pos, |comments, byte_pos, serialized| {
         comments.add_trailing(
             byte_pos,
@@ -236,7 +272,7 @@ pub fn add_trailing_comment_proxy(env: &CommentHostEnvironment, byte_pos: u32) {
 }
 
 #[tracing::instrument(level = "info", skip_all)]
-pub fn add_trailing_comments_proxy(env: &CommentHostEnvironment, byte_pos: u32) {
+pub fn add_trailing_comments_proxy(env: FunctionEnvMut<CommentHostEnvironment>, byte_pos: u32) {
     add_comments_inner(env, byte_pos, |comments, byte_pos, serialized| {
         comments.add_trailing_comments(
             byte_pos,
@@ -264,13 +300,22 @@ pub fn move_trailing_comments_proxy(from_byte_pos: u32, to_byte_pos: u32) {
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn take_trailing_comments_proxy(
-    env: &CommentHostEnvironment,
+    mut env: FunctionEnvMut<CommentHostEnvironment>,
     byte_pos: u32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    unwrap_comments_storage_with_env(
-        env,
-        |comments, memory, alloc_guest_memory| {
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
+
+    return unwrap_comments_storage_or_default(
+        |comments| {
             let trailing_comments = comments.take_trailing(BytePos(byte_pos));
             if let Some(leading_comments) = trailing_comments {
                 let serialized_leading_comments_vec_bytes =
@@ -279,6 +324,7 @@ pub fn take_trailing_comments_proxy(
 
                 allocate_return_values_into_guest(
                     memory,
+                    &mut env.as_store_mut(),
                     alloc_guest_memory,
                     allocated_ret_ptr,
                     &serialized_leading_comments_vec_bytes,
@@ -289,18 +335,27 @@ pub fn take_trailing_comments_proxy(
             }
         },
         0,
-    )
+    );
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn get_trailing_comments_proxy(
-    env: &CommentHostEnvironment,
+    mut env: FunctionEnvMut<CommentHostEnvironment>,
     byte_pos: u32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    unwrap_comments_storage_with_env(
-        env,
-        |comments, memory, alloc_guest_memory| {
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
+
+    return unwrap_comments_storage_or_default(
+        |comments| {
             let trailing_comments = comments.get_trailing(BytePos(byte_pos));
             if let Some(leading_comments) = trailing_comments {
                 let serialized_leading_comments_vec_bytes =
@@ -309,6 +364,7 @@ pub fn get_trailing_comments_proxy(
 
                 allocate_return_values_into_guest(
                     memory,
+                    &mut env.as_store_mut(),
                     alloc_guest_memory,
                     allocated_ret_ptr,
                     &serialized_leading_comments_vec_bytes,
@@ -319,7 +375,7 @@ pub fn get_trailing_comments_proxy(
             }
         },
         0,
-    )
+    );
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/swc_plugin_runner/src/imported_fn/handler.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/handler.rs
@@ -2,23 +2,33 @@ use swc_common::{
     errors::{Diagnostic, HANDLER},
     plugin::serialized::PluginSerializedBytes,
 };
+use wasmer::FunctionEnvMut;
 
 use crate::{host_environment::BaseHostEnvironment, memory_interop::copy_bytes_into_host};
 
 #[tracing::instrument(level = "info", skip_all)]
-pub fn emit_diagnostics(env: &BaseHostEnvironment, bytes_ptr: u32, bytes_ptr_len: u32) {
-    if let Some(memory) = env.memory_ref() {
-        if HANDLER.is_set() {
-            HANDLER.with(|handler| {
-                let diagnostics_bytes = copy_bytes_into_host(memory, bytes_ptr, bytes_ptr_len);
-                let serialized = PluginSerializedBytes::from_slice(&diagnostics_bytes[..]);
-                let diagnostic = PluginSerializedBytes::deserialize::<Diagnostic>(&serialized)
-                    .expect("Should able to be deserialized into diagnostic");
+pub fn emit_diagnostics(
+    env: FunctionEnvMut<BaseHostEnvironment>,
+    bytes_ptr: i32,
+    bytes_ptr_len: i32,
+) {
+    let memory = env
+        .data()
+        .memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-                let mut builder =
-                    swc_common::errors::DiagnosticBuilder::new_diagnostic(handler, diagnostic);
-                builder.emit();
-            })
-        }
+    if HANDLER.is_set() {
+        HANDLER.with(|handler| {
+            let diagnostics_bytes =
+                copy_bytes_into_host(&memory.view(&env), bytes_ptr, bytes_ptr_len);
+            let serialized = PluginSerializedBytes::from_slice(&diagnostics_bytes[..]);
+            let diagnostic = PluginSerializedBytes::deserialize::<Diagnostic>(&serialized)
+                .expect("Should able to be deserialized into diagnostic");
+
+            let mut builder =
+                swc_common::errors::DiagnosticBuilder::new_diagnostic(handler, diagnostic);
+            builder.emit();
+        })
     }
 }

--- a/crates/swc_plugin_runner/src/imported_fn/hygiene.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/hygiene.rs
@@ -1,6 +1,7 @@
 use swc_common::{
     hygiene::MutableMarkContext, plugin::serialized::PluginSerializedBytes, Mark, SyntaxContext,
 };
+use wasmer::{AsStoreMut, FunctionEnvMut};
 
 use crate::{host_environment::BaseHostEnvironment, memory_interop::write_into_memory_view};
 
@@ -30,39 +31,60 @@ pub fn mark_set_builtin_proxy(self_mark: u32, is_builtin: u32) {
 /// with return value accordingly.
 #[tracing::instrument(level = "info", skip_all)]
 pub fn mark_is_descendant_of_proxy(
-    env: &BaseHostEnvironment,
+    mut env: FunctionEnvMut<BaseHostEnvironment>,
     self_mark: u32,
     ancestor: u32,
     allocated_ptr: u32,
 ) {
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
     let self_mark = Mark::from_u32(self_mark);
     let ancestor = Mark::from_u32(ancestor);
 
     let return_value = self_mark.is_descendant_of(ancestor);
 
-    if let Some(memory) = env.memory_ref() {
-        let context = MutableMarkContext(self_mark.as_u32(), 0, return_value as u32);
-        let serialized_bytes =
-            PluginSerializedBytes::try_serialize(&context).expect("Should be serializable");
+    let context = MutableMarkContext(self_mark.as_u32(), 0, return_value as u32);
+    let serialized_bytes =
+        PluginSerializedBytes::try_serialize(&context).expect("Should be serializable");
 
-        write_into_memory_view(memory, &serialized_bytes, |_| allocated_ptr);
-    }
+    write_into_memory_view(
+        memory,
+        &mut env.as_store_mut(),
+        &serialized_bytes,
+        |_, _| allocated_ptr,
+    );
 }
 
 #[tracing::instrument(level = "info", skip_all)]
-pub fn mark_least_ancestor_proxy(env: &BaseHostEnvironment, a: u32, b: u32, allocated_ptr: u32) {
+pub fn mark_least_ancestor_proxy(
+    mut env: FunctionEnvMut<BaseHostEnvironment>,
+    a: u32,
+    b: u32,
+    allocated_ptr: u32,
+) {
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
     let a = Mark::from_u32(a);
     let b = Mark::from_u32(b);
 
     let return_value = Mark::least_ancestor(a, b).as_u32();
 
-    if let Some(memory) = env.memory_ref() {
-        let context = MutableMarkContext(a.as_u32(), b.as_u32(), return_value);
-        let serialized_bytes =
-            PluginSerializedBytes::try_serialize(&context).expect("Should be serializable");
+    let context = MutableMarkContext(a.as_u32(), b.as_u32(), return_value);
+    let serialized_bytes =
+        PluginSerializedBytes::try_serialize(&context).expect("Should be serializable");
 
-        write_into_memory_view(memory, &serialized_bytes, |_| allocated_ptr);
-    }
+    write_into_memory_view(
+        memory,
+        &mut env.as_store_mut(),
+        &serialized_bytes,
+        |_, _| allocated_ptr,
+    );
 }
 
 #[tracing::instrument(level = "info", skip_all)]
@@ -74,21 +96,29 @@ pub fn syntax_context_apply_mark_proxy(self_syntax_context: u32, mark: u32) -> u
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn syntax_context_remove_mark_proxy(
-    env: &BaseHostEnvironment,
+    mut env: FunctionEnvMut<BaseHostEnvironment>,
     self_mark: u32,
     allocated_ptr: u32,
 ) {
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
     let mut self_mark = SyntaxContext::from_u32(self_mark);
 
     let return_value = self_mark.remove_mark();
 
-    if let Some(memory) = env.memory_ref() {
-        let context = MutableMarkContext(self_mark.as_u32(), 0, return_value.as_u32());
-        let serialized_bytes =
-            PluginSerializedBytes::try_serialize(&context).expect("Should be serializable");
+    let context = MutableMarkContext(self_mark.as_u32(), 0, return_value.as_u32());
+    let serialized_bytes =
+        PluginSerializedBytes::try_serialize(&context).expect("Should be serializable");
 
-        write_into_memory_view(memory, &serialized_bytes, |_| allocated_ptr);
-    }
+    write_into_memory_view(
+        memory,
+        &mut env.as_store_mut(),
+        &serialized_bytes,
+        |_, _| allocated_ptr,
+    );
 }
 
 #[tracing::instrument(level = "info", skip_all)]

--- a/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/metadata_context.rs
@@ -5,18 +5,16 @@ use swc_common::plugin::{
     metadata::{TransformPluginMetadataContext, TransformPluginMetadataContextKind},
     serialized::PluginSerializedBytes,
 };
-use wasmer::{LazyInit, Memory, NativeFunc};
+use wasmer::{AsStoreMut, FunctionEnvMut, Memory, TypedFunction};
 
 use crate::memory_interop::{allocate_return_values_into_guest, copy_bytes_into_host};
 
-#[derive(wasmer::WasmerEnv, Clone)]
+#[derive(Clone)]
 pub struct MetadataContextHostEnvironment {
-    #[wasmer(export)]
-    pub memory: wasmer::LazyInit<Memory>,
+    pub memory: Option<Memory>,
     /// Attached imported fn `__alloc` to the hostenvironment to allow any other
     /// imported fn can allocate guest's memory space from host runtime.
-    #[wasmer(export(name = "__alloc"))]
-    pub alloc_guest_memory: LazyInit<NativeFunc<u32, u32>>,
+    pub alloc_guest_memory: Option<TypedFunction<u32, u32>>,
     pub metadata_context: Arc<TransformPluginMetadataContext>,
     pub transform_plugin_config: Option<serde_json::Value>,
     /// A buffer to string key to the context plugin need to pass to the host.
@@ -30,8 +28,8 @@ impl MetadataContextHostEnvironment {
         mutable_context_key_buffer: &Arc<Mutex<Vec<u8>>>,
     ) -> Self {
         MetadataContextHostEnvironment {
-            memory: LazyInit::default(),
-            alloc_guest_memory: LazyInit::default(),
+            memory: None,
+            alloc_guest_memory: None,
             metadata_context: metadata_context.clone(),
             transform_plugin_config: plugin_config.clone(),
             mutable_context_key_buffer: mutable_context_key_buffer.clone(),
@@ -43,135 +41,167 @@ impl MetadataContextHostEnvironment {
 /// in the host can read it.
 #[tracing::instrument(level = "info", skip_all)]
 pub fn copy_context_key_to_host_env(
-    env: &MetadataContextHostEnvironment,
-    bytes_ptr: u32,
-    bytes_ptr_len: u32,
+    mut env: FunctionEnvMut<MetadataContextHostEnvironment>,
+    bytes_ptr: i32,
+    bytes_ptr_len: i32,
 ) {
-    if let Some(memory) = env.memory_ref() {
-        (*env.mutable_context_key_buffer.lock()) =
-            copy_bytes_into_host(memory, bytes_ptr, bytes_ptr_len);
-    }
+    let memory = env
+        .data()
+        .memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
+    (*env.data_mut().mutable_context_key_buffer.lock()) =
+        copy_bytes_into_host(&memory.view(&env), bytes_ptr, bytes_ptr_len);
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn get_transform_plugin_config(
-    env: &MetadataContextHostEnvironment,
+    mut env: FunctionEnvMut<MetadataContextHostEnvironment>,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            let config_value = &env.transform_plugin_config;
-            if let Some(config_value) = config_value {
-                // Lazy as possible as we can - only deserialize json value if transform plugin
-                // actually needs it.
-                let config = serde_json::to_string(config_value).ok();
-                if let Some(config) = config {
-                    let serialized = PluginSerializedBytes::try_serialize(&config)
-                        .expect("Should be serializable");
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-                    allocate_return_values_into_guest(
-                        memory,
-                        alloc_guest_memory,
-                        allocated_ret_ptr,
-                        &serialized,
-                    );
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
 
-                    return 1;
-                }
-            }
+    let config_value = &env.data().transform_plugin_config;
+    if let Some(config_value) = config_value {
+        // Lazy as possible as we can - only deserialize json value if transform plugin
+        // actually needs it.
+        let config = serde_json::to_string(config_value).ok();
+        if let Some(config) = config {
+            let serialized =
+                PluginSerializedBytes::try_serialize(&config).expect("Should be serializable");
+
+            allocate_return_values_into_guest(
+                memory,
+                &mut env.as_store_mut(),
+                alloc_guest_memory,
+                allocated_ret_ptr,
+                &serialized,
+            );
+
+            return 1;
         }
     }
-    0
+    return 0;
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn get_transform_context(
-    env: &MetadataContextHostEnvironment,
+    mut env: FunctionEnvMut<MetadataContextHostEnvironment>,
     key: u32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            let value = env
-                .metadata_context
-                .get(&TransformPluginMetadataContextKind::from(key));
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-            if let Some(value) = value {
-                let serialized =
-                    PluginSerializedBytes::try_serialize(&value).expect("Should be serializable");
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
 
-                allocate_return_values_into_guest(
-                    memory,
-                    alloc_guest_memory,
-                    allocated_ret_ptr,
-                    &serialized,
-                );
+    let value = env
+        .data()
+        .metadata_context
+        .get(&TransformPluginMetadataContextKind::from(key));
 
-                return 1;
-            }
-        }
+    if let Some(value) = value {
+        let serialized =
+            PluginSerializedBytes::try_serialize(&value).expect("Should be serializable");
+
+        allocate_return_values_into_guest(
+            memory,
+            &mut env.as_store_mut(),
+            alloc_guest_memory,
+            allocated_ret_ptr,
+            &serialized,
+        );
+
+        return 1;
     }
-    0
+    return 0;
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn get_experimental_transform_context(
-    env: &MetadataContextHostEnvironment,
+    mut env: FunctionEnvMut<MetadataContextHostEnvironment>,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            let context_key_buffer = &*env.mutable_context_key_buffer.lock();
-            let key: String = PluginSerializedBytes::from_slice(&context_key_buffer[..])
-                .deserialize()
-                .expect("Should able to deserialize");
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-            let value = env
-                .metadata_context
-                .experimental
-                .get(&key)
-                .map(|v| v.to_string());
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
 
-            if let Some(value) = value {
-                let serialized =
-                    PluginSerializedBytes::try_serialize(&value).expect("Should be serializable");
+    let context_key_buffer = env.data().mutable_context_key_buffer.lock().clone();
+    let key: String = PluginSerializedBytes::from_slice(&context_key_buffer[..])
+        .deserialize()
+        .expect("Should able to deserialize");
 
-                allocate_return_values_into_guest(
-                    memory,
-                    alloc_guest_memory,
-                    allocated_ret_ptr,
-                    &serialized,
-                );
+    let value = env
+        .data()
+        .metadata_context
+        .experimental
+        .get(&key)
+        .map(|v| v.to_string());
 
-                return 1;
-            }
-        }
+    if let Some(value) = value {
+        let serialized =
+            PluginSerializedBytes::try_serialize(&value).expect("Should be serializable");
+
+        allocate_return_values_into_guest(
+            memory,
+            &mut env.as_store_mut(),
+            alloc_guest_memory,
+            allocated_ret_ptr,
+            &serialized,
+        );
+
+        return 1;
     }
-    0
+
+    return 0;
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn get_raw_experiemtal_transform_context(
-    env: &MetadataContextHostEnvironment,
+    mut env: FunctionEnvMut<MetadataContextHostEnvironment>,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        let experimental_context = &env.metadata_context.experimental;
-        let serialized_experimental_context_bytes =
-            PluginSerializedBytes::try_serialize(experimental_context)
-                .expect("Should be serializable");
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            allocate_return_values_into_guest(
-                memory,
-                alloc_guest_memory,
-                allocated_ret_ptr,
-                &serialized_experimental_context_bytes,
-            );
-            1
-        } else {
-            0
-        }
-    } else {
-        0
-    }
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
+
+    let experimental_context = env.data().metadata_context.experimental.clone();
+    let serialized_experimental_context_bytes =
+        PluginSerializedBytes::try_serialize(&experimental_context)
+            .expect("Should be serializable");
+
+    allocate_return_values_into_guest(
+        memory,
+        &mut env.as_store_mut(),
+        alloc_guest_memory,
+        allocated_ret_ptr,
+        &serialized_experimental_context_bytes,
+    );
+    1
 }

--- a/crates/swc_plugin_runner/src/imported_fn/mod.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/mod.rs
@@ -41,11 +41,7 @@
 * actual vec into guest it'll write pointer to the vec into the struct.
 */
 
-use std::sync::Arc;
-
-use parking_lot::Mutex;
-use swc_common::{plugin::metadata::TransformPluginMetadataContext, SourceMap};
-use wasmer::{imports, Function, ImportObject, Module};
+use wasmer::{imports, Function, FunctionEnv, Imports, Store};
 
 use crate::{
     host_environment::BaseHostEnvironment,
@@ -57,247 +53,190 @@ use crate::{
             has_trailing_comments_proxy, move_leading_comments_proxy, move_trailing_comments_proxy,
             take_leading_comments_proxy, take_trailing_comments_proxy, CommentHostEnvironment,
         },
+        diagnostics::{set_plugin_core_pkg_diagnostics, DiagnosticContextHostEnvironment},
         metadata_context::get_raw_experiemtal_transform_context,
         set_transform_result::{set_transform_result, TransformResultHostEnvironment},
+        source_map::span_to_source_proxy,
         span::span_dummy_with_cmt_proxy,
     },
 };
 
-mod comments;
-mod diagnostics;
-mod handler;
-mod hygiene;
-mod metadata_context;
-mod set_transform_result;
-mod source_map;
-mod span;
+pub(crate) mod comments;
+pub(crate) mod diagnostics;
+pub(crate) mod handler;
+pub(crate) mod hygiene;
+pub(crate) mod metadata_context;
+pub(crate) mod set_transform_result;
+pub(crate) mod source_map;
+pub(crate) mod span;
 
 use handler::*;
 use hygiene::*;
 
 use self::{
-    diagnostics::{set_plugin_core_pkg_diagnostics, DiagnosticContextHostEnvironment},
     metadata_context::{
         copy_context_key_to_host_env, get_experimental_transform_context, get_transform_context,
         get_transform_plugin_config, MetadataContextHostEnvironment,
     },
     source_map::{
         doctest_offset_line_proxy, lookup_byte_offset_proxy, lookup_char_pos_proxy,
-        merge_spans_proxy, span_to_filename_proxy, span_to_lines_proxy, span_to_source_proxy,
-        span_to_string_proxy, SourceMapHostEnvironment,
+        merge_spans_proxy, span_to_filename_proxy, span_to_lines_proxy, span_to_string_proxy,
+        SourceMapHostEnvironment,
     },
 };
 
 /// Create an ImportObject includes functions to be imported from host to the
 /// plugins.
 pub(crate) fn build_import_object(
-    module: &Module,
-    source_map: Arc<SourceMap>,
-    metadata_context: Arc<TransformPluginMetadataContext>,
-    plugin_config: Option<serde_json::Value>,
-    transform_result: &Arc<Mutex<Vec<u8>>>,
-    core_diag_buffer: &Arc<Mutex<Vec<u8>>>,
-) -> ImportObject {
-    let store = module.store();
-
+    wasmer_store: &mut Store,
+    metadata_env: &FunctionEnv<MetadataContextHostEnvironment>,
+    transform_env: &FunctionEnv<TransformResultHostEnvironment>,
+    base_env: &FunctionEnv<BaseHostEnvironment>,
+    comments_env: &FunctionEnv<CommentHostEnvironment>,
+    source_map_host_env: &FunctionEnv<SourceMapHostEnvironment>,
+    diagnostics_env: &FunctionEnv<DiagnosticContextHostEnvironment>,
+) -> Imports {
     // core_diagnostics
-    let set_transform_plugin_core_pkg_diagnostics_fn_decl = Function::new_native_with_env(
-        store,
-        DiagnosticContextHostEnvironment::new(core_diag_buffer),
+    let set_transform_plugin_core_pkg_diagnostics_fn_decl = Function::new_typed_with_env(
+        wasmer_store,
+        diagnostics_env,
         set_plugin_core_pkg_diagnostics,
     );
 
     // metadata
-    let context_key_buffer = Arc::new(Mutex::new(vec![]));
-    let copy_context_key_to_host_env_fn_decl = Function::new_native_with_env(
-        store,
-        MetadataContextHostEnvironment::new(&metadata_context, &plugin_config, &context_key_buffer),
-        copy_context_key_to_host_env,
-    );
-    let get_transform_plugin_config_fn_decl = Function::new_native_with_env(
-        store,
-        MetadataContextHostEnvironment::new(&metadata_context, &plugin_config, &context_key_buffer),
-        get_transform_plugin_config,
-    );
-    let get_transform_context_fn_decl = Function::new_native_with_env(
-        store,
-        MetadataContextHostEnvironment::new(&metadata_context, &plugin_config, &context_key_buffer),
-        get_transform_context,
-    );
-    let get_experimental_transform_context_fn_decl = Function::new_native_with_env(
-        store,
-        MetadataContextHostEnvironment::new(&metadata_context, &plugin_config, &context_key_buffer),
+    let copy_context_key_to_host_env_fn_decl =
+        Function::new_typed_with_env(wasmer_store, metadata_env, copy_context_key_to_host_env);
+    let get_transform_plugin_config_fn_decl =
+        Function::new_typed_with_env(wasmer_store, metadata_env, get_transform_plugin_config);
+    let get_transform_context_fn_decl =
+        Function::new_typed_with_env(wasmer_store, metadata_env, get_transform_context);
+
+    let get_experimental_transform_context_fn_decl = Function::new_typed_with_env(
+        wasmer_store,
+        metadata_env,
         get_experimental_transform_context,
     );
-    let get_raw_experiemtal_transform_context_fn_decl = Function::new_native_with_env(
-        store,
-        MetadataContextHostEnvironment::new(&metadata_context, &plugin_config, &context_key_buffer),
+    let get_raw_experiemtal_transform_context_fn_decl = Function::new_typed_with_env(
+        wasmer_store,
+        metadata_env,
         get_raw_experiemtal_transform_context,
     );
 
     // transform_result
-    let set_transform_result_fn_decl = Function::new_native_with_env(
-        store,
-        TransformResultHostEnvironment::new(transform_result),
-        set_transform_result,
-    );
+    let set_transform_result_fn_decl =
+        Function::new_typed_with_env(wasmer_store, transform_env, set_transform_result);
 
     // handler
     let emit_diagnostics_fn_decl =
-        Function::new_native_with_env(store, BaseHostEnvironment::new(), emit_diagnostics);
+        Function::new_typed_with_env(wasmer_store, base_env, emit_diagnostics);
 
     // hygiene
-    let mark_fresh_fn_decl = Function::new_native(store, mark_fresh_proxy);
-    let mark_parent_fn_decl = Function::new_native(store, mark_parent_proxy);
-    let mark_is_builtin_fn_decl = Function::new_native(store, mark_is_builtin_proxy);
-    let mark_set_builtin_fn_decl = Function::new_native(store, mark_set_builtin_proxy);
-    let mark_is_descendant_of_fn_decl = Function::new_native_with_env(
-        store,
-        BaseHostEnvironment::new(),
-        mark_is_descendant_of_proxy,
-    );
+    let mark_fresh_fn_decl = Function::new_typed(wasmer_store, mark_fresh_proxy);
+    let mark_parent_fn_decl = Function::new_typed(wasmer_store, mark_parent_proxy);
+    let mark_is_builtin_fn_decl = Function::new_typed(wasmer_store, mark_is_builtin_proxy);
+    let mark_set_builtin_fn_decl = Function::new_typed(wasmer_store, mark_set_builtin_proxy);
+    let mark_is_descendant_of_fn_decl =
+        Function::new_typed_with_env(wasmer_store, base_env, mark_is_descendant_of_proxy);
 
     let mark_least_ancestor_fn_decl =
-        Function::new_native_with_env(store, BaseHostEnvironment::new(), mark_least_ancestor_proxy);
+        Function::new_typed_with_env(wasmer_store, base_env, mark_least_ancestor_proxy);
 
     let syntax_context_apply_mark_fn_decl =
-        Function::new_native(store, syntax_context_apply_mark_proxy);
-    let syntax_context_remove_mark_fn_decl = Function::new_native_with_env(
-        store,
-        BaseHostEnvironment::new(),
-        syntax_context_remove_mark_proxy,
-    );
-    let syntax_context_outer_fn_decl = Function::new_native(store, syntax_context_outer_proxy);
+        Function::new_typed(wasmer_store, syntax_context_apply_mark_proxy);
+    let syntax_context_remove_mark_fn_decl =
+        Function::new_typed_with_env(wasmer_store, base_env, syntax_context_remove_mark_proxy);
+    let syntax_context_outer_fn_decl =
+        Function::new_typed(wasmer_store, syntax_context_outer_proxy);
 
     // Span
-    let span_dummy_with_cmt_fn_decl = Function::new_native(store, span_dummy_with_cmt_proxy);
+    let span_dummy_with_cmt_fn_decl = Function::new_typed(wasmer_store, span_dummy_with_cmt_proxy);
 
     // comments
-    let comment_buffer = Arc::new(Mutex::new(vec![]));
+    let copy_comment_to_host_env_fn_decl =
+        Function::new_typed_with_env(wasmer_store, comments_env, copy_comment_to_host_env);
 
-    let copy_comment_to_host_env_fn_decl = Function::new_native_with_env(
-        store,
-        CommentHostEnvironment::new(&comment_buffer),
-        copy_comment_to_host_env,
-    );
+    let add_leading_comment_fn_decl =
+        Function::new_typed_with_env(wasmer_store, comments_env, add_leading_comment_proxy);
 
-    let add_leading_comment_fn_decl = Function::new_native_with_env(
-        store,
-        CommentHostEnvironment::new(&comment_buffer),
-        add_leading_comment_proxy,
-    );
+    let add_leading_comments_fn_decl =
+        Function::new_typed_with_env(wasmer_store, comments_env, add_leading_comments_proxy);
 
-    let add_leading_comments_fn_decl = Function::new_native_with_env(
-        store,
-        CommentHostEnvironment::new(&comment_buffer),
-        add_leading_comments_proxy,
-    );
+    let has_leading_comments_fn_decl =
+        Function::new_typed(wasmer_store, has_leading_comments_proxy);
 
-    let has_leading_comments_fn_decl = Function::new_native(store, has_leading_comments_proxy);
+    let move_leading_comments_fn_decl =
+        Function::new_typed(wasmer_store, move_leading_comments_proxy);
 
-    let move_leading_comments_fn_decl = Function::new_native(store, move_leading_comments_proxy);
-
-    let take_leading_comments_fn_decl = Function::new_native_with_env(
-        store,
+    let take_leading_comments_fn_decl = Function::new_typed_with_env(
+        wasmer_store,
         // take_* doesn't need to share buffer to pass values from plugin to the host - do not
         // clone buffer here.
-        CommentHostEnvironment::new(&Default::default()),
+        comments_env,
         take_leading_comments_proxy,
     );
 
-    let get_leading_comments_fn_decl = Function::new_native_with_env(
-        store,
+    let get_leading_comments_fn_decl = Function::new_typed_with_env(
+        wasmer_store,
         // get_* doesn't need to share buffer to pass values from plugin to the host - do not clone
         // buffer here.
-        CommentHostEnvironment::new(&Default::default()),
+        comments_env,
         get_leading_comments_proxy,
     );
 
-    let add_trailing_comment_fn_decl = Function::new_native_with_env(
-        store,
-        CommentHostEnvironment::new(&comment_buffer),
-        add_trailing_comment_proxy,
-    );
+    let add_trailing_comment_fn_decl =
+        Function::new_typed_with_env(wasmer_store, comments_env, add_trailing_comment_proxy);
 
-    let add_trailing_comments_fn_decl = Function::new_native_with_env(
-        store,
-        CommentHostEnvironment::new(&comment_buffer),
-        add_trailing_comments_proxy,
-    );
+    let add_trailing_comments_fn_decl =
+        Function::new_typed_with_env(wasmer_store, comments_env, add_trailing_comments_proxy);
 
-    let has_trailing_comments_fn_decl = Function::new_native(store, has_trailing_comments_proxy);
+    let has_trailing_comments_fn_decl =
+        Function::new_typed(wasmer_store, has_trailing_comments_proxy);
 
-    let move_trailing_comments_fn_decl = Function::new_native(store, move_trailing_comments_proxy);
+    let move_trailing_comments_fn_decl =
+        Function::new_typed(wasmer_store, move_trailing_comments_proxy);
 
-    let take_trailing_comments_fn_decl = Function::new_native_with_env(
-        store,
+    let take_trailing_comments_fn_decl = Function::new_typed_with_env(
+        wasmer_store,
         // take_* doesn't need to share buffer to pass values from plugin to the host - do not
         // clone buffer here.
-        CommentHostEnvironment::new(&Default::default()),
+        comments_env,
         take_trailing_comments_proxy,
     );
 
-    let get_trailing_comments_fn_decl = Function::new_native_with_env(
-        store,
+    let get_trailing_comments_fn_decl = Function::new_typed_with_env(
+        wasmer_store,
         // get_* doesn't need to share buffer to pass values from plugin to the host - do not clone
         // buffer here.
-        CommentHostEnvironment::new(&Default::default()),
+        comments_env,
         get_trailing_comments_proxy,
     );
 
-    let add_pure_comment_fn_decl = Function::new_native(store, add_pure_comment_proxy);
+    let add_pure_comment_fn_decl = Function::new_typed(wasmer_store, add_pure_comment_proxy);
 
     // source_map
-    let source_map_buffer = Arc::new(Mutex::new(vec![]));
-    let source_map = Arc::new(Mutex::new(source_map));
+    let lookup_char_pos_source_map_fn_decl =
+        Function::new_typed_with_env(wasmer_store, source_map_host_env, lookup_char_pos_proxy);
 
-    let lookup_char_pos_source_map_fn_decl = Function::new_native_with_env(
-        store,
-        SourceMapHostEnvironment::new(&source_map, &source_map_buffer),
-        lookup_char_pos_proxy,
-    );
+    let doctest_offset_line_fn_decl =
+        Function::new_typed_with_env(wasmer_store, source_map_host_env, doctest_offset_line_proxy);
 
-    let doctest_offset_line_fn_decl = Function::new_native_with_env(
-        store,
-        SourceMapHostEnvironment::new(&source_map, &source_map_buffer),
-        doctest_offset_line_proxy,
-    );
+    let merge_spans_fn_decl =
+        Function::new_typed_with_env(wasmer_store, source_map_host_env, merge_spans_proxy);
 
-    let merge_spans_fn_decl = Function::new_native_with_env(
-        store,
-        SourceMapHostEnvironment::new(&source_map, &source_map_buffer),
-        merge_spans_proxy,
-    );
+    let span_to_string_fn_decl =
+        Function::new_typed_with_env(wasmer_store, source_map_host_env, span_to_string_proxy);
 
-    let span_to_string_fn_decl = Function::new_native_with_env(
-        store,
-        SourceMapHostEnvironment::new(&source_map, &source_map_buffer),
-        span_to_string_proxy,
-    );
+    let span_to_filename_fn_decl =
+        Function::new_typed_with_env(wasmer_store, source_map_host_env, span_to_filename_proxy);
 
-    let span_to_filename_fn_decl = Function::new_native_with_env(
-        store,
-        SourceMapHostEnvironment::new(&source_map, &source_map_buffer),
-        span_to_filename_proxy,
-    );
+    let span_to_source_fn_decl =
+        Function::new_typed_with_env(wasmer_store, source_map_host_env, span_to_source_proxy);
 
-    let span_to_source_fn_decl = Function::new_native_with_env(
-        store,
-        SourceMapHostEnvironment::new(&source_map, &source_map_buffer),
-        span_to_source_proxy,
-    );
+    let span_to_lines_fn_decl =
+        Function::new_typed_with_env(wasmer_store, source_map_host_env, span_to_lines_proxy);
 
-    let span_to_lines_fn_decl = Function::new_native_with_env(
-        store,
-        SourceMapHostEnvironment::new(&source_map, &source_map_buffer),
-        span_to_lines_proxy,
-    );
-
-    let lookup_byte_offset_fn_decl = Function::new_native_with_env(
-        store,
-        SourceMapHostEnvironment::new(&source_map, &source_map_buffer),
-        lookup_byte_offset_proxy,
-    );
+    let lookup_byte_offset_fn_decl =
+        Function::new_typed_with_env(wasmer_store, source_map_host_env, lookup_byte_offset_proxy);
 
     imports! {
         "env" => {

--- a/crates/swc_plugin_runner/src/imported_fn/set_transform_result.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/set_transform_result.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use parking_lot::Mutex;
-use wasmer::{LazyInit, Memory};
+use wasmer::{FunctionEnvMut, Memory};
 
 use crate::memory_interop::copy_bytes_into_host;
 
@@ -10,17 +10,16 @@ use crate::memory_interop::copy_bytes_into_host;
 ///
 /// When plugin performs its transform it'll fill in `transform_result` with
 /// serialized result. Host will reconstruct AST from those value.
-#[derive(wasmer::WasmerEnv, Clone)]
+#[derive(Clone)]
 pub struct TransformResultHostEnvironment {
-    #[wasmer(export)]
-    pub memory: wasmer::LazyInit<Memory>,
+    pub memory: Option<Memory>,
     pub transform_result: Arc<Mutex<Vec<u8>>>,
 }
 
 impl TransformResultHostEnvironment {
     pub fn new(transform_result: &Arc<Mutex<Vec<u8>>>) -> TransformResultHostEnvironment {
         TransformResultHostEnvironment {
-            memory: LazyInit::default(),
+            memory: None,
             transform_result: transform_result.clone(),
         }
     }
@@ -32,11 +31,16 @@ impl TransformResultHostEnvironment {
 /// this to set its result back to host.
 #[tracing::instrument(level = "info", skip_all)]
 pub fn set_transform_result(
-    env: &TransformResultHostEnvironment,
-    bytes_ptr: u32,
-    bytes_ptr_len: u32,
+    mut env: FunctionEnvMut<TransformResultHostEnvironment>,
+    bytes_ptr: i32,
+    bytes_ptr_len: i32,
 ) {
-    if let Some(memory) = env.memory_ref() {
-        (*env.transform_result.lock()) = copy_bytes_into_host(memory, bytes_ptr, bytes_ptr_len);
-    }
+    let memory = env
+        .data()
+        .memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
+
+    (*env.data_mut().transform_result.lock()) =
+        copy_bytes_into_host(&memory.view(&env), bytes_ptr, bytes_ptr_len);
 }

--- a/crates/swc_plugin_runner/src/imported_fn/source_map.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/source_map.rs
@@ -6,20 +6,18 @@ use swc_common::{
     source_map::{PartialFileLines, PartialLoc},
     BytePos, SourceMap, SourceMapper, Span, SyntaxContext,
 };
-use wasmer::{LazyInit, Memory, NativeFunc};
+use wasmer::{AsStoreMut, FunctionEnvMut, Memory, TypedFunction};
 
 use crate::memory_interop::{allocate_return_values_into_guest, write_into_memory_view};
 
 /// External environment state for imported (declared in host, injected into
 /// guest) fn for source map proxy.
-#[derive(wasmer::WasmerEnv, Clone)]
+#[derive(Clone)]
 pub struct SourceMapHostEnvironment {
-    #[wasmer(export)]
-    pub memory: wasmer::LazyInit<Memory>,
+    pub memory: Option<Memory>,
     /// Attached imported fn `__alloc` to the hostenvironment to allow any other
     /// imported fn can allocate guest's memory space from host runtime.
-    #[wasmer(export(name = "__alloc"))]
-    pub alloc_guest_memory: LazyInit<NativeFunc<u32, u32>>,
+    pub alloc_guest_memory: Option<TypedFunction<u32, u32>>,
     pub source_map: Arc<Mutex<Arc<SourceMap>>>,
     /// A buffer to non-determined size of return value from the host.
     pub mutable_source_map_buffer: Arc<Mutex<Vec<u8>>>,
@@ -31,8 +29,8 @@ impl SourceMapHostEnvironment {
         mutable_source_map_buffer: &Arc<Mutex<Vec<u8>>>,
     ) -> SourceMapHostEnvironment {
         SourceMapHostEnvironment {
-            memory: LazyInit::default(),
-            alloc_guest_memory: LazyInit::default(),
+            memory: None,
+            alloc_guest_memory: None,
             source_map: source_map.clone(),
             mutable_source_map_buffer: mutable_source_map_buffer.clone(),
         }
@@ -44,52 +42,54 @@ impl SourceMapHostEnvironment {
 /// to avoid unnecessary data copying.
 #[tracing::instrument(level = "info", skip_all)]
 pub fn lookup_char_pos_proxy(
-    env: &SourceMapHostEnvironment,
+    mut env: FunctionEnvMut<SourceMapHostEnvironment>,
     byte_pos: u32,
     should_include_source_file: i32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        let original_loc = (env.source_map.lock()).lookup_char_pos(BytePos(byte_pos));
-        let ret = PartialLoc {
-            source_file: if should_include_source_file == 0 {
-                None
-            } else {
-                Some(original_loc.file)
-            },
-            line: original_loc.line,
-            col: original_loc.col.0,
-            col_display: original_loc.col_display,
-        };
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-        let serialized_loc_bytes =
-            PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
-
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            allocate_return_values_into_guest(
-                memory,
-                alloc_guest_memory,
-                allocated_ret_ptr,
-                &serialized_loc_bytes,
-            );
-            1
+    let original_loc = (env.data().source_map.lock()).lookup_char_pos(BytePos(byte_pos));
+    let ret = PartialLoc {
+        source_file: if should_include_source_file == 0 {
+            None
         } else {
-            0
-        }
+            Some(original_loc.file)
+        },
+        line: original_loc.line,
+        col: original_loc.col.0,
+        col_display: original_loc.col_display,
+    };
+
+    let serialized_loc_bytes =
+        PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+
+    if let Some(alloc_guest_memory) = env.data().alloc_guest_memory.clone().as_ref() {
+        allocate_return_values_into_guest(
+            memory,
+            &mut env.as_store_mut(),
+            alloc_guest_memory,
+            allocated_ret_ptr,
+            &serialized_loc_bytes,
+        );
+        1
     } else {
         0
     }
 }
 
 #[tracing::instrument(level = "info", skip_all)]
-pub fn doctest_offset_line_proxy(env: &SourceMapHostEnvironment, orig: u32) -> u32 {
-    (env.source_map.lock()).doctest_offset_line(orig as usize) as u32
+pub fn doctest_offset_line_proxy(env: FunctionEnvMut<SourceMapHostEnvironment>, orig: u32) -> u32 {
+    (env.data().source_map.lock()).doctest_offset_line(orig as usize) as u32
 }
 
 #[allow(clippy::too_many_arguments)]
 #[tracing::instrument(level = "info", skip_all)]
 pub fn merge_spans_proxy(
-    env: &SourceMapHostEnvironment,
+    mut env: FunctionEnvMut<SourceMapHostEnvironment>,
     lhs_lo: u32,
     lhs_hi: u32,
     lhs_ctxt: u32,
@@ -98,28 +98,34 @@ pub fn merge_spans_proxy(
     rhs_ctxt: u32,
     allocated_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        let sp_lhs = Span {
-            lo: BytePos(lhs_lo),
-            hi: BytePos(lhs_hi),
-            ctxt: SyntaxContext::from_u32(lhs_ctxt),
-        };
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-        let sp_rhs = Span {
-            lo: BytePos(rhs_lo),
-            hi: BytePos(rhs_hi),
-            ctxt: SyntaxContext::from_u32(rhs_ctxt),
-        };
+    let sp_lhs = Span {
+        lo: BytePos(lhs_lo),
+        hi: BytePos(lhs_hi),
+        ctxt: SyntaxContext::from_u32(lhs_ctxt),
+    };
 
-        let ret = (env.source_map.lock()).merge_spans(sp_lhs, sp_rhs);
-        if let Some(span) = ret {
-            let serialized_bytes =
-                PluginSerializedBytes::try_serialize(&span).expect("Should be serializable");
-            write_into_memory_view(memory, &serialized_bytes, |_| allocated_ptr);
-            1
-        } else {
-            0
-        }
+    let sp_rhs = Span {
+        lo: BytePos(rhs_lo),
+        hi: BytePos(rhs_hi),
+        ctxt: SyntaxContext::from_u32(rhs_ctxt),
+    };
+
+    let ret = (env.data().source_map.lock()).merge_spans(sp_lhs, sp_rhs);
+    if let Some(span) = ret {
+        let serialized_bytes =
+            PluginSerializedBytes::try_serialize(&span).expect("Should be serializable");
+        write_into_memory_view(
+            memory,
+            &mut env.as_store_mut(),
+            &serialized_bytes,
+            |_, _| allocated_ptr,
+        );
+        1
     } else {
         0
     }
@@ -127,177 +133,192 @@ pub fn merge_spans_proxy(
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn span_to_lines_proxy(
-    env: &SourceMapHostEnvironment,
+    mut env: FunctionEnvMut<SourceMapHostEnvironment>,
     span_lo: u32,
     span_hi: u32,
     span_ctxt: u32,
     should_request_source_file: i32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        let span = Span {
-            lo: BytePos(span_lo),
-            hi: BytePos(span_hi),
-            ctxt: SyntaxContext::from_u32(span_ctxt),
-        };
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-        let ret = (env.source_map.lock())
-            .span_to_lines(span)
-            .map(|lines| PartialFileLines {
-                file: if should_request_source_file == 0 {
-                    None
-                } else {
-                    Some(lines.file)
-                },
-                lines: lines.lines,
-            });
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
 
-        let serialized_loc_bytes =
-            PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+    let span = Span {
+        lo: BytePos(span_lo),
+        hi: BytePos(span_hi),
+        ctxt: SyntaxContext::from_u32(span_ctxt),
+    };
 
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            allocate_return_values_into_guest(
-                memory,
-                alloc_guest_memory,
-                allocated_ret_ptr,
-                &serialized_loc_bytes,
-            );
-            1
-        } else {
-            0
-        }
-    } else {
-        0
-    }
+    let ret = (env.data().source_map.lock())
+        .span_to_lines(span)
+        .map(|lines| PartialFileLines {
+            file: if should_request_source_file == 0 {
+                None
+            } else {
+                Some(lines.file)
+            },
+            lines: lines.lines,
+        });
+
+    let serialized_loc_bytes =
+        PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+
+    allocate_return_values_into_guest(
+        memory,
+        &mut env.as_store_mut(),
+        alloc_guest_memory,
+        allocated_ret_ptr,
+        &serialized_loc_bytes,
+    );
+    1
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn lookup_byte_offset_proxy(
-    env: &SourceMapHostEnvironment,
+    mut env: FunctionEnvMut<SourceMapHostEnvironment>,
     byte_pos: u32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        let byte_pos = BytePos(byte_pos);
-        let ret = (env.source_map.lock()).lookup_byte_offset(byte_pos);
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-        let serialized_loc_bytes =
-            PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
 
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            allocate_return_values_into_guest(
-                memory,
-                alloc_guest_memory,
-                allocated_ret_ptr,
-                &serialized_loc_bytes,
-            );
-            1
-        } else {
-            0
-        }
-    } else {
-        0
-    }
+    let byte_pos = BytePos(byte_pos);
+    let ret = (env.data().source_map.lock()).lookup_byte_offset(byte_pos);
+
+    let serialized_loc_bytes =
+        PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+
+    allocate_return_values_into_guest(
+        memory,
+        &mut env.as_store_mut(),
+        alloc_guest_memory,
+        allocated_ret_ptr,
+        &serialized_loc_bytes,
+    );
+    1
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn span_to_string_proxy(
-    env: &SourceMapHostEnvironment,
+    mut env: FunctionEnvMut<SourceMapHostEnvironment>,
     span_lo: u32,
     span_hi: u32,
     span_ctxt: u32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        let span = Span {
-            lo: BytePos(span_lo),
-            hi: BytePos(span_hi),
-            ctxt: SyntaxContext::from_u32(span_ctxt),
-        };
-        let ret = (env.source_map.lock()).span_to_string(span);
-        let serialized_loc_bytes =
-            PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            allocate_return_values_into_guest(
-                memory,
-                alloc_guest_memory,
-                allocated_ret_ptr,
-                &serialized_loc_bytes,
-            );
-            1
-        } else {
-            0
-        }
-    } else {
-        0
-    }
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
+
+    let span = Span {
+        lo: BytePos(span_lo),
+        hi: BytePos(span_hi),
+        ctxt: SyntaxContext::from_u32(span_ctxt),
+    };
+    let ret = (env.data().source_map.lock()).span_to_string(span);
+    let serialized_loc_bytes =
+        PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+
+    allocate_return_values_into_guest(
+        memory,
+        &mut env.as_store_mut(),
+        alloc_guest_memory,
+        allocated_ret_ptr,
+        &serialized_loc_bytes,
+    );
+    1
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn span_to_filename_proxy(
-    env: &SourceMapHostEnvironment,
+    mut env: FunctionEnvMut<SourceMapHostEnvironment>,
     span_lo: u32,
     span_hi: u32,
     span_ctxt: u32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        let span = Span {
-            lo: BytePos(span_lo),
-            hi: BytePos(span_hi),
-            ctxt: SyntaxContext::from_u32(span_ctxt),
-        };
-        let ret = (env.source_map.lock()).span_to_filename(span);
-        let serialized_loc_bytes =
-            PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            allocate_return_values_into_guest(
-                memory,
-                alloc_guest_memory,
-                allocated_ret_ptr,
-                &serialized_loc_bytes,
-            );
-            1
-        } else {
-            0
-        }
-    } else {
-        0
-    }
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
+
+    let span = Span {
+        lo: BytePos(span_lo),
+        hi: BytePos(span_hi),
+        ctxt: SyntaxContext::from_u32(span_ctxt),
+    };
+    let ret = (env.data().source_map.lock()).span_to_filename(span);
+    let serialized_loc_bytes =
+        PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+
+    allocate_return_values_into_guest(
+        memory,
+        &mut env.as_store_mut(),
+        alloc_guest_memory,
+        allocated_ret_ptr,
+        &serialized_loc_bytes,
+    );
+    1
 }
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn span_to_source_proxy(
-    env: &SourceMapHostEnvironment,
+    mut env: FunctionEnvMut<SourceMapHostEnvironment>,
     span_lo: u32,
     span_hi: u32,
     span_ctxt: u32,
     allocated_ret_ptr: u32,
 ) -> i32 {
-    if let Some(memory) = env.memory_ref() {
-        let span = Span {
-            lo: BytePos(span_lo),
-            hi: BytePos(span_hi),
-            ctxt: SyntaxContext::from_u32(span_ctxt),
-        };
-        let ret = (env.source_map.lock()).span_to_snippet(span);
-        let serialized_loc_bytes =
-            PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+    let memory = env.data().memory.clone();
+    let memory = memory
+        .as_ref()
+        .expect("Memory instance should be available, check initialization");
 
-        if let Some(alloc_guest_memory) = env.alloc_guest_memory_ref() {
-            allocate_return_values_into_guest(
-                memory,
-                alloc_guest_memory,
-                allocated_ret_ptr,
-                &serialized_loc_bytes,
-            );
-            1
-        } else {
-            0
-        }
-    } else {
-        0
-    }
+    let alloc_guest_memory = env.data().alloc_guest_memory.clone();
+    let alloc_guest_memory = alloc_guest_memory
+        .as_ref()
+        .expect("Alloc guest memory fn should be available, check initialization");
+
+    let span = Span {
+        lo: BytePos(span_lo),
+        hi: BytePos(span_hi),
+        ctxt: SyntaxContext::from_u32(span_ctxt),
+    };
+    let ret = (*env.data().source_map.lock()).span_to_snippet(span);
+    let serialized_loc_bytes =
+        PluginSerializedBytes::try_serialize(&ret).expect("Should be serializable");
+
+    allocate_return_values_into_guest(
+        memory,
+        &mut env.as_store_mut(),
+        alloc_guest_memory,
+        allocated_ret_ptr,
+        &serialized_loc_bytes,
+    );
+    1
 }

--- a/crates/swc_plugin_runner/src/load_plugin.rs
+++ b/crates/swc_plugin_runner/src/load_plugin.rs
@@ -1,71 +1,184 @@
 use std::{env, sync::Arc};
 
-use anyhow::{Context, Error};
+use anyhow::Error;
 use parking_lot::Mutex;
-use swc_common::{plugin::metadata::TransformPluginMetadataContext, SourceMap};
-use wasmer::{ChainableNamedResolver, Instance};
-use wasmer_wasi::{is_wasi_module, WasiState};
+use swc_common::{
+    plugin::{
+        diagnostics::PluginCorePkgDiagnostics, metadata::TransformPluginMetadataContext,
+        serialized::PluginSerializedBytes,
+    },
+    SourceMap,
+};
+use wasmer::{FunctionEnv, Instance, Store};
+use wasmer_wasix::{default_fs_backing, is_wasi_module, WasiEnv, WasiFunctionEnv};
 
-use crate::imported_fn::build_import_object;
+use crate::{
+    host_environment::BaseHostEnvironment,
+    imported_fn::{
+        build_import_object, comments::CommentHostEnvironment,
+        diagnostics::DiagnosticContextHostEnvironment,
+        metadata_context::MetadataContextHostEnvironment,
+        set_transform_result::TransformResultHostEnvironment, source_map::SourceMapHostEnvironment,
+    },
+};
 
 #[tracing::instrument(level = "info", skip_all)]
 pub fn load_plugin(
+    store: &mut Store,
     plugin_path: &std::path::Path,
     cache: &once_cell::sync::Lazy<crate::cache::PluginModuleCache>,
     source_map: &Arc<SourceMap>,
     metadata_context: &Arc<TransformPluginMetadataContext>,
     plugin_config: Option<serde_json::Value>,
-    transform_result_buffer: &Arc<Mutex<Vec<u8>>>,
-    core_diag_buffer: &Arc<Mutex<Vec<u8>>>,
-) -> Result<Instance, Error> {
-    let module = cache.load_module(plugin_path)?;
+) -> Result<
+    (
+        Instance,
+        Arc<Mutex<Vec<u8>>>,
+        PluginCorePkgDiagnostics,
+        Option<WasiFunctionEnv>,
+    ),
+    Error,
+> {
+    let module = cache.load_module(store, plugin_path);
 
-    let import_object = build_import_object(
-        &module,
-        source_map.clone(),
-        metadata_context.clone(),
-        plugin_config,
-        transform_result_buffer,
-        core_diag_buffer,
-    );
+    match module {
+        Ok(module) => {
+            let context_key_buffer = Arc::new(Mutex::new(vec![]));
+            let metadata_env = FunctionEnv::new(
+                store,
+                MetadataContextHostEnvironment::new(
+                    metadata_context,
+                    &plugin_config,
+                    &context_key_buffer,
+                ),
+            );
 
-    // Plugin binary can be either wasm32-wasi or wasm32-unknown-unknown.
-    // Wasi specific env need to be initialized if given module targets wasm32-wasi.
-    // TODO: wasm host native runtime throws 'Memory should be set on `WasiEnv`
-    // first'
-    let instance = if is_wasi_module(&module) {
-        // Create the `WasiEnv`.
-        let mut wasi_env = WasiState::new(
-            plugin_path
-                .file_name()
-                .and_then(|f| f.to_str())
-                .expect("Plugin path missing file name"),
-        );
+            let transform_result: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(vec![]));
+            let transform_env = FunctionEnv::new(
+                store,
+                TransformResultHostEnvironment::new(&transform_result),
+            );
 
-        // Implicitly enable filesystem access for the wasi plugin to cwd.
-        //
-        // This allows wasi plugin can read arbitary data (i.e node_modules) or produce
-        // output for post process (i.e .lcov coverage data) directly.
-        //
-        // TODO: this is not finalized decision
-        // - should we support this?
-        // - can we limit to allowlisted input / output only?
-        // - should there be a top-level config from .swcrc to manually override this?
-        let wasi_env = if let Ok(cwd) = env::current_dir() {
-            wasi_env.map_dir("/cwd", cwd)?
-        } else {
-            &mut wasi_env
-        };
+            let base_env = FunctionEnv::new(store, BaseHostEnvironment::new());
 
-        let mut wasi_env = wasi_env.finalize()?;
+            let comment_buffer = Arc::new(Mutex::new(vec![]));
 
-        // Generate an `ImportObject` from wasi_env, overwrite into imported_object
-        let wasi_env_import_object = wasi_env.import_object(&module)?;
-        let chained_resolver = import_object.chain_front(wasi_env_import_object);
-        Instance::new(&module, &chained_resolver)
-    } else {
-        Instance::new(&module, &import_object)
-    };
+            let comments_env =
+                FunctionEnv::new(store, CommentHostEnvironment::new(&comment_buffer));
 
-    instance.context("Failed to create plugin instance")
+            let source_map_buffer = Arc::new(Mutex::new(vec![]));
+            let source_map = Arc::new(Mutex::new(source_map.clone()));
+
+            let source_map_host_env = FunctionEnv::new(
+                store,
+                SourceMapHostEnvironment::new(&source_map, &source_map_buffer),
+            );
+
+            let diagnostics_buffer: Arc<Mutex<Vec<u8>>> = Arc::new(Mutex::new(vec![]));
+            let diagnostics_env = FunctionEnv::new(
+                store,
+                DiagnosticContextHostEnvironment::new(&diagnostics_buffer),
+            );
+
+            let mut import_object = build_import_object(
+                store,
+                &metadata_env,
+                &transform_env,
+                &base_env,
+                &comments_env,
+                &source_map_host_env,
+                &diagnostics_env,
+            );
+
+            // Plugin binary can be either wasm32-wasi or wasm32-unknown-unknown.
+            // Wasi specific env need to be initialized if given module targets wasm32-wasi.
+            // TODO: wasm host native runtime throws 'Memory should be set on `WasiEnv`
+            // first'
+            let (instance, wasi_env) = if is_wasi_module(&module) {
+                let file_name = plugin_path
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .expect("Plugin path missing file name");
+
+                let builder = WasiEnv::builder(file_name);
+
+                // Implicitly enable filesystem access for the wasi plugin to cwd.
+                //
+                // This allows wasi plugin can read arbitary data (i.e node_modules) or produce
+                // output for post process (i.e .lcov coverage data) directly.
+                //
+                // TODO: this is not finalized decision
+                // - should we support this?
+                // - can we limit to allowlisted input / output only?
+                // - should there be a top-level config from .swcrc to manually override this?
+                let wasi_env_builder = if let Ok(cwd) = env::current_dir() {
+                    builder
+                        .fs(default_fs_backing())
+                        .map_dirs(vec![("/cwd".to_string(), cwd)].drain(..))?
+                } else {
+                    builder
+                };
+
+                //create the `WasiEnv`
+                let mut wasi_env = wasi_env_builder.finalize(store)?;
+
+                // Then, we get the import object related to our WASI,
+                // overwrite into imported_object
+                // and attach it to the Wasm instance.
+                let wasi_env_import_object = wasi_env.import_object(store, &module)?;
+                import_object.extend(&wasi_env_import_object);
+
+                let instance = Instance::new(store, &module, &import_object)?;
+
+                wasi_env.initialize(store, instance.clone())?;
+
+                (instance, Some(wasi_env))
+            } else {
+                (Instance::new(store, &module, &import_object)?, None)
+            };
+
+            // Attach the memory export
+            let memory = instance.exports.get_memory("memory")?;
+            import_object.define("env", "memory", memory.clone());
+
+            let alloc = instance.exports.get_typed_function(store, "__alloc")?;
+
+            // Unlike wasmer@2, have to manually `import` memory / necessary functions from
+            // the guest into env.
+            metadata_env.as_mut(store).memory = Some(memory.clone());
+            metadata_env.as_mut(store).alloc_guest_memory = Some(alloc.clone());
+
+            transform_env.as_mut(store).memory = Some(memory.clone());
+
+            base_env.as_mut(store).memory = Some(memory.clone());
+
+            comments_env.as_mut(store).memory = Some(memory.clone());
+            comments_env.as_mut(store).alloc_guest_memory = Some(alloc.clone());
+
+            source_map_host_env.as_mut(store).memory = Some(memory.clone());
+            source_map_host_env.as_mut(store).alloc_guest_memory = Some(alloc);
+
+            diagnostics_env.as_mut(store).memory = Some(memory.clone());
+
+            // As soon as instance is ready, host calls a fn to read plugin's swc_core pkg
+            // diagnostics as `handshake`. Once read those values will be available across
+            // whole plugin transform execution.
+
+            // IMPORTANT NOTE
+            // Note this is `handshake`, which we expect to success ALL TIME. Do not try to
+            // expand `PluginCorePkgDiagnostics` as it'll cause deserialization failure
+            // until we have forward-compat schema changes.
+            instance
+                .exports
+                .get_typed_function::<(), u32>(store, "__get_transform_plugin_core_pkg_diag")?
+                .call(store)?;
+
+            let diag_result: PluginCorePkgDiagnostics =
+                PluginSerializedBytes::from_slice(&(&(*diagnostics_buffer.lock()))[..])
+                    .deserialize()?;
+
+            Ok((instance, transform_result, diag_result, wasi_env))
+        }
+        Err(err) => Err(err),
+    }
 }

--- a/crates/swc_plugin_runner/src/memory_interop.rs
+++ b/crates/swc_plugin_runner/src/memory_interop.rs
@@ -1,59 +1,40 @@
 use swc_common::plugin::serialized::PluginSerializedBytes;
 use swc_plugin_proxy::AllocatedBytesPtr;
-use wasmer::{Array, Memory, NativeFunc, WasmPtr};
+use wasmer::{Memory, MemoryView, StoreMut, TypedFunction, WasmPtr};
 
 #[tracing::instrument(level = "info", skip_all)]
-pub fn copy_bytes_into_host(memory: &Memory, bytes_ptr: u32, bytes_ptr_len: u32) -> Vec<u8> {
-    let ptr: WasmPtr<u8, Array> = WasmPtr::new(bytes_ptr as _);
+pub fn copy_bytes_into_host(memory: &MemoryView, bytes_ptr: i32, bytes_ptr_len: i32) -> Vec<u8> {
+    let ptr: WasmPtr<u8> = WasmPtr::new(bytes_ptr as _);
+    let derefed_ptr = ptr.deref(memory);
+    let values = ptr.slice(memory, bytes_ptr_len as u32).expect("xxx");
 
-    // Deref & read through plugin's wasm memory space via returned ptr
-    let derefed_ptr = ptr
-        .deref(memory, 0, bytes_ptr_len)
-        .expect("Should able to deref from given ptr");
-
-    derefed_ptr
-        .iter()
-        .enumerate()
-        .take(bytes_ptr_len as usize)
-        .map(|(_size, cell)| cell.get())
-        .collect::<Vec<u8>>()
+    values
+        .read_to_vec()
+        .expect("Should able to read memory from given ptr")
 }
 
 /// Locate a view from given memory, write serialized bytes into.
 #[tracing::instrument(level = "info", skip_all)]
 pub fn write_into_memory_view<F>(
     memory: &Memory,
+    store: &mut StoreMut,
     serialized_bytes: &PluginSerializedBytes,
     get_allocated_ptr: F,
 ) -> (u32, u32)
 where
-    F: Fn(usize) -> u32,
+    F: Fn(&mut StoreMut, usize) -> u32,
 {
     let serialized_len = serialized_bytes.as_ptr().1;
 
-    let ptr_start: u32 = get_allocated_ptr(serialized_len);
-    let ptr_start_size: u32 = ptr_start;
-    let serialized_len_size: u32 = serialized_len.try_into().unwrap_or_else(|_| {
-        panic!(
-            "Should be able to convert the value {} to u32",
-            serialized_len
-        )
-    });
+    let ptr_start = get_allocated_ptr(store, serialized_len);
+    let ptr_start_size: u64 = ptr_start as u64;
 
     // Note: it's important to get a view from memory _after_ alloc completes
-    let view = memory.view::<u8>();
-
-    // Get a subarray for current memoryview starting from ptr address we just
-    // allocated above, perform copying into specified ptr. Wasm's memory layout
-    // is linear and we have atomic guarantee by not having any thread access,
-    // so can safely get subarray from allocated ptr address.
-    //
-    // If we want safer operation instead, refer previous implementation
-    // https://github.com/swc-project/swc/blob/1ef8f3749b6454eb7d40a36a5f9366137fa97928/crates/swc_plugin_runner/src/lib.rs#L56-L61
-    unsafe {
-        view.subarray(ptr_start_size, ptr_start_size + serialized_len_size)
-            .copy_from(serialized_bytes.as_slice());
-    }
+    let view = memory.view(store);
+    // [TODO]: we need wasmer@3 compatible optimization like before
+    // https://github.com/swc-project/swc/blob/f73f96dd94639f8b7edcdb6290653e16bf848db6/crates/swc_plugin_runner/src/memory_interop.rs#L54
+    view.write(ptr_start_size, serialized_bytes.as_slice())
+        .expect("Should able to write into memory view");
 
     (
         ptr_start,
@@ -70,34 +51,38 @@ where
 #[tracing::instrument(level = "info", skip_all)]
 pub fn allocate_return_values_into_guest(
     memory: &Memory,
-    alloc_guest_memory: &NativeFunc<u32, u32>,
+    store: &mut StoreMut,
+    alloc_guest_memory: &TypedFunction<u32, u32>,
     allocated_ret_ptr: u32,
     serialized_bytes: &PluginSerializedBytes,
 ) {
     let serialized_bytes_len: usize = serialized_bytes.as_ptr().1;
 
+    // In most cases our host-plugin trampoline works in a way that
+    // plugin pre-allocates
+    // memory before calling host imported fn. But in case of
+    // comments return value is Vec<Comments> which
+    // guest cannot predetermine size to allocate, instead
+    // let host allocate by calling guest's alloc via attached
+    // hostenvironment.
+    let guest_memory_ptr = alloc_guest_memory
+        .call(
+            store,
+            serialized_bytes_len
+                .try_into()
+                .expect("Should be able to convert size"),
+        )
+        .expect("Should able to allocate memory in the plugin");
+
     let (allocated_ptr, allocated_ptr_len) =
-        write_into_memory_view(memory, serialized_bytes, |_| {
-            // In most cases our host-plugin trampoline works in a way that
-            // plugin pre-allocates
-            // memory before calling host imported fn. But in case of
-            // comments return value is Vec<Comments> which
-            // guest cannot predetermine size to allocate, instead
-            // let host allocate by calling guest's alloc via attached
-            // hostenvironment.
-            alloc_guest_memory
-                .call(
-                    serialized_bytes_len
-                        .try_into()
-                        .expect("Should be able to convert size"),
-                )
-                .expect("Should able to allocate memory in the plugin")
-        });
+        write_into_memory_view(memory, store, serialized_bytes, |s, _| guest_memory_ptr);
 
     let allocated_bytes = AllocatedBytesPtr(allocated_ptr, allocated_ptr_len);
     // Retuning (allocated_ptr, len) into caller (plugin)
     let comment_ptr_serialized =
         PluginSerializedBytes::try_serialize(&allocated_bytes).expect("Should be serializable");
 
-    write_into_memory_view(memory, &comment_ptr_serialized, |_| allocated_ret_ptr);
+    write_into_memory_view(memory, store, &comment_ptr_serialized, |_, _| {
+        allocated_ret_ptr
+    });
 }

--- a/crates/swc_plugin_runner/src/transform_executor.rs
+++ b/crates/swc_plugin_runner/src/transform_executor.rs
@@ -13,22 +13,56 @@ use swc_common::{
     plugin::{diagnostics::PluginCorePkgDiagnostics, metadata::TransformPluginMetadataContext},
     SourceMap,
 };
-use wasmer::Instance;
+use wasmer::{AsStoreMut, Instance, Store, TypedFunction};
+use wasmer_wasix::WasiFunctionEnv;
 
 #[cfg(feature = "__rkyv")]
 use crate::memory_interop::write_into_memory_view;
 
+/// Creates an instnace of [Store].
+///
+/// This function exists because we need to disable simd.
+#[cfg(not(target_arch = "wasm32"))]
+#[allow(unused_mut)]
+fn new_store() -> Store {
+    // Use empty enumset to disable simd.
+    use enumset::EnumSet;
+    use wasmer::{BaseTunables, CompilerConfig, EngineBuilder, Target, Triple};
+    let mut set = EnumSet::new();
+
+    // [TODO]: Should we use is_x86_feature_detected! macro instead?
+    #[cfg(target_arch = "x86_64")]
+    set.insert(wasmer::CpuFeature::SSE2);
+    let target = Target::new(Triple::host(), set);
+
+    let config = wasmer_compiler_cranelift::Cranelift::default();
+    let mut engine = EngineBuilder::new(Box::new(config) as Box<dyn CompilerConfig>)
+        .set_target(Some(target))
+        .engine();
+    let tunables = BaseTunables::for_target(engine.target());
+    engine.set_tunables(tunables);
+
+    Store::new(engine)
+}
+
+#[cfg(target_arch = "wasm32")]
+fn new_store() -> Store {
+    Store::default()
+}
+
 /// A struct encapsule executing a plugin's transform interop to its teardown
 pub struct TransformExecutor {
     // Main transform interface plugin exports
-    exported_plugin_transform: wasmer::NativeFunc<(u32, u32, u32, u32), u32>,
+    exported_plugin_transform: TypedFunction<(u32, u32, u32, u32), u32>,
     // `__free` function automatically exported via swc_plugin sdk to allow deallocation in guest
     // memory space
-    exported_plugin_free: wasmer::NativeFunc<(u32, u32), u32>,
+    exported_plugin_free: TypedFunction<(u32, u32), u32>,
     // `__alloc` function automatically exported via swc_plugin sdk to allow allocation in guest
     // memory space
-    exported_plugin_alloc: wasmer::NativeFunc<u32, u32>,
+    exported_plugin_alloc: TypedFunction<u32, u32>,
+    wasi_env: Option<WasiFunctionEnv>,
     instance: Instance,
+    store: Store,
     // Reference to the pointers successfully allocated which'll be freed by Drop.
     allocated_ptr_vec: Vec<(u32, u32)>,
     transform_result: Arc<Mutex<Vec<u8>>>,
@@ -49,54 +83,33 @@ impl TransformExecutor {
         metadata_context: &Arc<TransformPluginMetadataContext>,
         plugin_config: Option<serde_json::Value>,
     ) -> Result<TransformExecutor, Error> {
-        let transform_result = Arc::new(Mutex::new(vec![]));
-        let core_diag_buffer = Arc::new(Mutex::new(vec![]));
+        let mut store = new_store();
 
-        let instance = crate::load_plugin::load_plugin(
-            path,
-            cache,
-            source_map,
-            metadata_context,
-            plugin_config,
-            &transform_result,
-            &core_diag_buffer,
-        )?;
+        let (instance, transform_result, diagnostics_buffer, wasi_env) =
+            crate::load_plugin::load_plugin(
+                &mut store,
+                path,
+                cache,
+                source_map,
+                metadata_context,
+                plugin_config,
+            )?;
 
-        // As soon as instance is ready, host calls a fn to read plugin's swc_core pkg
-        // diagnostics as `handshake`. Once read those values will be available across
-        // whole plugin transform execution.
-
-        // IMPORTANT NOTE
-        // Note this is `handshake`, which we expect to success ALL TIME. Do not try to
-        // expand `PluginCorePkgDiagnostics` as it'll cause deserialization failure
-        // until we have forward-compat schema changes.
-        instance
-            .exports
-            .get_native_function::<(), i32>("__get_transform_plugin_core_pkg_diag")?
-            .call()?;
-
-        let diag_result: PluginCorePkgDiagnostics =
-            PluginSerializedBytes::from_slice(&(&(*core_diag_buffer.lock()))[..]).deserialize()?;
-
-        let tracker = TransformExecutor {
+        let executor = TransformExecutor {
             exported_plugin_transform: instance
                 .exports
-                .get_native_function::<(u32, u32, u32, u32), u32>(
-                    "__transform_plugin_process_impl",
-                )?,
-            exported_plugin_free: instance
-                .exports
-                .get_native_function::<(u32, u32), u32>("__free")?,
-            exported_plugin_alloc: instance
-                .exports
-                .get_native_function::<u32, u32>("__alloc")?,
+                .get_typed_function(&store, "__transform_plugin_process_impl")?,
+            exported_plugin_free: instance.exports.get_typed_function(&store, "__free")?,
+            exported_plugin_alloc: instance.exports.get_typed_function(&store, "__alloc")?,
             instance,
+            store,
+            wasi_env,
             allocated_ptr_vec: Vec::with_capacity(3),
             transform_result,
-            plugin_core_diag: diag_result,
+            plugin_core_diag: diagnostics_buffer,
         };
 
-        Ok(tracker)
+        Ok(executor)
     }
 
     /// Copy host's serialized bytes into guest (plugin)'s allocated memory.
@@ -108,11 +121,22 @@ impl TransformExecutor {
     ) -> Result<(u32, u32), Error> {
         let memory = self.instance.exports.get_memory("memory")?;
 
-        let ptr = write_into_memory_view(memory, serialized_bytes, |serialized_len| {
-            self.exported_plugin_alloc
-                .call(serialized_len.try_into().expect(""))
-                .expect("")
-        });
+        let ptr = write_into_memory_view(
+            memory,
+            &mut self.store.as_store_mut(),
+            serialized_bytes,
+            |s, serialized_len| {
+                self.exported_plugin_alloc
+                    .call(s, serialized_len.try_into().expect("booo"))
+                    .expect(
+                        format!(
+                            "Should able to allocate memory for the size of {}",
+                            serialized_len
+                        )
+                        .as_str(),
+                    )
+            },
+        );
 
         self.allocated_ptr_vec.push(ptr);
         Ok(ptr)
@@ -154,7 +178,7 @@ impl TransformExecutor {
      * current runtime.
      */
     #[allow(unreachable_code)]
-    pub fn is_transform_schema_compatible(&self) -> Result<bool, Error> {
+    pub fn is_transform_schema_compatible(&mut self) -> Result<bool, Error> {
         #[cfg(any(
             feature = "plugin_transform_schema_v1",
             feature = "plugin_transform_schema_vtest"
@@ -191,6 +215,7 @@ impl TransformExecutor {
         let guest_program_ptr = self.write_bytes_into_guest(program)?;
 
         let result = self.exported_plugin_transform.call(
+            &mut self.store,
             guest_program_ptr.0,
             guest_program_ptr.1,
             unresolved_mark.as_u32(),
@@ -205,8 +230,12 @@ impl Drop for TransformExecutor {
     fn drop(&mut self) {
         for ptr in self.allocated_ptr_vec.iter() {
             self.exported_plugin_free
-                .call(ptr.0, ptr.1)
+                .call(&mut self.store, ptr.0, ptr.1)
                 .expect("Failed to free memory allocated in the plugin");
+        }
+
+        if let Some(wasi_env) = &self.wasi_env {
+            wasi_env.cleanup(&mut self.store, None);
         }
     }
 }

--- a/crates/swc_plugin_runner/tests/css_rkyv.rs
+++ b/crates/swc_plugin_runner/tests/css_rkyv.rs
@@ -84,8 +84,6 @@ fn invoke(input: PathBuf) -> Result<(), Error> {
         .into_iter()
         .collect();
 
-        info!("Creating cache");
-
         let mut plugin_transform_executor = swc_plugin_runner::create_plugin_transform_executor(
             &path,
             &PLUGIN_MODULE_CACHE,
@@ -146,7 +144,7 @@ fn invoke(input: PathBuf) -> Result<(), Error> {
             )),
             Some(json!({ "pluginConfig": "testValue" })),
         )
-        .expect("Should load plugin");
+        .expect("Should load first plugin");
 
         serialized_program = plugin_transform_executor
             .transform(&serialized_program, Mark::new(), false)
@@ -164,7 +162,7 @@ fn invoke(input: PathBuf) -> Result<(), Error> {
             )),
             Some(json!({ "pluginConfig": "testValue" })),
         )
-        .expect("Should load plugin");
+        .expect("Should load second plugin");
 
         serialized_program = plugin_transform_executor
             .transform(&serialized_program, Mark::new(), false)

--- a/crates/swc_plugin_runner/tests/fixture/swc_noop_plugin/Cargo.toml
+++ b/crates/swc_plugin_runner/tests/fixture/swc_noop_plugin/Cargo.toml
@@ -2,7 +2,7 @@
 
 [package]
 edition = "2021"
-name = "swc_noop_plugin"
+name    = "swc_noop_plugin"
 publish = false
 version = "0.1.0"
 
@@ -11,4 +11,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde = "1"
-swc_core = {path = "../../../../swc_core", features = ["ecma_plugin_transform"]}
+swc_core = { path = "../../../../swc_core", features = [
+  "ecma_plugin_transform",
+] }

--- a/crates/swc_plugin_runner/tests/fixture/swc_noop_plugin/src/lib.rs
+++ b/crates/swc_plugin_runner/tests/fixture/swc_noop_plugin/src/lib.rs
@@ -4,6 +4,6 @@ use swc_core::{
 };
 
 #[plugin_transform]
-pub fn process(program: Program, metadata: TransformPluginProgramMetadata) -> Program {
+pub fn process(program: Program, _metadata: TransformPluginProgramMetadata) -> Program {
     program
 }

--- a/deny.toml
+++ b/deny.toml
@@ -75,6 +75,7 @@ allow = [
   "Zlib",
   "MPL-2.0",
   "0BSD",
+  "LicenseRef-ring",                #ring
   "Unicode-DFS-2016",               #unicode-ident
 ]
 # List of explictly disallowed licenses
@@ -102,7 +103,7 @@ default = "deny"
 confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
-exceptions = []
+exceptions = [{ allow = ["BUSL-1.1"], name = "webc" }]
 
   [[licenses.clarify]]
   # The name of the crate the clarification applies to
@@ -117,6 +118,11 @@ exceptions = []
   # and the crate will be checked normally, which may produce warnings or errors
   # depending on the rest of your configuration
   license-files = [{ path = "COPYRIGHT", hash = 972598577 }]
+
+  [[licenses.clarify]]
+  expression    = "LicenseRef-ring"
+  license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+  name          = "ring"
 
   # Some crates don't have (easily) machine readable licensing information,
   # adding a clarification entry for it allows you to manually specify the

--- a/node-swc/e2e/plugins/plugins.compat.test.js
+++ b/node-swc/e2e/plugins/plugins.compat.test.js
@@ -61,7 +61,9 @@ const inferBinaryName = () => {
     );
 };
 
-describe("Published plugins", () => {
+// [TODO]: It is expected to have a breaking changes to the plugin,
+// disabling the test for now.
+describe.skip("Published plugins", () => {
     const packageName = platformPackagesMap[platform][arch];
 
     if (!!packageName) {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR reattempts https://github.com/swc-project/swc/pull/5456.

Most of changes are for the breaking changes of wasmer@3, as well as enabling rkyv's strict mode (https://github.com/swc-project/swc/pull/6922). This could not be seperated since wasmer@3 enables strict mode by default without way to turn it off.

There are couple of changes worth to note:

- Disabling in-memory module lookup: https://github.com/swc-project/swc/pull/7197/files#diff-3bda5def6ce2b7553c3b3a5ad241c0bdb7021e67b7de1e594df4cd5a54d403b3R154-R159 
- Disabling plugin_runner in bindings_wasm: https://github.com/swc-project/swc/pull/7197/files#diff-dc3ded556a1fd709a129acd588e5eda651b842c6acc3f5340d40088a1f927facR310-R312
- Skipping plugin compat test: https://github.com/swc-project/swc/pull/7197/files#diff-531197dfcefba05faca53f0cf442ecc2dc6b59d5ead01979f5ffb912aa36249aR64-R66