### PR TITLE
chore(es/transforms): Add `repository` field to `swc_ecma_ext_transforms`

### DIFF
--- a/crates/swc_ecma_ext_transforms/Cargo.toml
+++ b/crates/swc_ecma_ext_transforms/Cargo.toml
@@ -5,6 +5,7 @@ documentation = "https://rustdoc.swc.rs/swc_ecma_ext_transforms/"
 edition       = "2021"
 license       = "Apache-2.0"
 name          = "swc_ecma_ext_transforms"
+repository    = "https://github.com/swc-project/swc.git"
 version       = "0.113.13"
 
 [lib]


### PR DESCRIPTION
**Description:** Add the `repository` field to `swc_ecma_ext_transforms`, making it easier for users or automated tools to find the git repository a crate is published from.