### PR TITLE
fix(es/codegen): Fix placing of comments of yield arguments

### DIFF
--- a/crates/swc/tests/fixture/minify/comments/false-02/input/.swcrc
+++ b/crates/swc/tests/fixture/minify/comments/false-02/input/.swcrc
@@ -1,0 +1,19 @@
+{
+    "isModule": true,
+    "jsc": {
+        "target": "es2022",
+        "transform": {
+            "optimizer": {
+                "simplify": true,
+            }
+        },
+        "minify": {
+            "format": {
+                "comments": true
+            },
+            "compress": true,
+            "mangle": false
+        },
+    },
+    "minify": false,
+}

--- a/crates/swc/tests/fixture/minify/comments/false-02/input/index.js
+++ b/crates/swc/tests/fixture/minify/comments/false-02/input/index.js
@@ -1,0 +1,22 @@
+export var padding = ''
+
+// some-comment
+function exec1({
+	command,
+}) {
+	command();
+}
+
+export function exec2({
+	commands,
+}) {
+	return __awaiter(this, void 0, void 0, function* () {
+		for (let i2 = 0; i2 < commands.length; i2++) {
+			const command = commands[i2]
+			yield exec1({
+				command,
+				handleError,
+			})
+		}
+	})
+}

--- a/crates/swc/tests/fixture/minify/comments/false-02/output/index.js
+++ b/crates/swc/tests/fixture/minify/comments/false-02/output/index.js
@@ -3,12 +3,13 @@ export function exec2({ commands }) {
     return __awaiter(this, void 0, void 0, function*() {
         for(let i2 = 0; i2 < commands.length; i2++){
             let command = commands[i2];
-            yield function({ command }) {
+            yield(// some-comment
+            function({ command }) {
                 command();
             }({
                 command,
                 handleError
-            });
+            }));
         }
     });
 }

--- a/crates/swc/tests/fixture/minify/comments/false-02/output/index.js
+++ b/crates/swc/tests/fixture/minify/comments/false-02/output/index.js
@@ -1,0 +1,14 @@
+export var padding = '';
+export function exec2({ commands }) {
+    return __awaiter(this, void 0, void 0, function*() {
+        for(let i2 = 0; i2 < commands.length; i2++){
+            let command = commands[i2];
+            yield function({ command }) {
+                command();
+            }({
+                command,
+                handleError
+            });
+        }
+    });
+}

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1879,12 +1879,23 @@ where
         }
 
         if let Some(ref arg) = node.arg {
-            if !node.delegate && arg.starts_with_alpha_num() {
+            let need_paren = node
+                .arg
+                .as_deref()
+                .map(|expr| self.has_leading_comment(expr))
+                .unwrap_or(false);
+            if need_paren {
+                punct!("(")
+            } else if !node.delegate && arg.starts_with_alpha_num() {
                 space!()
             } else {
                 formatting_space!()
             }
+
             emit!(node.arg);
+            if need_paren {
+                punct!(")")
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Looks like the bug I ran into had nothing to do with the changes in #7856, since it's reproducible without it. Looks like it might have only surfaced now because https://github.com/swc-project/swc/pull/7853 changed the default value of `jsc.minify.format.comments`? Added a minimal test case here with the expected result.

Here's the actual output:

```js
 export var padding = '';
 export function exec2({ commands }) {
     return __awaiter(this, void 0, void 0, function*() {
         for(let i2 = 0; i2 < commands.length; i2++){
             let command = commands[i2];
             yield // some-comment
             function({ command }) {
                 command();
             }({
                 command,
                 handleError
             });
         }
     });
 }
```

The comment ends up getting added after the yield, which makes the output invalid.

Going to see if I can figure out a fix tomorrow, but let me know if you have any ideas on where to start looking in the meantime!

