### PR TITLE
perf: Introduce `SourceSlice`

### DIFF
--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -2,7 +2,10 @@ use std::str;
 
 use debug_unreachable::debug_unreachable;
 
-use crate::syntax_pos::{BytePos, SourceFile};
+use crate::{
+    source_slice::SourceSlice,
+    syntax_pos::{BytePos, SourceFile},
+};
 
 pub type SourceFileInput<'a> = StringInput<'a>;
 
@@ -254,6 +257,14 @@ pub trait Input: Clone {
     /// - start should be less than or equal to end.
     /// - start and end should be in the valid range of input.
     unsafe fn slice(&mut self, start: BytePos, end: BytePos) -> &str;
+
+    /// Returns a slice of input as [SourceSlice].
+    ///
+    /// # Safety
+    ///
+    /// - start should be less than or equal to end.
+    /// - start and end should be in the valid range of input.
+    unsafe fn slice_owned(&mut self, start: BytePos, end: BytePos) -> SourceSlice;
 
     /// Takes items from stream, testing each one with predicate. returns the
     /// range of items which passed predicate.

--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -16,8 +16,6 @@ pub struct StringInput<'a> {
     last_pos: BytePos,
     /// Current cursor
     iter: str::Chars<'a>,
-    orig: &'a str,
-    iter: str::CharIndices<'a>,
     orig: &'a Lrc<str>,
     /// Original start position.
     orig_start: BytePos,
@@ -151,9 +149,8 @@ impl<'a> Input for StringInput<'a> {
 
         let ret = SourceSlice::new(self.orig.clone(), start_idx, end_idx);
 
-        self.iter = unsafe { s.get_unchecked((end_idx as usize)..) }.char_indices();
+        self.iter = unsafe { s.get_unchecked((end_idx as usize)..) }.chars();
         self.last_pos = end;
-        self.start_pos_of_iter = end;
 
         ret
     }

--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -140,6 +140,25 @@ impl<'a> Input for StringInput<'a> {
     }
 
     #[inline]
+    unsafe fn slice_owned(&mut self, start: BytePos, end: BytePos) -> SourceSlice {
+        debug_assert!(start <= end, "Cannot slice {:?}..{:?}", start, end);
+        let s = self.orig;
+
+        let start_idx = (start - self.orig_start).0;
+        let end_idx = (end - self.orig_start).0;
+
+        debug_assert!((end_idx as usize) <= s.len());
+
+        let ret = SourceSlice::new(self.orig.clone(), start_idx, end_idx);
+
+        self.iter = unsafe { s.get_unchecked((end_idx as usize)..) }.char_indices();
+        self.last_pos = end;
+        self.start_pos_of_iter = end;
+
+        ret
+    }
+
+    #[inline]
     fn uncons_while<F>(&mut self, mut pred: F) -> &str
     where
         F: FnMut(char) -> bool,

--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -4,6 +4,7 @@ use debug_unreachable::debug_unreachable;
 
 use crate::{
     source_slice::SourceSlice,
+    sync::Lrc,
     syntax_pos::{BytePos, SourceFile},
 };
 
@@ -16,6 +17,8 @@ pub struct StringInput<'a> {
     /// Current cursor
     iter: str::Chars<'a>,
     orig: &'a str,
+    iter: str::CharIndices<'a>,
+    orig: &'a Lrc<str>,
     /// Original start position.
     orig_start: BytePos,
 }
