### PR TITLE
fix(es/lint): Ignore ambient context binding 

### DIFF
--- a/crates/swc/tests/fixture/issues-8xxx/8367/input/index.ts
+++ b/crates/swc/tests/fixture/issues-8xxx/8367/input/index.ts
@@ -1,0 +1,3 @@
+declare class Foo { }
+
+function Foo() { }

--- a/crates/swc/tests/fixture/issues-8xxx/8367/output/index.ts
+++ b/crates/swc/tests/fixture/issues-8xxx/8367/output/index.ts
@@ -1,0 +1,1 @@
+function Foo() {}

--- a/crates/swc/tests/tsc-references/classAbstractMergedDeclaration.1.normal.js
+++ b/crates/swc/tests/tsc-references/classAbstractMergedDeclaration.1.normal.js
@@ -31,35 +31,3 @@
 //!  19 | declare abstract class DCI {}
 //!  20 | interface DCI {}
 //!     `----
-//! 
-//!   x the name `DCC1` is defined multiple times
-//!     ,-[22:1]
-//!  22 | interface DIC {}
-//!  23 | declare abstract class DIC {}
-//!  24 | 
-//!  25 | declare abstract class DCC1 {}
-//!     :                        ^^|^
-//!     :                          `-- previous definition of `DCC1` here
-//!  26 | declare class DCC1 {}
-//!     :               ^^|^
-//!     :                 `-- `DCC1` redefined here
-//!  27 | 
-//!  28 | declare class DCC2 {}
-//!  29 | declare abstract class DCC2 {}
-//!     `----
-//! 
-//!   x the name `DCC2` is defined multiple times
-//!     ,-[25:1]
-//!  25 | declare abstract class DCC1 {}
-//!  26 | declare class DCC1 {}
-//!  27 | 
-//!  28 | declare class DCC2 {}
-//!     :               ^^|^
-//!     :                 `-- previous definition of `DCC2` here
-//!  29 | declare abstract class DCC2 {}
-//!     :                        ^^|^
-//!     :                          `-- `DCC2` redefined here
-//!  30 | 
-//!  31 | new CM;
-//!  32 | new MC;
-//!     `----

--- a/crates/swc/tests/tsc-references/classAbstractMergedDeclaration.2.minified.js
+++ b/crates/swc/tests/tsc-references/classAbstractMergedDeclaration.2.minified.js
@@ -31,35 +31,3 @@
 //!  19 | declare abstract class DCI {}
 //!  20 | interface DCI {}
 //!     `----
-//! 
-//!   x the name `DCC1` is defined multiple times
-//!     ,-[22:1]
-//!  22 | interface DIC {}
-//!  23 | declare abstract class DIC {}
-//!  24 | 
-//!  25 | declare abstract class DCC1 {}
-//!     :                        ^^|^
-//!     :                          `-- previous definition of `DCC1` here
-//!  26 | declare class DCC1 {}
-//!     :               ^^|^
-//!     :                 `-- `DCC1` redefined here
-//!  27 | 
-//!  28 | declare class DCC2 {}
-//!  29 | declare abstract class DCC2 {}
-//!     `----
-//! 
-//!   x the name `DCC2` is defined multiple times
-//!     ,-[25:1]
-//!  25 | declare abstract class DCC1 {}
-//!  26 | declare class DCC1 {}
-//!  27 | 
-//!  28 | declare class DCC2 {}
-//!     :               ^^|^
-//!     :                 `-- previous definition of `DCC2` here
-//!  29 | declare abstract class DCC2 {}
-//!     :                        ^^|^
-//!     :                          `-- `DCC2` redefined here
-//!  30 | 
-//!  31 | new CM;
-//!  32 | new MC;
-//!     `----

--- a/crates/swc/tests/tsc-references/declaredClassMergedwithSelf.1.normal.js
+++ b/crates/swc/tests/tsc-references/declaredClassMergedwithSelf.1.normal.js
@@ -1,35 +1,4 @@
 //// [declaredClassMergedwithSelf.ts]
 //// [file1.ts]
