### PR TITLE
fix(css/ast): Make `.hash()` of `Token` not recursive

### DIFF
--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -264,9 +264,7 @@ impl Hash for Token {
             | Token::LParen
             | Token::RParen
             | Token::LBrace
-            | Token::RBrace => {
-                self.hash(state);
-            }
+            | Token::RBrace => {}
         }
     }
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

when hash a stylesheet ast, it will trigger stack overflow.
the root cause is that ,  `Token`'s `hash` function recursively call itself.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
No
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

https://github.com/swc-project/swc/discussions/8142
