### PR TITLE
refactor(es/minifier): Remove `mutated` and `mutation_by_call_count`

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/props.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/props.rs
@@ -29,13 +29,11 @@ impl Optimizer<'_> {
                 .vars
                 .get(&name.to_id())
                 .map(|v| {
-                    !v.mutated
-                        && v.mutation_by_call_count == 0
+                    !v.mutated()
                         && !v.used_as_ref
                         && !v.used_as_arg
                         && !v.used_in_cond
                         && (!v.is_fn_local || !self.mode.should_be_very_correct())
-                        && !v.reassigned
                         && !v.is_infected()
                 })
                 .unwrap_or(false)
@@ -153,8 +151,7 @@ impl Optimizer<'_> {
                 .map(|v| {
                     v.ref_count == 1
                         && v.has_property_access
-                        && !v.mutated
-                        && v.mutation_by_call_count == 0
+                        && !v.mutated()
                         && v.is_fn_local
                         && !v.executed_multiple_time
                         && !v.used_as_arg

--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -215,8 +215,7 @@ impl Optimizer<'_> {
                         return true;
                     }
 
-                    if !usage.mutated && !usage.reassigned && usage.no_side_effect_for_member_access
-                    {
+                    if !usage.mutated() && usage.no_side_effect_for_member_access {
                         return false;
                     }
                 }

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
@@ -919,8 +919,8 @@ where
                 v.add_accessed_property(prop.sym.clone());
             }
 
-            if self.ctx.in_assign_lhs || self.ctx.is_delete_arg {
-                self.data.mark_property_mutattion(obj.to_id(), self.ctx)
+            if self.ctx.in_assign_lhs || self.ctx.in_update_arg || self.ctx.is_delete_arg {
+                self.data.mark_property_mutation(obj.to_id(), self.ctx)
             }
         })
     }

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/storage.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/storage.rs
@@ -30,7 +30,7 @@ pub trait Storage: Sized + Default {
     fn get_initialized_cnt(&self) -> usize;
     fn truncate_initialized_cnt(&mut self, len: usize);
 
-    fn mark_property_mutattion(&mut self, id: Id, ctx: Ctx);
+    fn mark_property_mutation(&mut self, id: Id, ctx: Ctx);
 }
 
 pub trait ScopeDataLike: Sized + Default + Clone {
@@ -64,8 +64,6 @@ pub trait VarDataLike: Sized {
     fn mark_indexed_with_dynamic_key(&mut self);
 
     fn add_accessed_property(&mut self, name: JsWord);
-
-    fn mark_mutated(&mut self);
 
     fn mark_used_as_ref(&mut self);
 


### PR DESCRIPTION
**Description:**

`mutated` can be seen as a combination of `reassigned` and `has_property_mutation`, and `mutation_by_call_count` is simply useless.
