### PR TITLE
fix(es/quote): Allow variables typed `AssignTarget`

### DIFF
--- a/crates/swc_ecma_quote/src/lib.rs
+++ b/crates/swc_ecma_quote/src/lib.rs
@@ -17,6 +17,7 @@ mod clone;
 ///
 ///  - `Expr`
 ///  - `Pat`
+///  - `AssignTarget`
 ///  - `Stmt`
 ///  - `ModuleItem`
 ///

--- a/crates/swc_ecma_quote_macros/src/ctxt.rs
+++ b/crates/swc_ecma_quote_macros/src/ctxt.rs
@@ -24,6 +24,7 @@ pub enum VarPos {
     Ident,
     Expr,
     Pat,
+    AssignTarget,
     Str,
 }
 
@@ -138,6 +139,7 @@ pub(super) fn prepare_vars(
                 VarPos::Ident => "Ident",
                 VarPos::Expr => "Expr",
                 VarPos::Pat => "Pat",
+                VarPos::AssignTarget => "AssignTarget",
                 VarPos::Str => "Str",
             },
             call_site(),

--- a/crates/swc_ecma_quote_macros/src/ret_type.rs
+++ b/crates/swc_ecma_quote_macros/src/ret_type.rs
@@ -39,6 +39,7 @@ pub(crate) fn parse_input_type(input_str: &str, ty: &Type) -> Result<BoxWrapper,
                 "Expr" => return parse(input_str, &mut |p| p.parse_expr().map(|v| *v)),
                 "Pat" => return parse(input_str, &mut |p| p.parse_pat()),
                 "Stmt" => return parse(input_str, &mut |p| p.parse_stmt_list_item(true)),
+                "AssignTarget" => return parse(input_str, &mut |p| p.parse_assign_target()),
                 "ModuleItem" => return parse(input_str, &mut |p| p.parse_module_item()),
                 _ => {}
             }

--- a/crates/swc_ecma_quote_macros/src/ret_type.rs
+++ b/crates/swc_ecma_quote_macros/src/ret_type.rs
@@ -2,7 +2,7 @@ use std::any::type_name;
 
 use anyhow::{anyhow, bail, Context, Error};
 use swc_common::{sync::Lrc, FileName, SourceMap};
-use swc_ecma_ast::EsVersion;
+use swc_ecma_ast::{AssignTarget, EsVersion};
 use swc_ecma_parser::{lexer::Lexer, PResult, Parser, StringInput};
 use syn::{GenericArgument, PathArguments, Type};
 
@@ -39,7 +39,12 @@ pub(crate) fn parse_input_type(input_str: &str, ty: &Type) -> Result<BoxWrapper,
                 "Expr" => return parse(input_str, &mut |p| p.parse_expr().map(|v| *v)),
                 "Pat" => return parse(input_str, &mut |p| p.parse_pat()),
                 "Stmt" => return parse(input_str, &mut |p| p.parse_stmt_list_item(true)),
-                "AssignTarget" => return parse(input_str, &mut |p| p.parse_assign_target()),
+                "AssignTarget" => {
+                    return parse(input_str, &mut |p| {
+                        Ok(AssignTarget::try_from(p.parse_pat()?)
+                            .expect("failed to parse AssignTarget"))
+                    })
+                }
                 "ModuleItem" => return parse(input_str, &mut |p| p.parse_module_item()),
                 _ => {}
             }


### PR DESCRIPTION
**Description:**

This is required to fix https://github.com/vercel/turbo/pull/7272


**Related issue:**

 - https://github.com/vercel/turbo/pull/7272