### PR TITLE
fix(es/utils): Skip var declarator name in `RefRewriter`

### DIFF
--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-8124/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-8124/input.ts
@@ -1,0 +1,9 @@
+namespace Foo {
+    export var a = 1;
+    for (var a; a < 5; a++) {}
+}
+
+namespace Bar {
+    export var b = 2;
+    var b = 3;
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-8124/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-8124/output.js
@@ -1,0 +1,10 @@
+var Foo;
+(function(Foo) {
+    Foo.a = 1;
+    for(var a; Foo.a < 5; Foo.a++){}
+})(Foo || (Foo = {}));
+var Bar;
+(function(Bar) {
+    Bar.b = 2;
+    var b = 3;
+})(Bar || (Bar = {}));

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -3062,6 +3062,11 @@ where
         }
     }
 
+    fn visit_mut_var_declarator(&mut self, n: &mut VarDeclarator) {
+        // skip var declarator name
+        n.init.visit_mut_with(self);
+    }
+
     fn visit_mut_pat(&mut self, n: &mut Pat) {
         match n {
             Pat::Ident(BindingIdent { id, .. }) => {


### PR DESCRIPTION
**Related issue:**
 - Closes #8124 