### PR TITLE
fix(es/minifier): Check if object shorthand is skippable for seq inliner

### DIFF
--- a/crates/swc_ecma_minifier/tests/fixture/issues/7984/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/7984/input.js
@@ -1,0 +1,17 @@
+getInitialProps = (code) => {
+    let statusCode, message;
+
+    if (code) {
+        statusCode = code;
+    }
+
+    switch (statusCode) {
+        case 404:
+            message = "404";
+            break;
+        default:
+            message = "500";
+    }
+
+    return { statusCode, message };
+};

--- a/crates/swc_ecma_minifier/tests/fixture/issues/7984/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/7984/output.js
@@ -1,0 +1,7 @@
+getInitialProps = (code)=>{
+    let statusCode, message;
+    return code && (statusCode = code), message = 404 === statusCode ? "404" : "500", {
+        statusCode,
+        message
+    };
+};


### PR DESCRIPTION
**Related issue:**

 - Closes #7984 