### PR TITLE
fix: ignore input sourcemap error

### DIFF
--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -306,7 +306,87 @@ impl Compiler {
                     }
                 };
 
-            let read_sourcemap = || -> Result<Option<sourcemap::SourceMap>, Error> {
+            let read_file_sourcemap =
+                |data_url: Option<&str>| -> Result<Option<sourcemap::SourceMap>, Error> {
+                    match &name {
+                        FileName::Real(filename) => {
+                            let dir = match filename.parent() {
+                                Some(v) => v,
+                                None => {
+                                    bail!("unexpected: root directory is given as a input file")
+                                }
+                            };
+
+                            let map_path = match data_url {
+                                Some(data_url) => {
+                                    let mut map_path = dir.join(data_url);
+                                    if !map_path.exists() {
+                                        // Old behavior. This check would prevent
+                                        // regressions.
+                                        // Perhaps it shouldn't be supported. Sometimes
+                                        // developers don't want to expose their source
+                                        // code.
+                                        // Map files are for internal troubleshooting
+                                        // convenience.
+                                        map_path =
+                                            PathBuf::from(format!("{}.map", filename.display()));
+                                        if !map_path.exists() {
+                                            bail!(
+                                                "failed to find input source map file {:?} in \
+                                                 {:?} file",
+                                                map_path.display(),
+                                                filename.display()
+                                            )
+                                        }
+                                    }
+
+                                    Some(map_path)
+                                }
+                                None => {
+                                    // Old behavior.
+                                    let map_path =
+                                        PathBuf::from(format!("{}.map", filename.display()));
+                                    if map_path.exists() {
+                                        Some(map_path)
+                                    } else {
+                                        None
+                                    }
+                                }
+                            };
+
+                            match map_path {
+                                Some(map_path) => {
+                                    let path = map_path.display().to_string();
+                                    let file = File::open(&path);
+
+                                    // Old behavior.
+                                    let file = if !is_default {
+                                        file?
+                                    } else {
+                                        match file {
+                                            Ok(v) => v,
+                                            Err(_) => return Ok(None),
+                                        }
+                                    };
+
+                                    Ok(Some(sourcemap::SourceMap::from_reader(file).with_context(
+                                        || {
+                                            format!(
+                                                "failed to read input source map
+                                from file at {}",
+                                                path
+                                            )
+                                        },
+                                    )?))
+                                }
+                                None => Ok(None),
+                            }
+                        }
+                        _ => Ok(None),
+                    }
+                };
+
+            let read_sourcemap = || -> Option<sourcemap::SourceMap> {
                 let s = "sourceMappingURL=";
                 let idx = fm.src.rfind(s);
 
@@ -320,89 +400,14 @@ impl Compiler {
                 });
 
                 match read_inline_sourcemap(data_url) {
-                    Ok(r) => Ok(r),
-                    Err(_) => {
+                    Ok(r) => r,
+                    Err(err) => {
                         // Load original source map if possible
-                        match &name {
-                            FileName::Real(filename) => {
-                                let dir = match filename.parent() {
-                                    Some(v) => v,
-                                    None => {
-                                        bail!("unexpected: root directory is given as a input file")
-                                    }
-                                };
-
-                                let map_path = match data_url {
-                                    Some(data_url) => {
-                                        let mut map_path = dir.join(data_url);
-                                        if !map_path.exists() {
-                                            // Old behavior. This check would prevent
-                                            // regressions.
-                                            // Perhaps it shouldn't be supported. Sometimes
-                                            // developers don't want to expose their source code.
-                                            // Map files are for internal troubleshooting
-                                            // convenience.
-                                            map_path = PathBuf::from(format!(
-                                                "{}.map",
-                                                filename.display()
-                                            ));
-                                            if !map_path.exists() {
-                                                bail!(
-                                                    "failed to find input source map file {:?} in \
-                                                     {:?} file",
-                                                    map_path.display(),
-                                                    filename.display()
-                                                )
-                                            }
-                                        }
-
-                                        Some(map_path)
-                                    }
-                                    None => {
-                                        // Old behavior.
-                                        let map_path =
-                                            PathBuf::from(format!("{}.map", filename.display()));
-                                        if map_path.exists() {
-                                            Some(map_path)
-                                        } else {
-                                            None
-                                        }
-                                    }
-                                };
-
-                                match map_path {
-                                    Some(map_path) => {
-                                        let path = map_path.display().to_string();
-                                        let file = File::open(&path);
-
-                                        // Old behavior.
-                                        let file = if !is_default {
-                                            file?
-                                        } else {
-                                            match file {
-                                                Ok(v) => v,
-                                                Err(_) => return Ok(None),
-                                            }
-                                        };
-
-                                        Ok(Some(
-                                            sourcemap::SourceMap::from_reader(file).with_context(
-                                                || {
-                                                    format!(
-                                                        "failed to read input source map
-                                        from file at {}",
-                                                        path
-                                                    )
-                                                },
-                                            )?,
-                                        ))
-                                    }
-                                    None => Ok(None),
-                                }
-                            }
-                            _ => {
-                                tracing::error!("Failed to load source map for non-file input");
-                                Ok(None)
+                        match read_file_sourcemap(data_url) {
+                            Ok(v) => v,
+                            Err(_) => {
+                                tracing::error!("failed to read input source map: {:?}", err);
+                                None
                             }
                         }
                     }
@@ -412,10 +417,10 @@ impl Compiler {
             // Load original source map
             match input_src_map {
                 InputSourceMap::Bool(false) => Ok(None),
-                InputSourceMap::Bool(true) => read_sourcemap(),
+                InputSourceMap::Bool(true) => Ok(read_sourcemap()),
                 InputSourceMap::Str(ref s) => {
                     if s == "inline" {
-                        read_sourcemap()
+                        Ok(read_sourcemap())
                     } else {
                         // Load source map passed by user
                         Ok(Some(

--- a/crates/swc/tests/source_map.rs
+++ b/crates/swc/tests/source_map.rs
@@ -80,6 +80,18 @@ fn case_inline_extra_content() {
 }
 
 #[test]
+fn case_none_file() {
+    file(
+        "tests/srcmap/case-none-file/input.js",
+        Config {
+            input_source_map: Some(InputSourceMap::Bool(true)),
+            ..Default::default()
+        },
+    )
+    .unwrap();
+}
+
+#[test]
 fn issue_622() {
     file("tests/srcmap/issue-622/index.js", Default::default()).unwrap();
 }

--- a/crates/swc/tests/srcmap/case-none-file/input.js
+++ b/crates/swc/tests/srcmap/case-none-file/input.js
@@ -1,0 +1,43 @@
+(self.webpackChunk_N_E = self.webpackChunk_N_E || []).push([
+    [
+        158
+    ],
+    {
+        2943: function(n, t, u) {
+            "use strict";
+            var r = function(n) {
+                var t = n.data;
+                return (0, _.jsx)("div", {
+                    children: t.foo
+                });
+            };
+            u.r(t), u.d(t, {
+                __N_SSG: function() {
+                    return i;
+                },
+                default: function() {
+                    return r;
+                }
+            });
+            var _ = u(4512), i = !0;
+        },
+        7139: function(n, t, u) {
+            (window.__NEXT_P = window.__NEXT_P || []).push([
+                "/static",
+                function() {
+                    return u(2943);
+                }
+            ]);
+        }
+    },
+    function(n) {
+        n.O(0, [
+            774,
+            888,
+            179
+        ], function() {
+            return n(n.s = 7139);
+        }), _N_E = n.O();
+    }
+]);
+//# sourceMappingURL=none.js.map


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

User's npm package is missing a .map file. If there is a compilation error, the user will not be able to compile the project.

babel :
https://github.com/babel/babel/blob/master/packages/babel-core/src/transformation/normalize-file.js#L63

**BREAKING CHANGE:**

no

**Related issue (if exists):**
