### PR TITLE
fix(es/minifier): Remove `raw` of strings after modification

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
@@ -742,7 +742,7 @@ impl Pure<'_> {
         };
 
         self.changed = true;
-        report_change!("evaluate: Evaluated `{}` of a string literal", method);
+        report_change!("evaluate: Evaluated `{method}` of a string literal");
         *e = Expr::Lit(Lit::Str(Str {
             value: new_val.into(),
             ..s

--- a/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
@@ -745,6 +745,7 @@ impl Pure<'_> {
         report_change!("evaluate: Evaluated `{method}` of a string literal");
         *e = Expr::Lit(Lit::Str(Str {
             value: new_val.into(),
+            raw: None,
             ..s
         }));
     }

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -11193,3 +11193,22 @@ fn issue_8246_1() {
         false,
     );
 }
+
+#[test]
+fn issue_8864_1() {
+    run_default_exec_test(
+        "
+        export class Renderer {
+            renderStaticFrame(string1, string2) {
+            const line1Text = `${string1} and ${string2}`.toUpperCase();
+            const line2Text = 'line 2 text'.toUpperCase();
+        
+            const text = `${line1Text}\n${line2Text}`;
+            return text;
+            }
+        }
+      
+        console.log(new Renderer().renderStaticFrame('a', 'b'));
+      ",
+    )
+}

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -11198,7 +11198,7 @@ fn issue_8246_1() {
 fn issue_8864_1() {
     run_default_exec_test(
         "
-        export class Renderer {
+        class Renderer {
             renderStaticFrame(string1, string2) {
             const line1Text = `${string1} and ${string2}`.toUpperCase();
             const line2Text = 'line 2 text'.toUpperCase();


### PR DESCRIPTION
**Related issue:**

 - Closes #8864