### PR TITLE
refactor(es/utils): Refine some APIs

### DIFF
--- a/crates/swc_bundler/src/bundler/chunk/cjs.rs
+++ b/crates/swc_bundler/src/bundler/chunk/cjs.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::atomic::Ordering};
 use anyhow::Error;
 use swc_common::{collections::AHashMap, Span, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{quote_ident, undefined, ExprFactory};
+use swc_ecma_utils::{quote_ident, ExprFactory};
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 use crate::{
@@ -168,7 +168,7 @@ fn wrap_module(
                 )
                 .make_member(Ident::new("bind".into(), DUMMY_SP))
                 .as_callee(),
-                args: vec![undefined(DUMMY_SP).as_arg(), module_fn.as_arg()],
+                args: vec![Expr::undefined(DUMMY_SP).as_arg(), module_fn.as_arg()],
                 type_args: None,
             }))),
             definite: false,

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -18,8 +18,8 @@ use crate::{
         TsAsExpr, TsConstAssertion, TsInstantiation, TsNonNullExpr, TsSatisfiesExpr, TsTypeAnn,
         TsTypeAssertion, TsTypeParamDecl, TsTypeParamInstantiation,
     },
-    ArrayPat, BindingIdent, ComputedPropName, Id, ImportPhase, Invalid, KeyValueProp, ObjectPat,
-    PropName, Str,
+    ArrayPat, BindingIdent, ComputedPropName, Id, ImportPhase, Invalid, KeyValueProp, Number,
+    ObjectPat, PropName, Str,
 };
 
 #[ast_node(no_clone)]
@@ -171,6 +171,22 @@ bridge_from!(Box<Expr>, Box<JSXElement>, JSXElement);
 // assert_eq_size!(Expr, [u8; 80]);
 
 impl Expr {
+    /// Creates `void 0`.
+    #[inline]
+    pub fn undefined(span: Span) -> Box<Expr> {
+        UnaryExpr {
+            span,
+            op: op!("void"),
+            arg: Lit::Num(Number {
+                span,
+                value: 0.0,
+                raw: None,
+            })
+            .into(),
+        }
+        .into()
+    }
+
     pub fn leftmost(&self) -> Option<&Ident> {
         match self {
             Expr::Ident(i) => Some(i),

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -7,7 +7,7 @@ use phf::phf_set;
 use scoped_tls::scoped_thread_local;
 use swc_atoms::{js_word, Atom};
 use swc_common::{
-    ast_node, util::take::Take, BytePos, EqIgnoreSpan, Span, Spanned, SyntaxContext, DUMMY_SP,
+    ast_node, util::take::Take, BytePos, EqIgnoreSpan, Mark, Span, Spanned, SyntaxContext, DUMMY_SP,
 };
 
 use crate::{typescript::TsTypeAnn, Expr};
@@ -305,6 +305,19 @@ impl Ident {
         }
 
         Err(buf)
+    }
+
+    /// Create a new identifier with the given prefix.
+    pub fn with_prefix(&self, prefix: &str) -> Ident {
+        Ident::new(format!("{}{}", prefix, self.sym).into(), self.span)
+    }
+
+    /// Create a private identifier that is unique in the file, but with the
+    /// same symbol.
+    pub fn into_private(self) -> Ident {
+        let span = self.span.apply_mark(Mark::new());
+
+        Self::new(self.sym, span)
     }
 
     #[inline]

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -459,7 +459,7 @@ static RESERVED_IN_ES3: phf::Set<&str> = phf_set!(
     "volatile",
 );
 
-pub trait IdentExt: AsRef<str> {
+pub trait EsReserved: AsRef<str> {
     fn is_reserved(&self) -> bool {
         RESERVED.contains(self.as_ref())
     }
@@ -487,7 +487,7 @@ pub trait IdentExt: AsRef<str> {
     }
 }
 
-impl IdentExt for Atom {}
-impl IdentExt for Ident {}
-impl IdentExt for &'_ str {}
-impl IdentExt for String {}
+impl EsReserved for Atom {}
+impl EsReserved for Ident {}
+impl EsReserved for &'_ str {}
+impl EsReserved for String {}

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -21,7 +21,7 @@ pub use self::{
     decl::{ClassDecl, Decl, FnDecl, UsingDecl, VarDecl, VarDeclKind, VarDeclarator},
     expr::*,
     function::{Function, Param, ParamOrTsParamProp},
-    ident::{BindingIdent, Id, Ident, IdentExt, PrivateName},
+    ident::{BindingIdent, EsReserved, Id, Ident, PrivateName},
     jsx::{
         JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXClosingElement, JSXClosingFragment,
         JSXElement, JSXElementChild, JSXElementName, JSXEmptyExpr, JSXExpr, JSXExprContainer,

--- a/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
+++ b/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
@@ -596,7 +596,7 @@ impl VisitMut for BlockScoping {
             if self.var_decl_kind == VarDeclKind::Var {
                 var.init = None
             } else {
-                var.init = Some(undefined(var.span()))
+                var.init = Some(Expr::undefined(var.span()))
             }
         }
     }

--- a/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
+++ b/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
@@ -13,7 +13,7 @@ use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
 use swc_ecma_utils::{
     find_pat_ids, function::FnEnvHoister, prepend_stmt, private_ident, quote_ident, quote_str,
-    undefined, ExprFactory, StmtLike,
+    ExprFactory, StmtLike,
 };
 use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, visit_mut_obj_and_computed, Fold, Visit,
@@ -819,7 +819,7 @@ impl VisitMut for FlowHelper<'_> {
                                 Box::new(Expr::Unary(UnaryExpr {
                                     span: DUMMY_SP,
                                     op: op!("void"),
-                                    arg: undefined(DUMMY_SP),
+                                    arg: Expr::undefined(DUMMY_SP),
                                 }))
                             }),
                         })))],
@@ -869,7 +869,7 @@ struct MutationHandler<'a> {
 impl MutationHandler<'_> {
     fn make_reassignment(&self, orig: Option<Box<Expr>>) -> Expr {
         if self.map.is_empty() {
-            return *orig.unwrap_or_else(|| undefined(DUMMY_SP));
+            return *orig.unwrap_or_else(|| Expr::undefined(DUMMY_SP));
         }
 
         let mut exprs = Vec::with_capacity(self.map.len() + 1);
@@ -885,7 +885,7 @@ impl MutationHandler<'_> {
                 ))),
             })));
         }
