### PR TITLE
perf(es/parser): Do not track `raw` by hand

### DIFF
--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -1020,6 +1020,8 @@ pub struct TplElement {
     /// don't have to worry about this value.
     pub cooked: Option<Atom>,
 
+    /// You may need to perform. `.replace("\r\n", "\n").replace('\r', "\n")` on
+    /// this value.
     pub raw: Atom,
 }
 

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1965,11 +1965,12 @@ where
     fn emit_quasi(&mut self, node: &TplElement) -> Result {
         srcmap!(node, true);
 
+        let raw = node.raw.replace("\r\n", "\n").replace('\r', "\n");
         if self.cfg.minify || (self.cfg.ascii_only && !node.raw.is_ascii()) {
-            let v = get_template_element_from_raw(&node.raw, self.cfg.ascii_only);
+            let v = get_template_element_from_raw(&raw, self.cfg.ascii_only);
             self.wr.write_str_lit(DUMMY_SP, &v)?;
         } else {
-            self.wr.write_str_lit(DUMMY_SP, &node.raw)?;
+            self.wr.write_str_lit(DUMMY_SP, &raw)?;
         }
 
         srcmap!(node, false);

--- a/crates/swc_ecma_codegen/tests/test262.rs
+++ b/crates/swc_ecma_codegen/tests/test262.rs
@@ -1,9 +1,6 @@
 use std::{
-    env,
     fs::read_to_string,
-    io::{self, Write},
     path::{Path, PathBuf},
-    sync::{Arc, RwLock},
 };
 
 use swc_common::comments::SingleThreadedComments;
@@ -105,7 +102,7 @@ fn do_test(entry: &Path, minify: bool) {
         "\n\n========== Running codegen test {}\nSource:\n{}\n",
         file_name, input
     );
-    let mut wr = Buf(Arc::new(RwLock::new(vec![])));
+    let mut wr = vec![];
 
     ::testing::run_test(false, |cm, handler| {
         let src = cm.load_file(entry).expect("failed to load file");
@@ -168,23 +165,11 @@ fn do_test(entry: &Path, minify: bool) {
         }
         let ref_file = format!("{}", ref_dir.join(&file_name).display());
 
-        let code_output = wr.0.read().unwrap();
+        let code_output = wr;
         let with_srcmap =
             NormalizedOutput::from(String::from_utf8_lossy(&code_output).into_owned());
         with_srcmap.compare_to_file(ref_file).unwrap();
         Ok(())
     })
     .expect("failed to run test");
-}
-
-#[derive(Debug, Clone)]
-struct Buf(Arc<RwLock<Vec<u8>>>);
-impl Write for Buf {
-    fn write(&mut self, data: &[u8]) -> io::Result<usize> {
-        self.0.write().unwrap().write(data)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.0.write().unwrap().flush()
-    }
 }

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -1000,10 +1000,7 @@ impl<'a> Lexer<'a> {
     fn read_str_lit(&mut self) -> LexResult<Token> {
         debug_assert!(self.cur() == Some('\'') || self.cur() == Some('"'));
         let start = self.cur_pos();
-        let mut raw = String::new();
         let quote = self.cur().unwrap();
-
-        raw.push(quote);
 
         self.bump(); // '"'
 
@@ -1015,15 +1012,20 @@ impl<'a> Lexer<'a> {
                         .input
                         .uncons_while(|c| c != quote && c != '\\' && !c.is_line_break());
                     out.push_str(s);
-                    raw.push_str(s);
                 }
                 l.cur()
             } {
                 match c {
                     c if c == quote => {
-                        raw.push(c);
-
                         l.bump();
+
+                        let end = l.cur_pos();
+
+                        let raw = unsafe {
+                            // Safety: start and end are valid position because we got them from
+                            // `self.input`
+                            l.input.slice(start, end)
+                        };
 
                         return Ok(Token::Str {
                             value: l.atoms.atom(&*out),
@@ -1031,8 +1033,6 @@ impl<'a> Lexer<'a> {
                         });
                     }
                     '\\' => {
-                        raw.push(c);
-
                         let mut wrapped = Raw(Some(Default::default()));
 
                         if let Some(chars) = l.read_escaped_char(&mut wrapped, false)? {
@@ -1040,17 +1040,12 @@ impl<'a> Lexer<'a> {
                                 out.extend(c);
                             }
                         }
-
-                        raw.push_str(&wrapped.0.unwrap());
                     }
                     c if c.is_line_break() => {
-                        raw.push(c);
-
                         break;
                     }
                     _ => {
                         out.push(c);
-                        raw.push(c);
 
                         l.bump();
                     }
@@ -1059,6 +1054,13 @@ impl<'a> Lexer<'a> {
 
             l.emit_error(start, SyntaxError::UnterminatedStrLit);
 
+            let end = l.cur_pos();
+
+            let raw = unsafe {
+                // Safety: start and end are valid position because we got them from
+                // `self.input`
+                l.input.slice(start, end)
+            };
             Ok(Token::Str {
                 value: l.atoms.atom(&*out),
                 raw: l.atoms.atom(raw),


### PR DESCRIPTION
**Description:**

We can skip this logic completely, as it's `raw`.

~I'm under the impression that I'm super stupid~