### PR TITLE
Use sha2 in place of sha-1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4915,7 +4915,7 @@ dependencies = [
  "hex",
  "serde",
  "serde_json",
- "sha-1",
+ "sha2",
  "sourcemap",
  "swc_common",
  "swc_ecma_ast",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4675,7 +4675,7 @@ version = "0.22.12"
 dependencies = [
  "anyhow",
  "hex",
- "sha-1",
+ "sha2",
  "testing",
  "tracing",
 ]

--- a/crates/swc_ecma_testing/Cargo.toml
+++ b/crates/swc_ecma_testing/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 [dependencies]
 anyhow  = "1"
 hex     = "0.4"
-sha2   = "0.10"
+sha2    = "0.10"
 tracing = "0.1.37"
 
 testing = { version = "0.35.12", path = "../testing" }

--- a/crates/swc_ecma_testing/Cargo.toml
+++ b/crates/swc_ecma_testing/Cargo.toml
@@ -14,7 +14,7 @@ bench = false
 [dependencies]
 anyhow  = "1"
 hex     = "0.4"
-sha-1   = "0.10"
+sha2   = "0.10"
 tracing = "0.1.37"
 
 testing = { version = "0.35.12", path = "../testing" }

--- a/crates/swc_ecma_testing/src/lib.rs
+++ b/crates/swc_ecma_testing/src/lib.rs
@@ -1,7 +1,7 @@
 use std::{env, fs, path::PathBuf, process::Command};
 
 use anyhow::{bail, Context, Result};
-use sha1::{Digest, Sha1};
+use sha2::{Digest, Sha256};
 use testing::CARGO_TARGET_DIR;
 use tracing::debug;
 
@@ -89,7 +89,7 @@ pub fn exec_node_js(js_code: &str, opts: JsExecOptions) -> Result<String> {
 }
 
 fn calc_hash(s: &str) -> String {
-    let mut hasher = Sha1::default();
+    let mut hasher = Sha256::default();
     hasher.update(s.as_bytes());
     let sum = hasher.finalize();
 

--- a/crates/swc_ecma_transforms_testing/Cargo.toml
+++ b/crates/swc_ecma_transforms_testing/Cargo.toml
@@ -18,7 +18,7 @@ base64     = "0.21"
 hex        = "0.4.3"
 serde      = "1"
 serde_json = "1"
-sha2      = "0.10"
+sha2       = "0.10"
 sourcemap  = "6.2"
 tempfile   = "3.6.0"
 

--- a/crates/swc_ecma_transforms_testing/Cargo.toml
+++ b/crates/swc_ecma_transforms_testing/Cargo.toml
@@ -18,7 +18,7 @@ base64     = "0.21"
 hex        = "0.4.3"
 serde      = "1"
 serde_json = "1"
-sha-1      = "0.10"
+sha2      = "0.10"
 sourcemap  = "6.2"
 tempfile   = "3.6.0"
 

--- a/crates/swc_ecma_transforms_testing/src/lib.rs
+++ b/crates/swc_ecma_transforms_testing/src/lib.rs
@@ -18,7 +18,7 @@ use ansi_term::Color;
 use anyhow::Error;
 use base64::prelude::{Engine, BASE64_STANDARD};
 use serde::de::DeserializeOwned;
-use sha1::{Digest, Sha1};
+use sha2::{Digest, Sha256};
 use swc_common::{
     chain,
     comments::SingleThreadedComments,
@@ -522,7 +522,7 @@ where
 }
 
 fn calc_hash(s: &str) -> String {
-    let mut hasher = Sha1::new();
+    let mut hasher = Sha256::new();
     hasher.update(s.as_bytes());
     let sum = hasher.finalize();
 


### PR DESCRIPTION
**Descrption:**

`sha-1` crate has been deprecated and the algorithm itself is not considered secure or collision-proof. Moving to `sha2` solves this.

**Related issue:**

 - Closes #8382
