### PR TITLE
perf(es): Use `&dyn Comments` to reduce binary size

### DIFF
--- a/crates/swc/src/builder.rs
+++ b/crates/swc/src/builder.rs
@@ -5,12 +5,8 @@ use either::Either;
 use rustc_hash::FxHashMap;
 use swc_atoms::JsWord;
 use swc_common::{
-    chain,
-    comments::{Comments, SingleThreadedComments},
-    errors::Handler,
-    sync::Lrc,
-    util::take::Take,
-    FileName, Mark, SourceMap,
+    chain, comments::Comments, errors::Handler, sync::Lrc, util::take::Take, FileName, Mark,
+    SourceMap,
 };
 use swc_ecma_ast::{EsVersion, Module, Script};
 use swc_ecma_minifier::option::{terser::TerserTopLevelOptions, MinifyOptions};
@@ -358,7 +354,7 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
             as_folder(MinifierPass {
                 options: self.minify,
                 cm: self.cm.clone(),
-                comments: comments.cloned(),
+                comments,
                 top_level_mark: self.top_level_mark,
             }),
             Optional::new(
@@ -373,14 +369,14 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
     }
 }
 
-struct MinifierPass {
+struct MinifierPass<'a> {
     options: Option<JsMinifyOptions>,
     cm: Lrc<SourceMap>,
-    comments: Option<SingleThreadedComments>,
+    comments: Option<&'a dyn Comments>,
     top_level_mark: Mark,
 }
 
-impl VisitMut for MinifierPass {
+impl VisitMut for MinifierPass<'_> {
     noop_visit_mut_type!();
 
     fn visit_mut_module(&mut self, m: &mut Module) {

--- a/crates/swc/src/builder.rs
+++ b/crates/swc/src/builder.rs
@@ -177,7 +177,7 @@ impl<'a, 'b, P: swc_ecma_visit::Fold> PassBuilder<'a, 'b, P> {
         base: &FileName,
         syntax: Syntax,
         module: Option<ModuleConfig>,
-        comments: Option<&'cmt SingleThreadedComments>,
+        comments: Option<&'cmt dyn Comments>,
     ) -> impl 'cmt + swc_ecma_visit::Fold
     where
         P: 'cmt,

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -25,7 +25,7 @@ use swc_cached::regex::CachedRegex;
 use swc_common::{
     chain,
     collections::{AHashMap, AHashSet},
-    comments::SingleThreadedComments,
+    comments::{Comments, SingleThreadedComments},
     errors::Handler,
     plugin::metadata::TransformPluginMetadataContext,
     FileName, Mark, SourceMap, SyntaxContext,
@@ -1476,7 +1476,7 @@ pub enum ModuleConfig {
 impl ModuleConfig {
     pub fn build<'cmt>(
         cm: Arc<SourceMap>,
-        comments: Option<&'cmt SingleThreadedComments>,
+        comments: Option<&'cmt dyn Comments>,
         base_url: PathBuf,
         paths: CompiledPaths,
         base: &FileName,

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -641,7 +641,7 @@ impl Options {
             base,
             syntax,
             cfg.module,
-            comments,
+            comments.map(|v| v as _),
         );
 
         let keep_import_assertions = experimental.keep_import_assertions.into_bool();


### PR DESCRIPTION
**Description:**


**Related issue:**

 - https://github.com/vercel/next.js/pull/50365