### PR TITLE
fix(es/minifier): Add WeakRef as a safe global reference

### DIFF
--- a/crates/swc_ecma_usage_analyzer/src/util.rs
+++ b/crates/swc_ecma_usage_analyzer/src/util.rs
@@ -39,6 +39,7 @@ pub fn is_global_var_with_pure_property_access(s: &str) -> bool {
             | "NaN"
             | "Symbol"
             | "Promise"
+            | "WeakRef"
     )
 }
 


### PR DESCRIPTION
**Description:**

I was trying to remove references to Weak Ref from minified code and despite the expression not being used, it was still included.

E.g.
```
var x = WeakRef;
```
with

```
{
   "minify": true,
  "jsc": {
      "minify": {
            "compress": {
                "pure_getters": true,
                "unused": true
            },
            "mangle": true
        }
    }
}
```
outputs

```
WeakRef;
```

but when I use something on this list e.g. parseFloat, it gets cleaned up and outputs empty string.

btw - I tried different options for pure_getters that I assumed would allow me to say WeakRef as a getter was pure, but it had no effect.

WeakRef getter is as safe to remove as the other items on this list and has no effect in accessing it.