### PR TITLE
chore(es/parser): Scope use of `lexical` to certain features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
   "crates/swc_timer",
   "crates/swc_xml",
 ]
-
+resolver = "2"
 [profile.release]
 # lto = true
 

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -25,7 +25,7 @@ verify     = ["swc_ecma_visit"]
 
 [dependencies]
 either      = { version = "1.4" }
-lexical     = { version = "6.1.0", features = ["power-of-two"] }
+lexical     = { version = "6.1.0", features = ["power-of-two", "parse-integers", "parse-floats"], default-features = false }
 num-bigint  = "0.4"
 serde       = { version = "1", features = ["derive"] }
 smallvec    = "1.8.0"


### PR DESCRIPTION
The entire `lexical` crate isn't being used, and the `lexical-write-*` APIs use a lot of unsafe code with tricky invariants.

Would be nice to be able to pull in just the crates needed.

Unfortunately, this PR does nothing unless https://github.com/Alexhuszagh/rust-lexical/pull/99 has been merged and published first.

<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**