### PR TITLE
fix(es/compat): Use `async` and `await` correctly in `block-scoping` pass

### DIFF
--- a/crates/swc/tests/fixture/issues-7xxx/7989/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-7xxx/7989/input/.swcrc
@@ -1,0 +1,24 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": false
+        },
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false,
+            "format": {
+                "comments": "all"
+            }
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": false,
+    "isModule": true,
+    "env": {
+        "targets": "supports async-functions"
+    }
+}

--- a/crates/swc/tests/fixture/issues-7xxx/7989/input/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7989/input/1.js
@@ -1,0 +1,6 @@
+async function foo(a, b) {
+    for (let i = 0; i < 5; i++) {
+        const boo = await a();
+        b(() => boo)
+    }
+}

--- a/crates/swc/tests/fixture/issues-7xxx/7989/output/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7989/output/1.js
@@ -1,0 +1,7 @@
+async function foo(a, b) {
+    var _loop = async function(i) {
+        var boo = await a();
+        b(()=>boo);
+    };
+    for(var i = 0; i < 5; i++)await _loop(i);
+}

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping/mod.rs
@@ -244,6 +244,14 @@ impl BlockScoping {
             }
             .into();
 
+            if flow_helper.has_await {
+                call = AwaitExpr {
+                    span: DUMMY_SP,
+                    arg: call.into(),
+                }
+                .into();
+            }
+
             if flow_helper.has_yield {
                 call = YieldExpr {
                     span: DUMMY_SP,

--- a/crates/swc_ecma_transforms_compat/src/es2015/block_scoping/mod.rs
+++ b/crates/swc_ecma_transforms_compat/src/es2015/block_scoping/mod.rs
@@ -161,6 +161,7 @@ impl BlockScoping {
                 has_break: false,
                 has_return: false,
                 has_yield: false,
+                has_await: false,
                 label: IndexMap::new(),
                 inner_label: AHashSet::default(),
                 mutated,
@@ -222,7 +223,7 @@ impl BlockScoping {
                         decorators: Default::default(),
                         body: Some(body_stmt),
                         is_generator: flow_helper.has_yield,
-                        is_async: false,
+                        is_async: flow_helper.has_await,
                         type_params: None,
                         return_type: None,
                     }
@@ -616,6 +617,7 @@ struct FlowHelper<'a> {
     has_break: bool,
     has_return: bool,
     has_yield: bool,
+    has_await: bool,
 
     // label cannot be shadowed, so it's pretty safe to use JsWord
     label: IndexMap<JsWord, Label>,
@@ -657,18 +659,6 @@ impl VisitMut for FlowHelper<'_> {
     /// noop
     fn visit_mut_arrow_expr(&mut self, _n: &mut ArrowExpr) {}
 
-    fn visit_mut_yield_expr(&mut self, e: &mut YieldExpr) {
-        e.visit_mut_children_with(self);
-
-        self.has_yield = true;
-    }
-
-    fn visit_mut_labeled_stmt(&mut self, l: &mut LabeledStmt) {
-        self.inner_label.insert(l.label.sym.clone());
-
-        l.visit_mut_children_with(self);
-    }
-
     fn visit_mut_assign_expr(&mut self, n: &mut AssignExpr) {
         match &n.left {
             PatOrExpr::Expr(e) => {
@@ -686,6 +676,12 @@ impl VisitMut for FlowHelper<'_> {
         }
 
         n.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_await_expr(&mut self, e: &mut AwaitExpr) {
+        e.visit_mut_children_with(self);
+
+        self.has_await = true;
     }
 
     /// https://github.com/swc-project/swc/pull/2916
@@ -722,6 +718,12 @@ impl VisitMut for FlowHelper<'_> {
 
     /// noop
     fn visit_mut_function(&mut self, _f: &mut Function) {}
+
+    fn visit_mut_labeled_stmt(&mut self, l: &mut LabeledStmt) {
+        self.inner_label.insert(l.label.sym.clone());
+
+        l.visit_mut_children_with(self);
+    }
 
     fn visit_mut_stmt(&mut self, node: &mut Stmt) {
         let span = node.span();
@@ -821,6 +823,12 @@ impl VisitMut for FlowHelper<'_> {
         self.in_nested_loop = true;
         s.visit_mut_children_with(self);
         self.in_nested_loop = old;
+    }
+
+    fn visit_mut_yield_expr(&mut self, e: &mut YieldExpr) {
+        e.visit_mut_children_with(self);
+
+        self.has_yield = true;
     }
 }
 

--- a/crates/swc_ecma_transforms_compat/tests/block-scoping/issue-7989/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/block-scoping/issue-7989/input.js
@@ -1,0 +1,6 @@
+async function foo(a, b) {
+    for (let i = 0; i < 5; i++) {
+        const boo = await a();
+        b(() => boo)
+    }
+}

--- a/crates/swc_ecma_transforms_compat/tests/block-scoping/issue-7989/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/block-scoping/issue-7989/output.js
@@ -1,0 +1,7 @@
+async function foo__2(a__3, b__3) {
+    var _loop__6 = async function(i__4) {
+        var boo__5 = await a__3();
+        b__3(()=>boo__5);
+    };
+    for(var i__4 = 0; i__4 < 5; i__4++)await _loop__6(i__4);
+}


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #7989