### PR TITLE
fix(es/codegen): Emit `?` for an optional computed property

### DIFF
--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1566,9 +1566,11 @@ where
         }
 
         emit!(n.key);
+
         if n.is_optional {
             punct!("?");
         }
+
         if let Some(type_ann) = &n.type_ann {
             if n.definite {
                 punct!("!");
@@ -1635,7 +1637,8 @@ where
 
         emit!(n.key);
 
-        // emit for a computed property, but not an identifier already marked as optional
+        // emit for a computed property, but not an identifier already marked as
+        // optional
         if n.is_optional && !n.key.as_ident().map(|i| i.optional).unwrap_or(false) {
             punct!("?");
         }

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1566,10 +1566,10 @@ where
         }
 
         emit!(n.key);
+        if n.is_optional {
+            punct!("?");
+        }
         if let Some(type_ann) = &n.type_ann {
-            if n.is_optional {
-                punct!("?");
-            }
             if n.definite {
                 punct!("!");
             }
@@ -1634,6 +1634,11 @@ where
         }
 
         emit!(n.key);
+
+        // emit for a computed property, but not an identifier already marked as optional
+        if n.is_optional && !n.key.as_ident().map(|i| i.optional).unwrap_or(false) {
+            punct!("?");
+        }
 
         if let Some(ty) = &n.type_ann {
             if n.definite {

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/input.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/input.js
@@ -3,9 +3,11 @@ class MyClass extends Base {
     prop2!: string;
     #prop3?: string;
     #prop4?: string = "test";
+    #privateOptionalNoType?;
     static readonly prop5!: string;
     readonly #prop6 = "asdf";
     public abstract override readonly prop7 = 5;
     override readonly #prop8 = 5;
     declare public static readonly prop9: string;
+    [value]?: string[];
 }

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/output.js
@@ -3,9 +3,11 @@ class MyClass extends Base {
     prop2!: string;
     #prop3?: string;
     #prop4?: string = "test";
+    #privateOptionalNoType?;
     static readonly prop5!: string;
     readonly #prop6 = "asdf";
     public abstract override readonly prop7 = 5;
     override readonly #prop8 = 5;
     declare public static readonly prop9: string;
+    [value]?: string[];
 }

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_prop/output.min.js
@@ -1,1 +1,1 @@
-class MyClass extends Base{prop1?: string;prop2!: string;#prop3?: string;#prop4?: string="test";static readonly prop5!: string;readonly #prop6="asdf";public abstract override readonly prop7=5;override readonly #prop8=5;declare public static readonly prop9: string}
+class MyClass extends Base{prop1?: string;prop2!: string;#prop3?: string;#prop4?: string="test";#privateOptionalNoType?;static readonly prop5!: string;readonly #prop6="asdf";public abstract override readonly prop7=5;override readonly #prop8=5;declare public static readonly prop9: string;[value]?: string[]}


### PR DESCRIPTION
**Description:** Emits optional `?` for a computed property.

**Related issue (if exists):** None