### PR TITLE
fix(es/parser): Skip `this` parameters in setter

### DIFF
--- a/crates/swc/tests/fixture/issues-8xxx/8156/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-8xxx/8156/input/.swcrc
@@ -1,0 +1,19 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": false
+        },
+        "target": "es2015",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "commonjs"
+    },
+    "minify": false,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-8xxx/8156/input/1.ts
+++ b/crates/swc/tests/fixture/issues-8xxx/8156/input/1.ts
@@ -1,0 +1,5 @@
+const s = {
+    set m(this: {}, value1: {}) {
+        console.log(value1)
+    }
+};

--- a/crates/swc/tests/fixture/issues-8xxx/8156/output/1.ts
+++ b/crates/swc/tests/fixture/issues-8xxx/8156/output/1.ts
@@ -1,0 +1,6 @@
+"use strict";
+const s = {
+    set m (value1){
+        console.log(value1);
+    }
+};


### PR DESCRIPTION
**Description:**

This is not a proper fix, but let's wait for the conf.

**Related issue:**

 - Closes #8156