### PR TITLE
refactor(plugin_runner): refine cache location

### DIFF
--- a/crates/swc_plugin_runner/src/cache.rs
+++ b/crates/swc_plugin_runner/src/cache.rs
@@ -35,7 +35,7 @@ compile_error!(
 /// however it is not gauranteed to be compatible across wasmer's
 /// internal changes.
 /// https://github.com/wasmerio/wasmer/issues/2781
-const MODULE_SERIALIZATION_VERSION: &str = "v5";
+const MODULE_SERIALIZATION_VERSION: &str = "v6";
 
 /// A shared instance to plugin's module bytecode cache.
 pub static PLUGIN_MODULE_CACHE: Lazy<PluginModuleCache> = Lazy::new(Default::default);
@@ -81,9 +81,11 @@ fn create_filesystem_cache(filesystem_cache_root: &Option<String>) -> Option<Fil
     if let Some(root_path) = &mut root_path {
         root_path.push("plugins");
         root_path.push(format!(
-            "{}_{}",
+            "{}_{}_{}_{}",
             MODULE_SERIALIZATION_VERSION,
-            option_env!("CARGO_PKG_RUST_VERSION").unwrap_or("default")
+            std::env::consts::OS,
+            std::env::consts::ARCH,
+            option_env!("CARGO_PKG_VERSION").unwrap_or("plugin_runner_unknown")
         ));
 
         return FileSystemCache::new(&root_path).ok();


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
I don't see how original change could affect ci in a negative way (theoretically, compile a module from IO / or in memory shouldn't be that different even in the worst case) but anyway, let's split changes to confirm. 

PR takes part of previous pr for fine grained cache path. _if this causes same regression_, that means accessing env is somehow excessively slow (which also shouldn't, but we'll see).