### PR TITLE
Fix comment typo (Serailize -> Serialize)

### DIFF
--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -103,7 +103,7 @@ pub struct Invalid {
     pub span: Span,
 }
 
-/// Note: This type implements `Serailize` and `Deserialize` if `serde` is
+/// Note: This type implements `Serialize` and `Deserialize` if `serde` is
 /// enabled, instead of requiring `serde-impl` feature.
 #[derive(Debug, Clone, Copy, PartialOrd, Ord, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]


### PR DESCRIPTION
**Description:**

I noticed a typo in the documentation, and this fixes it!