### PR TITLE
refactor(es/parser): Do not use `lexical`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4115,8 +4115,8 @@ version = "0.137.5"
 dependencies = [
  "criterion",
  "either",
- "lexical",
  "num-bigint",
+ "num-traits",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -25,8 +25,8 @@ verify     = ["swc_ecma_visit"]
 
 [dependencies]
 either      = { version = "1.4" }
-lexical     = { version = "6.1.0", features = ["power-of-two", "parse-integers", "parse-floats"], default-features = false }
 num-bigint  = "0.4"
+num-traits  = "0.2.15"
 serde       = { version = "1", features = ["derive"] }
 smallvec    = "1.8.0"
 smartstring = "1"

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -294,15 +294,9 @@ impl<'a> Lexer<'a> {
         let next = self.input.peek();
 
         let bigint = match next {
-            Some('x') | Some('X') => {
-                self.read_radix_number::<16, { lexical::NumberFormatBuilder::hexadecimal() }>()
-            }
-            Some('o') | Some('O') => {
-                self.read_radix_number::<8, { lexical::NumberFormatBuilder::octal() }>()
-            }
-            Some('b') | Some('B') => {
-                self.read_radix_number::<2, { lexical::NumberFormatBuilder::binary() }>()
-            }
+            Some('x') | Some('X') => self.read_radix_number::<16>(),
+            Some('o') | Some('O') => self.read_radix_number::<8>(),
+            Some('b') | Some('B') => self.read_radix_number::<2>(),
             _ => {
                 return self.read_number(false).map(|v| match v {
                     Left((value, raw)) => Num { value, raw },


### PR DESCRIPTION
This PR replaces the current usage of lexical within the swc_ecma_parser crate with equivalent parsing of large numbers using BigInt.

**Description:** As discussed in https://github.com/swc-project/swc/issues/7752, lexical contains a number of soundness issues but doesn't appear to be actively supported. Given the relatively low integration surface it seems reasonable to replace the usage of lexical with another package to avoid this issue.

**Related issue:**

- Closes #7752