### PR TITLE
fix(es/parser): Maybe fix segfault by removing arena

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4530,7 +4530,6 @@ dependencies = [
  "swc_malloc",
  "testing",
  "tracing",
- "typed-arena",
  "walkdir",
 ]
 
@@ -5887,12 +5886,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -31,7 +31,6 @@ serde       = { version = "1", features = ["derive"] }
 smallvec    = "1.8.0"
 smartstring = "1"
 tracing     = "0.1.40"
-typed-arena = "2.0.1"
 
 new_debug_unreachable = "1.0.4"
 phf                   = { version = "0.11.2", features = ["macros"] }

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1,5 +1,4 @@
 use swc_common::Spanned;
-use typed_arena::Arena;
 
 use super::{pat::PatType, *};
 use crate::error::SyntaxError;
@@ -25,7 +24,7 @@ impl<'a, I: Tokens> Parser<I> {
 
         let old_ctx = self.ctx();
 
-        let stmts = Arena::new();
+        let mut stmts = Vec::new();
         while {
             if self.input.cur().is_none() && end.is_some() {
                 let eof_text = self.input.dump_cur();
@@ -59,7 +58,7 @@ impl<'a, I: Tokens> Parser<I> {
                 }
             }
 
-            stmts.alloc(stmt);
+            stmts.push(stmt);
         }
 
         if self.input.cur().is_some() && end.is_some() {
@@ -68,7 +67,7 @@ impl<'a, I: Tokens> Parser<I> {
 
         self.set_ctx(old_ctx);
 
-        Ok(stmts.into_vec())
+        Ok(stmts)
     }
 
     /// Parse a statement but not a declaration.

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -24,7 +24,7 @@ impl<'a, I: Tokens> Parser<I> {
 
         let old_ctx = self.ctx();
 
-        let mut stmts = Vec::new();
+        let mut stmts = Vec::with_capacity(16);
         while {
             if self.input.cur().is_none() && end.is_some() {
                 let eof_text = self.input.dump_cur();


### PR DESCRIPTION
**Description:** The use of an arena here may be the reason for a segfault we're experiencing as perhaps the vector being created has a very large length (https://github.com/denoland/deno/pull/23187#issuecomment-2036260579). Using an arena was done for performance, but maybe it's not worth it?

**Related issue (if exists):** none

Using code:

```rs
#![feature(test)]

extern crate test;

struct Data {
    value: usize,
    data: String,
}

fn run_arena(count: usize) -> usize {
    let arena = typed_arena::Arena::new();
    for i in 0..count {
        let data = Data {
            value: i,
            data: "Hello, world!".to_string(),
        };
        arena.alloc(data);
    }
    arena.into_vec().len()
}

fn run_vec(count: usize) -> usize {
    let mut vec = Vec::with_capacity(16);
    for i in 0..count {
        let data = Data {
            value: i,
            data: "Hello, world!".to_string(),
        };
        vec.push(data);
    }
    vec.len()
}

#[cfg(test)]
mod tests {
    use super::*;
    use test::Bencher;

    #[bench]
    fn bench_5_arena(b: &mut Bencher) {
        b.iter(|| run_arena(5));
    }

    #[bench]
    fn bench_5_vec(b: &mut Bencher) {
        b.iter(|| run_vec(5));
    }

    #[bench]
    fn bench_10_arena(b: &mut Bencher) {
        b.iter(|| run_arena(10));
    }

    #[bench]
    fn bench_10_vec(b: &mut Bencher) {
        b.iter(|| run_vec(10));
    }

    #[bench]
    fn bench_20_arena(b: &mut Bencher) {
        b.iter(|| run_arena(20));
    }

    #[bench]
    fn bench_20_vec(b: &mut Bencher) {
        b.iter(|| run_vec(20));
    }

    #[bench]
    fn bench_50_arena(b: &mut Bencher) {
        b.iter(|| run_arena(50));
    }

    #[bench]
    fn bench_50_vec(b: &mut Bencher) {
        b.iter(|| run_vec(50));
    }

    #[bench]
    fn bench_100_arena(b: &mut Bencher) {
        b.iter(|| run_arena(100));
    }

    #[bench]
    fn bench_100_vec(b: &mut Bencher) {
        b.iter(|| run_vec(100));
    }

    #[bench]
    fn bench_500_arena(b: &mut Bencher) {
        b.iter(|| run_arena(500));
    }

    #[bench]
    fn bench_500_vec(b: &mut Bencher) {
        b.iter(|| run_vec(500));
    }

    #[bench]
    fn bench_1000_arena(b: &mut Bencher) {
        b.iter(|| run_arena(1000));
    }

    #[bench]
    fn bench_1000_vec(b: &mut Bencher) {
        b.iter(|| run_vec(1000));
    }
}
```

```
test tests::bench_1000_arena ... bench:      40,980 ns/iter (+/- 1,620)
test tests::bench_1000_vec   ... bench:      41,473 ns/iter (+/- 1,614)
test tests::bench_100_arena  ... bench:       4,409 ns/iter (+/- 140)
test tests::bench_100_vec    ... bench:       4,487 ns/iter (+/- 166)
test tests::bench_10_arena   ... bench:         457 ns/iter (+/- 46)
test tests::bench_10_vec     ... bench:         444 ns/iter (+/- 53)
test tests::bench_20_arena   ... bench:         889 ns/iter (+/- 104)
test tests::bench_20_vec     ... bench:         896 ns/iter (+/- 59)
test tests::bench_500_arena  ... bench:      21,222 ns/iter (+/- 1,164)
test tests::bench_500_vec    ... bench:      20,887 ns/iter (+/- 1,433)
test tests::bench_50_arena   ... bench:       2,314 ns/iter (+/- 94)
test tests::bench_50_vec     ... bench:       2,267 ns/iter (+/- 75)
test tests::bench_5_arena    ... bench:         254 ns/iter (+/- 19)
test tests::bench_5_vec      ... bench:         215 ns/iter (+/- 27)
```