### PR TITLE
fix(es/codegen): Fix replacement when `inline_script` is on

### DIFF
--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -646,7 +646,7 @@ where
         if self.cfg.inline_script {
             value = replace_close_inline_script(&value)
                 .replace("\x3c!--", "\\x3c!--")
-                .replace("/--\x3e/", "--\\x3e");
+                .replace("--\x3e", "--\\x3e");
         }
 
         self.wr.write_str_lit(DUMMY_SP, &value)?;

--- a/crates/swc_ecma_minifier/tests/format.rs
+++ b/crates/swc_ecma_minifier/tests/format.rs
@@ -74,8 +74,9 @@ fn assert_format(src: &str, expected: &str, opts: Config) {
 fn inline_script() {
     let src = r#"
 console.log("</sCrIpT>");
+foo("/-->/");
 "#;
-    let expected = r#"console.log("<\/sCrIpT>");"#;
+    let expected = r#"console.log("<\/sCrIpT>");foo("/--\x3e/");"#;
     assert_format(
         src,
         expected,


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The replacements for `inline_script` might be with mistake

https://github.com/swc-project/swc/blob/40682c8d1f55b42b0a086487e740e975244ed42a/crates/swc_ecma_codegen/src/lib.rs#L649

which in terser is:
![image](https://github.com/swc-project/swc/assets/18117084/e843e125-c001-44d1-9572-15bec355a34e)


https://github.com/terser/terser/blob/0ef05847fa8c892c109b6d8a9415e9463f3e0995/lib/output.js?plain=1#L414

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

https://github.com/web-infra-dev/rspack/issues/5757