### PR TITLE
fix(es/testing): Make `test_inline!` not read output as a file

### DIFF
--- a/crates/swc_ecma_transforms_testing/src/lib.rs
+++ b/crates/swc_ecma_transforms_testing/src/lib.rs
@@ -361,12 +361,10 @@ where
 {
     let _logger = testing::init();
 
-    let expected = read_to_string(output);
-    let _is_really_expected = expected.is_ok();
-    let expected = expected.unwrap_or_default();
+    let expected = output;
 
     let expected_src = Tester::run(|tester| {
-        let expected_module = tester.apply_transform(noop(), "expected.js", syntax, &expected)?;
+        let expected_module = tester.apply_transform(noop(), "expected.js", syntax, expected)?;
 
         let expected_src = tester.print(&expected_module, &Default::default());
 

--- a/crates/swc_ecma_transforms_testing/src/lib.rs
+++ b/crates/swc_ecma_transforms_testing/src/lib.rs
@@ -409,8 +409,8 @@ where
 
         Ok(actual_src)
     })
-    .1
-    .to_string();
+    .0
+    .unwrap();
 
     assert_eq!(
         expected_src, actual_src,


### PR DESCRIPTION
**Description:**

I made a mistake while working on `test_inline!`

**Related issue:**

 - #8568