### PR TITLE
fix(es/codegen): Fix codegen of `TsModuleDecl`

### DIFF
--- a/crates/swc_ecma_codegen/src/typescript.rs
+++ b/crates/swc_ecma_codegen/src/typescript.rs
@@ -578,12 +578,21 @@ where
             space!();
         }
 
-        keyword!("module");
-        space!();
-        emit!(n.id);
-        formatting_space!();
+        if n.global {
+            keyword!("global");
+        } else {
+            keyword!("module");
+            space!();
+            emit!(n.id);
+        }
 
-        if let Some(body) = &n.body {
+        if let Some(mut body) = n.body.as_ref() {
+            while let TsNamespaceBody::TsNamespaceDecl(decl) = body {
+                punct!(".");
+                emit!(decl.id);
+                body = &*decl.body;
+            }
+            formatting_space!();
             emit!(body);
         }
     }

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/module/input.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/module/input.js
@@ -1,0 +1,23 @@
+module Test {
+  1;
+}
+
+export module Test.Test {
+  1;
+}
+
+declare module Test.Test2 {
+  1;
+}
+
+declare global {
+  1;
+}
+
+declare namespace Test1.Test2 {
+  1;
+}
+
+export namespace Test1.Test2.Test3 {
+  2;
+}

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/module/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/module/output.js
@@ -1,0 +1,18 @@
+module Test {
+    1;
+}
+export module Test.Test {
+    1;
+}
+declare module Test.Test2 {
+    1;
+}
+declare global {
+    1;
+}
+declare module Test1.Test2 {
+    1;
+}
+export module Test1.Test2.Test3 {
+    2;
+}

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/module/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/module/output.min.js
@@ -1,0 +1,1 @@
+module Test{1;}export module Test.Test{1;}declare module Test.Test2{1;}declare global{1;}declare module Test1.Test2{1;}export module Test1.Test2.Test3{2;}


### PR DESCRIPTION
This improves/fixes the emit of TsModuleDecl when it hasn't been transformed to JavaScript. I'm working on a tool that emits typescript code as-is in some scenarios.