### PR TITLE
Fix for minor typo in cache.rs error meesage

### DIFF
--- a/crates/swc_plugin_runner/src/cache.rs
+++ b/crates/swc_plugin_runner/src/cache.rs
@@ -124,7 +124,7 @@ impl PluginModuleCacheInner {
             return Ok(());
         }
 
-        anyhow::bail!("Filesystem cache is not enabled, cannot read plugin from phsyical path");
+        anyhow::bail!("Filesystem cache is not enabled, cannot read plugin from physical path");
     }
 
     /// Returns a PluingModuleBytes can be compiled into a wasmer::Module.


### PR DESCRIPTION
**Description:**

Fixes a minor typo in cache.rs error message which I noticed today.

**BREAKING CHANGE:**

N/A

**Related issue (if exists):** No
