### PR TITLE
fix(es/codegen): Emit type arguments of jsx element names

### DIFF
--- a/crates/swc_ecma_codegen/src/jsx.rs
+++ b/crates/swc_ecma_codegen/src/jsx.rs
@@ -28,6 +28,10 @@ where
         punct!("<");
         emit!(node.name);
 
+        if let Some(type_args) = &node.type_args {
+            emit!(type_args);
+        }
+
         if !node.attrs.is_empty() {
             space!();
 

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/jsx_type_args/input.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/jsx_type_args/input.js
@@ -1,0 +1,2 @@
+<Foo<Bar> id="foo"></Foo>;
+<Foo<Bar> />;

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/jsx_type_args/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/jsx_type_args/output.js
@@ -1,0 +1,2 @@
+<Foo<Bar> id="foo"></Foo>;
+<Foo<Bar>/>;

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/jsx_type_args/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/jsx_type_args/output.min.js
@@ -1,0 +1,1 @@
+<Foo<Bar> id="foo"></Foo><Foo<Bar>/>;


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The ECMA code generation implementation was not emitting type arguments for jsx. This PR fixes that.


