### PR TITLE
fix(es/codegen): Use `emitAssertForImportAttributes`

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1248,6 +1248,9 @@ pub struct JsMinifyFormatOptions {
     /// Not implemented yet.
     #[serde(default, alias = "wrap_func_args")]
     pub wrap_func_args: bool,
+
+    #[serde(default)]
+    pub emit_assert_for_import_attributes: bool,
 }
 
 fn default_comments() -> BoolOrDataConfig<JsMinifyCommentOption> {

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -1155,7 +1155,10 @@ impl Compiler {
                 swc_ecma_codegen::Config::default()
                     .with_target(target)
                     .with_minify(true)
-                    .with_ascii_only(opts.format.ascii_only),
+                    .with_ascii_only(opts.format.ascii_only)
+                    .with_emit_assert_for_import_attributes(
+                        opts.format.emit_assert_for_import_attributes,
+                    ),
             )
         })
     }
@@ -1237,6 +1240,9 @@ impl Compiler {
                             .charset
                             .map(|v| matches!(v, OutputCharset::Ascii))
                             .unwrap_or(false),
+                    )
+                    .with_emit_assert_for_import_attributes(
+                        config.emit_assert_for_import_attributes,
                     ),
             )
         })

--- a/crates/swc/tests/fixture/issues-7xxx/7908/output/1/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7908/output/1/1.js
@@ -1,4 +1,4 @@
-import packageJSON from "./package.json" with {
+import packageJSON from "./package.json" assert {
     type: "json"
 };
 console.log(packageJSON);

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -311,7 +311,7 @@ where
         if let Some(with) = &n.with {
             formatting_space!();
             if self.cfg.emit_assert_for_import_attributes {
-                keyword!("asserts");
+                keyword!("assert");
             } else {
                 keyword!("with")
             };
@@ -458,7 +458,7 @@ where
             if let Some(with) = &node.with {
                 formatting_space!();
                 if self.cfg.emit_assert_for_import_attributes {
-                    keyword!("asserts");
+                    keyword!("assert");
                 } else {
                     keyword!("with")
                 };
@@ -488,7 +488,7 @@ where
         if let Some(with) = &node.with {
             formatting_space!();
             if self.cfg.emit_assert_for_import_attributes {
-                keyword!("asserts");
+                keyword!("assert");
             } else {
                 keyword!("with")
             };


### PR DESCRIPTION
**Description:**

 - Add `format.emitAssertForImportAttributes` to `minify()`
 - Use `jsc.experimental. emitAssertForImportAttributes`.

**Related issue (if exists):**

 - Closes #7926
 - Closes #7928