### PR TITLE
fix(es): Fix typo in a warning

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -374,7 +374,7 @@ impl Options {
         let top_level_mark = self.top_level_mark.unwrap_or_else(Mark::new);
 
         if target.is_some() && cfg.env.is_some() {
-            bail!("`jsc.env` and `jsc.target` cannot be used together");
+            bail!("`jsc.env` and `target` cannot be used together");
         }
 
         let es_version = target.unwrap_or_default();

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -374,7 +374,7 @@ impl Options {
         let top_level_mark = self.top_level_mark.unwrap_or_else(Mark::new);
 
         if target.is_some() && cfg.env.is_some() {
-            bail!("`jsc.env` and `target` cannot be used together");
+            bail!("`env` and `jsc.target` cannot be used together");
         }
 
         let es_version = target.unwrap_or_default();


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

With the recent versions, there's a new error that tells us that `jsc.env` should not be used with `jsc.target`. But `jsc.env` does not exist. It's a typo with `env` at the root of the config.

**BREAKING CHANGE:**

No breaking changes.

**Related issue (if exists):**
No linked issue.