### PR TITLE
fix(es/resolver): Resolve the super class before registering a class name

### DIFF
--- a/crates/swc/tests/fixture/issues-7xxx/7546/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-7xxx/7546/input/.swcrc
@@ -1,0 +1,10 @@
+{
+    "jsc": {
+        "loose": true
+    },
+    "env": {
+        "include": [
+            "transform-classes"
+        ]
+    }
+}

--- a/crates/swc/tests/fixture/issues-7xxx/7546/input/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7546/input/1.js
@@ -1,0 +1,9 @@
+import { ClassName } from './some-file';
+
+export default {
+    field: class ClassName extends ClassName {
+        constructor() {
+            super();
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issues-7xxx/7546/output/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7546/output/1.js
@@ -1,0 +1,12 @@
+import { _ as _inherits } from "@swc/helpers/_/_inherits";
+import { ClassName } from "./some-file";
+export default {
+    field: /*#__PURE__*/ function(ClassName) {
+        "use strict";
+        _inherits(ClassName1, ClassName);
+        function ClassName1() {
+            return ClassName.call(this);
+        }
+        return ClassName1;
+    }(ClassName)
+};

--- a/crates/swc_ecma_transforms_base/src/resolver/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/resolver/mod.rs
@@ -675,6 +675,8 @@ impl<'a> VisitMut for Resolver<'a> {
     fn visit_mut_class_expr(&mut self, n: &mut ClassExpr) {
         // Create a child scope. The class name is only accessible within the class.
 
+        n.class.super_class.visit_mut_with(self);
+
         self.with_child(ScopeKind::Fn, |child| {
             child.ident_type = IdentType::Binding;
             n.ident.visit_mut_with(child);

--- a/crates/swc_ecma_transforms_base/tests/resolver/issue-7546/input.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/issue-7546/input.js
@@ -1,0 +1,9 @@
+import { ClassName } from './some-file';
+
+export default {
+    field: class ClassName extends ClassName {
+        constructor() {
+            super();
+        }
+    }
+}

--- a/crates/swc_ecma_transforms_base/tests/resolver/issue-7546/output.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/issue-7546/output.js
@@ -1,0 +1,8 @@
+import { ClassName__2 } from './some-file';
+export default {
+    field: class ClassName__3 extends ClassName__2 {
+        constructor(){
+            super();
+        }
+    }
+};


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7546.