### PR TITLE
fix(tsc-resolver): Prioritze jsc.paths by length in tsc resolver

### DIFF
--- a/crates/swc_ecma_loader/tests/tsc_resolver.rs
+++ b/crates/swc_ecma_loader/tests/tsc_resolver.rs
@@ -189,6 +189,41 @@ fn base_url_precedence() {
     }
 }
 
+#[test]
+fn pattern_length_precedence() {
+    let mut map = HashMap::default();
+    map.insert(
+        "./packages/helpers/src/hello".to_string(),
+        "good".to_string(),
+    );
+
+    let r = TsConfigResolver::new(
+        TestResolver(map),
+        ".".into(),
+        vec![
+            ("@app/*".into(), vec!["./packages/*/src".into()]),
+            (
+                "@app/helpers/*".into(),
+                vec!["./packages/helpers/src/*".into()],
+            ),
+        ],
+    );
+
+    {
+        let resolved = r
+            .resolve(&FileName::Anon, "@app/helpers/hello")
+            .expect("should resolve @app/helpers/hello");
+
+        assert_eq!(
+            resolved,
+            Resolution {
+                filename: FileName::Custom("good".into()),
+                slug: None
+            }
+        );
+    }
+}
+
 struct TestResolver(AHashMap<String, String>);
 
 impl Resolve for TestResolver {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
See #8858 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
`jsc.paths` are now prioritized differently to align with `tsc`. The order is:
1. Exact matches
2. Wildcard pattern matches, sorted by length of prefix before wildcard
3. 
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):** #8858 
