### PR TITLE
fix(es/parser): Adjust context while parsing type arguments of TypeScript type queries

### DIFF
--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -361,7 +361,11 @@ impl<I: Tokens> Parser<I> {
         };
 
         let type_args = if !self.input.had_line_break_before_cur() && is!(self, '<') {
-            Some(self.parse_ts_type_args()?)
+            let ctx = Context {
+                should_not_lex_lt_or_gt_as_type: false,
+                ..self.ctx()
+            };
+            Some(self.with_ctx(ctx).parse_ts_type_args()?)
         } else {
             None
         };

--- a/crates/swc_ecma_parser/tests/typescript/issue-7580/input.tsx
+++ b/crates/swc_ecma_parser/tests/typescript/issue-7580/input.tsx
@@ -1,0 +1,5 @@
+const example = () => {
+    return {
+      func: callback<typeof something<Type1, Type2>>(options => null)
+    };
+  };

--- a/crates/swc_ecma_parser/tests/typescript/issue-7580/input.tsx.json
+++ b/crates/swc_ecma_parser/tests/typescript/issue-7580/input.tsx.json
@@ -1,0 +1,229 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 119,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 1,
+        "end": 119,
+        "ctxt": 0
+      },
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 7,
+            "end": 118,
+            "ctxt": 0
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 7,
+              "end": 14,
+              "ctxt": 0
+            },
+            "value": "example",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "span": {
+              "start": 17,
+              "end": 118,
+              "ctxt": 0
+            },
+            "params": [],
+            "body": {
+              "type": "BlockStatement",
+              "span": {
+                "start": 23,
+                "end": 118,
+                "ctxt": 0
+              },
+              "stmts": [
+                {
+                  "type": "ReturnStatement",
+                  "span": {
+                    "start": 29,
+                    "end": 114,
+                    "ctxt": 0
+                  },
+                  "argument": {
+                    "type": "ObjectExpression",
+                    "span": {
+                      "start": 36,
+                      "end": 113,
+                      "ctxt": 0
+                    },
+                    "properties": [
+                      {
+                        "type": "KeyValueProperty",
+                        "key": {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 44,
+                            "end": 48,
+                            "ctxt": 0
+                          },
+                          "value": "func",
+                          "optional": false
+                        },
+                        "value": {
+                          "type": "CallExpression",
+                          "span": {
+                            "start": 50,
+                            "end": 107,
+                            "ctxt": 0
+                          },
+                          "callee": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 50,
+                              "end": 58,
+                              "ctxt": 0
+                            },
+                            "value": "callback",
+                            "optional": false
+                          },
+                          "arguments": [
+                            {
+                              "spread": null,
+                              "expression": {
+                                "type": "ArrowFunctionExpression",
+                                "span": {
+                                  "start": 91,
+                                  "end": 106,
+                                  "ctxt": 0
+                                },
+                                "params": [
+                                  {
+                                    "type": "Identifier",
+                                    "span": {
+                                      "start": 91,
+                                      "end": 98,
+                                      "ctxt": 0
+                                    },
+                                    "value": "options",
+                                    "optional": false,
+                                    "typeAnnotation": null
+                                  }
+                                ],
+                                "body": {
+                                  "type": "NullLiteral",
+                                  "span": {
+                                    "start": 102,
+                                    "end": 106,
+                                    "ctxt": 0
+                                  }
+                                },
+                                "async": false,
+                                "generator": false,
+                                "typeParameters": null,
+                                "returnType": null
+                              }
+                            }
+                          ],
+                          "typeArguments": {
+                            "type": "TsTypeParameterInstantiation",
+                            "span": {
+                              "start": 58,
+                              "end": 90,
+                              "ctxt": 0
+                            },
+                            "params": [
+                              {
+                                "type": "TsTypeQuery",
+                                "span": {
+                                  "start": 59,
+                                  "end": 89,
+                                  "ctxt": 0
+                                },
+                                "exprName": {
+                                  "type": "Identifier",
+                                  "span": {
+                                    "start": 66,
+                                    "end": 75,
+                                    "ctxt": 0
+                                  },
+                                  "value": "something",
+                                  "optional": false
+                                },
+                                "typeArguments": {
+                                  "type": "TsTypeParameterInstantiation",
+                                  "span": {
+                                    "start": 75,
+                                    "end": 89,
+                                    "ctxt": 0
+                                  },
+                                  "params": [
+                                    {
+                                      "type": "TsTypeReference",
+                                      "span": {
+                                        "start": 76,
+                                        "end": 81,
+                                        "ctxt": 0
+                                      },
+                                      "typeName": {
+                                        "type": "Identifier",
+                                        "span": {
+                                          "start": 76,
+                                          "end": 81,
+                                          "ctxt": 0
+                                        },
+                                        "value": "Type1",
+                                        "optional": false
+                                      },
+                                      "typeParams": null
+                                    },
+                                    {
+                                      "type": "TsTypeReference",
+                                      "span": {
+                                        "start": 83,
+                                        "end": 88,
+                                        "ctxt": 0
+                                      },
+                                      "typeName": {
+                                        "type": "Identifier",
+                                        "span": {
+                                          "start": 83,
+                                          "end": 88,
+                                          "ctxt": 0
+                                        },
+                                        "value": "Type2",
+                                        "optional": false
+                                      },
+                                      "typeParams": null
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              ]
+            },
+            "async": false,
+            "generator": false,
+            "typeParameters": null,
+            "returnType": null
+          },
+          "definite": false
+        }
+      ]
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7580.