### PR TITLE
fix(plugin/runner): Use fs cache properly

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -696,17 +696,17 @@ impl Options {
                     // target.
                     init_plugin_module_cache_once(true, &experimental.cache_root);
 
+                    let mut inner_cache = PLUGIN_MODULE_CACHE
+                        .inner
+                        .get()
+                        .expect("Cache should be available")
+                        .lock();
+
                     // Populate cache to the plugin modules if not loaded
                     for plugin_config in plugins.iter() {
                         let plugin_name = &plugin_config.0;
 
-                        if !PLUGIN_MODULE_CACHE
-                            .inner
-                            .get()
-                            .unwrap()
-                            .lock()
-                            .contains(&plugin_name)
-                        {
+                        if !inner_cache.contains(&plugin_name) {
                             let resolved_path = plugin_resolver.resolve(
                                 &FileName::Real(PathBuf::from(&plugin_name)),
                                 &plugin_name,
@@ -718,12 +718,8 @@ impl Options {
                                 anyhow::bail!("Failed to resolve plugin path: {:?}", resolved_path);
                             };
 
-                            let mut inner_cache = PLUGIN_MODULE_CACHE
-                                .inner
-                                .get()
-                                .expect("Cache should be available")
-                                .lock();
                             inner_cache.store_bytes_from_path(&path, &plugin_name)?;
+                            tracing::debug!("Initialized WASM plugin {plugin_name}");
                         }
                     }
                 }


### PR DESCRIPTION
**Description**

## compile the same WASM module multiple times

I tried using swc-loader in webpack, and found out that if I have multiple entries, and using WASM plugins, it increased build time significantly. That's because Webpack run swc-loader multiple times, and since swc-loader is async, and then invoke process_js multiple times at nearly the same time, while the first WASM module is being compiled but not finished, the second time process_js get invoked, it sees that the WASM is not compiled, so it begins compiling too.

## File system cache is not used

Currently SWC does not read file system cache at all, and write new cache to FS every time.
As I'm very likely not understand the design of swc WASM cache that much, and cache is hard, so this fix needs carefully review from you team.

After the modification, my little app's build time has been from 12s to 7s

**Related issue (if exists):**
