### PR TITLE
perf(es/react): Don't use regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4279,7 +4279,6 @@ dependencies = [
  "indexmap",
  "once_cell",
  "rayon",
- "regex",
  "serde",
  "sha-1",
  "string_enum",

--- a/crates/swc_ecma_transforms_react/Cargo.toml
+++ b/crates/swc_ecma_transforms_react/Cargo.toml
@@ -24,7 +24,6 @@ dashmap   = "5.1.0"
 indexmap  = "1.6.1"
 once_cell = "1.10.0"
 rayon     = { version = "1.5.1", optional = true }
-regex     = "1.4.2"
 serde     = { version = "1.0.118", features = ["derive"], optional = true }
 sha-1     = "=0.10.0"
 

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -2,8 +2,6 @@
 
 use std::{borrow::Cow, iter, iter::once, sync::Arc};
 
-use once_cell::sync::Lazy;
-use regex::Regex;
 use serde::{Deserialize, Serialize};
 use string_enum::StringEnum;
 use swc_atoms::{js_word, Atom, JsWord};
@@ -1251,8 +1249,6 @@ fn to_prop_name(n: JSXAttrName) -> PropName {
 
 #[inline]
 fn jsx_text_to_str(t: Atom) -> JsWord {
-    static SPACE_START: Lazy<Regex> = Lazy::new(|| Regex::new("^[ ]+").unwrap());
-    static SPACE_END: Lazy<Regex> = Lazy::new(|| Regex::new("[ ]+$").unwrap());
     let mut buf = String::new();
     let replaced = t.replace('\t', " ");
 
@@ -1262,14 +1258,14 @@ fn jsx_text_to_str(t: Atom) -> JsWord {
         }
         let line = Cow::from(line);
         let line = if i != 0 {
-            SPACE_START.replace_all(&line, "")
+            Cow::Borrowed(line.trim_start_matches(' '))
         } else {
             line
         };
         let line = if is_last {
             line
         } else {
-            SPACE_END.replace_all(&line, "")
+            Cow::Borrowed(line.trim_end_matches(' '))
         };
         if line.len() == 0 {
             continue;


### PR DESCRIPTION
**Description:**

It's causing a performance problem in concurrent scenarios.

x-ref: https://linear.app/vercel/issue/WEB-921
x-ref: https://vercel.slack.com/archives/C02HY34AKME/p1681757237489689

**Related issue:**
