### PR TITLE
fix(es/minifier): Remove pure function used by variable initialization

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -470,6 +470,13 @@ impl Optimizer<'_> {
             return;
         }
 
+        trace_op!("iife: Checking pure");
+
+        if self.has_pure(call.span) {
+            log_abort!("iife: Has pure mark");
+            return;
+        }
+
         trace_op!("iife: Checking callee");
 
         match callee {

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -833,7 +833,8 @@ impl Optimizer<'_> {
                     BlockStmtOrExpr::Expr(_) => false,
                 },
                 _ => false,
-            } && args.is_empty() =>
+            } && args.is_empty()
+                || e.span().has_mark(self.marks.pure) =>
             {
                 report_change!("ignore_return_value: Dropping a pure call");
                 self.changed = true;

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -77,6 +77,11 @@ impl<'b> Optimizer<'b> {
         span.has_mark(self.marks.noinline)
     }
 
+    /// Check for `/*#__PURE__*/`
+    pub(super) fn has_pure(&self, span: Span) -> bool {
+        span.has_mark(self.marks.pure)
+    }
+
     /// RAII guard to change context temporarically
     pub(super) fn with_ctx(&mut self, mut ctx: Ctx) -> WithCtx<'_, 'b> {
         let mut scope_ctxt = ctx.scope;

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
@@ -1,4 +1,4 @@
-use swc_common::{collections::AHashMap, SyntaxContext};
+use swc_common::{collections::AHashMap, Spanned, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{find_pat_ids, ExprCtx, ExprExt, IsEmpty, StmtExt};
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
@@ -1294,7 +1294,7 @@ where
                 ..self.ctx
             };
 
-            if self.marks.is_some() {
+            if let Some(marks) = self.marks {
                 if let VarDeclarator {
                     name: Pat::Ident(id),
                     init: Some(init),
@@ -1306,7 +1306,8 @@ where
                     self.used_recursively.insert(
                         id.clone(),
                         RecursiveUsage::Var {
-                            can_ignore: !init.may_have_side_effects(&self.expr_ctx),
+                            can_ignore: !init.may_have_side_effects(&self.expr_ctx)
+                                || init.span().has_mark(marks.pure),
                         },
                     );
                     e.init.visit_with(&mut *self.with_ctx(ctx));


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

https://play.swc.rs/?version=1.6.5&code=H4sIAAAAAAAAA9PXVygvyixJVcgvUihILAYykvNTUhUyUotSubjKEosUwlNTs10SKxVsFfS1lOPjA0KDXOPjtfQVNNJK85JLMvPzFDSgSow0Faq5FGAajPQSgXqUgkvzUhIrlayBEkWpJaVFeXB5rlpNmE6FmhqF6lpNay4ADxpWp44AAAA%3D&config=H4sIAAAAAAAAA4WVO47jMAxA%2B5wiUD3FIsUWc4Dt5gyCYlGOsvoYIpWJMcjdl7aTiSdr2q4M8okUv%2Fra7ffqjI1633%2Fx7%2FSpzhSE8kPGUuwTmStLFTTRYFN8R%2BptTpxxUDsTEL7FtyehQs4ID2Imjz5517%2F6a3LsCiC%2ByFljSlsjJML%2Fbd31JX8OSir1VXfMOYBJG1ptUPtE0EKRnDQ5BNMh6IspgrUhAlM8ZsndAFQCq7uSO5FJ1pPPie%2BwTFgwVjfZgqD2BRryF5COs28%2BnpBDF2IdEQvH2rZjXyxYgYsJ1ZBwB7iOpeQoBA%2Bn7JG0q0lK9wSs5GkC7sVYsuCdLkC1pOXz5%2BzTSi3%2FAnCWgkFMJoLkY6Qc9%2BeaFbdpwSfHI0G9wPAcSVlI0HIRtPdOqMSQQSjkpW4oYGsDQyUa6Yp3ZCXV6C1ocI77TnCDn56ak3QJ6jvITlByjxgndeqk1N8bYIUZhm8D%2BcNZILlp71Q0dFonsI%2FHHDacRaBTthsQl4%2FyOlJ4a127daYmC9xiYEWs4qhcXkg8aJR1AJJ6jEeRres25ONzbc2g2%2FyEiia1z92z%2BHQQz9ToTgEefh0O%2FPDsZszzCZlFozx%2BZFvDz0lQ8SF7vCpju02mf6vJ6u72Dzzk3g4aBwAA

The above code will not be optimized in SWC but will be optimized in Terser. Terser analyzes variable usage step-by-step, so it first determines whether WeekDay is used at the top level. It does not consider the parameter in the call expression within the variable declaration as a reference to this variable. Additionally, Terser does not inline pure functions because inlining them would directly result in the variable being referenced at the top level.

See: https://github.com/terser/terser/blob/master/lib/compress/inline.js#L347

Perhaps this variable should be optimized during the DCE (Dead Code Elimination) phase? However, the DCE phase cannot determine the pure mark.

Maybe a more fundamental reason is that all side effect determinations should directly consider the pure mark, like: https://github.com/terser/terser/blob/9083832e6818eeda9b892c4140716a3d3a2632b7/lib/compress/inference.js#L884

I am not sure if the code I modified is correct, and I am somewhat confused about the determination of side effects and pure marks in the project...

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
