### PR TITLE
fix(codegen): remove non_exhaustive on Config

### DIFF
--- a/crates/swc_ecma_codegen/src/config.rs
+++ b/crates/swc_ecma_codegen/src/config.rs
@@ -5,7 +5,6 @@ use swc_ecma_ast::EsVersion;
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde-impl", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "serde-impl", serde(rename_all = "camelCase"))]
-#[non_exhaustive]
 pub struct Config {
     /// The target runtime environment.
     ///


### PR DESCRIPTION
It is incredibly useful to create `Config` using a struct expression in order to be notified about any config changes and to set the config exactly how the consumer would like.

```rs
let config = crate::swc::codegen::Config {
    minify: false,
    ascii_only: false,
    omit_last_semi: false,
    target: ES_VERSION,
    // with a struct expression, I get a compiler error when upgrading swc and
    // can decide how I want this functionality to behave. Additionally, I'm forced
    // to explicitly document the config behaviour I want.
    emit_assert_for_import_attributes: ,
}
```