### PR TITLE
perf(es/parser): Use faster unicode crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4175,7 +4175,7 @@ dependencies = [
  "string_enum",
  "swc_atoms",
  "swc_common",
- "unicode-id",
+ "unicode-id-start",
 ]
 
 [[package]]

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -35,18 +35,17 @@ bitflags  = "2.3.2"
 bytecheck = { version = "0.6.10", optional = true }
 is-macro = "0.3.0"
 num-bigint = { version = "0.4", features = ["serde"] }
+phf = { version = "0.11.2", features = ["macros"] }
 rkyv = { package = "rkyv", version = "=0.7.42", optional = true, features = [
   "strict",
   "validation",
 ] }
 scoped-tls = "1.0.1"
 serde = { version = "1.0.133", features = ["derive"], optional = true }
-unicode-id = "0.3"
-
 string_enum = { version = "0.4.2", path = "../string_enum" }
-swc_atoms   = { version = "0.6.5", path = "../swc_atoms" }
-swc_common  = { version = "0.33.20", path = "../swc_common" }
-phf = { version = "0.11.2", features = ["macros"] }
+swc_atoms = { version = "0.6.5", path = "../swc_atoms" }
+swc_common = { version = "0.33.20", path = "../swc_common" }
+unicode-id-start = "1.1.2"
 
 [dev-dependencies]
 serde_json = "1"

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -186,12 +186,6 @@ impl From<Ident> for Id {
     }
 }
 
-#[repr(C, align(64))]
-struct Align64<T>(pub(crate) T);
-
-const T: bool = true;
-const F: bool = false;
-
 impl Ident {
     /// In `op`, [EqIgnoreSpan] of [Ident] will ignore the syntax context.
     pub fn within_ignored_ctxt<F, Ret>(op: F) -> Ret

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -210,14 +210,14 @@ impl Ident {
     /// Returns true if `c` is a valid character for an identifier start.
     #[inline]
     pub fn is_valid_start(c: char) -> bool {
-        unicode_id_start::is_id_start(c)
+        c == '$' || c == '_' || unicode_id_start::is_id_start(c)
     }
 
     /// Returns true if `c` is a valid character for an identifier part after
     /// start.
     #[inline]
     pub fn is_valid_continue(c: char) -> bool {
-        unicode_id_start::is_id_continue(c)
+        c == '$' || unicode_id_start::is_id_continue(c)
     }
 
     /// Alternative for `toIdentifier` of babel.

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -9,7 +9,6 @@ use swc_atoms::{js_word, Atom};
 use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Span, Spanned, SyntaxContext, DUMMY_SP,
 };
-use unicode_id::UnicodeID;
 
 use crate::{typescript::TsTypeAnn, Expr};
 
@@ -217,40 +216,14 @@ impl Ident {
     /// Returns true if `c` is a valid character for an identifier start.
     #[inline]
     pub fn is_valid_start(c: char) -> bool {
-        // This contains `$` (36) and `_` (95)
-        const ASCII_START: Align64<[bool; 128]> = Align64([
-            F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
-            F, F, F, F, F, F, F, T, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
-            F, F, F, F, F, F, F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,
-            T, T, T, T, F, F, F, F, T, F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,
-            T, T, T, T, T, T, T, F, F, F, F, F,
-        ]);
-
-        if c.is_ascii() {
-            return ASCII_START.0[c as usize];
-        }
-
-        UnicodeID::is_id_start(c)
+        unicode_id_start::is_id_start(c)
     }
 
     /// Returns true if `c` is a valid character for an identifier part after
     /// start.
     #[inline]
     pub fn is_valid_continue(c: char) -> bool {
-        // This contains `$` (36)
-        const ASCII_CONTINUE: Align64<[bool; 128]> = Align64([
-            F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F, F,
-            F, F, F, F, F, F, F, T, F, F, F, F, F, F, F, F, F, F, F, T, T, T, T, T, T, T, T, T, T,
-            F, F, F, F, F, F, F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,
-            T, T, T, T, F, F, F, F, T, F, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T, T,
-            T, T, T, T, T, T, T, F, F, F, F, F,
-        ]);
-
-        if c.is_ascii() {
-            return ASCII_CONTINUE.0[c as usize];
-        }
-
-        UnicodeID::is_id_continue(c) || c == '\u{200c}' || c == '\u{200d}'
+        unicode_id_start::is_id_continue(c)
     }
 
     /// Alternative for `toIdentifier` of babel.


### PR DESCRIPTION
**Description:**

cc @Boshen


**Related issue (if exists):**
