### PR TITLE
chore(es): Allow using older `tokio`

### DIFF
--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -107,10 +107,7 @@ swc_plugin_proxy = { version = "0.41.5", path = "../swc_plugin_proxy", optional 
 swc_plugin_runner = { version = "0.106.11", path = "../swc_plugin_runner", optional = true, default-features = false }
 swc_timer = { version = "0.21.20", path = "../swc_timer" }
 swc_visit = { version = "0.5.10", path = "../swc_visit" }
-tokio = { version = "1.36.0", optional = true, features = [
-  "rt",
-  "rt-multi-thread",
-] }
+tokio = { version = "1", optional = true, features = ["rt", "rt-multi-thread"] }
 
 
   [dependencies.napi-derive]


### PR DESCRIPTION
**Description:**

I made a mistake while working on https://github.com/swc-project/swc/pull/8711

**Related issue:**
