### PR TITLE
fix(es/compat): wrap transpiled decorators in arrow functions

### DIFF
--- a/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
@@ -82,10 +82,23 @@ impl Decorator202203 {
             span: DUMMY_SP,
             op: op!("="),
             left: ident.clone().into(),
-            right: dec,
+            right: Box::new(Expr::Arrow(ArrowExpr {
+                span: DUMMY_SP,
+                params: Vec::default(),
+                body: Box::new(BlockStmtOrExpr::Expr(dec)),
+                is_async: false,
+                is_generator: false,
+                type_params: None,
+                return_type: None,
+            })),
         })));
 
-        ident.into()
+        Box::new(Expr::Call(CallExpr {
+            span: DUMMY_SP,
+            callee: Callee::Expr(ident.into()),
+            args: Vec::new(),
+            type_args: None,
+        }))
     }
 
     /// Moves `cur_inits` to `extra_stmts`.

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc--to-es2015/valid-expression-formats/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc--to-es2015/valid-expression-formats/output.js
@@ -1,14 +1,14 @@
-var _dec, _dec1, _dec2, _dec3, _initClass, _dec4, _dec5, _dec6, _dec7, _initProto;
+var _dec, _dec1, _dec2, _dec3, _initClass, _dec4, _dec5, _dec6, _dec7, _dec8, _dec9, _dec10, _dec11, _initProto;
 const dec = ()=>{};
 let _Foo;
