### PR TITLE
fix(es/loader): Exclude `.json` from default extension list

### DIFF
--- a/crates/swc_ecma_loader/src/resolvers/node.rs
+++ b/crates/swc_ecma_loader/src/resolvers/node.rs
@@ -109,7 +109,7 @@ pub struct NodeModulesResolver {
     ignore_node_modules: bool,
 }
 
-static EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "json", "node"];
+static EXTENSIONS: &[&str] = &["ts", "tsx", "js", "jsx", "node"];
 
 impl NodeModulesResolver {
     /// Create a node modules resolver for the target runtime environment.


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes #9121