### PR TITLE
refactor(es/utils): Use exact type for factory methods

### DIFF
--- a/crates/swc_bundler/src/bundler/chunk/merge.rs
+++ b/crates/swc_bundler/src/bundler/chunk/merge.rs
@@ -988,11 +988,12 @@ where
                                                 vars.push(VarDeclarator {
                                                     span: DUMMY_SP,
                                                     name: Pat::Ident(s.exported.clone().into()),
-                                                    init: Some(Box::new(
+                                                    init: Some(
                                                         mod_var
                                                             .clone()
-                                                            .make_member(quote_ident!("default")),
-                                                    )),
+                                                            .make_member(quote_ident!("default"))
+                                                            .into(),
+                                                    ),
                                                     definite: Default::default(),
                                                 });
                                             }
@@ -1020,9 +1021,12 @@ where
                                                     name: Pat::Ident(
                                                         exported.clone().unwrap().into(),
                                                     ),
-                                                    init: Some(Box::new(
-                                                        mod_var.clone().make_member(orig.clone()),
-                                                    )),
+                                                    init: Some(
+                                                        mod_var
+                                                            .clone()
+                                                            .make_member(orig.clone())
+                                                            .into(),
+                                                    ),
                                                     definite: Default::default(),
                                                 });
                                             }

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -53,6 +53,15 @@ impl BindingIdent {
     }
 }
 
+impl Take for BindingIdent {
+    fn dummy() -> Self {
+        BindingIdent {
+            id: Ident::dummy(),
+            type_ann: None,
+        }
+    }
+}
+
 impl From<Ident> for BindingIdent {
     fn from(id: Ident) -> Self {
         Self { id, type_ann: None }
@@ -121,6 +130,18 @@ pub struct Ident {
     /// TypeScript only. Used in case of an optional parameter.
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub optional: bool,
+}
+
+impl From<BindingIdent> for Ident {
+    fn from(bi: BindingIdent) -> Self {
+        bi.id
+    }
+}
+
+impl From<&'_ str> for Ident {
+    fn from(bi: &str) -> Self {
+        Ident::new(bi.into(), DUMMY_SP)
+    }
 }
 
 scoped_thread_local!(static EQ_IGNORE_SPAN_IGNORE_CTXT: ());

--- a/crates/swc_ecma_compat_es2015/src/classes/mod.rs
+++ b/crates/swc_ecma_compat_es2015/src/classes/mod.rs
@@ -1147,9 +1147,12 @@ where
                                 decls: vec![VarDeclarator {
                                     span: DUMMY_SP,
                                     name: proto.clone().into(),
-                                    init: Some(Box::new(
-                                        class_name.clone().make_member(quote_ident!("prototype")),
-                                    )),
+                                    init: Some(
+                                        class_name
+                                            .clone()
+                                            .make_member(quote_ident!("prototype"))
+                                            .into(),
+                                    ),
                                     definite: false,
                                 }],
                             }

