### PR TITLE
refactor: Remove dependency on swc_cached from swc_config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3969,7 +3969,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sourcemap",
- "swc_cached",
  "swc_config_macro",
 ]
 
@@ -4538,6 +4537,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_atoms",
+ "swc_cached",
  "swc_common",
  "swc_config",
  "swc_ecma_ast",

--- a/crates/swc_config/Cargo.toml
+++ b/crates/swc_config/Cargo.toml
@@ -15,7 +15,6 @@ serde      = { version = "1", features = ["derive"] }
 serde_json = "1"
 sourcemap  = { version = "6.4", optional = true }
 
-swc_cached       = { version = "0.3.19", path = "../swc_cached" }
 swc_config_macro = { version = "0.1.3", path = "../swc_config_macro" }
 
 [lib]

--- a/crates/swc_config/src/lib.rs
+++ b/crates/swc_config/src/lib.rs
@@ -7,7 +7,5 @@ pub mod merge;
 #[cfg(feature = "sourcemap")]
 mod source_map;
 
-pub use swc_cached::{regex::CachedRegex, Error};
-
 #[cfg(feature = "sourcemap")]
 pub use crate::source_map::*;

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -51,6 +51,7 @@ serde_json        = "1.0.61"
 tracing           = "0.1.37"
 
 swc_atoms = { version = "0.6.5", path = "../swc_atoms" }
+swc_cached = { version = "0.3.19", path = "../swc_cached" }
 swc_common = { version = "0.33.16", path = "../swc_common" }
 swc_config = { version = "0.1.10", path = "../swc_config", features = [
   "sourcemap",

--- a/crates/swc_ecma_minifier/src/option/mod.rs
+++ b/crates/swc_ecma_minifier/src/option/mod.rs
@@ -2,8 +2,9 @@
 
 use serde::{Deserialize, Serialize};
 use swc_atoms::JsWord;
+use swc_cached::regex::CachedRegex;
 use swc_common::{collections::AHashMap, Mark};
-use swc_config::{merge::Merge, CachedRegex};
+use swc_config::merge::Merge;
 use swc_ecma_ast::{EsVersion, Expr};
 
 /// Implement default using serde.


### PR DESCRIPTION
**Description:**

swc_ecma_transforms_react depends on swc_config, which depends on swc_cache, which depends on ahash, which causes some pain when trying to use in a Wasm environment. Looking into it, it seems like it's cleaner to break up the dependency here and instead import directly from swc_cached when needed?

Edit: actually, I don't believe this helps me, but seems like this is good to do anyway?

**BREAKING CHANGE:**

Removes re-export from swc_config.

**Related issue (if exists):**
