### PR TITLE
feat(es): Alias `format` as `output` for `minify()`

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1071,7 +1071,7 @@ pub struct JsMinifyOptions {
     #[serde(default)]
     pub mangle: BoolOrDataConfig<MangleOptions>,
 
-    #[serde(default)]
+    #[serde(default, alias = "output")]
     pub format: JsMinifyFormatOptions,
 
     #[serde(default)]


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7738.