### PR TITLE
fix(es/loader): Don't use browser versions for `jsc.paths`

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1747,12 +1747,16 @@ fn build_resolver(
     }
 
     let r = {
-        let r = TsConfigResolver::new(
-            NodeModulesResolver::without_node_modules(Default::default(), Default::default(), true),
-            base_url.clone(),
-            paths.clone(),
+        let r = NodeModulesResolver::without_node_modules(
+            swc_ecma_loader::TargetEnv::Node,
+            Default::default(),
+            true,
         );
-        let r = CachingResolver::new(40, r);
+
+        let r = CachingResolver::new(1024, r);
+
+        let r = TsConfigResolver::new(r, base_url.clone(), paths.clone());
+        let r = CachingResolver::new(256, r);
 
         let r = NodeImportResolver::with_config(
             r,

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -203,8 +203,9 @@ pub mod resolver {
     }
 }
 
-type SwcImportResolver =
-    Arc<NodeImportResolver<CachingResolver<TsConfigResolver<NodeModulesResolver>>>>;
+type SwcImportResolver = Arc<
+    NodeImportResolver<CachingResolver<TsConfigResolver<CachingResolver<NodeModulesResolver>>>>,
+>;
 
 /// All methods accept [Handler], which is a storage for errors.
 ///


### PR DESCRIPTION
**Description:**



**Related issue:**

 - https://github.com/vercel/next.js/issues/56144