### PR TITLE
fix: export default fn/class expr ident not collected 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4859,6 +4859,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_parser",
+ "swc_ecma_transforms_base",
  "swc_ecma_visit",
  "testing",
  "tracing",

--- a/crates/swc_ecma_utils/Cargo.toml
+++ b/crates/swc_ecma_utils/Cargo.toml
@@ -35,4 +35,5 @@ swc_ecma_visit = { version = "0.98.7", path = "../swc_ecma_visit" }
 
 [dev-dependencies]
 swc_ecma_parser = { version = "0.143.10", path = "../swc_ecma_parser" }
+swc_ecma_transforms_base = { version = "0.137.16", path = "../swc_ecma_transforms_base" }
 testing         = { version = "0.35.21", path = "../testing" }

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2798,6 +2798,23 @@ where
         self.is_pat_decl = old;
     }
 
+    fn visit_export_default_decl(&mut self, e: &ExportDefaultDecl) {
+        match &e.decl {
+            DefaultDecl::Class(ClassExpr {
+                ident: Some(ident), ..
+            }) => {
+                self.add(ident);
+            }
+            DefaultDecl::Fn(FnExpr {
+                ident: Some(ident),
+                function: f,
+            }) if f.body.is_some() => {
+                self.add(ident);
+            }
+            _ => {}
+        }
+    }
+
     fn visit_fn_decl(&mut self, node: &FnDecl) {
         node.visit_children_with(self);
 
@@ -3240,8 +3257,9 @@ where
 
 #[cfg(test)]
 mod test {
-    use swc_common::{input::StringInput, BytePos};
+    use swc_common::{input::StringInput, BytePos, GLOBALS};
     use swc_ecma_parser::{Parser, Syntax};
+    use swc_ecma_transforms_base::resolver;
 
     use super::*;
 
@@ -3252,6 +3270,29 @@ mod test {
             &["a", "b", "c", "d"],
         );
         run_collect_decls("const [ a, b = 1, [c], ...d ] = [];", &["a", "b", "c", "d"]);
+    }
+
+    #[test]
+    fn test_collect_export_default_expr() {
+        run_collect_decls("export default function foo(){}", &["foo"]);
+        run_collect_decls("export default class Foo{}", &["Foo"]);
+    }
+
+    #[test]
+    fn test_export_default_expr_should_be_in_top_level() {
+        let mut module = parse_module("export default function top(){}");
+        GLOBALS.set(&Default::default(), || {
+            let unresolved_mark: Mark = Mark::new();
+            let top_level_mark: Mark = Mark::new();
+            let top_ctxt = SyntaxContext::default().apply_mark(top_level_mark);
+            module.visit_mut_with(&mut resolver(unresolved_mark, top_level_mark, false));
+            let decls = collect_decls_with_ctxt(&module, top_ctxt)
+                .iter()
+                .map(|d: &Id| d.0.to_string())
+                .collect::<Vec<_>>();
+
+            assert_eq!(decls, ["top"]);
+        });
     }
 
     fn run_collect_decls(text: &str, expected_names: &[&str]) {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
this is a "minus pass" of https://github.com/swc-project/swc/issues/8755 

```js
export default function foo(){}
```
function `foo`  is treated as hoisted function , in my opinion it should be collected  by  util `collect_decls` and it should be in top level( according added test cases)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
No
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
https://github.com/swc-project/swc/issues/8755