### PR TITLE
fix(types): add missing typeAnnotation field in Identifier node

### DIFF
--- a/bindings/binding_core_wasm/src/types.rs
+++ b/bindings/binding_core_wasm/src/types.rs
@@ -1357,6 +1357,8 @@ export interface Identifier extends ExpressionBase {
 
   /// TypeScript only. Used in case of an optional parameter.
   optional: boolean;
+
+  typeAnnotation?: TsTypeAnnotation;
 }
 
 export interface OptionalChainingExpression extends ExpressionBase {

--- a/bindings/binding_core_wasm/src/types.rs
+++ b/bindings/binding_core_wasm/src/types.rs
@@ -1357,8 +1357,6 @@ export interface Identifier extends ExpressionBase {
 
   /// TypeScript only. Used in case of an optional parameter.
   optional: boolean;
-
-  typeAnnotation?: TsTypeAnnotation;
 }
 
 export interface OptionalChainingExpression extends ExpressionBase {
@@ -2014,6 +2012,8 @@ export interface BindingIdentifier extends PatternBase {
   type: "Identifier";
   value: string;
   optional: boolean;
+
+  typeAnnotation?: TsTypeAnnotation;
 }
 
 export interface ArrayPattern extends PatternBase {

--- a/bindings/binding_minifier_wasm/src/types.rs
+++ b/bindings/binding_minifier_wasm/src/types.rs
@@ -1357,6 +1357,8 @@ export interface Identifier extends ExpressionBase {
 
   /// TypeScript only. Used in case of an optional parameter.
   optional: boolean;
+
+  typeAnnotation?: TsTypeAnnotation;
 }
 
 export interface OptionalChainingExpression extends ExpressionBase {

--- a/bindings/binding_minifier_wasm/src/types.rs
+++ b/bindings/binding_minifier_wasm/src/types.rs
@@ -1357,8 +1357,6 @@ export interface Identifier extends ExpressionBase {
 
   /// TypeScript only. Used in case of an optional parameter.
   optional: boolean;
-
-  typeAnnotation?: TsTypeAnnotation;
 }
 
 export interface OptionalChainingExpression extends ExpressionBase {
@@ -2014,6 +2012,8 @@ export interface BindingIdentifier extends PatternBase {
   type: "Identifier";
   value: string;
   optional: boolean;
+
+  typeAnnotation?: TsTypeAnnotation;
 }
 
 export interface ArrayPattern extends PatternBase {

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1358,6 +1358,8 @@ export interface Identifier extends ExpressionBase {
 
     /// TypeScript only. Used in case of an optional parameter.
     optional: boolean;
+
+    typeAnnotation?: TsTypeAnnotation;
 }
 
 export interface OptionalChainingExpression extends ExpressionBase {

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1358,8 +1358,6 @@ export interface Identifier extends ExpressionBase {
 
     /// TypeScript only. Used in case of an optional parameter.
     optional: boolean;
-
-    typeAnnotation?: TsTypeAnnotation;
 }
 
 export interface OptionalChainingExpression extends ExpressionBase {
@@ -2015,6 +2013,8 @@ export interface BindingIdentifier extends PatternBase {
     type: "Identifier";
     value: string;
     optional: boolean;
+
+    typeAnnotation?: TsTypeAnnotation;
 }
 
 export interface ArrayPattern extends PatternBase {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I was working on a walker for SWC ast and found out that the Identifier can have a `typeAnnotation` field which is not documented in the `Identifier` type. I have added the `typeAnnotation` field to the `Identifier` type.

**BREAKING CHANGE:**

No breaking changes.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

No related issue.
