### PR TITLE
fix(es/jest): Handle `@jest/globals`

### DIFF
--- a/crates/swc/tests/fixture/jest/mock-globals/input/.swcrc
+++ b/crates/swc/tests/fixture/jest/mock-globals/input/.swcrc
@@ -1,0 +1,23 @@
+{
+    "$schema": "https://json.schemastore.org/swcrc",
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true,
+            "dynamicImport": true
+        },
+        "transform": {
+            "react": {
+                "runtime": "automatic"
+            }
+        },
+        "baseUrl": "./",
+        "target": "es2021",
+        "keepClassNames": true
+    },
+    "isModule": true,
+    "module": {
+        "type": "commonjs",
+        "ignoreDynamic": false
+    }
+}

--- a/crates/swc/tests/fixture/jest/mock-globals/input/1.js
+++ b/crates/swc/tests/fixture/jest/mock-globals/input/1.js
@@ -1,0 +1,17 @@
+
+import { setTimeout } from 'timers/promises';
+
+import { describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('timers/promises', () => ({
+    setTimeout: jest.fn(() => Promise.resolve())
+}));
+
+describe('suite', () => {
+    it('my-test', () => {
+        const totalDelay = jest
+            .mocked(setTimeout)
+            .mock.calls.reduce((agg, call) => agg + (call[0] as number), 0);
+        expect(totalDelay).toStrictEqual(0);
+    })
+})

--- a/crates/swc/tests/fixture/jest/mock-globals/output/1.js
+++ b/crates/swc/tests/fixture/jest/mock-globals/output/1.js
@@ -1,0 +1,15 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+const _promises = require("node:timers/promises");
+const _globals = require("@jest/globals");
+_globals.jest.mock('timers/promises', ()=>({
+        setTimeout: _globals.jest.fn(()=>Promise.resolve())
+    }));
+(0, _globals.describe)('suite', ()=>{
+    (0, _globals.it)('my-test', ()=>{
+        const totalDelay = _globals.jest.mocked(_promises.setTimeout).mock.calls.reduce((agg, call)=>agg + call[0], 0);
+        (0, _globals.expect)(totalDelay).toStrictEqual(0);
+    });
+});

--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -1,4 +1,5 @@
 use is_macro::Is;
+use swc_atoms::Atom;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 
 use crate::{
@@ -312,4 +313,14 @@ pub enum ModuleExportName {
 
     #[tag("StringLiteral")]
     Str(Str),
+}
+
+impl ModuleExportName {
+    /// Get the atom of the export name.
+    pub fn atom(&self) -> &Atom {
+        match self {
+            ModuleExportName::Ident(i) => &i.sym,
+            ModuleExportName::Str(s) => &s.value,
+        }
+    }
 }


### PR DESCRIPTION
**Description:**

 - We have two `jest` pass. One in `@swc/core` (via _hidden.jest flag), and one in the plugin. This PR fixes only the core one.

However, the linked issue is wrong because the code tries to break the rule of ESM specification. So although this PR closes the issue, the final form is not the issue author wanted.

**Related issue:**

 - Closes https://github.com/swc-project/plugins/issues/310