### PR TITLE
doc(ecma-macros): fix `*_children_with_path` typos

### DIFF
--- a/crates/swc_visit_macros/src/lib.rs
+++ b/crates/swc_visit_macros/src/lib.rs
@@ -1530,7 +1530,7 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
 
                     /// Visit children nodes with v and ast path appended
                     /// [AstParentNodeRef] describing `self`. The ast path will
-                    /// be resotred when this method returns.
+                    /// be restored when this method returns.
                     ///
                     /// This is the default implementaton of a handler method in
                     /// [VisitAstPath].
@@ -1636,7 +1636,7 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
 
                     /// Visit children nodes with v and ast path appended
                     /// [AstKind] of `self`. The ast path will
-                    /// be resotred when this method returns.
+                    /// be restored when this method returns.
                     ///
                     /// This is the default implementaton of a handler method in
                     /// [FoldAstPath].
@@ -1704,7 +1704,7 @@ fn make(mode: Mode, stmts: &[Stmt]) -> Quote {
                     fn visit_mut_with_path(&mut self, v: &mut V, ast_path: &mut AstKindPath);
 
                     /// Visit children nodes with v and ast path appended
-                    /// [AstKind] of `self`. The ast path will be resotred when
+                    /// [AstKind] of `self`. The ast path will be restored when
                     /// this method returns.
                     ///
                     /// This is the default implementaton of a handler method in


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

resotred -> restored

**BREAKING CHANGE:**
None. Changes to doc string only.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**