### PR TITLE
fix(es/compat): Handle `__proto__` edge case in `shorthand` pass

### DIFF
--- a/crates/swc_ecma_transforms_compat/tests/es2015_shorthand_propertie.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_shorthand_propertie.rs
@@ -1,0 +1,22 @@
+use std::path::PathBuf;
+
+use swc_common::{chain, Mark};
+use swc_ecma_transforms_base::resolver;
+use swc_ecma_transforms_compat::es2015::shorthand;
+use swc_ecma_transforms_testing::test_fixture;
+
+#[testing::fixture("tests/shorthand_properties/**/input.js")]
+fn fixture(input: PathBuf) {
+    let output = input.with_file_name("output.js");
+
+    test_fixture(
+        Default::default(),
+        &|_| {
+            let unresolved_mark = Mark::new();
+            chain!(resolver(unresolved_mark, Mark::new(), false), shorthand())
+        },
+        &input,
+        &output,
+        Default::default(),
+    );
+}

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/.method-type-annotations/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/.method-type-annotations/input.js
@@ -1,0 +1,6 @@
+// @flow
+var obj = {
+  method(a: string): number {
+    return 5 + 5;
+  }
+};

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/.method-type-annotations/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/.method-type-annotations/output.js
@@ -1,0 +1,6 @@
+// @flow
+var obj = {
+  method: function (a: string): number {
+    return 5 + 5;
+  }
+};

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/method-plain/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/method-plain/input.js
@@ -1,0 +1,5 @@
+var obj = {
+  method() {
+    return 5 + 5;
+  }
+};

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/method-plain/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/method-plain/output.js
@@ -1,0 +1,5 @@
+var obj = {
+  method: function () {
+    return 5 + 5;
+  }
+};

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/proto/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/proto/input.js
@@ -1,0 +1,7 @@
+var shorthand = {
+  __proto__,
+}
+
+var method = {
+  __proto__() {}
+}

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/proto/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/proto/output.js
@@ -1,0 +1,6 @@
+var shorthand = {
+  ["__proto__"]: __proto__
+};
+var method = {
+  ["__proto__"]: function () {}
+};

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-comments/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-comments/input.js
@@ -1,0 +1,4 @@
+var A = "a";
+var o = {
+  A // comment
+};

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-comments/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-comments/output.js
@@ -1,0 +1,4 @@
+var A = "a";
+var o = {
+  A: A // comment
+};

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-mixed/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-mixed/input.js
@@ -1,0 +1,1 @@
+var coords = { x, y, foo: "bar" };

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-mixed/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-mixed/output.js
@@ -1,0 +1,5 @@
+var coords = {
+  x: x,
+  y: y,
+  foo: "bar"
+};

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-multiple/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-multiple/input.js
@@ -1,0 +1,1 @@
+var coords = { x, y };

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-multiple/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-multiple/output.js
@@ -1,0 +1,4 @@
+var coords = {
+  x: x,
+  y: y
+};

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-single/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-single/input.js
@@ -1,0 +1,1 @@
+var coords = { x };

--- a/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-single/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/shorthand_properties/shorthand-single/output.js
@@ -1,0 +1,3 @@
+var coords = {
+  x: x
+};


### PR DESCRIPTION
**Related issue:**

 - https://github.com/babel/babel/pull/12664