### PR TITLE
fix(es/decorator): Preserve state while traversing the `module_items` scope

### DIFF
--- a/crates/swc/tests/fixture/issues-8xxx/8551/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-8xxx/8551/input/.swcrc
@@ -1,0 +1,13 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true
+        },
+        "transform": {
+            "decoratorVersion": "2022-03"
+        },
+        "target": "es2022"
+    },
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-8xxx/8551/input/index.ts
+++ b/crates/swc/tests/fixture/issues-8xxx/8551/input/index.ts
@@ -1,0 +1,7 @@
+class C {
+    [Symbol.iterator]() { }
+}
+
+namespace NS {
+    export function f() { }
+}

--- a/crates/swc/tests/fixture/issues-8xxx/8551/output/index.ts
+++ b/crates/swc/tests/fixture/issues-8xxx/8551/output/index.ts
@@ -1,0 +1,10 @@
+var _computedKey;
+_computedKey = Symbol.iterator;
+class C {
+    [_computedKey]() {}
+}
+var NS;
+(function(NS) {
+    function f() {}
+    NS.f = f;
+})(NS || (NS = {}));

--- a/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
@@ -1499,7 +1499,10 @@ impl VisitMut for Decorator202203 {
     }
 
     fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
-        let old_extra_lets = self.extra_lets.take();
+        let extra_vars = self.extra_vars.take();
+        let extra_lets = self.extra_lets.take();
+        let pre_class_inits = self.pre_class_inits.take();
+        let extra_exports = self.extra_exports.take();
 
         let mut new = Vec::with_capacity(n.len());
 
@@ -1559,7 +1562,10 @@ impl VisitMut for Decorator202203 {
             n.visit_mut_with(&mut IdentRenamer::new(&self.rename_map));
         }
 
-        self.extra_lets = old_extra_lets;
+        self.extra_vars = extra_vars;
+        self.extra_lets = extra_lets;
+        self.pre_class_inits = pre_class_inits;
+        self.extra_exports = extra_exports;
     }
 
     fn visit_mut_private_prop(&mut self, p: &mut PrivateProp) {


### PR DESCRIPTION
**Related issue:**
- Closes: #8551 
