### PR TITLE
fix(es/codegen): Emit implements clause with commas

### DIFF
--- a/crates/swc_ecma_ast/src/list.rs
+++ b/crates/swc_ecma_ast/src/list.rs
@@ -143,7 +143,7 @@ bitflags! {
             | Self::SpaceBetweenSiblings.bits()
             | Self::SpaceBetweenBraces.bits();
         const MultiLineFunctionBodyStatements = Self::MultiLine.bits();
-        const ClassHeritageClauses = Self::SingleLine.bits() | Self::SpaceBetweenSiblings.bits();
+        const ClassHeritageClauses = Self::CommaDelimited.bits() | Self::SingleLine.bits() | Self::SpaceBetweenSiblings.bits();
         const ClassMembers = Self::Indented.bits() | Self::MultiLine.bits();
         const InterfaceMembers = Self::Indented.bits() | Self::MultiLine.bits();
         const EnumMembers = Self::CommaDelimited.bits() | Self::Indented.bits() | Self::MultiLine.bits();

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_implements/input.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_implements/input.js
@@ -1,0 +1,2 @@
+class MyClass implements Interface1, Interface2 {
+}

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_implements/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_implements/output.js
@@ -1,0 +1,2 @@
+class MyClass implements Interface1, Interface2 {
+}

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_implements/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_implements/output.min.js
@@ -1,0 +1,1 @@
+class MyClass implements Interface1,Interface2{}


### PR DESCRIPTION
**Description:**

Emitting `implements` was missing commas.

**Related issue (if exists):** None