### PR TITLE
perf(es/parser): Use smarter lookup table for lexer

### DIFF
--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -151,6 +151,12 @@ impl From<Ident> for Id {
     }
 }
 
+#[repr(C, align(64))]
+struct Align64<T>(pub(crate) T);
+
+const T: bool = true;
+const F: bool = false;
+
 impl Ident {
     /// In `op`, [EqIgnoreSpan] of [Ident] will ignore the syntax context.
     pub fn within_ignored_ctxt<F, Ret>(op: F) -> Ret
@@ -175,26 +181,40 @@ impl Ident {
     /// Returns true if `c` is a valid character for an identifier start.
     #[inline]
     pub fn is_valid_start(c: char) -> bool {
-        c == '$' || c == '_' || c.is_ascii_alphabetic() || {
-            if c.is_ascii() {
-                false
-            } else {
-                UnicodeID::is_id_start(c)
-            }
+        // This contains `$` (36) and `_` (95)
+        const ASCII_START: Align64<[bool; 128]> = Align64([
+            F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+            F, F, F, F, F, F, F, T, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+            F, F, F, F, F, F, F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,
+            T, T, T, T, F, F, F, F, T, F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,
+            T, T, T, T, T, T, T, F, F, F, F, F,
+        ]);
+
+        if c.is_ascii() {
+            return ASCII_START.0[c as usize];
         }
+
+        UnicodeID::is_id_start(c)
     }
 
     /// Returns true if `c` is a valid character for an identifier part after
     /// start.
     #[inline]
     pub fn is_valid_continue(c: char) -> bool {
-        c == '$' || c == '_' || c == '\u{200c}' || c == '\u{200d}' || c.is_ascii_alphanumeric() || {
-            if c.is_ascii() {
-                false
-            } else {
-                UnicodeID::is_id_continue(c)
-            }
+        // This contains `$` (36)
+        const ASCII_CONTINUE: Align64<[bool; 128]> = Align64([
+            F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
+            F, F, F, F, F, F, F, T, F, F, F, F, F, F, F, F, F, F, F, T, T, T, T, T, T, T, T, T, T,
+            F, F, F, F, F, F, F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,
+            T, T, T, T, F, F, F, F, T, F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,
+            T, T, T, T, T, T, T, F, F, F, F, F,
+        ]);
+
+        if c.is_ascii() {
+            return ASCII_CONTINUE.0[c as usize];
         }
+
+        UnicodeID::is_id_continue(c) || c == '\u{200c}' || c == '\u{200d}'
     }
 
     /// Alternative for `toIdentifier` of babel.

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -822,7 +822,7 @@ impl<'a> Lexer<'a> {
                 {
                     let s = l.input.uncons_while(|c| {
                         // Performance optimization
-                        if c.is_ascii_uppercase() {
+                        if c.is_ascii_uppercase() || !c.is_ascii() {
                             can_be_keyword = false;
                         }
 

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -761,10 +761,20 @@ impl<'a> Lexer<'a> {
 
     /// This can be used if there's no keyword starting with the first
     /// character.
-    fn read_ident(&mut self) -> LexResult<Token> {
+    fn read_ident_unknown(&mut self) -> LexResult<Token> {
         debug_assert!(self.cur().is_some());
 
         let (word, _) = self.read_word_as_str_with(|s| Word::Ident(IdentLike::Other(s.into())))?;
+
+        Ok(Word(word))
+    }
+
+    /// This can be used if there's no keyword starting with the first
+    /// character.
+    fn read_ident_maybe_known(&mut self) -> LexResult<Token> {
+        debug_assert!(self.cur().is_some());
+
+        let (word, _) = self.read_word_as_str_with(|s| Word::Ident(IdentLike::from(s)))?;
 
         Ok(Word(word))
     }

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -822,7 +822,7 @@ impl<'a> Lexer<'a> {
                 {
                     let s = l.input.uncons_while(|c| {
                         // Performance optimization
-                        if c.is_ascii_uppercase() || !c.is_ascii() {
+                        if c.is_ascii_uppercase() || c.is_ascii_digit() || !c.is_ascii() {
                             can_be_keyword = false;
                         }
 

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -763,23 +763,10 @@ impl<'a> Lexer<'a> {
     /// character.
     fn read_ident(&mut self) -> LexResult<Token> {
         debug_assert!(self.cur().is_some());
-        let start = self.cur_pos();
 
-        let (word, has_escape) =
-            self.read_word_as_str_with(|s| Word::Ident(IdentLike::Other(s.into())))?;
+        let (word, _) = self.read_word_as_str_with(|s| Word::Ident(IdentLike::Other(s.into())))?;
 
-        // Note: ctx is store in lexer because of this error.
-        // 'await' and 'yield' may have semantic of reserved word, which means lexer
-        // should know context or parser should handle this error. Our approach to this
-        // problem is former one.
-        if has_escape && self.ctx.is_reserved(&word) {
-            self.error(
-                start,
-                SyntaxError::EscapeInReservedWord { word: word.into() },
-            )?
-        } else {
-            Ok(Word(word))
-        }
+        Ok(Word(word))
     }
 
     /// See https://tc39.github.io/ecma262/#sec-names-and-keywords

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -26,7 +26,7 @@ pub(super) static BYTE_HANDLERS: [ByteHandler; 256] = [
     AT_, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, // 4
     I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, BTO, I_U, BTC, CRT, I_U, // 5
     TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_M, I_U, I_K, I_U, I_M, I_K, I_U, I_K, I_K, // 6
-    I_U, I_U, I_K, I_K, I_K, I_K, I_K, I_K, I_U, I_K, I_U, BEO, PIP, BEC, TLD, ERR, // 7
+    I_M, I_U, I_K, I_K, I_K, I_K, I_K, I_K, I_U, I_K, I_U, BEO, PIP, BEC, TLD, ERR, // 7
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 8
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 9
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // A

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -11,7 +11,7 @@ use swc_ecma_ast::AssignOp;
 use super::{pos_span, util::CharExt, LexResult, Lexer};
 use crate::{
     error::SyntaxError,
-    token::{BinOpToken, Keyword, Token, Word},
+    token::{BinOpToken, IdentLike, Keyword, KnownIdent, Token, Word},
 };
 
 pub(super) type ByteHandler = Option<for<'aa> fn(&mut Lexer<'aa>) -> LexResult<Option<Token>>>;
@@ -69,6 +69,165 @@ const L_A: ByteHandler = Some(|lexer| {
     })
 });
 
+const L_B: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "break" => Some(Word::Keyword(Keyword::Break)),
+        _ => None,
+    })
+});
+
+const L_C: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "case" => Some(Word::Keyword(Keyword::Case)),
+        "catch" => Some(Word::Keyword(Keyword::Catch)),
+        "class" => Some(Word::Keyword(Keyword::Class)),
+        "const" => Some(Word::Keyword(Keyword::Const)),
+        "continue" => Some(Word::Keyword(Keyword::Continue)),
+        _ => None,
+    })
+});
+
+const L_D: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "debugger" => Some(Word::Keyword(Keyword::Debugger)),
+        "default" => Some(Word::Keyword(Keyword::Default_)),
+        "delete" => Some(Word::Keyword(Keyword::Delete)),
+        "do" => Some(Word::Keyword(Keyword::Do)),
+        _ => None,
+    })
+});
+
+const L_E: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "else" => Some(Word::Keyword(Keyword::Else)),
+        "enum" => Some(Word::Ident(IdentLike::Known(KnownIdent::Enum))),
+        "export" => Some(Word::Keyword(Keyword::Export)),
+        "extends" => Some(Word::Keyword(Keyword::Extends)),
+        _ => None,
+    })
+});
+
+const L_F: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "false" => Some(Word::False),
+        "finally" => Some(Word::Keyword(Keyword::Finally)),
+        "for" => Some(Word::Keyword(Keyword::For)),
+        "function" => Some(Word::Keyword(Keyword::Function)),
+        _ => None,
+    })
+});
+
+const L_G: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "global" => Some(Word::Ident(IdentLike::Known(KnownIdent::Global))),
+        _ => None,
+    })
+});
+
+const L_H: ByteHandler = IDN;
+
+const L_I: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "if" => Some(Word::Keyword(Keyword::If)),
+        "import" => Some(Word::Keyword(Keyword::Import)),
+        "in" => Some(Word::Keyword(Keyword::In)),
+        "instanceof" => Some(Word::Keyword(Keyword::InstanceOf)),
+        _ => None,
+    })
+});
+
+const L_J: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "let" => Some(Word::Keyword(Keyword::Let)),
+        _ => None,
+    })
+});
+
+const L_K: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "keyof" => Some(Word::Ident(IdentLike::Known(KnownIdent::Keyof))),
+        _ => None,
+    })
+});
+
+const L_L: ByteHandler = IDN;
+
+const L_M: ByteHandler = IDN;
+
+const L_N: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "new" => Some(Word::Keyword(Keyword::New)),
+        "null" => Some(Word::Null),
+        _ => None,
+    })
+});
+
+const L_O: ByteHandler = IDN;
+
+const L_P: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "public" => Some(Word::Ident(IdentLike::Known(KnownIdent::Public))),
+        _ => None,
+    })
+});
+
+const L_Q: ByteHandler = IDN;
+
+const L_R: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "return" => Some(Word::Keyword(Keyword::Return)),
+        _ => None,
+    })
+});
+
+const L_S: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "super" => Some(Word::Keyword(Keyword::Super)),
+        "switch" => Some(Word::Keyword(Keyword::Switch)),
+        _ => None,
+    })
+});
+
+const L_T: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "this" => Some(Word::Keyword(Keyword::This)),
+        "throw" => Some(Word::Keyword(Keyword::Throw)),
+        "true" => Some(Word::True),
+        "try" => Some(Word::Keyword(Keyword::Try)),
+        "type" => Some(Word::Ident(IdentLike::Known(KnownIdent::Type))),
+        _ => None,
+    })
+});
+
+const L_U: ByteHandler = IDN;
+
+const L_V: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "var" => Some(Word::Keyword(Keyword::Var)),
+        "void" => Some(Word::Keyword(Keyword::Void)),
+        _ => None,
+    })
+});
+
+const L_W: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "while" => Some(Word::Keyword(Keyword::While)),
+        "with" => Some(Word::Keyword(Keyword::With)),
+        _ => None,
+    })
+});
+
+const L_X: ByteHandler = IDN;
+
+const L_Y: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "yield" => Some(Word::Keyword(Keyword::Yield)),
+        _ => None,
+    })
+});
+
+const L_Z: ByteHandler = IDN;
+
 /// `0`
 const ZER: ByteHandler = Some(|lexer| lexer.read_token_zero().map(Some));
 
