### PR TITLE
fix(es/minifier): don't reserve identifiers in expressions or patterns

### DIFF
--- a/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_names/preserver.rs
@@ -101,7 +101,7 @@ impl Visit for Preserver {
         n.visit_children_with(self);
 
         if let Expr::Ident(i) = n {
-            if self.should_preserve || self.is_reserved(i) {
+            if self.should_preserve {
                 self.preserved.insert(i.to_id());
             }
         }
@@ -141,7 +141,7 @@ impl Visit for Preserver {
         n.visit_children_with(self);
 
         if let Pat::Ident(i) = n {
-            if self.should_preserve || self.is_reserved(&i.id) {
+            if self.should_preserve {
                 self.preserved.insert(i.to_id());
             }
         }

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8622/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8622/config.json
@@ -1,0 +1,4 @@
+{
+    "defaults": true,
+    "passes": 2
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8622/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8622/input.js
@@ -1,0 +1,15 @@
+export function foo(cond) {
+    let reserved = 1;
+    if (cond) {
+        reserved = 2;
+    }
+    return [reserved, bar(cond)];
+}
+
+function bar(cond) {
+    let reserved = 1;
+    if (cond) {
+        reserved = 2;
+    }
+    return reserved;
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8622/mangle.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8622/mangle.json
@@ -1,0 +1,3 @@
+{
+    "reserved": ["reserved"]
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8622/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8622/output.js
@@ -1,7 +1,7 @@
-export function foo(e) {
-    let reserved, reserved = 1;
-    return e && (reserved = 2), [
-        reserved,
-        (reserved = 1, e && (reserved = 2), reserved)
+export function foo(o) {
+    let t, e = 1;
+    return o && (e = 2), [
+        e,
+        (t = 1, o && (t = 2), t)
     ];
 }

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8622/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8622/output.js
@@ -1,0 +1,7 @@
+export function foo(e) {
+    let reserved, reserved = 1;
+    return e && (reserved = 2), [
+        reserved,
+        (reserved = 1, e && (reserved = 2), reserved)
+    ];
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

https://github.com/swc-project/swc/issues/3424 added support for the `reserved` mangle option which prevents identifiers from being mangled when listed in the array. This is fine in most cases but can cause issues when the compressor brings two reserved variables into the same scope. When this occurs the generated code results in a parsing error due to the duplicate identifier.

This PR adds a test to cover this case and a proposed fix by ignoring reserved identifiers for patterns and expressions.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
fixes #8622 