### PR TITLE
fix(es/renamer): Ensure that param and function body are in same scope

### DIFF
--- a/crates/swc/tests/tsc-references/privateNameStaticsAndStaticMethods.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNameStaticsAndStaticMethods.1.normal.js
@@ -1,8 +1,8 @@
 //// [privateNameStaticsAndStaticMethods.ts]
 class A {
     static #foo(a) {}
-    static async #bar(a1) {}
-    static async *#baz(a2) {
+    static async #bar(a) {}
+    static async *#baz(a) {
         return 3;
     }
     static #_quux;
@@ -21,7 +21,7 @@ class A {
     }
 }
 class B extends A {
-    static #foo(a3) {}
+    static #foo(a) {}
     constructor(){
         super();
         B.#foo("str");

--- a/crates/swc/tests/tsc-references/privateNamesAndMethods.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNamesAndMethods.1.normal.js
@@ -1,8 +1,8 @@
 //// [privateNamesAndMethods.ts]
 class A {
     #foo(a) {}
-    async #bar(a1) {}
-    async *#baz(a2) {
+    async #bar(a) {}
+    async *#baz(a) {
         return 3;
     }
     #_quux;
@@ -21,7 +21,7 @@ class A {
     }
 }
 class B extends A {
-    #foo(a3) {}
+    #foo(a) {}
     constructor(){
         super();
         this.#foo("str");

--- a/crates/swc/tests/tsc-references/privateNamesAndStaticMethods.1.normal.js
+++ b/crates/swc/tests/tsc-references/privateNamesAndStaticMethods.1.normal.js
@@ -1,8 +1,8 @@
 //// [privateNamesAndStaticMethods.ts]
 class A {
     static #foo(a) {}
-    static async #bar(a1) {}
-    static async *#baz(a2) {
+    static async #bar(a) {}
+    static async *#baz(a) {
         return 3;
     }
     static #_quux;
@@ -21,7 +21,7 @@ class A {
     }
 }
 class B extends A {
-    static #foo(a3) {}
+    static #foo(a) {}
     constructor(){
         super();
         B.#foo("str");

--- a/crates/swc_ecma_minifier/tests/mangle/issue-7261/input.js
+++ b/crates/swc_ecma_minifier/tests/mangle/issue-7261/input.js
@@ -1,0 +1,5 @@
+export function func(a, b) {
+    const { c: d } = a;
+    console.log(d);
+}
+eval("");

--- a/crates/swc_ecma_minifier/tests/mangle/issue-7261/output.js
+++ b/crates/swc_ecma_minifier/tests/mangle/issue-7261/output.js
@@ -1,0 +1,5 @@
+export function func(o, c) {
+    const { c: n  } = o;
+    console.log(n);
+}
+eval("");

--- a/crates/swc_ecma_minifier/tests/terser/compress/properties/mangle_private_properties/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/properties/mangle_private_properties/output.js
@@ -2,5 +2,5 @@ class s {
     #s = 123;
     #e() {}
     get #t() {}
-    set #t(e) {}
+    set #t(s) {}
 }

--- a/crates/swc_ecma_minifier/tests/terser/compress/properties/mangle_private_properties/output.mangleOnly.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/properties/mangle_private_properties/output.mangleOnly.js
@@ -2,5 +2,5 @@ class s {
     #s = 123;
     #e() {}
     get #t() {}
-    set #t(e) {}
+    set #t(s) {}
 }

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/mod.rs
@@ -235,11 +235,7 @@ impl Visit for Analyzer {
                     self.add_decl(id.to_id(), true);
                 }
 
-                self.with_fn_scope(|v| {
-                    f.function.decorators.visit_with(v);
-                    f.function.params.visit_with(v);
-                    v.visit_fn_body_within_same_scope(&f.function.body);
-                })
+                f.function.visit_with(self)
             }
             DefaultDecl::TsInterfaceDecl(_) => {}
         }
@@ -305,12 +301,17 @@ impl Visit for Analyzer {
                 });
             })
         } else {
-            self.with_fn_scope(|v| {
-                f.function.decorators.visit_with(v);
-                f.function.params.visit_with(v);
-                v.visit_fn_body_within_same_scope(&f.function.body);
-            })
+            f.function.visit_with(self)
         }
+    }
+
+    // ensure param and function body always in same scope
+    fn visit_function(&mut self, f: &Function) {
+        self.with_fn_scope(|v| {
+            f.decorators.visit_with(v);
+            f.params.visit_with(v);
+            v.visit_fn_body_within_same_scope(&f.body);
+        })
     }
 
     fn visit_for_in_stmt(&mut self, n: &ForInStmt) {
@@ -370,11 +371,7 @@ impl Visit for Analyzer {
     fn visit_method_prop(&mut self, f: &MethodProp) {
         f.key.visit_with(self);
 
-        self.with_fn_scope(|v| {
-            f.function.decorators.visit_with(v);
-            f.function.params.visit_with(v);
-            v.visit_fn_body_within_same_scope(&f.function.body);
-        })
+        f.function.visit_with(self)
     }
 
     fn visit_named_export(&mut self, n: &NamedExport) {

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -113,7 +113,7 @@ where
         &self,
         node: &N,
         skip_one: bool,
-        is_module_or_script: bool,
+        top_level: bool,
         has_eval: bool,
     ) -> AHashMap<Id, JsWord>
     where
@@ -139,7 +139,7 @@ where
 
         let mut map = RenameMap::default();
 
-        let mut unresolved = if !is_module_or_script {
+        let mut unresolved = if !top_level {
             let mut unresolved = self.unresolved.clone();
             unresolved.extend(self.get_unresolved(node, has_eval));
             Cow::Owned(unresolved)


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

The probleam arises in L235 of swc_ecma_transforms_base/src/rename/mod.rs
```rs
unit!(visit_mut_fn_decl, FnDecl, true);
```

which calls `get_map` and evals to
```rs
node.visit_children_with(&mut v);
```
with `FnDecl` and `Analyzer` in L132. However in `Analyzer`, a visit to raw function was not overloaded, so function arguments and function body are considered different scope.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
closes #7261 