### PR TITLE
fix(plugin): Set `swc_common::errors::HANDLER` while invoking plugins

### DIFF
--- a/crates/swc_core/src/plugin.rs
+++ b/crates/swc_core/src/plugin.rs
@@ -53,12 +53,7 @@ pub mod memory {
     )))
 )]
 pub mod errors {
-    /// global context HANDLER in plugin's transform function.
-    pub static HANDLER: swc_plugin::pseudo_scoped_key::PseudoScopedKey<
-        swc_common::errors::Handler,
-    > = swc_plugin::pseudo_scoped_key::PseudoScopedKey {
-        inner: once_cell::sync::OnceCell::new(),
-    };
+    pub use swc_common::errors::HANDLER;
 }
 
 /// Plugin's environment metadata context.

--- a/crates/swc_plugin_macro/src/lib.rs
+++ b/crates/swc_plugin_macro/src/lib.rs
@@ -152,6 +152,8 @@ fn handle_func(func: ItemFn, ast_type: Ident) -> TokenStream {
                 return construct_error_ptr(err);
             }
 
+            let handler_set_result = handler_set_result.unwrap();
+
             // Construct metadata to the `Program` for the transform plugin.
             let plugin_comments_proxy = if should_enable_comments_proxy == 1 { Some(swc_core::plugin::proxies::PluginCommentsProxy) } else { None };
             let mut metadata = swc_core::plugin::metadata::TransformPluginProgramMetadata {
@@ -161,7 +163,9 @@ fn handle_func(func: ItemFn, ast_type: Ident) -> TokenStream {
             };
 
             // Take original plugin fn ident, then call it with interop'ed args
-            let transformed_program = swc_core::common::plugin::serialized::VersionedSerializable::new(#ident(program, metadata));
+            let transformed_program = swc_core::common::plugin::serialized::VersionedSerializable::new(swc_core::common::errors::HANDLER.set(&handler, || {
+                #ident(program, metadata)
+            }));
 
             // Serialize transformed result, return back to the host.
             let serialized_result = swc_core::common::plugin::serialized::PluginSerializedBytes::try_serialize(

--- a/crates/swc_plugin_macro/src/lib.rs
+++ b/crates/swc_plugin_macro/src/lib.rs
@@ -143,16 +143,6 @@ fn handle_func(func: ItemFn, ast_type: Ident) -> TokenStream {
                 false,
                 Box::new(PluginDiagnosticsEmitter)
             );
-            let handler_set_result = swc_core::plugin::errors::HANDLER.inner.set(handler);
-
-            if handler_set_result.is_err() {
-                let err = swc_core::common::plugin::serialized::PluginError::Serialize(
-                        "Failed to set handler for plugin".to_string()
-                    );
-                return construct_error_ptr(err);
-            }
-
-            let handler_set_result = handler_set_result.unwrap();
 
             // Construct metadata to the `Program` for the transform plugin.
             let plugin_comments_proxy = if should_enable_comments_proxy == 1 { Some(swc_core::plugin::proxies::PluginCommentsProxy) } else { None };


### PR DESCRIPTION
**Description:**

 - `swc_common::errors::handler::HANDLER` should be used, and `swc_core::plugin::errors::HANDLER` is now a simple alias.




**Related issue:**

 - Closes #8502