### PR TITLE
fix(es/module): Fix handling of continuous assignments in `systemjs`

### DIFF
--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -562,6 +562,12 @@ impl Fold for SystemJs {
                 let assign_expr = AssignExpr {
                     right: match *assign.right {
                         Expr::Ident(ident) => Box::new(self.fold_module_name_ident(ident)),
+                        Expr::Assign(_) if assign.op == AssignOp::Assign => {
+                            return Expr::Assign(AssignExpr {
+                                right: assign.right,
+                                ..assign
+                            });
+                        }
                         _ => assign.right,
                     },
                     ..assign

--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -563,7 +563,7 @@ impl Fold for SystemJs {
                     right: match *assign.right {
                         Expr::Ident(ident) => Box::new(self.fold_module_name_ident(ident)),
                         Expr::Assign(_) if assign.op == AssignOp::Assign => {
-                            return Expr::Assign(AssignExpr {
+                            return self.replace_assign_expr(AssignExpr {
                                 right: assign.right,
                                 ..assign
                             });

--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -562,7 +562,10 @@ impl Fold for SystemJs {
                 let assign_expr = AssignExpr {
                     right: match *assign.right {
                         Expr::Ident(ident) => Box::new(self.fold_module_name_ident(ident)),
-                        Expr::Assign(_) if assign.op == AssignOp::Assign => {
+                        Expr::Assign(AssignExpr {
+                            op: AssignOp::Assign,
+                            ..
+                        }) => {
                             return self.replace_assign_expr(AssignExpr {
                                 right: assign.right,
                                 ..assign

--- a/crates/swc_ecma_transforms_module/tests/system_js.rs
+++ b/crates/swc_ecma_transforms_module/tests/system_js.rs
@@ -24,6 +24,24 @@ fn tr(_tester: &mut Tester<'_>, config: Config) -> impl Fold {
 
 test!(
     syntax(),
+    |tester| tr(tester, Default::default()),
+    allow_continuous_assignment,
+    r#"var e = {}; e.a = e.b = e.c = e.d = e.e = e.f = e.g = e.h = e.i = e.j = e.k = e.l = e.m = e.n = e.o = e.p = e.q = e.r = e.s = e.t = e.u = e.v = e.w = e.x = e.y = e.z = e.A = e.B = e.C = e.D = e.E = e.F = e.G = e.H = e.I = e.J = e.K = e.L = e.M = e.N = e.O = e.P = e.Q = e.R = e.S = void 0;"#,
+    r#"System.register([], function (_export, _context) {
+        "use strict";
+        var e;
+        return {
+            setters: [],
+            execute: function () {
+                e = {};
+                e.a = e.b = e.c = e.d = e.e = e.f = e.g = e.h = e.i = e.j = e.k = e.l = e.m = e.n = e.o = e.p = e.q = e.r = e.s = e.t = e.u = e.v = e.w = e.x = e.y = e.z = e.A = e.B = e.C = e.D = e.E = e.F = e.G = e.H = e.I = e.J = e.K = e.L = e.M = e.N = e.O = e.P = e.Q = e.R = e.S = void 0;
+            }
+        };
+    });"#
+);
+
+test!(
+    syntax(),
     |tester| tr(
         tester,
         Config {


### PR DESCRIPTION
**Description:**

Fix  transpile the continuous assignment code like `d.a = d.b = d.c = d.d = ... = void 0;` to SystemJS may cause Infinite loop.



**Related issue:**

 - Closes #7143.
