### PR TITLE
fix(es/typescript): Fix panic on invalid jsx pragma

### DIFF
--- a/crates/swc_ecma_transforms_typescript/tests/__swc_snapshots__/tests/strip.rs/ts_jsx_bad_pragma.js
+++ b/crates/swc_ecma_transforms_typescript/tests/__swc_snapshots__/tests/strip.rs/ts_jsx_bad_pragma.js
@@ -1,0 +1,1 @@
+/** @jsx bad-pragma */

--- a/crates/swc_ecma_transforms_typescript/tests/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip.rs
@@ -2797,3 +2797,27 @@ test!(
     console.log(I.A);
     "#
 );
+
+test!(
+    Syntax::Typescript(TsConfig::default()),
+    |t| {
+        let unresolved_mark = Mark::new();
+        let top_level_mark = Mark::new();
+
+        chain!(
+            resolver(unresolved_mark, top_level_mark, false),
+            tsx(
+                t.cm.clone(),
+                typescript::Config {
+                    verbatim_module_syntax: false,
+                    ..Default::default()
+                },
+                TsxConfig::default(),
+                t.comments.clone(),
+                top_level_mark,
+            )
+        )
+    },
+    ts_jsx_bad_pragma,
+    r#"/** @jsx bad-pragma */"#
+);


### PR DESCRIPTION

**Description:**

Currently a jsx pragma with an invalid js identifier (eg, with dashes: `@jsx bad-pragma` causes a panic.

This PR prevents a panic and will ignore an invalid pragma in a comment.

(There may be an argument for showing an error or warning instead, but given a jsx pragma is still valid ES I'm not sure whether that makes sense?)

[Original (Deno) issue here](https://github.com/denoland/deno/issues/21927)

