### PR TITLE
refactor(common): Make `ahash` optional

### DIFF
--- a/bindings/binding_core_wasm/Cargo.toml
+++ b/bindings/binding_core_wasm/Cargo.toml
@@ -37,7 +37,6 @@ serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.4.5"
 swc_core = { version = "0.79.55", features = [
   "ecma_ast_serde",
-  "common_perf",
   "binding_macro_wasm",
   "ecma_transforms",
   "ecma_visit",

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -70,6 +70,7 @@ url          = "2.4.0"
 swc_atoms = { version = "0.5.8", path = "../swc_atoms" }
 swc_cached = { version = "0.3.17", path = "../swc_cached" }
 swc_common = { version = "0.31.18", path = "../swc_common", features = [
+  "ahash",
   "sourcemap",
   "parking_lot",
 ] }

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -19,11 +19,11 @@ bench = false
 __plugin         = []
 __plugin_mode    = []
 __plugin_rt      = []
+ahash            = ["dep:ahash"]
 concurrent       = ["parking_lot"]
 debug            = []
 default          = []
 diagnostic-serde = []
-perf             = ["parking_lot"]
 plugin-base      = ["__plugin", "anyhow", "rkyv-impl", "diagnostic-serde"]
 plugin-mode      = ["__plugin_mode", "plugin-base"]
 plugin-rt        = ["__plugin_rt", "plugin-base"]
@@ -37,7 +37,7 @@ __rkyv    = []
 rkyv-impl = ["__rkyv", "rkyv", "swc_atoms/rkyv-impl", "bytecheck"]
 
 [dependencies]
-ahash     = "0.8.3"
+ahash     = { version = "0.8.3", optional = true }
 anyhow    = { version = "1.0.71", optional = true }
 arbitrary = { version = "1", optional = true, features = ["derive"] }
 atty      = { version = "0.2", optional = true }

--- a/crates/swc_common/src/collections.rs
+++ b/crates/swc_common/src/collections.rs
@@ -1,10 +1,10 @@
-#[cfg(not(feature = "perf"))]
+#[cfg(feature = "ahash")]
 pub use self::ahash::*;
-#[cfg(feature = "perf")]
-pub use self::fxhash::*;
+#[cfg(not(feature = "ahash"))]
+pub use self::rustchash::*;
 
-#[cfg(feature = "perf")]
-mod fxhash {
+#[cfg(not(feature = "ahash"))]
+mod rustchash {
     use std::{
         collections::{HashMap, HashSet},
         hash::BuildHasherDefault,
@@ -17,7 +17,7 @@ mod fxhash {
     pub type AHashSet<V> = HashSet<V, BuildHasherDefault<FxHasher>>;
 }
 
-#[cfg(not(feature = "perf"))]
+#[cfg(feature = "ahash")]
 mod ahash {
     use std::collections::{HashMap, HashSet};
 

--- a/crates/swc_common/src/lib.rs
+++ b/crates/swc_common/src/lib.rs
@@ -28,9 +28,9 @@
 //! Allows replacing operations related to thread-local variables with a trait.
 //!
 //!
-//! ## `perf`
+//! ## `ahash`
 //!
-//! Use `fxhash` instead of `ahash` for `AHashMap` and `AHashSet`.
+//! Use `ahash` instead of `rustc_hash` for `AHashMap` and `AHashSet`.
 #![deny(clippy::all)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -9,7 +9,6 @@ repository    = "https://github.com/swc-project/swc.git"
 version       = "0.79.59"
   [package.metadata.docs.rs]
   features = [
-    "common_perf",
     "allocator_node",
     "base",
     "base_node",
@@ -38,8 +37,8 @@ doctest = false
 ## but changes internal logics to perform differently. These flag should be turned on in combination with
 ## actual features. Refer build.rs for more details.
 
-# swc_common/perf
-common_perf = ["swc_common/perf"]
+# swc_common/ahash
+common_ahash = ["swc_common/ahash"]
 
 # swc_ecma_loader/cache*
 ecma_loader_lru         = ["swc_ecma_loader/lru"]

--- a/crates/swc_core/tests/fixture/stub_wasm/Cargo.toml
+++ b/crates/swc_core/tests/fixture/stub_wasm/Cargo.toml
@@ -19,7 +19,6 @@ anyhow = "1.0.66"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.4.5"
 swc_core = { path = "../../../../swc_core", features = [
-  "common_perf",
   "ecma_ast_serde",
   "binding_macro_wasm",
   "ecma_transforms",


### PR DESCRIPTION
**Description:**

This adds the ability to not include `ahash` with swc_common, which caused some issues for me compiling dprint-plugin-typescript to Wasm because of:

```
   Compiling ahash v0.8.3
   Compiling getrandom v0.2.10
error: the wasm*-unknown-unknown targets are not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
   --> C:\Users\david\.cargo\registry\src\index.crates.io-6f17d22bba15001f\getrandom-0.2.10\src\lib.rs:285:9
    |
285 | /         compile_error!("the wasm*-unknown-unknown targets are not supported by \
286 | |                         default, you may need to enable the \"js\" feature. \
287 | |                         For more information see: \
288 | |                         https://docs.rs/getrandom/#webassembly-support");
    | |________________________________________________________________________^
``` 

(I can't enable the JS feature because it's running the wasm file in Wasmer and also I don't support Wasi in dprint plugins)

**BREAKING CHANGE:**

This removes swc_common's "perf" feature and makes it the default, then adds an `ahash` feature instead. An alternative would be to make the `ahash` dep optional and part of the default features, then do `default-features = false` in the downstream crates (I think, but I'm not sure), but I figure most people will be using the perf default anyway? I'm not sure what's preferable.

**Related issue:**

 - Closes #7729.