### PR TITLE
fix(es/compat): Use return statements for method and setter decorator

### DIFF
--- a/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
@@ -850,18 +850,15 @@ impl VisitMut for Decorator202203 {
 
             match p.kind {
                 MethodKind::Method => {
-                    *n = ClassMember::PrivateProp(PrivateProp {
-                        accessibility: Default::default(),
-                        span: p.span,
-                        key: p.key.clone(),
-                        is_optional: Default::default(),
-                        is_override: Default::default(),
-                        is_static: p.is_static,
-                        value: Some(init.into()),
-                        type_ann: Default::default(),
-                        decorators: Default::default(),
-                        definite: Default::default(),
-                        readonly: Default::default(),
+                    let call_stmt = Stmt::Return(ReturnStmt {
+                        span: DUMMY_SP,
+                        arg: Some(Box::new(Expr::Ident(init))),
+                    });
+
+                    p.kind = MethodKind::Getter;
+                    p.function.body = Some(BlockStmt {
+                        span: DUMMY_SP,
+                        stmts: vec![call_stmt],
                     });
                 }
                 MethodKind::Getter => {
@@ -881,9 +878,9 @@ impl VisitMut for Decorator202203 {
                     });
                 }
                 MethodKind::Setter => {
-                    let call_stmt = Stmt::Expr(ExprStmt {
+                    let call_stmt = Stmt::Return(ReturnStmt {
                         span: DUMMY_SP,
-                        expr: Box::new(Expr::Call(CallExpr {
+                        arg: Some(Box::new(Expr::Call(CallExpr {
                             span: DUMMY_SP,
                             callee: init.as_callee(),
                             args: vec![
@@ -891,7 +888,7 @@ impl VisitMut for Decorator202203 {
                                 p.function.params[0].pat.clone().expect_ident().id.as_arg(),
                             ],
                             type_args: Default::default(),
-                        })),
+                        }))),
                     });
 
                     p.function.body = Some(BlockStmt {

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-getters-and-setters--to-es2015/private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-getters-and-setters--to-es2015/private/output.js
@@ -42,5 +42,5 @@ function get_a() {
     return _call_a(this);
 }
 function set_a(v) {
-    _call_a1(this, v);
+    return _call_a1(this, v);
 }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-getters-and-setters--to-es2015/static-private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-getters-and-setters--to-es2015/static-private/output.js
@@ -15,7 +15,7 @@ var _a = {
 var __ = {
     writable: true,
     value: (()=>{
-        ({ e: [_call_a, _call_a1, _initStatic]  } = _apply_decs_2203_r(Foo, [
+        ({ e: [_call_a, _call_a1, _initStatic] } = _apply_decs_2203_r(Foo, [
             [
                 dec,
                 8,
@@ -41,5 +41,5 @@ function get_a() {
     return _call_a(this);
 }
 function set_a(v) {
-    _call_a1(this, v);
+    return _call_a1(this, v);
 }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-getters-and-setters/private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-getters-and-setters/private/output.js
@@ -2,7 +2,7 @@ var _call_a, _call_a1, _initProto;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_a, _call_a1, _initProto]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_a, _call_a1, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 3,
@@ -29,7 +29,7 @@ class Foo {
         return _call_a(this);
     }
     set #a(v) {
-        _call_a1(this, v);
+        return _call_a1(this, v);
     }
     getA() {
         return this.#a;

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-getters-and-setters/static-private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-getters-and-setters/static-private/output.js
@@ -2,7 +2,7 @@ var _call_a, _call_a1, _initStatic;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_a, _call_a1, _initStatic]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_a, _call_a1, _initStatic] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 8,
@@ -27,7 +27,7 @@ class Foo {
         return _call_a(this);
     }
     static set #a(v) {
-        _call_a1(this, v);
+        return _call_a1(this, v);
     }
     static getA() {
         return this.#a;

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods--to-es2015/private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods--to-es2015/private/output.js
@@ -6,11 +6,11 @@ class Foo {
         return _class_private_field_get(this, _a).call(this);
     }
     constructor(){
-        _define_property(this, "value", 1);
         _class_private_field_init(this, _a, {
-            writable: true,
-            value: _call_a
+            get: get_a,
+            set: void 0
         });
+        _define_property(this, "value", 1);
         _initProto(this);
     }
 }
@@ -27,3 +27,6 @@ var __ = {
         ]
     ], [])
 };
+function get_a() {
+    return _call_a;
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods--to-es2015/static-private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods--to-es2015/static-private/output.js
@@ -5,10 +5,14 @@ class Foo {
         return _class_static_private_field_spec_get(this, Foo, _a).call(Foo);
     }
 }
+var _a = {
+    get: get_a,
+    set: void 0
+};
 var __ = {
     writable: true,
     value: (()=>{
-        ({ e: [_call_a, _initStatic]  } = _apply_decs_2203_r(Foo, [
+        ({ e: [_call_a, _initStatic] } = _apply_decs_2203_r(Foo, [
             [
                 dec,
                 7,
@@ -22,7 +26,6 @@ var __ = {
     })()
 };
 _define_property(Foo, "value", 1);
-var _a = {
-    writable: true,
-    value: _call_a
-};
+function get_a() {
+    return _call_a;
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods/private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods/private/output.js
@@ -2,7 +2,7 @@ var _call_a, _initProto;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_a, _initProto]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_a, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 2,
@@ -17,7 +17,9 @@ class Foo {
         _initProto(this);
     }
     value = 1;
-    #a = _call_a;
+    get #a() {
+        return _call_a;
+    }
     callA() {
         return this.#a();
     }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods/static-private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods/static-private/output.js
@@ -2,7 +2,7 @@ var _call_a, _initStatic;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_a, _initStatic]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_a, _initStatic] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 7,
@@ -15,7 +15,9 @@ class Foo {
         _initStatic(this);
     }
     static value = 1;
-    static #a = _call_a;
+    static get #a() {
+        return _call_a;
+    }
     static callA() {
         return this.#a();
     }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/all-decorators/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/all-decorators/output.js
@@ -8,7 +8,7 @@ new class extends _identity {
     static{
         class Class {
             static{
-                ({ e: [_init_m, _call_o, _call_p, _call_q, _init_r, _get___r, _set___r, _init_i, _init_n, _init_d, _call_f, _call_g, _call_g1, _init_h, _get___h, _set___h, _init_a, _init_e, _initProto, _initStatic] , c: [_Class, _initClass]  } = _apply_decs_2203_r(this, [
+                ({ e: [_init_m, _call_o, _call_p, _call_q, _init_r, _get___r, _set___r, _init_i, _init_n, _init_d, _call_f, _call_g, _call_g1, _init_h, _get___h, _set___h, _init_a, _init_e, _initProto, _initStatic], c: [_Class, _initClass] } = _apply_decs_2203_r(this, [
                     [
                         dec,
                         7,
@@ -156,12 +156,14 @@ new class extends _identity {
                 this.#___private_d = _v;
             }
             #e = _init_e(this);
-            #f = _call_f;
+            get #f() {
+                return _call_f;
+            }
             get #g() {
                 return _call_g(this);
             }
             set #g(v) {
-                _call_g1(this, v);
+                return _call_g1(this, v);
             }
             #__h = _init_h(this);
             get #h() {
@@ -184,12 +186,14 @@ new class extends _identity {
     }
     #___private_m = _init_m(this);
     #n = _init_n(this);
-    #o = _call_o;
+    get #o() {
+        return _call_o;
+    }
     get #p() {
         return _call_p(this);
     }
     set #q(v) {
-        _call_q(this, v);
+        return _call_q(this, v);
     }
     #__r = _init_r(this);
     get #r() {

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method-via-array-pattern/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method-via-array-pattern/output.js
@@ -2,7 +2,7 @@ var _call_x, _initProto;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_x, _initProto]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_x, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 2,
@@ -14,7 +14,9 @@ class Foo {
     constructor(){
         _initProto(this);
     }
-    #x = _call_x;
+    get #x() {
+        return _call_x;
+    }
     bar() {
         [this.#x] = this.baz;
     }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method-via-for-of/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method-via-for-of/output.js
@@ -2,7 +2,7 @@ var _call_x, _initProto;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_x, _initProto]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_x, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 2,
@@ -14,7 +14,9 @@ class Foo {
     constructor(){
         _initProto(this);
     }
-    #x = _call_x;
+    get #x() {
+        return _call_x;
+    }
     bar() {
         for (this.#x of this.baz);
     }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method-via-object-pattern/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method-via-object-pattern/output.js
@@ -2,7 +2,7 @@ var _call_x, _initProto;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_x, _initProto]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_x, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 2,
@@ -14,8 +14,10 @@ class Foo {
     constructor(){
         _initProto(this);
     }
-    #x = _call_x;
+    get #x() {
+        return _call_x;
+    }
     bar() {
-        ({ x: this.#x  } = this.baz);
+        ({ x: this.#x } = this.baz);
     }
 }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method-via-rest/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method-via-rest/output.js
@@ -2,7 +2,7 @@ var _call_x, _initProto;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_x, _initProto]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_x, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 2,
@@ -14,7 +14,9 @@ class Foo {
     constructor(){
         _initProto(this);
     }
-    #x = _call_x;
+    get #x() {
+        return _call_x;
+    }
     bar() {
         [...this.#x] = this.baz;
     }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method-via-update/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method-via-update/output.js
@@ -2,7 +2,7 @@ var _call_x, _initProto;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_x, _initProto]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_x, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 2,
@@ -14,7 +14,9 @@ class Foo {
     constructor(){
         _initProto(this);
     }
-    #x = _call_x;
+    get #x() {
+        return _call_x;
+    }
     bar() {
         this.#x++;
     }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/setting-private-method/output.js
@@ -2,7 +2,7 @@ var _call_x, _initProto;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_x, _initProto]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_x, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 2,
@@ -14,7 +14,9 @@ class Foo {
     constructor(){
         _initProto(this);
     }
-    #x = _call_x;
+    get #x() {
+        return _call_x;
+    }
     bar() {
         this.#x = 123;
     }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/super-in-private-method/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/super-in-private-method/output.js
@@ -2,7 +2,7 @@ var _call_x, _initProto;
 const dec = ()=>{};
 class Foo extends Bar {
     static{
-        ({ e: [_call_x, _initProto]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_x, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 2,
@@ -17,5 +17,7 @@ class Foo extends Bar {
         super(...args);
         _initProto(this);
     }
-    #x = _call_x;
+    get #x() {
+        return _call_x;
+    }
 }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-ordering/accessor-simple/1/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-ordering/accessor-simple/1/output.js
@@ -2,7 +2,7 @@ var _initClass, _init_b, _init_c, _get___c, _set___c, _call_d, _initProto, _init
 let _A;
 class A {
     static{
-        ({ e: [_init_b, _init_c, _get___c, _set___c, _call_d, _initProto, _initStatic] , c: [_A, _initClass]  } = _apply_decs_2203_r(this, [
+        ({ e: [_init_b, _init_c, _get___c, _set___c, _call_d, _initProto, _initStatic], c: [_A, _initClass] } = _apply_decs_2203_r(this, [
             [
                 dec3,
                 6,
@@ -53,7 +53,9 @@ class A {
     static set #c(_v) {
         _set___c(this, _v);
     }
-    #d = _call_d;
+    get #d() {
+        return _call_d;
+    }
     static{
         _initClass();
     }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-ordering/accessor-static-method-initializers/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-ordering/accessor-static-method-initializers/output.js
@@ -10,7 +10,7 @@ new class extends _identity {
     static{
         class A {
             static{
-                ({ e: [_call_c, _init_a, _init_d, _get___d, _set___d, _initProto, _initStatic] , c: [_A, _initClass]  } = _apply_decs_2203_r(this, [
+                ({ e: [_call_c, _init_a, _init_d, _get___d, _set___d, _initProto, _initStatic], c: [_A, _initClass] } = _apply_decs_2203_r(this, [
                     [
                         [
                             _dec4,
@@ -76,5 +76,7 @@ new class extends _identity {
             }
         }
     }
-    #c = _call_c;
+    get #c() {
+        return _call_c;
+    }
 }();

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-ordering/initializers/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-ordering/initializers/output.js
@@ -8,7 +8,7 @@ new class extends _identity {
     static{
         class A {
             static{
-                ({ e: [_call_c, _init_f, _init_g, _get___g, _set___g, _call_d, _init_e, _init_h, _get___h, _set___h, _initProto, _initStatic] , c: [_A, _initClass]  } = _apply_decs_2203_r(this, [
+                ({ e: [_call_c, _init_f, _init_g, _get___g, _set___g, _call_d, _init_e, _init_h, _get___h, _set___h, _initProto, _initStatic], c: [_A, _initClass] } = _apply_decs_2203_r(this, [
                     [
                         [
                             _dec4,
@@ -95,7 +95,9 @@ new class extends _identity {
             }
             a() {}
             static b() {}
-            #d = _call_d;
+            get #d() {
+                return _call_d;
+            }
             #___private_e = (_initProto(this), _init_e(this));
             get e() {
                 return this.#___private_e;
@@ -118,7 +120,9 @@ new class extends _identity {
             }
         }
     }
-    #c = _call_c;
+    get #c() {
+        return _call_c;
+    }
     #___private_f = _init_f(this);
     #__g = _init_g(this);
     get #g() {

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-setters--to-es2015/private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-setters--to-es2015/private/output.js
@@ -28,5 +28,5 @@ var __ = {
     ], [])
 };
 function set_a(v) {
-    _call_a(this, v);
+    return _call_a(this, v);
 }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-setters--to-es2015/static-private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-setters--to-es2015/static-private/output.js
@@ -12,7 +12,7 @@ var _a = {
 var __ = {
     writable: true,
     value: (()=>{
-        ({ e: [_call_a, _initStatic]  } = _apply_decs_2203_r(Foo, [
+        ({ e: [_call_a, _initStatic] } = _apply_decs_2203_r(Foo, [
             [
                 dec,
                 9,
@@ -27,5 +27,5 @@ var __ = {
 };
 _define_property(Foo, "value", 1);
 function set_a(v) {
-    _call_a(this, v);
+    return _call_a(this, v);
 }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-setters/private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-setters/private/output.js
@@ -2,7 +2,7 @@ var _call_a, _initProto;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_a, _initProto]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_a, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 4,
@@ -18,7 +18,7 @@ class Foo {
     }
     value = 1;
     set #a(v) {
-        _call_a(this, v);
+        return _call_a(this, v);
     }
     setA(v) {
         this.#a = v;

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-setters/static-private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-setters/static-private/output.js
@@ -2,7 +2,7 @@ var _call_a, _initStatic;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_call_a, _initStatic]  } = _apply_decs_2203_r(this, [
+        ({ e: [_call_a, _initStatic] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 9,
@@ -16,7 +16,7 @@ class Foo {
     }
     static value = 1;
     static set #a(v) {
-        _call_a(this, v);
+        return _call_a(this, v);
     }
     static setA(v) {
         this.#a = v;


### PR DESCRIPTION
**Description:**
This aligns with other implementations such as TypeScript's and correctly implements the currently proposed behavior.

**Related issue:**

 - Closes #8015.