-//! 
-//!   x the name `C1` is defined multiple times
-//!    ,-[1:1]
-//!  1 | 
-//!  2 | declare class C1 {}
-//!    :               ^|
-//!    :                `-- previous definition of `C1` here
-//!  3 | 
-//!  4 | declare class C1 {}
-//!    :               ^|
-//!    :                `-- `C1` redefined here
-//!  5 | 
-//!  6 | declare class C2 {}
-//!    `----
-//! 
-//!   x the name `C2` is defined multiple times
-//!     ,-[3:1]
-//!   3 | 
-//!   4 | declare class C1 {}
-//!   5 | 
-//!   6 | declare class C2 {}
-//!     :               ^|
-//!     :                `-- previous definition of `C2` here
-//!   7 | 
-//!   8 | interface C2 {}
-//!   9 | 
-//!  10 | declare class C2 {}
-//!     :               ^|
-//!     :                `-- `C2` redefined here
-//!  11 | 
-//!     `----
 //// [file2.ts]
 //// [file3.ts]

--- a/crates/swc/tests/tsc-references/declaredClassMergedwithSelf.2.minified.js
+++ b/crates/swc/tests/tsc-references/declaredClassMergedwithSelf.2.minified.js
@@ -1,35 +1,4 @@
 //// [declaredClassMergedwithSelf.ts]
 //// [file1.ts]
-//! 
-//!   x the name `C1` is defined multiple times
-//!    ,-[1:1]
-//!  1 | 
-//!  2 | declare class C1 {}
-//!    :               ^|
-//!    :                `-- previous definition of `C1` here
-//!  3 | 
-//!  4 | declare class C1 {}
-//!    :               ^|
-//!    :                `-- `C1` redefined here
-//!  5 | 
-//!  6 | declare class C2 {}
-//!    `----
-//! 
-//!   x the name `C2` is defined multiple times
-//!     ,-[3:1]
-//!   3 | 
-//!   4 | declare class C1 {}
-//!   5 | 
-//!   6 | declare class C2 {}
-//!     :               ^|
-//!     :                `-- previous definition of `C2` here
-//!   7 | 
-//!   8 | interface C2 {}
-//!   9 | 
-//!  10 | declare class C2 {}
-//!     :               ^|
-//!     :                `-- `C2` redefined here
-//!  11 | 
-//!     `----
 //// [file2.ts]
 //// [file3.ts]

--- a/crates/swc_ecma_lints/src/rules/duplicate_bindings.rs
+++ b/crates/swc_ecma_lints/src/rules/duplicate_bindings.rs
@@ -185,6 +185,10 @@ impl Visit for DuplicateBindings {
     }
 
     fn visit_class_decl(&mut self, d: &ClassDecl) {
+        if d.declare {
+            return;
+        }
+
         self.add(
             d.ident.sym.clone(),
             BindingInfo {
@@ -211,16 +215,18 @@ impl Visit for DuplicateBindings {
     }
 
     fn visit_fn_decl(&mut self, d: &FnDecl) {
-        if d.function.body.is_some() {
-            self.add(
-                d.ident.sym.clone(),
-                BindingInfo {
-                    span: d.ident.span,
-                    unique: self.lexical_function,
-                    is_function: true,
-                },
-            );
+        if d.function.body.is_none() || d.declare {
+            return;
         }
+
+        self.add(
+            d.ident.sym.clone(),
+            BindingInfo {
+                span: d.ident.span,
+                unique: self.lexical_function,
+                is_function: true,
+            },
+        );
 
         d.visit_children_with(self);
     }
@@ -351,6 +357,10 @@ impl Visit for DuplicateBindings {
     }
 
     fn visit_var_decl(&mut self, d: &VarDecl) {
+        if d.declare {
+            return;
+        }
+
         self.visit_with_kind(d, Some(d.kind))
     }
 


### PR DESCRIPTION
**Related issue:**
- Closes: #8367 