### PR TITLE
refactor(es/parser): Rename `EsConfig` and `TsConfig`

### DIFF
--- a/crates/jsdoc/tests/fixture.rs
+++ b/crates/jsdoc/tests/fixture.rs
@@ -5,7 +5,7 @@ use swc_common::{
     comments::{Comment, CommentKind, Comments},
     BytePos, DUMMY_SP,
 };
-use swc_ecma_parser::{parse_file_as_module, EsConfig, Syntax};
+use swc_ecma_parser::{parse_file_as_module, EsSyntax, Syntax};
 use testing::NormalizedOutput;
 
 #[testing::fixture("tests/fixtures/**/*.js")]
@@ -19,7 +19,7 @@ fn fixture(path: PathBuf) {
 
         if let Err(err) = parse_file_as_module(
             &fm,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -41,7 +41,7 @@ pub use swc_ecma_minifier::js::*;
 use swc_ecma_minifier::option::terser::TerserTopLevelOptions;
 #[allow(deprecated)]
 pub use swc_ecma_parser::JscTarget;
-use swc_ecma_parser::{parse_file_as_expr, Syntax, TsConfig};
+use swc_ecma_parser::{parse_file_as_expr, Syntax, TsSyntax};
 use swc_ecma_transforms::{
     feature::FeatureFlag,
     hygiene, modules,
@@ -852,7 +852,7 @@ impl Default for Rc {
                 test: Some(FileMatcher::Regex("\\.tsx$".into())),
                 exclude: None,
                 jsc: JscConfig {
-                    syntax: Some(Syntax::Typescript(TsConfig {
+                    syntax: Some(Syntax::Typescript(TsSyntax {
                         tsx: true,
                         ..Default::default()
                     })),
@@ -865,7 +865,7 @@ impl Default for Rc {
                 test: Some(FileMatcher::Regex("\\.(cts|mts)$".into())),
                 exclude: None,
                 jsc: JscConfig {
-                    syntax: Some(Syntax::Typescript(TsConfig {
+                    syntax: Some(Syntax::Typescript(TsSyntax {
                         tsx: false,
                         disallow_ambiguous_jsx_like: true,
                         ..Default::default()
@@ -879,7 +879,7 @@ impl Default for Rc {
                 test: Some(FileMatcher::Regex("\\.ts$".into())),
                 exclude: None,
                 jsc: JscConfig {
-                    syntax: Some(Syntax::Typescript(TsConfig {
+                    syntax: Some(Syntax::Typescript(TsSyntax {
                         tsx: false,
                         ..Default::default()
                     })),
@@ -980,7 +980,7 @@ impl Config {
     ///
     /// - typescript: `tsx` will be modified if file extension is `ts`.
     pub fn adjust(&mut self, file: &Path) {
-        if let Some(Syntax::Typescript(TsConfig { tsx, dts, .. })) = &mut self.jsc.syntax {
+        if let Some(Syntax::Typescript(TsSyntax { tsx, dts, .. })) = &mut self.jsc.syntax {
             let is_dts = file
                 .file_name()
                 .and_then(|f| f.to_str())

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -141,7 +141,7 @@ use swc_ecma_loader::resolvers::{
     lru::CachingResolver, node::NodeModulesResolver, tsc::TsConfigResolver,
 };
 use swc_ecma_minifier::option::{MinifyOptions, TopLevelOptions};
-use swc_ecma_parser::{EsConfig, Syntax};
+use swc_ecma_parser::{EsSyntax, Syntax};
 use swc_ecma_transforms::{
     fixer,
     helpers::{self, Helpers},
@@ -820,7 +820,7 @@ impl Compiler {
                     fm.clone(),
                     handler,
                     target,
-                    Syntax::Es(EsConfig {
+                    Syntax::Es(EsSyntax {
                         jsx: true,
                         decorators: true,
                         decorators_before_export: true,

--- a/crates/swc/tests/exec.rs
+++ b/crates/swc/tests/exec.rs
@@ -16,7 +16,7 @@ use swc::{
 };
 use swc_common::{errors::ColorConfig, SourceMap, GLOBALS};
 use swc_ecma_ast::EsVersion;
-use swc_ecma_parser::{Syntax, TsConfig};
+use swc_ecma_parser::{Syntax, TsSyntax};
 use swc_ecma_testing::{exec_node_js, JsExecOptions};
 use testing::{assert_eq, find_executable, unignore_fixture};
 use tracing::{span, Level};
@@ -133,7 +133,7 @@ fn create_matrix(entry: &Path) -> Vec<Options> {
 
         if let Some(ext) = entry.extension() {
             if ext == "ts" {
-                let ts = Syntax::Typescript(TsConfig {
+                let ts = Syntax::Typescript(TsSyntax {
                     decorators: true,
                     ..Default::default()
                 });
@@ -279,7 +279,7 @@ fn get_expected_stdout(input: &Path) -> Result<String, Error> {
                             config: Config {
                                 jsc: JscConfig {
                                     target: Some(EsVersion::Es2022),
-                                    syntax: Some(Syntax::Typescript(TsConfig {
+                                    syntax: Some(Syntax::Typescript(TsSyntax {
                                         decorators: true,
                                         ..Default::default()
                                     })),

--- a/crates/swc/tests/projects.rs
+++ b/crates/swc/tests/projects.rs
@@ -23,7 +23,7 @@ use swc_common::{
 use swc_compiler_base::{IsModule, PrintArgs};
 use swc_ecma_ast::*;
 use swc_ecma_minifier::option::MangleOptions;
-use swc_ecma_parser::{EsSyntax, Syntax, TsConfig};
+use swc_ecma_parser::{EsSyntax, Syntax, TsSyntax};
 use swc_ecma_transforms::{
     helpers::{self, Helpers},
     pass::noop,
@@ -544,7 +544,7 @@ fn issue_879() {
                 env: Some(Default::default()),
                 module: Some(ModuleConfig::CommonJs(Default::default())),
                 jsc: JscConfig {
-                    syntax: Some(Syntax::Typescript(TsConfig {
+                    syntax: Some(Syntax::Typescript(TsSyntax {
                         tsx: true,
                         decorators: true,
                         ..Default::default()
@@ -914,7 +914,7 @@ fn issue_2224() {
         Options {
             config: Config {
                 jsc: JscConfig {
-                    syntax: Some(Syntax::Typescript(TsConfig {
+                    syntax: Some(Syntax::Typescript(TsSyntax {
                         decorators: true,
                         ..Default::default()
                     })),

--- a/crates/swc/tests/projects.rs
+++ b/crates/swc/tests/projects.rs
@@ -23,7 +23,7 @@ use swc_common::{
 use swc_compiler_base::{IsModule, PrintArgs};
 use swc_ecma_ast::*;
 use swc_ecma_minifier::option::MangleOptions;
-use swc_ecma_parser::{EsConfig, Syntax, TsConfig};
+use swc_ecma_parser::{EsSyntax, Syntax, TsConfig};
 use swc_ecma_transforms::{
     helpers::{self, Helpers},
     pass::noop,
@@ -711,7 +711,7 @@ fn should_visit() {
                     &swc::config::Options {
                         config: swc::config::Config {
                             jsc: JscConfig {
-                                syntax: Some(Syntax::Es(EsConfig {
+                                syntax: Some(Syntax::Es(EsSyntax {
                                     jsx: true,
                                     ..Default::default()
                                 })),

--- a/crates/swc/tests/rust_api.rs
+++ b/crates/swc/tests/rust_api.rs
@@ -4,7 +4,7 @@ use swc::{
 };
 use swc_common::{comments::SingleThreadedComments, FileName};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{EsConfig, Syntax, TsConfig};
+use swc_ecma_parser::{EsSyntax, Syntax, TsConfig};
 use swc_ecma_transforms::pass::noop;
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, VisitMut};
 
@@ -86,7 +86,7 @@ fn shopify_1_check_filename() {
             &Options {
                 config: Config {
                     jsc: JscConfig {
-                        syntax: Some(Syntax::Es(EsConfig {
+                        syntax: Some(Syntax::Es(EsSyntax {
                             jsx: true,
                             ..Default::default()
                         })),
@@ -279,7 +279,7 @@ fn shopify_4_reduce_more() {
         let opts = Options {
             config: Config {
                 jsc: JscConfig {
-                    syntax: Some(Syntax::Es(EsConfig {
+                    syntax: Some(Syntax::Es(EsSyntax {
                         jsx: true,
                         ..Default::default()
                     })),

--- a/crates/swc/tests/rust_api.rs
+++ b/crates/swc/tests/rust_api.rs
@@ -4,7 +4,7 @@ use swc::{
 };
 use swc_common::{comments::SingleThreadedComments, FileName};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{EsSyntax, Syntax, TsConfig};
+use swc_ecma_parser::{EsSyntax, Syntax, TsSyntax};
 use swc_ecma_transforms::pass::noop;
 use swc_ecma_visit::{as_folder, noop_visit_mut_type, VisitMut};
 
@@ -129,7 +129,7 @@ fn shopify_2_same_opt() {
                 test: None,
                 exclude: None,
                 jsc: JscConfig {
-                    syntax: Some(Syntax::Typescript(TsConfig {
+                    syntax: Some(Syntax::Typescript(TsSyntax {
                         tsx: true,
                         decorators: false,
                         dts: false,
@@ -211,7 +211,7 @@ fn shopify_3_reduce_defaults() {
         let opts = Options {
             config: Config {
                 jsc: JscConfig {
-                    syntax: Some(Syntax::Typescript(TsConfig {
+                    syntax: Some(Syntax::Typescript(TsSyntax {
                         tsx: true,
                         ..Default::default()
                     })),

--- a/crates/swc/tests/simple.rs
+++ b/crates/swc/tests/simple.rs
@@ -4,7 +4,7 @@ use swc::{
 };
 use swc_common::FileName;
 use swc_ecma_ast::EsVersion;
-use swc_ecma_parser::{Syntax, TsConfig};
+use swc_ecma_parser::{Syntax, TsSyntax};
 use testing::Tester;
 
 fn compile(src: &str, options: Options) -> String {
@@ -96,7 +96,7 @@ fn test_tsx_escape_xhtml() {
         Options {
             config: Config {
                 jsc: JscConfig {
-                    syntax: Some(Syntax::Typescript(TsConfig {
+                    syntax: Some(Syntax::Typescript(TsSyntax {
                         tsx: true,
                         ..Default::default()
                     })),
@@ -117,7 +117,7 @@ fn test_tsx_escape_xhtml() {
         Options {
             config: Config {
                 jsc: JscConfig {
-                    syntax: Some(Syntax::Typescript(TsConfig {
+                    syntax: Some(Syntax::Typescript(TsSyntax {
                         tsx: true,
                         ..Default::default()
                     })),

--- a/crates/swc/tests/tsc.rs
+++ b/crates/swc/tests/tsc.rs
@@ -21,7 +21,7 @@ use swc_common::{
     collections::AHashSet, errors::ColorConfig, FileName, SourceFile, SourceMap, GLOBALS,
 };
 use swc_ecma_ast::EsVersion;
-use swc_ecma_parser::{Syntax, TsConfig};
+use swc_ecma_parser::{Syntax, TsSyntax};
 use testing::NormalizedOutput;
 
 #[testing::fixture(
@@ -383,7 +383,7 @@ fn matrix(input: &Path) -> Vec<TestUnitData> {
                 let opts = Options {
                     config: Config {
                         jsc: JscConfig {
-                            syntax: Some(Syntax::Typescript(TsConfig {
+                            syntax: Some(Syntax::Typescript(TsSyntax {
                                 tsx: is_jsx,
                                 decorators,
                                 dts: false,

--- a/crates/swc_bundler/tests/common/mod.rs
+++ b/crates/swc_bundler/tests/common/mod.rs
@@ -18,7 +18,7 @@ use swc_common::{
 };
 use swc_ecma_ast::{EsVersion, Program};
 use swc_ecma_loader::resolve::Resolution;
-use swc_ecma_parser::{parse_file_as_module, Syntax, TsConfig};
+use swc_ecma_parser::{parse_file_as_module, Syntax, TsSyntax};
 use swc_ecma_transforms_base::{
     helpers::{inject_helpers, Helpers, HELPERS},
     resolver,
@@ -117,7 +117,7 @@ impl Load for Loader {
 
         let module = parse_file_as_module(
             &fm,
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 decorators: true,
                 tsx,
                 ..Default::default()

--- a/crates/swc_ecma_codegen/src/tests.rs
+++ b/crates/swc_ecma_codegen/src/tests.rs
@@ -5,7 +5,7 @@ use swc_ecma_parser;
 use swc_ecma_testing::{exec_node_js, JsExecOptions};
 use testing::DebugUsingDisplay;
 
-use self::swc_ecma_parser::{EsConfig, Parser, StringInput, Syntax};
+use self::swc_ecma_parser::{EsSyntax, Parser, StringInput, Syntax};
 use super::*;
 use crate::text_writer::omit_trailing_semi;
 
@@ -305,7 +305,7 @@ fn export_namespace_from() {
         "export * as Foo from 'foo';",
         "export * as Foo from 'foo';",
         Default::default(),
-        Syntax::Es(EsConfig::default()),
+        Syntax::Es(EsSyntax::default()),
     );
 }
 
@@ -318,7 +318,7 @@ fn export_namespace_from_min() {
             minify: true,
             ..Default::default()
         },
-        Syntax::Es(EsConfig::default()),
+        Syntax::Es(EsSyntax::default()),
     );
 }
 
@@ -328,9 +328,9 @@ fn named_and_namespace_export_from() {
         "export * as Foo, { bar } from 'foo';",
         "export * as Foo, { bar } from 'foo';",
         Default::default(),
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             export_default_from: true,
-            ..EsConfig::default()
+            ..EsSyntax::default()
         }),
     );
 }
@@ -344,9 +344,9 @@ fn named_and_namespace_export_from_min() {
             minify: true,
             ..Default::default()
         },
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             export_default_from: true,
-            ..EsConfig::default()
+            ..EsSyntax::default()
         }),
     );
 }
@@ -508,7 +508,7 @@ fn jsx_1() {
         "<Foo title=\"name\" desc=\"<empty>\" bool it>foo</Foo>;",
         "<Foo title=\"name\" desc=\"<empty>\" bool it>foo</Foo>;",
         Default::default(),
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             jsx: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_codegen/tests/fixture.rs
+++ b/crates/swc_ecma_codegen/tests/fixture.rs
@@ -5,7 +5,7 @@ use swc_ecma_codegen::{
     text_writer::{JsWriter, WriteJs},
     Emitter,
 };
-use swc_ecma_parser::{parse_file_as_module, Syntax, TsConfig};
+use swc_ecma_parser::{parse_file_as_module, Syntax, TsSyntax};
 use testing::{run_test2, NormalizedOutput};
 
 fn run(input: &Path, minify: bool) {
@@ -27,7 +27,7 @@ fn run(input: &Path, minify: bool) {
 
         let m = parse_file_as_module(
             &fm,
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 decorators: true,
                 tsx: true,
                 ..Default::default()

--- a/crates/swc_ecma_compat_es2015/src/object_super.rs
+++ b/crates/swc_ecma_compat_es2015/src/object_super.rs
@@ -473,7 +473,7 @@ impl SuperReplacer {
 #[cfg(test)]
 mod tests {
     use swc_common::{chain, Mark};
-    use swc_ecma_parser::{EsConfig, Syntax};
+    use swc_ecma_parser::{EsSyntax, Syntax};
     use swc_ecma_transforms_base::resolver;
     use swc_ecma_transforms_testing::test;
 
@@ -555,7 +555,7 @@ mod tests {
         }"
     );
     test!(
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             allow_super_outside_method: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_lints/tests/fixture.rs
+++ b/crates/swc_ecma_lints/tests/fixture.rs
@@ -22,7 +22,7 @@ fn pass(input: PathBuf) {
             if input.extension().unwrap() == "ts" {
                 Syntax::Typescript(Default::default())
             } else if input.extension().unwrap() == "tsx" {
-                Syntax::Typescript(swc_ecma_parser::TsConfig {
+                Syntax::Typescript(swc_ecma_parser::TsSyntax {
                     tsx: true,
                     ..Default::default()
                 })

--- a/crates/swc_ecma_minifier/tests/compress.rs
+++ b/crates/swc_ecma_minifier/tests/compress.rs
@@ -36,7 +36,7 @@ use swc_ecma_minifier::{
 };
 use swc_ecma_parser::{
     lexer::{input::SourceFileInput, Lexer},
-    EsConfig, Parser, Syntax,
+    EsSyntax, Parser, Syntax,
 };
 use swc_ecma_testing::{exec_node_js, JsExecOptions};
 use swc_ecma_transforms_base::{
@@ -183,7 +183,7 @@ fn run(
         let minification_start = Instant::now();
 
         let lexer = Lexer::new(
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),

--- a/crates/swc_ecma_minifier/tests/eval.rs
+++ b/crates/swc_ecma_minifier/tests/eval.rs
@@ -8,7 +8,7 @@ use swc_ecma_minifier::{
     eval::{EvalResult, Evaluator},
     marks::Marks,
 };
-use swc_ecma_parser::{parse_file_as_expr, parse_file_as_module, EsConfig, Syntax};
+use swc_ecma_parser::{parse_file_as_expr, parse_file_as_module, EsSyntax, Syntax};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 use testing::{assert_eq, DebugUsingDisplay};
@@ -88,7 +88,7 @@ impl PartialInliner {
 
             let mut module = parse_file_as_module(
                 &fm,
-                Syntax::Es(EsConfig {
+                Syntax::Es(EsSyntax {
                     jsx: true,
                     ..Default::default()
                 }),
@@ -121,7 +121,7 @@ impl PartialInliner {
 
                 parse_file_as_module(
                     &fm,
-                    Syntax::Es(EsConfig {
+                    Syntax::Es(EsSyntax {
                         jsx: true,
                         ..Default::default()
                     }),

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -23,7 +23,7 @@ use swc_ecma_minifier::{
         MinifyOptions,
     },
 };
-use swc_ecma_parser::{parse_file_as_module, EsConfig, Syntax};
+use swc_ecma_parser::{parse_file_as_module, EsSyntax, Syntax};
 use swc_ecma_testing::{exec_node_js, JsExecOptions};
 use swc_ecma_transforms_base::{fixer::fixer, hygiene::hygiene, resolver};
 use swc_ecma_visit::{FoldWith, VisitMutWith};
@@ -114,7 +114,7 @@ fn run(
 
     let program = parse_file_as_module(
         &fm,
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             jsx: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_minifier/tests/terser_exec.rs
+++ b/crates/swc_ecma_minifier/tests/terser_exec.rs
@@ -30,7 +30,7 @@ use swc_ecma_minifier::{
 };
 use swc_ecma_parser::{
     lexer::{input::SourceFileInput, Lexer},
-    EsConfig, Parser, Syntax,
+    EsSyntax, Parser, Syntax,
 };
 use swc_ecma_transforms_base::{
     fixer::{fixer, paren_remover},
@@ -189,7 +189,7 @@ fn run(cm: Lrc<SourceMap>, handler: &Handler, input: &Path, config: &str) -> Opt
         let minification_start = Instant::now();
 
         let lexer = Lexer::new(
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),

--- a/crates/swc_ecma_parser/benches/lexer.rs
+++ b/crates/swc_ecma_parser/benches/lexer.rs
@@ -2,7 +2,7 @@ extern crate swc_malloc;
 
 use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use swc_common::FileName;
-use swc_ecma_parser::{lexer::Lexer, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, StringInput, Syntax, TsSyntax};
 
 fn bench_module(b: &mut Bencher, syntax: Syntax, src: &'static str) {
     let _ = ::testing::run_test(false, |cm, _| {
@@ -86,7 +86,7 @@ fn bench_files(c: &mut Criterion) {
     c.bench_function("es/lexer/cal-com", |b| {
         bench_module(
             b,
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 tsx: true,
                 ..Default::default()
             }),

--- a/crates/swc_ecma_parser/benches/parser.rs
+++ b/crates/swc_ecma_parser/benches/parser.rs
@@ -2,7 +2,7 @@ extern crate swc_malloc;
 
 use criterion::{black_box, criterion_group, criterion_main, Bencher, Criterion};
 use swc_common::{comments::SingleThreadedComments, FileName};
-use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
 
 fn bench_module(b: &mut Bencher, syntax: Syntax, src: &'static str) {
     let _ = ::testing::run_test(false, |cm, _| {
@@ -93,7 +93,7 @@ fn bench_files(c: &mut Criterion) {
     c.bench_function("es/parser/cal-com", |b| {
         bench_module(
             b,
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 tsx: true,
                 ..Default::default()
             }),

--- a/crates/swc_ecma_parser/examples/perf.rs
+++ b/crates/swc_ecma_parser/examples/perf.rs
@@ -4,7 +4,7 @@ use std::{collections::hash_map::DefaultHasher, hash::Hash};
 
 use criterion::black_box;
 use swc_common::{sync::Lrc, SourceMap};
-use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
 
 fn main() {
     let mut cnt = 0;
@@ -23,7 +23,7 @@ fn main() {
         let fm = cm.load_file(entry.path()).unwrap();
 
         let lexer = Lexer::new(
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 no_early_errors: true,
                 tsx: entry.path().to_string_lossy().ends_with(".tsx"),
                 ..Default::default()

--- a/crates/swc_ecma_parser/src/lexer/tests.rs
+++ b/crates/swc_ecma_parser/src/lexer/tests.rs
@@ -992,7 +992,7 @@ a"
 fn jsx_01() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1011,7 +1011,7 @@ fn jsx_01() {
 fn jsx_02() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1034,7 +1034,7 @@ fn jsx_02() {
 fn jsx_03() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1062,7 +1062,7 @@ fn jsx_03() {
 fn jsx_04() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1104,7 +1104,7 @@ fn empty() {
 fn issue_191() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1161,7 +1161,7 @@ fn issue_5722() {
 fn jsx_05() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1187,7 +1187,7 @@ fn jsx_05() {
 fn issue_299_01() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1221,7 +1221,7 @@ fn issue_299_01() {
 fn issue_299_02() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1255,7 +1255,7 @@ fn issue_299_02() {
 fn jsx_string_1() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1289,7 +1289,7 @@ fn jsx_string_1() {
 fn jsx_string_2() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1323,7 +1323,7 @@ fn jsx_string_2() {
 fn jsx_string_3() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1357,7 +1357,7 @@ fn jsx_string_3() {
 fn jsx_string_4() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1391,7 +1391,7 @@ fn jsx_string_4() {
 fn jsx_string_5() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1425,7 +1425,7 @@ fn jsx_string_5() {
 fn jsx_string_6() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1459,7 +1459,7 @@ fn jsx_string_6() {
 fn jsx_string_7() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1493,7 +1493,7 @@ fn jsx_string_7() {
 fn jsx_string_8() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1527,7 +1527,7 @@ fn jsx_string_8() {
 fn jsx_string_9() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1587,7 +1587,7 @@ fn issue_401() {
 fn issue_481() {
     assert_eq!(
         lex_tokens(
-            crate::Syntax::Es(crate::EsConfig {
+            crate::Syntax::Es(crate::EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1928,7 +1928,7 @@ fn issue_2853_4_ts() {
 #[test]
 fn issue_2853_5_jsx() {
     let (tokens, errors) = lex_errors(
-        crate::Syntax::Es(crate::EsConfig {
+        crate::Syntax::Es(crate::EsSyntax {
             jsx: true,
             ..Default::default()
         }),
@@ -1978,7 +1978,7 @@ fn issue_2853_6_tsx() {
 #[test]
 fn issue_2853_7_jsx() {
     let (tokens, errors) = lex_errors(
-        crate::Syntax::Es(crate::EsConfig {
+        crate::Syntax::Es(crate::EsSyntax {
             jsx: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_parser/src/lexer/tests.rs
+++ b/crates/swc_ecma_parser/src/lexer/tests.rs
@@ -1953,7 +1953,7 @@ fn issue_2853_5_jsx() {
 #[test]
 fn issue_2853_6_tsx() {
     let (tokens, errors) = lex_errors(
-        crate::Syntax::Typescript(crate::TsConfig {
+        crate::Syntax::Typescript(crate::TsSyntax {
             tsx: true,
             ..Default::default()
         }),
@@ -2003,7 +2003,7 @@ fn issue_2853_7_jsx() {
 #[test]
 fn issue_2853_8_tsx() {
     let (tokens, errors) = lex_errors(
-        crate::Syntax::Typescript(crate::TsConfig {
+        crate::Syntax::Typescript(crate::TsSyntax {
             tsx: true,
             ..Default::default()
         }),
@@ -2084,7 +2084,7 @@ class C {
 #[test]
 fn conflict_marker_trivia3() {
     let (_, errors) = lex_errors(
-        crate::Syntax::Typescript(crate::TsConfig {
+        crate::Syntax::Typescript(crate::TsSyntax {
             tsx: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -331,6 +331,9 @@ pub struct TsSyntax {
     pub disallow_ambiguous_jsx_like: bool,
 }
 
+#[deprecated(note = "Use 'TsSyntax' instead")]
+pub type TsConfig = TsSyntax;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EsSyntax {
@@ -372,6 +375,9 @@ pub struct EsSyntax {
     #[serde(default)]
     pub explicit_resource_management: bool,
 }
+
+#[deprecated(note = "Use 'EsSyntax' instead")]
+pub type EsConfig = EsSyntax;
 
 /// Syntactic context.
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -150,7 +150,7 @@ mod parser;
 pub enum Syntax {
     /// Standard
     #[serde(rename = "ecmascript")]
-    Es(EsConfig),
+    Es(EsSyntax),
     /// This variant requires the cargo feature `typescript` to be enabled.
     #[cfg(feature = "typescript")]
     #[cfg_attr(docsrs, doc(cfg(feature = "typescript")))]
@@ -167,7 +167,7 @@ impl Default for Syntax {
 impl Syntax {
     fn auto_accessors(self) -> bool {
         match self {
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 auto_accessors: true,
                 ..
             }) => true,
@@ -179,7 +179,7 @@ impl Syntax {
 
     pub fn import_attributes(self) -> bool {
         match self {
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 import_attributes, ..
             }) => import_attributes,
             #[cfg(feature = "typescript")]
@@ -190,7 +190,7 @@ impl Syntax {
     /// Should we parse jsx?
     pub fn jsx(self) -> bool {
         match self {
-            Syntax::Es(EsConfig { jsx: true, .. }) => true,
+            Syntax::Es(EsSyntax { jsx: true, .. }) => true,
             #[cfg(feature = "typescript")]
             Syntax::Typescript(TsConfig { tsx: true, .. }) => true,
             _ => false,
@@ -198,12 +198,12 @@ impl Syntax {
     }
 
     pub fn fn_bind(self) -> bool {
-        matches!(self, Syntax::Es(EsConfig { fn_bind: true, .. }))
+        matches!(self, Syntax::Es(EsSyntax { fn_bind: true, .. }))
     }
 
     pub fn decorators(self) -> bool {
         match self {
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 decorators: true, ..
             }) => true,
             #[cfg(feature = "typescript")]
@@ -216,7 +216,7 @@ impl Syntax {
 
     pub fn decorators_before_export(self) -> bool {
         match self {
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 decorators_before_export: true,
                 ..
             }) => true,
@@ -241,7 +241,7 @@ impl Syntax {
     pub fn export_default_from(self) -> bool {
         matches!(
             self,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: true,
                 ..
             })
@@ -258,7 +258,7 @@ impl Syntax {
 
     pub(crate) fn allow_super_outside_method(self) -> bool {
         match self {
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 allow_super_outside_method,
                 ..
             }) => allow_super_outside_method,
@@ -269,7 +269,7 @@ impl Syntax {
 
     pub(crate) fn allow_return_outside_function(self) -> bool {
         match self {
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 allow_return_outside_function,
                 ..
             }) => allow_return_outside_function,
@@ -296,7 +296,7 @@ impl Syntax {
 
     pub fn explicit_resource_management(&self) -> bool {
         match self {
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 explicit_resource_management: using_decl,
                 ..
             }) => *using_decl,
@@ -333,7 +333,7 @@ pub struct TsConfig {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct EsConfig {
+pub struct EsSyntax {
     #[serde(default)]
     pub jsx: bool,
 

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -155,7 +155,7 @@ pub enum Syntax {
     #[cfg(feature = "typescript")]
     #[cfg_attr(docsrs, doc(cfg(feature = "typescript")))]
     #[serde(rename = "typescript")]
-    Typescript(TsConfig),
+    Typescript(TsSyntax),
 }
 
 impl Default for Syntax {
@@ -192,7 +192,7 @@ impl Syntax {
         match self {
             Syntax::Es(EsSyntax { jsx: true, .. }) => true,
             #[cfg(feature = "typescript")]
-            Syntax::Typescript(TsConfig { tsx: true, .. }) => true,
+            Syntax::Typescript(TsSyntax { tsx: true, .. }) => true,
             _ => false,
         }
     }
@@ -207,7 +207,7 @@ impl Syntax {
                 decorators: true, ..
             }) => true,
             #[cfg(feature = "typescript")]
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 decorators: true, ..
             }) => true,
             _ => false,
@@ -308,7 +308,7 @@ impl Syntax {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct TsConfig {
+pub struct TsSyntax {
     #[serde(default)]
     pub tsx: bool,
 

--- a/crates/swc_ecma_parser/src/parser/expr/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/tests.rs
@@ -4,10 +4,10 @@ use swc_common::{FileName, SourceMap, DUMMY_SP as span};
 use swc_ecma_visit::assert_eq_ignore_span;
 
 use super::*;
-use crate::{parse_file_as_expr, EsConfig};
+use crate::{parse_file_as_expr, EsSyntax};
 
 fn syntax() -> Syntax {
-    Syntax::Es(EsConfig {
+    Syntax::Es(EsSyntax {
         allow_super_outside_method: true,
         ..Default::default()
     })

--- a/crates/swc_ecma_parser/src/parser/jsx/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/jsx/tests.rs
@@ -6,7 +6,7 @@ use super::*;
 fn jsx(src: &'static str) -> Box<Expr> {
     test_parser(
         src,
-        crate::Syntax::Es(crate::EsConfig {
+        crate::Syntax::Es(crate::EsSyntax {
             jsx: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     error::SyntaxError,
     lexer::Lexer,
     token::{Token, Word},
-    Context, EsVersion, Syntax, TsConfig,
+    Context, EsVersion, Syntax, TsSyntax,
 };
 #[cfg(test)]
 extern crate test;
@@ -70,7 +70,7 @@ impl<I: Tokens> Parser<I> {
         #[cfg(feature = "typescript")]
         let in_declare = matches!(
             input.syntax(),
-            Syntax::Typescript(TsConfig { dts: true, .. })
+            Syntax::Typescript(TsSyntax { dts: true, .. })
         );
         #[cfg(not(feature = "typescript"))]
         let in_declare = false;

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1490,7 +1490,7 @@ mod tests {
     use swc_ecma_visit::assert_eq_ignore_span;
 
     use super::*;
-    use crate::EsConfig;
+    use crate::EsSyntax;
 
     fn stmt(s: &'static str) -> Stmt {
         test_parser(s, Syntax::default(), |p| p.parse_stmt(true))
@@ -1626,7 +1626,7 @@ mod tests {
             @dec2
             class Foo {}
             ",
-                Syntax::Es(EsConfig {
+                Syntax::Es(EsSyntax {
                     decorators: true,
                     ..Default::default()
                 }),
@@ -1673,7 +1673,7 @@ ReactDOM.render(<App />, document.getElementById('root'))
 "#;
         test_parser(
             src,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1692,7 +1692,7 @@ function App() {
 export default App"#;
         test_parser(
             src,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 jsx: true,
                 ..Default::default()
             }),
@@ -1705,7 +1705,7 @@ export default App"#;
         let src = "export v, { x, y as w } from 'mod';";
         test_parser(
             src,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: true,
                 ..Default::default()
             }),
@@ -1718,7 +1718,7 @@ export default App"#;
         let src = "export foo from 'bar';";
         test_parser(
             src,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: true,
                 ..Default::default()
             }),
@@ -1731,7 +1731,7 @@ export default App"#;
         let src = "export default from 'bar';";
         test_parser(
             src,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: true,
                 ..Default::default()
             }),
@@ -1744,7 +1744,7 @@ export default App"#;
         let src = "export default, {foo} from 'bar';";
         test_parser(
             src,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: true,
                 ..Default::default()
             }),
@@ -1774,7 +1774,7 @@ let x = 4";
     fn issue_226() {
         test_parser(
             "export * as Foo from 'bar';",
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: true,
                 ..Default::default()
             }),
@@ -1787,7 +1787,7 @@ let x = 4";
     fn issue_4369_1() {
         test_parser(
             r#"export * as foo, { bar } from "mod""#,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: false,
                 ..Default::default()
             }),
@@ -1799,7 +1799,7 @@ let x = 4";
     fn issue_4369_2() {
         test_parser(
             r#"export foo, * as bar, { baz } from "mod""#,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: true,
                 ..Default::default()
             }),
@@ -1811,7 +1811,7 @@ let x = 4";
     fn issue_4369_3() {
         test_parser(
             r#"export foo, * as bar from "mod""#,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: true,
                 ..Default::default()
             }),
@@ -1823,7 +1823,7 @@ let x = 4";
     fn issue_4369_4() {
         test_parser(
             r#"export * as bar, { baz } from "mod""#,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: true,
                 ..Default::default()
             }),
@@ -1835,7 +1835,7 @@ let x = 4";
     fn issue_4369_5() {
         test_parser(
             r#"export foo, { baz } from "mod""#,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 export_default_from: true,
                 ..Default::default()
             }),
@@ -2494,7 +2494,7 @@ export default function waitUntil(callback, options = {}) {
         let src = "import('foo',)";
         test_parser(
             src,
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 import_attributes: true,
                 ..Default::default()
             }),

--- a/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
@@ -899,7 +899,7 @@ impl<'a, I: Tokens> StmtLikeParser<'a, ModuleItem> for Parser<I> {
 
 #[cfg(test)]
 mod tests {
-    use crate::{EsConfig, Syntax};
+    use crate::{EsSyntax, Syntax};
 
     #[test]
     fn test_legacy_decorator() {
@@ -910,7 +910,7 @@ export default class Foo {
     class Baz {}
   }
 }",
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 decorators: true,
                 decorators_before_export: true,
                 ..Default::default()

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -185,7 +185,7 @@ fn issue_2264_1() {
     let _ = super::test_parser_comment(
         &c,
         s,
-        Syntax::Typescript(TsConfig {
+        Syntax::Typescript(TsSyntax {
             tsx: true,
             ..Default::default()
         }),
@@ -228,7 +228,7 @@ fn issue_2264_3() {
     let _ = super::test_parser_comment(
         &c,
         s,
-        Syntax::Typescript(TsConfig {
+        Syntax::Typescript(TsSyntax {
             tsx: true,
             ..Default::default()
         }),
@@ -255,7 +255,7 @@ fn issue_2339_1() {
     let _ = super::test_parser_comment(
         &c,
         s,
-        Syntax::Typescript(TsConfig {
+        Syntax::Typescript(TsSyntax {
             tsx: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -1,7 +1,7 @@
 use swc_common::comments::SingleThreadedComments;
 
 use super::*;
-use crate::EsConfig;
+use crate::EsSyntax;
 
 fn program(src: &'static str) -> Program {
     test_parser(src, Default::default(), |p| p.parse_program())
@@ -209,7 +209,7 @@ fn issue_2264_2() {
     let _ = super::test_parser_comment(
         &c,
         s,
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             jsx: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2370,7 +2370,7 @@ impl<I: Tokens> Parser<I> {
         if self.ctx().in_declare
             && matches!(
                 self.syntax(),
-                Syntax::Typescript(TsConfig { dts: false, .. })
+                Syntax::Typescript(TsSyntax { dts: false, .. })
             )
         {
             let span_of_declare = span!(self, start);

--- a/crates/swc_ecma_parser/tests/comments.rs
+++ b/crates/swc_ecma_parser/tests/comments.rs
@@ -7,7 +7,7 @@ use swc_common::{
     BytePos, Span,
 };
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsConfig};
 use swc_ecma_visit::{Visit, VisitWith};
 use testing::{fixture, Tester};
 
@@ -23,7 +23,7 @@ fn test(input: PathBuf) {
             //
             let fm = cm.load_file(&input).unwrap();
             let syntax = match &*ext {
-                "js" => Syntax::Es(EsConfig {
+                "js" => Syntax::Es(EsSyntax {
                     jsx: false,
                     fn_bind: false,
                     decorators: true,

--- a/crates/swc_ecma_parser/tests/comments.rs
+++ b/crates/swc_ecma_parser/tests/comments.rs
@@ -7,7 +7,7 @@ use swc_common::{
     BytePos, Span,
 };
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsSyntax};
 use swc_ecma_visit::{Visit, VisitWith};
 use testing::{fixture, Tester};
 
@@ -32,7 +32,7 @@ fn test(input: PathBuf) {
                     import_attributes: true,
                     ..Default::default()
                 }),
-                "ts" | "tsx" => Syntax::Typescript(TsConfig {
+                "ts" | "tsx" => Syntax::Typescript(TsSyntax {
                     tsx: ext == "tsx",
                     decorators: true,
                     no_early_errors: true,

--- a/crates/swc_ecma_parser/tests/errors.rs
+++ b/crates/swc_ecma_parser/tests/errors.rs
@@ -40,7 +40,7 @@ where
         .unwrap_or_default();
 
     let syntax = if is_ts {
-        ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsConfig {
+        ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsSyntax {
             tsx: is_jsx,
             ..Default::default()
         })

--- a/crates/swc_ecma_parser/tests/errors.rs
+++ b/crates/swc_ecma_parser/tests/errors.rs
@@ -45,7 +45,7 @@ where
             ..Default::default()
         })
     } else {
-        ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+        ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
             jsx: is_jsx,
             explicit_resource_management: true,
             ..Default::default()

--- a/crates/swc_ecma_parser/tests/js.rs
+++ b/crates/swc_ecma_parser/tests/js.rs
@@ -8,7 +8,7 @@ use std::{
 
 use swc_common::{comments::SingleThreadedComments, FileName};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, EsConfig, PResult, Parser, Syntax};
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, PResult, Parser, Syntax};
 use swc_ecma_visit::FoldWith;
 use testing::StdErr;
 
@@ -90,7 +90,7 @@ where
             .unwrap_or_else(|e| panic!("failed to load {}: {}", file_name.display(), e));
 
         let lexer = Lexer::new(
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 explicit_resource_management: true,
                 import_attributes: true,
                 decorators: true,

--- a/crates/swc_ecma_parser/tests/jsx.rs
+++ b/crates/swc_ecma_parser/tests/jsx.rs
@@ -28,7 +28,7 @@ where
         .unwrap_or_else(|e| panic!("failed to load {}: {}", file_name.display(), e));
 
     let mut p = Parser::new(
-        ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+        ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
             jsx: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_parser/tests/span.rs
+++ b/crates/swc_ecma_parser/tests/span.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use swc_common::{comments::SingleThreadedComments, errors::Handler, Spanned};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsSyntax};
 use swc_ecma_visit::{Visit, VisitWith};
 
 #[testing::fixture("tests/span/**/*.js")]
@@ -29,7 +29,7 @@ fn span(entry: PathBuf) {
                     ..Default::default()
                 })
             } else {
-                Syntax::Typescript(TsConfig {
+                Syntax::Typescript(TsSyntax {
                     tsx: true,
                     decorators: true,
                     no_early_errors: true,

--- a/crates/swc_ecma_parser/tests/span.rs
+++ b/crates/swc_ecma_parser/tests/span.rs
@@ -2,7 +2,7 @@ use std::path::PathBuf;
 
 use swc_common::{comments::SingleThreadedComments, errors::Handler, Spanned};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsConfig};
 use swc_ecma_visit::{Visit, VisitWith};
 
 #[testing::fixture("tests/span/**/*.js")]
@@ -23,7 +23,7 @@ fn span(entry: PathBuf) {
         let comments = SingleThreadedComments::default();
         let lexer = Lexer::new(
             if file_name.ends_with(".js") {
-                Syntax::Es(EsConfig {
+                Syntax::Es(EsSyntax {
                     jsx: true,
                     decorators: true,
                     ..Default::default()

--- a/crates/swc_ecma_parser/tests/typescript.rs
+++ b/crates/swc_ecma_parser/tests/typescript.rs
@@ -9,7 +9,7 @@ use std::{
 use pretty_assertions::assert_eq;
 use swc_common::{comments::SingleThreadedComments, FileName};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{lexer::Lexer, PResult, Parser, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, PResult, Parser, Syntax, TsSyntax};
 use swc_ecma_visit::FoldWith;
 use testing::StdErr;
 
@@ -254,7 +254,7 @@ where
             .unwrap_or_else(|e| panic!("failed to load {}: {}", file_name.display(), e));
 
         let lexer = Lexer::new(
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 dts: fname.ends_with(".d.ts"),
                 tsx: fname.contains("tsx"),
                 decorators: true,

--- a/crates/swc_ecma_transforms/tests/decorators.rs
+++ b/crates/swc_ecma_transforms/tests/decorators.rs
@@ -8,7 +8,7 @@
 use std::{fs, path::PathBuf};
 
 use swc_common::{chain, Mark};
-use swc_ecma_parser::{EsConfig, Syntax, TsConfig};
+use swc_ecma_parser::{EsSyntax, Syntax, TsConfig};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_transforms_compat::{
     class_fields_use_set::class_fields_use_set,
@@ -29,7 +29,7 @@ fn ts() -> Syntax {
 }
 
 fn syntax(decorators_before_export: bool) -> Syntax {
-    Syntax::Es(EsConfig {
+    Syntax::Es(EsSyntax {
         decorators_before_export,
         decorators: true,
         ..Default::default()
@@ -3657,7 +3657,7 @@ c = 456;
 );
 
 fn issue_395_syntax() -> ::swc_ecma_parser::Syntax {
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         decorators: true,
         ..Default::default()
     })

--- a/crates/swc_ecma_transforms/tests/decorators.rs
+++ b/crates/swc_ecma_transforms/tests/decorators.rs
@@ -8,7 +8,7 @@
 use std::{fs, path::PathBuf};
 
 use swc_common::{chain, Mark};
-use swc_ecma_parser::{EsSyntax, Syntax, TsConfig};
+use swc_ecma_parser::{EsSyntax, Syntax, TsSyntax};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_transforms_compat::{
     class_fields_use_set::class_fields_use_set,
@@ -22,7 +22,7 @@ use swc_ecma_transforms_typescript::{strip, typescript};
 use swc_ecma_visit::Fold;
 
 fn ts() -> Syntax {
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     })
@@ -4001,7 +4001,7 @@ test!(
 );
 
 test_exec!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -4030,7 +4030,7 @@ fn fixture_exec(input: PathBuf) {
 
     swc_ecma_transforms_testing::exec_tr(
         "decorator",
-        Syntax::Typescript(TsConfig {
+        Syntax::Typescript(TsSyntax {
             decorators: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_transforms_base/tests/fixture.rs
+++ b/crates/swc_ecma_transforms_base/tests/fixture.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use swc_common::{chain, sync::Lrc, Mark, SourceMap, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_codegen::Emitter;
-use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, StringInput, Syntax, TsSyntax};
 use swc_ecma_transforms_base::{fixer::fixer, resolver};
 use swc_ecma_visit::{
     as_folder, visit_mut_obj_and_computed, Fold, FoldWith, VisitMut, VisitMutWith,
@@ -88,7 +88,7 @@ fn test_resolver(input: PathBuf) {
 #[fixture("tests/ts-resolver/**/input.ts")]
 fn test_ts_resolver(input: PathBuf) {
     run(
-        Syntax::Typescript(TsConfig {
+        Syntax::Typescript(TsSyntax {
             decorators: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_transforms_base/tests/fixture.rs
+++ b/crates/swc_ecma_transforms_base/tests/fixture.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use swc_common::{chain, sync::Lrc, Mark, SourceMap, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_codegen::Emitter;
-use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, StringInput, Syntax, TsConfig};
 use swc_ecma_transforms_base::{fixer::fixer, resolver};
 use swc_ecma_visit::{
     as_folder, visit_mut_obj_and_computed, Fold, FoldWith, VisitMut, VisitMutWith,
@@ -68,7 +68,7 @@ where
 #[fixture("tests/resolver/**/input.js")]
 fn test_resolver(input: PathBuf) {
     run(
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             jsx: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
+++ b/crates/swc_ecma_transforms_base/tests/ts_resolver.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use swc_common::{Mark, SyntaxContext};
 use swc_ecma_ast::*;
-use swc_ecma_parser::{parse_file_as_module, Syntax, TsConfig};
+use swc_ecma_parser::{parse_file_as_module, Syntax, TsSyntax};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_visit::{FoldWith, Visit, VisitWith};
 use testing::fixture;
@@ -19,7 +19,7 @@ fn no_empty(input: PathBuf) {
 
         let module = match parse_file_as_module(
             &fm,
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 tsx: input.ends_with("tsx"),
                 decorators: true,
                 no_early_errors: true,

--- a/crates/swc_ecma_transforms_module/tests/amd.rs
+++ b/crates/swc_ecma_transforms_module/tests/amd.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, path::PathBuf, rc::Rc};
 
 use swc_common::{chain, comments::SingleThreadedComments, Mark};
-use swc_ecma_parser::{Syntax, TsConfig};
+use swc_ecma_parser::{Syntax, TsSyntax};
 use swc_ecma_transforms_base::{feature::FeatureFlag, resolver};
 use swc_ecma_transforms_compat::es2015::for_of;
 use swc_ecma_transforms_module::amd::{self, amd};
@@ -13,7 +13,7 @@ fn syntax() -> Syntax {
 }
 
 fn ts_syntax() -> Syntax {
-    Syntax::Typescript(TsConfig::default())
+    Syntax::Typescript(TsSyntax::default())
 }
 
 fn tr(config: amd::Config, typescript: bool, comments: Rc<SingleThreadedComments>) -> impl Fold {

--- a/crates/swc_ecma_transforms_module/tests/common_js.rs
+++ b/crates/swc_ecma_transforms_module/tests/common_js.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, path::PathBuf, rc::Rc};
 
 use swc_common::{chain, comments::SingleThreadedComments, Mark};
-use swc_ecma_parser::{Syntax, TsConfig};
+use swc_ecma_parser::{Syntax, TsSyntax};
 use swc_ecma_transforms_base::{feature::FeatureFlag, resolver};
 use swc_ecma_transforms_compat::es2015::for_of;
 use swc_ecma_transforms_module::common_js::{self, common_js};
@@ -13,7 +13,7 @@ fn syntax() -> Syntax {
 }
 
 fn ts_syntax() -> Syntax {
-    Syntax::Typescript(TsConfig::default())
+    Syntax::Typescript(TsSyntax::default())
 }
 
 fn tr(

--- a/crates/swc_ecma_transforms_module/tests/umd.rs
+++ b/crates/swc_ecma_transforms_module/tests/umd.rs
@@ -1,7 +1,7 @@
 use std::{fs::File, path::PathBuf};
 
 use swc_common::{chain, Mark};
-use swc_ecma_parser::{Syntax, TsConfig};
+use swc_ecma_parser::{Syntax, TsSyntax};
 use swc_ecma_transforms_base::{feature::FeatureFlag, resolver};
 use swc_ecma_transforms_module::umd::{umd, Config};
 use swc_ecma_transforms_testing::{test_fixture, Tester};
@@ -12,7 +12,7 @@ fn syntax() -> Syntax {
 }
 
 fn ts_syntax() -> Syntax {
-    Syntax::Typescript(TsConfig::default())
+    Syntax::Typescript(TsSyntax::default())
 }
 
 fn tr(tester: &mut Tester<'_>, config: Config, typescript: bool) -> impl Fold {

--- a/crates/swc_ecma_transforms_optimization/tests/fixture.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/fixture.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use swc_common::{chain, pass::Repeat, Mark};
-use swc_ecma_parser::{EsConfig, Syntax};
+use swc_ecma_parser::{EsSyntax, Syntax};
 use swc_ecma_transforms_base::fixer::paren_remover;
 use swc_ecma_transforms_optimization::simplify::{dce::dce, expr_simplifier};
 use swc_ecma_transforms_testing::{test_fixture, Tester};
@@ -18,7 +18,7 @@ fn dce_single_pass(input: PathBuf) {
     let output = input.with_file_name("output.js");
 
     test_fixture(
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             decorators: true,
             ..Default::default()
         }),
@@ -38,7 +38,7 @@ fn dce_repeated(input: PathBuf) {
     let output = input.with_file_name("output.full.js");
 
     test_fixture(
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             decorators: true,
             ..Default::default()
         }),
@@ -59,7 +59,7 @@ fn dce_jsx(input: PathBuf) {
     let output = input.with_file_name("output.js");
 
     test_fixture(
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             decorators: true,
             jsx: true,
             ..Default::default()

--- a/crates/swc_ecma_transforms_optimization/tests/remove_imports_with_side_effects.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/remove_imports_with_side_effects.rs
@@ -1,5 +1,5 @@
 use swc_common::{chain, pass::Repeat, Mark};
-use swc_ecma_parser::{EsConfig, Syntax};
+use swc_ecma_parser::{EsSyntax, Syntax};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_transforms_optimization::simplify::dce::{dce, Config};
 use swc_ecma_transforms_testing::test;
@@ -19,7 +19,7 @@ fn tr() -> impl Fold {
 macro_rules! to {
     ($name:ident, $src:expr) => {
         test!(
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 decorators: true,
                 ..Default::default()
             }),

--- a/crates/swc_ecma_transforms_optimization/tests/simplify.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/simplify.rs
@@ -3,7 +3,7 @@
 #![deny(warnings)]
 
 use swc_common::{chain, pass::Repeat, Mark};
-use swc_ecma_parser::{Syntax, TsConfig};
+use swc_ecma_parser::{Syntax, TsSyntax};
 use swc_ecma_transforms_base::{helpers::inject_helpers, resolver};
 use swc_ecma_transforms_compat::{es2015, es2016, es2017, es2018, es2022::class_properties, es3};
 use swc_ecma_transforms_module::{common_js::common_js, import_analysis::import_analyzer};
@@ -490,7 +490,7 @@ fn test_template_strings_known_methods() {
 }
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),

--- a/crates/swc_ecma_transforms_optimization/tests/simplify_dce.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/simplify_dce.rs
@@ -1,5 +1,5 @@
 use swc_common::{chain, pass::Repeat, Mark};
-use swc_ecma_parser::{EsConfig, Syntax, TsConfig};
+use swc_ecma_parser::{EsSyntax, Syntax, TsConfig};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_transforms_compat::es2022::class_properties;
 use swc_ecma_transforms_optimization::simplify::dce::{dce, Config};
@@ -21,7 +21,7 @@ fn tr() -> impl Fold {
 macro_rules! to {
     ($name:ident, $src:expr) => {
         test!(
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 decorators: true,
                 ..Default::default()
             }),

--- a/crates/swc_ecma_transforms_optimization/tests/simplify_dce.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/simplify_dce.rs
@@ -1,5 +1,5 @@
 use swc_common::{chain, pass::Repeat, Mark};
-use swc_ecma_parser::{EsSyntax, Syntax, TsConfig};
+use swc_ecma_parser::{EsSyntax, Syntax, TsSyntax};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_transforms_compat::es2022::class_properties;
 use swc_ecma_transforms_optimization::simplify::dce::{dce, Config};
@@ -367,7 +367,7 @@ export default class X {
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -399,7 +399,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -426,7 +426,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -461,7 +461,7 @@ new A();
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -501,7 +501,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -555,7 +555,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -584,7 +584,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),

--- a/crates/swc_ecma_transforms_optimization/tests/simplify_inlining.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/simplify_inlining.rs
@@ -1,7 +1,7 @@
 //! Copied from https://github.com/google/closure-compiler/blob/6ca3b62990064488074a1a8931b9e8dc39b148b3/test/com/google/javascript/jscomp/InlineVariablesTest.java
 
 use swc_common::{chain, Mark};
-use swc_ecma_parser::{Syntax, TsConfig};
+use swc_ecma_parser::{Syntax, TsSyntax};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_transforms_compat::es2022::class_properties;
 use swc_ecma_transforms_optimization::simplify::inlining::inlining;
@@ -2057,7 +2057,7 @@ fn test_tagged_template_literals() {
 }
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -2096,7 +2096,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -2149,7 +2149,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -2183,7 +2183,7 @@ const STATUS_TEXT = new Map([
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),

--- a/crates/swc_ecma_transforms_proposal/tests/decorator_esbuild.rs
+++ b/crates/swc_ecma_transforms_proposal/tests/decorator_esbuild.rs
@@ -30,7 +30,7 @@ fn execute() {
 
             let program = parse_file_as_program(
                 &fm,
-                swc_ecma_parser::Syntax::Es(swc_ecma_parser::EsConfig {
+                swc_ecma_parser::Syntax::Es(swc_ecma_parser::EsSyntax {
                     decorators: true,
                     auto_accessors: true,
                     ..Default::default()

--- a/crates/swc_ecma_transforms_proposal/tests/decorators.rs
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators.rs
@@ -7,7 +7,7 @@ use std::{
 
 use serde::Deserialize;
 use swc_common::{chain, comments::SingleThreadedComments, Mark};
-use swc_ecma_parser::{EsSyntax, Syntax, TsConfig};
+use swc_ecma_parser::{EsSyntax, Syntax, TsSyntax};
 use swc_ecma_transforms_base::{assumptions::Assumptions, resolver};
 use swc_ecma_transforms_proposal::decorator_2022_03::decorator_2022_03;
 use swc_ecma_transforms_testing::{test_fixture, FixtureTestConfig};
@@ -25,7 +25,7 @@ fn syntax_default() -> Syntax {
 }
 
 fn syntax_default_ts() -> Syntax {
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     })
@@ -41,7 +41,7 @@ fn exec_inner(input: PathBuf) {
 
     swc_ecma_transforms_testing::exec_tr(
         "decorator",
-        Syntax::Typescript(TsConfig {
+        Syntax::Typescript(TsSyntax {
             decorators: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_transforms_proposal/tests/decorators.rs
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators.rs
@@ -7,14 +7,14 @@ use std::{
 
 use serde::Deserialize;
 use swc_common::{chain, comments::SingleThreadedComments, Mark};
-use swc_ecma_parser::{EsConfig, Syntax, TsConfig};
+use swc_ecma_parser::{EsSyntax, Syntax, TsConfig};
 use swc_ecma_transforms_base::{assumptions::Assumptions, resolver};
 use swc_ecma_transforms_proposal::decorator_2022_03::decorator_2022_03;
 use swc_ecma_transforms_testing::{test_fixture, FixtureTestConfig};
 use swc_ecma_visit::Fold;
 
 fn syntax_default() -> Syntax {
-    Syntax::Es(EsConfig {
+    Syntax::Es(EsSyntax {
         decorators: true,
         auto_accessors: true,
         allow_super_outside_method: true,

--- a/crates/swc_ecma_transforms_proposal/tests/explicit_resource_management.rs
+++ b/crates/swc_ecma_transforms_proposal/tests/explicit_resource_management.rs
@@ -1,7 +1,7 @@
 use std::{fs::read_to_string, path::PathBuf};
 
 use swc_common::{chain, Mark};
-use swc_ecma_parser::{EsConfig, Syntax};
+use swc_ecma_parser::{EsSyntax, Syntax};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_transforms_proposal::explicit_resource_management::explicit_resource_management;
 use swc_ecma_transforms_testing::{exec_tr, test_fixture, FixtureTestConfig};
@@ -11,7 +11,7 @@ use swc_ecma_transforms_testing::{exec_tr, test_fixture, FixtureTestConfig};
 fn exec(input: PathBuf) {
     exec_tr(
         "explicit-resource-management",
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             explicit_resource_management: true,
             ..Default::default()
         }),
@@ -41,7 +41,7 @@ fn run_fixture(input: PathBuf) {
     ));
 
     test_fixture(
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             explicit_resource_management: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_transforms_proposal/tests/export.rs
+++ b/crates/swc_ecma_transforms_proposal/tests/export.rs
@@ -1,12 +1,12 @@
 use swc_common::chain;
-use swc_ecma_parser::{EsConfig, Syntax};
+use swc_ecma_parser::{EsSyntax, Syntax};
 use swc_ecma_transforms_compat::es2020::export_namespace_from;
 use swc_ecma_transforms_proposal::export_default_from;
 use swc_ecma_transforms_testing::test;
 use swc_ecma_visit::Fold;
 
 fn syntax_default() -> Syntax {
-    Syntax::Es(EsConfig {
+    Syntax::Es(EsSyntax {
         export_default_from: true,
         ..Default::default()
     })

--- a/crates/swc_ecma_transforms_proposal/tests/import_assertions.rs
+++ b/crates/swc_ecma_transforms_proposal/tests/import_assertions.rs
@@ -1,4 +1,4 @@
-use swc_ecma_parser::{EsConfig, Syntax};
+use swc_ecma_parser::{EsSyntax, Syntax};
 use swc_ecma_transforms_proposal::import_assertions;
 use swc_ecma_transforms_testing::test;
 use swc_ecma_visit::Fold;
@@ -8,7 +8,7 @@ fn tr() -> impl Fold {
 }
 
 fn syntax() -> Syntax {
-    Syntax::Es(EsConfig {
+    Syntax::Es(EsSyntax {
         import_attributes: true,
         ..Default::default()
     })

--- a/crates/swc_ecma_transforms_react/src/jsx/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/tests.rs
@@ -7,7 +7,7 @@ use std::{
 
 use swc_common::chain;
 use swc_ecma_codegen::{Config, Emitter};
-use swc_ecma_parser::{EsConfig, Parser, StringInput};
+use swc_ecma_parser::{EsSyntax, Parser, StringInput};
 use swc_ecma_transforms_base::{fixer::fixer, hygiene, resolver};
 use swc_ecma_transforms_compat::{
     es2015::{arrow, classes},
@@ -109,7 +109,7 @@ fn integration_tr(t: &mut Tester, mut options: FixtureOptions) -> impl Fold {
     )
 }
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -123,7 +123,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -141,7 +141,7 @@ var bar = function () {
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -165,7 +165,7 @@ var x =
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -180,7 +180,7 @@ Component = React.createClass({
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -196,7 +196,7 @@ export default React.createClass({
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -220,7 +220,7 @@ var Bar = React.createClass({
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -237,7 +237,7 @@ exports = {
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -253,7 +253,7 @@ exports.Component = React.createClass({
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -269,7 +269,7 @@ var Component = React.createClass({
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -284,7 +284,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -301,7 +301,7 @@ var profile = <div>
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -320,7 +320,7 @@ var profile = <div>
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -344,7 +344,7 @@ var profile = <div>
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -354,7 +354,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -366,7 +366,7 @@ test!(
 test!(
     // Optimization is not implemented yet
     ignore,
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -394,7 +394,7 @@ class App extends React.Component {
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -407,7 +407,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -417,7 +417,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -427,7 +427,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -437,7 +437,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -447,7 +447,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -470,7 +470,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -484,7 +484,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -499,7 +499,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -525,7 +525,7 @@ var x = <Composite>
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -535,7 +535,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -545,7 +545,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -559,7 +559,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -580,7 +580,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -592,7 +592,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -604,7 +604,7 @@ test!(
 test!(
     // FIXME
     ignore,
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -616,7 +616,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -638,7 +638,7 @@ React.render(<HelloMessage name={
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -648,7 +648,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -664,7 +664,7 @@ var x = <div>
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -691,7 +691,7 @@ var x =
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -701,7 +701,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -711,7 +711,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -721,7 +721,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -732,7 +732,7 @@ test!(
 
 test!(
     // Comments are currently stripped out
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -753,7 +753,7 @@ var x = (
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -763,7 +763,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -781,7 +781,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -791,7 +791,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -804,7 +804,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -814,7 +814,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -824,7 +824,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -834,7 +834,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -844,7 +844,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -854,7 +854,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -865,7 +865,7 @@ const b = <div>test</div>"
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -888,7 +888,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -899,7 +899,7 @@ test!(
 
 // https://github.com/swc-project/swc/issues/517
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -929,7 +929,7 @@ fn jsx_text() {
 
 // https://github.com/swc-project/swc/issues/542
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -942,7 +942,7 @@ test!(
 test!(
     // Module
     ignore,
-    Syntax::Es(EsConfig {
+    Syntax::Es(EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -983,7 +983,7 @@ return (
 );
 
 test!(
-    Syntax::Es(EsConfig {
+    Syntax::Es(EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -1016,7 +1016,7 @@ fn fixture(input: PathBuf) {
     }
 
     test_fixture(
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             jsx: true,
             ..Default::default()
         }),
@@ -1041,7 +1041,7 @@ fn integration(input: PathBuf) {
     }
 
     test_fixture(
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             jsx: true,
             ..Default::default()
         }),
@@ -1075,7 +1075,7 @@ fn test_script(src: &str, output: &Path, options: Options) {
             .cm
             .new_source_file(FileName::Real("input.js".into()), src.into());
 
-        let syntax = Syntax::Es(EsConfig {
+        let syntax = Syntax::Es(EsSyntax {
             jsx: true,
             ..Default::default()
         });

--- a/crates/swc_ecma_transforms_react/src/jsx_self/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx_self/tests.rs
@@ -7,7 +7,7 @@ fn tr() -> impl Fold {
 }
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),

--- a/crates/swc_ecma_transforms_react/src/jsx_src/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx_src/tests.rs
@@ -10,7 +10,7 @@ fn tr() -> impl Fold {
 
 test_exec!(
     ignore,
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -35,7 +35,7 @@ expect(actual).toBe(expected);
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -46,7 +46,7 @@ test!(
 
 test_exec!(
     ignore,
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),

--- a/crates/swc_ecma_transforms_react/src/pure_annotations/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/pure_annotations/tests.rs
@@ -11,7 +11,7 @@ fn parse(
     tester: &mut Tester,
     src: &str,
 ) -> Result<(Module, Lrc<SourceMap>, Lrc<SingleThreadedComments>), ()> {
-    let syntax = ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    let syntax = ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     });

--- a/crates/swc_ecma_transforms_react/src/refresh/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/tests.rs
@@ -25,7 +25,7 @@ fn tr(t: &mut Tester) -> impl Fold {
 }
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -43,7 +43,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -68,7 +68,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -89,7 +89,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -105,7 +105,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -119,7 +119,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -140,7 +140,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -160,7 +160,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -186,7 +186,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -209,7 +209,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -219,7 +219,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -239,7 +239,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -253,7 +253,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -267,7 +267,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -283,7 +283,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -301,7 +301,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -336,7 +336,7 @@ test!(
 // A doesn't get registered because it's not declared locally.
 // Alias doesn't get registered because its definition is just an identifier.
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -377,7 +377,7 @@ test!(
 
 test!(
     ignore,
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -393,7 +393,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -410,7 +410,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -426,7 +426,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -451,7 +451,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -480,7 +480,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -496,7 +496,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -513,7 +513,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -577,7 +577,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -628,7 +628,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -651,7 +651,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -667,7 +667,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -740,7 +740,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),
@@ -758,7 +758,7 @@ const a = (a) => {
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsConfig {
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
         jsx: true,
         ..Default::default()
     }),

--- a/crates/swc_ecma_transforms_react/src/refresh/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/tests.rs
@@ -536,7 +536,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsConfig {
+    ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsSyntax {
         tsx: true,
         ..Default::default()
     }),
@@ -601,7 +601,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsConfig {
+    ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsSyntax {
         tsx: true,
         ..Default::default()
     }),
@@ -700,7 +700,7 @@ test!(
 );
 
 test!(
-    ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsConfig {
+    ::swc_ecma_parser::Syntax::Typescript(::swc_ecma_parser::TsSyntax {
         tsx: true,
         ..Default::default()
     }),

--- a/crates/swc_ecma_transforms_testing/tests/visited.rs
+++ b/crates/swc_ecma_transforms_testing/tests/visited.rs
@@ -1,5 +1,5 @@
 use swc_ecma_ast::*;
-use swc_ecma_parser::{EsConfig, Syntax};
+use swc_ecma_parser::{EsSyntax, Syntax};
 use swc_ecma_transforms_testing::test_transform;
 use swc_ecma_visit::Fold;
 
@@ -22,7 +22,7 @@ impl Fold for Panicking {
 #[should_panic = "visited"]
 fn ensure_visited() {
     test_transform(
-        Syntax::Es(EsConfig {
+        Syntax::Es(EsSyntax {
             jsx: true,
             ..Default::default()
         }),

--- a/crates/swc_ecma_transforms_typescript/examples/ts_to_js.rs
+++ b/crates/swc_ecma_transforms_typescript/examples/ts_to_js.rs
@@ -11,7 +11,7 @@ use swc_common::{
     Globals, Mark, SourceMap, GLOBALS,
 };
 use swc_ecma_codegen::to_code_default;
-use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
 use swc_ecma_transforms_base::{fixer::fixer, hygiene::hygiene, resolver};
 use swc_ecma_transforms_typescript::strip;
 use swc_ecma_visit::FoldWith;
@@ -36,7 +36,7 @@ fn main() {
     let comments = SingleThreadedComments::default();
 
     let lexer = Lexer::new(
-        Syntax::Typescript(TsConfig {
+        Syntax::Typescript(TsSyntax {
             tsx: input.ends_with(".tsx"),
             ..Default::default()
         }),

--- a/crates/swc_ecma_transforms_typescript/tests/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use swc_common::{chain, comments::SingleThreadedComments, pass::Optional, Mark};
-use swc_ecma_parser::{Syntax, TsConfig};
+use swc_ecma_parser::{Syntax, TsSyntax};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_transforms_compat::{
     class_fields_use_set::class_fields_use_set,
@@ -599,7 +599,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -634,7 +634,7 @@ test!(
 );
 
 test_exec!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -1744,7 +1744,7 @@ export default (identifier: string, level = 0, b = "", m = false) => {
 to!(bin_01, "a!!!! + b!!!!!! + c!!!!!");
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -1757,7 +1757,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -1769,7 +1769,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -1792,7 +1792,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         tsx: true,
         ..Default::default()
     }),
@@ -1809,7 +1809,7 @@ serve((_req) =>
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         tsx: true,
         ..Default::default()
     }),
@@ -1827,7 +1827,7 @@ serve((_req) =>
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -1867,7 +1867,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -1948,7 +1948,7 @@ class C {
 );
 
 test!(
-    Syntax::Typescript(TsConfig {
+    Syntax::Typescript(TsSyntax {
         decorators: true,
         ..Default::default()
     }),
@@ -2646,7 +2646,7 @@ namespace Namespace {
 fn exec(input: PathBuf) {
     let output = input.with_file_name("output.js");
     test_fixture(
-        Syntax::Typescript(TsConfig {
+        Syntax::Typescript(TsSyntax {
             tsx: input.to_string_lossy().ends_with(".tsx"),
             ..Default::default()
         }),
@@ -2673,7 +2673,7 @@ let b = class {
 );
 
 test!(
-    Syntax::Typescript(TsConfig::default()),
+    Syntax::Typescript(TsSyntax::default()),
     |_| tr_config(None, None, true),
     export_import_assign,
     r#"
@@ -2684,7 +2684,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig::default()),
+    Syntax::Typescript(TsSyntax::default()),
     |_| tr_config(
         Some(typescript::Config {
             import_export_assign_config: TsImportExportAssignConfig::NodeNext,
@@ -2702,7 +2702,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig::default()),
+    Syntax::Typescript(TsSyntax::default()),
     |_| tr_config(
         Some(typescript::Config {
             import_export_assign_config: TsImportExportAssignConfig::NodeNext,
@@ -2756,7 +2756,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig::default()),
+    Syntax::Typescript(TsSyntax::default()),
     |_| tr_config(
         Some(typescript::Config {
             ts_enum_is_mutable: true,
@@ -2799,7 +2799,7 @@ test!(
 );
 
 test!(
-    Syntax::Typescript(TsConfig::default()),
+    Syntax::Typescript(TsSyntax::default()),
     |t| {
         let unresolved_mark = Mark::new();
         let top_level_mark = Mark::new();

--- a/crates/swc_ecma_transforms_typescript/tests/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip.rs
@@ -95,7 +95,7 @@ fn properties(t: &Tester, loose: bool) -> impl Fold {
 macro_rules! to {
     ($name:ident, $from:expr) => {
         test!(
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 decorators: true,
                 ..Default::default()
             }),
@@ -115,7 +115,7 @@ macro_rules! test_with_config {
     };
     ($name:ident, $config:expr, $use_define:expr,$from:expr) => {
         test!(
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 decorators: true,
                 ..Default::default()
             }),

--- a/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use swc_common::{FileName, Mark};
 use swc_ecma_ast::*;
 use swc_ecma_codegen::to_code_default;
-use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsSyntax};
 use swc_ecma_transforms_base::{fixer::fixer, hygiene::hygiene, resolver};
 use swc_ecma_transforms_typescript::typescript;
 use swc_ecma_visit::FoldWith;
@@ -83,7 +83,7 @@ fn identity(entry: PathBuf) {
         println!("{}", src.src);
 
         let mut parser: Parser<Lexer> = Parser::new(
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 tsx: file_name.contains("tsx"),
                 decorators: true,
                 dts: false,

--- a/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use swc_common::{FileName, Mark};
 use swc_ecma_ast::*;
 use swc_ecma_codegen::to_code_default;
-use swc_ecma_parser::{lexer::Lexer, EsConfig, Parser, Syntax, TsConfig};
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, Syntax, TsConfig};
 use swc_ecma_transforms_base::{fixer::fixer, hygiene::hygiene, resolver};
 use swc_ecma_transforms_typescript::typescript;
 use swc_ecma_visit::FoldWith;
@@ -132,7 +132,7 @@ fn identity(entry: PathBuf) {
         let js_fm = cm.new_source_file(FileName::Anon, js_content.clone());
 
         let mut parser: Parser<Lexer> = Parser::new(
-            Syntax::Es(EsConfig {
+            Syntax::Es(EsSyntax {
                 jsx: file_name.contains("tsx"),
                 decorators: true,
                 decorators_before_export: true,

--- a/crates/swc_estree_compat/tests/convert.rs
+++ b/crates/swc_estree_compat/tests/convert.rs
@@ -16,7 +16,7 @@ use swc_common::{
     errors::{ColorConfig, Handler},
     FileName, FilePathMapping, SourceMap, GLOBALS,
 };
-use swc_ecma_parser::{EsConfig, Syntax};
+use swc_ecma_parser::{EsSyntax, Syntax};
 use swc_estree_compat::babelify::{Babelify, Context};
 use test::{test_main, DynTestFn, ShouldPanic, TestDesc, TestDescAndFn, TestName, TestType};
 use testing::{json::diff_json_value, DebugUsingDisplay};
@@ -85,7 +85,7 @@ fn fixtures() -> Result<(), Error> {
                     let syntax = if is_typescript {
                         Syntax::Typescript(Default::default())
                     } else if is_jsx {
-                        Syntax::Es(EsConfig {
+                        Syntax::Es(EsSyntax {
                             jsx: true,
                             ..Default::default()
                         })

--- a/crates/swc_plugin_runner/tests/ecma_rkyv.rs
+++ b/crates/swc_plugin_runner/tests/ecma_rkyv.rs
@@ -15,7 +15,7 @@ use swc_common::{
     Mark,
 };
 use swc_ecma_ast::{EsVersion, Program};
-use swc_ecma_parser::{parse_file_as_program, Syntax, TsConfig};
+use swc_ecma_parser::{parse_file_as_program, Syntax, TsSyntax};
 use testing::CARGO_TARGET_DIR;
 use tracing::info;
 
@@ -86,7 +86,7 @@ fn internal(input: PathBuf) {
 
             let parsed = parse_file_as_program(
                 &fm,
-                Syntax::Typescript(TsConfig {
+                Syntax::Typescript(TsSyntax {
                     tsx: input.to_string_lossy().ends_with(".tsx"),
                     ..Default::default()
                 }),

--- a/crates/swc_typescript/tests/fast_dts_deno.rs
+++ b/crates/swc_typescript/tests/fast_dts_deno.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use swc_ecma_ast::EsVersion;
 use swc_ecma_codegen::to_code;
-use swc_ecma_parser::{parse_file_as_module, Syntax, TsConfig};
+use swc_ecma_parser::{parse_file_as_module, Syntax, TsSyntax};
 use swc_typescript::fast_dts::FastDts;
 
 #[track_caller]
@@ -19,7 +19,7 @@ fn transform_dts_test(source: &str, expected: &str) {
 
         let mut module = parse_file_as_module(
             &fm,
-            Syntax::Typescript(TsConfig {
+            Syntax::Typescript(TsSyntax {
                 ..Default::default()
             }),
             EsVersion::latest(),


### PR DESCRIPTION
**Description:**

`EsConfig` and `TsConfig` sound like a general configuration for the whole language, while actually it's only about parsing. 

To avoid a breaking change, I created type aliases that will work without changing the code, while warning the users.

**Related issue:**

 - Closes #9089.