### PR TITLE
perf(atoms): Update `hstr` to make global APIs fast

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1633,11 +1633,10 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hstr"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5700a2810cdc52f9a306f40c88031fac8d480f3d51ef38b9ca9ff5b8d4f3814"
+checksum = "94f8eaaa1bccc114f3ed94b7b66f0195cbf48151402d3efc27f7f6e362042416"
 dependencies = [
- "dashmap",
  "new_debug_unreachable",
  "once_cell",
  "phf 0.11.2",

--- a/crates/swc_atoms/Cargo.toml
+++ b/crates/swc_atoms/Cargo.toml
@@ -18,7 +18,7 @@ rkyv-impl = ["__rkyv", "rkyv", "bytecheck"]
 [dependencies]
 # bytecheck version should be in sync with rkyv version. Do not bump individually.
 bytecheck = { version = "0.6.10", optional = true }
-hstr = "0.2.3"
+hstr = "0.2.4"
 once_cell = "1"
 rkyv = { package = "rkyv", version = "=0.7.42", optional = true, features = [
   "strict",


### PR DESCRIPTION
**Description:**


**Related issue:**

 - https://github.com/dudykr/ddbase/pull/14