@@ -96,7 +255,7 @@ const UNI: ByteHandler = Some(|lexer| {
     // Identifier or keyword. '\uXXXX' sequences are allowed in
     // identifiers, so '\' also dispatches to that.
     if c == '\\' || c.is_ident_start() {
-        return lexer.read_ident_or_keyword().map(Some);
+        return lexer.read_ident_unknown().map(Some);
     }
 
     let start = lexer.cur_pos();

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -21,12 +21,12 @@ pub(super) static BYTE_HANDLERS: [ByteHandler; 256] = [
     //   0    1    2    3    4    5    6    7    8    9    A    B    C    D    E    F   //
     EOF, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, // 0
     ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, // 1
-    ___, EXL, QOT, HSH, I_N, PRC, AMP, QOT, PNO, PNC, ATR, PLS, COM, MIN, PRD, SLH, // 2
+    ___, EXL, QOT, HSH, I_U, PRC, AMP, QOT, PNO, PNC, ATR, PLS, COM, MIN, PRD, SLH, // 2
     ZER, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, COL, SEM, LSS, EQL, MOR, QST, // 3
-    AT_, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, // 4
-    I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, BTO, I_N, BTC, CRT, I_N, // 5
-    TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_N, I_N, I_K, I_N, I_N, I_K, I_N, I_K, I_K, // 6
-    I_N, I_N, I_K, I_K, I_K, I_K, I_K, I_K, I_N, I_K, I_N, BEO, PIP, BEC, TLD, ERR, // 7
+    AT_, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_M, I_U, I_U, I_U, I_U, // 4
+    I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, BTO, I_U, BTC, CRT, I_U, // 5
+    TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_U, I_U, I_K, I_U, I_U, I_K, I_U, I_K, I_K, // 6
+    I_U, I_U, I_K, I_K, I_K, I_K, I_K, I_K, I_U, I_K, I_U, BEO, PIP, BEC, TLD, ERR, // 7
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 8
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 9
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // A
@@ -62,8 +62,10 @@ const ERR: ByteHandler = Some(|lexer| {
 /// Identifier
 const I_K: ByteHandler = Some(|lexer| lexer.read_ident_or_keyword().map(Some));
 
-/// Identifier, but not keyword
-const I_N: ByteHandler = Some(|lexer| lexer.read_ident().map(Some));
+/// Identifier, but unknown.
+const I_U: ByteHandler = Some(|lexer| lexer.read_ident_unknown().map(Some));
+
+const I_M: ByteHandler = Some(|lexer| lexer.read_ident_maybe_known().map(Some));
 
 /// `0`
 const ZER: ByteHandler = Some(|lexer| lexer.read_token_zero().map(Some));

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -64,9 +64,14 @@ const IDN: ByteHandler = Some(|lexer| lexer.read_ident_unknown().map(Some));
 
 const L_A: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {
+        "abstract" => Some(Word::Ident(IdentLike::Known(KnownIdent::Abstract))),
         "as" => Some(Word::Ident(IdentLike::Known(KnownIdent::As))),
         "await" => Some(Word::Keyword(Keyword::Await)),
         "async" => Some(Word::Ident(IdentLike::Known(KnownIdent::Async))),
+        "assert" => Some(Word::Ident(IdentLike::Known(KnownIdent::Assert))),
+        "asserts" => Some(Word::Ident(IdentLike::Known(KnownIdent::Asserts))),
+        "any" => Some(Word::Ident(IdentLike::Known(KnownIdent::Any))),
+        "accessor" => Some(Word::Ident(IdentLike::Known(KnownIdent::Accessor))),
         _ => None,
     })
 });
@@ -74,6 +79,8 @@ const L_A: ByteHandler = Some(|lexer| {
 const L_B: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {
         "break" => Some(Word::Keyword(Keyword::Break)),
+        "boolean" => Some(Word::Ident(IdentLike::Known(KnownIdent::Boolean))),
+        "bigint" => Some(Word::Ident(IdentLike::Known(KnownIdent::Bigint))),
         _ => None,
     })
 });
@@ -95,6 +102,7 @@ const L_D: ByteHandler = Some(|lexer| {
         "default" => Some(Word::Keyword(Keyword::Default_)),
         "delete" => Some(Word::Keyword(Keyword::Delete)),
         "do" => Some(Word::Keyword(Keyword::Do)),
+        "declare" => Some(Word::Ident(IdentLike::Known(KnownIdent::Declare))),
         _ => None,
     })
 });