-        exprs.push(orig.unwrap_or_else(|| undefined(DUMMY_SP)));
+        exprs.push(orig.unwrap_or_else(|| Expr::undefined(DUMMY_SP)));
 
         Expr::Seq(SeqExpr {
             span: DUMMY_SP,

--- a/crates/swc_ecma_compat_es2015/src/classes/mod.rs
+++ b/crates/swc_ecma_compat_es2015/src/classes/mod.rs
@@ -12,7 +12,7 @@ use swc_ecma_transforms_macros::fast_path;
 use swc_ecma_utils::{
     alias_if_required, contains_this_expr, default_constructor, is_valid_ident,
     is_valid_prop_ident, prepend_stmt, private_ident, prop_name_to_expr, quote_expr, quote_ident,
-    quote_str, replace_ident, ExprFactory, IdentExt, ModuleItemLike, StmtLike,
+    quote_str, replace_ident, ExprFactory, ModuleItemLike, StmtLike,
 };
 use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
@@ -264,7 +264,7 @@ where
         } = d
         {
             if let Expr::Class(c @ ClassExpr { ident: None, .. }) = &mut **init {
-                c.ident = Some(i.id.clone().private())
+                c.ident = Some(i.id.clone().into_private())
             }
         }
 
@@ -275,7 +275,7 @@ where
     fn visit_mut_assign_pat_prop(&mut self, n: &mut AssignPatProp) {
         if let Some(value) = &mut n.value {
             if let Expr::Class(c @ ClassExpr { ident: None, .. }) = &mut **value {
-                c.ident = Some((*n.key).clone().private());
+                c.ident = Some((*n.key).clone().into_private());
             }
         }
 
@@ -290,7 +290,7 @@ where
             Expr::Class(c @ ClassExpr { ident: None, .. }),
         ) = (&*n.left, &mut *n.right)
         {
-            c.ident = Some(id.clone().private())
+            c.ident = Some(id.clone().into_private())
         }
 
         n.visit_mut_children_with(self);
@@ -305,7 +305,7 @@ where
         if let Expr::Class(c @ ClassExpr { ident: None, .. }) = &mut *n.value {
             match &n.key {
                 PropName::Ident(ident) => {
-                    c.ident = Some(ident.clone().private());
+                    c.ident = Some(ident.clone().into_private());
                 }
                 PropName::Str(Str { value, span, .. }) => {
                     if is_valid_prop_ident(value) {
@@ -336,7 +336,7 @@ where
         {
             if let Expr::Class(c @ ClassExpr { ident: None, .. }) = &mut **right {
                 if let AssignTarget::Simple(SimpleAssignTarget::Ident(ident)) = left {
-                    c.ident = Some((**ident).clone().private())
+                    c.ident = Some((**ident).clone().into_private())
                 }
             }
         }

--- a/crates/swc_ecma_compat_es2015/src/destructuring.rs
+++ b/crates/swc_ecma_compat_es2015/src/destructuring.rs
@@ -682,7 +682,7 @@ impl VisitMut for AssignFolder {
                                                 debug_assert_eq!(e.spread, None);
                                                 e.expr
                                             })
-                                            .unwrap_or_else(|| undefined(p.span()));
+                                            .unwrap_or_else(|| Expr::undefined(p.span()));
 
                                         let p = p.take();
                                         let mut expr = if let Pat::Assign(pat) = p {

--- a/crates/swc_ecma_compat_es2015/src/destructuring.rs
+++ b/crates/swc_ecma_compat_es2015/src/destructuring.rs
@@ -8,7 +8,7 @@ use swc_ecma_transforms_base::{helper, helper_expr, perf::Check};
 use swc_ecma_transforms_macros::fast_path;
 use swc_ecma_utils::{
     alias_ident_for, alias_if_required, has_rest_pat, is_literal, member_expr, private_ident,
-    prop_name_to_expr, quote_ident, undefined, ExprFactory, StmtLike,
+    prop_name_to_expr, quote_ident, ExprFactory, StmtLike,
 };
 use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
@@ -1002,7 +1002,7 @@ impl VisitMut for AssignFolder {
         if var_decl.kind == VarDeclKind::Const {
             var_decl.decls.iter_mut().for_each(|v| {
                 if v.init.is_none() {
-                    v.init = Some(undefined(DUMMY_SP));
+                    v.init = Some(Expr::undefined(DUMMY_SP));
                 }
             })
         }

--- a/crates/swc_ecma_compat_es2015/src/generator.rs
+++ b/crates/swc_ecma_compat_es2015/src/generator.rs
@@ -14,8 +14,7 @@ use swc_common::{
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
 use swc_ecma_utils::{
-    function::FnEnvHoister, private_ident, prop_name_to_expr_value, quote_ident, undefined,
-    ExprFactory,
+    function::FnEnvHoister, private_ident, prop_name_to_expr_value, quote_ident, ExprFactory,
 };
 use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,
@@ -812,7 +811,7 @@ impl VisitMut for Generator {
                     &mut args,
                     Some(ExprOrSpread {
                         spread: None,
-                        expr: undefined(DUMMY_SP),
+                        expr: Expr::undefined(DUMMY_SP),
                     }),
                     None,
                 ))
@@ -3463,7 +3462,7 @@ impl Generator {
                 if is_new_call {
                     callee
                 } else {
-                    undefined(DUMMY_SP)
+                    Expr::undefined(DUMMY_SP)
                 },
             ),
 
@@ -3481,7 +3480,7 @@ impl Generator {
 
             _ => {
                 if !is_new_call {
-                    (callee, undefined(DUMMY_SP))
+                    (callee, Expr::undefined(DUMMY_SP))
                 } else {
                     let this_arg = self.create_temp_variable();
                     let target = callee.make_assign_to(op!("="), this_arg.clone().into());

--- a/crates/swc_ecma_compat_es2015/src/new_target.rs
+++ b/crates/swc_ecma_compat_es2015/src/new_target.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, mem};
 use swc_common::{pass::CompilerPass, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::perf::{should_work, Check};
-use swc_ecma_utils::{private_ident, quote_ident, undefined, ExprFactory};
+use swc_ecma_utils::{private_ident, quote_ident, ExprFactory};
 use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith,
 };
@@ -68,7 +68,7 @@ impl VisitMut for NewTarget {
             };
             match &self.ctx {
                 Ctx::Constructor => *e = this_ctor(*span),
-                Ctx::Method => *e = *undefined(DUMMY_SP),
+                Ctx::Method => *e = *Expr::undefined(DUMMY_SP),
                 Ctx::Function(i) => {
                     *e = Expr::Cond(CondExpr {
                         span: *span,
@@ -81,7 +81,7 @@ impl VisitMut for NewTarget {
                         })),
                         cons: Box::new(this_ctor(DUMMY_SP)),
                         // void 0
-                        alt: undefined(DUMMY_SP),
+                        alt: Expr::undefined(DUMMY_SP),
                     })
                 }
             }

--- a/crates/swc_ecma_compat_es2015/src/object_super.rs
+++ b/crates/swc_ecma_compat_es2015/src/object_super.rs
@@ -5,7 +5,6 @@ use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
 use swc_ecma_utils::{
     alias_ident_for, is_rest_arguments, prepend_stmt, private_ident, quote_ident, ExprFactory,
-    IdentExt,
 };
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 use swc_trace_macro::swc_trace;
@@ -397,7 +396,7 @@ impl SuperReplacer {
                     self.get_proto(),
                     super_token,
                     if computed {
-                        let ref_ident = alias_ident_for(&rhs, "_ref").private();
+                        let ref_ident = alias_ident_for(&rhs, "_ref").into_private();
                         self.vars.push(ref_ident.clone());
                         *prop = Expr::Assign(AssignExpr {
                             span: DUMMY_SP,
@@ -427,7 +426,7 @@ impl SuperReplacer {
                             .as_arg(),
                         )
                     } else {
-                        let update_ident = alias_ident_for(&rhs, "_super").private();
+                        let update_ident = alias_ident_for(&rhs, "_super").into_private();
                         self.vars.push(update_ident.clone());
                         Expr::Seq(SeqExpr {
                             span: DUMMY_SP,

--- a/crates/swc_ecma_compat_es2015/src/parameters.rs
+++ b/crates/swc_ecma_compat_es2015/src/parameters.rs
@@ -8,7 +8,7 @@ use swc_ecma_ast::*;
 // use swc_ecma_transforms_macros::parallel;
 use swc_ecma_utils::{
     function::{init_this, FnEnvHoister},
-    member_expr, prepend_stmt, prepend_stmts, private_ident, quote_ident, undefined, ExprFactory,
+    member_expr, prepend_stmt, prepend_stmts, private_ident, quote_ident, ExprFactory,
 };
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 use swc_trace_macro::swc_trace;
@@ -148,7 +148,7 @@ impl Params {
                                     right: Box::new(Expr::Bin(BinExpr {
                                         left: make_arg_nth(i).into(),
                                         op: op!("!=="),
-                                        right: undefined(DUMMY_SP),
+                                        right: Expr::undefined(DUMMY_SP),
                                         span: DUMMY_SP,
                                     })),
                                     span,
@@ -170,7 +170,7 @@ impl Params {
                                 span: DUMMY_SP,
                                 left: Box::new(Expr::Ident(ident.id.clone())),
                                 op: op!("==="),
-                                right: undefined(DUMMY_SP),
+                                right: Expr::undefined(DUMMY_SP),
                             })),
                             cons: Box::new(Stmt::Expr(ExprStmt {
                                 span,
@@ -203,7 +203,7 @@ impl Params {
                                             span: DUMMY_SP,
                                             left: Box::new(Expr::Ident(binding.clone())),
                                             op: op!("==="),
-                                            right: undefined(DUMMY_SP),
+                                            right: Expr::undefined(DUMMY_SP),
                                         })),
                                         cons: right,
                                         alt: Box::new(Expr::Ident(binding)),
@@ -786,7 +786,7 @@ fn check_arg_len_or_undef(n: usize) -> Expr {
     Expr::Cond(CondExpr {
         test: Box::new(check_arg_len(n)),
         cons: make_arg_nth(n).into(),
-        alt: undefined(DUMMY_SP),
+        alt: Expr::undefined(DUMMY_SP),
         span: DUMMY_SP,
     })
 }

--- a/crates/swc_ecma_compat_es2015/src/spread.rs
+++ b/crates/swc_ecma_compat_es2015/src/spread.rs
@@ -95,7 +95,7 @@ impl VisitMut for Spread {
                         (Box::new(Expr::Ident(obj.as_ident().unwrap().clone())), None)
                     }
 
-                    Expr::Ident(Ident { span, .. }) => (undefined(*span), None),
+                    Expr::Ident(Ident { span, .. }) => (Expr::undefined(*span), None),
 
                     Expr::Member(MemberExpr { span, obj, prop }) => {
                         let ident = alias_ident_for(obj, "_instance");

--- a/crates/swc_ecma_compat_es2015/src/spread.rs
+++ b/crates/swc_ecma_compat_es2015/src/spread.rs
@@ -6,7 +6,7 @@ use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{ext::ExprRefExt, helper, perf::Check};
 use swc_ecma_transforms_macros::fast_path;
 use swc_ecma_utils::{
-    alias_ident_for, member_expr, prepend_stmt, quote_ident, undefined, ExprFactory, StmtLike,
+    alias_ident_for, member_expr, prepend_stmt, quote_ident, ExprFactory, StmtLike,
 };
 use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, Fold, Visit, VisitMut, VisitMutWith, VisitWith,

--- a/crates/swc_ecma_compat_es2015/src/template_literal.rs
+++ b/crates/swc_ecma_compat_es2015/src/template_literal.rs
@@ -6,7 +6,7 @@ use swc_common::{util::take::Take, BytePos, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{helper, perf::Parallel};
 use swc_ecma_utils::{
-    is_literal, prepend_stmts, private_ident, quote_ident, undefined, ExprFactory, StmtLike,
+    is_literal, prepend_stmts, private_ident, quote_ident, ExprFactory, StmtLike,
 };
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 use swc_trace_macro::swc_trace;
@@ -291,7 +291,7 @@ impl VisitMut for TemplateLiteral {
                                                     .into_iter()
                                                     .map(|elem| match elem.cooked {
                                                         Some(cooked) => cooked.as_arg(),
-                                                        None => undefined(DUMMY_SP).as_arg(),
+                                                        None => Expr::undefined(DUMMY_SP).as_arg(),
                                                     })
                                                     .map(Some)
                                                     .collect(),

--- a/crates/swc_ecma_compat_es2020/src/nullish_coalescing.rs
+++ b/crates/swc_ecma_compat_es2020/src/nullish_coalescing.rs
@@ -3,9 +3,7 @@ use std::mem::take;
 use serde::Deserialize;
 use swc_common::{util::take::Take, Span, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{
-    alias_ident_for_simple_assign_tatget, alias_if_required, undefined, StmtLike,
-};
+use swc_ecma_utils::{alias_ident_for_simple_assign_tatget, alias_if_required, StmtLike};
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 use swc_trace_macro::swc_trace;
 
@@ -246,7 +244,7 @@ fn make_cond(c: Config, span: Span, alias: &Ident, var_expr: Expr, init: Box<Exp
                     span: DUMMY_SP,
                     left: Box::new(Expr::Ident(alias.clone())),
                     op: op!("!=="),
-                    right: undefined(DUMMY_SP),
+                    right: Expr::undefined(DUMMY_SP),
                 })),
             })),
             cons: Box::new(Expr::Ident(alias.clone())),

--- a/crates/swc_ecma_compat_es2022/src/class_properties/member_init.rs
+++ b/crates/swc_ecma_compat_es2022/src/class_properties/member_init.rs
@@ -1,9 +1,7 @@
 use swc_common::{Span, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
-use swc_ecma_utils::{
-    prop_name_to_expr, prop_name_to_expr_value, quote_ident, undefined, ExprFactory,
-};
+use swc_ecma_utils::{prop_name_to_expr, prop_name_to_expr_value, quote_ident, ExprFactory};
 use swc_trace_macro::swc_trace;
 
 use super::Config;
@@ -342,13 +340,13 @@ fn get_accessor_desc(getter: Option<Ident>, setter: Option<Ident>) -> ObjectLit 
                 key: PropName::Ident(quote_ident!("get")),
                 value: getter
                     .map(|id| Box::new(id.into()))
-                    .unwrap_or_else(|| undefined(DUMMY_SP)),
+                    .unwrap_or_else(|| Expr::undefined(DUMMY_SP)),
             }))),
             PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
                 key: PropName::Ident(quote_ident!("set")),
                 value: setter
                     .map(|id| Box::new(id.into()))
-                    .unwrap_or_else(|| undefined(DUMMY_SP)),
+                    .unwrap_or_else(|| Expr::undefined(DUMMY_SP)),
             }))),
         ],
     }

--- a/crates/swc_ecma_compat_es2022/src/class_properties/mod.rs
+++ b/crates/swc_ecma_compat_es2022/src/class_properties/mod.rs
@@ -632,7 +632,7 @@ impl<C: Comments> ClassProperties<C> {
                         _ => (),
                     };
 
-                    let mut value = prop.value.unwrap_or_else(|| undefined(prop_span));
+                    let mut value = prop.value.unwrap_or_else(|| Expr::undefined(prop_span));
 
                     value.visit_mut_with(&mut NewTargetInProp);
 
@@ -738,7 +738,7 @@ impl<C: Comments> ClassProperties<C> {
                         });
                     }
 
