### PR TITLE
fix(es/quote): Add support for import phase to quote macro

### DIFF
--- a/crates/swc_ecma_quote_macros/src/ast/enums.rs
+++ b/crates/swc_ecma_quote_macros/src/ast/enums.rs
@@ -75,3 +75,4 @@ impl_simple_enum!(
 impl_simple_enum!(Accessibility, [Public, Protected, Private]);
 impl_simple_enum!(MethodKind, [Method, Getter, Setter]);
 impl_simple_enum!(MetaPropKind, [NewTarget, ImportMeta]);
+impl_simple_enum!(ImportPhase, [Defer, Source, Evaluation]);

--- a/crates/swc_ecma_quote_macros/src/ast/expr.rs
+++ b/crates/swc_ecma_quote_macros/src/ast/expr.rs
@@ -75,7 +75,7 @@ impl_struct!(CondExpr, [span, test, cons, alt]);
 impl_struct!(CallExpr, [span, callee, args, type_args]);
 impl_struct!(ExprOrSpread, [spread, expr]);
 impl_struct!(Super, [span]);
-impl_struct!(Import, [span]);
+impl_struct!(Import, [span, phase]);
 impl_struct!(NewExpr, [span, callee, args, type_args]);
 impl_struct!(SeqExpr, [span, exprs]);
 

--- a/crates/swc_ecma_quote_macros/src/ast/module_decl.rs
+++ b/crates/swc_ecma_quote_macros/src/ast/module_decl.rs
@@ -15,7 +15,7 @@ impl_enum!(
     ]
 );
 
-impl_struct!(ImportDecl, [span, specifiers, src, type_only, with]);
+impl_struct!(ImportDecl, [span, specifiers, src, type_only, with, phase]);
 impl_struct!(ExportDecl, [span, decl]);
 impl_struct!(ExportDefaultDecl, [span, decl]);
 impl_struct!(ExportDefaultExpr, [span, expr]);


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

When using quote! to generate import decl, compile error: missing field `phase` in initializer of 'swc_core::ecma::ast::Import'

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