@@ -123,6 +131,7 @@ const L_F: ByteHandler = Some(|lexer| {
 const L_G: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {
         "global" => Some(Word::Ident(IdentLike::Known(KnownIdent::Global))),
+        "get" => Some(Word::Ident(IdentLike::Known(KnownIdent::Get))),
         _ => None,
     })
 });
@@ -135,6 +144,11 @@ const L_I: ByteHandler = Some(|lexer| {
         "import" => Some(Word::Keyword(Keyword::Import)),
         "in" => Some(Word::Keyword(Keyword::In)),
         "instanceof" => Some(Word::Keyword(Keyword::InstanceOf)),
+        "is" => Some(Word::Ident(IdentLike::Known(KnownIdent::Is))),
+        "infer" => Some(Word::Ident(IdentLike::Known(KnownIdent::Infer))),
+        "interface" => Some(Word::Ident(IdentLike::Known(KnownIdent::Interface))),
+        "implements" => Some(Word::Ident(IdentLike::Known(KnownIdent::Implements))),
+        "intrinsic" => Some(Word::Ident(IdentLike::Known(KnownIdent::Intrinsic))),
         _ => None,
     })
 });
@@ -160,12 +174,20 @@ const L_L: ByteHandler = Some(|lexer| {
     })
 });
 
