### PR TITLE
perf(es/lexer): Reduce allocation while lexing identifiers

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,6 +1,9 @@
 name: Benchmark
 
 on:
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - main

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -1,9 +1,6 @@
 name: Benchmark
 
 on:
-  pull_request:
-    branches:
-      - main
   push:
     branches:
       - main

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -853,6 +853,7 @@ impl<'a> Lexer<'a> {
                         }
 
                         slice_start = l.cur_pos();
+                        continue;
                     }
 
                     // ASCII but not a valid identifier

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -866,7 +866,6 @@ impl<'a> Lexer<'a> {
                 }
 
                 if let Some(c) = l.input.cur() {
-                    can_be_keyword = false;
                     if Ident::is_valid_continue(c) {
                         l.bump();
                         continue;

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -858,6 +858,7 @@ impl<'a> Lexer<'a> {
                 }
 
                 if let Some(c) = l.input.cur() {
+                    can_be_keyword = false;
                     if Ident::is_valid_continue(c) {
                         l.bump();
                         continue;

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -821,15 +821,18 @@ impl<'a> Lexer<'a> {
                         }
 
                         {
-                            let end = l.cur_pos();
+                            let end = l.input.cur_pos();
                             let s = unsafe {
                                 // Safety: start and end are valid position because we got them from
                                 // `self.input`
-                                l.input.slice(slice_start, end)
+                                l.input.slice(slice_start, start)
                             };
                             buf.push_str(s);
+                            unsafe {
+                                // Safety: We got end from `self.input`
+                                l.input.reset_to(end);
+                            }
                         }
-                        buf.push('\\');
 
                         let chars = l.read_unicode_escape()?;
 

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -861,7 +861,6 @@ impl<'a> Lexer<'a> {
                 }
 
                 if let Some(c) = l.input.cur() {
-                    can_be_keyword = false;
                     if Ident::is_valid_continue(c) {
                         l.bump();
                         continue;

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -799,6 +799,11 @@ impl<'a> Lexer<'a> {
         self.with_buf(|l, buf| {
             loop {
                 if let Some(c) = l.input.cur_as_ascii() {
+                    // Performance optimization
+                    if c.is_ascii_uppercase() || c.is_ascii_digit() {
+                        can_be_keyword = false;
+                    }
+
                     if Ident::is_valid_continue(c as _) {
                         l.bump();
                         continue;
@@ -811,7 +816,6 @@ impl<'a> Lexer<'a> {
                     // unicode escape
                     if c == b'\\' {
                         first = false;
-                        can_be_keyword = false;
                         has_escape = true;
                         let start = l.cur_pos();
                         l.bump();
@@ -862,6 +866,7 @@ impl<'a> Lexer<'a> {
                 }
 
                 if let Some(c) = l.input.cur() {
+                    can_be_keyword = false;
                     if Ident::is_valid_continue(c) {
                         l.bump();
                         continue;


### PR DESCRIPTION
**Description:**

In the fast path, we don't even use the buffer.

```
Benchmarking es/lexer/cal-com
Benchmarking es/lexer/cal-com: Warming up for 3.0000 s
Benchmarking es/lexer/cal-com: Collecting 100 samples in estimated 5.5395 s (900 iterations)
Benchmarking es/lexer/cal-com: Analyzing
es/lexer/cal-com        time:   [6.1799 ms 6.2010 ms 6.2250 ms]
                        change: [-4.4027% -3.9504% -3.5372%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 17 outliers among 100 measurements (17.00%)
  4 (4.00%) high mild
  13 (13.00%) high severe

```