-                    let value = prop.value.unwrap_or_else(|| undefined(prop_span));
+                    let value = prop.value.unwrap_or_else(|| Expr::undefined(prop_span));
 
                     if prop.is_static && prop.span.has_mark(self.c.static_blocks_mark) {
                         let init = MemberInit::StaticBlock(value);

--- a/crates/swc_ecma_compat_es2022/src/class_properties/mod.rs
+++ b/crates/swc_ecma_compat_es2022/src/class_properties/mod.rs
@@ -8,7 +8,7 @@ use swc_ecma_transforms_classes::super_field::SuperFieldAccessFolder;
 use swc_ecma_transforms_macros::fast_path;
 use swc_ecma_utils::{
     alias_ident_for, alias_if_required, constructor::inject_after_super, default_constructor,
-    is_literal, prepend_stmt, private_ident, quote_ident, replace_ident, undefined, ExprFactory,
+    is_literal, prepend_stmt, private_ident, quote_ident, replace_ident, ExprFactory,
     ModuleItemLike, StmtLike,
 };
 use swc_ecma_visit::{

--- a/crates/swc_ecma_compat_es2022/src/class_properties/this_in_static.rs
+++ b/crates/swc_ecma_compat_es2022/src/class_properties/this_in_static.rs
@@ -1,5 +1,4 @@
 use swc_ecma_ast::*;
-use swc_ecma_utils::undefined;
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 use swc_trace_macro::swc_trace;
 
@@ -42,7 +41,7 @@ impl VisitMut for NewTargetInProp {
             kind: MetaPropKind::NewTarget,
         }) = e
         {
-            *e = *undefined(*span);
+            *e = *Expr::undefined(*span);
         }
     }
 

