### PR TITLE
fix(es/decorators): Do not insert duplicate constructors

### DIFF
--- a/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
@@ -282,16 +282,18 @@ impl Decorator202203 {
                 insert_index = i + 1;
                 // decorators occur before typescript's type strip, so skip ctor overloads
                 if constructor.body.is_some() {
-                return unsafe {
-                    // Safety: We need polonius
-                    transmute::<&mut Constructor, &'a mut Constructor>(constructor)
-                };
-            }
+                    return unsafe {
+                        // Safety: We need polonius
+                        transmute::<&mut Constructor, &'a mut Constructor>(constructor)
+                    };
+                }
             }
         }
 
-        c.body
-            .insert(insert_index, default_constructor(c.super_class.is_some()).into());
+        c.body.insert(
+            insert_index,
+            default_constructor(c.super_class.is_some()).into(),
+        );
 
         if let Some(ClassMember::Constructor(c)) = c.body.get_mut(insert_index) {
             c

--- a/crates/swc_ecma_transforms_proposal/tests/decorators.rs
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators.rs
@@ -23,6 +23,13 @@ fn syntax_default() -> Syntax {
     })
 }
 
+fn syntax_default_ts() -> Syntax {
+    Syntax::Typescript(TsConfig {
+        decorators: true,
+        ..Default::default()
+    })
+}
+
 #[testing::fixture("tests/decorators/**/exec.js")]
 fn exec(input: PathBuf) {
     exec_inner(input)
@@ -44,6 +51,7 @@ fn exec_inner(input: PathBuf) {
 
 #[testing::fixture("tests/decorators/**/input.js")]
 #[testing::fixture("tests/decorators/**/input.mjs")]
+#[testing::fixture("tests/decorators/**/input.ts")]
 fn fixture(input: PathBuf) {
     fixture_inner(input)
 }
@@ -57,7 +65,11 @@ fn fixture_inner(input: PathBuf) {
     ));
 
     test_fixture(
-        syntax_default(),
+        if input.to_string_lossy().ends_with(".ts") {
+            syntax_default_ts()
+        } else {
+            syntax_default()
+        },
         &|t| create_pass(t.comments.clone(), &input),
         &input,
         &output,

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8631/1/input.ts
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8631/1/input.ts
@@ -1,0 +1,13 @@
+const decorate = (target: unknown, context: DecoratorContext) => {
+  console.log("decorated");
+};
+
+export class Color {
+  constructor(hex: string);
+  constructor(r: number, g: number, b: number, a?: number);
+  constructor(r: string | number, g?: number, b?: number, a = 1) {}
+
+  @decorate get rgba() {
+    return [0, 0, 0, 1];
+  }
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8631/1/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8631/1/output.js
@@ -1,0 +1,2 @@
+export default class T {
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8631/1/output.ts
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8631/1/output.ts
@@ -1,0 +1,28 @@
+var _initProto;
+const decorate = (target: unknown, context: DecoratorContext)=>{
+    console.log("decorated");
+};
+export class Color {
+    static{
+        ({ e: [_initProto] } = _apply_decs_2203_r(this, [
+            [
+                decorate,
+                3,
+                "rgba"
+            ]
+        ], []));
+    }
+    constructor(hex: string);
+    constructor(r: number, g: number, b: number, a?: number);
+    constructor(r: string | number, g?: number, b?: number, a = 1){
+        _initProto(this);
+    }
+    get rgba() {
+        return [
+            0,
+            0,
+            0,
+            1
+        ];
+    }
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8631/options.json
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-8631/options.json
@@ -1,0 +1,3 @@
+{
+    "plugins": [["proposal-decorators", { "version": "2022-03" }]]
+}


### PR DESCRIPTION
**Description:**

Doesn't insert a duplicate ctor when the ctor uses overloads in TS.


**Related issue:** 

 - Closes #8630.
