### PR TITLE
feat(es/parser): Add `disallowAssertKeywords` option

### DIFF
--- a/crates/swc/tests/rust_api.rs
+++ b/crates/swc/tests/rust_api.rs
@@ -132,6 +132,7 @@ fn shopify_2_same_opt() {
                     syntax: Some(Syntax::Typescript(TsConfig {
                         tsx: true,
                         decorators: false,
+                        disallow_assert_keywords: false,
                         dts: false,
                         no_early_errors: false,
                         disallow_ambiguous_jsx_like: false,

--- a/crates/swc/tests/tsc.rs
+++ b/crates/swc/tests/tsc.rs
@@ -386,6 +386,7 @@ fn matrix(input: &Path) -> Vec<TestUnitData> {
                             syntax: Some(Syntax::Typescript(TsConfig {
                                 tsx: is_jsx,
                                 decorators,
+                                disallow_assert_keywords: false,
                                 dts: false,
                                 no_early_errors: false,
                                 disallow_ambiguous_jsx_like: false,

--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -291,6 +291,8 @@ pub enum SyntaxError {
 
     ReservedTypeAssertion,
     ReservedArrowTypeParam,
+
+    InvalidAssertKeywords,
 }
 
 impl SyntaxError {
@@ -754,6 +756,9 @@ impl SyntaxError {
                                                     as in `<T,>() => ...`."
                 .into(),
             SyntaxError::InvalidAssignTarget => "Invalid assignment target".into(),
+            SyntaxError::InvalidAssertKeywords => "The `assert` keyword is disallowed. Use the \
+                                                   `with` keyword instead for import attributes"
+                .into(),
         }
     }
 }

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -187,6 +187,20 @@ impl Syntax {
         }
     }
 
+    pub fn disallow_assert_keywords(self) -> bool {
+        match self {
+            Syntax::Es(EsConfig {
+                disallow_assert_keywords,
+                ..
+            }) => disallow_assert_keywords,
+            #[cfg(feature = "typescript")]
+            Syntax::Typescript(TsConfig {
+                disallow_assert_keywords,
+                ..
+            }) => disallow_assert_keywords,
+        }
+    }
+
     /// Should we parse jsx?
     pub fn jsx(self) -> bool {
         match self {
@@ -315,6 +329,9 @@ pub struct TsConfig {
     #[serde(default)]
     pub decorators: bool,
 
+    #[serde(default)]
+    pub disallow_assert_keywords: bool,
+
     /// `.d.ts`
     #[serde(skip, default)]
     pub dts: bool,
@@ -359,6 +376,9 @@ pub struct EsConfig {
     /// Stage 3.
     #[serde(default, alias = "importAssertions")]
     pub import_attributes: bool,
+
+    #[serde(default)]
+    pub disallow_assert_keywords: bool,
 
     #[serde(default, rename = "allowSuperOutsideMethod")]
     pub allow_super_outside_method: bool,

--- a/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
@@ -54,13 +54,25 @@ impl<I: Tokens> Parser<I> {
                 _ => unreachable!(),
             };
             let _ = cur!(self, false);
+            let with_start = cur_pos!(self);
             let with = if self.input.syntax().import_attributes()
                 && !self.input.had_line_break_before_cur()
-                && (eat!(self, "assert") || eat!(self, "with"))
             {
-                match *self.parse_object::<Box<Expr>>()? {
-                    Expr::Object(v) => Some(Box::new(v)),
-                    _ => unreachable!(),
+                if eat!(self, "assert") {
+                    if self.input.syntax().disallow_assert_keywords() {
+                        self.emit_err(span!(self, with_start), SyntaxError::InvalidAssertKeywords);
+                    }
+                    match *self.parse_object::<Box<Expr>>()? {
+                        Expr::Object(v) => Some(Box::new(v)),
+                        _ => unreachable!(),
+                    }
+                } else if eat!(self, "with") {
+                    match *self.parse_object::<Box<Expr>>()? {
+                        Expr::Object(v) => Some(Box::new(v)),
+                        _ => unreachable!(),
+                    }
+                } else {
+                    None
                 }
             } else {
                 None
@@ -178,17 +190,28 @@ impl<I: Tokens> Parser<I> {
         };
 
         let _ = cur!(self, false);
-        let with = if self.input.syntax().import_attributes()
-            && !self.input.had_line_break_before_cur()
-            && (eat!(self, "assert") || eat!(self, "with"))
-        {
-            match *self.parse_object::<Box<Expr>>()? {
-                Expr::Object(v) => Some(Box::new(v)),
-                _ => unreachable!(),
-            }
-        } else {
-            None
-        };
+        let with_start = cur_pos!(self);
+        let with =
+            if self.input.syntax().import_attributes() && !self.input.had_line_break_before_cur() {
+                if eat!(self, "assert") {
+                    if self.input.syntax().disallow_assert_keywords() {
+                        self.emit_err(span!(self, with_start), SyntaxError::InvalidAssertKeywords);
+                    }
+                    match *self.parse_object::<Box<Expr>>()? {
+                        Expr::Object(v) => Some(Box::new(v)),
+                        _ => unreachable!(),
+                    }
+                } else if eat!(self, "with") {
+                    match *self.parse_object::<Box<Expr>>()? {
+                        Expr::Object(v) => Some(Box::new(v)),
+                        _ => unreachable!(),
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
 
         expect!(self, ';');
 
@@ -847,17 +870,28 @@ impl<I: Tokens> Parser<I> {
             _ => unexpected!(self, "a string literal"),
         };
         let _ = cur!(self, false);
-        let with = if self.input.syntax().import_attributes()
-            && !self.input.had_line_break_before_cur()
-            && (eat!(self, "assert") || eat!(self, "with"))
-        {
-            match *self.parse_object::<Box<Expr>>()? {
-                Expr::Object(v) => Some(Box::new(v)),
-                _ => unreachable!(),
-            }
-        } else {
-            None
-        };
+        let with_start = cur_pos!(self);
+        let with =
+            if self.input.syntax().import_attributes() && !self.input.had_line_break_before_cur() {
+                if eat!(self, "assert") {
+                    if self.input.syntax().disallow_assert_keywords() {
+                        self.emit_err(span!(self, with_start), SyntaxError::InvalidAssertKeywords);
+                    }
+                    match *self.parse_object::<Box<Expr>>()? {
+                        Expr::Object(v) => Some(Box::new(v)),
+                        _ => unreachable!(),
+                    }
+                } else if eat!(self, "with") {
+                    match *self.parse_object::<Box<Expr>>()? {
+                        Expr::Object(v) => Some(Box::new(v)),
+                        _ => unreachable!(),
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
         expect!(self, ';');
         Ok((src, with))
     }

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -318,6 +318,7 @@ fn illegal_language_mode_directive1() {
         },
     );
 }
+
 #[test]
 fn illegal_language_mode_directive2() {
     test_parser(
@@ -347,4 +348,63 @@ fn illegal_language_mode_directive2() {
 #[test]
 fn parse_non_strict_for_loop() {
     script("for (var v1 = 1 in v3) {}");
+}
+
+#[test]
+fn disallow_assert_keywords1() {
+    test_parser(
+        r#"import foo from "foo.json" assert { type: "json" }"#,
+        Syntax::Es(EsConfig {
+            import_attributes: true,
+            disallow_assert_keywords: true,
+            ..Default::default()
+        }),
+        |p| {
+            let program = p.parse_program()?;
+
+            let errors = p.take_errors();
+            assert_eq!(
+                errors,
+                vec![Error::new(
+                    Span {
+                        lo: BytePos(28),
+                        hi: BytePos(34),
+                        ctxt: swc_common::SyntaxContext::empty()
+                    },
+                    crate::parser::SyntaxError::InvalidAssertKeywords
+                )]
+            );
+
+            Ok(program)
+        },
+    );
+}
+
+#[test]
+fn disallow_assert_keywords2() {
+    test_parser(
+        r#"import foo from "foo.json" assert { type: "json" }"#,
+        Syntax::Typescript(TsConfig {
+            disallow_assert_keywords: true,
+            ..Default::default()
+        }),
+        |p| {
+            let program = p.parse_program()?;
+
+            let errors = p.take_errors();
+            assert_eq!(
+                errors,
+                vec![Error::new(
+                    Span {
+                        lo: BytePos(28),
+                        hi: BytePos(34),
+                        ctxt: swc_common::SyntaxContext::empty()
+                    },
+                    crate::parser::SyntaxError::InvalidAssertKeywords
+                )]
+            );
+
+            Ok(program)
+        },
+    );
 }

--- a/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
@@ -90,6 +90,7 @@ fn identity(entry: PathBuf) {
             Syntax::Typescript(TsConfig {
                 tsx: file_name.contains("tsx"),
                 decorators: true,
+                disallow_assert_keywords: false,
                 dts: false,
                 no_early_errors: false,
                 disallow_ambiguous_jsx_like: false,

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -767,6 +767,9 @@ export interface EsParserConfig {
      * Defaults to `false`
      */
     explicitResourceManagement?: boolean;
+    /**
+     * Defaults to `false`
+     */
     disallowAssertKeywords?: boolean;
 }
 

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -675,6 +675,10 @@ export interface TsParserConfig {
      * @deprecated Always true because it's in ecmascript spec.
      */
     dynamicImport?: boolean;
+    /**
+     * Defaults to `false`
+     */
+    disallowAssertKeywords?: boolean;
 }
 
 export interface EsParserConfig {
@@ -763,6 +767,7 @@ export interface EsParserConfig {
      * Defaults to `false`
      */
     explicitResourceManagement?: boolean;
+    disallowAssertKeywords?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

V8 will remove support for the `assert` keywords, so Node.js and Chrome will follow suit.

> Hey, quick update on this. Node.js is planning to remove support for `assert` in v22 (which will be released in April) and Chrome in v126 (which will be released in May).

https://github.com/denoland/deno/issues/17944#issuecomment-2027005952

Disallow the `assert` keywords in Deno by adding the `disallowAssertKeywords` option in this PR.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

N/A

**Related issue (if exists):**

https://github.com/swc-project/swc/issues/8893#issuecomment-2080369150
