### PR TITLE
fix(es): Fix plugin template & restore `test!` as `test_inline!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3480,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.5"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9db03534dff993187064c4e0c05a5708d2a9728ace9a8959b77bedf415dac5"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",

--- a/crates/swc_cli_impl/src/commands/plugin.rs
+++ b/crates/swc_cli_impl/src/commands/plugin.rs
@@ -238,7 +238,7 @@ build-wasm32 = "build --target wasm32-unknown-unknown"
             src_path.join("lib.rs"),
             r##"use swc_core::ecma::{
     ast::Program,
-    transforms::testing::test,
+    transforms::testing::test_inline,
     visit::{as_folder, FoldWith, VisitMut},
 };
 use swc_core::plugin::{plugin_transform, proxies::TransformPluginProgramMetadata};
@@ -275,7 +275,7 @@ pub fn process_transform(program: Program, _metadata: TransformPluginProgramMeta
 // Recommended strategy to test plugin's transform is verify
 // the Visitor's behavior, instead of trying to run `process_transform` with mocks
 // unless explicitly required to do so.
-test!(
+test_inline!(
     Default::default(),
     |_| as_folder(TransformVisitor),
     boo,

--- a/crates/swc_ecma_transforms_testing/Cargo.toml
+++ b/crates/swc_ecma_transforms_testing/Cargo.toml
@@ -18,7 +18,7 @@ base64     = "0.21"
 hex        = "0.4.3"
 serde      = "1"
 serde_json = "1"
-sha2       = "0.10"
+sha2       = "0.10.8"
 sourcemap  = "6.2"
 tempfile   = "3.6.0"
 

--- a/crates/swc_ecma_transforms_testing/src/lib.rs
+++ b/crates/swc_ecma_transforms_testing/src/lib.rs
@@ -487,17 +487,25 @@ macro_rules! test_inline {
         #[test]
         #[ignore]
         fn $test_name() {
-            $crate::test_inline_input_output($syntax, $tr, $input, Some($output))
+            $crate::test_inline_input_output($syntax, $tr, $input, $output)
         }
     };
 
     ($syntax:expr, $tr:expr, $test_name:ident, $input:expr, $output:expr) => {
         #[test]
         fn $test_name() {
-            $crate::test_inline_input_output($syntax, $tr, $input, Some($output))
+            $crate::test_inline_input_output($syntax, $tr, $input, $output)
         }
     };
 }
+
+test_inline!(
+    Syntax::default(),
+    |_| noop(),
+    noop_test,
+    "class Foo {}",
+    "class Foo {}"
+);
 
 #[macro_export]
 macro_rules! test {

--- a/crates/swc_ecma_transforms_testing/src/lib.rs
+++ b/crates/swc_ecma_transforms_testing/src/lib.rs
@@ -359,7 +359,7 @@ pub fn test_inlined_transform<F, P>(
     syntax: Syntax,
     tr: F,
     input: &str,
-    _always_ok_if_code_eq: bool,
+    expected_output: Option<&str>,
 ) where
     F: FnOnce(&mut Tester) -> P,
     P: Fold,
@@ -394,28 +394,57 @@ macro_rules! test_location {
     }};
 }
 
-/// Test transformation.
+#[macro_export]
+macro_rules! test_inline {
+    (ignore, $syntax:expr, $tr:expr, $test_name:ident, $input:expr, $output:expr) => {
+        #[test]
+        #[ignore]
+        fn $test_name() {
+            $crate::test_inlined_transform(
+                stringify!($test_name),
+                $syntax,
+                $tr,
+                $input,
+                Some($output),
+            )
+        }
+    };
+
+    ($syntax:expr, $tr:expr, $test_name:ident, $input:expr, $output:expr) => {
+        #[test]
+        fn $test_name() {
+            $crate::test_inlined_transform(
+                stringify!($test_name),
+                $syntax,
+                $tr,
+                $input,
+                Some($output),
+            )
+        }
+    };
+}
+
 #[macro_export]
 macro_rules! test {
     (ignore, $syntax:expr, $tr:expr, $test_name:ident, $input:expr) => {
         #[test]
         #[ignore]
         fn $test_name() {
-            $crate::test_inlined_transform(stringify!($test_name), $syntax, $tr, $input, false)
+            $crate::test_inlined_transform(stringify!($test_name), $syntax, $tr, $input, None)
         }
     };
 
     ($syntax:expr, $tr:expr, $test_name:ident, $input:expr) => {
         #[test]
         fn $test_name() {
-            $crate::test_inlined_transform(stringify!($test_name), $syntax, $tr, $input, false)
+            $crate::test_inlined_transform(stringify!($test_name), $syntax, $tr, $input, None)
         }
     };
 
     ($syntax:expr, $tr:expr, $test_name:ident, $input:expr, ok_if_code_eq) => {
         #[test]
         fn $test_name() {
-            $crate::test_inlined_transform(stringify!($test_name), $syntax, $tr, $input, true)
+            $crate::test_inlined_transform(stringify!($test_name), $syntax, $tr, $input, None)
         }
     };
 }

--- a/crates/swc_ecma_transforms_testing/src/lib.rs
+++ b/crates/swc_ecma_transforms_testing/src/lib.rs
@@ -500,6 +500,15 @@ macro_rules! test_inline {
 }
 
 test_inline!(
+    ignore,
+    Syntax::default(),
+    |_| noop(),
+    noop_ignored,
+    "class Foo {}",
+    "class Foo {}"
+);
+
+test_inline!(
     Syntax::default(),
     |_| noop(),
     noop_test,


### PR DESCRIPTION
**Description:**

I made a bad decision while migrating tests in the core repository to snapshot testing. So, I'm adding the `test!` macro back with a slight renaming.

**Related issue:**

 - Closes #8504