### PR TITLE
fix(es/module): Make `jsc.paths` fully resolve TypeScript files

### DIFF
--- a/crates/swc/tests/fixture/deno/paths/issue-2126/output/src/index.ts
+++ b/crates/swc/tests/fixture/deno/paths/issue-2126/output/src/index.ts
@@ -2,5 +2,5 @@
 Object.defineProperty(exports, "__esModule", {
     value: true
 });
-const _a = require("../packages/a/src");
+const _a = require("../packages/a/src/index.js");
 console.log(`${(0, _a.displayA)()}`);

--- a/crates/swc/tests/fixture/deno/paths/issue-2724/output/src/index.ts
+++ b/crates/swc/tests/fixture/deno/paths/issue-2724/output/src/index.ts
@@ -4,6 +4,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 const _interop_require_wildcard = require("@swc/helpers/_/_interop_require_wildcard");
 (async function() {
-    const { displayA } = await Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard._(require("../packages/a/src")));
+    const { displayA } = await Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard._(require("../packages/a/src/index.js")));
     console.log(displayA());
 })();

--- a/crates/swc/tests/fixture/deno/paths/issue-2753/1/output/src/index.ts
+++ b/crates/swc/tests/fixture/deno/paths/issue-2753/1/output/src/index.ts
@@ -1,2 +1,2 @@
-import test from "./utils";
+import test from "./utils/index.js";
 test();

--- a/crates/swc/tests/fixture/deno/paths/issue-2844/output/src/index.ts
+++ b/crates/swc/tests/fixture/deno/paths/issue-2844/output/src/index.ts
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", {
     value: true
 });
 require("./core/module/moduleFile");
-require("./core/utils");
+require("./core/utils/index.js");
 require("./core/utilFile");
-require("./utils");
+require("./utils/index.js");
 console.log("SUCCESS");

--- a/crates/swc/tests/fixture/issues-6xxx/6782/1/output/src/index.ts
+++ b/crates/swc/tests/fixture/issues-6xxx/6782/1/output/src/index.ts
@@ -1,1 +1,1 @@
-import{config}from"../config";const main=()=>config();main();
+import{config}from"../config/index.js";const main=()=>config();main();

--- a/crates/swc/tests/fixture/issues-7xxx/7417/output/src/lib/foo.ts
+++ b/crates/swc/tests/fixture/issues-7xxx/7417/output/src/lib/foo.ts
@@ -9,7 +9,7 @@ Object.defineProperty(exports, "default", {
     }
 });
 const _interop_require_default = require("@swc/helpers/_/_interop_require_default");
-const _ = /*#__PURE__*/ _interop_require_default._(require("."));
+const _ = /*#__PURE__*/ _interop_require_default._(require("./index.js"));
 function bar() {
     console.log(_.default);
 }

--- a/crates/swc/tests/fixture/issues-7xxx/7829/1/output/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7829/1/output/1.js
@@ -1,2 +1,2 @@
-import { fn } from "./libs/pkg/src";
+import { fn } from "./libs/pkg/src/index.js";
 console.log(fn);

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -306,11 +306,7 @@ fn to_specifier(mut target_path: PathBuf, orig_filename: Option<&str>) -> JsWord
                 target_path.set_extension("js");
             }
         } else if is_resolved_as_ts && is_resolved_as_index {
-            if orig_filename == "index" {
-                target_path.set_extension("");
-            } else {
-                target_path.pop();
-            }
+            target_path.set_extension("js");
         }
     } else {
         target_path.set_extension("");

--- a/crates/swc_ecma_transforms_module/tests/fixture-manual/issue-4730/output/index.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture-manual/issue-4730/output/index.js
@@ -1,6 +1,6 @@
-import { displayB } from "../packages/b/src";
+import { displayB } from "../packages/b/src/index.js";
 async function display() {
-    const displayA = await import("../packages/a/src").then((c)=>c.displayA);
+    const displayA = await import("../packages/a/src/index.js").then((c)=>c.displayA);
     console.log(displayA());
     console.log(displayB());
 }

--- a/crates/swc_ecma_transforms_module/tests/paths/issue-7417/output/index.ts
+++ b/crates/swc_ecma_transforms_module/tests/paths/issue-7417/output/index.ts
@@ -1,4 +1,4 @@
-import o from ".";
+import o from "./index.js";
 export default function bar() {
     console.log(o);
 }

--- a/node-swc/__tests__/transform/issue_4730_test.mjs
+++ b/node-swc/__tests__/transform/issue_4730_test.mjs
@@ -38,9 +38,9 @@ it("should work", async () => {
             value: true
         });
         const _interop_require_wildcard = require(\\"@swc/helpers/_/_interop_require_wildcard\\");
-        const _b = require(\\"../packages/b/src\\");
+        const _b = require(\\"../packages/b/src/index.js\\");
         async function display() {
-            const displayA = await Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard._(require(\\"../packages/a/src\\"))).then((c)=>c.displayA);
+            const displayA = await Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard._(require(\\"../packages/a/src/index.js\\"))).then((c)=>c.displayA);
             console.log(displayA());
             console.log((0, _b.displayB)());
         }


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7861
 - Closes #7898
