### PR TITLE
fix(es/typescript): Drop definite class properites

### DIFF
--- a/crates/swc_ecma_transforms_typescript/src/strip_type.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip_type.rs
@@ -62,7 +62,8 @@ impl VisitMut for StripType {
                 ClassProp { declare: true, .. }
                 | ClassProp {
                     is_abstract: true, ..
-                },
+                }
+                | ClassProp { definite: true, .. },
             ) => false,
 
             _ => true,

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-8792/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-8792/input.ts
@@ -1,0 +1,12 @@
+class MyClass {
+    ["constructor"]!: typeof MyClass;
+    other!: number;
+
+    static myStatic() {
+        console.log("myStatic")
+    }
+
+    myMethod() {
+        this.constructor.myStatic();
+    }
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-8792/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-8792/output.js
@@ -1,0 +1,8 @@
+class MyClass {
+    static myStatic() {
+        console.log("myStatic");
+    }
+    myMethod() {
+        this.constructor.myStatic();
+    }
+}


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #8792