-const L_M: ByteHandler = IDN;
+const L_M: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "meta" => Some(Word::Ident(IdentLike::Known(KnownIdent::Meta))),
+        _ => None,
+    })
+});
 
 const L_N: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {
         "new" => Some(Word::Keyword(Keyword::New)),
         "null" => Some(Word::Null),
+        "number" => Some(Word::Ident(IdentLike::Known(KnownIdent::Number))),
+        "never" => Some(Word::Ident(IdentLike::Known(KnownIdent::Never))),
+        "namespacae" => Some(Word::Ident(IdentLike::Known(KnownIdent::Namespace))),
         _ => None,
     })
 });
@@ -173,6 +195,7 @@ const L_N: ByteHandler = Some(|lexer| {
 const L_O: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {
         "of" => Some(Word::Ident(IdentLike::Known(KnownIdent::Of))),
+        "object" => Some(Word::Ident(IdentLike::Known(KnownIdent::Object))),
         _ => None,
     })
 });
@@ -180,6 +203,9 @@ const L_O: ByteHandler = Some(|lexer| {
 const L_P: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {
         "public" => Some(Word::Ident(IdentLike::Known(KnownIdent::Public))),
+        "pacakge" => Some(Word::Ident(IdentLike::Known(KnownIdent::Package))),
+        "protected" => Some(Word::Ident(IdentLike::Known(KnownIdent::Protected))),
+        "private" => Some(Word::Ident(IdentLike::Known(KnownIdent::Private))),
         _ => None,
     })
 });