--- a/crates/swc_ecma_compat_es2022/src/optional_chaining_impl.rs
+++ b/crates/swc_ecma_compat_es2022/src/optional_chaining_impl.rs
@@ -2,9 +2,7 @@ use std::mem;
 
 use swc_common::{util::take::Take, Mark, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{
-    alias_ident_for, prepend_stmt, quote_ident, undefined, ExprFactory, StmtLike,
-};
+use swc_ecma_utils::{alias_ident_for, prepend_stmt, quote_ident, ExprFactory, StmtLike};
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 /// Not a public API and may break any time. Don't use it directly.
@@ -306,7 +304,7 @@ impl OptionalChaining {
                         cons: if is_delete {
                             true.into()
                         } else {
-                            undefined(DUMMY_SP)
+                            Expr::undefined(DUMMY_SP)
                         },
                         alt: Take::dummy(),
                     });
@@ -327,7 +325,7 @@ impl OptionalChaining {
                         cons: if is_delete {
                             true.into()
                         } else {
-                            undefined(DUMMY_SP)
+                            Expr::undefined(DUMMY_SP)
                         },
                         alt: Take::dummy(),
                     });
@@ -458,7 +456,7 @@ fn init_and_eq_null_or_undefined(i: &Memo, init: Expr, no_document_all: bool) ->
         span: DUMMY_SP,
         left: left_expr,
         op: op!("==="),
-        right: undefined(DUMMY_SP),
+        right: Expr::undefined(DUMMY_SP),
     }));
 
     Box::new(Expr::Bin(BinExpr {

--- a/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
@@ -132,7 +132,7 @@ impl Optimizer<'_> {
                         }
                     }
 
-                    *l = *undefined(l.span());
+                    *l = *Expr::undefined(l.span());
                     *r = *arg.take();
                     true
                 }

--- a/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
@@ -1,7 +1,7 @@
 use swc_common::{util::take::Take, EqIgnoreSpan, Span, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{
-    undefined, ExprExt, Type,
+    ExprExt, Type,
     Value::{self, Known},
 };
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
@@ -3,7 +3,7 @@ use std::num::FpCategory;
 use swc_atoms::atom;
 use swc_common::{util::take::Take, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{undefined, ExprExt, Value::Known};
+use swc_ecma_utils::{ExprExt, Value::Known};
 
 use super::Optimizer;
 use crate::{compress::util::eval_as_number, maybe_par, DISABLE_BUGGY_PASSES};
@@ -107,7 +107,7 @@ impl Optimizer<'_> {
             Expr::Ident(Ident { span, sym, .. }) if &**sym == "undefined" => {
                 report_change!("evaluate: `undefined` -> `void 0`");
                 self.changed = true;
-                *e = *undefined(*span);
+                *e = *Expr::undefined(*span);
             }
 
             Expr::Ident(Ident { span, sym, .. }) if &**sym == "Infinity" => {

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -427,7 +427,7 @@ impl Optimizer<'_> {
                 let cons = Box::new(self.merge_if_returns_to(*cons, vec![]));
                 let alt = match alt {
                     Some(alt) => Box::new(self.merge_if_returns_to(*alt, vec![])),
-                    None => undefined(DUMMY_SP),
+                    None => Expr::undefined(DUMMY_SP),
                 };
 
                 exprs.push(test);

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -1,7 +1,7 @@
 use swc_common::{util::take::Take, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_optimization::debug_assert_valid;
-use swc_ecma_utils::{undefined, StmtExt, StmtLike};
+use swc_ecma_utils::{StmtExt, StmtLike};
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use super::Optimizer;

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -455,7 +455,7 @@ impl Optimizer<'_> {
             }
             Stmt::Return(stmt) => {
                 let span = stmt.span;
-                exprs.push(stmt.arg.unwrap_or_else(|| undefined(span)));
+                exprs.push(stmt.arg.unwrap_or_else(|| Expr::undefined(span)));
                 Expr::Seq(SeqExpr {
                     span: DUMMY_SP,
                     exprs,

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -989,7 +989,7 @@ impl Optimizer<'_> {
 
                 Stmt::Return(stmt) => {
                     let span = stmt.span;
-                    let val = *stmt.arg.unwrap_or_else(|| undefined(span));
+                    let val = *stmt.arg.unwrap_or_else(|| Expr::undefined(span));
                     exprs.push(Box::new(val));
 
                     let mut e = SeqExpr {
@@ -1013,7 +1013,7 @@ impl Optimizer<'_> {
                 arg: last.take(),
             }));
         } else {
-            return Some(*undefined(body.span));
+            return Some(*Expr::undefined(body.span));
         }
 
         let mut e = SeqExpr {

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -3,9 +3,7 @@ use std::{collections::HashMap, mem::swap};
 use rustc_hash::FxHashMap;
 use swc_common::{pass::Either, util::take::Take, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{
-    contains_arguments, contains_this_expr, find_pat_ids, undefined, ExprFactory,
-};
+use swc_ecma_utils::{contains_arguments, contains_this_expr, find_pat_ids, ExprFactory};
 use swc_ecma_visit::VisitMutWith;
 
 use super::{util::NormalMultiReplacer, Optimizer};
@@ -905,7 +903,7 @@ impl Optimizer<'_> {
                 span: DUMMY_SP,
                 name: Pat::Ident(param.clone().into()),
                 init: if self.ctx.executed_multiple_time && no_arg {
-                    Some(undefined(DUMMY_SP))
+                    Some(Expr::undefined(DUMMY_SP))
                 } else {
                     None
                 },

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -233,7 +233,7 @@ impl Optimizer<'_> {
                                 param.id.span.ctxt
                             );
 
-                            vars.insert(param.to_id(), undefined(param.span()));
+                            vars.insert(param.to_id(), Expr::undefined(param.span()));
                         }
                     }
 
@@ -634,7 +634,7 @@ impl Optimizer<'_> {
                 if body.stmts.is_empty() && call.args.is_empty() {
                     self.changed = true;
                     report_change!("iife: Inlining an empty function call as `undefined`");
-                    *e = *undefined(f.function.span);
+                    *e = *Expr::undefined(f.function.span);
                     return;
                 }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -626,7 +626,7 @@ impl Optimizer<'_> {
     fn compress_undefined(&mut self, e: &mut Expr) {
         if let Expr::Ident(Ident { span, sym, .. }) = e {
             if &**sym == "undefined" {
-                *e = *undefined(*span);
+                *e = *Expr::undefined(*span);
             }
         }
     }
@@ -1214,12 +1214,12 @@ impl Optimizer<'_> {
                     cons: cons.unwrap_or_else(|| {
                         report_change!("ignore_return_value: Dropped `cons`");
                         self.changed = true;
-                        undefined(cons_span)
+                        Expr::undefined(cons_span)
                     }),
                     alt: alt.unwrap_or_else(|| {
                         report_change!("ignore_return_value: Dropped `alt`");
                         self.changed = true;
-                        undefined(alt_span)
+                        Expr::undefined(alt_span)
                     }),
                 }));
             }

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -12,8 +12,7 @@ use swc_ecma_ast::*;
 use swc_ecma_transforms_optimization::debug_assert_valid;
 use swc_ecma_usage_analyzer::{analyzer::UsageAnalyzer, marks::Marks};
 use swc_ecma_utils::{
-    prepend_stmts, undefined, ExprCtx, ExprExt, ExprFactory, IsEmpty, ModuleItemLike, StmtLike,
-    Type, Value,
+    prepend_stmts, ExprCtx, ExprExt, ExprFactory, IsEmpty, ModuleItemLike, StmtLike, Type, Value,
 };
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith, VisitWith};
 #[cfg(feature = "debug")]
@@ -2014,7 +2013,7 @@ impl VisitMut for Optimizer<'_> {
                     #[cfg(feature = "debug")]
                     dump_change_detail!("Removed {}", start);
 
