### PR TITLE
fix(es/module): Make `jsc.paths` not produce absolute paths on windows

### DIFF
--- a/crates/swc_ecma_transforms_module/tests/path_node.rs
+++ b/crates/swc_ecma_transforms_module/tests/path_node.rs
@@ -34,9 +34,7 @@ fn node_modules() {
 
 #[test]
 fn issue_4730() {
-    let dir = Path::new("tests/fixture-manual/issue-4730")
-        .canonicalize()
-        .unwrap();
+    let dir = Path::new("tests/fixture-manual/issue-4730");
     let input_dir = dir.join("input");
     let output_dir = dir.join("output");
 


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7806.