### PR TITLE
fix(es/typescript): Rename wrong `unresolved_mark`

### DIFF
--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -91,7 +91,7 @@ impl From<f64> for TsEnumRecordValue {
 
 pub(crate) struct EnumValueComputer<'a> {
     pub enum_id: &'a Id,
-    pub unresolved_mark: Mark,
+    pub top_level_mark: Mark,
     pub record: &'a TsEnumRecord,
 }
 
@@ -111,12 +111,12 @@ impl<'a> EnumValueComputer<'a> {
                 span,
                 sym: js_word!("NaN"),
                 ..
-            }) if span.ctxt.has_mark(self.unresolved_mark) => TsEnumRecordValue::Number(f64::NAN),
+            }) if span.ctxt.has_mark(self.top_level_mark) => TsEnumRecordValue::Number(f64::NAN),
             Expr::Ident(Ident {
                 span,
                 sym: js_word!("Infinity"),
                 ..
-            }) if span.ctxt.has_mark(self.unresolved_mark) => {
+            }) if span.ctxt.has_mark(self.top_level_mark) => {
                 TsEnumRecordValue::Number(f64::INFINITY)
             }
             Expr::Ident(ref ident) => self


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This is just a typo fix. No functional changes are expected. 
However, correcting the wrong parameter name will avoid confusing our Rust-side users.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
- Closes: #8016