-                    undefined(DUMMY_SP)
+                    Expr::undefined(DUMMY_SP)
                 });
             }
         } else {

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -7,8 +7,7 @@ use swc_ecma_usage_analyzer::{
     util::is_global_var_with_pure_property_access,
 };
 use swc_ecma_utils::{
-    contains_arguments, contains_this_expr, prepend_stmts, undefined, ExprExt, IdentUsageFinder,
-    StmtLike,
+    contains_arguments, contains_this_expr, prepend_stmts, ExprExt, IdentUsageFinder, StmtLike,
 };
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 #[cfg(feature = "debug")]
@@ -2334,7 +2333,7 @@ impl Optimizer<'_> {
                                 return Ok(false);
                             }
 
-                            right_val = undefined(DUMMY_SP);
+                            right_val = Expr::undefined(DUMMY_SP);
                             (left, Some(&mut right_val))
                         }
                     }
@@ -2394,7 +2393,7 @@ impl Optimizer<'_> {
 
                         if let Some(usage) = self.data.vars.get(&left_id.to_id()) {
                             if usage.var_kind == Some(VarDeclKind::Const) {
-                                a.init = Some(undefined(DUMMY_SP));
+                                a.init = Some(Expr::undefined(DUMMY_SP));
                             }
                         }
 
@@ -2402,7 +2401,7 @@ impl Optimizer<'_> {
                     } else {
                         a.init.clone()
                     }
-                    .unwrap_or_else(|| undefined(DUMMY_SP))
+                    .unwrap_or_else(|| Expr::undefined(DUMMY_SP))
                 }
                 Mergable::Expr(a) => {
                     if can_remove || force_drop {

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -191,7 +191,7 @@ impl Optimizer<'_> {
                                     e.prepend_exprs(take(&mut exprs));
                                 }
                                 _ => {
-                                    let mut e = undefined(stmt.span);
+                                    let mut e = Expr::undefined(stmt.span);
                                     e.prepend_exprs(take(&mut exprs));
 
                                     stmt.arg = Some(e);

--- a/crates/swc_ecma_minifier/src/compress/pure/drop_console.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/drop_console.rs
@@ -46,7 +46,7 @@ impl Pure<'_> {
 
                 report_change!("drop_console: Removing console call");
                 self.changed = true;
-                *e = *undefined(DUMMY_SP);
+                *e = *Expr::undefined(DUMMY_SP);
             }
         }
     }

--- a/crates/swc_ecma_minifier/src/compress/pure/drop_console.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/drop_console.rs
@@ -1,6 +1,5 @@
 use swc_common::DUMMY_SP;
 use swc_ecma_ast::*;
-use swc_ecma_utils::undefined;
 
 use super::Pure;
 

--- a/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
@@ -154,7 +154,7 @@ impl Pure<'_> {
                 *obj = arr.elems[0]
                     .take()
                     .map(|elem| elem.expr)
-                    .unwrap_or_else(|| undefined(*span));
+                    .unwrap_or_else(|| Expr::undefined(*span));
             }
         }
     }
@@ -529,7 +529,7 @@ impl Pure<'_> {
                          always null or undefined"
                     );
 
-                    *e = *undefined(*span);
+                    *e = *Expr::undefined(*span);
                 }
             }
 
@@ -541,7 +541,7 @@ impl Pure<'_> {
                          because object is always null or undefined"
                     );
 
-                    *e = *undefined(*span);
+                    *e = *Expr::undefined(*span);
                 }
             }
         }

--- a/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
@@ -1,7 +1,7 @@
 use radix_fmt::Radix;
 use swc_common::{util::take::Take, Spanned, SyntaxContext};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{number::ToJsString, undefined, ExprExt, IsEmpty, Value};
+use swc_ecma_utils::{number::ToJsString, ExprExt, IsEmpty, Value};
 
 use super::Pure;
 use crate::compress::util::{eval_as_number, is_pure_undefined_or_null};

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -7,7 +7,7 @@ use swc_ecma_ast::*;
 use swc_ecma_transforms_optimization::debug_assert_valid;
 use swc_ecma_usage_analyzer::util::is_global_var_with_pure_property_access;
 use swc_ecma_utils::{
-    undefined, ExprExt, ExprFactory, IdentUsageFinder, Type,
+    ExprExt, ExprFactory, IdentUsageFinder, Type,
     Value::{self, Known},
 };
 

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -82,7 +82,7 @@ impl Pure<'_> {
                                 None => {
                                     new_args.push(ExprOrSpread {
                                         spread: None,
-                                        expr: undefined(DUMMY_SP),
+                                        expr: Expr::undefined(DUMMY_SP),
                                     });
                                 }
                             }

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -6,7 +6,7 @@ use swc_common::{pass::Repeated, util::take::Take, SyntaxContext, DUMMY_SP, GLOB
 use swc_ecma_ast::*;
 use swc_ecma_transforms_optimization::debug_assert_valid;
 use swc_ecma_usage_analyzer::marks::Marks;
-use swc_ecma_utils::{undefined, ExprCtx};
+use swc_ecma_utils::ExprCtx;
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith, VisitWith};
 #[cfg(feature = "debug")]
 use tracing::{debug, span, Level};
@@ -375,7 +375,7 @@ impl VisitMut for Pure<'_> {
                         },
                     );
                     if arg.is_invalid() {
-                        *e = *undefined(*span);
+                        *e = *Expr::undefined(*span);
                         return;
                     }
                 }

--- a/crates/swc_ecma_minifier/src/eval.rs
+++ b/crates/swc_ecma_minifier/src/eval.rs
@@ -227,7 +227,7 @@ impl Evaluator {
             let res = self.eval(expr)?;
             exprs.push(match res {
                 EvalResult::Lit(v) => Box::new(Expr::Lit(v)),
-                EvalResult::Undefined => undefined(DUMMY_SP),
+                EvalResult::Undefined => Expr::undefined(DUMMY_SP),
             });
         }
 

