### PR TITLE
refactor(common): Remove string_cache dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,7 +3891,6 @@ dependencies = [
  "serde_json",
  "siphasher",
  "sourcemap",
- "string_cache",
  "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",

--- a/crates/swc_bundler/src/bundler/load.rs
+++ b/crates/swc_bundler/src/bundler/load.rs
@@ -411,7 +411,7 @@ pub(crate) struct Source {
     pub local_ctxt: SyntaxContext,
     pub export_ctxt: SyntaxContext,
 
-    // Clone is relatively cheap, thanks to string_cache.
+    // Clone is relatively cheap, thanks to hstr.
     pub src: Str,
 }
 

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -57,7 +57,6 @@ rustc-hash = "1.1.0"
 serde = { version = "1.0.119", features = ["derive"] }
 siphasher = "0.3.9"
 sourcemap = { version = "6", optional = true }
-string_cache = "0.8.7"
 termcolor = { version = "1.0", optional = true }
 tracing = "0.1.37"
 unicode-width = "0.1.4"

--- a/crates/swc_common/src/eq.rs
+++ b/crates/swc_common/src/eq.rs
@@ -1,7 +1,6 @@
-use std::{cell::RefCell, cmp::PartialEq, rc::Rc, sync::Arc};
+use std::{cell::RefCell, rc::Rc, sync::Arc};
 
 use num_bigint::BigInt;
-use string_cache::Atom;
 
 use crate::{BytePos, Span, SyntaxContext};
 
@@ -135,20 +134,6 @@ eq!(usize, u8, u16, u32, u64, u128);
 eq!(isize, i8, i16, i32, i64, i128);
 eq!(f32, f64);
 eq!(char, str, String);
-
-impl<S: PartialEq> EqIgnoreSpan for Atom<S> {
-    #[inline]
-    fn eq_ignore_span(&self, other: &Self) -> bool {
-        self == other
-    }
-}
-
-impl<S: PartialEq> TypeEq for Atom<S> {
-    #[inline]
-    fn type_eq(&self, other: &Self) -> bool {
-        self == other
-    }
-}
 
 macro_rules! deref {
     ($T:ident) => {


### PR DESCRIPTION
**Description:**

I believe we can remove this now because of hstr?

(I don't need this. I just noticed it was not used in the swc repo anymore. Maybe it's used elsewhere though?)

**BREAKING CHANGE:** Removes `EqIgnoreSpan` and `TypeEq` implementations for `string_cache::Atom`