@@ -29,7 +32,7 @@ impl<'a> StringInput<'a> {
     /// some methods of [SourceMap].
     /// If you are not going to use methods from
     /// [SourceMap], you may use any value.
-    pub fn new(src: &'a str, start: BytePos, end: BytePos) -> Self {
+    pub fn new(src: &'a Lrc<str>, start: BytePos, end: BytePos) -> Self {
         assert!(start <= end);
 
         StringInput {

--- a/crates/swc_common/src/lib.rs
+++ b/crates/swc_common/src/lib.rs
@@ -54,6 +54,7 @@ pub use self::{
 };
 #[doc(hidden)]
 pub mod private;
+pub mod source_slice;
 
 /// A trait for ast nodes.
 pub trait AstNode: Debug + PartialEq + Clone + Spanned {

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -205,14 +205,14 @@ impl SourceMap {
     pub fn new_source_file(&self, filename: FileName, mut src: String) -> Lrc<SourceFile> {
         remove_bom(&mut src);
 
-        self.new_source_file_from(filename, Lrc::new(src))
+        self.new_source_file_from(filename, src.into())
     }
 
     /// Creates a new source_file.
     /// This does not ensure that only one SourceFile exists per file name.
     ///
     /// `src` should not have UTF8 BOM
-    pub fn new_source_file_from(&self, filename: FileName, src: Lrc<String>) -> Lrc<SourceFile> {
+    pub fn new_source_file_from(&self, filename: FileName, src: Lrc<str>) -> Lrc<SourceFile> {
         // The path is used to determine the directory for loading submodules and
         // include files, so it must be before remapping.
         // Note that filename may not be a valid path, eg it may be `<anon>` etc,

--- a/crates/swc_common/src/source_slice.rs
+++ b/crates/swc_common/src/source_slice.rs
@@ -1,0 +1,1 @@
+pub struct SourceSlice {}

--- a/crates/swc_common/src/source_slice.rs
+++ b/crates/swc_common/src/source_slice.rs
@@ -1,1 +1,14 @@
-pub struct SourceSlice {}
+use crate::sync::Lrc;
+
+#[derive(Clone)]
+pub struct SourceSlice(Repr);
+
+#[derive(Clone)]
+enum Repr {
+    Owned(Lrc<String>),
+    Pointer {
+        src: Lrc<String>,
+        start: u32,
+        end: u32,
+    },
+}

--- a/crates/swc_common/src/source_slice.rs
+++ b/crates/swc_common/src/source_slice.rs
@@ -1,4 +1,8 @@
-use std::ops::Deref;
+use std::{
+    fmt::{Debug, Display},
+    hash::Hash,
+    ops::Deref,
+};
 
 use crate::sync::Lrc;
 
@@ -52,3 +56,21 @@ impl PartialEq for SourceSlice {
 }
 
 impl Eq for SourceSlice {}
+
+impl Debug for SourceSlice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl Display for SourceSlice {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        Display::fmt(self.as_str(), f)
+    }
+}
+
+impl Hash for SourceSlice {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.as_str().hash(state)
+    }
+}

--- a/crates/swc_common/src/source_slice.rs
+++ b/crates/swc_common/src/source_slice.rs
@@ -28,8 +28,10 @@ impl SourceSlice {
         SourceSlice(Repr::Pointer { src, start, end })
     }
 
-    pub fn new_owned(value: Lrc<str>) -> Self {
-        SourceSlice(Repr::Owned { value })
+    pub fn new_owned(value: impl Into<Lrc<str>>) -> Self {
+        SourceSlice(Repr::Owned {
+            value: value.into(),
+        })
     }
 
     #[inline]
@@ -126,7 +128,7 @@ impl<'de> serde::Deserialize<'de> for SourceSlice {
         D: serde::Deserializer<'de>,
     {
         let s = String::deserialize(deserializer)?;
-        Ok(SourceSlice::new_owned(s.into()))
+        Ok(SourceSlice::new_owned(s))
     }
 }
 

--- a/crates/swc_common/src/source_slice.rs
+++ b/crates/swc_common/src/source_slice.rs
@@ -21,22 +21,22 @@ use crate::sync::Lrc;
     feature = "rkyv-impl",
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
-pub struct SourceSlice(Repr);
+pub struct SourceSlice(Box<Repr>);
 
 impl SourceSlice {
     pub fn new(src: Lrc<str>, start: u32, end: u32) -> Self {
-        SourceSlice(Repr::Pointer { src, start, end })
+        SourceSlice(Box::new(Repr::Pointer { src, start, end }))
     }
 
     pub fn new_owned(value: impl Into<Lrc<str>>) -> Self {
-        SourceSlice(Repr::Owned {
+        SourceSlice(Box::new(Repr::Owned {
             value: value.into(),
-        })
+        }))
     }
 
     #[inline]
     pub fn as_str(&self) -> &str {
-        match &self.0 {
+        match &*self.0 {
             Repr::Owned { value } => value,
             Repr::Pointer { src, start, end } => &src[*start as usize..*end as usize],
         }

--- a/crates/swc_common/src/source_slice.rs
+++ b/crates/swc_common/src/source_slice.rs
@@ -4,23 +4,17 @@ use crate::sync::Lrc;
 pub struct SourceSlice(Repr);
 
 impl SourceSlice {
-    pub fn new(src: Lrc<String>, start: u32, end: u32) -> Self {
+    pub fn new(src: Lrc<str>, start: u32, end: u32) -> Self {
         SourceSlice(Repr::Pointer { src, start, end })
     }
 
-    pub fn new_owned(value: Lrc<String>) -> Self {
+    pub fn new_owned(value: Lrc<str>) -> Self {
         SourceSlice(Repr::Owned { value })
     }
 }
 
 #[derive(Clone)]
 enum Repr {
-    Owned {
-        value: Lrc<String>,
-    },
-    Pointer {
-        src: Lrc<String>,
-        start: u32,
-        end: u32,
-    },
+    Owned { value: Lrc<str> },
+    Pointer { src: Lrc<str>, start: u32, end: u32 },
 }

--- a/crates/swc_common/src/source_slice.rs
+++ b/crates/swc_common/src/source_slice.rs
@@ -1,3 +1,5 @@
+use std::ops::Deref;
+
 use crate::sync::Lrc;
 
 #[derive(Clone)]
@@ -17,4 +19,15 @@ impl SourceSlice {
 enum Repr {
     Owned { value: Lrc<str> },
     Pointer { src: Lrc<str>, start: u32, end: u32 },
+}
+
+impl Deref for SourceSlice {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        match &self.0 {
+            Repr::Owned { value } => value,
+            Repr::Pointer { src, start, end } => &src[*start as usize..*end as usize],
+        }
+    }
 }

--- a/crates/swc_common/src/source_slice.rs
+++ b/crates/swc_common/src/source_slice.rs
@@ -1,4 +1,5 @@
 use std::{
+    borrow::Cow,
     fmt::{Debug, Display},
     hash::Hash,
     ops::Deref,
@@ -61,6 +62,26 @@ impl Deref for SourceSlice {
     #[inline]
     fn deref(&self) -> &str {
         self.as_str()
+    }
+}
+
+macro_rules! impl_eq {
+    ($T:ty) => {
+        impl PartialEq<$T> for SourceSlice {
+            fn eq(&self, other: &$T) -> bool {
+                *self.as_str() == *other
+            }
+        }
+    };
+}
+
+impl_eq!(str);
+impl_eq!(String);
+impl_eq!(Cow<'_, str>);
+
+impl PartialEq<&'_ str> for SourceSlice {
+    fn eq(&self, other: &&'_ str) -> bool {
+        self.as_str() == *other
     }
 }
 

--- a/crates/swc_common/src/source_slice.rs
+++ b/crates/swc_common/src/source_slice.rs
@@ -3,9 +3,21 @@ use crate::sync::Lrc;
 #[derive(Clone)]
 pub struct SourceSlice(Repr);
 
+impl SourceSlice {
+    pub fn new(src: Lrc<String>, start: u32, end: u32) -> Self {
+        SourceSlice(Repr::Pointer { src, start, end })
+    }
+
+    pub fn new_owned(value: Lrc<String>) -> Self {
+        SourceSlice(Repr::Owned { value })
+    }
+}
+
 #[derive(Clone)]
 enum Repr {
-    Owned(Lrc<String>),
+    Owned {
+        value: Lrc<String>,
+    },
     Pointer {
         src: Lrc<String>,
         start: u32,

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -966,7 +966,7 @@ impl SourceFile {
             name,
             name_was_remapped,
             unmapped_path,
-            Lrc::new(src),
+            src.into(),
             start_pos,
         )
     }

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -864,12 +864,12 @@ impl Sub<BytePos> for NonNarrowChar {
 pub struct EncodeArcString;
 
 #[cfg(feature = "rkyv-impl")]
-impl rkyv::with::ArchiveWith<Lrc<String>> for EncodeArcString {
+impl rkyv::with::ArchiveWith<Lrc<str>> for EncodeArcString {
     type Archived = rkyv::Archived<String>;
     type Resolver = rkyv::Resolver<String>;
 
     unsafe fn resolve_with(
-        field: &Lrc<String>,
+        field: &Lrc<str>,
         pos: usize,
         resolver: Self::Resolver,
         out: *mut Self::Archived,
@@ -880,24 +880,24 @@ impl rkyv::with::ArchiveWith<Lrc<String>> for EncodeArcString {
 }
 
 #[cfg(feature = "rkyv-impl")]
-impl<S> rkyv::with::SerializeWith<Lrc<String>, S> for EncodeArcString
+impl<S> rkyv::with::SerializeWith<Lrc<str>, S> for EncodeArcString
 where
     S: ?Sized + rkyv::ser::Serializer,
 {
-    fn serialize_with(field: &Lrc<String>, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+    fn serialize_with(field: &Lrc<str>, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
         rkyv::string::ArchivedString::serialize_from_str(field, serializer)
     }
 }
 
 #[cfg(feature = "rkyv-impl")]
-impl<D> rkyv::with::DeserializeWith<rkyv::Archived<String>, Lrc<String>, D> for EncodeArcString
+impl<D> rkyv::with::DeserializeWith<rkyv::Archived<String>, Lrc<str>, D> for EncodeArcString
 where
     D: ?Sized + rkyv::Fallible,
 {
     fn deserialize_with(
         field: &rkyv::Archived<String>,
         deserializer: &mut D,
-    ) -> Result<Lrc<String>, D::Error> {
+    ) -> Result<Lrc<str>, D::Error> {
         use rkyv::Deserialize;
 
         let s: String = field.deserialize(deserializer)?;
@@ -929,7 +929,7 @@ pub struct SourceFile {
     pub crate_of_origin: u32,
     /// The complete source code
     #[cfg_attr(any(feature = "rkyv-impl"), with(EncodeArcString))]
-    pub src: Lrc<String>,
+    pub src: Lrc<str>,
     /// The source code's hash
     pub src_hash: u128,
     /// The start position of this source in the `SourceMap`
@@ -976,7 +976,7 @@ impl SourceFile {
         name: FileName,
         name_was_remapped: bool,
         unmapped_path: FileName,
-        src: Lrc<String>,
+        src: Lrc<str>,
         start_pos: BytePos,
     ) -> SourceFile {
         debug_assert_ne!(

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -4,7 +4,10 @@ use std::mem::transmute;
 use is_macro::Is;
 use string_enum::StringEnum;
 use swc_atoms::Atom;
-use swc_common::{ast_node, util::take::Take, BytePos, EqIgnoreSpan, Span, Spanned, DUMMY_SP};
+use swc_common::{
+    ast_node, source_slice::SourceSlice, util::take::Take, BytePos, EqIgnoreSpan, Span, Spanned,
+    DUMMY_SP,
+};
 
 use crate::{
     class::Class,
@@ -1154,9 +1157,7 @@ pub struct TplElement {
     /// don't have to worry about this value.
     pub cooked: Option<Atom>,
 
-    /// You may need to perform. `.replace("\r\n", "\n").replace('\r', "\n")` on
-    /// this value.
-    pub raw: Atom,
+    pub raw: SourceSlice,
 }
 
 impl Take for TplElement {

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -6,7 +6,9 @@ use std::{
 
 use num_bigint::BigInt as BigIntValue;
 use swc_atoms::{js_word, Atom};
-use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
+use swc_common::{
+    ast_node, source_slice::SourceSlice, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP,
+};
 
 use crate::jsx::JSXText;
 
@@ -83,7 +85,7 @@ pub struct BigInt {
 
     /// Use `None` value only for transformations to avoid recalculate
     /// characters in big integer
-    pub raw: Option<Atom>,
+    pub raw: Option<SourceSlice>,
 }
 
 impl EqIgnoreSpan for BigInt {
@@ -180,7 +182,7 @@ pub struct Str {
 
     /// Use `None` value only for transformations to avoid recalculate escaped
     /// characters in strings
-    pub raw: Option<Atom>,
+    pub raw: Option<SourceSlice>,
 }
 
 impl Take for Str {
@@ -385,7 +387,7 @@ pub struct Number {
 
     /// Use `None` value only for transformations to avoid recalculate
     /// characters in number literal
-    pub raw: Option<Atom>,
+    pub raw: Option<SourceSlice>,
 }
 
 impl Eq for Number {}

--- a/crates/swc_ecma_parser/src/lexer/jsx.rs
+++ b/crates/swc_ecma_parser/src/lexer/jsx.rs
@@ -57,10 +57,7 @@ impl<'a> Lexer<'a> {
                         self.atoms.atom(out)
                     };
 
-                    return Ok(Some(Token::JSXText { raw }));
-                    return Ok(Some(Token::JSXText {
-                        name: self.atoms.atom(out),
-                    }));
+                    return Ok(Some(Token::JSXText { name: raw }));
                 }
                 '>' => {
                     self.emit_error(
@@ -342,12 +339,7 @@ impl<'a> Lexer<'a> {
             self.input.slice_owned(start, end)
         };
 
-        Ok(Token::Str {
-            value,
-            raw: self.atoms.atom(raw),
-            value: self.atoms.atom(out),
-            raw,
-        })
+        Ok(Token::Str { value, raw })
     }
 
     /// Read a JSX identifier (valid tag or attribute name).

--- a/crates/swc_ecma_parser/src/lexer/jsx.rs
+++ b/crates/swc_ecma_parser/src/lexer/jsx.rs
@@ -58,6 +58,9 @@ impl<'a> Lexer<'a> {
                     };
 
                     return Ok(Some(Token::JSXText { raw }));
+                    return Ok(Some(Token::JSXText {
+                        name: self.atoms.atom(out),
+                    }));
                 }
                 '>' => {
                     self.emit_error(

--- a/crates/swc_ecma_parser/src/lexer/jsx.rs
+++ b/crates/swc_ecma_parser/src/lexer/jsx.rs
@@ -339,12 +339,14 @@ impl<'a> Lexer<'a> {
         let end = self.input.cur_pos();
         let raw = unsafe {
             // Safety: Both of `start` and `end` are generated from `cur_pos()`
-            self.input.slice(start, end)
+            self.input.slice_owned(start, end)
         };
 
         Ok(Token::Str {
             value,
             raw: self.atoms.atom(raw),
+            value: self.atoms.atom(out),
+            raw,
         })
     }
 

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -1054,11 +1054,15 @@ impl<'a> Lexer<'a> {
                         let raw = unsafe {
                             // Safety: start and end are valid position because we got them from
                             // `self.input`
-                            l.input.slice(start, end)
+                            l.input.slice_owned(start, end)
                         };
                         let raw = l.atoms.atom(raw);
 
                         return Ok(Token::Str { value, raw });
+                        return Ok(Token::Str {
+                            value: l.atoms.atom(&*out),
+                            raw,
+                        });
                     }
 
                     if c == b'\\' {
@@ -1126,11 +1130,13 @@ impl<'a> Lexer<'a> {
             let raw = unsafe {
                 // Safety: start and end are valid position because we got them from
                 // `self.input`
-                l.input.slice(start, end)
+                l.input.slice_owned(start, end)
             };
             Ok(Token::Str {
                 value: l.atoms.atom(&*buf),
                 raw: l.atoms.atom(raw),
+                value: l.atoms.atom(&*out),
+                raw,
             })
         })
     }
@@ -1278,11 +1284,13 @@ impl<'a> Lexer<'a> {
                 let raw = unsafe {
                     // Safety: Both of start and last_pos are valid position because we got them
                     // from `self.input`
-                    self.input.slice(raw_slice_start, end)
+                    self.input.slice_owned(raw_slice_start, end)
                 };
                 return Ok(Token::Template {
                     cooked,
                     raw: self.atoms.atom(raw),
+                    cooked: cooked.map(Atom::from),
+                    raw,
                 });
             }
 

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -1056,13 +1056,8 @@ impl<'a> Lexer<'a> {
                             // `self.input`
                             l.input.slice_owned(start, end)
                         };
-                        let raw = l.atoms.atom(raw);
 
                         return Ok(Token::Str { value, raw });
-                        return Ok(Token::Str {
-                            value: l.atoms.atom(&*out),
-                            raw,
-                        });
                     }
 
                     if c == b'\\' {
@@ -1134,8 +1129,6 @@ impl<'a> Lexer<'a> {
             };
             Ok(Token::Str {
                 value: l.atoms.atom(&*buf),
-                raw: l.atoms.atom(raw),
-                value: l.atoms.atom(&*out),
                 raw,
             })
         })
@@ -1286,12 +1279,7 @@ impl<'a> Lexer<'a> {
                     // from `self.input`
                     self.input.slice_owned(raw_slice_start, end)
                 };
-                return Ok(Token::Template {
-                    cooked,
-                    raw: self.atoms.atom(raw),
-                    cooked: cooked.map(Atom::from),
-                    raw,
-                });
+                return Ok(Token::Template { cooked, raw });
             }
 
             if c == '\\' {

--- a/crates/swc_ecma_parser/src/lexer/number.rs
+++ b/crates/swc_ecma_parser/src/lexer/number.rs
@@ -7,8 +7,6 @@ use std::borrow::Cow;
 use either::Either;
 use num_bigint::BigInt as BigIntValue;
 use num_traits::{Num as NumTrait, ToPrimitive};
-use swc_common::SyntaxContext;
-use smartstring::LazyCompact;
 use swc_common::{source_slice::SourceSlice, SyntaxContext};
 use tracing::trace;
 

--- a/crates/swc_ecma_parser/src/lexer/tests.rs
+++ b/crates/swc_ecma_parser/src/lexer/tests.rs
@@ -1021,7 +1021,7 @@ fn jsx_02() {
             Token::JSXTagStart,
             Token::JSXName { name: "a".into() },
             Token::JSXTagEnd,
-            Token::JSXText { raw: "foo".into() },
+            Token::JSXText { name: "foo".into() },
             Token::JSXTagStart,
             tok!('/'),
             Token::JSXName { name: "a".into() },
@@ -1205,7 +1205,7 @@ fn issue_299_01() {
                 raw: "'\\ '".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1239,7 +1239,7 @@ fn issue_299_02() {
                 raw: "'\\\\'".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1273,7 +1273,7 @@ fn jsx_string_1() {
                 raw: "'abc'".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1307,7 +1307,7 @@ fn jsx_string_2() {
                 raw: "\"abc\"".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1341,7 +1341,7 @@ fn jsx_string_3() {
                 raw: "'\n'".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1375,7 +1375,7 @@ fn jsx_string_4() {
                 raw: "'&sup3;'".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1409,7 +1409,7 @@ fn jsx_string_5() {
                 raw: "'&#42;'".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1443,7 +1443,7 @@ fn jsx_string_6() {
                 raw: "'&#x23;'".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1477,7 +1477,7 @@ fn jsx_string_7() {
                 raw: "'&'".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1511,7 +1511,7 @@ fn jsx_string_8() {
                 raw: "'&;'".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1545,7 +1545,7 @@ fn jsx_string_9() {
                 raw: "'&&'".into(),
             },
             Token::JSXTagEnd,
-            JSXText { raw: "ABC".into() },
+            JSXText { name: "ABC".into() },
             JSXTagStart,
             tok!('/'),
             JSXName {
@@ -1599,7 +1599,7 @@ fn issue_481() {
                 name: "span".into()
             },
             Token::JSXTagEnd,
-            JSXText { raw: " ".into() },
+            JSXText { name: " ".into() },
             LBrace,
             Word(Word::Ident("foo".into())),
             RBrace,

--- a/crates/swc_ecma_parser/src/parser/jsx.rs
+++ b/crates/swc_ecma_parser/src/parser/jsx.rs
@@ -428,11 +428,11 @@ impl<I: Tokens> Parser<I> {
         let token = bump!(self);
         let span = self.input.prev_span();
         match token {
-            Token::JSXText { raw } => Ok(JSXText {
+            Token::JSXText { name } => Ok(JSXText {
                 span,
                 // TODO
-                value: raw.clone(),
-                raw,
+                value: name.clone(),
+                raw: name,
             }),
             _ => unreachable!(),
         }

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2,7 +2,7 @@ use std::fmt::Write;
 
 use either::Either;
 use swc_atoms::js_word;
-use swc_common::{Spanned, SyntaxContext};
+use swc_common::{source_slice::SourceSlice, Spanned, SyntaxContext};
 
 use super::*;
 use crate::{lexer::TokenContexts, parser::class_and_fn::IsSimpleParameterList, token::Keyword};
@@ -313,7 +313,7 @@ impl<I: Tokens> Parser<I> {
                 Str {
                     span: arg_span,
                     value: "".into(),
-                    raw: Some("\"\"".into()),
+                    raw: Some(SourceSlice::new_owned("\"\"")),
                 }
             }
         };
@@ -751,7 +751,7 @@ impl<I: Tokens> Parser<I> {
                 TsEnumMemberId::Str(Str {
                     span,
                     value: value.to_string().into(),
-                    raw: Some(new_raw.into()),
+                    raw: Some(SourceSlice::new_owned(new_raw)),
                 })
             }
             Token::LBracket => {
@@ -2117,7 +2117,7 @@ impl<I: Tokens> Parser<I> {
                         TsLit::Number(Number {
                             span,
                             value: -value,
-                            raw: Some(new_raw.into()),
+                            raw: Some(SourceSlice::new_owned(new_raw)),
                         })
                     }
                     Lit::BigInt(BigInt { span, value, raw }) => {
@@ -2135,7 +2135,7 @@ impl<I: Tokens> Parser<I> {
                         TsLit::BigInt(BigInt {
                             span,
                             value: Box::new(-*value),
-                            raw: Some(new_raw.into()),
+                            raw: Some(SourceSlice::new_owned(new_raw)),
                         })
                     }
                     _ => unreachable!(),

--- a/crates/swc_ecma_parser/src/token.rs
+++ b/crates/swc_ecma_parser/src/token.rs
@@ -8,7 +8,7 @@ use std::{
 
 use num_bigint::BigInt as BigIntValue;
 use swc_atoms::{atom, Atom, AtomStore, JsWord};
-use swc_common::{Span, Spanned};
+use swc_common::{source_slice::SourceSlice, Span, Spanned};
 use swc_ecma_ast::{AssignOp, BinaryOp};
 
 pub(crate) use self::{Keyword::*, Token::*};
@@ -254,7 +254,7 @@ pub enum Token {
     /// '`'
     BackQuote,
     Template {
-        raw: Atom,
+        raw: SourceSlice,
         cooked: LexResult<Atom>,
     },
     /// ':'
@@ -279,7 +279,7 @@ pub enum Token {
     /// String literal. Span of this token contains quote.
     Str {
         value: JsWord,
-        raw: Atom,
+        raw: SourceSlice,
     },
 
     /// Regexp literal.
@@ -288,12 +288,12 @@ pub enum Token {
     /// TODO: Make Num as enum and separate decimal, binary, ..etc
     Num {
         value: f64,
-        raw: Atom,
+        raw: SourceSlice,
     },
 
     BigInt {
         value: Box<BigIntValue>,
-        raw: Atom,
+        raw: SourceSlice,
     },
 
     JSXName {

--- a/crates/swc_ecma_parser/src/token.rs
+++ b/crates/swc_ecma_parser/src/token.rs
@@ -300,7 +300,7 @@ pub enum Token {
         name: JsWord,
     },
     JSXText {
-        raw: Atom,
+        name: Atom,
     },
     JSXTagStart,
     JSXTagEnd,
@@ -980,7 +980,7 @@ impl Debug for Token {
             Num { value, raw, .. } => write!(f, "numeric literal ({}, {})", value, raw)?,
             BigInt { value, raw } => write!(f, "bigint literal ({}, {})", value, raw)?,
             JSXName { name } => write!(f, "jsx name ({})", name)?,
-            JSXText { raw } => write!(f, "jsx text ({})", raw)?,
+            JSXText { name: raw } => write!(f, "jsx text ({})", raw)?,
             JSXTagStart => write!(f, "< (jsx tag start)")?,
             JSXTagEnd => write!(f, "> (jsx tag end)")?,
             Shebang(_) => write!(f, "#!")?,

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -13,6 +13,7 @@ use swc_atoms::Atom;
 use swc_common::{pass::CompilerPass, Span, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_visit::{define, AndThen, Repeat, Repeated};
+use swc_common::source_slice::SourceSlice;
 
 impl<A, B> Fold for AndThen<A, B>
 where
@@ -843,7 +844,7 @@ define!({
         pub span: Span,
         pub tail: bool,
         pub cooked: Option<Atom>,
-        pub raw: Atom,
+        pub raw: SourceSlice,
     }
     pub struct ParenExpr {
         pub span: Span,
@@ -1053,12 +1054,12 @@ define!({
     pub struct BigInt {
         pub span: Span,
         pub value: Box<BigIntValue>,
-        pub raw: Option<Atom>,
+        pub raw: Option<SourceSlice>,
     }
     pub struct Str {
         pub span: Span,
         pub value: Atom,
-        pub raw: Option<Atom>,
+        pub raw: Option<SourceSlice>,
     }
     pub struct Bool {
         pub span: Span,
@@ -1075,7 +1076,7 @@ define!({
     pub struct Number {
         pub span: Span,
         pub value: f64,
-        pub raw: Option<Atom>,
+        pub raw: Option<SourceSlice>,
     }
     pub enum Program {
         Module(Module),


### PR DESCRIPTION
**Description:**

`SourceSlice` is sort of `&' input str` that is owned. It works by using `Lrc<str>`, which is the type of `SourceFile.src`. This type is used to avoid (enormous amount of) allocations for `raw` fields. With this PR, `raw` fields are now `SourceSlice`, which does not allocate.


**BREAKING CHANGE:**

 - `swc_common::SourceFile.src` is now `Lrc<str>` instead of `Lrc<String>`.
 - `swc_common::input::StringInput` now takes `&'a Lrc<str>` instead of `&'a str`.