### PR TITLE
refactor(swc_core): Make `common_plugin_transform` agnostic to mode

### DIFF
--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -239,14 +239,15 @@ __common_plugin_transform = [
   "ecma_visit",
   "__common",
   "swc_atoms/rkyv-impl",
-  "swc_common/plugin-mode",
-  "swc_plugin_proxy/plugin-mode",
   "swc_plugin_macro",
   "once_cell",
   "swc_plugin",
 ]
 
 __css_plugin_transform = [
+  "swc_common/plugin-mode",
+  "swc_plugin_proxy/plugin-mode",
+
   # Dependent features
   "__common_plugin_transform",
   "css_visit",
@@ -254,6 +255,9 @@ __css_plugin_transform = [
   "swc_css_ast/rkyv-impl",
 ]
 __ecma_plugin_transform = [
+  "swc_common/plugin-mode",
+  "swc_plugin_proxy/plugin-mode",
+
   # Dependent features
   "__common_plugin_transform",
   "ecma_visit",


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

PR moves out mode-specific features (`plugin-mode`) so `common-plugin-transform` can be used in either plugin host or plugin transforms.