### PR TITLE
fix(core): correctly expose plugin with host

### DIFF
--- a/crates/swc_core/src/lib.rs
+++ b/crates/swc_core/src/lib.rs
@@ -12,8 +12,18 @@ pub mod quote;
 pub extern crate swc_ecma_quote_macros;
 
 // Plugins
-#[cfg(feature = "__common_plugin_transform")]
-#[cfg_attr(docsrs, doc(cfg(feature = "__common_plugin_transform")))]
+#[cfg(any(
+    docsrs,
+    feature = "__common_plugin_transform",
+    feature = "__plugin_transform_host"
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "__common_plugin_transform",
+        feature = "__plugin_transform_host"
+    )))
+)]
 pub mod plugin;
 
 #[cfg(feature = "__ecma")]

--- a/crates/swc_core/src/plugin.rs
+++ b/crates/swc_core/src/plugin.rs
@@ -1,7 +1,32 @@
 // #[plugin_transform] macro
-#[cfg(any(docsrs, feature = "__common_plugin_transform"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "__common_plugin_transform")))]
-pub use swc_plugin_macro::{css_plugin_transform, plugin_transform};
+#[cfg(any(
+    docsrs,
+    feature = "__common_plugin_transform",
+    feature = "__css_plugin_transform",
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "__common_plugin_transform",
+        feature = "__css_plugin_transform"
+    )))
+)]
+pub use swc_plugin_macro::css_plugin_transform;
+#[cfg(any(
+    docsrs,
+    feature = "__common_plugin_transform",
+    feature = "__css_plugin_transform",
+    feature = "__ecma_plugin_transform"
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "__common_plugin_transform",
+        feature = "__css_plugin_transform",
+        feature = "__ecma_plugin_transform"
+    )))
+)]
+pub use swc_plugin_macro::plugin_transform;
 
 /// exported __alloc / __free fn for the guest (plugin)
 /// allows to allocate memory from the host side.
@@ -13,8 +38,20 @@ pub mod memory {
 
 /// Global HANDLER implementation for the plugin
 /// for error reporting.
-#[cfg(any(docsrs, feature = "__common_plugin_transform"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "__common_plugin_transform")))]
+#[cfg(any(
+    docsrs,
+    feature = "__common_plugin_transform",
+    feature = "__css_plugin_transform",
+    feature = "__ecma_plugin_transform"
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "__common_plugin_transform",
+        feature = "__css_plugin_transform",
+        feature = "__ecma_plugin_transform"
+    )))
+)]
 pub mod errors {
     /// global context HANDLER in plugin's transform function.
     pub static HANDLER: swc_plugin::pseudo_scoped_key::PseudoScopedKey<
@@ -25,14 +62,27 @@ pub mod errors {
 }
 
 /// Plugin's environment metadata context.
-#[cfg(any(docsrs, feature = "__common_plugin_transform"))]
-#[cfg_attr(docsrs, doc(cfg(feature = "__common_plugin_transform")))]
+#[cfg(any(
+    docsrs,
+    feature = "__common_plugin_transform",
+    feature = "__css_plugin_transform",
+    feature = "__ecma_plugin_transform"
+))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(
+        feature = "__common_plugin_transform",
+        feature = "__css_plugin_transform",
+        feature = "__ecma_plugin_transform"
+    )))
+)]
 pub mod metadata {
     pub use swc_common::plugin::metadata::TransformPluginMetadataContextKind;
     pub use swc_plugin_proxy::TransformPluginProgramMetadata;
 }
 
 /// Proxy to the host's data not attached to the AST, like sourcemap / comments.
+/// Or interfaces to setup the plugin's environment from the host.
 #[cfg(any(
     docsrs,
     feature = "__common_plugin_transform",


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Following up https://github.com/swc-project/swc/pull/7422, `swc_core::plugin` itself is not exposed to `__plugin_transform_host` so still not able to access inner plugin proxy.