### PR TITLE
perf(es/lints): Avoid needless allocations in `no-dupe-args`

### DIFF
--- a/crates/swc/tests/errors/lints/no-dupe-args/hash-mode/input.js
+++ b/crates/swc/tests/errors/lints/no-dupe-args/hash-mode/input.js
@@ -1,0 +1,9 @@
+function foo(
+    [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+    [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+    [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+    [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+    [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+
+}

--- a/crates/swc/tests/errors/lints/no-dupe-args/hash-mode/input.js
+++ b/crates/swc/tests/errors/lints/no-dupe-args/hash-mode/input.js
@@ -3,6 +3,7 @@ function foo(
     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+    [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
 

--- a/crates/swc/tests/errors/lints/no-dupe-args/hash-mode/output.swc-stderr
+++ b/crates/swc/tests/errors/lints/no-dupe-args/hash-mode/output.swc-stderr
@@ -1,0 +1,680 @@
+
+  x the name `a0` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :      ^|
+   :       `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :      ^|
+   :       `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `a1` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :          ^|
+   :           `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :          ^|
+   :           `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `a2` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :              ^|
+   :               `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :              ^|
+   :               `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `a3` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                  ^|
+   :                   `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                  ^|
+   :                   `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `a4` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                      ^|
+   :                       `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                      ^|
+   :                       `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `a5` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                          ^|
+   :                           `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                          ^|
+   :                           `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `a6` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                              ^|
+   :                               `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                              ^|
+   :                               `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `a7` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                  ^|
+   :                                   `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                  ^|
+   :                                   `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `a8` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                      ^|
+   :                                       `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                      ^|
+   :                                       `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `a9` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                          ^|
+   :                                           `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                          ^|
+   :                                           `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `b0` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                ^|
+   :                                                 `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                ^|
+   :                                                 `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `b1` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                    ^|
+   :                                                     `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                    ^|
+   :                                                     `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `b2` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                        ^|
+   :                                                         `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                        ^|
+   :                                                         `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `b3` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                            ^|
+   :                                                             `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                            ^|
+   :                                                             `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `b4` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                ^|
+   :                                                                 `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                ^|
+   :                                                                 `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `b5` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                    ^|
+   :                                                                     `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                    ^|
+   :                                                                     `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `b6` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                        ^|
+   :                                                                         `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                        ^|
+   :                                                                         `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `b7` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                            ^|
+   :                                                                             `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                            ^|
+   :                                                                             `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `b8` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                                ^|
+   :                                                                                 `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                                ^|
+   :                                                                                 `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `b9` is bound more than once in this parameter list
+   ,-[1:1]
+ 1 | function foo(
+ 2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                                    ^|
+   :                                                                                     `-- previous definition here
+ 3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+ 4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+ 5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+ 6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+   :                                                                                    ^|
+   :                                                                                     `-- used as parameter more than once
+ 7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+ 8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+   `----
+
+  x the name `a0` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :      ^|
+    :       `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :      ^|
+    :       `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `a1` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :          ^|
+    :           `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :          ^|
+    :           `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `a2` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :              ^|
+    :               `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :              ^|
+    :               `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `a3` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                  ^|
+    :                   `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                  ^|
+    :                   `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `a4` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                      ^|
+    :                       `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                      ^|
+    :                       `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `a5` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                          ^|
+    :                           `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                          ^|
+    :                           `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `a6` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                              ^|
+    :                               `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                              ^|
+    :                               `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `a7` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                  ^|
+    :                                   `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                  ^|
+    :                                   `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `a8` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                      ^|
+    :                                       `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                      ^|
+    :                                       `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `a9` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                          ^|
+    :                                           `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                          ^|
+    :                                           `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `b0` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                                ^|
+    :                                                 `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                                ^|
+    :                                                 `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `b1` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                                    ^|
+    :                                                     `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                                    ^|
+    :                                                     `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `b2` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                                        ^|
+    :                                                         `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                                        ^|
+    :                                                         `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `b3` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                                            ^|
+    :                                                             `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                                            ^|
+    :                                                             `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `b4` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                                                ^|
+    :                                                                 `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                                                ^|
+    :                                                                 `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `b5` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                                                    ^|
+    :                                                                     `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                                                    ^|
+    :                                                                     `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `b6` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                                                        ^|
+    :                                                                         `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                                                        ^|
+    :                                                                         `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `b7` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                                                            ^|
+    :                                                                             `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                                                            ^|
+    :                                                                             `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `b8` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                                                                ^|
+    :                                                                                 `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                                                                ^|
+    :                                                                                 `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----
+
+  x the name `b9` is bound more than once in this parameter list
+    ,-[1:1]
+  1 | function foo(
+  2 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+    :                                                                                    ^|
+    :                                                                                     `-- previous definition here
+  3 |     [c0, c1, c2, c3, c4, c5, c6, c7, c8, c9], [d0, d1, d2, d3, d4, d5, d6, d7, d8, d9],
+  4 |     [e0, e1, e2, e3, e4, e5, e6, e7, e8, e9], [f0, f1, f2, f3, f4, f5, f6, f7, f8, f9],
+  5 |     [g0, g1, g2, g3, g4, g5, g6, g7, g8, g9], [h0, h1, h2, h3, h4, h5, h6, h7, h8, h9],
+  6 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],
+  7 |     [i0, i1, i2, i3, i4, i5, i6, i7, i8, i9], [j0, j1, j2, j3, j4, j5, j6, j7, j8, j9],
+  8 |     [a0, a1, a2, a3, a4, a5, a6, a7, a8, a9], [b0, b1, b2, b3, b4, b5, b6, b7, b8, b9],) {
+    :                                                                                    ^|
+    :                                                                                     `-- used as parameter more than once
+  9 | 
+ 10 | }
+    `----

--- a/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
+++ b/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
@@ -16,7 +16,9 @@ struct NoDupeArgs {}
 /// is usually small.
 macro_rules! check {
     ($node:expr) => {{
-        // This allocates only if there are duplicate parameters.
+        // This vector allocates only if there are duplicate parameters.
+        // This is used to handle the case where the same parameter is used 3 or more
+        // times.
         let mut done = vec![];
 
         let mut i1 = 0;

--- a/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
+++ b/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
@@ -16,6 +16,9 @@ struct NoDupeArgs {}
 /// is usually small.
 macro_rules! check {
     ($node:expr) => {{
+        // This allocates only if there are duplicate parameters.
+        let mut done = vec![];
+
         let mut i1 = 0;
         for_each_binding_ident($node, |id1| {
             i1 += 1;
@@ -24,9 +27,11 @@ macro_rules! check {
             for_each_binding_ident($node, |id2| {
                 i2 += 1;
 
-                if i1 >= i2 {
+                if i1 >= i2 || done.contains(&i1) {
                     return;
                 }
+
+                done.push(i1);
 
                 if id1.span.ctxt == id2.span.ctxt && id1.sym == id2.sym {
                     HANDLER.with(|handler| {

--- a/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
+++ b/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
@@ -24,7 +24,7 @@ macro_rules! check {
             for_each_binding_ident($node, |id2| {
                 i2 += 1;
 
-                if i1 == i2 {
+                if i1 >= i2 {
                     return;
                 }
 

--- a/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
+++ b/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
@@ -31,9 +31,9 @@ macro_rules! check {
                     return;
                 }
 
-                done.push(i1);
-
                 if id1.span.ctxt == id2.span.ctxt && id1.sym == id2.sym {
+                    done.push(i1);
+
                     HANDLER.with(|handler| {
                         handler
                             .struct_span_err(

--- a/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
+++ b/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
@@ -21,6 +21,8 @@ macro_rules! check {
         // times.
         let mut done = vec![];
 
+        let mut hash_mode = false;
+
         let mut i1 = 0;
         for_each_binding_ident($node, |id1| {
             i1 += 1;
@@ -28,6 +30,15 @@ macro_rules! check {
             let mut i2 = 0;
             for_each_binding_ident($node, |id2| {
                 i2 += 1;
+
+                if hash_mode {
+                    return;
+                } else if i2 >= 100 {
+                    // While iterating for the first `id1`, we detect that there are more than 100
+                    // identifiers. We switch to hash mode.
+                    hash_mode = true;
+                    return;
+                }
 
                 if i1 >= i2 || done.contains(&i1) {
                     return;

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2407,7 +2407,8 @@ where
     op: F,
 }
 
-/// Finds all **binding** idents of `node`.
+/// Finds all **binding** idents of `node`. **Any nested identifiers in
+/// expressions are ignored**.
 pub fn for_each_binding_ident<T, F>(node: &T, op: F)
 where
     T: VisitWith<BindingIdentifierVisitor<F>>,
@@ -2426,12 +2427,9 @@ where
     /// No-op (we don't care about expressions)
     fn visit_expr(&mut self, _: &Expr) {}
 
-    fn visit_ident(&mut self, i: &Ident) {
+    fn visit_binding_ident(&mut self, i: &BindingIdent) {
         (self.op)(i);
     }
-
-    /// No-op (we don't care about expressions)
-    fn visit_prop_name(&mut self, _: &PropName) {}
 }
 
 pub fn is_valid_ident(s: &JsWord) -> bool {

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2373,6 +2373,8 @@ pub struct DestructuringFinder<I: IdentLike> {
 }
 
 /// Finds all **binding** idents of `node`.
+///
+/// If you want to avoid allocation, use [`for_each_binding_ident`] instead.
 pub fn find_pat_ids<T, I: IdentLike>(node: &T) -> Vec<I>
 where
     T: VisitWith<DestructuringFinder<I>>,
@@ -2391,6 +2393,41 @@ impl<I: IdentLike> Visit for DestructuringFinder<I> {
 
     fn visit_ident(&mut self, i: &Ident) {
         self.found.push(I::from_ident(i));
+    }
+
+    /// No-op (we don't care about expressions)
+    fn visit_prop_name(&mut self, _: &PropName) {}
+}
+
+/// Finds all **binding** idents of variables.
+pub struct BindingIdentifierVisitor<F>
+where
+    F: for<'a> FnMut(&'a Ident),
+{
+    op: F,
+}
+
+/// Finds all **binding** idents of `node`.
+pub fn for_each_binding_ident<T, F>(node: &T, op: F)
+where
+    T: VisitWith<BindingIdentifierVisitor<F>>,
+    F: for<'a> FnMut(&'a Ident),
+{
+    let mut v = BindingIdentifierVisitor { op };
+    node.visit_with(&mut v);
+}
+
+impl<F> Visit for BindingIdentifierVisitor<F>
+where
+    F: for<'a> FnMut(&'a Ident),
+{
+    noop_visit_type!();
+
+    /// No-op (we don't care about expressions)
+    fn visit_expr(&mut self, _: &Expr) {}
+
+    fn visit_ident(&mut self, i: &Ident) {
+        (self.op)(i);
     }
 
     /// No-op (we don't care about expressions)


### PR DESCRIPTION
**Description:**

I introduced a zero-allocation variant for `swc_ecma_utils::DestructuringFinder` that does not allocate anything.

**Related issue (if exists):**
