### PR TITLE
Make usage of lexical from swc_ecma_parser optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4117,6 +4117,7 @@ dependencies = [
  "either",
  "lexical",
  "num-bigint",
+ "num-traits",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -19,14 +19,15 @@ bench = false
 [features]
 # Used for debugging
 debug      = []
-default    = ["typescript", "stacker"]
+default    = ["typescript", "stacker", "lexical"]
 typescript = []
 verify     = ["swc_ecma_visit"]
 
 [dependencies]
 either      = { version = "1.4" }
-lexical     = { version = "6.1.0", features = ["power-of-two", "parse-integers", "parse-floats"], default-features = false }
+lexical     = { version = "6.1.0", features = ["power-of-two", "parse-integers", "parse-floats"], default-features = false, optional = true }
 num-bigint  = "0.4"
+num-traits  = "0.2.15"
 serde       = { version = "1", features = ["derive"] }
 smallvec    = "1.8.0"
 smartstring = "1"

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -293,6 +293,7 @@ impl<'a> Lexer<'a> {
     fn read_token_zero(&mut self) -> LexResult<Token> {
         let next = self.input.peek();
 
+        #[cfg(feature = "lexical")]
         let bigint = match next {
             Some('x') | Some('X') => {
                 self.read_radix_number::<16, { lexical::NumberFormatBuilder::hexadecimal() }>()
@@ -303,6 +304,18 @@ impl<'a> Lexer<'a> {
             Some('b') | Some('B') => {
                 self.read_radix_number::<2, { lexical::NumberFormatBuilder::binary() }>()
             }
+            _ => {
+                return self.read_number(false).map(|v| match v {
+                    Left((value, raw)) => Num { value, raw },
+                    Right((value, raw)) => BigInt { value, raw },
+                });
+            }
+        };
+        #[cfg(not(feature = "lexical"))]
+        let bigint = match next {
+            Some('x') | Some('X') => self.read_radix_number::<16, 0>(),
+            Some('o') | Some('O') => self.read_radix_number::<8, 0>(),
+            Some('b') | Some('B') => self.read_radix_number::<2, 0>(),
             _ => {
                 return self.read_number(false).map(|v| match v {
                     Left((value, raw)) => Num { value, raw },


### PR DESCRIPTION
This PR makes lexical part of the default features for the swc_ecma_parser crate but allows it to be turned off to use BigInt for equivalent parsing of large numbers.

**Description:** As discussed in https://github.com/swc-project/swc/issues/7752, lexical contains a number of soundness issues but doesn't appear to be actively supported. Given the relatively low integration surface it seems reasonable to replace the usage of lexical with another package to avoid this issue. This does so in an optional fashion so that the decision can be made by the user which mechanism to use.

Related issue (if exists): https://github.com/swc-project/swc/issues/7752