### PR TITLE
perf(es/parser): Add a check before performing numeric operations

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -800,7 +800,7 @@ impl<'a> Lexer<'a> {
             loop {
                 if let Some(c) = l.input.cur_as_ascii() {
                     // Performance optimization
-                    if c.is_ascii_uppercase() || c.is_ascii_digit() {
+                    if can_be_keyword && (c.is_ascii_uppercase() || c.is_ascii_digit()) {
                         can_be_keyword = false;
                     }
 


### PR DESCRIPTION
**Description:**

`c.is_ascii_uppercase()` was expensive than expected.