### PR TITLE
fix(es/codegen): Fix codegen of optional chaining expr with a comment

### DIFF
--- a/crates/swc/tests/fixture/issues-8xxx/8004/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-8xxx/8004/input/.swcrc
@@ -1,0 +1,18 @@
+{
+    "jsc": {
+        "transform": {
+            "decoratorVersion": "2022-03"
+        },
+        "parser": {
+            "syntax": "typescript",
+            "tsx": false
+        },
+        "target": "es2021",
+        "loose": false,
+    },
+    "module": {
+        "type": "commonjs"
+    },
+    "isModule": true,
+    "minify": false
+}

--- a/crates/swc/tests/fixture/issues-8xxx/8004/input/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8004/input/1.js
@@ -1,0 +1,35 @@
+const string1 = { errorCode: 'test' };
+const string2 = 'test';
+
+function evaluateWithoutComment() {
+    return string1.errorCode === string2;
+}
+
+function evaluateWithComment() {
+    return (
+        // This comment doesn't break return evaluation
+        string1?.errorCode === string2
+    );
+}
+
+function evaluateWithCast() {
+    return (
+        (string1 as { errorCode: string })?.errorCode === string2
+    );
+}
+
+function evaluateWithCastAndComment() {
+    return (
+        // This comment seems to cause wrapping parantheses to get stripped, breaking the return evaluation
+        (string1 as { errorCode: string })?.errorCode === string2
+    );
+}
+
+// Works, returns true
+console.log(`evaluateWithoutComment: ${evaluateWithoutComment()}`);
+// Works, returns true
+console.log(`evaluateWithComment: ${evaluateWithComment()}`);
+// Works, returns true
+console.log(`evaluateWithCast: ${evaluateWithCast()}`);
+// Breaks, returns undefined due to stripped parantheses
+console.log(`evaluateWithCastAndComment: ${evaluateWithCastAndComment()}`);

--- a/crates/swc/tests/fixture/issues-8xxx/8004/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8004/output/1.js
@@ -1,0 +1,27 @@
+"use strict";
+const string1 = {
+    errorCode: 'test'
+};
+const string2 = 'test';
+function evaluateWithoutComment() {
+    return string1.errorCode === string2;
+}
+function evaluateWithComment() {
+    return(// This comment doesn't break return evaluation
+    string1?.errorCode === string2);
+}
+function evaluateWithCast() {
+    return string1?.errorCode === string2;
+}
+function evaluateWithCastAndComment() {
+    return(// This comment seems to cause wrapping parantheses to get stripped, breaking the return evaluation
+    string1?.errorCode === string2);
+}
+// Works, returns true
+console.log(`evaluateWithoutComment: ${evaluateWithoutComment()}`);
+// Works, returns true
+console.log(`evaluateWithComment: ${evaluateWithComment()}`);
+// Works, returns true
+console.log(`evaluateWithCast: ${evaluateWithCast()}`);
+// Breaks, returns undefined due to stripped parantheses
+console.log(`evaluateWithCastAndComment: ${evaluateWithCastAndComment()}`);

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -2941,6 +2941,19 @@ where
                 }
             }
 
+            Expr::OptChain(e) => match &*e.base {
+                OptChainBase::Member(m) => {
+                    if self.has_leading_comment(&m.obj) {
+                        return true;
+                    }
+                }
+                OptChainBase::Call(c) => {
+                    if self.has_leading_comment(&c.callee) {
+                        return true;
+                    }
+                }
+            },
+
             _ => {}
         }
 


### PR DESCRIPTION
**Related issue:**

 - Closes #8004