### PR TITLE
perf(es/minifier): Make minifier not overly generic

### DIFF
--- a/crates/swc_common/src/plugin/serialized.rs
+++ b/crates/swc_common/src/plugin/serialized.rs
@@ -80,6 +80,7 @@ impl PluginSerializedBytes {
      * Internal fn to constructs an instance from raw bytes ptr.
      */
     #[tracing::instrument(level = "info", skip_all)]
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     pub fn from_raw_ptr(
         raw_allocated_ptr: *const u8,
         raw_allocated_ptr_len: usize,

--- a/crates/swc_ecma_minifier/src/compress/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/mod.rs
@@ -69,10 +69,7 @@ where
     )
 }
 
-struct Compressor<'a, M>
-where
-    M: Mode,
-{
+struct Compressor<'a> {
     marks: Marks,
     options: &'a CompressOptions,
     module_info: &'a ModuleInfo,
@@ -81,13 +78,10 @@ where
 
     dump_for_infinite_loop: Vec<String>,
 
-    mode: &'a M,
+    mode: &'a dyn Mode,
 }
 
-impl<M> CompilerPass for Compressor<'_, M>
-where
-    M: Mode,
-{
+impl CompilerPass for Compressor<'_> {
     fn name() -> Cow<'static, str> {
         "compressor".into()
     }

--- a/crates/swc_ecma_minifier/src/compress/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/mod.rs
@@ -87,15 +87,12 @@ impl CompilerPass for Compressor<'_> {
     }
 }
 