@@ -189,6 +215,8 @@ const L_Q: ByteHandler = IDN;
 const L_R: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {
         "return" => Some(Word::Keyword(Keyword::Return)),
+        "readonly" => Some(Word::Ident(IdentLike::Known(KnownIdent::Readonly))),
+        "require" => Some(Word::Ident(IdentLike::Known(KnownIdent::Require))),
         _ => None,
     })
 });
@@ -198,6 +226,10 @@ const L_S: ByteHandler = Some(|lexer| {
         "super" => Some(Word::Keyword(Keyword::Super)),
         "static" => Some(Word::Ident(IdentLike::Known(KnownIdent::Static))),
         "switch" => Some(Word::Keyword(Keyword::Switch)),
+        "symbol" => Some(Word::Ident(IdentLike::Known(KnownIdent::Symbol))),
+        "set" => Some(Word::Ident(IdentLike::Known(KnownIdent::Set))),
+        "string" => Some(Word::Ident(IdentLike::Known(KnownIdent::String))),
+        "satisfies" => Some(Word::Ident(IdentLike::Known(KnownIdent::Satisfies))),
         _ => None,
     })
 });
@@ -209,11 +241,20 @@ const L_T: ByteHandler = Some(|lexer| {
         "true" => Some(Word::True),
         "try" => Some(Word::Keyword(Keyword::Try)),
         "type" => Some(Word::Ident(IdentLike::Known(KnownIdent::Type))),
+        "target" => Some(Word::Ident(IdentLike::Known(KnownIdent::Target))),
         _ => None,
     })
 });
 
