### PR TITLE
fix(es/minifier): Mark args of `new`s as references

### DIFF
--- a/crates/swc/tests/fixture/issues-7xxx/7739/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-7xxx/7739/input/.swcrc
@@ -1,0 +1,8 @@
+{
+    "minify": true,
+    "jsc": {
+        "minify": {
+            "compress": true
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issues-7xxx/7739/input/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7739/input/1.js
@@ -1,0 +1,11 @@
+const formatterOpt = {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+};
+
+if (withCurrency) {
+    formatterOpt.style = 'currency';
+}
+
+const formatter = new Intl.NumberFormat('en', formatterOpt);
+console.log(formatter.format(amount));

--- a/crates/swc/tests/fixture/issues-7xxx/7739/output/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7739/output/1.js
@@ -1,0 +1,1 @@
+var formatterOpt={minimumFractionDigits:0,maximumFractionDigits:0};withCurrency&&(formatterOpt.style="currency"),console.log(new Intl.NumberFormat("en",formatterOpt).format(amount));

--- a/crates/swc_ecma_minifier/tests/TODO.txt
+++ b/crates/swc_ecma_minifier/tests/TODO.txt
@@ -196,7 +196,6 @@ harmony/issue_2794_2/input.js
 harmony/issue_2874_1/input.js
 harmony/issue_2874_2/input.js
 harmony/module_enabled/input.js
-harmony/module_enables_strict_mode/input.js
 harmony/module_mangle_scope/input.js
 harmony/regression_cannot_use_of/input.js
 if_return/if_return_same_value/input.js

--- a/crates/swc_ecma_minifier/tests/fixture/issues/7739/1/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/7739/1/config.json
@@ -1,0 +1,4 @@
+{
+    "defaults": true,
+    "toplevel": true
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/7739/1/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/7739/1/input.js
@@ -1,0 +1,11 @@
+const formatterOpt = {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+};
+
+if (withCurrency) {
+    formatterOpt.style = 'currency';
+}
+
+const formatter = new Intl.NumberFormat('en', formatterOpt);
+console.log(formatter.format(amount));

--- a/crates/swc_ecma_minifier/tests/fixture/issues/7739/1/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/7739/1/output.js
@@ -1,0 +1,7 @@
+const formatterOpt = {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0
+};
+withCurrency && (formatterOpt.style = 'currency');
+const formatter = new Intl.NumberFormat('en', formatterOpt);
+console.log(formatter.format(amount));

--- a/crates/swc_ecma_minifier/tests/passing.txt
+++ b/crates/swc_ecma_minifier/tests/passing.txt
@@ -532,6 +532,7 @@ evaluate/prop_function/input.js
 evaluate/string_case/input.js
 evaluate/string_charCodeAt/input.js
 evaluate/unary_prefix/input.js
+evaluate/unsafe_array/input.js
 evaluate/unsafe_array_bad_index/input.js
 evaluate/unsafe_constant/input.js
 evaluate/unsafe_string/input.js
@@ -634,10 +635,12 @@ functions/issue_2783/input.js
 functions/issue_2842/input.js
 functions/issue_3054/input.js
 functions/issue_485_crashing_1530/input.js
+functions/loop_init_arg/input.js
 functions/no_webkit/input.js
 functions/non_ascii_function_identifier_name/input.js
 functions/recursive_inline_1/input.js
 functions/recursive_inline_2/input.js
+functions/use_before_init_in_loop/input.js
 functions/webkit/input.js
 global_defs/conditional_chains/input.js
 global_defs/expanded/input.js
@@ -705,6 +708,7 @@ harmony/issue_2874_3/input.js
 harmony/issue_3028/input.js
 harmony/issue_3061/input.js
 harmony/issue_t80/input.js
+harmony/module_enables_strict_mode/input.js
 harmony/new_target/input.js
 harmony/number_literals/input.js
 harmony/object_literal_method_using_arguments/input.js

--- a/crates/swc_ecma_minifier/tests/postponed.txt
+++ b/crates/swc_ecma_minifier/tests/postponed.txt
@@ -1,7 +1,6 @@
 array_constructor/array_constructor_unsafe/input.js
 conditionals/hoist_decl/input.js
 dead_code/unsafe_builtin/input.js
-evaluate/unsafe_array/input.js
 evaluate/unsafe_charAt/input.js
 evaluate/unsafe_charAt_bad_index/input.js
 evaluate/unsafe_charAt_noop/input.js

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
@@ -966,6 +966,7 @@ where
             let ctx = Ctx {
                 in_call_arg_of: Some(CalleeKind::from_expr(&n.callee, &self.expr_ctx)),
                 is_exact_arg: true,
+                is_id_ref: true,
                 ..self.ctx
             };
             n.args.visit_with(&mut *self.with_ctx(ctx));


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7739.