### PR TITLE
feat: add support for linux riscv64 gnu

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -118,6 +118,17 @@ jobs:
               rm -rf target/release/.cargo-lock &&
               cp bindings/target/aarch64-unknown-linux-musl/release/swc . && chmod +x ./swc &&
               env RUSTFLAGS='-C target-feature=-crt-static' yarn build --target=aarch64-unknown-linux-musl
+          - host: ubuntu-latest
+            target: riscv64gc-unknown-linux-gnu
+            setup: |
+              sudo apt-get update
+              sudo apt-get install gcc-riscv64-linux-gnu -y
+            build: >-
+              set -e &&
+              CARGO_TARGET_RISCV64GC_UNKNOWN_LINUX_GNU_LINKER=riscv64-linux-gnu-gcc cargo build --manifest-path ./bindings/swc_cli/Cargo.toml --release --features plugin --target riscv64gc-unknown-linux-gnu &&
+              rm -rf bindings/target/riscv64gc-unknown-linux-gnu/release/.cargo-lock &&
+              cp bindings/target/riscv64gc-unknown-linux-gnu/release/swc . && chmod +x ./swc &&
+              yarn build --target riscv64gc-unknown-linux-gnu
           - host: windows-latest
             target: aarch64-pc-windows-msvc
             # Disable `LTO` and increase `codegen-units` to avoid llvm `OOM` on GitHub Actions.

--- a/.github/workflows/publish-extra-bindings.yml
+++ b/.github/workflows/publish-extra-bindings.yml
@@ -93,6 +93,13 @@ jobs:
               rustup toolchain install $(cat ./rust-toolchain) &&
               rustup target add aarch64-unknown-linux-musl &&
               (cd packages/${{ github.event.inputs.package }} && env RUSTFLAGS='-C target-feature=-crt-static' yarn build --target=aarch64-unknown-linux-musl)
+          - host: ubuntu-latest
+            target: riscv64gc-unknown-linux-gnu
+            setup: |
+              sudo apt-get update
+              sudo apt-get install gcc-riscv64-linux-gnu -y
+            build: |
+              (cd packages/${{ github.event.inputs.package }} && yarn build --target riscv64gc-unknown-linux-gnu)
           - host: windows-latest
             target: aarch64-pc-windows-msvc
             # Disable `LTO` and increase `codegen-units` to avoid llvm `OOM` on GitHub Actions.

--- a/node-swc/src/binding.js
+++ b/node-swc/src/binding.js
@@ -269,6 +269,35 @@ switch (platform) {
           loadError = e
         }
         break
+      case 'riscv64':
+        if (isMusl()) {
+          localFileExisted = existsSync(
+            join(__dirname, 'swc.linux-riscv64-musl.node')
+          )
+          try {
+            if (localFileExisted) {
+              nativeBinding = require('./swc.linux-riscv64-musl.node')
+            } else {
+              nativeBinding = require('@swc/core-linux-riscv64-musl')
+            }
+          } catch (e) {
+            loadError = e
+          }
+        } else {
+          localFileExisted = existsSync(
+            join(__dirname, 'swc.linux-riscv64-gnu.node')
+          )
+          try {
+            if (localFileExisted) {
+              nativeBinding = require('./swc.linux-riscv64-gnu.node')
+            } else {
+              nativeBinding = require('@swc/core-linux-riscv64-gnu')
+            }
+          } catch (e) {
+            loadError = e
+          }
+        }
+        break
       default:
         throw new Error(`Unsupported architecture on Linux: ${arch}`)
     }

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
                 "aarch64-unknown-linux-gnu",
                 "aarch64-apple-darwin",
                 "aarch64-unknown-linux-musl",
-                "aarch64-pc-windows-msvc"
+                "aarch64-pc-windows-msvc",
+                "riscv64gc-unknown-linux-gnu"
             ]
         }
     },

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -30,7 +30,8 @@
                 "aarch64-unknown-linux-gnu",
                 "aarch64-apple-darwin",
                 "aarch64-unknown-linux-musl",
