### PR TITLE
fix(es/parser): Consider ASI while parsing TypeScript type aliases

### DIFF
--- a/crates/swc/tests/fixture/issues-7xxx/7561/es2019/output/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7561/es2019/output/1.js
@@ -1,6 +1,6 @@
 var _class_private_field_get = require("@swc/helpers/_/_class_private_field_get");
 var _class_private_field_init = require("@swc/helpers/_/_class_private_field_init");
-var _x = /*#__PURE__*/ new WeakMap();
+var _x = new WeakMap();
 class Foo {
     test() {
         var _this, _this_y;

--- a/crates/swc/tests/fixture/issues-7xxx/7561/es2021/output/1.js
+++ b/crates/swc/tests/fixture/issues-7xxx/7561/es2021/output/1.js
@@ -1,6 +1,6 @@
 var _class_private_field_get = require("@swc/helpers/_/_class_private_field_get");
 var _class_private_field_init = require("@swc/helpers/_/_class_private_field_init");
-var _x = /*#__PURE__*/ new WeakMap();
+var _x = new WeakMap();
 class Foo {
     test() {
         var _this, _this_y;

--- a/crates/swc/tests/fixture/issues-8xxx/8073/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-8xxx/8073/input/.swcrc
@@ -1,0 +1,19 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": false
+        },
+        "target": "es2022",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": false,
+    "isModule": "unknown"
+}

--- a/crates/swc/tests/fixture/issues-8xxx/8073/input/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8073/input/1.js
@@ -1,0 +1,8 @@
+avplay.setListener({
+    onsubtitlechange: (duration, subtitles, type, attributes) => {
+        duration // $ExpectType string
+        subtitles // $ExpectType string
+        type // $ExpectType string
+        attributes // $ExpectType AVPlaySubtitleAttribute[]
+    }
+})

--- a/crates/swc/tests/fixture/issues-8xxx/8073/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8073/output/1.js
@@ -1,0 +1,8 @@
+avplay.setListener({
+    onsubtitlechange: (duration, subtitles, type, attributes)=>{
+        duration;
+        subtitles;
+        type;
+        attributes;
+    }
+});

--- a/crates/swc/tests/fixture/issues-8xxx/8199/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8199/output/1.js
@@ -1,7 +1,7 @@
 import { jsx as _jsx } from "react/jsx-runtime";
 export const IconSpecHotkey = (param)=>{
     let { icon } = param;
-    return /*#__PURE__*/ _jsx("div", {
+    return _jsx("div", {
         children: icon
     });
 };

--- a/crates/swc/tests/fixture/issues-8xxx/8210/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8210/output/1.js
@@ -1,7 +1,7 @@
 import { jsxDEV as _jsxDEV } from "react/jsx-dev-runtime";
 const Component = ()=>{
-    return /*#__PURE__*/ _jsxDEV("p", {
-        thing: /*#__PURE__*/ _jsxDEV("a", {}, void 0, false, {
+    return _jsxDEV("p", {
+        thing: _jsxDEV("a", {}, void 0, false, {
             fileName: "$DIR/tests/fixture/issues-8xxx/8210/input/1.js",
             lineNumber: 2,
             columnNumber: 23

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2581,7 +2581,7 @@ impl<I: Tokens> Parser<I> {
             }
 
             "type" => {
-                if next || is!(self, IdentRef) {
+                if next || (!self.input.had_line_break_before_cur() && is!(self, IdentRef)) {
                     if next {
                         bump!(self);
                     }

--- a/crates/swc_ecma_parser/tests/tsc/asiPreventsParsingAsTypeAlias01.json
+++ b/crates/swc_ecma_parser/tests/tsc/asiPreventsParsingAsTypeAlias01.json
@@ -106,32 +106,59 @@
       ]
     },
     {
-      "type": "TsTypeAliasDeclaration",
+      "type": "ExpressionStatement",
       "span": {
         "start": 34,
+        "end": 38,
+        "ctxt": 0
+      },
+      "expression": {
+        "type": "Identifier",
+        "span": {
+          "start": 34,
+          "end": 38,
+          "ctxt": 0
+        },
+        "value": "type",
+        "optional": false
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 39,
         "end": 52,
         "ctxt": 0
       },
-      "declare": false,
-      "id": {
-        "type": "Identifier",
+      "expression": {
+        "type": "AssignmentExpression",
         "span": {
           "start": 39,
-          "end": 42,
-          "ctxt": 0
-        },
-        "value": "Foo",
-        "optional": false
-      },
-      "typeParams": null,
-      "typeAnnotation": {
-        "type": "TsKeywordType",
-        "span": {
-          "start": 45,
           "end": 51,
           "ctxt": 0
         },
-        "kind": "string"
+        "operator": "=",
+        "left": {
+          "type": "Identifier",
+          "span": {
+            "start": 39,
+            "end": 42,
+            "ctxt": 0
+          },
+          "value": "Foo",
+          "optional": false,
+          "typeAnnotation": null
+        },
+        "right": {
+          "type": "Identifier",
+          "span": {
+            "start": 45,
+            "end": 51,
+            "ctxt": 0
+          },
+          "value": "string",
+          "optional": false
+        }
       }
     }
   ],

--- a/crates/swc_ecma_parser/tests/tsc/asiPreventsParsingAsTypeAlias02.json
+++ b/crates/swc_ecma_parser/tests/tsc/asiPreventsParsingAsTypeAlias02.json
@@ -133,32 +133,59 @@
         },
         "body": [
           {
-            "type": "TsTypeAliasDeclaration",
+            "type": "ExpressionStatement",
             "span": {
               "start": 60,
+              "end": 64,
+              "ctxt": 0
+            },
+            "expression": {
+              "type": "Identifier",
+              "span": {
+                "start": 60,
+                "end": 64,
+                "ctxt": 0
+              },
+              "value": "type",
+              "optional": false
+            }
+          },
+          {
+            "type": "ExpressionStatement",
+            "span": {
+              "start": 69,
               "end": 82,
               "ctxt": 0
             },
-            "declare": false,
-            "id": {
-              "type": "Identifier",
+            "expression": {
+              "type": "AssignmentExpression",
               "span": {
                 "start": 69,
-                "end": 72,
-                "ctxt": 0
-              },
-              "value": "Foo",
-              "optional": false
-            },
-            "typeParams": null,
-            "typeAnnotation": {
-              "type": "TsKeywordType",
-              "span": {
-                "start": 75,
                 "end": 81,
                 "ctxt": 0
               },
-              "kind": "string"
+              "operator": "=",
+              "left": {
+                "type": "Identifier",
+                "span": {
+                  "start": 69,
+                  "end": 72,
+                  "ctxt": 0
+                },
+                "value": "Foo",
+                "optional": false,
+                "typeAnnotation": null
+              },
+              "right": {
+                "type": "Identifier",
+                "span": {
+                  "start": 75,
+                  "end": 81,
+                  "ctxt": 0
+                },
+                "value": "string",
+                "optional": false
+              }
             }
           }
         ]

--- a/crates/swc_ecma_parser/tests/typescript/issue-8073/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/issue-8073/input.ts
@@ -1,0 +1,8 @@
+avplay.setListener({
+    onsubtitlechange: (duration, subtitles, type, attributes) => {
+        duration // $ExpectType string
+        subtitles // $ExpectType string
+        type // $ExpectType string
+        attributes // $ExpectType AVPlaySubtitleAttribute[]
+    }
+})

--- a/crates/swc_ecma_parser/tests/typescript/issue-8073/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/issue-8073/input.ts.json
@@ -1,0 +1,224 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 271,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 1,
+        "end": 271,
+        "ctxt": 0
+      },
+      "expression": {
+        "type": "CallExpression",
+        "span": {
+          "start": 1,
+          "end": 271,
+          "ctxt": 0
+        },
+        "callee": {
+          "type": "MemberExpression",
+          "span": {
+            "start": 1,
+            "end": 19,
+            "ctxt": 0
+          },
+          "object": {
+            "type": "Identifier",
+            "span": {
+              "start": 1,
+              "end": 7,
+              "ctxt": 0
+            },
+            "value": "avplay",
+            "optional": false
+          },
+          "property": {
+            "type": "Identifier",
+            "span": {
+              "start": 8,
+              "end": 19,
+              "ctxt": 0
+            },
+            "value": "setListener",
+            "optional": false
+          }
+        },
+        "arguments": [
+          {
+            "spread": null,
+            "expression": {
+              "type": "ObjectExpression",
+              "span": {
+                "start": 20,
+                "end": 270,
+                "ctxt": 0
+              },
+              "properties": [
+                {
+                  "type": "KeyValueProperty",
+                  "key": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 26,
+                      "end": 42,
+                      "ctxt": 0
+                    },
+                    "value": "onsubtitlechange",
+                    "optional": false
+                  },
+                  "value": {
+                    "type": "ArrowFunctionExpression",
+                    "span": {
+                      "start": 44,
+                      "end": 268,
+                      "ctxt": 0
+                    },
+                    "params": [
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 45,
+                          "end": 53,
+                          "ctxt": 0
+                        },
+                        "value": "duration",
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 55,
+                          "end": 64,
+                          "ctxt": 0
+                        },
+                        "value": "subtitles",
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 66,
+                          "end": 70,
+                          "ctxt": 0
+                        },
+                        "value": "type",
+                        "optional": false,
+                        "typeAnnotation": null
+                      },
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 72,
+                          "end": 82,
+                          "ctxt": 0
+                        },
+                        "value": "attributes",
+                        "optional": false,
+                        "typeAnnotation": null
+                      }
+                    ],
+                    "body": {
+                      "type": "BlockStatement",
+                      "span": {
+                        "start": 87,
+                        "end": 268,
+                        "ctxt": 0
+                      },
+                      "stmts": [
+                        {
+                          "type": "ExpressionStatement",
+                          "span": {
+                            "start": 97,
+                            "end": 105,
+                            "ctxt": 0
+                          },
+                          "expression": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 97,
+                              "end": 105,
+                              "ctxt": 0
+                            },
+                            "value": "duration",
+                            "optional": false
+                          }
+                        },
+                        {
+                          "type": "ExpressionStatement",
+                          "span": {
+                            "start": 136,
+                            "end": 145,
+                            "ctxt": 0
+                          },
+                          "expression": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 136,
+                              "end": 145,
+                              "ctxt": 0
+                            },
+                            "value": "subtitles",
+                            "optional": false
+                          }
+                        },
+                        {
+                          "type": "ExpressionStatement",
+                          "span": {
+                            "start": 176,
+                            "end": 180,
+                            "ctxt": 0
+                          },
+                          "expression": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 176,
+                              "end": 180,
+                              "ctxt": 0
+                            },
+                            "value": "type",
+                            "optional": false
+                          }
+                        },
+                        {
+                          "type": "ExpressionStatement",
+                          "span": {
+                            "start": 211,
+                            "end": 221,
+                            "ctxt": 0
+                          },
+                          "expression": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 211,
+                              "end": 221,
+                              "ctxt": 0
+                            },
+                            "value": "attributes",
+                            "optional": false
+                          }
+                        }
+                      ]
+                    },
+                    "async": false,
+                    "generator": false,
+                    "typeParameters": null,
+                    "returnType": null
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        "typeArguments": null
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Description:**

**Related issue:**

 - Closes #8073.