### PR TITLE
fix(es/visit): Skip `TsExprWithTypeArgs` from `noop_visit/fold_type` macros

### DIFF
--- a/crates/swc_ecma_transforms_typescript/src/strip_import_export.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip_import_export.rs
@@ -28,13 +28,6 @@ impl Visit for UsageCollect {
         // skip
     }
 
-    fn visit_class(&mut self, n: &Class) {
-        // skip implements
-        n.decorators.visit_with(self);
-        n.body.visit_with(self);
-        n.super_class.visit_with(self);
-    }
-
     fn visit_fn_decl(&mut self, n: &FnDecl) {
         // skip function ident
         n.function.visit_with(self);

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -350,6 +350,7 @@ macro_rules! noop_fold_type {
         noop_fold_type!(fold_ts_enum_decl, TsEnumDecl);
         noop_fold_type!(fold_ts_enum_member, TsEnumMember);
         noop_fold_type!(fold_ts_enum_member_id, TsEnumMemberId);
+        noop_fold_type!(fold_ts_expr_with_type_args, TsExprWithTypeArgs);
         noop_fold_type!(fold_ts_external_module_ref, TsExternalModuleRef);
         noop_fold_type!(fold_ts_fn_or_constructor_type, TsFnOrConstructorType);
         noop_fold_type!(fold_ts_fn_param, TsFnParam);
@@ -421,6 +422,7 @@ macro_rules! noop_visit_type {
         noop_visit_type!(visit_ts_construct_signature_decl, TsConstructSignatureDecl);
         noop_visit_type!(visit_ts_constructor_type, TsConstructorType);
         noop_visit_type!(visit_ts_entity_name, TsEntityName);
+        noop_visit_type!(visit_ts_expr_with_type_args, TsExprWithTypeArgs);
         noop_visit_type!(visit_ts_external_module_ref, TsExternalModuleRef);
         noop_visit_type!(visit_ts_fn_or_constructor_type, TsFnOrConstructorType);
         noop_visit_type!(visit_ts_fn_param, TsFnParam);
@@ -485,6 +487,7 @@ macro_rules! noop_visit_mut_type {
         );
         noop_visit_mut_type!(visit_mut_ts_constructor_type, TsConstructorType);
         noop_visit_mut_type!(visit_mut_ts_entity_name, TsEntityName);
+        noop_visit_mut_type!(visit_mut_ts_expr_with_type_args, TsExprWithTypeArgs);
         noop_visit_mut_type!(visit_mut_ts_external_module_ref, TsExternalModuleRef);
         noop_visit_mut_type!(visit_mut_ts_fn_or_constructor_type, TsFnOrConstructorType);
         noop_visit_mut_type!(visit_mut_ts_fn_param, TsFnParam);


### PR DESCRIPTION
**Description:** See https://github.com/swc-project/swc/discussions/8669

**BREAKING CHANGE:**

`TsExprWithTypeArgs` is now skipped in these macros. This fix might be a breaking change for anyone who was relying on the previous behaviour even though this is more correct now.

**Related issue (if exists):**
