### PR TITLE
feat(cli): Support generating `.d.ts` files

### DIFF
--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -957,6 +957,17 @@ impl Compiler {
     ) -> Result<TransformOutput, Error> {
         self.run(|| {
             let program = config.program;
+
+            if config.emit_isolated_dts && !config.syntax.typescript() {
+                HANDLER.with(|h| {
+                    h.struct_warn(
+                        "jsc.experimental.emitIsolatedDts is enabled but the syntax is not \
+                         TypeScript",
+                    )
+                    .emit();
+                });
+            }
+
             let emit_dts = config.syntax.typescript() && config.emit_isolated_dts;
             let source_map_names = if config.source_maps.enabled() {
                 let mut v = swc_compiler_base::IdentCollector {

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -959,13 +959,9 @@ impl Compiler {
             let program = config.program;
 
             if config.emit_isolated_dts && !config.syntax.typescript() {
-                HANDLER.with(|h| {
-                    h.struct_warn(
-                        "jsc.experimental.emitIsolatedDts is enabled but the syntax is not \
-                         TypeScript",
-                    )
-                    .emit();
-                });
+                handler.warn(
+                    "jsc.experimental.emitIsolatedDts is enabled but the syntax is not TypeScript",
+                );
             }
 
             let emit_dts = config.syntax.typescript() && config.emit_isolated_dts;

--- a/crates/swc_cli_impl/examples/cli.rs
+++ b/crates/swc_cli_impl/examples/cli.rs
@@ -1,0 +1,3 @@
+fn main() -> anyhow::Result<()> {
+    swc_cli_impl::run()
+}

--- a/crates/swc_cli_impl/src/commands/compile.rs
+++ b/crates/swc_cli_impl/src/commands/compile.rs
@@ -237,7 +237,17 @@ fn emit_output(
             fs::write(source_map_path, source_map)?;
         }
 
-        fs::write(output_file_path, &output.code)?;
+        fs::write(&output_file_path, &output.code)?;
+
+        if let Some(extra) = &output.output {
+            let mut extra: serde_json::Map<String, serde_json::Value> =
+                serde_json::from_str(extra).context("failed to parse extra output")?;
+
+            if let Some(dts_code) = extra.remove("__swc_isolated_declarations__") {
+                let dts_file_path = output_file_path.with_extension("d.ts");
+                fs::write(dts_file_path, dts_code.as_str().unwrap())?;
+            }
+        }
     } else {
         let source_map = if let Some(ref source_map) = output.map {
             &**source_map

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -634,6 +634,11 @@ export interface JscConfig {
          * Disable builtin transforms. If enabled, only Wasm plugins are used.
          */
         disableBuiltinTransformsForInternalTesting?: boolean;
+
+        /**
+         * Emit isolated dts files for each module.
+         */
+        emitIsolatedDts?: boolean;
     };
 
     baseUrl?: string;

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@swc/types",
     "packageManager": "yarn@4.0.2",
-    "version": "0.1.8",
+    "version": "0.1.9",
     "description": "Typings for the swc project.",
     "sideEffects": false,
     "scripts": {


### PR DESCRIPTION
**Description:**

I verified that `swc_cli` (Rust) works with 

```json
{
    "jsc": {
        "parser": {
            "syntax": "typescript"
        },
        "experimental": {
            "emitIsolatedDts": true
        }
    }
}
```