### PR TITLE
fix(es/codegen): Fix codegen of ts specific syntax in class props

### DIFF
--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1533,6 +1533,12 @@ where
 
         emit!(n.key);
         if let Some(type_ann) = &n.type_ann {
+            if n.is_optional {
+                punct!("?");
+            }
+            if n.definite {
+                punct!("!");
+            }
             punct!(":");
             space!();
             emit!(type_ann);
@@ -1583,6 +1589,9 @@ where
         emit!(n.key);
 
         if let Some(ty) = &n.type_ann {
+            if n.definite {
+                punct!("!");
+            }
             punct!(":");
             space!();
             emit!(ty);

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/input.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/input.js
@@ -1,0 +1,8 @@
+class MyClass {
+    prop1?: string;
+    prop2!: string;
+    #prop3?: string;
+    #prop4?: string = "test";
+    static readonly prop5!: string;
+    readonly #prop6 = "asdf";
+}

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/output.js
@@ -1,0 +1,8 @@
+class MyClass {
+    prop1?: string;
+    prop2!: string;
+    #prop3?: string;
+    #prop4?: string = "test";
+    static readonly prop5!: string;
+    readonly #prop6 = "asdf";
+}

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/output.min.js
@@ -1,0 +1,1 @@
+class MyClass{prop1?: string;prop2!: string;#prop3?: string;#prop4?: string="test";static readonly prop5!: string;readonly #prop6="asdf"}

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/1160/1/output.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/1160/1/output.ts
@@ -3,7 +3,7 @@ enum MyEnum {
     y = "yyy"
 }
 class Xpto {
-    value: MyEnum;
+    value!: MyEnum;
 }
 _ts_decorate([
     Decorator(),

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/1421/1/output.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/1421/1/output.ts
@@ -1,5 +1,5 @@
 class User {
-    currency: "usd" | "eur" | "yen";
+    currency!: "usd" | "eur" | "yen";
 }
 _ts_decorate([
     column(),

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-only/issues/862/1/output.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-only/issues/862/1/output.ts
@@ -1,10 +1,10 @@
 export class Product extends TimestampedEntity {
-    id: string;
-    price: number;
-    type: ProductType;
-    productEntityId: string;
-    /* ANCHOR: Relations ------------------------------------------------------ */ orders: Order[];
-    discounts: Discount[];
+    id!: string;
+    price!: number;
+    type!: ProductType;
+    productEntityId!: string;
+    /* ANCHOR: Relations ------------------------------------------------------ */ orders!: Order[];
+    discounts!: Discount[];
 }
 _ts_decorate([
     PrimaryGeneratedColumn("uuid")

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-only/issues/862/2/output.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-only/issues/862/2/output.ts
@@ -1,5 +1,5 @@
 export class Product extends TimestampedEntity {
-    id: string;
+    id!: string;
 }
 _ts_decorate([
     PrimaryGeneratedColumn("uuid")

--- a/crates/swc_ecma_transforms_typescript/src/strip_type.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip_type.rs
@@ -144,6 +144,7 @@ impl VisitMut for StripType {
         prop.readonly = false;
         prop.is_override = false;
         prop.is_optional = false;
+        prop.definite = false;
         prop.accessibility = None;
         prop.visit_mut_children_with(self);
     }
@@ -152,6 +153,7 @@ impl VisitMut for StripType {
         prop.readonly = false;
         prop.is_override = false;
         prop.is_optional = false;
+        prop.definite = false;
         prop.accessibility = None;
         prop.visit_mut_children_with(self);
     }


### PR DESCRIPTION
**Description:** This fixes the codegen of private properties with `is_optional` or`definite` and class properties with `definite`.

**Related issue (if exists):** None
