### PR TITLE
fix(es/minifier): Don't invoke IIFE containing reserved words

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -357,6 +357,14 @@ impl Optimizer<'_> {
         self.options.top_level()
     }
 
+    fn ident_reserved(&self, sym: &JsWord) -> bool {
+        if let Some(MangleOptions { reserved, .. }) = self.mangle_options {
+            reserved.contains(sym)
+        } else {
+            false
+        }
+    }
+
     fn handle_stmts(&mut self, stmts: &mut Vec<Stmt>, will_terminate: bool) {
         // Skip if `use asm` exists.
         if maybe_par!(

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8622/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8622/input.js
@@ -1,0 +1,15 @@
+export function foo(cond) {
+    let reserved = 1;
+    if (cond) {
+        reserved = 2;
+    }
+    return [reserved, bar(cond)];
+}
+
+function bar(cond) {
+    let reserved = 1;
+    if (cond) {
+        reserved = 2;
+    }
+    return reserved;
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8622/mangle.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8622/mangle.json
@@ -1,0 +1,3 @@
+{
+    "reserved": ["reserved"]
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8622/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8622/output.js
@@ -1,0 +1,10 @@
+export function foo(e) {
+    let reserved = 1;
+    return e && (reserved = 2), [
+        reserved,
+        function(e) {
+            let reserved = 1;
+            return e && (reserved = 2), reserved;
+        }(e)
+    ];
+}


### PR DESCRIPTION
**Description:**

`inline` and `seq inline` should apply this change too.


**Related issue:**

 - Closes #8622