--- a/crates/swc_ecma_compat_es2015/src/computed_props.rs
+++ b/crates/swc_ecma_compat_es2015/src/computed_props.rs
@@ -196,11 +196,11 @@ impl VisitMut for ComputedProps {
                             // mutator[f] = mutator[f] || {}
                             exprs.push(Box::new(Expr::Assign(AssignExpr {
                                 span,
-                                left: PatOrExpr::Expr(Box::new(mutator_elem.clone())),
+                                left: mutator_elem.clone().into(),
                                 op: op!("="),
                                 right: Box::new(Expr::Bin(BinExpr {
                                     span,
-                                    left: Box::new(mutator_elem.clone()),
+                                    left: mutator_elem.clone().into(),
                                     op: op!("||"),
                                     right: Box::new(Expr::Object(ObjectLit {
                                         span,
@@ -212,9 +212,9 @@ impl VisitMut for ComputedProps {
                             // mutator[f].get = function(){}
                             exprs.push(Box::new(Expr::Assign(AssignExpr {
                                 span,
-                                left: PatOrExpr::Expr(Box::new(
-                                    mutator_elem.make_member(quote_ident!(gs_prop_name.unwrap())),
-                                )),
+                                left: mutator_elem
+                                    .make_member(quote_ident!(gs_prop_name.unwrap()))
+                                    .into(),
                                 op: op!("="),
                                 right: Box::new(Expr::Fn(FnExpr {
                                     ident: None,

--- a/crates/swc_ecma_compat_es2015/src/computed_props.rs
+++ b/crates/swc_ecma_compat_es2015/src/computed_props.rs
@@ -254,7 +254,7 @@ impl VisitMut for ComputedProps {
                     Box::new(Expr::Assign(AssignExpr {
                         span,
                         op: op!("="),
-                        left: PatOrExpr::Expr(Box::new(left)),
+                        left: left.into(),
                         right: value.into(),
                     }))
                 } else {

--- a/crates/swc_ecma_compat_es2015/src/destructuring.rs
+++ b/crates/swc_ecma_compat_es2015/src/destructuring.rs
@@ -267,7 +267,7 @@ impl AssignFolder {
                             // This might be pattern.
                             // So we fold it again.
                             name: elem,
-                            init: Some(Box::new(make_ref_idx_expr(&ref_ident, i))),
+                            init: Some(make_ref_idx_expr(&ref_ident, i).into()),
                             definite: false,
                         },
                     };
@@ -771,7 +771,7 @@ impl VisitMut for AssignFolder {
                                     span: elem_span,
                                     op: op!("="),
                                     left: PatOrExpr::Pat(Box::new(elem.take())),
-                                    right: Box::new(make_ref_idx_expr(&ref_ident, i)),
+                                    right: make_ref_idx_expr(&ref_ident, i).into(),
                                 });
 
                                 assign_expr.visit_mut_with(self);

--- a/crates/swc_ecma_compat_es2015/src/destructuring.rs
+++ b/crates/swc_ecma_compat_es2015/src/destructuring.rs
@@ -804,7 +804,7 @@ impl VisitMut for AssignFolder {
                                 span: *span,
                                 op: op!("="),
                                 left: PatOrExpr::Pat(p.key.clone().into()),
-                                right: Box::new(right.take().make_member(p.key.clone())),
+                                right: right.take().make_member(p.key.clone()).into(),
                             });
                             return;
                         }
@@ -1039,7 +1039,7 @@ impl Destructuring {
     }
 }
 
-fn make_ref_idx_expr(ref_ident: &Ident, i: usize) -> Expr {
+fn make_ref_idx_expr(ref_ident: &Ident, i: usize) -> MemberExpr {
     ref_ident.clone().computed_member(i as f64)
 }
 

--- a/crates/swc_ecma_compat_es2015/src/destructuring.rs
+++ b/crates/swc_ecma_compat_es2015/src/destructuring.rs
@@ -318,7 +318,7 @@ impl AssignFolder {
                         decls.push(VarDeclarator {
                             span: decl.span,
                             name: p.key.clone().into(),
-                            init: Some(Box::new(decl.init.unwrap().make_member(p.key.clone()))),
+                            init: Some(decl.init.unwrap().make_member(p.key.clone()).into()),
                             definite: false,
                         });
                         return;
@@ -734,7 +734,7 @@ impl VisitMut for AssignFolder {
                                     span: DUMMY_SP,
                                     left: PatOrExpr::Pat(assign_ref_ident.clone().into()),
                                     op: op!("="),
-                                    right: Box::new(ref_ident.clone().computed_member(i as f64)),
+                                    right: ref_ident.clone().computed_member(i as f64).into(),
                                 })));
 
                                 let mut assign_expr = Expr::Assign(AssignExpr {

--- a/crates/swc_ecma_compat_es2015/src/for_of.rs
+++ b/crates/swc_ecma_compat_es2015/src/for_of.rs
@@ -154,7 +154,7 @@ impl ForOf {
                             decls: vec![VarDeclarator {
                                 span: DUMMY_SP,
                                 name: var.decls.into_iter().next().unwrap().name,
-                                init: Some(Box::new(Expr::Ident(arr).computed_member(i))),
+                                init: Some(Expr::Ident(arr).computed_member(i).into()),
                                 definite: false,
                             }],
                         }
@@ -335,7 +335,7 @@ impl ForOf {
         };
 
         let step = quote_ident!(var_span, "_step");
-        let step_value = Box::new(step.clone().make_member(quote_ident!("value")));
+        let step_value = step.clone().make_member(quote_ident!("value"));
         body.stmts.insert(
             0,
             match left {
@@ -345,7 +345,7 @@ impl ForOf {
                         span: var.span,
                         kind: var.kind,
                         decls: vec![VarDeclarator {
-                            init: Some(step_value),
+                            init: Some(step_value.into()),
                             ..var.decls.pop().unwrap()
                         }],
                         declare: false,
@@ -356,7 +356,7 @@ impl ForOf {
                     span: DUMMY_SP,
                     left: PatOrExpr::Pat(pat),
                     op: op!("="),
-                    right: step_value,
+                    right: step_value.into(),
                 }
                 .into_stmt(),
 

--- a/crates/swc_ecma_compat_es2015/src/for_of.rs
+++ b/crates/swc_ecma_compat_es2015/src/for_of.rs
@@ -368,7 +368,7 @@ impl ForOf {
 
         let iterator = quote_ident!(var_span, "_iterator");
         // `_iterator.return`
-        let iterator_return = Box::new(iterator.clone().make_member(quote_ident!("return")));
+        let iterator_return = iterator.clone().make_member(quote_ident!("return")).into();
 
         let normal_completion_ident = Ident::new("_iteratorNormalCompletion".into(), var_span);
         self.top_level_vars.push(VarDeclarator {
@@ -409,7 +409,7 @@ impl ForOf {
                             init: Some(Box::new(Expr::Call(CallExpr {
                                 span: DUMMY_SP,
                                 callee: right
-                                    .computed_member(*member_expr!(DUMMY_SP, Symbol.iterator))
+                                    .computed_member(member_expr!(DUMMY_SP, Symbol.iterator))
                                     .as_callee(),
                                 args: vec![],
                                 type_args: Default::default(),
@@ -449,7 +449,7 @@ impl ForOf {
                         span: DUMMY_SP,
                         left: PatOrExpr::Pat(normal_completion_ident.clone().into()),
                         op: op!("="),
-                        right: Box::new(step_expr.make_member(quote_ident!("done"))),
+                        right: step_expr.make_member(quote_ident!("done")).into(),
                     }))
                 },
             }))),

--- a/crates/swc_ecma_compat_es2015/src/for_of.rs
+++ b/crates/swc_ecma_compat_es2015/src/for_of.rs
@@ -104,7 +104,7 @@ impl ForOf {
                 span: DUMMY_SP,
                 left: Box::new(Expr::Ident(i.clone())),
                 op: op!("<"),
-                right: Box::new(arr.clone().make_member(quote_ident!("length"))),
+                right: arr.clone().make_member(quote_ident!("length")).into(),
             })));
             let update = Some(Box::new(Expr::Update(UpdateExpr {
                 span: DUMMY_SP,

--- a/crates/swc_ecma_compat_es2015/src/generator.rs
+++ b/crates/swc_ecma_compat_es2015/src/generator.rs
@@ -803,7 +803,7 @@ impl VisitMut for Generator {
 
             let (target, this_arg) = self.create_call_binding(node.callee.take(), true);
 
-            let callee = self.cache_expression(Box::new(target.make_member(quote_ident!("bind"))));
+            let callee = self.cache_expression(target.make_member(quote_ident!("bind")).into());
 
             let mut arg = if let Some(args) = node.args.take() {
                 let mut args = args.into_iter().map(Some).collect::<Vec<_>>();
@@ -2821,7 +2821,7 @@ impl Generator {
             let label_expr = self.state.clone().make_member(quote_ident!("label"));
             let switch_stmt = SwitchStmt {
                 span: DUMMY_SP,
-                discriminant: Box::new(label_expr),
+                discriminant: label_expr.into(),
                 cases: clauses,
             };
             return vec![Stmt::Switch(switch_stmt)];
@@ -3009,9 +3009,7 @@ impl Generator {
                     expr: Box::new(Expr::Assign(AssignExpr {
                         span: DUMMY_SP,
                         op: op!("="),
-                        left: PatOrExpr::Expr(Box::new(
-                            self.state.clone().make_member(quote_ident!("label")),
-                        )),
+                        left: self.state.clone().make_member(quote_ident!("label")).into(),
                         right: (self.label_number + 1).into(),
                     })),
                 }));

--- a/crates/swc_ecma_compat_es2015/src/new_target.rs
+++ b/crates/swc_ecma_compat_es2015/src/new_target.rs
@@ -61,7 +61,11 @@ impl VisitMut for NewTarget {
             span,
         }) = e
         {
-            let this_ctor = |span| ThisExpr { span }.make_member(quote_ident!("constructor"));
+            let this_ctor = |span| {
+                ThisExpr { span }
+                    .make_member(quote_ident!("constructor"))
+                    .into()
+            };
             match &self.ctx {
                 Ctx::Constructor => *e = this_ctor(*span),
                 Ctx::Method => *e = *undefined(DUMMY_SP),

--- a/crates/swc_ecma_compat_es2015/src/parameters.rs
+++ b/crates/swc_ecma_compat_es2015/src/parameters.rs
@@ -298,7 +298,7 @@ impl Params {
                                     VarDeclarator {
                                         span,
                                         name: len_ident.clone().into(),
-                                        init: Some(member_expr!(span, arguments.length)),
+                                        init: Some(member_expr!(span, arguments.length).into()),
                                         definite: false,
                                     },
                                     // a1 = new Array(_len - $i)

--- a/crates/swc_ecma_compat_es2015/src/parameters.rs
+++ b/crates/swc_ecma_compat_es2015/src/parameters.rs
@@ -360,9 +360,9 @@ impl Params {
 
                                 AssignExpr {
                                     span,
-                                    left: PatOrExpr::Expr(Box::new(
-                                        arg.computed_member(make_minus_i(&idx_ident, false)),
-                                    )),
+                                    left: arg
+                                        .computed_member(make_minus_i(&idx_ident, false))
+                                        .into(),
                                     op: op!("="),
                                     right: Box::new(
                                         MemberExpr {

--- a/crates/swc_ecma_compat_es2015/src/parameters.rs
+++ b/crates/swc_ecma_compat_es2015/src/parameters.rs
@@ -146,14 +146,14 @@ impl Params {
                                     left: Box::new(check_arg_len(i)),
                                     op: op!("&&"),
                                     right: Box::new(Expr::Bin(BinExpr {
-                                        left: Box::new(make_arg_nth(i)),
+                                        left: make_arg_nth(i).into(),
                                         op: op!("!=="),
                                         right: undefined(DUMMY_SP),
                                         span: DUMMY_SP,
                                     })),
                                     span,
                                 })),
-                                cons: Box::new(make_arg_nth(i)),
+                                cons: make_arg_nth(i).into(),
                                 alt: right,
                             }))),
                             definite: false,
@@ -767,16 +767,15 @@ impl VisitMut for Params {
     }
 }
 
-fn make_arg_nth(n: usize) -> Expr {
+fn make_arg_nth(n: usize) -> MemberExpr {
     Expr::Ident(Ident::new("arguments".into(), DUMMY_SP)).computed_member(n)
 }
 
 fn check_arg_len(n: usize) -> Expr {
     Expr::Bin(BinExpr {
-        left: Box::new(
-            Expr::Ident(Ident::new("arguments".into(), DUMMY_SP))
-                .make_member(Ident::new("length".into(), DUMMY_SP)),
-        ),
+        left: Expr::Ident(Ident::new("arguments".into(), DUMMY_SP))
+            .make_member(Ident::new("length".into(), DUMMY_SP))
+            .into(),
         op: op!(">"),
         right: n.into(),
         span: DUMMY_SP,
@@ -786,7 +785,7 @@ fn check_arg_len(n: usize) -> Expr {
 fn check_arg_len_or_undef(n: usize) -> Expr {
     Expr::Cond(CondExpr {
         test: Box::new(check_arg_len(n)),
-        cons: Box::new(make_arg_nth(n)),
+        cons: make_arg_nth(n).into(),
         alt: undefined(DUMMY_SP),
         span: DUMMY_SP,
     })

--- a/crates/swc_ecma_compat_es2017/src/async_to_generator.rs
+++ b/crates/swc_ecma_compat_es2017/src/async_to_generator.rs
@@ -587,7 +587,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             let value_var = VarDeclarator {
                 span: DUMMY_SP,
                 name: value.clone().into(),
-                init: Some(Box::new(step.clone().make_member(quote_ident!("value")))),
+                init: Some(step.clone().make_member(quote_ident!("value")).into()),
                 definite: false,
             };
             for_loop_body.push(
@@ -715,7 +715,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
                 let right = Box::new(Expr::Unary(UnaryExpr {
                     span: DUMMY_SP,
                     op: op!("!"),
-                    arg: Box::new(assign_to_step.make_member(quote_ident!("done"))),
+                    arg: assign_to_step.make_member(quote_ident!("done")).into(),
                 }));
 
                 let left = PatOrExpr::Pat(iterator_abrupt_completion.clone().into());
@@ -820,7 +820,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
                 right: Box::new(Expr::Bin(BinExpr {
                     span: DUMMY_SP,
                     op: op!("!="),
-                    left: Box::new(iterator.make_member(quote_ident!("return"))),
+                    left: iterator.make_member(quote_ident!("return")).into(),
                     right: Null { span: DUMMY_SP }.into(),
                 })),
             })),

--- a/crates/swc_ecma_compat_es2018/src/object_rest.rs
+++ b/crates/swc_ecma_compat_es2018/src/object_rest.rs
@@ -704,7 +704,7 @@ impl ObjectRest {
                                 index,
                                 elem,
                                 if use_member_for_array {
-                                    Box::new(obj.clone().computed_member(i as f64))
+                                    obj.clone().computed_member(i as f64).into()
                                 } else {
                                     obj.clone()
                                 },

--- a/crates/swc_ecma_compat_es2022/src/class_properties/member_init.rs
+++ b/crates/swc_ecma_compat_es2022/src/class_properties/member_init.rs
@@ -154,10 +154,10 @@ impl MemberInitRecord {
                         let this = ThisExpr { span: DUMMY_SP };
                         Expr::Assign(AssignExpr {
                             span,
-                            left: PatOrExpr::Expr(Box::new(match name {
-                                PropName::Ident(id) => this.make_member(id),
-                                _ => this.computed_member(prop_name_to_expr(name)),
-                            })),
+                            left: match name {
+                                PropName::Ident(id) => this.make_member(id).into(),
+                                _ => this.computed_member(prop_name_to_expr(name)).into(),
+                            },
                             op: op!("="),
                             right: value,
                         })
@@ -197,10 +197,10 @@ impl MemberInitRecord {
                             let class = class_ident.clone();
                             Expr::Assign(AssignExpr {
                                 span,
-                                left: PatOrExpr::Expr(Box::new(match name {
-                                    PropName::Ident(id) => class.make_member(id),
-                                    _ => class.computed_member(prop_name_to_expr(name)),
-                                })),
+                                left: match name {
+                                    PropName::Ident(id) => class.make_member(id).into(),
+                                    _ => class.computed_member(prop_name_to_expr(name)).into(),
+                                },
                                 op: op!("="),
                                 right: value,
                             })

--- a/crates/swc_ecma_compat_es2022/src/class_properties/private_field.rs
+++ b/crates/swc_ecma_compat_es2022/src/class_properties/private_field.rs
@@ -259,7 +259,8 @@ impl<'a> VisitMut for PrivateAccessVisitor<'a> {
                     args: vec![obj.take().as_arg(), ident.clone().as_arg()],
                     type_args: None,
                 })
-                .computed_member(ident);
+                .computed_member(ident)
+                .into();
             } else {
                 e.visit_mut_children_with(self)
             }
@@ -558,7 +559,8 @@ impl<'a> PrivateAccessVisitor<'a> {
 
                             type_args: Default::default(),
                         }
-                        .make_member(quote_ident!("value")),
+                        .make_member(quote_ident!("value"))
+                        .into(),
                         Some(*obj),
                     );
                 }
@@ -577,7 +579,8 @@ impl<'a> PrivateAccessVisitor<'a> {
 
                             type_args: Default::default(),
                         }
-                        .make_member(quote_ident!("value")),
+                        .make_member(quote_ident!("value"))
+                        .into(),
                         Some(*obj),
                     );
                 }
@@ -626,7 +629,8 @@ impl<'a> PrivateAccessVisitor<'a> {
 
                             type_args: Default::default(),
                         }
-                        .make_member(quote_ident!("value")),
+                        .make_member(quote_ident!("value"))
+                        .into(),
                         Some(*obj),
                     )
                 }
@@ -641,7 +645,8 @@ impl<'a> PrivateAccessVisitor<'a> {
 
                             type_args: Default::default(),
                         }
-                        .make_member(quote_ident!("value")),
+                        .make_member(quote_ident!("value"))
+                        .into(),
                         Some(*obj),
                     )
                 }

--- a/crates/swc_ecma_transforms_classes/src/super_field.rs
+++ b/crates/swc_ecma_transforms_classes/src/super_field.rs
@@ -356,7 +356,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
                     if self.is_static && self.super_class.is_some() {
                         Expr::Ident(name)
                     } else {
-                        name.make_member(quote_ident!("prototype"))
+                        name.make_member(quote_ident!("prototype")).into()
                     }
                 }),
                 prop: match prop {
@@ -451,7 +451,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
             type_args: Default::default(),
         });
 
-        expr.make_member(quote_ident!("_"))
+        expr.make_member(quote_ident!("_")).into()
     }
 
     fn proto_arg(&mut self) -> Expr {
@@ -463,6 +463,7 @@ impl<'a> SuperFieldAccessFolder<'a> {
             self.class_name
                 .clone()
                 .make_member(quote_ident!("prototype"))
+                .into()
         };
 
         if self.constant_super {

--- a/crates/swc_ecma_transforms_compat/src/class_fields_use_set.rs
+++ b/crates/swc_ecma_transforms_compat/src/class_fields_use_set.rs
@@ -307,8 +307,7 @@ impl VisitMut for ComputedFieldsHandler {
                 });
 
                 self.static_init_blocks.push({
-                    let assign_expr =
-                        computed_expr.make_assign_to(op!("="), ref_key.as_pat_or_expr());
+                    let assign_expr = computed_expr.make_assign_to(op!("="), ref_key.into());
 
                     assign_expr.into_stmt()
                 });

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -411,7 +411,7 @@ where
                     stmts.push(stmt)
                 } else if need_interop {
                     let stmt = import_expr
-                        .make_assign_to(op!("="), mod_ident.as_pat_or_expr())
+                        .make_assign_to(op!("="), mod_ident.into())
                         .into_stmt();
                     stmts.push(stmt);
                 } else if need_re_export {

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -426,7 +426,7 @@ where
                     let assign_expr = AssignExpr {
                         span,
                         op: op!("="),
-                        left: id.as_pat_or_expr(),
+                        left: id.into(),
                         right: Box::new(require),
                     };
 
@@ -466,7 +466,7 @@ where
                     span: export_item.export_name_span(),
                     prop,
                 };
-                let expr = expr.make_assign_to(op!("="), export_binding.as_pat_or_expr());
+                let expr = expr.make_assign_to(op!("="), export_binding.into());
                 let expr = BinExpr {
                     span: DUMMY_SP,
                     op: op!("&&"),
@@ -639,7 +639,7 @@ pub fn lazy_require(expr: Expr, mod_ident: Ident, var_kind: VarDeclKind) -> FnDe
         .clone()
         .into_lazy_fn(Default::default())
         .into_fn_expr(None)
-        .make_assign_to(op!("="), mod_ident.clone().as_pat_or_expr())
+        .make_assign_to(op!("="), mod_ident.clone().into())
         .into_stmt();
     let return_stmt = data.into_return_stmt().into();
 

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -426,7 +426,7 @@ where
                     let assign_expr = AssignExpr {
                         span,
                         op: op!("="),
-                        left: id.into(),
+                        left: self.exports().make_member(id).into(),
                         right: Box::new(require),
                     };
 

--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -120,7 +120,11 @@ impl SystemJs {
 
     fn fold_module_name_ident(&mut self, ident: Ident) -> Expr {
         if &*ident.sym == "__moduleName" && ident.span.ctxt().outer() == self.unresolved_mark {
-            return self.context_ident.clone().make_member(quote_ident!("id"));
+            return self
+                .context_ident
+                .clone()
+                .make_member(quote_ident!("id"))
+                .into();
         }
         Expr::Ident(ident)
     }
@@ -344,10 +348,8 @@ impl SystemJs {
                             stmts: vec![AssignExpr {
                                 span: DUMMY_SP,
                                 op: op!("="),
-                                left: PatOrExpr::Expr(Box::new(
-                                    export_obj.clone().computed_member(key_ident.clone()),
-                                )),
-                                right: Box::new(target.computed_member(key_ident)),
+                                left: export_obj.clone().computed_member(key_ident.clone()).into(),
+                                right: target.computed_member(key_ident).into(),
                             }
                             .into_stmt()],
                         })),

--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -366,9 +366,7 @@ impl SystemJs {
                     AssignExpr {
                         span: DUMMY_SP,
                         op: op!("="),
-                        left: PatOrExpr::Expr(Box::new(
-                            export_obj.clone().make_member(quote_ident!(sym)),
-                        )),
+                        left: export_obj.clone().make_member(quote_ident!(sym)).into(),
                         right: value,
                     }
                     .into_stmt(),
@@ -597,9 +595,11 @@ impl Fold for SystemJs {
                 _ => Expr::Call(call),
             },
             Expr::MetaProp(meta_prop_expr) => match meta_prop_expr.kind {
-                MetaPropKind::ImportMeta => {
-                    self.context_ident.clone().make_member(quote_ident!("meta"))
-                }
+                MetaPropKind::ImportMeta => self
+                    .context_ident
+                    .clone()
+                    .make_member(quote_ident!("meta"))
+                    .into(),
                 _ => Expr::MetaProp(meta_prop_expr),
             },
             Expr::Await(await_expr) => {
@@ -699,10 +699,9 @@ impl Fold for SystemJs {
                                             left: PatOrExpr::Expr(Box::new(Expr::Ident(
                                                 specifier.local,
                                             ))),
-                                            right: Box::new(
-                                                quote_ident!(source_alias.clone())
-                                                    .make_member(quote_ident!("default")),
-                                            ),
+                                            right: quote_ident!(source_alias.clone())
+                                                .make_member(quote_ident!("default"))
+                                                .into(),
                                         }
                                         .into_stmt(),
                                     );
@@ -790,10 +789,11 @@ impl Fold for SystemJs {
                                     }
                                     ExportSpecifier::Default(specifier) => {
                                         export_names.push(specifier.exported.sym.clone());
-                                        export_values.push(Box::new(
+                                        export_values.push(
                                             quote_ident!(source_alias.clone())
-                                                .make_member(quote_ident!("default")),
-                                        ));
+                                                .make_member(quote_ident!("default"))
+                                                .into(),
+                                        );
                                     }
                                     ExportSpecifier::Namespace(specifier) => {
                                         export_names

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -290,7 +290,7 @@ where
                     stmts.push(stmt)
                 } else if need_interop {
                     let stmt = import_expr
-                        .make_assign_to(op!("="), mod_ident.as_pat_or_expr())
+                        .make_assign_to(op!("="), mod_ident.into())
                         .into_stmt();
                     stmts.push(stmt);
                 } else if need_re_export {
@@ -401,7 +401,7 @@ where
                     span: DUMMY_SP,
                     props: Default::default(),
                 })
-                .make_assign_to(op!("="), global_lib.as_pat_or_expr())
+                .make_assign_to(op!("="), global_lib.into())
                 .as_arg(),
             );
             factory_params.push(self.exports().into());
@@ -447,8 +447,7 @@ where
             .make_bin(op!("&&"), js_typeof!(module_exports.clone() => "object"));
         let mut cjs_if_body = factory.clone().as_call(DUMMY_SP, cjs_args);
         if is_export_assign {
-            cjs_if_body =
-                cjs_if_body.make_assign_to(op!("="), module_exports.clone().as_pat_or_expr());
+            cjs_if_body = cjs_if_body.make_assign_to(op!("="), module_exports.clone().into());
         }
 
         let amd_if_test = js_typeof!(define.clone() => "function").make_bin(op!("&&"), define_amd);
@@ -470,12 +469,11 @@ where
             cons: Box::new(global_this.into()),
             alt: Box::new(global.clone().make_bin(op!("||"), js_self)),
         }
-        .make_assign_to(op!("="), global.clone().as_pat_or_expr());
+        .make_assign_to(op!("="), global.clone().into());
 
         let mut browser_if_body = factory.clone().as_call(DUMMY_SP, browser_args);
         if is_export_assign {
-            browser_if_body =
-                browser_if_body.make_assign_to(op!("="), module_exports.as_pat_or_expr());
+            browser_if_body = browser_if_body.make_assign_to(op!("="), module_exports.into());
         }
 
         let adapter_body = BlockStmt {

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -282,7 +282,7 @@ pub(crate) fn esm_export() -> Function {
 
     let getter = KeyValueProp {
         key: quote_ident!("get").into(),
-        value: Box::new(all.clone().computed_member(Expr::from(name.clone()))),
+        value: all.clone().computed_member(Expr::from(name.clone())).into(),
     };
 
     let body = object_define_enumerable(

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -461,7 +461,7 @@ impl Transform {
                                 // Foo.foo = bar.baz
                                 mutable_export_ids.insert(decl.id.to_id());
                                 let left = id.clone().make_member(decl.id.clone());
-                                let expr = init.make_assign_to(op!("="), left.as_pat_or_expr());
+                                let expr = init.make_assign_to(op!("="), left.into());
 
                                 ExprStmt {
                                     span: decl.span,
@@ -815,10 +815,8 @@ impl Transform {
 impl Transform {
     // Foo.x = x;
     fn assign_prop(id: &Id, prop: &Ident, span: Span) -> Stmt {
-        let expr = Expr::Ident(prop.clone()).make_assign_to(
-            op!("="),
-            id.clone().make_member(prop.clone()).as_pat_or_expr(),
-        );
+        let expr = Expr::Ident(prop.clone())
+            .make_assign_to(op!("="), id.clone().make_member(prop.clone()).into());
 
         Stmt::Expr(ExprStmt {
             span,
@@ -1027,10 +1025,7 @@ impl Transform {
                                     if decl.is_export {
                                         init = init.make_assign_to(
                                             op!("="),
-                                            cjs_exports
-                                                .clone()
-                                                .make_member(decl.id.clone())
-                                                .as_pat_or_expr(),
+                                            cjs_exports.clone().make_member(decl.id.clone()).into(),
                                         )
                                     }
 
@@ -1137,7 +1132,7 @@ impl Transform {
                             span,
                             expr: Box::new(expr.make_assign_to(
                                 op!("="),
-                                member_expr!(unresolved_span, module.exports).as_pat_or_expr(),
+                                member_expr!(unresolved_span, module.exports).into(),
                             )),
                         })
                         .into(),
@@ -1274,7 +1269,7 @@ impl EnumMemberItem {
             op!("="),
             Ident::from(enum_id.clone())
                 .computed_member(self.name.clone())
-                .as_pat_or_expr(),
+                .into(),
         );
 
         let outer_assign = if is_string {
@@ -1286,7 +1281,7 @@ impl EnumMemberItem {
                 op!("="),
                 Ident::from(enum_id.clone())
                     .computed_member(inner_assign)
-                    .as_pat_or_expr(),
+                    .into(),
             )
         };
 

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -869,7 +869,7 @@ impl Transform {
 
         if is_export {
             if let Some(id) = container_name.clone() {
-                left = Ident::from(id).make_member(ident);
+                left = Ident::from(id).make_member(ident).into();
                 assign_left = Pat::Expr(Box::new(left.clone()))
             }
         }
@@ -1181,7 +1181,7 @@ impl VisitMut for ExportedPatRewriter {
 
     fn visit_mut_pat(&mut self, n: &mut Pat) {
         if let Pat::Ident(BindingIdent { id, .. }) = n {
-            *n = Pat::Expr(Box::new(self.id.clone().make_member(id.take())));
+            *n = Pat::Expr(self.id.clone().make_member(id.take()).into());
             return;
         }
 
@@ -1223,7 +1223,7 @@ impl QueryRef for ExportQuery {
     fn query_ref(&self, ident: &Ident) -> Option<Expr> {
         self.export_id_list
             .contains(&ident.to_id())
-            .then(|| self.namesapce_id.clone().make_member(ident.clone()))
+            .then(|| self.namesapce_id.clone().make_member(ident.clone()).into())
     }
 
     fn query_lhs(&self, ident: &Ident) -> Option<Expr> {

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -302,7 +302,7 @@ impl<'a> VisitMut for EnumValueComputer<'a> {
                     member_name: ident.sym.clone(),
                 }) =>
             {
-                *expr = self.enum_id.clone().make_member(ident.clone());
+                *expr = self.enum_id.clone().make_member(ident.clone()).into();
             }
             Expr::Member(MemberExpr {
                 obj,

--- a/crates/swc_ecma_utils/src/constructor.rs
+++ b/crates/swc_ecma_utils/src/constructor.rs
@@ -145,9 +145,7 @@ impl VisitMut for ExprInjector<'_> {
                 span: DUMMY_SP,
                 exprs: iter::once(Box::new(Expr::Assign(AssignExpr {
                     span: DUMMY_SP,
-                    left: PatOrExpr::Pat(Box::new(Pat::Ident(
-                        self.injected_tmp.as_ref().cloned().unwrap().into(),
-                    ))),
+                    left: self.injected_tmp.as_ref().cloned().unwrap().into(),
                     op: op!("="),
                     right: Box::new(e),
                 })))

--- a/crates/swc_ecma_utils/src/factory.rs
+++ b/crates/swc_ecma_utils/src/factory.rs
@@ -15,7 +15,7 @@ use swc_ecma_ast::*;
 ///
 /// to create literals. Almost all rust core types implements `Into<Expr>`.
 #[allow(clippy::wrong_self_convention)]
-pub trait ExprFactory: Into<Expr> {
+pub trait ExprFactory: Into<Box<Expr>> {
     /// Creates an [ExprOrSpread] using the given [Expr].
     ///
     /// This is recommended way to create [ExprOrSpread].
@@ -37,14 +37,9 @@ pub trait ExprFactory: Into<Expr> {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn as_arg(self) -> ExprOrSpread {
         ExprOrSpread {
-            expr: Box::new(self.into()),
+            expr: self.into(),
             spread: None,
         }
-    }
-
-    #[cfg_attr(not(debug_assertions), inline(always))]
-    fn as_pat_or_expr(self) -> PatOrExpr {
-        PatOrExpr::Expr(Box::new(self.into()))
     }
 
     /// Creates an expression statement with `self`.
@@ -52,7 +47,7 @@ pub trait ExprFactory: Into<Expr> {
     fn into_stmt(self) -> Stmt {
         Stmt::Expr(ExprStmt {
             span: DUMMY_SP,
-            expr: Box::new(self.into()),
+            expr: self.into(),
         })
     }
 
@@ -61,13 +56,13 @@ pub trait ExprFactory: Into<Expr> {
     fn into_return_stmt(self) -> ReturnStmt {
         ReturnStmt {
             span: DUMMY_SP,
-            arg: Some(Box::new(self.into())),
+            arg: Some(self.into()),
         }
     }
 
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn as_callee(self) -> Callee {
-        Callee::Expr(Box::new(self.into()))
+        Callee::Expr(self.into())
     }
 
     #[cfg_attr(not(debug_assertions), inline(always))]
@@ -87,7 +82,7 @@ pub trait ExprFactory: Into<Expr> {
         ArrowExpr {
             span: DUMMY_SP,
             params,
-            body: Box::new(BlockStmtOrExpr::from(self)),
+            body: Box::new(BlockStmtOrExpr::Expr(self.into())),
             is_async: false,
             is_generator: false,
             type_params: None,
@@ -132,7 +127,7 @@ pub trait ExprFactory: Into<Expr> {
         let var_declarator = VarDeclarator {
             span: DUMMY_SP,
             name,
-            init: Some(Box::new(self.into())),
+            init: Some(self.into()),
             definite: false,
         };
 
@@ -148,7 +143,7 @@ pub trait ExprFactory: Into<Expr> {
     fn into_new_expr(self, span: Span, args: Option<Vec<ExprOrSpread>>) -> NewExpr {
         NewExpr {
             span,
-            callee: Box::new(self.into()),
+            callee: self.into(),
             args,
             type_args: None,
         }
@@ -190,7 +185,7 @@ pub trait ExprFactory: Into<Expr> {
 
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn as_fn_decl(self) -> Option<FnDecl> {
-        match self.into() {
+        match *self.into() {
             Expr::Fn(FnExpr {
                 ident: Some(ident),
                 function,
@@ -205,7 +200,7 @@ pub trait ExprFactory: Into<Expr> {
 
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn as_class_decl(self) -> Option<ClassDecl> {
-        match self.into() {
+        match *self.into() {
             Expr::Class(ClassExpr {
                 ident: Some(ident),
                 class,
@@ -220,7 +215,7 @@ pub trait ExprFactory: Into<Expr> {
 
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn wrap_with_paren(self) -> Expr {
-        let expr = Box::new(self.into());
+        let expr = self.into();
         let span = expr.span();
         Expr::Paren(ParenExpr { expr, span })
     }
@@ -244,7 +239,7 @@ pub trait ExprFactory: Into<Expr> {
 
         Expr::Bin(BinExpr {
             span: DUMMY_SP,
-            left: Box::new(self.into()),
+            left: self.into(),
             op,
             right,
         })
@@ -252,8 +247,8 @@ pub trait ExprFactory: Into<Expr> {
 
     /// Creates a assign expr `$lhs $op $self`
     #[cfg_attr(not(debug_assertions), inline(always))]
-    fn make_assign_to(self, op: AssignOp, left: PatOrExpr) -> Expr {
-        let right = Box::new(self.into());
+    fn make_assign_to(self, op: AssignOp, left: AssignTarget) -> Expr {
+        let right = self.into();
 
         Expr::Assign(AssignExpr {
             span: DUMMY_SP,
@@ -264,34 +259,34 @@ pub trait ExprFactory: Into<Expr> {
     }
 
     #[cfg_attr(not(debug_assertions), inline(always))]
-    fn make_member<T>(self, prop: T) -> Expr
+    fn make_member<T>(self, prop: T) -> MemberExpr
     where
         T: Into<Ident>,
     {
-        Expr::Member(MemberExpr {
-            obj: Box::new(self.into()),
+        MemberExpr {
+            obj: self.into(),
             span: DUMMY_SP,
             prop: MemberProp::Ident(prop.into()),
-        })
+        }
     }
 
     #[cfg_attr(not(debug_assertions), inline(always))]
-    fn computed_member<T>(self, prop: T) -> Expr
+    fn computed_member<T>(self, prop: T) -> MemberExpr
     where
-        T: Into<Expr>,
+        T: Into<Box<Expr>>,
     {
-        Expr::Member(MemberExpr {
-            obj: Box::new(self.into()),
+        MemberExpr {
+            obj: self.into(),
             span: DUMMY_SP,
             prop: MemberProp::Computed(ComputedPropName {
                 span: DUMMY_SP,
-                expr: Box::new(prop.into()),
+                expr: prop.into(),
             }),
-        })
+        }
     }
 }
 
-impl<T: Into<Expr>> ExprFactory for T {}
+impl<T: Into<Box<Expr>>> ExprFactory for T {}
 
 pub trait IntoIndirectCall
 where
@@ -343,12 +338,12 @@ impl IntoIndirectCall for TaggedTpl {
     }
 }
 
-pub trait FunctionFactory: Into<Function> {
+pub trait FunctionFactory: Into<Box<Function>> {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn into_fn_expr(self, ident: Option<Ident>) -> FnExpr {
         FnExpr {
             ident,
-            function: Box::new(self.into()),
+            function: self.into(),
         }
     }
 
@@ -357,7 +352,7 @@ pub trait FunctionFactory: Into<Function> {
         FnDecl {
             ident,
             declare: false,
-            function: Box::new(self.into()),
+            function: self.into(),
         }
     }
 
@@ -365,9 +360,9 @@ pub trait FunctionFactory: Into<Function> {
     fn into_method_prop(self, key: PropName) -> MethodProp {
         MethodProp {
             key,
-            function: Box::new(self.into()),
+            function: self.into(),
         }
     }
 }
 
-impl<T: Into<Function>> FunctionFactory for T {}
+impl<T: Into<Box<Function>>> FunctionFactory for T {}

--- a/crates/swc_ecma_utils/src/factory.rs
+++ b/crates/swc_ecma_utils/src/factory.rs
@@ -247,7 +247,7 @@ pub trait ExprFactory: Into<Box<Expr>> {
 
     /// Creates a assign expr `$lhs $op $self`
     #[cfg_attr(not(debug_assertions), inline(always))]
-    fn make_assign_to(self, op: AssignOp, left: AssignTarget) -> Expr {
+    fn make_assign_to(self, op: AssignOp, left: PatOrExpr) -> Expr {
         let right = self.into();
 
         Expr::Assign(AssignExpr {

--- a/crates/swc_ecma_utils/src/function/function_wrapper.rs
+++ b/crates/swc_ecma_utils/src/function/function_wrapper.rs
@@ -195,7 +195,7 @@ impl<T> FunctionWrapper<T> {
         let assign_stmt = AssignExpr {
             span: DUMMY_SP,
             op: op!("="),
-            left: PatOrExpr::Expr(Box::new(Expr::Ident(ref_ident.clone()))),
+            left: ref_ident.clone().into(),
             right: Box::new(self.function.take()),
         }
         .into_stmt();

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -489,7 +489,7 @@ impl Visit for Hoister {
     fn visit_assign_pat_prop(&mut self, node: &AssignPatProp) {
         node.value.visit_with(self);
 
-        self.vars.push(node.key.id.clone());
+        self.vars.push(node.key.clone());
     }
 
     fn visit_fn_decl(&mut self, f: &FnDecl) {
@@ -2975,18 +2975,18 @@ impl VisitMut for IdentRenamer<'_> {
                 match p.value.take() {
                     Some(default) => {
                         *i = ObjectPatProp::KeyValue(KeyValuePatProp {
-                            key: PropName::Ident(orig.id),
+                            key: PropName::Ident(orig),
                             value: Box::new(Pat::Assign(AssignPat {
                                 span: DUMMY_SP,
-                                left: Box::new(Pat::Ident(p.key.clone())),
+                                left: p.key.clone().into(),
                                 right: default,
                             })),
                         });
                     }
                     None => {
                         *i = ObjectPatProp::KeyValue(KeyValuePatProp {
-                            key: PropName::Ident(orig.id),
-                            value: Box::new(Pat::Ident(p.key.clone())),
+                            key: PropName::Ident(orig),
+                            value: p.key.clone().into(),
                         });
                     }
                 }

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -489,7 +489,7 @@ impl Visit for Hoister {
     fn visit_assign_pat_prop(&mut self, node: &AssignPatProp) {
         node.value.visit_with(self);
 
-        self.vars.push(node.key.clone());
+        self.vars.push(node.key.id.clone());
     }
 
     fn visit_fn_decl(&mut self, f: &FnDecl) {
@@ -2975,18 +2975,18 @@ impl VisitMut for IdentRenamer<'_> {
                 match p.value.take() {
                     Some(default) => {
                         *i = ObjectPatProp::KeyValue(KeyValuePatProp {
-                            key: PropName::Ident(orig),
+                            key: PropName::Ident(orig.id),
                             value: Box::new(Pat::Assign(AssignPat {
                                 span: DUMMY_SP,
-                                left: Box::new(Pat::Ident(p.key.clone().into())),
+                                left: Box::new(Pat::Ident(p.key.clone())),
                                 right: default,
                             })),
                         });
                     }
                     None => {
                         *i = ObjectPatProp::KeyValue(KeyValuePatProp {
-                            key: PropName::Ident(orig),
-                            value: Box::new(Pat::Ident(p.key.clone().into())),
+                            key: PropName::Ident(orig.id),
+                            value: Box::new(Pat::Ident(p.key.clone())),
                         });
                     }
                 }

--- a/crates/swc_ecma_utils/src/macros.rs
+++ b/crates/swc_ecma_utils/src/macros.rs
@@ -83,11 +83,11 @@ macro_rules! member_expr {
         use $crate::swc_ecma_ast::*;
         let prop = MemberProp::Ident($crate::quote_ident!($span, stringify!($first)));
 
-        Box::new(Expr::Member(MemberExpr{
+        MemberExpr{
             span: $crate::swc_common::DUMMY_SP,
             obj: $obj,
             prop,
-        }))
+        }
     }};
 }
 
@@ -100,7 +100,7 @@ mod tests {
 
     #[test]
     fn quote_member_expr() {
-        let expr: Box<Expr> = drop_span(member_expr!(span, Function.prototype.bind));
+        let expr: Box<Expr> = drop_span(member_expr!(span, Function.prototype.bind)).into();
 
         assert_eq!(
             expr,

--- a/crates/swc_ecma_utils/src/node_ignore_span.rs
+++ b/crates/swc_ecma_utils/src/node_ignore_span.rs
@@ -78,8 +78,8 @@ fn test_hash_eq_ignore_span_expr_ref() {
             let meaningful_ident_expr = Expr::Ident(Ident::new("foo".into(), meaningful_sp));
             let dummy_ident_expr = Expr::Ident(Ident::new("foo".into(), dummy_sp));
 
-            let meaningful_member_expr = member_expr!(meaningful_sp, foo.bar);
-            let dummy_member_expr = member_expr!(dummy_sp, foo.bar);
+            let meaningful_member_expr = member_expr!(meaningful_sp, foo.bar).into();
+            let dummy_member_expr = member_expr!(dummy_sp, foo.bar).into();
 
             let meaningful_null_expr = quote_expr!(meaningful_sp, null);
             let dummy_null_expr = quote_expr!(dummy_sp, null);
@@ -123,7 +123,7 @@ fn test_hash_eq_ignore_span_expr_ref() {
 
             // Should not equal ignoring span and syntax context
             let dummy_ident_expr = Expr::Ident(Ident::new("baz".into(), dummy_sp));
-            let dummy_member_expr = member_expr!(dummy_sp, baz.bar);
+            let dummy_member_expr = member_expr!(dummy_sp, baz.bar).into();
             let dummy_arrow_expr = Box::new(Expr::Arrow(ArrowExpr::dummy()));
             assert!(!set.contains(&expr_ref(&dummy_ident_expr)));
             assert!(!set.contains(&expr_ref(&dummy_member_expr)));


### PR DESCRIPTION
**Description:**

This PR is extracted from #8333 because it's too large. 

**Breaking Changes**:
  - `ExprFactory::make_member()` now returns `MemberExpr` instead of `Box<Expr>`.
  - `member_expr!()` now returns `MemberExpr` instead of `Box<Expr>`.


**Related issue (if exists):**