-const L_U: ByteHandler = IDN;
+const L_U: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "using" => Some(Word::Ident(IdentLike::Known(KnownIdent::Using))),
+        "unique" => Some(Word::Ident(IdentLike::Known(KnownIdent::Unique))),
+        "undefined" => Some(Word::Ident(IdentLike::Known(KnownIdent::Undefined))),
+        "unknown" => Some(Word::Ident(IdentLike::Known(KnownIdent::Unknown))),
+        _ => None,
+    })
+});
 
 const L_V: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -21,12 +21,12 @@ pub(super) static BYTE_HANDLERS: [ByteHandler; 256] = [
     //   0    1    2    3    4    5    6    7    8    9    A    B    C    D    E    F   //
     EOF, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, // 0
     ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, // 1
-    ___, EXL, QOT, HSH, W_U, PRC, AMP, QOT, PNO, PNC, ATR, PLS, COM, MIN, PRD, SLH, // 2
+    ___, EXL, QOT, HSH, IDN, PRC, AMP, QOT, PNO, PNC, ATR, PLS, COM, MIN, PRD, SLH, // 2
     ZER, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, COL, SEM, LSS, EQL, MOR, QST, // 3
-    AT_, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, // 4
-    W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, BTO, W_U, BTC, CRT, W_U, // 5
-    TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_M, W_U, I_K, W_U, I_M, I_K, W_U, I_K, I_K, // 6
-    I_M, W_U, I_K, I_K, I_K, I_K, I_K, I_K, W_U, I_K, W_U, BEO, PIP, BEC, TLD, ERR, // 7
+    AT_, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, // 4
+    IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, IDN, BTO, IDN, BTC, CRT, IDN, // 5
+    TPL, L_A, L_B, L_C, L_D, L_E, L_F, L_G, L_H, L_I, L_J, L_K, L_L, L_M, L_N, L_O, // 6
+    L_P, L_Q, L_R, L_S, L_T, L_U, L_V, L_W, L_X, L_Y, L_Z, BEO, PIP, BEC, TLD, ERR, // 7
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 8
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 9
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // A
@@ -59,11 +59,11 @@ const ERR: ByteHandler = Some(|lexer| {
     lexer.error_span(pos_span(start), SyntaxError::UnexpectedChar { c })?
 });
 
+/// Identifier and we know that this cannot be a keyword or known ident.
+const IDN: ByteHandler = Some(|lexer| lexer.read_ident_unknown().map(Some));
+
 /// Identifier or keyword.
 const I_K: ByteHandler = Some(|lexer| lexer.read_ident_or_keyword().map(Some));
-
-/// Identifier, but unknown.
-const W_U: ByteHandler = Some(|lexer| lexer.read_ident_unknown().map(Some));
 
 /// Identifier, not keyword but maybe known.
 const I_M: ByteHandler = Some(|lexer| lexer.read_ident_maybe_known().map(Some));

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -239,6 +239,7 @@ const L_T: ByteHandler = Some(|lexer| {
         "this" => Some(Word::Keyword(Keyword::This)),
         "throw" => Some(Word::Keyword(Keyword::Throw)),
         "true" => Some(Word::True),
+        "typeof" => Some(Word::Keyword(Keyword::TypeOf)),
         "try" => Some(Word::Keyword(Keyword::Try)),
         "type" => Some(Word::Ident(IdentLike::Known(KnownIdent::Type))),
         "target" => Some(Word::Ident(IdentLike::Known(KnownIdent::Target))),

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -25,7 +25,7 @@ pub(super) static BYTE_HANDLERS: [ByteHandler; 256] = [
     ZER, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, COL, SEM, LSS, EQL, MOR, QST, // 3
     AT_, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, // 4
     I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, BTO, I_U, BTC, CRT, I_U, // 5
-    TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_U, I_U, I_K, I_U, I_M, I_K, I_U, I_K, I_K, // 6
+    TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_M, I_U, I_K, I_U, I_M, I_K, I_U, I_K, I_K, // 6
     I_U, I_U, I_K, I_K, I_K, I_K, I_K, I_K, I_U, I_K, I_U, BEO, PIP, BEC, TLD, ERR, // 7
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 8
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 9

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -187,7 +187,7 @@ const L_N: ByteHandler = Some(|lexer| {
         "null" => Some(Word::Null),
         "number" => Some(Word::Ident(IdentLike::Known(KnownIdent::Number))),
         "never" => Some(Word::Ident(IdentLike::Known(KnownIdent::Never))),
-        "namespacae" => Some(Word::Ident(IdentLike::Known(KnownIdent::Namespace))),
+        "namespace" => Some(Word::Ident(IdentLike::Known(KnownIdent::Namespace))),
         _ => None,
     })
 });

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -11,7 +11,7 @@ use swc_ecma_ast::AssignOp;
 use super::{pos_span, util::CharExt, LexResult, Lexer};
 use crate::{
     error::SyntaxError,
-    token::{BinOpToken, Token},
+    token::{BinOpToken, Keyword, Token, Word},
 };
 
 pub(super) type ByteHandler = Option<for<'aa> fn(&mut Lexer<'aa>) -> LexResult<Option<Token>>>;
@@ -62,11 +62,12 @@ const ERR: ByteHandler = Some(|lexer| {
 /// Identifier and we know that this cannot be a keyword or known ident.
 const IDN: ByteHandler = Some(|lexer| lexer.read_ident_unknown().map(Some));
 
-/// Identifier or keyword.
-const I_K: ByteHandler = Some(|lexer| lexer.read_ident_or_keyword().map(Some));
-
-/// Identifier, not keyword but maybe known.
-const I_M: ByteHandler = Some(|lexer| lexer.read_ident_maybe_known().map(Some));
+const L_A: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "await" => Some(Word::Keyword(Keyword::Await)),
+        _ => None,
+    })
+});
 
 /// `0`
 const ZER: ByteHandler = Some(|lexer| lexer.read_token_zero().map(Some));

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -59,12 +59,13 @@ const ERR: ByteHandler = Some(|lexer| {
     lexer.error_span(pos_span(start), SyntaxError::UnexpectedChar { c })?
 });
 
