### PR TITLE
fix(es/codegen): Emit type arguments for call expressions

### DIFF
--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -857,6 +857,10 @@ where
 
         emit!(node.callee);
 
+        if let Some(type_args) = &node.type_args {
+            emit!(type_args);
+        }
+
         punct!("(");
         self.emit_expr_or_spreads(node.span(), &node.args, ListFormat::CallExpressionArguments)?;
         punct!(")");

--- a/crates/swc_ecma_codegen/src/typescript.rs
+++ b/crates/swc_ecma_codegen/src/typescript.rs
@@ -1122,4 +1122,14 @@ mod tests {
             "var memory:WebAssembly.Memory",
         );
     }
+
+    #[test]
+    fn type_arg() {
+        assert_min_typescript("do_stuff<T>()", "do_stuff<T>()");
+    }
+
+    #[test]
+    fn no_type_arg() {
+        assert_min_typescript("do_stuff()", "do_stuff()");
+    }
 }


### PR DESCRIPTION
**Description:**

The ECMA code generation implementation was not emitting type arguments for call expressions. This PR fixes that.