### PR TITLE
fix(es/preset-env): Don't log `Yield` to the console

### DIFF
--- a/crates/swc_ecma_preset_env/src/corejs2/mod.rs
+++ b/crates/swc_ecma_preset_env/src/corejs2/mod.rs
@@ -317,7 +317,6 @@ impl Visit for UsageVisitor {
     /// - `yield*`
     fn visit_yield_expr(&mut self, e: &YieldExpr) {
         e.visit_children_with(self);
-        println!("Yield");
 
         if e.delegate {
             self.add(&["web.dom.iterable"])


### PR DESCRIPTION
**Description:**

When a `yield` token is encountered by the parser, the word "Yield" is unnecessarily logged to the console. This PR removes the extra logging.

**Related issue (if exists):**
