### PR TITLE
refactor(es/compat): Remove usage of `box_patterns`

### DIFF
--- a/crates/swc_ecma_transforms_compat/src/lib.rs
+++ b/crates/swc_ecma_transforms_compat/src/lib.rs
@@ -3,7 +3,6 @@
 #![allow(clippy::vec_box)]
 #![allow(clippy::boxed_local)]
 #![allow(clippy::match_like_matches_macro)]
-#![feature(box_patterns)]
 
 pub use self::{
     bugfixes::bugfixes, es2015::es2015, es2016::es2016, es2017::es2017, es2018::es2018,


### PR DESCRIPTION
I know it's more painful, but allows swc_ecma_transforms_compat to compile without a nightly compiler. I really wish there were box patterns in stable rust (or I guess now deref patterns).

Added in https://github.com/swc-project/swc/pull/7530/files?file-filters%5B%5D=.rs&show-viewed-files=true#diff-df2677fffc3c16f81f8e400f8d94cb7530e35bcf1ccf06dcbe0713cee22de5a3R6