### PR TITLE
fix(es/minifier): Fix evaluation of array literals with `void 0`

### DIFF
--- a/crates/swc_ecma_minifier/tests/fixture/issues/8706/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8706/config.json
@@ -1,0 +1,3 @@
+{
+    "defaults": true
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8706/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8706/input.js
@@ -1,0 +1,1 @@
+console.log([void 0] + 'swc');

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8706/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8706/output.js
@@ -1,0 +1,1 @@
+console.log("swc");

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -1027,6 +1027,16 @@ pub trait ExprExt {
                             let ExprOrSpread { ref expr, .. } = *elem;
                             match &**expr {
                                 Expr::Lit(Lit::Null(..)) => Cow::Borrowed(""),
+                                Expr::Unary(UnaryExpr {
+                                    op: op!("void"),
+                                    arg,
+                                    ..
+                                }) => {
+                                    if arg.may_have_side_effects(ctx) {
+                                        return Value::Unknown;
+                                    }
+                                    Cow::Borrowed("")
+                                }
                                 Expr::Ident(Ident { sym: undefined, .. })
                                     if &**undefined == "undefined" =>
                                 {


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #8706