### PR TITLE
fix(es/codegen): Fix panic due to `\\ud`

### DIFF
--- a/crates/swc/tests/fixture/issues-8xxx/8345/input/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8345/input/1.js
@@ -1,0 +1,2 @@
+const data = '\\ud';
+console.log(data);

--- a/crates/swc/tests/fixture/issues-8xxx/8345/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8345/output/1.js
@@ -1,0 +1,2 @@
+var data = "\\ud";
+console.log(data);

--- a/crates/swc/tests/fixture/issues-8xxx/8345/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8345/output/1.js
@@ -1,2 +1,0 @@
-var data = "ud";
-console.log(data);

--- a/crates/swc/tests/fixture/issues-8xxx/8345/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8345/output/1.js
@@ -1,0 +1,2 @@
+var data = "ud";
+console.log(data);

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -3916,9 +3916,9 @@ fn get_quoted_utf16(v: &str, ascii_only: bool, target: EsVersion) -> String {
                                 2..6
                             };
 
-                            let val_str = &inner_buf[range];
-
                             if is_valid {
+                                let val_str = &inner_buf[range];
+
                                 let v = u32::from_str_radix(val_str, 16).unwrap_or_else(|err| {
                                     unreachable!(
                                         "failed to parse {} as a hex value: {:?}",

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -3939,6 +3939,8 @@ fn get_quoted_utf16(v: &str, ascii_only: bool, target: EsVersion) -> String {
                                 } else {
                                     buf.push_str("\\\\");
                                 }
+                            } else {
+                                buf.push_str("\\\\")
                             }
                         } else if is_curly {
                             buf.push_str("\\\\");


### PR DESCRIPTION
**Description:**



**Related issue:**

 - Closes #8345