### PR TITLE
fix(xml/codegen): Fix wrong minification of spaces in a self-closing tag

### DIFF
--- a/crates/swc_xml_codegen/src/lib.rs
+++ b/crates/swc_xml_codegen/src/lib.rs
@@ -166,22 +166,7 @@ where
         }
 
         if is_void_element {
-            if self.config.minify {
-                let need_space = match n.attributes.last() {
-                    Some(Attribute {
-                        value: Some(value), ..
-                    }) => !value.chars().any(|c| match c {
-                        c if c.is_ascii_whitespace() => true,
-                        '`' | '=' | '<' | '>' | '"' | '\'' => true,
-                        _ => false,
-                    }),
-                    _ => false,
-                };
-
-                if need_space {
-                    write_raw!(self, " ");
-                }
-            } else {
+            if !self.config.minify {
                 write_raw!(self, " ");
             }
 

--- a/crates/swc_xml_codegen/tests/fixture/base/input.xml
+++ b/crates/swc_xml_codegen/tests/fixture/base/input.xml
@@ -11,4 +11,5 @@
     <foo attributeName="He said &apos;OK&apos;"></foo>
     <foo attributeName="He said &amp;OK&amp;"></foo>
     <foo>He said &gt;OK&gt;</foo>
+    <foo attributeName="OK" />
 </note>

--- a/crates/swc_xml_codegen/tests/fixture/base/output.min.xml
+++ b/crates/swc_xml_codegen/tests/fixture/base/output.min.xml
@@ -10,4 +10,5 @@
     <foo attributeName="He said 'OK'"/>
     <foo attributeName="He said &amp;OK&amp;"/>
     <foo>He said &gt;OK&gt;</foo>
+    <foo attributeName="OK"/>
 </note>

--- a/crates/swc_xml_codegen/tests/fixture/base/output.xml
+++ b/crates/swc_xml_codegen/tests/fixture/base/output.xml
@@ -10,4 +10,5 @@
     <foo attributeName="He said 'OK'" />
     <foo attributeName="He said &amp;OK&amp;" />
     <foo>He said &gt;OK&gt;</foo>
+    <foo attributeName="OK" />
 </note>


### PR DESCRIPTION
**Description:**

xml codegen with option `minify: true`.

input:
```xml
<foo attributeName="OK" />
```

expected:
```xml
<foo attributeName="OK"/>
```

actual:

```xml
<foo attributeName="OK" />
```

---

We already escape the attribute value in `escape_string` function, so we do not need to check whether it contains a specific string.