### PR TITLE
feat(binding): Create Wasm package for stripping only TypeScript

### DIFF
--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -508,13 +508,13 @@ jobs:
       matrix:
         settings:
           - crate: "binding_core_wasm"
-            npm: "@swc/wasm"
+            npm: "@swc\\/wasm"
             target: nodejs
           - crate: "binding_core_wasm"
-            npm: "@swc/wasm-web"
+            npm: "@swc\\/wasm-web"
             target: web
           - crate: "binding_typescript_wasm"
-            npm: "@swc/wasm-typescript"
+            npm: "@swc\\/wasm-typescript"
             target: no-modules
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/publish-core.yml
+++ b/.github/workflows/publish-core.yml
@@ -513,6 +513,9 @@ jobs:
           - crate: "binding_core_wasm"
             npm: "@swc/wasm-web"
             target: web
+          - crate: "binding_typescript_wasm"
+            npm: "@swc/wasm-typescript"
+            target: no-modules
     steps:
       - uses: actions/checkout@v4
 

--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -311,6 +311,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "swc_core",
+ "swc_error_reporters",
  "tracing",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -310,6 +310,7 @@ dependencies = [
  "getrandom",
  "serde",
  "serde-wasm-bindgen",
+ "serde_json",
  "swc_core",
  "swc_ecma_codegen",
  "swc_error_reporters",
@@ -2669,9 +2670,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.115"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12dc5c46daa8e9fdf4f5e71b6cf9a53f2487da0e86e55808e2d35539666497dd"
+checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
 dependencies = [
  "itoa",
  "ryu",

--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -3223,6 +3223,7 @@ dependencies = [
  "swc_ecma_minifier",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
+ "swc_ecma_transforms_typescript",
  "swc_ecma_visit",
  "swc_malloc",
  "swc_node_bundler",

--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -311,6 +311,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "swc_core",
+ "swc_ecma_codegen",
  "swc_error_reporters",
  "tracing",
  "wasm-bindgen",

--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -303,6 +303,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "binding_typescript_wasm"
+version = "1.6.6"
+dependencies = [
+ "anyhow",
+ "getrandom",
+ "serde",
+ "serde-wasm-bindgen",
+ "swc_core",
+ "tracing",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/bindings/Cargo.lock
+++ b/bindings/Cargo.lock
@@ -313,6 +313,7 @@ dependencies = [
  "swc_core",
  "tracing",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
 ]
 
 [[package]]

--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "binding_core_wasm",
   "binding_minifier_node",
   "binding_minifier_wasm",
+  "binding_typescript_wasm",
   "swc_cli",
 ]
 resolver = "2"

--- a/bindings/binding_core_node/build.rs
+++ b/bindings/binding_core_node/build.rs
@@ -17,7 +17,7 @@ fn main() {
     let out_dir = env::var("OUT_DIR").expect("Outdir should exist");
     let dest_path = Path::new(&out_dir).join("triple.txt");
     let mut f =
-        BufWriter::new(File::create(&dest_path).expect("Failed to create target triple text"));
+        BufWriter::new(File::create(dest_path).expect("Failed to create target triple text"));
     write!(
         f,
         "{}",

--- a/bindings/binding_minifier_node/src/minify.rs
+++ b/bindings/binding_minifier_node/src/minify.rs
@@ -7,8 +7,7 @@ use napi::{
 };
 use serde::Deserialize;
 use swc_compiler_base::{
-    minify_file_comments, parse_js, IdentCollector, IsModule, PrintArgs, SourceMapsConfig,
-    TransformOutput,
+    minify_file_comments, parse_js, IdentCollector, PrintArgs, SourceMapsConfig, TransformOutput,
 };
 use swc_config::config_types::BoolOr;
 use swc_core::{
@@ -23,7 +22,7 @@ use swc_core::{
             js::{JsMinifyCommentOption, JsMinifyOptions},
             option::{MinifyOptions, TopLevelOptions},
         },
-        parser::{EsConfig, EsSyntax, Syntax},
+        parser::{EsSyntax, Syntax},
         transforms::base::{fixer::fixer, hygiene::hygiene, resolver},
         visit::{FoldWith, VisitMutWith, VisitWith},
     },
@@ -172,7 +171,7 @@ fn do_work(input: MinifyTarget, options: JsMinifyOptions) -> napi::Result<Transf
 
         let is_mangler_enabled = min_opts.mangle.is_some();
 
-        let module = (|| {
+        let module = {
             let module = module.fold_with(&mut resolver(unresolved_mark, top_level_mark, false));
 
             let mut module = swc_core::ecma::minifier::optimize(
@@ -192,7 +191,7 @@ fn do_work(input: MinifyTarget, options: JsMinifyOptions) -> napi::Result<Transf
             }
             module.visit_mut_with(&mut fixer(Some(&comments as &dyn Comments)));
             module
-        })();
+        };
 
         let preserve_comments = options
             .format

--- a/bindings/binding_minifier_wasm/scripts/build.sh
+++ b/bindings/binding_minifier_wasm/scripts/build.sh
@@ -1,1 +1,0 @@
-wasm-pack build --debug --scope swc -t nodejs --features plugin --features getrandom/js $@

--- a/bindings/binding_minifier_wasm/scripts/build_nodejs_release.sh
+++ b/bindings/binding_minifier_wasm/scripts/build_nodejs_release.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# run this script from the wasm folder ./scripts/build_nodejs_release.sh
-npx wasm-pack build --scope swc -t nodejs --features plugin

--- a/bindings/binding_minifier_wasm/scripts/build_web_release.sh
+++ b/bindings/binding_minifier_wasm/scripts/build_web_release.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# run this script from the wasm folder ./scripts/build_web_release.sh
-npx wasm-pack build --scope swc --features plugin

--- a/bindings/binding_minifier_wasm/scripts/test.sh
+++ b/bindings/binding_minifier_wasm/scripts/test.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -eu
-
-./scripts/build.sh
-npx jest $@

--- a/bindings/binding_typescript_wasm/Cargo.toml
+++ b/bindings/binding_typescript_wasm/Cargo.toml
@@ -1,0 +1,36 @@
+[package]
+authors     = ["강동윤 <kdy1997.dev@gmail.com>"]
+description = "wasm module for swc"
+edition     = "2021"
+license     = "Apache-2.0"
+name        = "binding_typescript_wasm"
+publish     = false
+repository  = "https://github.com/swc-project/swc.git"
+version     = "1.6.6"
+
+[lib]
+bench      = false
+crate-type = ["cdylib"]
+
+[features]
+default = ["swc_v1"]
+swc_v1  = []
+swc_v2  = []
+
+[dependencies]
+anyhow = "1.0.66"
+getrandom = { version = "0.2.10", features = ["js"] }
+serde = { version = "1", features = ["derive"] }
+serde-wasm-bindgen = "0.4.5"
+swc_core = { version = "0.95.10", features = [
+  "ecma_ast_serde",
+  "ecma_codegen",
+  "binding_macro_wasm",
+  "ecma_transforms",
+  "ecma_visit",
+] }
+tracing = { version = "0.1.37", features = ["max_level_off"] }
+wasm-bindgen = { version = "0.2.82", features = ["enable-interning"] }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false

--- a/bindings/binding_typescript_wasm/Cargo.toml
+++ b/bindings/binding_typescript_wasm/Cargo.toml
@@ -29,6 +29,7 @@ swc_core = { version = "0.95.10", features = [
   "ecma_transforms_typescript",
   "ecma_visit",
 ] }
+swc_ecma_codegen = { version = "0.151.1", features = ["serde-impl"] }
 swc_error_reporters = "0.18.0"
 tracing = { version = "0.1.37", features = ["max_level_off"] }
 wasm-bindgen = { version = "0.2.82", features = ["enable-interning"] }

--- a/bindings/binding_typescript_wasm/Cargo.toml
+++ b/bindings/binding_typescript_wasm/Cargo.toml
@@ -22,6 +22,7 @@ anyhow = "1.0.66"
 getrandom = { version = "0.2.10", features = ["js"] }
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.4.5"
+serde_json = "1.0.120"
 swc_core = { version = "0.95.10", features = [
   "ecma_ast_serde",
   "ecma_codegen",

--- a/bindings/binding_typescript_wasm/Cargo.toml
+++ b/bindings/binding_typescript_wasm/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-authors     = ["강동윤 <kdy1997.dev@gmail.com>"]
+authors = ["강동윤 <kdy1997.dev@gmail.com>"]
 description = "wasm module for swc"
-edition     = "2021"
-license     = "Apache-2.0"
-name        = "binding_typescript_wasm"
-publish     = false
-repository  = "https://github.com/swc-project/swc.git"
-version     = "1.6.6"
+edition = "2021"
+license = "Apache-2.0"
+name = "binding_typescript_wasm"
+publish = false
+repository = "https://github.com/swc-project/swc.git"
+version = "1.6.6"
 
 [lib]
-bench      = false
+bench = false
 crate-type = ["cdylib"]
 
 [features]
 default = ["swc_v1"]
-swc_v1  = []
-swc_v2  = []
+swc_v1 = []
+swc_v2 = []
 
 [dependencies]
 anyhow = "1.0.66"
@@ -31,6 +31,7 @@ swc_core = { version = "0.95.10", features = [
 ] }
 tracing = { version = "0.1.37", features = ["max_level_off"] }
 wasm-bindgen = { version = "0.2.82", features = ["enable-interning"] }
+wasm-bindgen-futures = { version = "0.4.41" }
 
 [package.metadata.wasm-pack.profile.release]
 wasm-opt = false

--- a/bindings/binding_typescript_wasm/Cargo.toml
+++ b/bindings/binding_typescript_wasm/Cargo.toml
@@ -26,6 +26,7 @@ swc_core = { version = "0.95.10", features = [
   "ecma_ast_serde",
   "ecma_codegen",
   "ecma_transforms",
+  "ecma_transforms_typescript",
   "ecma_visit",
 ] }
 swc_error_reporters = "0.18.0"

--- a/bindings/binding_typescript_wasm/Cargo.toml
+++ b/bindings/binding_typescript_wasm/Cargo.toml
@@ -25,7 +25,6 @@ serde-wasm-bindgen = "0.4.5"
 swc_core = { version = "0.95.10", features = [
   "ecma_ast_serde",
   "ecma_codegen",
-  "binding_macro_wasm",
   "ecma_transforms",
   "ecma_visit",
 ] }

--- a/bindings/binding_typescript_wasm/Cargo.toml
+++ b/bindings/binding_typescript_wasm/Cargo.toml
@@ -1,21 +1,21 @@
 [package]
-authors = ["강동윤 <kdy1997.dev@gmail.com>"]
+authors     = ["강동윤 <kdy1997.dev@gmail.com>"]
 description = "wasm module for swc"
-edition = "2021"
-license = "Apache-2.0"
-name = "binding_typescript_wasm"
-publish = false
-repository = "https://github.com/swc-project/swc.git"
-version = "1.6.6"
+edition     = "2021"
+license     = "Apache-2.0"
+name        = "binding_typescript_wasm"
+publish     = false
+repository  = "https://github.com/swc-project/swc.git"
+version     = "1.6.6"
 
 [lib]
-bench = false
+bench      = false
 crate-type = ["cdylib"]
 
 [features]
 default = ["swc_v1"]
-swc_v1 = []
-swc_v2 = []
+swc_v1  = []
+swc_v2  = []
 
 [dependencies]
 anyhow = "1.0.66"
@@ -28,6 +28,7 @@ swc_core = { version = "0.95.10", features = [
   "ecma_transforms",
   "ecma_visit",
 ] }
+swc_error_reporters = "0.18.0"
 tracing = { version = "0.1.37", features = ["max_level_off"] }
 wasm-bindgen = { version = "0.2.82", features = ["enable-interning"] }
 wasm-bindgen-futures = { version = "0.4.41" }

--- a/bindings/binding_typescript_wasm/package.json
+++ b/bindings/binding_typescript_wasm/package.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "jest": "^25.1.0"
+    }
+}

--- a/bindings/binding_typescript_wasm/src/lib.rs
+++ b/bindings/binding_typescript_wasm/src/lib.rs
@@ -1,7 +1,24 @@
+use anyhow::Error;
 use serde::{Deserialize, Serialize};
 use swc_core::{
-    base::HandlerOpts,
-    common::{errors::ColorConfig, sync::Lrc, SourceMap, GLOBALS},
+    base::{config::ErrorFormat, HandlerOpts},
+    common::{
+        comments::SingleThreadedComments, errors::ColorConfig, sync::Lrc, FileName, Mark,
+        SourceMap, GLOBALS,
+    },
+    ecma::{
+        ast::{EsVersion, Program},
+        parser::{
+            parse_file_as_module, parse_file_as_program, parse_file_as_script, Syntax, TsSyntax,
+        },
+        transforms::base::{
+            fixer::fixer,
+            helpers::{inject_helpers, Helpers, HELPERS},
+            hygiene::hygiene,
+            resolver,
+        },
+        visit::VisitMutWith,
+    },
 };
 use swc_error_reporters::handler::try_with_handler;
 use wasm_bindgen::prelude::*;
@@ -19,7 +36,25 @@ export function transformSync(src: string, opts?: Options): TransformOutput;
 "#;
 
 #[derive(Deserialize)]
-pub struct Options {}
+#[serde(rename_all = "camelCase")]
+pub struct Options {
+    #[serde(default)]
+    pub module: Option<bool>,
+    #[serde(default)]
+    pub filename: Option<String>,
+
+    #[serde(default)]
+    pub parser: TsSyntax,
+
+    #[serde(default)]
+    pub external_helpers: bool,
+
+    #[serde(default)]
+    pub transform: swc_core::ecma::transforms::typescript::Config,
+
+    #[serde(default)]
+    pub source_maps: bool,
+}
 
 #[derive(Serialize)]
 pub struct TransformOutput {
@@ -36,15 +71,109 @@ pub fn transform(input: JsString, options: JsValue) -> Promise {
 pub fn transform_sync(input: JsString, options: JsValue) -> Result<JsValue, JsValue> {
     let options: Options = serde_wasm_bindgen::from_value(options)?;
 
+    let input = input.as_string().unwrap().into();
+
+    let result = GLOBALS.set(&Default::default(), || operate(input, options));
+
+    Ok(())
+}
+
+fn operate(input: String, options: Options) -> Result<TransformOutput, Error> {
     let cm = Lrc::new(SourceMap::default());
-    GLOBALS.set(&Default::default(), || {
-        try_with_handler(
-            cm.clone(),
-            HandlerOpts {
-                color: ColorConfig::Never,
-                skip_filename: true,
-            },
-            |handler| {},
-        )
-    })
+
+    try_with_handler(
+        cm.clone(),
+        HandlerOpts {
+            color: ColorConfig::Never,
+            skip_filename: true,
+        },
+        |handler| {
+            let fileame = options
+                .filename
+                .map_or(FileName::Anon, |f| FileName::Real(f.into()));
+
+            let fm = cm.new_source_file(filename, input);
+
+            let syntax = Syntax::Typescript(options.parser);
+            let target = EsVersion::latest();
+
+            let comments = SingleThreadedComments::default();
+            let mut errors = vec![];
+
+            let mut program = match options.module {
+                Some(true) => {
+                    parse_file_as_module(&fm, syntax, target, Some(&comments), &mut errors)
+                        .map(Program::Module)
+                }
+                Some(false) => {
+                    parse_file_as_script(&fm, syntax, target, Some(&comments), &mut errors)
+                        .map(Program::Script)
+                }
+                None => parse_file_as_program(&fm, syntax, target, Some(&comments), &mut errors),
+            };
+
+            let mut program = match program {
+                Ok(program) => program,
+                Err(err) => {
+                    err.into_diagnostic(&handler).emit();
+
+                    for e in errors {
+                        e.into_diagnostic(&handler).emit();
+                    }
+
+                    return Err(anyhow::anyhow!("failed to parse"));
+                }
+            };
+
+            if !errors.is_empty() {
+                for e in errors {
+                    e.into_diagnostic(&handler).emit();
+                }
+
+                return Err(anyhow::anyhow!("failed to parse"));
+            }
+
+            let mut unresolved_mark = Mark::new();
+            let top_level_mark = Mark::new();
+
+            HELPERS.set(&Helpers::new(options.external_helpers), || {
+                // Apply resolver
+
+                program.visit_mut_with(&mut resolver(unresolved_mark, top_level_mark, true));
+
+                // Strip typescript types
+
+                program.visit_mut_with(&mut swc_core::ecma::transforms::typescript::typescript(
+                    options.transform,
+                    top_level_mark,
+                ));
+
+                // Apply external helpers
+
+                program.visit_mut_with(&mut inject_helpers(unresolved_mark));
+
+                // Apply hygiene
+
+                program.visit_mut_with(&mut hygiene());
+
+                // Apply fixer
+
+                program.visit_mut_with(&mut fixer(Some(&comments)));
+            });
+
+            // Generate code
+
+            Ok(TransformOutput {})
+        },
+    )
+}
+
+pub fn convert_err(
+    err: Error,
+    error_format: Option<ErrorFormat>,
+) -> wasm_bindgen::prelude::JsValue {
+    error_format
+        .unwrap_or(ErrorFormat::Normal)
+        .format(&err)
+        .into()
 }

--- a/bindings/binding_typescript_wasm/src/lib.rs
+++ b/bindings/binding_typescript_wasm/src/lib.rs
@@ -1,13 +1,29 @@
 use swc_core::binding_macros::{build_minify, build_minify_sync};
 use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::{
+    future_to_promise,
+    js_sys::{JsString, Promise},
+};
 
 /// Custom interface definitions for the @swc/wasm's public interface instead of
 /// auto generated one, which is not reflecting most of types in detail.
 #[wasm_bindgen(typescript_custom_section)]
 const INTERFACE_DEFINITIONS: &'static str = r#"
-export function minify(src: string, opts?: JsMinifyOptions): Promise<Output>;
-export function minifySync(code: string, opts?: JsMinifyOptions): Output;
+export function transform(src: string, opts?: Options): Promise<TransformOutput>;
+export function transformSync(src: string, opts?: Options): TransformOutput;
 "#;
 
-build_minify_sync!(#[wasm_bindgen(js_name = "minifySync", typescript_type = "minifySync",skip_typescript)]);
-build_minify!(#[wasm_bindgen(js_name = "minify", typescript_type = "minify",skip_typescript)]);
+pub struct Options {}
+
+pub struct TransformOutput {
+    code: String,
+    map: Option<String>,
+}
+
+#[wasm_bindgen]
+pub fn transform(input: JsString, options: JsValue) -> Promise {
+    future_to_promise(async move { transform_sync(input, options) })
+}
+
+#[wasm_bindgen]
+pub fn transform_sync(input: JsString, options: JsValue) -> Result<JsValue, JsValue> {}

--- a/bindings/binding_typescript_wasm/src/lib.rs
+++ b/bindings/binding_typescript_wasm/src/lib.rs
@@ -1,0 +1,13 @@
+use swc_core::binding_macros::{build_minify, build_minify_sync};
+use wasm_bindgen::prelude::*;
+
+/// Custom interface definitions for the @swc/wasm's public interface instead of
+/// auto generated one, which is not reflecting most of types in detail.
+#[wasm_bindgen(typescript_custom_section)]
+const INTERFACE_DEFINITIONS: &'static str = r#"
+export function minify(src: string, opts?: JsMinifyOptions): Promise<Output>;
+export function minifySync(code: string, opts?: JsMinifyOptions): Output;
+"#;
+
+build_minify_sync!(#[wasm_bindgen(js_name = "minifySync", typescript_type = "minifySync",skip_typescript)]);
+build_minify!(#[wasm_bindgen(js_name = "minify", typescript_type = "minify",skip_typescript)]);

--- a/bindings/binding_typescript_wasm/src/lib.rs
+++ b/bindings/binding_typescript_wasm/src/lib.rs
@@ -75,7 +75,7 @@ pub fn transform(input: JsString, options: JsValue) -> Promise {
 pub fn transform_sync(input: JsString, options: JsValue) -> Result<JsValue, JsValue> {
     let options: Options = serde_wasm_bindgen::from_value(options)?;
 
-    let input = input.as_string().unwrap().into();
+    let input = input.as_string().unwrap();
 
     let result = GLOBALS
         .set(&Default::default(), || operate(input, options))
@@ -106,7 +106,7 @@ fn operate(input: String, options: Options) -> Result<TransformOutput, Error> {
             let comments = SingleThreadedComments::default();
             let mut errors = vec![];
 
-            let mut program = match options.module {
+            let program = match options.module {
                 Some(true) => {
                     parse_file_as_module(&fm, syntax, target, Some(&comments), &mut errors)
                         .map(Program::Module)
@@ -121,10 +121,10 @@ fn operate(input: String, options: Options) -> Result<TransformOutput, Error> {
             let mut program = match program {
                 Ok(program) => program,
                 Err(err) => {
-                    err.into_diagnostic(&handler).emit();
+                    err.into_diagnostic(handler).emit();
 
                     for e in errors {
-                        e.into_diagnostic(&handler).emit();
+                        e.into_diagnostic(handler).emit();
                     }
 
                     return Err(anyhow::anyhow!("failed to parse"));
@@ -133,13 +133,13 @@ fn operate(input: String, options: Options) -> Result<TransformOutput, Error> {
 
             if !errors.is_empty() {
                 for e in errors {
-                    e.into_diagnostic(&handler).emit();
+                    e.into_diagnostic(handler).emit();
                 }
 
                 return Err(anyhow::anyhow!("failed to parse"));
             }
 
-            let mut unresolved_mark = Mark::new();
+            let unresolved_mark = Mark::new();
             let top_level_mark = Mark::new();
 
             HELPERS.set(&Helpers::new(options.external_helpers), || {

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -19,7 +19,7 @@ echo "Publishing $version with swc_core $swc_core_version"
 # Update version
 (cd ./packages/core && npm version "$version" --no-git-tag-version --allow-same-version || true)
 (cd ./packages/minifier && npm version "$version" --no-git-tag-version --allow-same-version || true)
-(cd ./bindings && cargo set-version $version -p binding_core_wasm -p binding_minifier_wasm)
+(cd ./bindings && cargo set-version $version -p binding_core_wasm -p binding_minifier_wasm -p binding_typescript_wasm)
 (cd ./bindings && cargo set-version --bump patch -p swc_cli)
 
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6323,6 +6323,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"binding_typescript_wasm-2142ce@workspace:bindings/binding_typescript_wasm":
+  version: 0.0.0-use.local
+  resolution: "binding_typescript_wasm-2142ce@workspace:bindings/binding_typescript_wasm"
+  dependencies:
+    jest: "npm:^25.1.0"
+  languageName: unknown
+  linkType: soft
+
 "bindings@npm:^1.5.0":
   version: 1.5.0
   resolution: "bindings@npm:1.5.0"


### PR DESCRIPTION
**Description:**

This PR adds a Wasm binding which is only capable of stripping TypeScript types.


**Related issue:**

 - https://github.com/marco-ippolito/node/pull/2