### PR TITLE
refactor(es/typescript): Extract type annotation proposal out

### DIFF
--- a/bindings/binding_typescript_wasm/src/lib.rs
+++ b/bindings/binding_typescript_wasm/src/lib.rs
@@ -18,7 +18,7 @@ use swc_core::{
                 hygiene::hygiene,
                 resolver,
             },
-            typescript::typescript,
+            typescript::strip_type,
         },
         visit::VisitMutWith,
     },
@@ -55,9 +55,8 @@ pub struct Options {
     #[serde(default)]
     pub source_maps: bool,
 
-    #[serde(default)]
-    pub transform: swc_core::ecma::transforms::typescript::Config,
-
+    // #[serde(default)]
+    // pub transform: swc_core::ecma::transforms::typescript::Config,
     #[serde(default)]
     pub codegen: swc_core::ecma::codegen::Config,
 }
@@ -151,7 +150,7 @@ fn operate(input: String, options: Options) -> Result<TransformOutput, Error> {
 
                 // Strip typescript types
 
-                program.visit_mut_with(&mut typescript(options.transform, top_level_mark));
+                program.visit_mut_with(&mut strip_type());
 
                 // Apply external helpers
 

--- a/bindings/binding_typescript_wasm/src/lib.rs
+++ b/bindings/binding_typescript_wasm/src/lib.rs
@@ -11,12 +11,15 @@ use swc_core::{
         parser::{
             parse_file_as_module, parse_file_as_program, parse_file_as_script, Syntax, TsSyntax,
         },
-        transforms::{base::{
-            fixer::fixer,
-            helpers::{inject_helpers, Helpers, HELPERS},
-            hygiene::hygiene,
-            resolver,
-        }, typescript::typescript},
+        transforms::{
+            base::{
+                fixer::fixer,
+                helpers::{inject_helpers, Helpers, HELPERS},
+                hygiene::hygiene,
+                resolver,
+            },
+            typescript::typescript,
+        },
         visit::VisitMutWith,
     },
 };
@@ -148,10 +151,7 @@ fn operate(input: String, options: Options) -> Result<TransformOutput, Error> {
 
                 // Strip typescript types
 
-                program.visit_mut_with(&mut typescript(
-                    options.transform,
-                    top_level_mark,
-                ));
+                program.visit_mut_with(&mut typescript(options.transform, top_level_mark));
 
                 // Apply external helpers
 

--- a/bindings/binding_typescript_wasm/src/lib.rs
+++ b/bindings/binding_typescript_wasm/src/lib.rs
@@ -11,12 +11,12 @@ use swc_core::{
         parser::{
             parse_file_as_module, parse_file_as_program, parse_file_as_script, Syntax, TsSyntax,
         },
-        transforms::base::{
+        transforms::{base::{
             fixer::fixer,
             helpers::{inject_helpers, Helpers, HELPERS},
             hygiene::hygiene,
             resolver,
-        },
+        }, typescript::typescript},
         visit::VisitMutWith,
     },
 };
@@ -148,7 +148,7 @@ fn operate(input: String, options: Options) -> Result<TransformOutput, Error> {
 
                 // Strip typescript types
 
-                program.visit_mut_with(&mut swc_core::ecma::transforms::typescript::typescript(
+                program.visit_mut_with(&mut typescript(
                     options.transform,
                     top_level_mark,
                 ));

--- a/crates/swc_ecma_transforms_typescript/src/lib.rs
+++ b/crates/swc_ecma_transforms_typescript/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::vec_box)]
 #![allow(clippy::mutable_key_type)]
 
-pub use self::typescript::*;
+pub use self::{strip_type::*, typescript::*};
 mod config;
 mod macros;
 mod strip_import_export;

--- a/crates/swc_ecma_transforms_typescript/src/strip_type.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip_type.rs
@@ -5,6 +5,10 @@ use swc_ecma_visit::{VisitMut, VisitMutWith};
 
 use crate::{type_to_none, unreachable_visit_mut_type};
 
+pub fn strip_type() -> impl VisitMut {
+    StripType::default()
+}
+
 /// This Module will strip all types/generics/interface/declares
 /// and type import/export
 #[derive(Default)]


### PR DESCRIPTION
**Description:**

The Node.js team wants a Wasm package that only implements type annotation proposals. So we need to refactor our TypeScript transform to allow it.


**Related issue:**

 - https://github.com/nodejs/loaders/issues/208#issuecomment-2205063110