### PR TITLE
feat(es/ast): Add `as_import_with` to `ObjectLit` to provide easier API

### DIFF
--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -24,7 +24,7 @@ use crate::{
         TsAsExpr, TsConstAssertion, TsInstantiation, TsNonNullExpr, TsSatisfiesExpr, TsTypeAnn,
         TsTypeAssertion, TsTypeParamDecl, TsTypeParamInstantiation,
     },
-    ComputedPropName, Id, Invalid, PropName, Str,
+    ComputedPropName, Id, Invalid, KeyValueProp, PropName, Str,
 };
 
 #[ast_node(no_clone)]
@@ -412,6 +412,24 @@ impl ObjectLit {
             span: self.span,
             values,
         })
+    }
+}
+
+impl From<ImportWith> for ObjectLit {
+    fn from(v: ImportWith) -> Self {
+        ObjectLit {
+            span: v.span,
+            props: v
+                .values
+                .into_iter()
+                .map(|item| {
+                    PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                        key: PropName::Ident(item.key),
+                        value: Box::new(Expr::Lit(Lit::Str(item.value))),
+                    })))
+                })
+                .collect(),
+        }
     }
 }
 

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -378,6 +378,27 @@ pub struct ObjectLit {
     pub props: Vec<PropOrSpread>,
 }
 
+impl ObjectLit {
+    /// See [ImportWith] for details.
+    pub fn as_import_with(&self) -> ImportWith {}
+}
+
+/// According to the current spec `with` of [crate::ImportDecl] can only have
+/// strings or idents as keys, can't be nested, can only have string literals as
+/// values:
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, EqIgnoreSpan)]
+pub struct ImportWith {
+    pub span: Span,
+    pub values: Vec<ImportWithItem>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, EqIgnoreSpan)]
+pub struct ImportWithItem {
+    pub key: Ident,
+    pub value: Str,
+}
+
 impl Take for ObjectLit {
     fn dummy() -> Self {
         ObjectLit {


### PR DESCRIPTION
**Description:**