-                "aarch64-pc-windows-msvc"
+                "aarch64-pc-windows-msvc",
+                "riscv64gc-unknown-linux-gnu"
             ]
         }
     },

--- a/packages/html/scripts/npm/linux-riscv64-gnu/README.md
+++ b/packages/html/scripts/npm/linux-riscv64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/html-linux-riscv64-gnu`
+
+This is the **riscv64gc-unknown-linux-gnu** binary for `@swc/html`

--- a/packages/html/scripts/npm/linux-riscv64-gnu/package.json
+++ b/packages/html/scripts/npm/linux-riscv64-gnu/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@swc/html-linux-riscv64-gnu",
+    "version": "1.2.130",
+    "os": [
+        "linux"
+    ],
+    "cpu": [
+        "riscv64"
+    ],
+    "main": "html.linux-riscv64-gnu.node",
+    "files": [
+        "html.linux-riscv64-gnu.node",
+        "swc"
+    ],
+    "libc": [
+        "glibc"
+    ],
+    "description": "Super-fast alternative for babel",
+    "keywords": [
+        "swc",
+        "swcpack",
+        "babel",
+        "typescript",
+        "rust",
+        "webpack",
+        "tsc"
+    ],
+    "author": "강동윤 <kdy1997.dev@gmail.com>",
+    "homepage": "https://swc.rs",
+    "license": "Apache-2.0 AND MIT",
+    "engines": {
+        "node": ">=10"
+    },
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/swc-project/swc.git"
+    },
+    "bugs": {
+        "url": "https://github.com/swc-project/swc/issues"
+    }
+}

--- a/packages/minifier/package.json
+++ b/packages/minifier/package.json
@@ -32,7 +32,8 @@
                 "armv7-unknown-linux-gnueabihf",
                 "aarch64-apple-darwin",
                 "aarch64-unknown-linux-musl",
-                "aarch64-pc-windows-msvc"
+                "aarch64-pc-windows-msvc",
+                "riscv64gc-unknown-linux-gnu"
             ]
         }
     },

--- a/packages/minifier/scripts/npm/linux-riscv64-gnu/README.md
+++ b/packages/minifier/scripts/npm/linux-riscv64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/minifier-linux-riscv64-gnu`
+
+This is the **riscv64gc-unknown-linux-gnu** binary for `@swc/minifier`

--- a/packages/minifier/scripts/npm/linux-riscv64-gnu/package.json
+++ b/packages/minifier/scripts/npm/linux-riscv64-gnu/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@swc/minifier-linux-riscv64-gnu",
+    "version": "1.3.100",
+    "os": [
+        "linux"
+    ],
+    "cpu": [
+        "riscv64"
+    ],
+    "main": "minifier.linux-riscv64-gnu.node",
+    "files": [
+        "minifier.linux-riscv64-gnu.node",
+        "swc"
+    ],
+    "libc": [
+        "glibc"
+    ],
+    "description": "Super-fast alternative for babel",
+    "keywords": [
+        "swc",
+        "swcpack",
+        "babel",
+        "typescript",
+        "rust",
+        "webpack",
+        "tsc"
+    ],
+    "author": "강동윤 <kdy1997.dev@gmail.com>",
+    "homepage": "https://swc.rs",
+    "license": "Apache-2.0 AND MIT",
+    "engines": {
+        "node": ">=10"
+    },
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/swc-project/swc.git"
+    },
+    "bugs": {
+        "url": "https://github.com/swc-project/swc/issues"
+    }
+}

--- a/packages/minifier/src/binding.js
+++ b/packages/minifier/src/binding.js
@@ -269,6 +269,35 @@ switch (platform) {
           loadError = e
         }
         break
