### PR TITLE
refactor(common): Mark some methods of `Input` unsafe

### DIFF
--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -261,6 +261,10 @@ pub trait Input: Clone {
 
     fn last_pos(&self) -> BytePos;
 
+    /// # Safety
+    ///
+    /// - start should be less than or equal to end.
+    /// - start and end should be in the valid range of input.
     unsafe fn slice(&mut self, start: BytePos, end: BytePos) -> &str;
 
     /// Takes items from stream, testing each one with predicate. returns the
@@ -274,6 +278,9 @@ pub trait Input: Clone {
     where
         F: FnMut(char) -> bool;
 
+    /// # Safety
+    ///
+    /// - `to` be in the valid range of input.
     unsafe fn reset_to(&mut self, to: BytePos);
 
     /// Implementors can override the method to make it faster.

--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -330,13 +330,13 @@ mod tests {
     #[test]
     fn src_input_slice_1() {
         with_test_sess("foo/d", |mut i| {
-            assert_eq!(i.slice(BytePos(1), BytePos(2)), "f");
+            assert_eq!(unsafe { i.slice(BytePos(1), BytePos(2)) }, "f");
             assert_eq!(i.last_pos, BytePos(2));
             assert_eq!(i.start_pos_of_iter, BytePos(2));
             assert_eq!(i.cur(), Some('o'));
 
-            assert_eq!(i.slice(BytePos(2), BytePos(4)), "oo");
-            assert_eq!(i.slice(BytePos(1), BytePos(4)), "foo");
+            assert_eq!(unsafe { i.slice(BytePos(2), BytePos(4)) }, "oo");
+            assert_eq!(unsafe { i.slice(BytePos(1), BytePos(4)) }, "foo");
             assert_eq!(i.last_pos, BytePos(4));
             assert_eq!(i.start_pos_of_iter, BytePos(4));
             assert_eq!(i.cur(), Some('/'));
@@ -346,11 +346,11 @@ mod tests {
     #[test]
     fn src_input_reset_to_1() {
         with_test_sess("load", |mut i| {
-            assert_eq!(i.slice(BytePos(1), BytePos(3)), "lo");
+            assert_eq!(unsafe { i.slice(BytePos(1), BytePos(3)) }, "lo");
             assert_eq!(i.last_pos, BytePos(3));
             assert_eq!(i.start_pos_of_iter, BytePos(3));
             assert_eq!(i.cur(), Some('a'));
-            i.reset_to(BytePos(1));
+            unsafe { i.reset_to(BytePos(1)) };
 
             assert_eq!(i.cur(), Some('l'));
             assert_eq!(i.last_pos, BytePos(1));
@@ -371,11 +371,15 @@ mod tests {
             assert_eq!(i.start_pos_of_iter, BytePos(4));
             assert_eq!(i.cur(), Some('/'));
 
-            i.bump();
+            unsafe {
+                i.bump();
+            }
             assert_eq!(i.last_pos, BytePos(5));
             assert_eq!(i.cur(), Some('d'));
 
-            i.bump();
+            unsafe {
+                i.bump();
+            }
             assert_eq!(i.last_pos, BytePos(6));
             assert_eq!(i.cur(), None);
         });

--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -46,7 +46,10 @@ impl<'a> StringInput<'a> {
 
     #[inline]
     pub fn bump_bytes(&mut self, n: usize) {
-        self.reset_to(self.last_pos + BytePos(n as u32));
+        unsafe {
+            // Safety: We only proceed, not go back.
+            self.reset_to(self.last_pos + BytePos(n as u32));
+        }
     }
 }
 

--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -115,7 +115,7 @@ impl<'a> Input for StringInput<'a> {
     }
 
     #[inline]
-    fn slice(&mut self, start: BytePos, end: BytePos) -> &str {
+    unsafe fn slice(&mut self, start: BytePos, end: BytePos) -> &str {
         debug_assert!(start <= end, "Cannot slice {:?}..{:?}", start, end);
         let s = self.orig;
 
@@ -233,7 +233,7 @@ pub trait Input: Clone {
     fn cur(&mut self) -> Option<char>;
     fn peek(&mut self) -> Option<char>;
     fn peek_ahead(&mut self) -> Option<char>;
-    fn bump(&mut self);
+    unsafe fn bump(&mut self);
 
     /// Returns [None] if it's end of input **or** current character is not an
     /// ascii character.
@@ -266,7 +266,7 @@ pub trait Input: Clone {
     where
         F: FnMut(char) -> bool;
 
-    fn reset_to(&mut self, to: BytePos);
+    unsafe fn reset_to(&mut self, to: BytePos);
 
     /// Implementors can override the method to make it faster.
     ///

--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -200,12 +200,12 @@ impl<'a> Input for StringInput<'a> {
 
     #[inline]
     fn is_byte(&mut self, c: u8) -> bool {
-        if self.iter.as_str().is_empty() {
-            false
-        } else {
-            // Safety: We checked that `self.iter.as_str().len() > 0`
-            unsafe { *self.iter.as_str().as_bytes().get_unchecked(0) == c }
-        }
+        self.iter
+            .as_str()
+            .as_bytes()
+            .first()
+            .map(|b| *b == c)
+            .unwrap_or(false)
     }
 
     #[inline]


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7709