-/// Identifier
+/// Identifier or keyword.
 const I_K: ByteHandler = Some(|lexer| lexer.read_ident_or_keyword().map(Some));
 
 /// Identifier, but unknown.
 const I_U: ByteHandler = Some(|lexer| lexer.read_ident_unknown().map(Some));
 
+/// Identifier, not keyword but maybe known.
 const I_M: ByteHandler = Some(|lexer| lexer.read_ident_maybe_known().map(Some));
 
 /// `0`

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -196,6 +196,7 @@ const L_R: ByteHandler = Some(|lexer| {
 const L_S: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {
         "super" => Some(Word::Keyword(Keyword::Super)),
+        "static" => Some(Word::Ident(IdentLike::Known(KnownIdent::Static))),
         "switch" => Some(Word::Keyword(Keyword::Switch)),
         _ => None,
     })

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -21,12 +21,12 @@ pub(super) static BYTE_HANDLERS: [ByteHandler; 256] = [
     //   0    1    2    3    4    5    6    7    8    9    A    B    C    D    E    F   //
     EOF, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, // 0
     ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, // 1
-    ___, EXL, QOT, HSH, IDT, PRC, AMP, QOT, PNO, PNC, ATR, PLS, COM, MIN, PRD, SLH, // 2
+    ___, EXL, QOT, HSH, I_N, PRC, AMP, QOT, PNO, PNC, ATR, PLS, COM, MIN, PRD, SLH, // 2
     ZER, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, COL, SEM, LSS, EQL, MOR, QST, // 3
-    AT_, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, // 4
-    IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, BTO, IDT, BTC, CRT, IDT, // 5
-    TPL, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, // 6
-    IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, IDT, BEO, PIP, BEC, TLD, ERR, // 7
+    AT_, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, // 4
+    I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, I_N, BTO, I_N, BTC, CRT, I_N, // 5
+    TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_N, I_N, I_K, I_N, I_N, I_K, I_N, I_K, I_K, // 6
+    I_N, I_N, I_K, I_K, I_K, I_K, I_K, I_K, I_N, I_K, I_N, BEO, PIP, BEC, TLD, ERR, // 7
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 8
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 9
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // A
@@ -60,7 +60,10 @@ const ERR: ByteHandler = Some(|lexer| {
 });
 
 /// Identifier
-const IDT: ByteHandler = Some(|lexer| lexer.read_ident_or_keyword().map(Some));
+const I_K: ByteHandler = Some(|lexer| lexer.read_ident_or_keyword().map(Some));
+
+/// Identifier, but not keyword
+const I_N: ByteHandler = Some(|lexer| lexer.read_ident().map(Some));
 
 /// `0`
 const ZER: ByteHandler = Some(|lexer| lexer.read_token_zero().map(Some));

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -21,12 +21,12 @@ pub(super) static BYTE_HANDLERS: [ByteHandler; 256] = [
     //   0    1    2    3    4    5    6    7    8    9    A    B    C    D    E    F   //
     EOF, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, // 0
     ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, // 1
-    ___, EXL, QOT, HSH, I_U, PRC, AMP, QOT, PNO, PNC, ATR, PLS, COM, MIN, PRD, SLH, // 2
+    ___, EXL, QOT, HSH, W_U, PRC, AMP, QOT, PNO, PNC, ATR, PLS, COM, MIN, PRD, SLH, // 2
     ZER, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, COL, SEM, LSS, EQL, MOR, QST, // 3
-    AT_, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, // 4
-    I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, BTO, I_U, BTC, CRT, I_U, // 5
-    TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_M, I_U, I_K, I_U, I_M, I_K, I_U, I_K, I_K, // 6
-    I_M, I_U, I_K, I_K, I_K, I_K, I_K, I_K, I_U, I_K, I_U, BEO, PIP, BEC, TLD, ERR, // 7
+    AT_, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, // 4
+    W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, W_U, BTO, W_U, BTC, CRT, W_U, // 5
+    TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_M, W_U, I_K, W_U, I_M, I_K, W_U, I_K, I_K, // 6
+    I_M, W_U, I_K, I_K, I_K, I_K, I_K, I_K, W_U, I_K, W_U, BEO, PIP, BEC, TLD, ERR, // 7
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 8
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 9
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // A
@@ -63,7 +63,7 @@ const ERR: ByteHandler = Some(|lexer| {
 const I_K: ByteHandler = Some(|lexer| lexer.read_ident_or_keyword().map(Some));
 
 /// Identifier, but unknown.
-const I_U: ByteHandler = Some(|lexer| lexer.read_ident_unknown().map(Some));
+const W_U: ByteHandler = Some(|lexer| lexer.read_ident_unknown().map(Some));
 
 /// Identifier, not keyword but maybe known.
 const I_M: ByteHandler = Some(|lexer| lexer.read_ident_maybe_known().map(Some));

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -66,6 +66,7 @@ const L_A: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {
         "as" => Some(Word::Ident(IdentLike::Known(KnownIdent::As))),
         "await" => Some(Word::Keyword(Keyword::Await)),
+        "async" => Some(Word::Ident(IdentLike::Known(KnownIdent::Async))),
         _ => None,
     })
 });
@@ -169,7 +170,12 @@ const L_N: ByteHandler = Some(|lexer| {
     })
 });
 
