### PR TITLE
fix(es/typescript): Handle exported JSX binding name in TypeScript namespace

### DIFF
--- a/crates/swc/tests/fixture/issues-8xxx/8594/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-8xxx/8594/input/.swcrc
@@ -1,0 +1,19 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "target": "es2015",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": false,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-8xxx/8594/input/index.tsx
+++ b/crates/swc/tests/fixture/issues-8xxx/8594/input/index.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+
+export namespace FooNs {
+    export const Shared = () => 'I\'m shared component';
+    export const Main = () => <Shared/>;
+}

--- a/crates/swc/tests/fixture/issues-8xxx/8594/output/index.tsx
+++ b/crates/swc/tests/fixture/issues-8xxx/8594/output/index.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+export var FooNs;
+(function(FooNs) {
+    FooNs.Shared = ()=>'I\'m shared component';
+    FooNs.Main = ()=>React.createElement(FooNs.Shared, null);
+})(FooNs || (FooNs = {}));

--- a/crates/swc_ecma_transforms_module/src/module_ref_rewriter.rs
+++ b/crates/swc_ecma_transforms_module/src/module_ref_rewriter.rs
@@ -71,6 +71,11 @@ impl QueryRef for ImportQuery {
         None
     }
 
+    fn query_jsx(&self, _: &Ident) -> Option<JSXElementName> {
+        // We do not need to handle JSX since there is no jsx preserve option in swc
+        None
+    }
+
     fn should_fix_this(&self, ident: &Ident) -> bool {
         if self.helper_ctxt.iter().any(|ctxt| ctxt == &ident.span.ctxt) {
             return false;

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -1231,6 +1231,16 @@ impl QueryRef for ExportQuery {
         self.query_ref(ident)
     }
 
+    fn query_jsx(&self, ident: &Ident) -> Option<JSXElementName> {
+        self.export_id_list.contains(&ident.to_id()).then(|| {
+            JSXMemberExpr {
+                obj: JSXObject::Ident(self.namesapce_id.clone().into()),
+                prop: ident.clone(),
+            }
+            .into()
+        })
+    }
+
     fn should_fix_this(&self, _: &Ident) -> bool {
         // tsc does not care about `this` in namespace.
         false

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -3021,13 +3021,21 @@ impl VisitMut for IdentRenamer<'_> {
 }
 
 pub trait QueryRef {
-    fn query_ref(&self, ident: &Ident) -> Option<Expr>;
-    fn query_lhs(&self, ident: &Ident) -> Option<Expr>;
+    fn query_ref(&self, _ident: &Ident) -> Option<Expr> {
+        None
+    }
+    fn query_lhs(&self, _ident: &Ident) -> Option<Expr> {
+        None
+    }
     /// ref used in JSX
-    fn query_jsx(&self, ident: &Ident) -> Option<JSXElementName>;
+    fn query_jsx(&self, _ident: &Ident) -> Option<JSXElementName> {
+        None
+    }
     /// when `foo()` is replaced with `bar.baz()`,
     /// should `bar.baz` be indirect call?
-    fn should_fix_this(&self, ident: &Ident) -> bool;
+    fn should_fix_this(&self, _ident: &Ident) -> bool {
+        false
+    }
 }
 
 /// Replace `foo` with `bar` or `bar.baz`

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -3023,6 +3023,8 @@ impl VisitMut for IdentRenamer<'_> {
 pub trait QueryRef {
     fn query_ref(&self, ident: &Ident) -> Option<Expr>;
     fn query_lhs(&self, ident: &Ident) -> Option<Expr>;
+    /// ref used in JSX
+    fn query_jsx(&self, ident: &Ident) -> Option<JSXElementName>;
     /// when `foo()` is replaced with `bar.baz()`,
     /// should `bar.baz` be indirect call?
     fn should_fix_this(&self, ident: &Ident) -> bool;
@@ -3127,6 +3129,14 @@ where
 
         if should_fix_this && n.tag.is_member() {
             *n = n.take().into_indirect()
+        }
+    }
+
+    fn visit_mut_jsx_element_name(&mut self, n: &mut JSXElementName) {
+        if let JSXElementName::Ident(ident) = n {
+            if let Some(expr) = self.query.query_jsx(ident) {
+                *n = expr;
+            }
         }
     }
 }

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -3133,6 +3133,8 @@ where
     }
 
     fn visit_mut_jsx_element_name(&mut self, n: &mut JSXElementName) {
+        n.visit_mut_children_with(self);
+
         if let JSXElementName::Ident(ident) = n {
             if let Some(expr) = self.query.query_jsx(ident) {
                 *n = expr;


### PR DESCRIPTION
**Related issue:**
- Closes: #8594 
