### PR TITLE
fix(css/modules): Preserve attribute selectors used with `:global`

### DIFF
--- a/crates/swc_css_modules/src/lib.rs
+++ b/crates/swc_css_modules/src/lib.rs
@@ -512,8 +512,7 @@ where
                                 } else {
                                     if sel_index > 0 {
                                         if let Some(n) = n.as_mut_compound_selector() {
-                                            n.subclass_selectors =
-                                                n.subclass_selectors.split_at(sel_index).0.to_vec();
+                                            n.subclass_selectors.remove(sel_index);
                                         }
                                         new_children.push(n);
                                     }
@@ -539,8 +538,7 @@ where
                                 } else {
                                     if sel_index > 0 {
                                         if let Some(n) = n.as_mut_compound_selector() {
-                                            n.subclass_selectors =
-                                                n.subclass_selectors.split_at(sel_index).0.to_vec();
+                                            n.subclass_selectors.remove(sel_index);
                                         }
                                         new_children.push(n);
                                     }

--- a/crates/swc_css_modules/tests/fixture/issues/issue-7669.compiled.css
+++ b/crates/swc_css_modules/tests/fixture/issues/issue-7669.compiled.css
@@ -1,0 +1,15 @@
+.__local__class > .inner {
+  color: blue;
+}
+.__local__class[data-x=true] > .inner {
+  color: red;
+}
+.__local__class[data-x=true] > .__local__inner {
+  color: green;
+}
+.__local__class[data-x=true] > .inner {
+  color: yellow;
+}
+.__local__class[data-x=true] > .__local__inner {
+  color: black;
+}

--- a/crates/swc_css_modules/tests/fixture/issues/issue-7669.css
+++ b/crates/swc_css_modules/tests/fixture/issues/issue-7669.css
@@ -1,0 +1,16 @@
+.class:global > .inner {
+    color: blue;
+}
+.class:global[data-x=true] > .inner {
+    color: red;
+}
+.class:local[data-x=true] > .inner {
+    color: green;
+}
+.class[data-x=true]:global > .inner {
+    color: yellow;
+}
+.class[data-x=true]:local > .inner {
+    color: black;
+}
+

--- a/crates/swc_css_modules/tests/fixture/issues/issue-7669.transform.json
+++ b/crates/swc_css_modules/tests/fixture/issues/issue-7669.transform.json
@@ -1,0 +1,14 @@
+{
+  "class": [
+    {
+      "type": "local",
+      "name": "__local__class"
+    }
+  ],
+  "inner": [
+    {
+      "type": "local",
+      "name": "__local__inner"
+    }
+  ]
+}


### PR DESCRIPTION
**Description:**

**Related issue:**

 - Closes #7669 