--- a/crates/swc_ecma_minifier/src/eval.rs
+++ b/crates/swc_ecma_minifier/src/eval.rs
@@ -6,7 +6,7 @@ use swc_common::{collections::AHashMap, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_optimization::simplify::{expr_simplifier, ExprSimplifierConfig};
 use swc_ecma_usage_analyzer::marks::Marks;
-use swc_ecma_utils::{undefined, ExprCtx, ExprExt};
+use swc_ecma_utils::{ExprCtx, ExprExt};
 use swc_ecma_visit::VisitMutWith;
 
 use crate::{

--- a/crates/swc_ecma_transforms_compat/tests/es2015_parameters.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_parameters.rs
@@ -399,7 +399,7 @@ test_exec!(
   let d = rest[rest.length - 1];
   return [a, b, c, d];
 }
-expect(f1(1, 2)).toEqual([1, undefined, 2]);
+expect(f1(1, 2)).toEqual([1, undefined, undefined, 2]);
 
 function f2(a, ...rest) {
   return rest[-1];

--- a/crates/swc_ecma_transforms_compat/tests/es2015_parameters.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_parameters.rs
@@ -399,7 +399,7 @@ test_exec!(
   let d = rest[rest.length - 1];
   return [a, b, c, d];
 }
-expect(f1(1, 2)).toEqual([1, undefined, undefined, 2]);
+expect(f1(1, 2)).toEqual([1, undefined, 2]);
 
 function f2(a, ...rest) {
   return rest[-1];

--- a/crates/swc_ecma_transforms_compat/tests/es2018_object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2018_object_rest_spread.rs
@@ -394,7 +394,7 @@ const {
 expect(rest).toEqual({"foo": "bar"});
 expect(omit).toBe("three");
 
-const [k1, k2, k3, k4, k5] = [null, true, false, {toString() { return "warrior"; }}];
+const [k1, k2, k3, k4, k5] = [null, undefined, true, false, {toString() { return "warrior"; }}];
 const c = {
   [k1]: "1"
   [k2]: "2"
@@ -457,7 +457,7 @@ const {
 expect(rest).toEqual({"foo": "bar"});
 expect(omit).toBe("three");
 
-const [k1, k2, k3, k4, k5] = [null, true, false, {toString() { return "warrior"; }}];
+const [k1, k2, k3, k4, k5] = [null, undefined, true, false, {toString() { return "warrior"; }}];
 const c = {
   [k1]: "1"
   [k2]: "2"
@@ -1641,7 +1641,7 @@ expect(log).toEqual([1]);
 //expect(rest).toEqual({"foo": "bar"});
 //expect(omit).toBe("three");
 //
-//const [k1, k2, k3, k4, k5] = [null, true, false, {toString() {
+//const [k1, k2, k3, k4, k5] = [null, undefined, true, false, {toString() {
 // return "warrior"; }}]; const c = {
 //  [k1]: "1"
 //  [k2]: "2"
@@ -1696,7 +1696,7 @@ expect(log).toEqual([1]);
 //  "foo": "bar"
 //});
 //expect(omit).toBe("three");
-//const [k1, k2, k3, k4, k5] = [null, true, false, {
+//const [k1, k2, k3, k4, k5] = [null, undefined, true, false, {
 //  toString() {
 //    return "warrior";
 //  }
@@ -1854,7 +1854,7 @@ const {
 expect(rest).toEqual({"foo": "bar"});
 expect(omit).toBe("three");
 
-const [k1, k2, k3, k4, k5] = [null, true, false, {toString() { return "warrior"; }}];
+const [k1, k2, k3, k4, k5] = [null, undefined, true, false, {toString() { return "warrior"; }}];
 const c = {
   [k1]: "1",
   [k2]: "2",

--- a/crates/swc_ecma_transforms_compat/tests/es2018_object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2018_object_rest_spread.rs
@@ -394,7 +394,7 @@ const {
 expect(rest).toEqual({"foo": "bar"});
 expect(omit).toBe("three");
 
-const [k1, k2, k3, k4, k5] = [null, undefined, true, false, {toString() { return "warrior"; }}];
+const [k1, k2, k3, k4, k5] = [null, true, false, {toString() { return "warrior"; }}];
 const c = {
   [k1]: "1"
   [k2]: "2"
@@ -457,7 +457,7 @@ const {
 expect(rest).toEqual({"foo": "bar"});
 expect(omit).toBe("three");
 
-const [k1, k2, k3, k4, k5] = [null, undefined, true, false, {toString() { return "warrior"; }}];
+const [k1, k2, k3, k4, k5] = [null, true, false, {toString() { return "warrior"; }}];
 const c = {
   [k1]: "1"
   [k2]: "2"
@@ -1641,7 +1641,7 @@ expect(log).toEqual([1]);
 //expect(rest).toEqual({"foo": "bar"});
 //expect(omit).toBe("three");
 //
-//const [k1, k2, k3, k4, k5] = [null, undefined, true, false, {toString() {
+//const [k1, k2, k3, k4, k5] = [null, true, false, {toString() {
 // return "warrior"; }}]; const c = {
 //  [k1]: "1"
 //  [k2]: "2"
@@ -1696,7 +1696,7 @@ expect(log).toEqual([1]);
 //  "foo": "bar"
 //});
 //expect(omit).toBe("three");
-//const [k1, k2, k3, k4, k5] = [null, undefined, true, false, {
+//const [k1, k2, k3, k4, k5] = [null, true, false, {
 //  toString() {
 //    return "warrior";
 //  }
@@ -1854,7 +1854,7 @@ const {
 expect(rest).toEqual({"foo": "bar"});
 expect(omit).toBe("three");
 
-const [k1, k2, k3, k4, k5] = [null, undefined, true, false, {toString() { return "warrior"; }}];
+const [k1, k2, k3, k4, k5] = [null, true, false, {toString() { return "warrior"; }}];
 const c = {
   [k1]: "1",
   [k2]: "2",

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -10,8 +10,7 @@ use swc_common::{
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{feature::FeatureFlag, helper_expr};
 use swc_ecma_utils::{
-    member_expr, private_ident, quote_ident, quote_str, undefined, ExprFactory, FunctionFactory,
-    IsDirective,
+    member_expr, private_ident, quote_ident, quote_str, ExprFactory, FunctionFactory, IsDirective,
 };
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
@@ -154,7 +153,7 @@ where
         }
 
         if !self.config.allow_top_level_this {
-            top_level_this(&mut n.body, *undefined(DUMMY_SP));
+            top_level_this(&mut n.body, *Expr::undefined(DUMMY_SP));
         }
 
         let import_interop = self.config.import_interop();

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -4,8 +4,7 @@ use swc_common::{
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{feature::FeatureFlag, helper_expr};
 use swc_ecma_utils::{
-    member_expr, private_ident, quote_expr, quote_ident, undefined, ExprFactory, FunctionFactory,
-    IsDirective,
+    member_expr, private_ident, quote_expr, quote_ident, ExprFactory, FunctionFactory, IsDirective,
 };
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
@@ -110,7 +109,7 @@ where
         }
 
         if !self.config.allow_top_level_this {
-            top_level_this(&mut n.body, *undefined(DUMMY_SP));
+            top_level_this(&mut n.body, *Expr::undefined(DUMMY_SP));
         }
 
         let import_interop = self.config.import_interop();

--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -4,7 +4,7 @@ use swc_atoms::JsWord;
 use swc_common::{collections::AHashMap, FileName, Mark, Span, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{
-    member_expr, private_ident, quote_ident, quote_str, undefined, var::VarCollector, ExprFactory,
+    member_expr, private_ident, quote_ident, quote_str, var::VarCollector, ExprFactory,
 };
 use swc_ecma_visit::{noop_fold_type, Fold, FoldWith, VisitWith};
 
@@ -393,7 +393,7 @@ impl SystemJs {
                         if (sym.clone(), ctxt) == *k {
                             for value in v.iter() {
                                 self.export_names.push(value.clone());
-                                self.export_values.push(undefined(DUMMY_SP));
+                                self.export_values.push(Expr::undefined(DUMMY_SP));
                             }
                             break;
                         }
@@ -434,7 +434,7 @@ impl SystemJs {
                             if to == *k {
                                 for value in v.iter() {
                                     self.export_names.push(value.clone());
-                                    self.export_values.push(undefined(DUMMY_SP));
+                                    self.export_values.push(Expr::undefined(DUMMY_SP));
                                 }
                                 break;
                             }
@@ -620,7 +620,7 @@ impl Fold for SystemJs {
         let module = {
             let mut module = module;
             if !self.config.allow_top_level_this {
-                top_level_this(&mut module, *undefined(DUMMY_SP));
+                top_level_this(&mut module, *Expr::undefined(DUMMY_SP));
             }
             module
         };
@@ -816,7 +816,7 @@ impl Fold for SystemJs {
                             Decl::Class(class_decl) => {
                                 let ident = class_decl.ident;
                                 self.export_names.push(ident.sym.clone());
-                                self.export_values.push(undefined(DUMMY_SP));
+                                self.export_values.push(Expr::undefined(DUMMY_SP));
                                 self.add_declare_var_idents(&ident);
                                 self.add_export_name(ident.to_id(), ident.sym.clone());
                                 execute_stmts.push(
@@ -867,7 +867,7 @@ impl Fold for SystemJs {
                             DefaultDecl::Class(class_expr) => {
                                 if let Some(ident) = &class_expr.ident {
                                     self.export_names.push("default".into());
-                                    self.export_values.push(undefined(DUMMY_SP));
+                                    self.export_values.push(Expr::undefined(DUMMY_SP));
                                     self.add_declare_var_idents(ident);
                                     self.add_export_name(ident.to_id(), "default".into());
                                     execute_stmts.push(

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -6,7 +6,7 @@ use swc_common::{
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{feature::FeatureFlag, helper_expr};
 use swc_ecma_utils::{
-    is_valid_prop_ident, private_ident, quote_ident, quote_str, undefined, ExprFactory, IsDirective,
+    is_valid_prop_ident, private_ident, quote_ident, quote_str, ExprFactory, IsDirective,
 };
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
@@ -127,7 +127,7 @@ where
         }
 
         if !self.config.config.allow_top_level_this {
-            top_level_this(module_items, *undefined(DUMMY_SP));
+            top_level_this(module_items, *Expr::undefined(DUMMY_SP));
         }
 
         let import_interop = self.config.config.import_interop();

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -1493,7 +1493,11 @@ fn ignore_result(e: Expr, drop_str_lit: bool, ctx: &ExprCtx) -> Option<Expr> {
 
             match (left, right) {
                 (Some(l), Some(r)) => ignore_result(
-                    ctx.preserve_effects(span, *undefined(span), vec![Box::new(l), Box::new(r)]),
+                    ctx.preserve_effects(
+                        span,
+                        *Expr::undefined(span),
+                        vec![Box::new(l), Box::new(r)],
+                    ),
                     true,
                     ctx,
                 ),
@@ -1607,7 +1611,7 @@ fn ignore_result(e: Expr, drop_str_lit: bool, ctx: &ExprCtx) -> Option<Expr> {
                 ignore_result(
                     ctx.preserve_effects(
                         span,
-                        *undefined(span),
+                        *Expr::undefined(span),
                         elems.into_iter().map(|v| v.unwrap().expr),
                     ),
                     true,
@@ -1674,14 +1678,14 @@ fn ignore_result(e: Expr, drop_str_lit: bool, ctx: &ExprCtx) -> Option<Expr> {
         ),
 
         Expr::Tpl(Tpl { span, exprs, .. }) => ignore_result(
-            ctx.preserve_effects(span, *undefined(span), exprs),
+            ctx.preserve_effects(span, *Expr::undefined(span), exprs),
             true,
             ctx,
         ),
 
         Expr::TaggedTpl(TaggedTpl { span, tag, tpl, .. }) if tag.is_pure_callee(ctx) => {
             ignore_result(
-                ctx.preserve_effects(span, *undefined(span), tpl.exprs),
+                ctx.preserve_effects(span, *Expr::undefined(span), tpl.exprs),
                 true,
                 ctx,
             )

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -11,8 +11,8 @@ use swc_ecma_transforms_base::{
     perf::{cpu_count, Parallel, ParallelExt},
 };
 use swc_ecma_utils::{
-    extract_var_ids, is_literal, prepend_stmt, undefined, ExprCtx, ExprExt, ExprFactory, Hoister,
-    IsEmpty, StmtExt, StmtLike, Value::Known,
+    extract_var_ids, is_literal, prepend_stmt, ExprCtx, ExprExt, ExprFactory, Hoister, IsEmpty,
+    StmtExt, StmtLike, Value::Known,
 };
 use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith,
@@ -1634,7 +1634,7 @@ fn ignore_result(e: Expr, drop_str_lit: bool, ctx: &ExprCtx) -> Option<Expr> {
                 ignore_result(
                     ctx.preserve_effects(
                         span,
-                        *undefined(DUMMY_SP),
+                        *Expr::undefined(DUMMY_SP),
                         once(Box::new(Expr::Object(ObjectLit { span, props }))),
                     ),
                     true,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -161,7 +161,7 @@ impl SimplifyExpr {
                 KnownOp::Index(idx) if (idx as usize) < value.len() => {
                     if idx < 0 {
                         self.changed = true;
-                        *expr = *undefined(*span)
+                        *expr = *Expr::undefined(*span)
                     } else if let Some(value) = nth_char(value, idx as _) {
                         self.changed = true;
                         *expr = Expr::Lit(Lit::Str(Str {
@@ -235,7 +235,7 @@ impl SimplifyExpr {
                     };
 
                     let v = match e {
-                        None => undefined(*span),
+                        None => Expr::undefined(*span),
                         Some(e) => e.expr,
                     };
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -13,8 +13,8 @@ use swc_ecma_transforms_base::{
     perf::{cpu_count, Parallel, ParallelExt},
 };
 use swc_ecma_utils::{
-    is_literal, prop_name_eq, to_int32, undefined, BoolType, ExprCtx, ExprExt, NullType,
-    NumberType, ObjectType, StringType, SymbolType, UndefinedType, Value,
+    is_literal, prop_name_eq, to_int32, BoolType, ExprCtx, ExprExt, NullType, NumberType,
+    ObjectType, StringType, SymbolType, UndefinedType, Value,
 };
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, VisitMut, VisitMutWith};
 use Value::{Known, Unknown};
@@ -1363,7 +1363,7 @@ impl VisitMut for SimplifyExpr {
                             e.extend(expr.array().unwrap().elems.into_iter().map(|elem| {
                                 Some(elem.unwrap_or_else(|| ExprOrSpread {
                                     spread: None,
-                                    expr: undefined(DUMMY_SP),
+                                    expr: Expr::undefined(DUMMY_SP),
                                 }))
                             }));
                         }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/inlining/mod.rs
@@ -6,7 +6,7 @@ use swc_common::{
 };
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{pass::RepeatedJsPass, scope::IdentType};
-use swc_ecma_utils::{contains_this_expr, find_pat_ids, undefined};
+use swc_ecma_utils::{contains_this_expr, find_pat_ids};
 use swc_ecma_visit::{
     as_folder, noop_visit_mut_type, noop_visit_type, visit_obj_and_computed, Visit, VisitMut,
     VisitMutWith, VisitWith,
@@ -316,7 +316,7 @@ impl VisitMut for Inlining<'_> {
                                 tracing::debug!("Inlining: {:?} as undefined", id);
 
                                 if var.is_undefined.get() {
-                                    *node = *undefined(i.span);
+                                    *node = *Expr::undefined(i.span);
                                     return;
                                 } else {
                                     tracing::trace!("Not a cheap expression");

--- a/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_2022_03.rs
@@ -8,7 +8,7 @@ use swc_ecma_transforms_base::{helper, helper_expr};
 use swc_ecma_utils::{
     alias_ident_for, constructor::inject_after_super, default_constructor,
     is_maybe_branch_directive, private_ident, prop_name_to_expr_value, quote_ident, replace_ident,
-    stack_size::maybe_grow_default, ExprFactory, IdentExt, IdentRenamer,
+    stack_size::maybe_grow_default, ExprFactory, IdentRenamer,
 };
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
@@ -437,7 +437,7 @@ impl Decorator202203 {
             definite: false,
         });
 
-        let preserved_class_name = c.ident.clone().private();
+        let preserved_class_name = c.ident.clone().into_private();
         let new_class_name = private_ident!(format!("_{}", c.ident.sym));
 
         self.extra_lets.push(VarDeclarator {

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
@@ -8,7 +8,7 @@ use swc_common::{
 };
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
-use swc_ecma_utils::{quote_ident, undefined, ExprFactory};
+use swc_ecma_utils::{quote_ident, ExprFactory};
 use swc_ecma_visit::{VisitMut, VisitMutWith};
 
 use super::EnumKind;
@@ -495,7 +495,7 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
 
     let param = match param {
         Some(v) => &v.type_ann,
-        None => return *undefined(DUMMY_SP),
+        None => return *Expr::undefined(DUMMY_SP),
     };
 
     serialize_type_node(class_name.map(|v| &*v.sym).unwrap_or(""), param)

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
@@ -405,7 +405,7 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
             | TsType::TsKeywordType(TsKeywordType {
                 kind: TsKeywordTypeKind::TsNeverKeyword,
                 ..
-            }) => *undefined(span),
+            }) => *Expr::undefined(span),
 
             TsType::TsParenthesizedType(ty) => serialize_type_node(class_name, &ty.type_ann),
 

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
@@ -4,9 +4,7 @@ use swc_atoms::JsWord;
 use swc_common::{collections::AHashMap, util::take::Take, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
-use swc_ecma_utils::{
-    private_ident, prop_name_to_expr_value, quote_ident, undefined, ExprFactory, StmtLike,
-};
+use swc_ecma_utils::{private_ident, prop_name_to_expr_value, quote_ident, ExprFactory, StmtLike};
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
 use self::metadata::{Metadata, ParamMetadata};
@@ -359,7 +357,7 @@ impl VisitMut for TscDecorator {
                     c.decorators.drain(..).map(|d| d.expr),
                     target,
                     key.as_arg(),
-                    undefined(DUMMY_SP).as_arg(),
+                    Expr::undefined(DUMMY_SP).as_arg(),
                 );
             }
         }

--- a/crates/swc_ecma_transforms_proposal/src/decorators/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/mod.rs
@@ -8,8 +8,7 @@ use swc_ecma_transforms_base::helper;
 use swc_ecma_transforms_classes::super_field::SuperFieldAccessFolder;
 use swc_ecma_utils::{
     alias_ident_for, constructor::inject_after_super, default_constructor, prepend_stmt,
-    private_ident, prop_name_to_expr, prop_name_to_expr_value, quote_ident, quote_str, undefined,
-    ExprFactory,
+    private_ident, prop_name_to_expr, prop_name_to_expr_value, quote_ident, quote_str, ExprFactory,
 };
 use swc_ecma_visit::{as_folder, noop_fold_type, Fold, FoldWith, Visit, VisitWith};
 
@@ -532,7 +531,7 @@ impl Decorators {
                                     }),
                                     _ => Prop::KeyValue(KeyValueProp {
                                         key: PropName::Ident(quote_ident!("value")),
-                                        value: undefined(DUMMY_SP),
+                                        value: Expr::undefined(DUMMY_SP),
                                     }),
                                 }))))
                                 .collect(),

--- a/crates/swc_ecma_transforms_proposal/src/decorators/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/mod.rs
@@ -9,7 +9,7 @@ use swc_ecma_transforms_classes::super_field::SuperFieldAccessFolder;
 use swc_ecma_utils::{
     alias_ident_for, constructor::inject_after_super, default_constructor, prepend_stmt,
     private_ident, prop_name_to_expr, prop_name_to_expr_value, quote_ident, quote_str, undefined,
-    ExprFactory, IdentExt,
+    ExprFactory,
 };
 use swc_ecma_visit::{as_folder, noop_fold_type, Fold, FoldWith, Visit, VisitWith};
 
@@ -402,7 +402,7 @@ impl Decorators {
                                 key: PropName::Ident(quote_ident!("value")),
                                 value: Box::new(
                                     FnExpr {
-                                        ident: fn_name.map(IdentExt::private),
+                                        ident: fn_name.map(Ident::into_private),
                                         function: Function {
                                             decorators: vec![],
                                             ..*method.function

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -16,9 +16,7 @@ use swc_common::{
 use swc_config::merge::Merge;
 use swc_ecma_ast::*;
 use swc_ecma_parser::{parse_file_as_expr, Syntax};
-use swc_ecma_utils::{
-    drop_span, prepend_stmt, private_ident, quote_ident, undefined, ExprFactory, StmtLike,
-};
+use swc_ecma_utils::{drop_span, prepend_stmt, private_ident, quote_ident, ExprFactory, StmtLike};
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, Fold, VisitMut, VisitMutWith};
 
 use self::static_check::should_use_create_element;
@@ -528,7 +526,7 @@ where
                 let args = once(fragment.as_arg()).chain(once(props_obj.as_arg()));
 
                 let args = if self.development {
-                    args.chain(once(undefined(DUMMY_SP).as_arg()))
+                    args.chain(once(Expr::undefined(DUMMY_SP).as_arg()))
                         .chain(once(use_jsxs.as_arg()))
                         .collect()
                 } else {
@@ -794,19 +792,19 @@ where
                     // set undefined literal to key if key is None
                     let key = match key {
                         Some(key) => key,
-                        None => undefined(DUMMY_SP).as_arg(),
+                        None => Expr::undefined(DUMMY_SP).as_arg(),
                     };
 
                     // set undefined literal to __source if __source is None
                     let source_props = match source_props {
                         Some(source_props) => source_props,
-                        None => undefined(DUMMY_SP).as_arg(),
+                        None => Expr::undefined(DUMMY_SP).as_arg(),
                     };
 
                     // set undefined literal to __self if __self is None
                     let self_props = match self_props {
                         Some(self_props) => self_props,
-                        None => undefined(DUMMY_SP).as_arg(),
+                        None => Expr::undefined(DUMMY_SP).as_arg(),
                     };
                     args.chain(once(key))
                         .chain(once(use_jsxs.as_arg()))

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -3,7 +3,7 @@ use std::mem;
 use swc_atoms::JsWord;
 use swc_common::{collections::AHashMap, Mark, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{number::ToJsString, undefined, ExprFactory};
+use swc_ecma_utils::{number::ToJsString, ExprFactory};
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -77,7 +77,7 @@ impl From<TsEnumRecordValue> for Expr {
                 value: num,
                 raw: None,
             })),
-            TsEnumRecordValue::Void => *undefined(DUMMY_SP),
+            TsEnumRecordValue::Void => *Expr::undefined(DUMMY_SP),
             TsEnumRecordValue::Opaque(expr) => *expr,
         }
     }

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2349,24 +2349,6 @@ impl IsDirective for &ModuleItem {
     }
 }
 
-pub trait IdentExt {
-    fn prefix(&self, prefix: &str) -> Ident;
-
-    fn private(self) -> Ident;
-}
-
-impl IdentExt for Ident {
-    fn prefix(&self, prefix: &str) -> Ident {
-        Ident::new(format!("{}{}", prefix, self.sym).into(), self.span)
-    }
-
-    fn private(self) -> Ident {
-        let span = self.span.apply_mark(Mark::fresh(Mark::root()));
-
-        Ident::new(self.sym, span)
-    }
-}
-
 /// Finds all **binding** idents of variables.
 pub struct DestructuringFinder<I: IdentLike> {
     pub found: Vec<I>,

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -1140,7 +1140,7 @@ pub trait ExprExt {
                 }
 
                 if !may_be_str(lt) && !may_be_str(rt) {
-                    // ADD used with compilations of null, undefined, boolean and number always
+                    // ADD used with compilations of null, boolean and number always
                     // result in numbers.
                     return Known(NumberType);
                 }

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2207,22 +2207,6 @@ pub fn is_rest_arguments(e: &ExprOrSpread) -> bool {
     e.expr.is_ident_ref_to("arguments")
 }
 
-/// Creates `void 0`.
-#[inline]
-pub fn undefined(span: Span) -> Box<Expr> {
-    UnaryExpr {
-        span,
-        op: op!("void"),
-        arg: Lit::Num(Number {
-            span,
-            value: 0.0,
-            raw: None,
-        })
-        .into(),
-    }
-    .into()
-}
-
 pub fn opt_chain_test(
     left: Box<Expr>,
     right: Box<Expr>,
@@ -2250,7 +2234,7 @@ pub fn opt_chain_test(
                 span: DUMMY_SP,
                 left: right,
                 op: op!("==="),
-                right: undefined(DUMMY_SP),
+                right: Expr::undefined(DUMMY_SP),
             })),
         })
     }


### PR DESCRIPTION
**Description:**

This PR
 - moves some APIs into `swc_ecma_ast`.
 - removes needless types.

**BREAKING CHANGE:**

 - `swc_ecma_utils::IdentExt::private` => `swc_ecma_ast::Ident::into_private`.
 - `swc_ecma_utils::IdentExt::prefix` => `swc_ecma_ast::Ident::with_prefix`.
 - `swc_ecma_utils::undefined` => `swc_ecma_ast::Expr::undefined`.


**Related issue (if exists):**
