### PR TITLE
perf(es/lexer): Use `memchr::memmem` for lexing block comments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4509,6 +4509,7 @@ version = "0.146.3"
 dependencies = [
  "criterion",
  "either",
+ "memchr",
  "new_debug_unreachable",
  "num-bigint",
  "num-traits",

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -26,6 +26,7 @@ verify        = ["swc_ecma_visit"]
 
 [dependencies]
 either      = { workspace = true }
+memchr      = { workspace = true, features = ["use_std"] }
 num-bigint  = { workspace = true }
 num-traits  = { workspace = true }
 serde       = { workspace = true, features = ["derive"] }

--- a/crates/swc_ecma_parser/src/lexer/jsx.rs
+++ b/crates/swc_ecma_parser/src/lexer/jsx.rs
@@ -26,7 +26,7 @@ impl<'a> Lexer<'a> {
 
                     self.emit_error_span(span, SyntaxError::TS1185);
                     self.skip_line_comment(6);
-                    self.skip_space::<true>()?;
+                    self.skip_space::<true>();
                     return self.read_token();
                 }
                 '<' | '{' => {

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -379,7 +379,7 @@ impl<'a> Lexer<'a> {
                 let span = fixed_len_span(start, 7);
                 self.emit_error_span(span, SyntaxError::TS1185);
                 self.skip_line_comment(5);
-                self.skip_space::<true>()?;
+                self.skip_space::<true>();
                 return self.error_span(span, SyntaxError::TS1185);
             }
 
@@ -572,7 +572,7 @@ impl<'a> Lexer<'a> {
             if self.state.had_line_break && c == b'-' && self.eat(b'>') {
                 self.emit_module_mode_error(start, SyntaxError::LegacyCommentInModule);
                 self.skip_line_comment(0);
-                self.skip_space::<true>()?;
+                self.skip_space::<true>();
                 return self.read_token();
             }
 
@@ -617,7 +617,7 @@ impl<'a> Lexer<'a> {
                     if had_line_break_before_last && self.is_str("====") {
                         self.emit_error_span(fixed_len_span(start, 7), SyntaxError::TS1185);
                         self.skip_line_comment(4);
-                        self.skip_space::<true>()?;
+                        self.skip_space::<true>();
                         return self.read_token();
                     }
 
@@ -676,7 +676,7 @@ impl<'a> Lexer<'a> {
         // XML style comment. `<!--`
         if c == '<' && self.is(b'!') && self.peek() == Some('-') && self.peek_ahead() == Some('-') {
             self.skip_line_comment(3);
-            self.skip_space::<true>()?;
+            self.skip_space::<true>();
             self.emit_module_mode_error(start, SyntaxError::LegacyCommentInModule);
 
             return self.read_token();
@@ -732,7 +732,7 @@ impl<'a> Lexer<'a> {
         {
             self.emit_error_span(fixed_len_span(start, 7), SyntaxError::TS1185);
             self.skip_line_comment(5);
-            self.skip_space::<true>()?;
+            self.skip_space::<true>();
             return self.read_token();
         }
 

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -254,7 +254,7 @@ impl Lexer<'_> {
 
         // skip spaces before getting next character, if we are allowed to.
         if self.state.can_skip_space() {
-            self.skip_space::<true>()?;
+            self.skip_space::<true>();
             *start = self.input.cur_pos();
         };
 
@@ -320,7 +320,7 @@ impl Lexer<'_> {
 
                         self.emit_error_span(span, SyntaxError::TS1185);
                         self.skip_line_comment(6);
-                        self.skip_space::<true>()?;
+                        self.skip_space::<true>();
                         return self.read_token();
                     }
 

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -247,9 +247,10 @@ impl Lexer<'_> {
             if let Some(shebang) = self.read_shebang()? {
                 return Ok(Some(Token::Shebang(shebang)));
             }
-        } else {
-            self.state.is_first = false;
         }
+
+        self.state.had_line_break = self.state.is_first;
+        self.state.is_first = false;
 
         // skip spaces before getting next character, if we are allowed to.
         if self.state.can_skip_space() {
@@ -385,7 +386,7 @@ impl State {
         State {
             is_expr_allowed: true,
             next_regexp: None,
-            had_line_break: true,
+            had_line_break: false,
             had_line_break_before_last: false,
             is_first: true,
             start: BytePos(0),

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -194,6 +194,50 @@ impl Tokens for Lexer<'_> {
 }
 
 impl Lexer<'_> {
+    /// Consume pending comments.
+    ///
+    /// This is called when the input is exhausted.
+    #[cold]
+    #[inline(never)]
+    fn consume_pending_comments(&mut self) {
+        if let Some(comments) = self.comments.as_mut() {
+            let comments_buffer = self.comments_buffer.as_mut().unwrap();
+            let last = self.state.prev_hi;
+
+            // move the pending to the leading or trailing
+            for c in comments_buffer.take_pending_leading() {
+                // if the file had no tokens and no shebang, then treat any
+                // comments in the leading comments buffer as leading.
+                // Otherwise treat them as trailing.
+                if last == self.start_pos {
+                    comments_buffer.push(BufferedComment {
+                        kind: BufferedCommentKind::Leading,
+                        pos: last,
+                        comment: c,
+                    });
+                } else {
+                    comments_buffer.push(BufferedComment {
+                        kind: BufferedCommentKind::Trailing,
+                        pos: last,
+                        comment: c,
+                    });
+                }
+            }
+
+            // now fill the user's passed in comments
+            for comment in comments_buffer.take_comments() {
+                match comment.kind {
+                    BufferedCommentKind::Leading => {
+                        comments.add_leading(comment.pos, comment.comment);
+                    }
+                    BufferedCommentKind::Trailing => {
+                        comments.add_trailing(comment.pos, comment.comment);
+                    }
+                }
+            }
+        }
+    }
+
     fn next_token(&mut self, start: &mut BytePos) -> Result<Option<Token>, Error> {
         if let Some(start) = self.state.next_regexp {
             return Ok(Some(self.read_regexp(start)?));
@@ -217,42 +261,7 @@ impl Lexer<'_> {
             Some(..) => {}
             // End of input.
             None => {
-                if let Some(comments) = self.comments.as_mut() {
-                    let comments_buffer = self.comments_buffer.as_mut().unwrap();
-                    let last = self.state.prev_hi;
-
-                    // move the pending to the leading or trailing
-                    for c in comments_buffer.take_pending_leading() {
-                        // if the file had no tokens and no shebang, then treat any
-                        // comments in the leading comments buffer as leading.
-                        // Otherwise treat them as trailing.
-                        if last == self.start_pos {
-                            comments_buffer.push(BufferedComment {
-                                kind: BufferedCommentKind::Leading,
-                                pos: last,
-                                comment: c,
-                            });
-                        } else {
-                            comments_buffer.push(BufferedComment {
-                                kind: BufferedCommentKind::Trailing,
-                                pos: last,
-                                comment: c,
-                            });
-                        }
-                    }
-
-                    // now fill the user's passed in comments
-                    for comment in comments_buffer.take_comments() {
-                        match comment.kind {
-                            BufferedCommentKind::Leading => {
-                                comments.add_leading(comment.pos, comment.comment);
-                            }
-                            BufferedCommentKind::Trailing => {
-                                comments.add_trailing(comment.pos, comment.comment);
-                            }
-                        }
-                    }
-                }
+                self.consume_pending_comments();
 
                 return Ok(None);
             }

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -203,10 +203,9 @@ impl Lexer<'_> {
             if let Some(shebang) = self.read_shebang()? {
                 return Ok(Some(Token::Shebang(shebang)));
             }
+        } else {
+            self.state.is_first = false;
         }
-
-        self.state.had_line_break = self.state.is_first;
-        self.state.is_first = false;
 
         // skip spaces before getting next character, if we are allowed to.
         if self.state.can_skip_space() {
@@ -377,7 +376,7 @@ impl State {
         State {
             is_expr_allowed: true,
             next_regexp: None,
-            had_line_break: false,
+            had_line_break: true,
             had_line_break_before_last: false,
             is_first: true,
             start: BytePos(0),

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -160,7 +160,7 @@ impl<'a> Lexer<'a> {
     ///
     /// See https://tc39.github.io/ecma262/#sec-white-space
     #[inline(never)]
-    pub(super) fn skip_space<const LEX_COMMENTS: bool>(&mut self) -> LexResult<()> {
+    pub(super) fn skip_space<const LEX_COMMENTS: bool>(&mut self) {
         loop {
             let (offset, newline) = {
                 let mut skip = SkipWhitespace {
@@ -182,15 +182,13 @@ impl<'a> Lexer<'a> {
                     self.skip_line_comment(2);
                     continue;
                 } else if self.peek() == Some('*') {
-                    self.skip_block_comment()?;
+                    self.skip_block_comment();
                     continue;
                 }
             }
 
             break;
         }
-
-        Ok(())
     }
 
     #[inline(never)]
@@ -250,7 +248,7 @@ impl<'a> Lexer<'a> {
 
     /// Expects current char to be '/' and next char to be '*'.
     #[inline(never)]
-    pub(super) fn skip_block_comment(&mut self) -> LexResult<()> {
+    pub(super) fn skip_block_comment(&mut self) {
         let start = self.cur_pos();
 
         debug_assert_eq!(self.cur(), Some('/'));
@@ -276,7 +274,7 @@ impl<'a> Lexer<'a> {
 
                 let end = self.cur_pos();
 
-                self.skip_space::<false>()?;
+                self.skip_space::<false>();
 
                 if self.input.is_byte(b';') {
                     is_for_next = false;
@@ -284,7 +282,7 @@ impl<'a> Lexer<'a> {
 
                 self.store_comment(is_for_next, start, end, slice_start);
 
-                return Ok(());
+                return;
             }
             if c.is_line_terminator() {
                 self.state.had_line_break = true;
@@ -294,7 +292,7 @@ impl<'a> Lexer<'a> {
             self.bump();
         }
 
-        self.error(start, SyntaxError::UnterminatedBlockComment)?
+        self.emit_error(start, SyntaxError::UnterminatedBlockComment)
     }
 
     #[inline(never)]

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -283,7 +283,12 @@ impl<'a> Lexer<'a> {
             return;
         }
 
-        self.emit_error(start, SyntaxError::UnterminatedBlockComment)
+        let len = self.input.as_str().bytes().len();
+        self.input.bump_bytes(len);
+
+        let span = self.span(start);
+
+        self.emit_error_span(span, SyntaxError::UnterminatedBlockComment)
     }
 
     #[inline(never)]


### PR DESCRIPTION
**Description:**

This PR also makes the lexer more CPU-cache friendly.