### PR TITLE
perf(es/lexer): Make lexing of string literals faster

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -1036,8 +1036,13 @@ impl<'a> Lexer<'a> {
                     continue;
                 }
 
-                if l.input.cur().is_none() {
-                    break;
+                match l.input.cur() {
+                    Some(c) => {
+                        if c.is_line_break() {
+                            break;
+                        }
+                    }
+                    None => break,
                 }
             }
 

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -969,23 +969,18 @@ impl<'a> Lexer<'a> {
     fn read_str_lit(&mut self) -> LexResult<Token> {
         debug_assert!(self.cur() == Some('\'') || self.cur() == Some('"'));
         let start = self.cur_pos();
-        let quote = self.cur().unwrap();
+        let quote = self.cur().unwrap() as u8;
 
         self.bump(); // '"'
 
-        self.with_buf(|l, out| {
-            while let Some(c) = {
-                // Optimization
-                {
-                    let s = l
-                        .input
-                        .uncons_while(|c| c != quote && c != '\\' && !c.is_line_break());
-                    out.push_str(s);
-                }
-                l.cur()
-            } {
-                match c {
-                    c if c == quote => {
+        let mut has_escape = false;
+        let mut slice_start = self.input.cur_pos();
+
+        self.with_buf(|l, buf| {
+            loop {
+                if let Some(c) = l.input.cur_as_ascii() {
+                    if c == quote {
+                        let value_end = l.cur_pos();
                         l.bump();
 
                         let end = l.cur_pos();
@@ -995,28 +990,61 @@ impl<'a> Lexer<'a> {
                             // `self.input`
                             l.input.slice(start, end)
                         };
+                        let raw = l.atoms.atom(raw);
 
-                        return Ok(Token::Str {
-                            value: l.atoms.atom(&*out),
-                            raw: l.atoms.atom(raw),
-                        });
+                        let value = if !has_escape {
+                            let s = unsafe {
+                                // Safety: slice_start and value_end are valid position because we
+                                // got them from `self.input`
+                                l.input.slice(slice_start, value_end)
+                            };
+
+                            l.atoms.atom(s)
+                        } else {
+                            l.atoms.atom(&**buf)
+                        };
+
+                        return Ok(Token::Str { value, raw });
                     }
-                    '\\' => {
+
+                    if c == b'\\' {
+                        has_escape = true;
+
+                        {
+                            let end = l.cur_pos();
+                            let s = unsafe {
+                                // Safety: start and end are valid position because we got them from
+                                // `self.input`
+                                l.input.slice(slice_start, end)
+                            };
+                            buf.push_str(s);
+                        }
+
                         if let Some(chars) = l.read_escaped_char(false)? {
                             for c in chars {
-                                out.extend(c);
+                                buf.extend(c);
                             }
                         }
+
+                        slice_start = l.cur_pos();
                     }
-                    c if c.is_line_break() => {
+
+                    if (c as char).is_line_break() {
                         break;
                     }
-                    _ => {
-                        out.push(c);
 
-                        l.bump();
-                    }
+                    continue;
                 }
+            }
+
+            {
+                let end = l.cur_pos();
+                let s = unsafe {
+                    // Safety: start and end are valid position because we got them from
+                    // `self.input`
+                    l.input.slice(slice_start, end)
+                };
+                buf.push_str(s);
             }
 
             l.emit_error(start, SyntaxError::UnterminatedStrLit);
@@ -1029,7 +1057,7 @@ impl<'a> Lexer<'a> {
                 l.input.slice(start, end)
             };
             Ok(Token::Str {
-                value: l.atoms.atom(&*out),
+                value: l.atoms.atom(&*buf),
                 raw: l.atoms.atom(raw),
             })
         })

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -977,10 +977,8 @@ impl<'a> Lexer<'a> {
         let mut slice_start = self.input.cur_pos();
 
         self.with_buf(|l, buf| {
-            dbg!("start", l.input.cur());
             loop {
                 if let Some(c) = l.input.cur_as_ascii() {
-                    dbg!(c as char);
                     if c == quote {
                         let value_end = l.cur_pos();
 
@@ -1058,6 +1056,10 @@ impl<'a> Lexer<'a> {
                     Some(c) => {
                         if c.is_line_break() {
                             break;
+                        }
+                        unsafe {
+                            // Safety: cur is Some(c)
+                            l.input.bump();
                         }
                     }
                     None => break,

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -981,7 +981,10 @@ impl<'a> Lexer<'a> {
                 if let Some(c) = l.input.cur_as_ascii() {
                     if c == quote {
                         let value_end = l.cur_pos();
-                        l.bump();
+                        unsafe {
+                            // Safety: cur is quote
+                            l.input.bump();
+                        }
 
                         let end = l.cur_pos();
 
@@ -1009,6 +1012,10 @@ impl<'a> Lexer<'a> {
 
                     if c == b'\\' {
                         has_escape = true;
+                        unsafe {
+                            // Safety: cur is '\'
+                            l.input.bump();
+                        }
 
                         {
                             let end = l.cur_pos();
@@ -1033,6 +1040,10 @@ impl<'a> Lexer<'a> {
                         break;
                     }
 
+                    unsafe {
+                        // Safety: cur is a ascii character
+                        l.input.bump();
+                    }
                     continue;
                 }
 

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -1034,6 +1034,7 @@ impl<'a> Lexer<'a> {
                         }
 
                         slice_start = l.cur_pos();
+                        continue;
                     }
 
                     if (c as char).is_line_break() {

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -993,6 +993,13 @@ impl<'a> Lexer<'a> {
 
                             l.atoms.atom(s)
                         } else {
+                            let s = unsafe {
+                                // Safety: slice_start and value_end are valid position because we
+                                // got them from `self.input`
+                                l.input.slice(slice_start, value_end)
+                            };
+                            buf.push_str(s);
+
                             l.atoms.atom(&**buf)
                         };
 
@@ -1015,10 +1022,6 @@ impl<'a> Lexer<'a> {
 
                     if c == b'\\' {
                         has_escape = true;
-                        unsafe {
-                            // Safety: cur is '\'
-                            l.input.bump();
-                        }
 
                         {
                             let end = l.cur_pos();

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -1035,6 +1035,10 @@ impl<'a> Lexer<'a> {
 
                     continue;
                 }
+
+                if l.input.cur().is_none() {
+                    break;
+                }
             }
 
             {


### PR DESCRIPTION
**Description:**

This profiling result does not include improvements from https://github.com/swc-project/swc/pull/9076

```
Benchmarking es/lexer/cal-com
es/lexer/cal-com        time:   [6.4555 ms 6.4936 ms 6.5368 ms]
```