### PR TITLE
refactor(es/parser): Make `stacker` an optional dependency

### DIFF
--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -19,7 +19,7 @@ bench = false
 [features]
 # Used for debugging
 debug      = []
-default    = ["typescript"]
+default    = ["typescript", "stacker"]
 typescript = []
 verify     = ["swc_ecma_visit"]
 
@@ -39,7 +39,7 @@ swc_ecma_ast   = { version = "0.107.2", path = "../swc_ecma_ast" }
 swc_ecma_visit = { version = "0.93.2", path = "../swc_ecma_visit", optional = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "arm")))'.dependencies]
-stacker = "0.1.15"
+stacker = { version = "0.1.15", optional = true }
 
 [dev-dependencies]
 criterion         = "0.5"

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -490,13 +490,16 @@ expose!(parse_file_as_script, Script, |p| { p.parse_script() });
 expose!(parse_file_as_program, Program, |p| { p.parse_program() });
 
 #[inline(always)]
-#[cfg(any(target_arch = "wasm32", target_arch = "arm"))]
+#[cfg(any(target_arch = "wasm32", target_arch = "arm", not(feature = "stacker")))]
 fn maybe_grow<R, F: FnOnce() -> R>(_red_zone: usize, _stack_size: usize, callback: F) -> R {
     callback()
 }
 
 #[inline(always)]
-#[cfg(not(any(target_arch = "wasm32", target_arch = "arm")))]
+#[cfg(all(
+    not(any(target_arch = "wasm32", target_arch = "arm")),
+    feature = "stacker"
+))]
 fn maybe_grow<R, F: FnOnce() -> R>(red_zone: usize, stack_size: usize, callback: F) -> R {
     stacker::maybe_grow(red_zone, stack_size, callback)
 }


### PR DESCRIPTION
**Description:**

Makes the `stacker` dependency optional (enabled by default). This allows disabling the dependency e.g. due to one of the reasons outlined in https://github.com/swc-project/swc/issues/7719.

**Related issue (if exists):**
Closes https://github.com/swc-project/swc/issues/7719
