### PR TITLE
refactor(es/parser): Do not validate top-level await with target

### DIFF
--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -67,7 +67,6 @@ pub enum SyntaxError {
     GetterParam,
     SetterParam,
 
-    TopLevelAwait,
     TopLevelAwaitInScript,
 
     LegacyDecimal,
@@ -299,9 +298,6 @@ impl SyntaxError {
             SyntaxError::PrivateNameInInterface => {
                 "private names are not allowed in interface".into()
             }
-            SyntaxError::TopLevelAwait => "top level await requires target to es2017 or higher \
-                                           and topLevelAwait:true for ecmascript"
-                .into(),
             SyntaxError::TopLevelAwaitInScript => {
                 "top level await is only allowed in module".into()
             }

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -86,10 +86,6 @@ impl<I: Tokens> Parser<I> {
         self.input().take_errors()
     }
 
-    pub(crate) fn target(&self) -> EsVersion {
-        self.input.target()
-    }
-
     pub fn parse_script(&mut self) -> PResult<Script> {
         trace_cur!(self, parse_script);
 

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -122,12 +122,6 @@ impl<'a, I: Tokens> Parser<I> {
         trace_cur!(self, parse_stmt_internal);
 
         if top_level && is!(self, "await") {
-            let valid = self.target() >= EsVersion::Es2017;
-
-            if !valid {
-                self.emit_err(self.input.cur_span(), SyntaxError::TopLevelAwait);
-            }
-
             self.state.found_module_item = true;
             if !self.ctx().can_be_module {
                 self.emit_err(self.input.cur_span(), SyntaxError::TopLevelAwaitInScript);

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/1aefe47e20eb91fa.module.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/1aefe47e20eb91fa.module.js.swc-stderr
@@ -1,10 +1,4 @@
 
-  x top level await requires target to es2017 or higher and topLevelAwait:true for ecmascript
-   ,-[$DIR/tests/test262-parser/fail/1aefe47e20eb91fa.module.js:1:1]
- 1 | await
-   : ^^^^^
-   `----
-
   x `await` cannot be used as an identifier in an async context
    ,-[$DIR/tests/test262-parser/fail/1aefe47e20eb91fa.module.js:1:1]
  1 | await

--- a/crates/swc_ecma_parser/tests/typescript-errors/custom/top-level-await-jsc-target/input.ts.swc-stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/custom/top-level-await-jsc-target/input.ts.swc-stderr
@@ -1,10 +1,4 @@
 
-  x top level await requires target to es2017 or higher and topLevelAwait:true for ecmascript
-   ,-[$DIR/tests/typescript-errors/custom/top-level-await-jsc-target/input.ts:1:1]
- 1 | await foo
-   : ^^^^^
-   `----
-
   x top level await is only allowed in module
    ,-[$DIR/tests/typescript-errors/custom/top-level-await-jsc-target/input.ts:1:1]
  1 | await foo


### PR DESCRIPTION
**Description:**

Now that we cannot use jsc.target and env.targets at the same time, top-level await will be always failed to parse if we use env.targets.

How about adding extra browserslist validate for it ?

Or is parser not supposed to take care target ?

**BREAKING CHANGE:**


**Related issue (if exists):**
