### PR TITLE
fix(es/parser): Allow using `package` as a parameter name in TS interface

### DIFF
--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -1808,6 +1808,7 @@ impl<I: Tokens> Parser<I> {
     /// `tsParseParenthesizedType`
     fn parse_ts_parenthesized_type(&mut self) -> PResult<TsParenthesizedType> {
         debug_assert!(self.input.syntax().typescript());
+        trace_cur!(self, parse_ts_parenthesized_type);
 
         let start = cur_pos!(self);
         expect!(self, '(');

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -1254,7 +1254,7 @@ impl<I: Tokens> Parser<I> {
 
         let _ = self.eat_any_ts_modifier()?;
 
-        if is_one_of!(self, IdentRef, "this") {
+        if is_one_of!(self, IdentName, "this") {
             bump!(self);
             return Ok(true);
         }

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -185,6 +185,7 @@ impl<I: Tokens> Parser<I> {
     /// `tsParseEntityName`
     fn parse_ts_entity_name(&mut self, allow_reserved_words: bool) -> PResult<TsEntityName> {
         debug_assert!(self.input.syntax().typescript());
+        trace_cur!(self, parse_ts_entity_name);
 
         let init = self.parse_ident_name()?;
         if let Ident {

--- a/crates/swc_ecma_parser/tests/typescript/issue-7186/1/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/issue-7186/1/input.ts
@@ -1,0 +1,3 @@
+export interface PackageManager {
+    onDidUnloadPackage(callback: (package: Package) => void): Disposable;
+}

--- a/crates/swc_ecma_parser/tests/typescript/issue-7186/1/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/issue-7186/1/input.ts.json
@@ -1,0 +1,184 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 110,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ExportDeclaration",
+      "span": {
+        "start": 1,
+        "end": 110,
+        "ctxt": 0
+      },
+      "declaration": {
+        "type": "TsInterfaceDeclaration",
+        "span": {
+          "start": 8,
+          "end": 110,
+          "ctxt": 0
+        },
+        "id": {
+          "type": "Identifier",
+          "span": {
+            "start": 18,
+            "end": 32,
+            "ctxt": 0
+          },
+          "value": "PackageManager",
+          "optional": false
+        },
+        "declare": false,
+        "typeParams": null,
+        "extends": [],
+        "body": {
+          "type": "TsInterfaceBody",
+          "span": {
+            "start": 33,
+            "end": 110,
+            "ctxt": 0
+          },
+          "body": [
+            {
+              "type": "TsMethodSignature",
+              "span": {
+                "start": 39,
+                "end": 108,
+                "ctxt": 0
+              },
+              "readonly": false,
+              "key": {
+                "type": "Identifier",
+                "span": {
+                  "start": 39,
+                  "end": 57,
+                  "ctxt": 0
+                },
+                "value": "onDidUnloadPackage",
+                "optional": false
+              },
+              "computed": false,
+              "optional": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 58,
+                    "end": 94,
+                    "ctxt": 0
+                  },
+                  "value": "callback",
+                  "optional": false,
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 66,
+                      "end": 94,
+                      "ctxt": 0
+                    },
+                    "typeAnnotation": {
+                      "type": "TsFunctionType",
+                      "span": {
+                        "start": 68,
+                        "end": 94,
+                        "ctxt": 0
+                      },
+                      "params": [
+                        {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 69,
+                            "end": 85,
+                            "ctxt": 0
+                          },
+                          "value": "package",
+                          "optional": false,
+                          "typeAnnotation": {
+                            "type": "TsTypeAnnotation",
+                            "span": {
+                              "start": 76,
+                              "end": 85,
+                              "ctxt": 0
+                            },
+                            "typeAnnotation": {
+                              "type": "TsTypeReference",
+                              "span": {
+                                "start": 78,
+                                "end": 85,
+                                "ctxt": 0
+                              },
+                              "typeName": {
+                                "type": "Identifier",
+                                "span": {
+                                  "start": 78,
+                                  "end": 85,
+                                  "ctxt": 0
+                                },
+                                "value": "Package",
+                                "optional": false
+                              },
+                              "typeParams": null
+                            }
+                          }
+                        }
+                      ],
+                      "typeParams": null,
+                      "typeAnnotation": {
+                        "type": "TsTypeAnnotation",
+                        "span": {
+                          "start": 87,
+                          "end": 94,
+                          "ctxt": 0
+                        },
+                        "typeAnnotation": {
+                          "type": "TsKeywordType",
+                          "span": {
+                            "start": 90,
+                            "end": 94,
+                            "ctxt": 0
+                          },
+                          "kind": "void"
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "typeAnn": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 95,
+                  "end": 107,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 97,
+                    "end": 107,
+                    "ctxt": 0
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 97,
+                      "end": 107,
+                      "ctxt": 0
+                    },
+                    "value": "Disposable",
+                    "optional": false
+                  },
+                  "typeParams": null
+                }
+              },
+              "typeParams": null
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/typescript/issue-7186/2/input.tsx
+++ b/crates/swc_ecma_parser/tests/typescript/issue-7186/2/input.tsx
@@ -1,0 +1,3 @@
+export interface PackageManager {
+    onDidUnloadPackage(callback: (package: Package) => void): Disposable;
+}

--- a/crates/swc_ecma_parser/tests/typescript/issue-7186/2/input.tsx.json
+++ b/crates/swc_ecma_parser/tests/typescript/issue-7186/2/input.tsx.json
@@ -1,0 +1,184 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 110,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ExportDeclaration",
+      "span": {
+        "start": 1,
+        "end": 110,
+        "ctxt": 0
+      },
+      "declaration": {
+        "type": "TsInterfaceDeclaration",
+        "span": {
+          "start": 8,
+          "end": 110,
+          "ctxt": 0
+        },
+        "id": {
+          "type": "Identifier",
+          "span": {
+            "start": 18,
+            "end": 32,
+            "ctxt": 0
+          },
+          "value": "PackageManager",
+          "optional": false
+        },
+        "declare": false,
+        "typeParams": null,
+        "extends": [],
+        "body": {
+          "type": "TsInterfaceBody",
+          "span": {
+            "start": 33,
+            "end": 110,
+            "ctxt": 0
+          },
+          "body": [
+            {
+              "type": "TsMethodSignature",
+              "span": {
+                "start": 39,
+                "end": 108,
+                "ctxt": 0
+              },
+              "readonly": false,
+              "key": {
+                "type": "Identifier",
+                "span": {
+                  "start": 39,
+                  "end": 57,
+                  "ctxt": 0
+                },
+                "value": "onDidUnloadPackage",
+                "optional": false
+              },
+              "computed": false,
+              "optional": false,
+              "params": [
+                {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 58,
+                    "end": 94,
+                    "ctxt": 0
+                  },
+                  "value": "callback",
+                  "optional": false,
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 66,
+                      "end": 94,
+                      "ctxt": 0
+                    },
+                    "typeAnnotation": {
+                      "type": "TsFunctionType",
+                      "span": {
+                        "start": 68,
+                        "end": 94,
+                        "ctxt": 0
+                      },
+                      "params": [
+                        {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 69,
+                            "end": 85,
+                            "ctxt": 0
+                          },
+                          "value": "package",
+                          "optional": false,
+                          "typeAnnotation": {
+                            "type": "TsTypeAnnotation",
+                            "span": {
+                              "start": 76,
+                              "end": 85,
+                              "ctxt": 0
+                            },
+                            "typeAnnotation": {
+                              "type": "TsTypeReference",
+                              "span": {
+                                "start": 78,
+                                "end": 85,
+                                "ctxt": 0
+                              },
+                              "typeName": {
+                                "type": "Identifier",
+                                "span": {
+                                  "start": 78,
+                                  "end": 85,
+                                  "ctxt": 0
+                                },
+                                "value": "Package",
+                                "optional": false
+                              },
+                              "typeParams": null
+                            }
+                          }
+                        }
+                      ],
+                      "typeParams": null,
+                      "typeAnnotation": {
+                        "type": "TsTypeAnnotation",
+                        "span": {
+                          "start": 87,
+                          "end": 94,
+                          "ctxt": 0
+                        },
+                        "typeAnnotation": {
+                          "type": "TsKeywordType",
+                          "span": {
+                            "start": 90,
+                            "end": 94,
+                            "ctxt": 0
+                          },
+                          "kind": "void"
+                        }
+                      }
+                    }
+                  }
+                }
+              ],
+              "typeAnn": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 95,
+                  "end": 107,
+                  "ctxt": 0
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 97,
+                    "end": 107,
+                    "ctxt": 0
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 97,
+                      "end": 107,
+                      "ctxt": 0
+                    },
+                    "value": "Disposable",
+                    "optional": false
+                  },
+                  "typeParams": null
+                }
+              },
+              "typeParams": null
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7186.