### PR TITLE
fix(es/parser): Check for existence of modifiers while parsing `accessor` token

### DIFF
--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -669,7 +669,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         let accessor_token = accessor_token.or_else(|| {
-            if self.syntax().auto_accessors() {
+            if self.syntax().auto_accessors() && readonly.is_none() {
                 let start = cur_pos!(self);
                 if eat!(self, "accessor") {
                     Some(span!(self, start))

--- a/crates/swc_ecma_parser/tests/typescript/issue-8526/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/issue-8526/input.ts
@@ -1,0 +1,7 @@
+class SomeClass {
+    readonly accessor: string;
+
+    constructor() {
+        this.accessor = '';
+    }
+}

--- a/crates/swc_ecma_parser/tests/typescript/issue-8526/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/issue-8526/input.ts.json
@@ -1,0 +1,167 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 106,
+    "ctxt": 0
+  },
+  "body": [
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 7,
+          "end": 16,
+          "ctxt": 0
+        },
+        "value": "SomeClass",
+        "optional": false
+      },
+      "declare": false,
+      "span": {
+        "start": 1,
+        "end": 106,
+        "ctxt": 0
+      },
+      "decorators": [],
+      "body": [
+        {
+          "type": "ClassProperty",
+          "span": {
+            "start": 23,
+            "end": 49,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 32,
+              "end": 40,
+              "ctxt": 0
+            },
+            "value": "accessor",
+            "optional": false
+          },
+          "value": null,
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 40,
+              "end": 48,
+              "ctxt": 0
+            },
+            "typeAnnotation": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 42,
+                "end": 48,
+                "ctxt": 0
+              },
+              "kind": "string"
+            }
+          },
+          "isStatic": false,
+          "decorators": [],
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false,
+          "readonly": true,
+          "declare": false,
+          "definite": false
+        },
+        {
+          "type": "Constructor",
+          "span": {
+            "start": 55,
+            "end": 104,
+            "ctxt": 0
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 55,
+              "end": 66,
+              "ctxt": 0
+            },
+            "value": "constructor",
+            "optional": false
+          },
+          "params": [],
+          "body": {
+            "type": "BlockStatement",
+            "span": {
+              "start": 69,
+              "end": 104,
+              "ctxt": 0
+            },
+            "stmts": [
+              {
+                "type": "ExpressionStatement",
+                "span": {
+                  "start": 79,
+                  "end": 98,
+                  "ctxt": 0
+                },
+                "expression": {
+                  "type": "AssignmentExpression",
+                  "span": {
+                    "start": 79,
+                    "end": 97,
+                    "ctxt": 0
+                  },
+                  "operator": "=",
+                  "left": {
+                    "type": "MemberExpression",
+                    "span": {
+                      "start": 79,
+                      "end": 92,
+                      "ctxt": 0
+                    },
+                    "object": {
+                      "type": "ThisExpression",
+                      "span": {
+                        "start": 79,
+                        "end": 83,
+                        "ctxt": 0
+                      }
+                    },
+                    "property": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 84,
+                        "end": 92,
+                        "ctxt": 0
+                      },
+                      "value": "accessor",
+                      "optional": false
+                    }
+                  },
+                  "right": {
+                    "type": "StringLiteral",
+                    "span": {
+                      "start": 95,
+                      "end": 97,
+                      "ctxt": 0
+                    },
+                    "value": "",
+                    "raw": "''"
+                  }
+                }
+              }
+            ]
+          },
+          "accessibility": null,
+          "isOptional": false
+        }
+      ],
+      "superClass": null,
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #8526