### PR TITLE
fix(es/transforms): Do not add `PURE` comment to `BytePos(0)`

### DIFF
--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -436,11 +436,15 @@ where
     }
 
     fn jsx_frag_to_expr(&mut self, el: JSXFragment) -> Expr {
-        let span = el.span();
+        let mut span = el.span();
 
         let use_jsxs = count_children(&el.children) > 1;
 
         if let Some(comments) = &self.comments {
+            if span.lo.is_dummy() {
+                span.lo = Span::dummy_with_cmt().lo;
+            }
+
             comments.add_pure_comment(span.lo);
         }
 
@@ -543,13 +547,17 @@ where
     /// <div></div> => React.createElement('div', null);
     fn jsx_elem_to_expr(&mut self, el: JSXElement) -> Expr {
         let top_level_node = self.top_level_node;
-        let span = el.span();
+        let mut span = el.span();
         let use_create_element = should_use_create_element(&el.opening.attrs);
         self.top_level_node = false;
 
         let name = self.jsx_name(el.opening.name);
 
         if let Some(comments) = &self.comments {
+            if span.lo.is_dummy() {
+                span.lo = Span::dummy_with_cmt().lo;
+            }
+
             comments.add_pure_comment(span.lo);
         }
 

--- a/crates/swc_ecma_transforms_react/src/pure_annotations/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/pure_annotations/mod.rs
@@ -1,5 +1,5 @@
 use swc_atoms::JsWord;
-use swc_common::{collections::AHashMap, comments::Comments};
+use swc_common::{collections::AHashMap, comments::Comments, Span};
 use swc_ecma_ast::*;
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
@@ -108,6 +108,10 @@ where
 
         if is_react_call {
             if let Some(comments) = &self.comments {
+                if call.span.lo.is_dummy() {
+                    call.span.lo = Span::dummy_with_cmt().lo;
+                }
+
                 comments.add_pure_comment(call.span.lo);
             }
         }


### PR DESCRIPTION
**Description:**


**Related issue:**

 - https://github.com/vercel/next.js/pull/57904 (CI failed)