### PR TITLE
fix(es/codegen): Add quotes to property names when `ascii_only` is `true`

### DIFF
--- a/crates/swc/tests/fixture/issues-7xxx/7240/output/index.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7240/output/index.js
@@ -8,6 +8,6 @@ Object.defineProperty(exports, "__esModule", {
     }
 });
 var _obj, _default = ((_obj = {
-    \u3131: "\u11B0",
-    \u3141: "\u11B1"
+    "\u3131": "\u11B0",
+    "\u3141": "\u11B1"
 })["\u3142"] = "\u11B2", _obj);

--- a/crates/swc/tests/fixture/issues-7xxx/7805/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-7xxx/7805/input/.swcrc
@@ -1,0 +1,22 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": false
+        },
+        "externalHelpers": true,
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false,
+            "format": {
+                "asciiOnly": true
+            }
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": false,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-7xxx/7805/input/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7805/input/1.js
@@ -1,0 +1,48 @@
+/**
+ * Source: ftp://ftp.unicode.org/Public/UCD/latest/ucd/SpecialCasing.txt
+ */
+var SUPPORTED_LOCALE = {
+    tr: {
+        regexp: /\u0130|\u0049|\u0049\u0307/g,
+        map: {
+            İ: "\u0069",
+            I: "\u0131",
+            İ: "\u0069",
+        },
+    },
+    az: {
+        regexp: /\u0130/g,
+        map: {
+            İ: "\u0069",
+            I: "\u0131",
+            İ: "\u0069",
+        },
+    },
+    lt: {
+        regexp: /\u0049|\u004A|\u012E|\u00CC|\u00CD|\u0128/g,
+        map: {
+            I: "\u0069\u0307",
+            J: "\u006A\u0307",
+            Į: "\u012F\u0307",
+            Ì: "\u0069\u0307\u0300",
+            Í: "\u0069\u0307\u0301",
+            Ĩ: "\u0069\u0307\u0303",
+        },
+    },
+};
+/**
+ * Localized lower case.
+ */
+export function localeLowerCase(str, locale) {
+    var lang = SUPPORTED_LOCALE[locale.toLowerCase()];
+    if (lang)
+        return lowerCase(str.replace(lang.regexp, function (m) { return lang.map[m]; }));
+    return lowerCase(str);
+}
+/**
+ * Lower case as a function.
+ */
+export function lowerCase(str) {
+    return str.toLowerCase();
+}
+//# sourceMappingURL=index.js.map

--- a/crates/swc/tests/fixture/issues-7xxx/7805/output/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7805/output/1.js
@@ -1,0 +1,39 @@
+var SUPPORTED_LOCALE = {
+    tr: {
+        regexp: /\u0130|\u0049|\u0049\u0307/g,
+        map: {
+            "\u0130": "i",
+            I: "\u0131",
+            "I\u0307": "i"
+        }
+    },
+    az: {
+        regexp: /\u0130/g,
+        map: {
+            "\u0130": "i",
+            I: "\u0131",
+            "I\u0307": "i"
+        }
+    },
+    lt: {
+        regexp: /\u0049|\u004A|\u012E|\u00CC|\u00CD|\u0128/g,
+        map: {
+            I: "i\u0307",
+            J: "j\u0307",
+            "\u012E": "\u012F\u0307",
+            "\xcc": "i\u0307\u0300",
+            "\xcd": "i\u0307\u0301",
+            "\u0128": "i\u0307\u0303"
+        }
+    }
+};
+export function localeLowerCase(str, locale) {
+    var lang = SUPPORTED_LOCALE[locale.toLowerCase()];
+    if (lang) return lowerCase(str.replace(lang.regexp, function(m) {
+        return lang.map[m];
+    }));
+    return lowerCase(str);
+}
+export function lowerCase(str) {
+    return str.toLowerCase();
+}

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1603,8 +1603,21 @@ where
 
     #[emitter]
     fn emit_prop_name(&mut self, node: &PropName) -> Result {
-        match *node {
-            PropName::Ident(ref n) => emit!(n),
+        match node {
+            PropName::Ident(ident) => {
+                if self.cfg.ascii_only && !ident.sym.is_ascii() {
+                    self.wr.write_symbol(
+                        DUMMY_SP,
+                        &get_ascii_only_ident(
+                            &handle_invalid_unicodes(&ident.sym),
+                            self.cfg.target,
+                        ),
+                    )?;
+                    return Ok(());
+                }
+
+                emit!(ident)
+            }
             PropName::Str(ref n) => emit!(n),
             PropName::Num(ref n) => emit!(n),
             PropName::BigInt(ref n) => emit!(n),

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1606,6 +1606,7 @@ where
         match node {
             PropName::Ident(ident) => {
                 if self.cfg.ascii_only && !ident.sym.is_ascii() {
+                    punct!("\"");
                     self.wr.write_symbol(
                         DUMMY_SP,
                         &get_ascii_only_ident(
@@ -1613,6 +1614,8 @@ where
                             self.cfg.target,
                         ),
                     )?;
+                    punct!("\"");
+
                     return Ok(());
                 }
 

--- a/crates/swc_ecma_codegen/src/tests.rs
+++ b/crates/swc_ecma_codegen/src/tests.rs
@@ -872,17 +872,17 @@ fn ascii_only_tpl_lit() {
 #[test]
 fn ascii_only_issue_7240() {
     test_all(
-        r"
+        r#"
         export default {
-            \u3131: '\u11B0',
+            "\u3131": '\u11B0',
         }
-        ",
-        r"
+        "#,
+        r#"
 export default {
-    \u3131: '\u11B0'
+    "\u3131": '\u11B0'
 };
-        ",
-        r#"export default{\u3131:"\u11B0"}"#,
+        "#,
+        r#"export default{"\u3131":"\u11B0"}"#,
         Config {
             ascii_only: true,
             ..Default::default()


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7805.