-const L_O: ByteHandler = IDN;
+const L_O: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "of" => Some(Word::Ident(IdentLike::Known(KnownIdent::Of))),
+        _ => None,
+    })
+});
 
 const L_P: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -64,6 +64,7 @@ const IDN: ByteHandler = Some(|lexer| lexer.read_ident_unknown().map(Some));
 
 const L_A: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {
+        "as" => Some(Word::Ident(IdentLike::Known(KnownIdent::As))),
         "await" => Some(Word::Keyword(Keyword::Await)),
         _ => None,
     })
@@ -113,6 +114,7 @@ const L_F: ByteHandler = Some(|lexer| {
         "finally" => Some(Word::Keyword(Keyword::Finally)),
         "for" => Some(Word::Keyword(Keyword::For)),
         "function" => Some(Word::Keyword(Keyword::Function)),
+        "from" => Some(Word::Ident(IdentLike::Known(KnownIdent::From))),
         _ => None,
     })
 });
@@ -150,7 +152,12 @@ const L_K: ByteHandler = Some(|lexer| {
     })
 });
 
-const L_L: ByteHandler = IDN;
+const L_L: ByteHandler = Some(|lexer| {
+    lexer.read_word_with(|s| match s {
+        "let" => Some(Word::Keyword(Keyword::Let)),
+        _ => None,
+    })
+});
 
 const L_M: ByteHandler = IDN;
 

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -23,9 +23,9 @@ pub(super) static BYTE_HANDLERS: [ByteHandler; 256] = [
     ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, ___, // 1
     ___, EXL, QOT, HSH, I_U, PRC, AMP, QOT, PNO, PNC, ATR, PLS, COM, MIN, PRD, SLH, // 2
     ZER, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, DIG, COL, SEM, LSS, EQL, MOR, QST, // 3
-    AT_, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_M, I_U, I_U, I_U, I_U, // 4
+    AT_, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, // 4
     I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, I_U, BTO, I_U, BTC, CRT, I_U, // 5
-    TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_U, I_U, I_K, I_U, I_U, I_K, I_U, I_K, I_K, // 6
+    TPL, I_K, I_K, I_K, I_K, I_K, I_K, I_U, I_U, I_K, I_U, I_M, I_K, I_U, I_K, I_K, // 6
     I_U, I_U, I_K, I_K, I_K, I_K, I_K, I_K, I_U, I_K, I_U, BEO, PIP, BEC, TLD, ERR, // 7
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 8
     UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, UNI, // 9


### PR DESCRIPTION
**Description:**

`phf` is slower than expected.


**Related issue (if exists):**
