### PR TITLE
refactor(es): Make the code compile with `miri`

### DIFF
--- a/crates/swc_ecma_codegen/src/comments.rs
+++ b/crates/swc_ecma_codegen/src/comments.rs
@@ -1,5 +1,3 @@
-use swc_common::comments::CommentKind;
-
 use super::*;
 
 macro_rules! write_comments {

--- a/crates/swc_ecma_codegen/src/text_writer.rs
+++ b/crates/swc_ecma_codegen/src/text_writer.rs
@@ -1,5 +1,3 @@
-use swc_common::Span;
-
 pub use self::{basic_impl::JsWriter, semicolon::omit_trailing_semi};
 use super::*;
 

--- a/crates/swc_ecma_parser/src/lexer/jsx.rs
+++ b/crates/swc_ecma_parser/src/lexer/jsx.rs
@@ -1,7 +1,6 @@
 use either::Either;
 
 use super::*;
-use crate::token::Token;
 
 impl<'a> Lexer<'a> {
     pub(super) fn read_jsx_token(&mut self) -> LexResult<Option<Token>> {

--- a/crates/swc_ecma_parser/src/lexer/number.rs
+++ b/crates/swc_ecma_parser/src/lexer/number.rs
@@ -7,12 +7,11 @@ use std::{borrow::Cow, fmt::Write};
 use either::Either;
 use num_bigint::BigInt as BigIntValue;
 use num_traits::{Num as NumTrait, ToPrimitive};
-use smartstring::{LazyCompact, SmartString};
+use smartstring::LazyCompact;
 use swc_common::SyntaxContext;
 use tracing::trace;
 
 use super::*;
-use crate::error::SyntaxError;
 
 struct LazyBigInt<const RADIX: u8> {
     value: String,

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -513,6 +513,7 @@ expose!(parse_file_as_program, Program, |p| { p.parse_program() });
     target_arch = "wasm32",
     target_arch = "arm",
     not(feature = "stacker"),
+    // miri does not work with stacker
     miri
 ))]
 fn maybe_grow<R, F: FnOnce() -> R>(_red_zone: usize, _stack_size: usize, callback: F) -> R {

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -509,14 +509,14 @@ expose!(parse_file_as_script, Script, |p| { p.parse_script() });
 expose!(parse_file_as_program, Program, |p| { p.parse_program() });
 
 #[inline(always)]
-#[cfg(any(target_arch = "wasm32", target_arch = "arm", not(feature = "stacker")))]
+#[cfg(any(target_arch = "wasm32", target_arch = "arm", not(feature = "stacker"), miri))]
 fn maybe_grow<R, F: FnOnce() -> R>(_red_zone: usize, _stack_size: usize, callback: F) -> R {
     callback()
 }
 
 #[inline(always)]
 #[cfg(all(
-    not(any(target_arch = "wasm32", target_arch = "arm")),
+    not(any(target_arch = "wasm32", target_arch = "arm", miri)),
     feature = "stacker"
 ))]
 fn maybe_grow<R, F: FnOnce() -> R>(red_zone: usize, stack_size: usize, callback: F) -> R {

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -509,7 +509,12 @@ expose!(parse_file_as_script, Script, |p| { p.parse_script() });
 expose!(parse_file_as_program, Program, |p| { p.parse_program() });
 
 #[inline(always)]
-#[cfg(any(target_arch = "wasm32", target_arch = "arm", not(feature = "stacker"), miri))]
+#[cfg(any(
+    target_arch = "wasm32",
+    target_arch = "arm",
+    not(feature = "stacker"),
+    miri
+))]
 fn maybe_grow<R, F: FnOnce() -> R>(_red_zone: usize, _stack_size: usize, callback: F) -> R {
     callback()
 }

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -1,7 +1,7 @@
 use swc_common::{Spanned, SyntaxContext};
 
 use super::*;
-use crate::{error::SyntaxError, lexer::TokenContext, Tokens};
+use crate::lexer::TokenContext;
 
 /// Parser for function expression and function declaration.
 impl<I: Tokens> Parser<I> {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1,5 +1,5 @@
 use either::Either;
-use swc_common::{ast_node, collections::AHashMap, util::take::Take, Spanned};
+use swc_common::{ast_node, util::take::Take, Spanned};
 
 use super::{pat::PatType, util::ExprExt, *};
 use crate::{lexer::TokenContext, parser::class_and_fn::IsSimpleParameterList};

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -1,5 +1,4 @@
 //! Parser for unary operations and binary operations.
-use swc_common::Spanned;
 use tracing::trace;
 
 use super::*;

--- a/crates/swc_ecma_parser/src/parser/jsx.rs
+++ b/crates/swc_ecma_parser/src/parser/jsx.rs
@@ -1,5 +1,5 @@
 use either::Either;
-use swc_common::{Span, Spanned, SyntaxContext};
+use swc_common::{Spanned, SyntaxContext};
 
 use super::*;
 
@@ -436,27 +436,6 @@ impl<I: Tokens> Parser<I> {
             }),
             _ => unreachable!(),
         }
-    }
-}
-
-trait IsFragment {
-    fn is_fragment(&self) -> bool;
-}
-
-impl IsFragment for Either<JSXOpeningFragment, JSXOpeningElement> {
-    fn is_fragment(&self) -> bool {
-        matches!(*self, Either::Left(..))
-    }
-}
-
-impl IsFragment for Either<JSXClosingFragment, JSXClosingElement> {
-    fn is_fragment(&self) -> bool {
-        matches!(*self, Either::Left(..))
-    }
-}
-impl<T: IsFragment> IsFragment for Option<T> {
-    fn is_fragment(&self) -> bool {
-        self.as_ref().map(|s| s.is_fragment()).unwrap_or(false)
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -6,7 +6,7 @@ use swc_common::{
     util::take::Take,
     Mark, Span, Spanned, SyntaxContext, DUMMY_SP,
 };
-use swc_ecma_ast::{Ident, Lit, *};
+use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{
     ext::ExprRefExt,
     pass::RepeatedJsPass,


### PR DESCRIPTION
**Description:** Makes the code compile with miri.

For some reason, Miri seems more strict.

**BREAKING CHANGE:**

**Related issue (if exists):** None
