### PR TITLE
fix(es/codegen): Correct emit for type-only export declarations

### DIFF
--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -483,7 +483,7 @@ where
 
         if let Some(spec) = namespace_spec {
             emit!(spec);
-             if has_named_specs {
+            if has_named_specs {
                 punct!(",");
                 formatting_space!();
             }

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -415,6 +415,11 @@ where
 
         srcmap!(node, true);
 
+        if node.is_type_only {
+            keyword!("type");
+            space!();
+        }
+
         if let Some(exported) = &node.exported {
             emit!(node.orig);
             space!();
@@ -470,10 +475,15 @@ where
 
         keyword!("export");
 
+        if node.type_only {
+            space!();
+            keyword!("type");
+        }
         formatting_space!();
+
         if let Some(spec) = namespace_spec {
             emit!(spec);
-            if has_named_specs {
+             if has_named_specs {
                 punct!(",");
                 formatting_space!();
             }
@@ -521,7 +531,15 @@ where
         srcmap!(node, true);
 
         keyword!("export");
-        formatting_space!();
+
+        if node.type_only {
+            space!();
+            keyword!("type");
+            space!();
+        } else {
+            formatting_space!();
+        }
+
         punct!("*");
         formatting_space!();
         keyword!("from");

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/exports/input.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/exports/input.js
@@ -1,0 +1,3 @@
+export type * as test from "./a.ts";
+export type { a } from "./a.ts";
+export { b, type b2 } from "./b.ts";

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/exports/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/exports/output.js
@@ -1,0 +1,3 @@
+export type * as test from "./a.ts";
+export type { a } from "./a.ts";
+export { b, type b2 } from "./b.ts";

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/exports/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/exports/output.min.js
@@ -1,0 +1,1 @@
+export type*as test from"./a.ts";export type{a}from"./a.ts";export{b,type b2}from"./b.ts";

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/imports/input.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/imports/input.js
@@ -1,0 +1,4 @@
+import type test from "./a.ts";
+import type { a } from "./a.ts";
+import type * as name from "./a.ts";
+import { b, type c } from "./a.ts";

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/imports/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/imports/output.js
@@ -1,0 +1,4 @@
+import type test from "./a.ts";
+import type { a } from "./a.ts";
+import type * as name from "./a.ts";
+import { b, type c } from "./a.ts";

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/imports/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/imports/output.min.js
@@ -1,0 +1,1 @@
+import type test from"./a.ts";import type{a}from"./a.ts";import type*as name from"./a.ts";import{b,type c}from"./a.ts";

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/ts_import_equals/input.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/ts_import_equals/input.js
@@ -1,2 +1,3 @@
 import Test1 = MyNamespace.Test1;
 import Test2 = Test1;
+export import Test3 = Test1;

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/ts_import_equals/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/ts_import_equals/output.js
@@ -1,2 +1,3 @@
 import Test1 = MyNamespace.Test1;
 import Test2 = Test1;
+export import Test3 = Test1;

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/ts_import_equals/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/ts_import_equals/output.min.js
@@ -1,1 +1,1 @@
-import Test1=MyNamespace.Test1;import Test2=Test1;
+import Test1=MyNamespace.Test1;import Test2=Test1;export import Test3=Test1;


### PR DESCRIPTION
**Description:**

This fixes the emit for `export type { } from "..."` and `export { type A } from "..."`.

**Related issue (if exists):** None