+      case 'riscv64':
+        if (isMusl()) {
+          localFileExisted = existsSync(
+            join(__dirname, 'minifier.linux-riscv64-musl.node')
+          )
+          try {
+            if (localFileExisted) {
+              nativeBinding = require('./minifier.linux-riscv64-musl.node')
+            } else {
+              nativeBinding = require('@swc/minifier-linux-riscv64-musl')
+            }
+          } catch (e) {
+            loadError = e
+          }
+        } else {
+          localFileExisted = existsSync(
+            join(__dirname, 'minifier.linux-riscv64-gnu.node')
+          )
+          try {
+            if (localFileExisted) {
+              nativeBinding = require('./minifier.linux-riscv64-gnu.node')
+            } else {
+              nativeBinding = require('@swc/minifier-linux-riscv64-gnu')
+            }
+          } catch (e) {
+            loadError = e
+          }
+        }
+        break
       default:
         throw new Error(`Unsupported architecture on Linux: ${arch}`)
     }

--- a/packages/xml/package.json
+++ b/packages/xml/package.json
@@ -30,7 +30,8 @@
                 "aarch64-unknown-linux-gnu",
                 "aarch64-apple-darwin",
                 "aarch64-unknown-linux-musl",
-                "aarch64-pc-windows-msvc"
+                "aarch64-pc-windows-msvc",
+                "riscv64gc-unknown-linux-gnu"
             ]
         }
     },

--- a/packages/xml/scripts/npm/linux-riscv64-gnu/README.md
+++ b/packages/xml/scripts/npm/linux-riscv64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/xml-linux-riscv64-gnu`
+
+This is the **riscv64gc-unknown-linux-gnu** binary for `@swc/xml`

--- a/packages/xml/scripts/npm/linux-riscv64-gnu/package.json
+++ b/packages/xml/scripts/npm/linux-riscv64-gnu/package.json
@@ -1,0 +1,45 @@
+{
+    "name": "@swc/xml-linux-riscv64-gnu",
+    "version": "1.2.130",
+    "os": [
+        "linux"
+    ],
+    "cpu": [
+        "riscv64"
+    ],
+    "main": "xml.linux-riscv64-gnu.node",
+    "files": [
+        "xml.linux-riscv64-gnu.node",
+        "swc"
+    ],
+    "libc": [
+        "glibc"
+    ],
+    "description": "Super-fast alternative for babel",
+    "keywords": [
+        "swc",
+        "swcpack",
+        "babel",
+        "typescript",
+        "rust",
+        "webpack",
+        "tsc"
+    ],
+    "author": "강동윤 <kdy1997.dev@gmail.com>",
+    "homepage": "https://swc.rs",
+    "license": "Apache-2.0 AND MIT",
+    "engines": {
+        "node": ">=10"
+    },
+    "publishConfig": {
+        "registry": "https://registry.npmjs.org/",
+        "access": "public"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/swc-project/swc.git"
+    },
+    "bugs": {
+        "url": "https://github.com/swc-project/swc/issues"
+    }
+}

--- a/scripts/npm/linux-riscv64-gnu/README.md
+++ b/scripts/npm/linux-riscv64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/core-linux-riscv64-gnu`
+
+This is the **riscv64gc-unknown-linux-gnu** binary for `@swc/core`

--- a/scripts/npm/linux-riscv64-gnu/package.json
+++ b/scripts/npm/linux-riscv64-gnu/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@swc/core-linux-riscv64-gnu",
+  "version": "1.3.100",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "riscv64"
+  ],
+  "main": "swc.linux-riscv64-gnu.node",
+  "files": [
+    "swc.linux-riscv64-gnu.node",
+    "swc"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast alternative for babel",
+  "keywords": [
+    "swc",
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR adds build for riscv64 linux gnu target.

`packages/html` and `packages/xml` seem to reference non existent crates like `bindings/binding_html_node` so I didn't regenerate the `binding.js` file for them. Looks like `@swc-lab/xml` and `@swc-lab/html` are not published to npm anyway.



