### PR TITLE
fix(es/minifier): Handle `ModuleDecl` when transform const modules

### DIFF
--- a/crates/swc_ecma_transforms_optimization/src/const_modules.rs
+++ b/crates/swc_ecma_transforms_optimization/src/const_modules.rs
@@ -151,11 +151,7 @@ impl VisitMut for ConstModules {
             return;
         }
 
-        n.iter_mut().for_each(|item| {
-            if let ModuleItem::Stmt(stmt) = item {
-                stmt.visit_mut_with(self);
-            }
-        });
+        n.visit_mut_children_with(self);
     }
 
     fn visit_mut_expr(&mut self, n: &mut Expr) {

--- a/crates/swc_ecma_transforms_optimization/tests/const-modules/issue-7747/globals.json
+++ b/crates/swc_ecma_transforms_optimization/tests/const-modules/issue-7747/globals.json
@@ -1,0 +1,5 @@
+{
+    "some-const-module": {
+        "default": "42"
+    }
+}

--- a/crates/swc_ecma_transforms_optimization/tests/const-modules/issue-7747/input.js
+++ b/crates/swc_ecma_transforms_optimization/tests/const-modules/issue-7747/input.js
@@ -1,0 +1,5 @@
+import foo from "some-const-module";
+console.log(foo);
+export function _() {
+    console.log(foo);
+}

--- a/crates/swc_ecma_transforms_optimization/tests/const-modules/issue-7747/output.js
+++ b/crates/swc_ecma_transforms_optimization/tests/const-modules/issue-7747/output.js
@@ -1,0 +1,4 @@
+console.log(42);
+export function _() {
+    console.log(42);
+}

--- a/crates/swc_ecma_transforms_optimization/tests/const_modules.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/const_modules.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, fs::read_to_string, path::PathBuf};
 
 use swc_ecma_transforms_optimization::const_modules;
 use swc_ecma_transforms_testing::{test, test_fixture, Tester};
@@ -169,12 +169,10 @@ fn const_modules_test(input: PathBuf) {
     test_fixture(
         ::swc_ecma_parser::Syntax::default(),
         &|t| {
-            let globals = if globals.exists() {
-                let s = std::fs::read_to_string(&globals).unwrap();
-                serde_json::from_str(&s).unwrap()
-            } else {
-                Default::default()
-            };
+            let globals = read_to_string(&globals)
+                .ok()
+                .and_then(|s| serde_json::from_str(&s).ok())
+                .unwrap_or_default();
 
             const_modules(t.cm.clone(), globals)
         },

--- a/crates/swc_ecma_transforms_optimization/tests/const_modules.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/const_modules.rs
@@ -1,7 +1,7 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 use swc_ecma_transforms_optimization::const_modules;
-use swc_ecma_transforms_testing::{test, Tester};
+use swc_ecma_transforms_testing::{test, test_fixture, Tester};
 use swc_ecma_visit::Fold;
 
 fn tr(t: &mut Tester<'_>, sources: &[(&str, &[(&str, &str)])]) -> impl Fold {
@@ -160,3 +160,26 @@ console.log(something);
 console.log(true);
 "#
 );
+
+#[testing::fixture("tests/const-modules/**/input.js")]
+fn const_modules_test(input: PathBuf) {
+    let globals = input.with_file_name("globals.json");
+    let output = input.with_file_name("output.js");
+
+    test_fixture(
+        ::swc_ecma_parser::Syntax::default(),
+        &|t| {
+            let globals = if globals.exists() {
+                let s = std::fs::read_to_string(&globals).unwrap();
+                serde_json::from_str(&s).unwrap()
+            } else {
+                Default::default()
+            };
+
+            const_modules(t.cm.clone(), globals)
+        },
+        &input,
+        &output,
+        Default::default(),
+    );
+}


### PR DESCRIPTION
**Related issue:**

 - Closes #7747 