### PR TITLE
perf(es/visit): Use `debug_unreachable` to reduce binary size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4492,6 +4492,7 @@ dependencies = [
 name = "swc_ecma_visit"
 version = "0.95.1"
 dependencies = [
+ "new_debug_unreachable",
  "num-bigint",
  "serde",
  "swc_atoms",

--- a/crates/swc_ecma_visit/Cargo.toml
+++ b/crates/swc_ecma_visit/Cargo.toml
@@ -21,9 +21,10 @@ default = []
 path    = []
 
 [dependencies]
-num-bigint = { version = "0.4", features = ["serde"] }
-serde      = { version = "1", optional = true }
-tracing    = "0.1.37"
+new_debug_unreachable = "1"
+num-bigint            = { version = "0.4", features = ["serde"] }
+serde                 = { version = "1", optional = true }
+tracing               = "0.1.37"
 
 swc_atoms    = { version = "0.5.9", path = "../swc_atoms" }
 swc_common   = { version = "0.32.1", path = "../swc_common" }

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -4,6 +4,8 @@
 #![allow(clippy::ptr_arg)]
 
 #[doc(hidden)]
+pub extern crate debug_unreachable;
+#[doc(hidden)]
 pub extern crate swc_ecma_ast;
 
 use std::{borrow::Cow, fmt::Debug};
@@ -335,7 +337,7 @@ where
 macro_rules! noop_fold_type {
     ($name:ident, $N:tt) => {
         fn $name(&mut self, _: $crate::swc_ecma_ast::$N) -> $crate::swc_ecma_ast::$N {
-            unsafe { new_debug_unreachable::debug_unreachable!("noop_fold_type") }
+            unsafe { $crate::debug_unreachable::debug_unreachable!("noop_fold_type") }
         }
     };
     () => {
@@ -411,7 +413,7 @@ macro_rules! noop_fold_type {
 macro_rules! noop_visit_type {
     ($name:ident, $N:tt) => {
         fn $name(&mut self, _: &$crate::swc_ecma_ast::$N) {
-            unsafe { new_debug_unreachable::debug_unreachable!("noop_visit_type") }
+            unsafe { $crate::debug_unreachable::debug_unreachable!("noop_visit_type") }
         }
     };
     () => {
@@ -474,7 +476,7 @@ macro_rules! noop_visit_type {
 macro_rules! noop_visit_mut_type {
     ($name:ident, $N:ident) => {
         fn $name(&mut self, _: &mut $crate::swc_ecma_ast::$N) {
-            unsafe { new_debug_unreachable::debug_unreachable!("noop_visit_mut_type") }
+            unsafe { $crate::debug_unreachable::debug_unreachable!("noop_visit_mut_type") }
         }
     };
     () => {

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -336,6 +336,7 @@ where
 #[macro_export]
 macro_rules! noop_fold_type {
     ($name:ident, $N:tt) => {
+        #[cfg_attr(not(debug_assertions), inline(always))]
         fn $name(&mut self, _: $crate::swc_ecma_ast::$N) -> $crate::swc_ecma_ast::$N {
             unsafe { $crate::debug_unreachable::debug_unreachable!("noop_fold_type") }
         }
@@ -412,6 +413,7 @@ macro_rules! noop_fold_type {
 #[macro_export]
 macro_rules! noop_visit_type {
     ($name:ident, $N:tt) => {
+        #[cfg_attr(not(debug_assertions), inline(always))]
         fn $name(&mut self, _: &$crate::swc_ecma_ast::$N) {
             unsafe { $crate::debug_unreachable::debug_unreachable!("noop_visit_type") }
         }
@@ -475,6 +477,7 @@ macro_rules! noop_visit_type {
 #[macro_export]
 macro_rules! noop_visit_mut_type {
     ($name:ident, $N:ident) => {
+        #[cfg_attr(not(debug_assertions), inline(always))]
         fn $name(&mut self, _: &mut $crate::swc_ecma_ast::$N) {
             unsafe { $crate::debug_unreachable::debug_unreachable!("noop_visit_mut_type") }
         }

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -334,8 +334,8 @@ where
 #[macro_export]
 macro_rules! noop_fold_type {
     ($name:ident, $N:tt) => {
-        fn $name(&mut self, node: $crate::swc_ecma_ast::$N) -> $crate::swc_ecma_ast::$N {
-            node
+        fn $name(&mut self, _: $crate::swc_ecma_ast::$N) -> $crate::swc_ecma_ast::$N {
+            unsafe { new_debug_unreachable::debug_unreachable!("noop_fold_type") }
         }
     };
     () => {
@@ -410,7 +410,9 @@ macro_rules! noop_fold_type {
 #[macro_export]
 macro_rules! noop_visit_type {
     ($name:ident, $N:tt) => {
-        fn $name(&mut self, _: &$crate::swc_ecma_ast::$N) {}
+        fn $name(&mut self, _: &$crate::swc_ecma_ast::$N) {
+            unsafe { new_debug_unreachable::debug_unreachable!("noop_visit_type") }
+        }
     };
     () => {
         noop_visit_type!(visit_accessibility, Accessibility);
@@ -471,7 +473,9 @@ macro_rules! noop_visit_type {
 #[macro_export]
 macro_rules! noop_visit_mut_type {
     ($name:ident, $N:ident) => {
-        fn $name(&mut self, _: &mut $crate::swc_ecma_ast::$N) {}
+        fn $name(&mut self, _: &mut $crate::swc_ecma_ast::$N) {
+            unsafe { new_debug_unreachable::debug_unreachable!("noop_visit_mut_type") }
+        }
     };
     () => {
         noop_visit_mut_type!(visit_mut_accessibility, Accessibility);


### PR DESCRIPTION
**Description:**

**Related issue (if exists):**
