### PR TITLE
fix(es/compat): Handle export default decorator only if not empty

### DIFF
--- a/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
@@ -1449,7 +1449,7 @@ impl VisitMut for Decorator202203 {
             ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(ExportDefaultDecl {
                 span: _,
                 decl: DefaultDecl::Class(c),
-            })) => {
+            })) if !c.class.decorators.is_empty() => {
                 self.handle_class_expr(&mut c.class, c.ident.as_ref());
                 s.visit_mut_children_with(self);
             }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8098/1/input.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8098/1/input.js
@@ -1,0 +1,1 @@
+export default class T {}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8098/1/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8098/1/output.js
@@ -1,0 +1,2 @@
+export default class T {
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8098/options.json
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8098/options.json
@@ -1,0 +1,3 @@
+{
+    "plugins": [["proposal-decorators", { "version": "2022-03" }]]
+}


### PR DESCRIPTION
**Related issue:**

 - Closes: #8098 