### PR TITLE
fix(es/compat): Use dummy span for blocks in `parameters`

### DIFF
--- a/crates/swc/tests/fixture/issues-8xxx/8199/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-8xxx/8199/input/.swcrc
@@ -1,0 +1,26 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "externalHelpers": true,
+        "transform": {
+            "react": {
+                "runtime": "automatic"
+            }
+        },
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "minify": false,
+    "module": {
+        "type": "es6"
+    },
+    "env": {
+        "targets": "safari>15"
+    }
+}

--- a/crates/swc/tests/fixture/issues-8xxx/8199/input/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8199/input/1.js
@@ -1,0 +1,2 @@
+export const IconSpecHotkey = ({ icon }) =>
+    <div>{icon}</div>

--- a/crates/swc/tests/fixture/issues-8xxx/8199/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8199/output/1.js
@@ -1,0 +1,7 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+export const IconSpecHotkey = (param)=>{
+    let { icon } = param;
+    return /*#__PURE__*/ _jsx("div", {
+        children: icon
+    });
+};

--- a/crates/swc_ecma_compat_es2015/src/parameters.rs
+++ b/crates/swc_ecma_compat_es2015/src/parameters.rs
@@ -582,7 +582,6 @@ impl VisitMut for Params {
                     }
                 }
 
-                let body_span = f.body.span();
                 let mut params = f
                     .params
                     .take()

--- a/crates/swc_ecma_compat_es2015/src/parameters.rs
+++ b/crates/swc_ecma_compat_es2015/src/parameters.rs
@@ -353,7 +353,7 @@ impl Params {
                             arg: Box::new(idx_ident.clone().into()),
                         }))),
                         body: Box::new(Stmt::Block(BlockStmt {
-                            span,
+                            span: DUMMY_SP,
                             stmts: vec![{
                                 let prop = Box::new(Expr::Ident(idx_ident.clone()));
                                 // a1[_key - i] = arguments[_key];
@@ -597,7 +597,7 @@ impl VisitMut for Params {
                 let mut body = match *f.body.take() {
                     BlockStmtOrExpr::BlockStmt(block) => block,
                     BlockStmtOrExpr::Expr(expr) => BlockStmt {
-                        span: body_span,
+                        span: DUMMY_SP,
                         stmts: vec![Stmt::Return(ReturnStmt {
                             span: DUMMY_SP,
                             arg: Some(expr),


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #8199