### PR TITLE
fix(es/minifier): Don't drop unused properties of top-level vars

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -835,6 +835,10 @@ impl Optimizer<'_> {
             return None;
         }
 
+        if self.ctx.top_level && !self.options.top_level() {
+            return None;
+        }
+
         let name = v.name.as_ident()?;
         let obj = v.init.as_mut()?.as_mut_object()?;
 

--- a/crates/swc_ecma_minifier/tests/fixture/projects/wmr/archive-1/chunks/index.bf24abaa/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/projects/wmr/archive-1/chunks/index.bf24abaa/output.js
@@ -1,5 +1,6 @@
 import { s as style, m } from "../index.f66dda46.js";
 const process = {
+    browser: !0,
     env: {
         FOO: "bar",
         OVERRIDE: "11",

--- a/crates/swc_ecma_minifier/tests/fixture/projects/wmr/archive-1/chunks/index.ddc4110d/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/projects/wmr/archive-1/chunks/index.ddc4110d/output.js
@@ -1,5 +1,7 @@
 import { s as style, y, m } from "../index.f66dda46.js";
-const styles = {};
+const styles = {
+    about: "about_migxty"
+};
 function About({ query, title }) {
     return y(()=>(console.log("Mounted About: ", title), ()=>{
             console.log("Unmounting About: ", title);


### PR DESCRIPTION
**Description:**

**Related issue (if exists):**

 - Closes #7635.