### PR TITLE
fix(es/decorators): Handle ref of decorated class

### DIFF
--- a/crates/swc/tests/fixture/issues-8xxx/8095/es2020/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8095/es2020/output/1.js
@@ -6,4 +6,4 @@ const foo = (_class = class _class {
     }
 }, _ts_decorate([
     foo
-], _class.prototype, "foo", null));
+], _class.prototype, "foo", null), _class);

--- a/crates/swc/tests/fixture/issues-8xxx/8095/es2022/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8095/es2022/output/1.js
@@ -6,4 +6,4 @@ const foo = (_class = class _class {
     }
 }, _ts_decorate([
     foo
-], _class.prototype, "foo", null));
+], _class.prototype, "foo", null), _class);

--- a/crates/swc/tests/fixture/issues-8xxx/8095/es5/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8095/es5/output/1.js
@@ -18,4 +18,4 @@ var foo = (_class = function() {
     return _class;
 }(), _ts_decorate([
     foo
-], _class.prototype, "foo", null));
+], _class.prototype, "foo", null), _class);

--- a/crates/swc/tests/fixture/issues-8xxx/8515/output/index.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8515/output/index.js
@@ -5,7 +5,7 @@ var C = (_class = class _class extends Component {
 }, _class = _ts_decorate([
     addX,
     addY
-], _class));
+], _class), _class);
 let OtherClass = class OtherClass extends Component {
 };
 OtherClass = _ts_decorate([

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
@@ -285,11 +285,12 @@ impl VisitMut for TscDecorator {
                 exprs: iter::once(AssignExpr {
                     span: DUMMY_SP,
                     op: op!("="),
-                    left: var_name.into(),
+                    left: var_name.clone().into(),
                     right: Box::new(e.take()),
                 })
                 .map(Into::into)
                 .chain(appended_exprs)
+                .chain(iter::once(var_name.into()))
                 .collect(),
             });
         }


### PR DESCRIPTION
**Related issue:**

Follow up #8515 
Ts Decorator does not always return a class; we need to give it the correct reference.