### PR TITLE
fix(es/helpers): Add missing helpers

### DIFF
--- a/packages/helpers/esm/_identity.js
+++ b/packages/helpers/esm/_identity.js
@@ -1,0 +1,3 @@
+export function _identity(x) { return x; }
+
+export { _identity as _ };


### PR DESCRIPTION
when i use @swc/core to build my code and set tsconfig with `"importHelpers": true`

it has error `Missing "./_/_identity" specifier in "@swc/helpers" package`.

I found that the reason for the error is that this file is missing.






