### PR TITLE
fix(es/codegen): Emit `namespace` keyword of `TsModuleDecl` if possible

### DIFF
--- a/crates/swc_ecma_codegen/src/typescript.rs
+++ b/crates/swc_ecma_codegen/src/typescript.rs
@@ -581,7 +581,12 @@ where
         if n.global {
             keyword!("global");
         } else {
-            keyword!("module");
+            match &n.id {
+                // prefer namespace keyword because TS might
+                // deprecate the module keyword in this context
+                TsModuleName::Ident(_) => keyword!("namespace"),
+                TsModuleName::Str(_) => keyword!("module"),
+            }
             space!();
             emit!(n.id);
         }

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/module/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/module/output.js
@@ -1,18 +1,18 @@
-module Test {
+namespace Test {
     1;
 }
-export module Test.Test {
+export namespace Test.Test {
     1;
 }
-declare module Test.Test2 {
+declare namespace Test.Test2 {
     1;
 }
 declare global {
     1;
 }
-declare module Test1.Test2 {
+declare namespace Test1.Test2 {
     1;
 }
-export module Test1.Test2.Test3 {
+export namespace Test1.Test2.Test3 {
     2;
 }

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/module/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/module/output.min.js
@@ -1,1 +1,1 @@
-module Test{1;}export module Test.Test{1;}declare module Test.Test2{1;}declare global{1;}declare module Test1.Test2{1;}export module Test1.Test2.Test3{2;}
+namespace Test{1;}export namespace Test.Test{1;}declare namespace Test.Test2{1;}declare global{1;}declare namespace Test1.Test2{1;}export namespace Test1.Test2.Test3{2;}

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/internalModules/codeGeneration/importStatements/output.ts
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/internalModules/codeGeneration/importStatements/output.ts
@@ -1,13 +1,13 @@
-module A__2 {
+namespace A__2 {
     export class Point__3 {
         constructor(public x__4: number, public y__4: number){}
     }
     export var Origin__3 = new Point__3(0, 0);
 }
-module B__2 {
+namespace B__2 {
     import a__5 = A__2;
 }
-module C__2 {
+namespace C__2 {
     import a__6 = A__2;
     var m__6: typeof a__6;
     var p__6: a__6.Point;
@@ -16,11 +16,11 @@ module C__2 {
         y: 0
     };
 }
-module D__2 {
+namespace D__2 {
     import a__7 = A__2;
     var p__7 = new a__7.Point(1, 1);
 }
-module E__2 {
+namespace E__2 {
     import a__8 = A__2;
     export function xDist__8(x__9: a__8.Point) {
         return a__8.Origin.x - x__9.x;

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/issues/1653/1/output.ts
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/issues/1653/1/output.ts
@@ -1,10 +1,10 @@
-module X__2 {
-    export module Z__3 {
+namespace X__2 {
+    export namespace Z__3 {
         export const foo__4 = 0;
     }
 }
-module Y__2 {
-    export module Z__5 {
+namespace Y__2 {
+    export namespace Z__5 {
         export const bar__6 = 1;
     }
 }

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/issues/1653/2/output.ts
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/issues/1653/2/output.ts
@@ -1,10 +1,10 @@
-module X__2 {
-    export module Z__3 {
+namespace X__2 {
+    export namespace Z__3 {
         export const foo__4 = 0;
     }
 }
-module Y__2 {
-    export module Z__5 {
+namespace Y__2 {
+    export namespace Z__5 {
         export const bar__6 = 1;
     }
 }

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/namepsace/hoisting/1/output.ts
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/namepsace/hoisting/1/output.ts
@@ -1,4 +1,4 @@
-declare module RangeParser__2 {
+declare namespace RangeParser__2 {
     interface Ranges__3 extends Array<Range__3> {
         type__0: string;
     }

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/ts_as_operator_ambiguity_2/output.ts
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/ts_as_operator_ambiguity_2/output.ts
@@ -1,4 +1,4 @@
-module Top__2 {
+namespace Top__2 {
     interface A__3<T__4> {
         x__0: T__4;
     }

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/ts_if_do_while_statements_01/output.ts
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/ts_if_do_while_statements_01/output.ts
@@ -1,4 +1,4 @@
-module M__2 {
+namespace M__2 {
     export class A__3 {
         name: string;
     }
@@ -6,7 +6,7 @@ module M__2 {
         return x__4.toString();
     }
 }
-module N__2 {
+namespace N__2 {
     export class A__5 {
         id: number;
     }

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/ts_module_name_1/output.ts
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/ts_module_name_1/output.ts
@@ -1,5 +1,5 @@
-module Top__2 {
-    module A__3 {
+namespace Top__2 {
+    namespace A__3 {
         export function b__4() {}
     }
     A__3.b();

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/type-alias/hoisting/1/output.ts
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/type-alias/hoisting/1/output.ts
@@ -1,4 +1,4 @@
-module Foo__2 {
+namespace Foo__2 {
     export type ServerHandle__3 = HandleFunction__3 | http.Server;
     export class IncomingMessage__3 extends http.IncomingMessage {
         originalUrl?: http.IncomingMessage["url"] | undefined;


### PR DESCRIPTION
**Description:** Emits the namespace keyword for TsModuleDecls when able.

Been meaning to open a PR for this one for a while, but the module keyword may be deprecated in the future in TS in non-ambient modules, so it's better to do this.

**BREAKING CHANGE:** No.

**Related issue (if exists):** None.