-impl<M> Compressor<'_, M>
-where
-    M: Mode,
-{
+impl Compressor<'_> {
     fn optimize_unit_repeatedly<N>(&mut self, n: &mut N)
     where
         N: CompileUnit
             + VisitWith<UsageAnalyzer<ProgramData>>
-            + for<'aa> VisitMutWith<Compressor<'aa, M>>
+            + for<'aa> VisitMutWith<Compressor<'aa>>
             + VisitWith<AssertValid>,
     {
         trace_op!(
@@ -142,7 +139,7 @@ where
     where
         N: CompileUnit
             + VisitWith<UsageAnalyzer<ProgramData>>
-            + for<'aa> VisitMutWith<Compressor<'aa, M>>
+            + for<'aa> VisitMutWith<Compressor<'aa>>
             + VisitWith<AssertValid>,
     {
         let _timer = timer!("optimize", pass = self.pass);
@@ -239,7 +236,7 @@ where
                 self.marks,
                 PureOptimizerConfig {
                     enable_join_vars: self.pass > 1,
-                    force_str_for_tpl: M::force_str_for_tpl(),
+                    force_str_for_tpl: self.mode.force_str_for_tpl(),
                     #[cfg(feature = "debug")]
                     debug_infinite_loop: self.pass >= 20,
                 },
@@ -324,10 +321,7 @@ where
     }
 }
 
-impl<M> VisitMut for Compressor<'_, M>
-where
-    M: Mode,
-{
+impl VisitMut for Compressor<'_> {
     noop_visit_mut_type!();
 
     fn visit_mut_script(&mut self, n: &mut Script) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/arguments.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/arguments.rs
@@ -7,13 +7,10 @@ use swc_ecma_utils::{find_pat_ids, is_valid_prop_ident, private_ident};
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 use super::Optimizer;
-use crate::{compress::optimize::is_left_access_to_arguments, mode::Mode};
+use crate::compress::optimize::is_left_access_to_arguments;
 
 /// Methods related to the option `arguments`.
-impl<M> Optimizer<'_>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     ///
     /// - `arguments['foo']` => `arguments.foo`
     pub(super) fn optimize_str_access_to_arguments(&mut self, e: &mut Expr) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/arguments.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/arguments.rs
@@ -10,7 +10,7 @@ use super::Optimizer;
 use crate::{compress::optimize::is_left_access_to_arguments, mode::Mode};
 
 /// Methods related to the option `arguments`.
-impl<M> Optimizer<'_, M>
+impl<M> Optimizer<'_>
 where
     M: Mode,
 {

--- a/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 /// Methods related to the options `bools` and `bool_as_ints`.
-impl<M> Optimizer<'_, M>
+impl<M> Optimizer<'_>
 where
     M: Mode,
 {
@@ -120,7 +120,7 @@ where
     ///
     /// - `"undefined" == typeof value;` => `void 0 === value`
     pub(super) fn compress_typeof_undefined(&mut self, e: &mut BinExpr) {
-        fn opt<M>(o: &mut Optimizer<M>, l: &mut Expr, r: &mut Expr) -> bool {
+        fn opt<M>(o: &mut Optimizer, l: &mut Expr, r: &mut Expr) -> bool {
             match (&mut *l, &mut *r) {
                 (
                     Expr::Lit(Lit::Str(Str {

--- a/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
@@ -15,10 +15,7 @@ use crate::{
 };
 
 /// Methods related to the options `bools` and `bool_as_ints`.
-impl<M> Optimizer<'_>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// **This negates bool**.
     ///
     /// Returns true if it's negated.

--- a/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
@@ -7,12 +7,9 @@ use swc_ecma_utils::{
 };
 
 use super::Optimizer;
+use crate::compress::{optimize::Ctx, util::negate_cost};
 #[cfg(feature = "debug")]
 use crate::debug::dump;
-use crate::{
-    compress::{optimize::Ctx, util::negate_cost},
-    mode::Mode,
-};
 
 /// Methods related to the options `bools` and `bool_as_ints`.
 impl Optimizer<'_> {
@@ -117,7 +114,7 @@ impl Optimizer<'_> {
     ///
     /// - `"undefined" == typeof value;` => `void 0 === value`
     pub(super) fn compress_typeof_undefined(&mut self, e: &mut BinExpr) {
-        fn opt<M>(o: &mut Optimizer, l: &mut Expr, r: &mut Expr) -> bool {
+        fn opt(o: &mut Optimizer, l: &mut Expr, r: &mut Expr) -> bool {
             match (&mut *l, &mut *r) {
                 (
                     Expr::Lit(Lit::Str(Str {

--- a/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
@@ -12,7 +12,6 @@ use crate::{
         optimize::Ctx,
         util::{negate, negate_cost},
     },
-    mode::Mode,
     DISABLE_BUGGY_PASSES,
 };
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
@@ -18,7 +18,7 @@ use crate::{
 
 /// Methods related to the option `conditionals`. All methods are noop if
 /// `conditionals` is false.
-impl<M> Optimizer<'_, M>
+impl<M> Optimizer<'_>
 where
     M: Mode,
 {

--- a/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
@@ -18,10 +18,7 @@ use crate::{
 
 /// Methods related to the option `conditionals`. All methods are noop if
 /// `conditionals` is false.
-impl<M> Optimizer<'_>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// Negates the condition of a `if` statement to reduce body size.
     pub(super) fn negate_if_stmt(&mut self, stmt: &mut IfStmt) {
         let alt = match stmt.alt.as_deref_mut() {

--- a/crates/swc_ecma_minifier/src/compress/optimize/dead_code.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/dead_code.rs
@@ -2,7 +2,6 @@ use swc_common::util::take::Take;
 use swc_ecma_ast::*;
 
 use super::Optimizer;
-use crate::mode::Mode;
 
 /// Methods related to option `dead_code`.
 impl Optimizer<'_> {

--- a/crates/swc_ecma_minifier/src/compress/optimize/dead_code.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/dead_code.rs
@@ -5,10 +5,7 @@ use super::Optimizer;
 use crate::mode::Mode;
 
 /// Methods related to option `dead_code`.
-impl<M> Optimizer<'_>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// Optimize return value or argument of throw.
     ///
     /// This methods removes some useless assignments.

--- a/crates/swc_ecma_minifier/src/compress/optimize/dead_code.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/dead_code.rs
@@ -5,7 +5,7 @@ use super::Optimizer;
 use crate::mode::Mode;
 
 /// Methods related to option `dead_code`.
-impl<M> Optimizer<'_, M>
+impl<M> Optimizer<'_>
 where
     M: Mode,
 {

--- a/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
@@ -9,7 +9,7 @@ use super::Optimizer;
 use crate::{compress::util::eval_as_number, maybe_par, mode::Mode, DISABLE_BUGGY_PASSES};
 
 /// Methods related to the option `evaluate`.
-impl<M> Optimizer<'_, M>
+impl<M> Optimizer<'_>
 where
     M: Mode,
 {

--- a/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
@@ -6,7 +6,7 @@ use swc_ecma_ast::*;
 use swc_ecma_utils::{undefined, ExprExt, Value::Known};
 
 use super::Optimizer;
-use crate::{compress::util::eval_as_number, maybe_par, mode::Mode, DISABLE_BUGGY_PASSES};
+use crate::{compress::util::eval_as_number, maybe_par, DISABLE_BUGGY_PASSES};
 
 /// Methods related to the option `evaluate`.
 impl Optimizer<'_> {

--- a/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
@@ -9,10 +9,7 @@ use super::Optimizer;
 use crate::{compress::util::eval_as_number, maybe_par, mode::Mode, DISABLE_BUGGY_PASSES};
 
 /// Methods related to the option `evaluate`.
-impl<M> Optimizer<'_>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// Evaluate expression if possible.
     ///
     /// This method call appropriate methods for each ast types.

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -11,7 +11,7 @@ use crate::{compress::util::is_pure_undefined, mode::Mode, util::ExprOptExt};
 
 /// Methods related to the option `if_return`. All methods are noop if
 /// `if_return` is false.
-impl<M> Optimizer<'_, M>
+impl<M> Optimizer<'_>
 where
     M: Mode,
 {

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -11,10 +11,7 @@ use crate::{compress::util::is_pure_undefined, mode::Mode, util::ExprOptExt};
 
 /// Methods related to the option `if_return`. All methods are noop if
 /// `if_return` is false.
-impl<M> Optimizer<'_>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     pub(super) fn merge_nested_if(&mut self, s: &mut IfStmt) {
         if !self.options.conditionals && !self.options.bools {
             return;

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -7,7 +7,7 @@ use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 use super::Optimizer;
 #[cfg(feature = "debug")]
 use crate::debug::dump;
-use crate::{compress::util::is_pure_undefined, mode::Mode, util::ExprOptExt};
+use crate::{compress::util::is_pure_undefined, util::ExprOptExt};
 
 /// Methods related to the option `if_return`. All methods are noop if
 /// `if_return` is false.

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -14,7 +14,6 @@ use super::{util::NormalMultiReplacer, Optimizer};
 use crate::debug::dump;
 use crate::{
     compress::optimize::Ctx,
-    mode::Mode,
     util::{idents_captured_by, idents_used_by, make_number},
 };
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 
 /// Methods related to the option `negate_iife`.
-impl<M> Optimizer<'_, M>
+impl<M> Optimizer<'_>
 where
     M: Mode,
 {
@@ -115,7 +115,7 @@ where
 }
 
 /// Methods related to iife.
-impl<M> Optimizer<'_, M>
+impl<M> Optimizer<'_>
 where
     M: Mode,
 {

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -19,10 +19,7 @@ use crate::{
 };
 
 /// Methods related to the option `negate_iife`.
-impl<M> Optimizer<'_>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// Negates iife, while ignore return value.
     pub(super) fn negate_iife_ignoring_ret(&mut self, e: &mut Expr) {
         if !self.options.negate_iife || self.ctx.in_bang_arg || self.ctx.dont_use_negated_iife {
@@ -115,10 +112,7 @@ where
 }
 
 /// Methods related to iife.
-impl<M> Optimizer<'_>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// # Example
     ///
     /// ## Input

--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -9,7 +9,6 @@ use swc_ecma_visit::VisitMutWith;
 use super::Optimizer;
 use crate::{
     compress::optimize::util::is_valid_for_lhs,
-    mode::Mode,
     program_data::VarUsageInfo,
     util::{
         idents_captured_by, idents_used_by, idents_used_by_ignoring_nested, size::SizeWithCtxt,

--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -17,10 +17,7 @@ use crate::{
 };
 
 /// Methods related to option `inline`.
-impl<M> Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// Stores the value of a variable to inline it.
     ///
     /// This method may remove value of initializer. It mean that the value will

--- a/crates/swc_ecma_minifier/src/compress/optimize/loops.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/loops.rs
@@ -8,10 +8,7 @@ use crate::{
 };
 
 /// Methods related to the option `loops`.
-impl<M> Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// `for(a;b;c;) break;` => `a;b;`
     pub(super) fn optimize_loops_with_break(&mut self, s: &mut Stmt) {
         if !self.options.loops {

--- a/crates/swc_ecma_minifier/src/compress/optimize/loops.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/loops.rs
@@ -2,10 +2,7 @@ use swc_common::{util::take::Take, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{ExprExt, Value::Known};
 
-use crate::{
-    compress::{optimize::Optimizer, util::UnreachableHandler},
-    mode::Mode,
-};
+use crate::compress::{optimize::Optimizer, util::UnreachableHandler};
 
 /// Methods related to the option `loops`.
 impl Optimizer<'_> {

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -297,7 +297,7 @@ impl Vars {
     }
 }
 
-impl<M> Repeated for Optimizer<'_> {
+impl Repeated for Optimizer<'_> {
     fn changed(&self) -> bool {
         self.changed
     }
@@ -1429,7 +1429,7 @@ impl Optimizer<'_> {
     }
 }
 
-impl<M> VisitMut for Optimizer<'_> {
+impl VisitMut for Optimizer<'_> {
     noop_visit_mut_type!();
 
     #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -192,7 +192,7 @@ impl Ctx {
     }
 }
 
-struct Optimizer<'a, M> {
+struct Optimizer<'a> {
     marks: Marks,
     expr_ctx: ExprCtx,
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -56,17 +56,14 @@ mod unused;
 mod util;
 
 /// This pass is similar to `node.optimize` of terser.
-pub(super) fn optimizer<'a, M>(
+pub(super) fn optimizer<'a>(
     marks: Marks,
     options: &'a CompressOptions,
     module_info: &'a ModuleInfo,
     data: &'a mut ProgramData,
-    mode: &'a M,
+    mode: &'a dyn Mode,
     debug_infinite_loop: bool,
-) -> impl 'a + VisitMut + Repeated
-where
-    M: Mode,
-{
+) -> impl 'a + VisitMut + Repeated {
     assert!(
         options.top_retain.iter().all(|s| s.trim() != ""),
         "top_retain should not contain empty string"

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -224,7 +224,7 @@ struct Optimizer<'a> {
     /// Setting this to `None` means the label should be removed.
     label: Option<Id>,
 
-    mode: &'a M,
+    mode: &'a dyn Mode,
 
     #[allow(unused)]
     debug_infinite_loop: bool,
@@ -297,7 +297,7 @@ impl Vars {
     }
 }
 
-impl<M> Repeated for Optimizer<'_, M> {
+impl<M> Repeated for Optimizer<'_> {
     fn changed(&self) -> bool {
         self.changed
     }
@@ -324,10 +324,7 @@ impl From<&Function> for FnMetadata {
     }
 }
 
-impl<M> Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     fn handle_stmts(&mut self, stmts: &mut Vec<Stmt>, will_terminate: bool) {
         // Skip if `use asm` exists.
         if maybe_par!(
@@ -1432,10 +1429,7 @@ where
     }
 }
 
-impl<M> VisitMut for Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl<M> VisitMut for Optimizer<'_> {
     noop_visit_mut_type!();
 
     #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]

--- a/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
@@ -11,10 +11,7 @@ use crate::{
     util::{make_bool, ValueExt},
 };
 
-impl<M> Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     ///
     /// - `'12' === `foo` => '12' == 'foo'`
     pub(super) fn optimize_bin_equal(&mut self, e: &mut BinExpr) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
@@ -7,7 +7,6 @@ use Value::Known;
 use super::Optimizer;
 use crate::{
     compress::util::negate,
-    mode::Mode,
     util::{make_bool, ValueExt},
 };
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/props.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/props.rs
@@ -6,10 +6,7 @@ use super::{unused::PropertyAccessOpts, Optimizer};
 use crate::{mode::Mode, util::deeply_contains_this_expr};
 
 /// Methods related to the option `hoist_props`.
-impl<M> Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// Store values of properties so we can replace property accesses with the
     /// values.
     pub(super) fn store_var_for_prop_hoisting(&mut self, n: &mut VarDeclarator) {
@@ -228,10 +225,7 @@ where
     }
 }
 
-impl<M> Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// Converts `{ a: 1 }.a` into `1`.
     pub(super) fn handle_property_access(&mut self, e: &mut Expr) {
         if !self.options.props {

--- a/crates/swc_ecma_minifier/src/compress/optimize/props.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/props.rs
@@ -3,7 +3,7 @@ use swc_ecma_ast::*;
 use swc_ecma_utils::{contains_this_expr, prop_name_eq, ExprExt};
 
 use super::{unused::PropertyAccessOpts, Optimizer};
-use crate::{mode::Mode, util::deeply_contains_this_expr};
+use crate::util::deeply_contains_this_expr;
 
 /// Methods related to the option `hoist_props`.
 impl Optimizer<'_> {

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -23,7 +23,6 @@ use crate::{
         optimize::{unused::PropertyAccessOpts, util::replace_id_with_expr},
         util::{is_directive, is_ident_used_by, replace_expr},
     },
-    mode::Mode,
     option::CompressOptions,
     util::{idents_used_by, idents_used_by_ignoring_nested, ExprOptExt, ModuleItemExt},
 };

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -30,10 +30,7 @@ use crate::{
 
 /// Methods related to the option `sequences`. All methods are noop if
 /// `sequences` is false.
-impl<M> Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     ///
     /// # Example
     ///

--- a/crates/swc_ecma_minifier/src/compress/optimize/strings.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/strings.rs
@@ -4,7 +4,6 @@ use swc_ecma_ast::*;
 use swc_ecma_utils::{ExprExt, Value::Known};
 
 use super::Optimizer;
-use crate::mode::Mode;
 
 impl Optimizer<'_> {
     pub(super) fn optimize_expr_in_str_ctx_unsafely(&mut self, e: &mut Expr) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/strings.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/strings.rs
@@ -6,10 +6,7 @@ use swc_ecma_utils::{ExprExt, Value::Known};
 use super::Optimizer;
 use crate::mode::Mode;
 
-impl<M> Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     pub(super) fn optimize_expr_in_str_ctx_unsafely(&mut self, e: &mut Expr) {
         if !self.options.unsafe_passes {
             return;

--- a/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
@@ -7,10 +7,7 @@ use super::Optimizer;
 use crate::{compress::util::is_primitive, mode::Mode, util::idents_used_by};
 
 /// Methods related to option `switches`.
-impl<M> Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     /// Handle switches in the case where we can know which branch will be
     /// taken.
     pub(super) fn optimize_const_switches(&mut self, s: &mut Stmt) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
@@ -4,7 +4,7 @@ use swc_ecma_utils::{prepend_stmt, ExprExt, ExprFactory, StmtExt};
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use super::Optimizer;
-use crate::{compress::util::is_primitive, mode::Mode, util::idents_used_by};
+use crate::{compress::util::is_primitive, util::idents_used_by};
 
 /// Methods related to option `switches`.
 impl Optimizer<'_> {

--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -7,9 +7,7 @@ use swc_ecma_utils::contains_ident_ref;
 use super::Optimizer;
 #[cfg(feature = "debug")]
 use crate::debug::dump;
-use crate::{
-    compress::optimize::util::extract_class_side_effect, mode::Mode, option::PureGetterOption,
-};
+use crate::{compress::optimize::util::extract_class_side_effect, option::PureGetterOption};
 
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct PropertyAccessOpts {

--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -19,10 +19,7 @@ pub(crate) struct PropertyAccessOpts {
 }
 
 /// Methods related to the option `unused`.
-impl<M> Optimizer<'_, M>
-where
-    M: Mode,
-{
+impl Optimizer<'_> {
     #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
     pub(super) fn drop_unused_var_declarator(
         &mut self,

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -15,10 +15,7 @@ use tracing::debug;
 use super::{Ctx, Optimizer};
 use crate::{mode::Mode, HEAVY_TASK_PARALLELS};
 
-impl<'b, M> Optimizer<'b>
-where
-    M: Mode,
-{
+impl<'b> Optimizer<'b> {
     pub(super) fn normalize_expr(&mut self, e: &mut Expr) {
         match e {
             Expr::Seq(seq) => {
@@ -112,7 +109,7 @@ pub(super) struct WithCtx<'a, 'b> {
     orig_ctx: Ctx,
 }
 
-impl<'b, M> Deref for WithCtx<'_, 'b> {
+impl<'b> Deref for WithCtx<'_, 'b> {
     type Target = Optimizer<'b>;
 
     fn deref(&self) -> &Self::Target {
@@ -120,13 +117,13 @@ impl<'b, M> Deref for WithCtx<'_, 'b> {
     }
 }
 
-impl<M> DerefMut for WithCtx<'_, '_> {
+impl DerefMut for WithCtx<'_, '_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.reducer
     }
 }
 
-impl<M> Drop for WithCtx<'_, '_> {
+impl Drop for WithCtx<'_, '_> {
     fn drop(&mut self) {
         self.reducer.ctx = self.orig_ctx;
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -13,7 +13,7 @@ use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 use tracing::debug;
 
 use super::{Ctx, Optimizer};
-use crate::{mode::Mode, HEAVY_TASK_PARALLELS};
+use crate::HEAVY_TASK_PARALLELS;
 
 impl<'b> Optimizer<'b> {
     pub(super) fn normalize_expr(&mut self, e: &mut Expr) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -15,7 +15,7 @@ use tracing::debug;
 use super::{Ctx, Optimizer};
 use crate::{mode::Mode, HEAVY_TASK_PARALLELS};
 
-impl<'b, M> Optimizer<'b, M>
+impl<'b, M> Optimizer<'b>
 where
     M: Mode,
 {
@@ -81,7 +81,7 @@ where
     }
 
     /// RAII guard to change context temporarically
-    pub(super) fn with_ctx(&mut self, mut ctx: Ctx) -> WithCtx<'_, 'b, M> {
+    pub(super) fn with_ctx(&mut self, mut ctx: Ctx) -> WithCtx<'_, 'b> {
         let mut scope_ctxt = ctx.scope;
 
         if self.ctx.scope != scope_ctxt {
@@ -107,26 +107,26 @@ where
     }
 }
 
-pub(super) struct WithCtx<'a, 'b, M> {
-    reducer: &'a mut Optimizer<'b, M>,
+pub(super) struct WithCtx<'a, 'b> {
+    reducer: &'a mut Optimizer<'b>,
     orig_ctx: Ctx,
 }
 
-impl<'b, M> Deref for WithCtx<'_, 'b, M> {
-    type Target = Optimizer<'b, M>;
+impl<'b, M> Deref for WithCtx<'_, 'b> {
+    type Target = Optimizer<'b>;
 
     fn deref(&self) -> &Self::Target {
         self.reducer
     }
 }
 
-impl<M> DerefMut for WithCtx<'_, '_, M> {
+impl<M> DerefMut for WithCtx<'_, '_> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.reducer
     }
 }
 
-impl<M> Drop for WithCtx<'_, '_, M> {
+impl<M> Drop for WithCtx<'_, '_> {
     fn drop(&mut self) {
         self.reducer.ctx = self.orig_ctx;
     }

--- a/crates/swc_ecma_minifier/src/eval.rs
+++ b/crates/swc_ecma_minifier/src/eval.rs
@@ -240,7 +240,7 @@ impl Evaluator {
                 self.marks,
                 PureOptimizerConfig {
                     enable_join_vars: false,
-                    force_str_for_tpl: Eval::force_str_for_tpl(),
+                    force_str_for_tpl: Eval.force_str_for_tpl(),
                     #[cfg(feature = "debug")]
                     debug_infinite_loop: false,
                 },

--- a/crates/swc_ecma_minifier/src/eval.rs
+++ b/crates/swc_ecma_minifier/src/eval.rs
@@ -63,7 +63,7 @@ impl Mode for Eval {
         w.cache.insert(id, Box::new(value.clone()));
     }
 
-    fn force_str_for_tpl() -> bool {
+    fn force_str_for_tpl(&self) -> bool {
         true
     }
 }

--- a/crates/swc_ecma_minifier/src/eval.rs
+++ b/crates/swc_ecma_minifier/src/eval.rs
@@ -240,7 +240,7 @@ impl Evaluator {
                 self.marks,
                 PureOptimizerConfig {
                     enable_join_vars: false,
-                    force_str_for_tpl: Eval.force_str_for_tpl(),
+                    force_str_for_tpl: self.data.force_str_for_tpl(),
                     #[cfg(feature = "debug")]
                     debug_infinite_loop: false,
                 },

--- a/crates/swc_ecma_minifier/src/lib.rs
+++ b/crates/swc_ecma_minifier/src/lib.rs
@@ -237,7 +237,7 @@ pub fn optimize(
                 None,
                 marks,
                 PureOptimizerConfig {
-                    force_str_for_tpl: Minification::force_str_for_tpl(),
+                    force_str_for_tpl: Minification.force_str_for_tpl(),
                     enable_join_vars: true,
                     #[cfg(feature = "debug")]
                     debug_infinite_loop: false,

--- a/crates/swc_ecma_minifier/src/mode.rs
+++ b/crates/swc_ecma_minifier/src/mode.rs
@@ -5,7 +5,7 @@ pub(crate) trait Mode: Send + Sync {
 
     /// If this returns true, template literals with `\n` or `\r` will be
     /// converted to [Lit::Str].
-    fn force_str_for_tpl() -> bool;
+    fn force_str_for_tpl(&self) -> bool;
 }
 
 pub struct Minification;
@@ -13,7 +13,7 @@ pub struct Minification;
 impl Mode for Minification {
     fn store(&self, _: Id, _: &Expr) {}
 
-    fn force_str_for_tpl() -> bool {
+    fn force_str_for_tpl(&self) -> bool {
         false
     }
 }


### PR DESCRIPTION
**Description:**

This causes binary bloat.

**Related issue:**

 - https://github.com/vercel/next.js/pull/50365

---

`cargo bloat --release -n 200`:


```
 File  .text     Size                            Crate Name
0.0%   0.0%   7.5KiB                            serde <serde::__private::de::FlatMapDeserializer<serde_json::error::Error> as serde::de::Deserializer>::deserialize_struct::<<swc::config::Config as serde::de::Deserialize>::deserialize::__Visi...
 0.0%   0.0%   7.5KiB                        next_core <next_core::next_config::ImageConfig as turbo_tasks::debug::ValueDebugFormat>::value_debug_format::{closure#0}
 0.0%   0.0%   7.5KiB                     swc_ecma_ast <swc_ecma_ast::stmt::Stmt as core::clone::Clone>::clone
 0.0%   0.0%   7.4KiB       swc_ecma_transforms_compat <swc_ecma_transforms_compat::es2015::block_scoping::BlockScoping>::handle_capture_of_vars
 0.0%   0.0%   7.4KiB             turbopack_ecmascript <scoped_tls::ScopedKey<swc_ecma_transforms_base::helpers::Helpers>>::set::<turbopack_ecmascript::parse::parse_content::{closure#0}::{closure#1}::{closure#0}::{closure#0}::{closure#0}, cor...
 0.0%   0.0%   7.4KiB                swc_ecma_minifier <swc_ecma_minifier::compress::optimize::Optimizer<swc_ecma_minifier::mode::Minification>>::ignore_return_value
 0.0%   0.0%   7.4KiB                swc_ecma_minifier <swc_ecma_minifier::compress::optimize::Optimizer<swc_ecma_minifier::eval::Eval>>::ignore_return_value
 0.0%   0.0%   7.4KiB                               h2 <h2::server::Peer as h2::proto::peer::Peer>::convert_poll_message
 0.0%   0.0%   7.4KiB             turbopack_ecmascript swc_ecma_visit::visit_expr_with_path::<turbopack_ecmascript::references::AssetReferencesVisitor>
 0.0%   0.0%   7.4KiB                               h2 <h2::frame::headers::HeaderBlock>::load::{closure#0}

```