### PR TITLE
fix(es/parser): The non ident part should not affect the keyword evaluation

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -824,12 +824,16 @@ impl<'a> Lexer<'a> {
                 // Optimization
                 {
                     let s = l.input.uncons_while(|c| {
+                        if !c.is_ident_part() {
+                            return false;
+                        }
+
                         // Performance optimization
                         if c.is_ascii_uppercase() || c.is_ascii_digit() || !c.is_ascii() {
                             can_be_keyword = false;
                         }
 
-                        c.is_ident_part()
+                        true
                     });
                     if !s.is_empty() {
                         first = false;

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -153,12 +153,7 @@ const L_I: ByteHandler = Some(|lexer| {
     })
 });
 
-const L_J: ByteHandler = Some(|lexer| {
-    lexer.read_word_with(|s| match s {
-        "let" => Some(Word::Keyword(Keyword::Let)),
-        _ => None,
-    })
-});
+const L_J: ByteHandler = IDN;
 
 const L_K: ByteHandler = Some(|lexer| {
     lexer.read_word_with(|s| match s {


### PR DESCRIPTION
**Related issue:**

- Closes: #8482 
