### PR TITLE
fix(es/minifier): Do not drop properties from a var used in export default

### DIFF
--- a/crates/swc/tests/fixture/issues-7xxx/7710/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-7xxx/7710/input/.swcrc
@@ -1,0 +1,13 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript"
+        },
+        "loose": false,
+        "minify": {
+            "compress": {
+                "hoist_props": true
+            }
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issues-7xxx/7710/input/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7710/input/1.js
@@ -1,0 +1,8 @@
+const obj = {
+    foo: 1,
+    bar: 2,
+};
+
+console.log(obj.bar);
+
+export default obj;

--- a/crates/swc/tests/fixture/issues-7xxx/7710/output/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7710/output/1.js
@@ -1,0 +1,6 @@
+var obj = {
+    foo: 1,
+    bar: 2
+};
+console.log(obj.bar);
+export default obj;

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
@@ -571,6 +571,15 @@ where
         }));
     }
 
+    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    fn visit_export_default_expr(&mut self, n: &ExportDefaultExpr) {
+        n.visit_children_with(self);
+
+        if let Expr::Ident(ident) = &*n.expr {
+            self.data.var_or_default(ident.to_id()).mark_used_as_ref();
+        }
+    }
+
     #[cfg_attr(feature = "debug", tracing::instrument(skip(self, n)))]
     fn visit_export_decl(&mut self, n: &ExportDecl) {
         n.visit_children_with(self);


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7710.