-_dec = call(), _dec1 = chain.expr(), _dec2 = arbitrary + expr, _dec3 = array[expr], _dec4 = call(), _dec5 = chain.expr(), _dec6 = arbitrary + expr, _dec7 = array[expr];
+_dec = ()=>call(), _dec1 = ()=>chain.expr(), _dec2 = ()=>arbitrary + expr, _dec3 = ()=>array[expr], _dec4 = ()=>call(), _dec5 = ()=>chain.expr(), _dec6 = ()=>arbitrary + expr, _dec7 = ()=>array[expr], _dec8 = ()=>_dec4(), _dec9 = ()=>_dec5(), _dec10 = ()=>_dec6(), _dec11 = ()=>_dec7();
 var _a = /*#__PURE__*/ new WeakMap();
 class Foo {
     method() {}
     makeClass() {
         var _Nested, __;
-        var _dec, _init_bar;
-        _dec = _class_private_field_get(this, _a);
+        var _dec, _dec1, _init_bar;
+        _dec = ()=>_class_private_field_get(this, _a), _dec1 = ()=>_dec();
         return _Nested = class Nested {
             constructor(){
                 _define_property(this, "bar", _init_bar(this));
@@ -17,7 +17,7 @@ class Foo {
             writable: true,
             value: { e: [_init_bar] } = _apply_decs_2203_r(_Nested, [
                 [
-                    _dec,
+                    _dec1(),
                     0,
                     "bar"
                 ]
@@ -38,20 +38,20 @@ var __ = {
         [
             [
                 dec,
-                _dec4,
-                _dec5,
-                _dec6,
-                _dec7
+                _dec8(),
+                _dec9(),
+                _dec10(),
+                _dec11()
             ],
             2,
             "method"
         ]
     ], [
         dec,
-        _dec,
-        _dec1,
-        _dec2,
-        _dec3
+        _dec(),
+        _dec1(),
+        _dec2(),
+        _dec3()
     ])
 };
 var __1 = {

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/valid-expression-formats/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/valid-expression-formats/output.js
@@ -1,27 +1,27 @@
-var _dec, _dec1, _dec2, _dec3, _initClass, _dec4, _dec5, _dec6, _dec7, _initProto;
+var _dec, _dec1, _dec2, _dec3, _initClass, _dec4, _dec5, _dec6, _dec7, _dec8, _dec9, _dec10, _dec11, _initProto;
 const dec = ()=>{};
 let _Foo;
-_dec = call(), _dec1 = chain.expr(), _dec2 = arbitrary + expr, _dec3 = array[expr], _dec4 = call(), _dec5 = chain.expr(), _dec6 = arbitrary + expr, _dec7 = array[expr];
+_dec = ()=>call(), _dec1 = ()=>chain.expr(), _dec2 = ()=>arbitrary + expr, _dec3 = ()=>array[expr], _dec4 = ()=>call(), _dec5 = ()=>chain.expr(), _dec6 = ()=>arbitrary + expr, _dec7 = ()=>array[expr], _dec8 = ()=>_dec4(), _dec9 = ()=>_dec5(), _dec10 = ()=>_dec6(), _dec11 = ()=>_dec7();
 class Foo {
     static{
         ({ e: [_initProto], c: [_Foo, _initClass] } = _apply_decs_2203_r(this, [
             [
                 [
                     dec,
-                    _dec4,
-                    _dec5,
-                    _dec6,
-                    _dec7
+                    _dec8(),
+                    _dec9(),
+                    _dec10(),
+                    _dec11()
                 ],
                 2,
                 "method"
             ]
         ], [
             dec,
-            _dec,
-            _dec1,
-            _dec2,
-            _dec3
+            _dec(),
+            _dec1(),
+            _dec2(),
+            _dec3()
         ]));
     }
     constructor(){
@@ -30,13 +30,13 @@ class Foo {
     #a;
     method() {}
     makeClass() {
-        var _dec, _init_bar;
-        _dec = this.#a;
+        var _dec, _dec1, _init_bar;
+        _dec = ()=>this.#a, _dec1 = ()=>_dec();
         return class Nested {
             static{
                 ({ e: [_init_bar] } = _apply_decs_2203_r(this, [
                     [
-                        _dec,
+                        _dec1(),
                         0,
                         "bar"
                     ]

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-ordering/accessor-static-method-initializers/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-ordering/accessor-static-method-initializers/output.js
@@ -1,6 +1,6 @@
-var _dec, _dec1, _initClass, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _dec9, _init_a, _call_c, _init_d, _get___d, _set___d, _initProto, _initStatic;
+var _dec, _dec1, _initClass, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _dec9, _dec10, _dec11, _dec12, _dec13, _dec14, _dec15, _dec16, _dec17, _dec18, _dec19, _init_a, _dec20, _dec21, _dec22, _dec23, _call_c, _dec24, _dec25, _init_d, _get___d, _set___d, _initProto, _initStatic;
 let _A;
-_dec = logClassDecoratorRun(0, 19, 29), _dec1 = logClassDecoratorRun(1, 18, 28), _dec2 = logAccessorDecoratorRun(2, 15, 31, 35), _dec3 = logAccessorDecoratorRun(3, 14, 30, 34), _dec4 = logMethodDecoratorRun(4, 11, 21, 25), _dec5 = logMethodDecoratorRun(5, 10, 20, 24), _dec6 = logMethodDecoratorRun(6, 13, 23, 27), _dec7 = logMethodDecoratorRun(7, 12, 22, 26), _dec8 = logAccessorDecoratorRun(8, 17, 33, 37), _dec9 = logAccessorDecoratorRun(9, 16, 32, 36);
+_dec = ()=>logClassDecoratorRun(0, 19, 29), _dec1 = ()=>logClassDecoratorRun(1, 18, 28), _dec2 = ()=>logAccessorDecoratorRun(2, 15, 31, 35), _dec3 = ()=>logAccessorDecoratorRun(3, 14, 30, 34), _dec4 = ()=>logMethodDecoratorRun(4, 11, 21, 25), _dec5 = ()=>logMethodDecoratorRun(5, 10, 20, 24), _dec6 = ()=>logMethodDecoratorRun(6, 13, 23, 27), _dec7 = ()=>logMethodDecoratorRun(7, 12, 22, 26), _dec8 = ()=>logAccessorDecoratorRun(8, 17, 33, 37), _dec9 = ()=>logAccessorDecoratorRun(9, 16, 32, 36), _dec10 = ()=>_dec2(), _dec11 = ()=>_dec3(), _dec12 = ()=>_dec4(), _dec13 = ()=>_dec5(), _dec14 = ()=>_dec6(), _dec15 = ()=>_dec7(), _dec16 = ()=>_dec8(), _dec17 = ()=>_dec9(), _dec18 = ()=>_dec10(), _dec19 = ()=>_dec11(), _dec20 = ()=>_dec12(), _dec21 = ()=>_dec13(), _dec22 = ()=>_dec14(), _dec23 = ()=>_dec15(), _dec24 = ()=>_dec16(), _dec25 = ()=>_dec17();
 new class extends _identity {
     constructor(){
         super(_A), (()=>{
@@ -13,16 +13,16 @@ new class extends _identity {
                 ({ e: [_call_c, _init_a, _init_d, _get___d, _set___d, _initProto, _initStatic], c: [_A, _initClass] } = _apply_decs_2203_r(this, [
                     [
                         [
-                            _dec4,
-                            _dec5
+                            _dec20(),
+                            _dec21()
                         ],
                         7,
                         "b"
                     ],
                     [
                         [
-                            _dec6,
-                            _dec7
+                            _dec22(),
+                            _dec23()
                         ],
                         7,
                         "c",
@@ -30,16 +30,16 @@ new class extends _identity {
                     ],
                     [
                         [
-                            _dec2,
-                            _dec3
+                            _dec18(),
+                            _dec19()
                         ],
                         1,
                         "a"
                     ],
                     [
                         [
-                            _dec8,
-                            _dec9
+                            _dec24(),
+                            _dec25()
                         ],
                         1,
                         "d",
@@ -51,8 +51,8 @@ new class extends _identity {
                         }
                     ]
                 ], [
-                    _dec,
-                    _dec1
+                    _dec(),
+                    _dec1()
                 ]));
                 _initStatic(this);
             }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-ordering/initializers/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-ordering/initializers/output.js
@@ -1,6 +1,6 @@
-var _dec, _dec1, _initClass, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _dec9, _dec10, _dec11, _dec12, _dec13, _dec14, _dec15, _dec16, _dec17, _call_c, _call_d, _init_e, _init_f, _init_g, _get___g, _set___g, _init_h, _get___h, _set___h, _initProto, _initStatic;
+var _dec, _dec1, _initClass, _dec2, _dec3, _dec4, _dec5, _dec6, _dec7, _dec8, _dec9, _dec10, _dec11, _dec12, _dec13, _dec14, _dec15, _dec16, _dec17, _dec18, _dec19, _dec20, _dec21, _dec22, _dec23, _dec24, _dec25, _dec26, _dec27, _dec28, _dec29, _dec30, _dec31, _dec32, _dec33, _dec34, _dec35, _dec36, _dec37, _dec38, _dec39, _call_c, _dec40, _dec41, _call_d, _dec42, _dec43, _init_e, _dec44, _dec45, _init_f, _dec46, _dec47, _init_g, _get___g, _set___g, _dec48, _dec49, _init_h, _get___h, _set___h, _initProto, _initStatic;
 let _A;
-_dec = logDecoratorRun(0, 35, 45), _dec1 = logDecoratorRun(1, 34, 44), _dec2 = logDecoratorRun(2, 27, 47), _dec3 = logDecoratorRun(3, 26, 46), _dec4 = logDecoratorRun(4, 19, 37), _dec5 = logDecoratorRun(5, 18, 36), _dec6 = logDecoratorRun(6, 21, 39), _dec7 = logDecoratorRun(7, 20, 38), _dec8 = logDecoratorRun(8, 29, 49), _dec9 = logDecoratorRun(9, 28, 48), _dec10 = logDecoratorRun(10, 31, 51), _dec11 = logDecoratorRun(11, 30, 50), _dec12 = logDecoratorRun(12, 23, 41), _dec13 = logDecoratorRun(13, 22, 40), _dec14 = logDecoratorRun(14, 25, 43), _dec15 = logDecoratorRun(15, 24, 42), _dec16 = logDecoratorRun(16, 33, 53), _dec17 = logDecoratorRun(17, 32, 52);
+_dec = ()=>logDecoratorRun(0, 35, 45), _dec1 = ()=>logDecoratorRun(1, 34, 44), _dec2 = ()=>logDecoratorRun(2, 27, 47), _dec3 = ()=>logDecoratorRun(3, 26, 46), _dec4 = ()=>logDecoratorRun(4, 19, 37), _dec5 = ()=>logDecoratorRun(5, 18, 36), _dec6 = ()=>logDecoratorRun(6, 21, 39), _dec7 = ()=>logDecoratorRun(7, 20, 38), _dec8 = ()=>logDecoratorRun(8, 29, 49), _dec9 = ()=>logDecoratorRun(9, 28, 48), _dec10 = ()=>logDecoratorRun(10, 31, 51), _dec11 = ()=>logDecoratorRun(11, 30, 50), _dec12 = ()=>logDecoratorRun(12, 23, 41), _dec13 = ()=>logDecoratorRun(13, 22, 40), _dec14 = ()=>logDecoratorRun(14, 25, 43), _dec15 = ()=>logDecoratorRun(15, 24, 42), _dec16 = ()=>logDecoratorRun(16, 33, 53), _dec17 = ()=>logDecoratorRun(17, 32, 52), _dec18 = ()=>_dec2(), _dec19 = ()=>_dec3(), _dec20 = ()=>_dec4(), _dec21 = ()=>_dec5(), _dec22 = ()=>_dec6(), _dec23 = ()=>_dec7(), _dec24 = ()=>_dec8(), _dec25 = ()=>_dec9(), _dec26 = ()=>_dec10(), _dec27 = ()=>_dec11(), _dec28 = ()=>_dec12(), _dec29 = ()=>_dec13(), _dec30 = ()=>_dec14(), _dec31 = ()=>_dec15(), _dec32 = ()=>_dec16(), _dec33 = ()=>_dec17(), _dec34 = ()=>_dec18(), _dec35 = ()=>_dec19(), _dec36 = ()=>_dec20(), _dec37 = ()=>_dec21(), _dec38 = ()=>_dec22(), _dec39 = ()=>_dec23(), _dec40 = ()=>_dec24(), _dec41 = ()=>_dec25(), _dec42 = ()=>_dec26(), _dec43 = ()=>_dec27(), _dec44 = ()=>_dec28(), _dec45 = ()=>_dec29(), _dec46 = ()=>_dec30(), _dec47 = ()=>_dec31(), _dec48 = ()=>_dec32(), _dec49 = ()=>_dec33();
 new class extends _identity {
     constructor(){
         super(_A), _initClass();
@@ -11,16 +11,16 @@ new class extends _identity {
                 ({ e: [_call_c, _init_f, _init_g, _get___g, _set___g, _call_d, _init_e, _init_h, _get___h, _set___h, _initProto, _initStatic], c: [_A, _initClass] } = _apply_decs_2203_r(this, [
                     [
                         [
-                            _dec4,
-                            _dec5
+                            _dec36(),
+                            _dec37()
                         ],
                         7,
                         "b"
                     ],
                     [
                         [
-                            _dec6,
-                            _dec7
+                            _dec38(),
+                            _dec39()
                         ],
                         7,
                         "c",
@@ -28,16 +28,16 @@ new class extends _identity {
                     ],
                     [
                         [
-                            _dec12,
-                            _dec13
+                            _dec44(),
+                            _dec45()
                         ],
                         6,
                         "f"
                     ],
                     [
                         [
-                            _dec14,
-                            _dec15
+                            _dec46(),
+                            _dec47()
                         ],
                         6,
                         "g",
@@ -50,16 +50,16 @@ new class extends _identity {
                     ],
                     [
                         [
-                            _dec2,
-                            _dec3
+                            _dec34(),
+                            _dec35()
                         ],
                         2,
                         "a"
                     ],
                     [
                         [
-                            _dec8,
-                            _dec9
+                            _dec40(),
+                            _dec41()
                         ],
                         2,
                         "d",
@@ -67,16 +67,16 @@ new class extends _identity {
                     ],
                     [
                         [
-                            _dec10,
-                            _dec11
+                            _dec42(),
+                            _dec43()
                         ],
                         1,
                         "e"
                     ],
                     [
                         [
-                            _dec16,
-                            _dec17
+                            _dec48(),
+                            _dec49()
                         ],
                         1,
                         "h",
@@ -88,8 +88,8 @@ new class extends _identity {
                         }
                     ]
                 ], [
-                    _dec,
-                    _dec1
+                    _dec(),
+                    _dec1()
                 ]));
                 _initStatic(this);
             }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-7358/1/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-7358/1/output.js
@@ -1,21 +1,21 @@
-var _dec, _initClass, _dec1, _dec2, _initProto;
+var _dec, _initClass, _dec1, _dec2, _dec3, _dec4, _initProto;
 let _Foo;
-_dec = decorate(), _dec1 = decorate(), _dec2 = decorate();
+_dec = ()=>decorate(), _dec1 = ()=>decorate(), _dec2 = ()=>decorate(), _dec3 = ()=>_dec1(), _dec4 = ()=>_dec2();
 class Foo {
     static{
-        ({ e: [_initProto] , c: [_Foo, _initClass]  } = _apply_decs_2203_r(this, [
+        ({ e: [_initProto], c: [_Foo, _initClass] } = _apply_decs_2203_r(this, [
             [
-                _dec1,
+                _dec3(),
                 3,
                 "name"
             ],
             [
-                _dec2,
+                _dec4(),
                 2,
                 "sayHi"
             ]
         ], [
-            _dec
+            _dec()
         ]));
     }
     constructor(){
@@ -32,7 +32,7 @@ class Foo {
     }
 }
 function decorate() {
-    return function(target, { kind  }) {
+    return function(target, { kind }) {
         console.log(target, kind);
     };
 }


### PR DESCRIPTION
**Description:**

This PR wraps transpiled decorators with arrow functions to prevent https://github.com/swc-project/swc/issues/8021. This allows lazy execution of the decorator until it is executed in the initial static block, which exists _within_ the class declaration.

**Related issue:**

 - #8021.