### PR TITLE
fix(es/minifier): Always consider `reassigned` when inlining

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -175,7 +175,7 @@ impl Optimizer<'_> {
             if is_inline_enabled
                 && usage.declared_count == 1
                 && usage.assign_count == 1
-                && (!usage.has_property_mutation || !usage.reassigned)
+                && !usage.reassigned
                 && match init {
                     Expr::Ident(Ident { sym, .. }) if &**sym == "eval" => false,
 

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8161/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8161/input.js
@@ -1,0 +1,10 @@
+function run(flag, output = "a output") {
+    if (flag === "b") {
+        output = "b output";
+    }
+
+    console.log(output);
+}
+
+run("a");
+run("b");

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8161/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8161/output.js
@@ -1,0 +1,4 @@
+function run(flag, output = "a output") {
+    "b" === flag && (output = "b output"), console.log(output);
+}
+run("a"), run("b");


### PR DESCRIPTION
**Related issue:**

 - Closes #8161.