### PR TITLE
perf(es/lexer): Use `debug_unreachable!`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2312,9 +2312,9 @@ dependencies = [
 
 [[package]]
 name = "new_debug_unreachable"
-version = "1.0.4"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ resolver = "2"
   miette                   = "4.2.1"
   napi                     = { version = "2.0.0", default-features = false }
   napi-derive              = { version = "2.0.0", default-features = false }
-  new_debug_unreachable    = "1.0.4"
+  new_debug_unreachable    = "1.0.6"
   nom                      = "7.1.3"
   ntest                    = "0.7.2"
   num-bigint               = "0.4.3"

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -2,6 +2,7 @@
 
 use std::{cell::RefCell, char, iter::FusedIterator, mem::transmute, rc::Rc};
 
+use debug_unreachable::debug_unreachable;
 use either::Either::{Left, Right};
 use smallvec::{smallvec, SmallVec};
 use swc_atoms::{Atom, AtomStoreCell};
@@ -186,14 +187,10 @@ impl<'a> Lexer<'a> {
 
         match handler {
             Some(handler) => handler(self),
-            None => {
-                let start = self.cur_pos();
-                self.input.bump_bytes(1);
-                self.error_span(
-                    pos_span(start),
-                    SyntaxError::UnexpectedChar { c: byte as _ },
-                )
-            }
+            None => unsafe {
+                // Safety: We declare byte handlers for all possible bytes.
+                debug_unreachable!("No handler for byte")
+            },
         }
     }
 


### PR DESCRIPTION
**Description:**

This will result in a smaller binary and a minor performance gain.