### PR TITLE
fix(es/renamer): Remove `FastJsWord`

### DIFF
--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/reverse_map.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/reverse_map.rs
@@ -1,16 +1,16 @@
 use rustc_hash::FxHashMap;
-
-use super::scope::{FastId, FastJsWord};
+use swc_atoms::Atom;
+use swc_ecma_ast::Id;
 
 #[derive(Debug, Default)]
 pub(crate) struct ReverseMap<'a> {
     prev: Option<&'a ReverseMap<'a>>,
 
-    inner: FxHashMap<FastJsWord, Vec<FastId>>,
+    inner: FxHashMap<Atom, Vec<Id>>,
 }
 
 impl ReverseMap<'_> {
-    pub fn push_entry(&mut self, key: FastJsWord, id: FastId) {
+    pub fn push_entry(&mut self, key: Atom, id: Id) {
         self.inner.entry(key).or_default().push(id);
     }
 
@@ -18,7 +18,7 @@ impl ReverseMap<'_> {
         Iter { cur: Some(self) }
     }
 
-    pub fn get<'a>(&'a self, key: &'a FastJsWord) -> impl Iterator<Item = &'a FastId> + 'a {
+    pub fn get<'a>(&'a self, key: &'a Atom) -> impl Iterator<Item = &'a Id> + 'a {
         self.iter()
             .filter_map(|v| v.inner.get(key))
             .flat_map(|v| v.iter())

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -8,7 +8,7 @@ use std::{
 #[cfg(feature = "concurrent-renamer")]
 use rayon::prelude::*;
 use rustc_hash::FxHashSet;
-use swc_atoms::JsWord;
+use swc_atoms::Atom;
 use swc_common::{collections::AHashMap, util::take::Take, Mark, SyntaxContext};
 use swc_ecma_ast::*;
 use tracing::debug;
@@ -36,38 +36,7 @@ pub(crate) struct Scope {
     pub(super) children: Vec<Scope>,
 }
 
-/// [JsWord] without clone or drop. This is unsafe and creator should ensure
-/// that [JsWord] stored in this type is not dropped until all operations are
-/// finished.
-#[repr(transparent)]
-#[derive(Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub(crate) struct FastJsWord(ManuallyDrop<JsWord>);
-
-impl Clone for FastJsWord {
-    fn clone(&self) -> Self {
-        unsafe { Self(ManuallyDrop::new(transmute_copy(&self.0))) }
-    }
-}
-
-impl Display for FastJsWord {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        Display::fmt(&*self.0, f)
-    }
-}
-
-impl FastJsWord {
-    pub fn new(src: JsWord) -> Self {
-        FastJsWord(ManuallyDrop::new(src))
-    }
-
-    pub fn into_inner(self) -> JsWord {
-        ManuallyDrop::into_inner(self.0)
-    }
-}
-
-pub(crate) type FastId = (FastJsWord, SyntaxContext);
-
-pub(crate) type RenameMap = AHashMap<FastId, JsWord>;
+pub(crate) type RenameMap = AHashMap<Id, Atom>;
 
 #[derive(Debug, Default)]
 pub(super) struct ScopeData {
@@ -77,7 +46,7 @@ pub(super) struct ScopeData {
     ///
     /// If the add-only contraint is violated, it is very likely to be a bug,
     /// because we merge every items in children to current scope.
-    all: FxHashSet<FastId>,
+    all: FxHashSet<Id>,
 
     queue: Vec<Id>,
 }
@@ -88,9 +57,7 @@ impl Scope {
             return;
         }
 
-        let fid = fast_id(id.clone());
-
-        self.data.all.insert(fid);
+        self.data.all.insert(id.clone());
 
         if !self.data.queue.contains(id) {
             if has_eval && id.1.outer().is_descendant_of(top_level_mark) {
@@ -106,7 +73,7 @@ impl Scope {
             return;
         }
 
-        self.data.all.insert(fast_id(id));
+        self.data.all.insert(id);
     }
 
     /// Copy `children.data.all` to `self.data.all`.
@@ -124,7 +91,7 @@ impl Scope {
         to: &mut RenameMap,
         previous: &RenameMap,
         reverse: &mut ReverseMap,
-        preserved_symbols: &FxHashSet<JsWord>,
+        preserved_symbols: &FxHashSet<Atom>,
     ) where
         R: Renamer,
     {
@@ -159,15 +126,14 @@ impl Scope {
         previous: &RenameMap,
         reverse: &mut ReverseMap,
         queue: Vec<Id>,
-        preserved_symbols: &FxHashSet<JsWord>,
+        preserved_symbols: &FxHashSet<Atom>,
     ) where
         R: Renamer,
     {
         let mut n = 0;
 
         for id in queue {
-            let fid = fast_id(id.clone());
-            if to.get(&fid).is_some() || previous.get(&fid).is_some() || id.0 == "eval" {
+            if to.get(&id).is_some() || previous.get(&id).is_some() || id.0 == "eval" {
                 continue;
             }
 
@@ -181,16 +147,14 @@ impl Scope {
                 if preserved_symbols.contains(&sym) {
                     continue;
                 }
-                let sym = FastJsWord::new(sym);
 
                 if self.can_rename(&id, &sym, reverse) {
                     if cfg!(debug_assertions) {
                         debug!("Renaming `{}{:?}` to `{}`", id.0, id.1, sym);
                     }
 
-                    let fid = fast_id(id);
-                    reverse.push_entry(sym.clone(), fid.clone());
-                    to.insert(fid, sym.into_inner());
+                    reverse.push_entry(sym.clone(), id.clone());
+                    to.insert(id, sym);
 
                     break;
                 }
@@ -198,12 +162,12 @@ impl Scope {
         }
     }
 
-    fn can_rename(&self, id: &Id, symbol: &FastJsWord, reverse: &ReverseMap) -> bool {
+    fn can_rename(&self, id: &Id, symbol: &Atom, reverse: &ReverseMap) -> bool {
         // We can optimize this
         // We only need to check the current scope and parents (ignoring `a` generated
         // for unrelated scopes)
         for left in reverse.get(symbol) {
-            if left.1 == id.1 && *left.0 .0 == id.0 {
+            if left.1 == id.1 && *left.0 == id.0 {
                 continue;
             }
 
@@ -223,7 +187,7 @@ impl Scope {
         previous: &RenameMap,
         reverse: &ReverseMap,
         preserved: &FxHashSet<Id>,
-        preserved_symbols: &FxHashSet<JsWord>,
+        preserved_symbols: &FxHashSet<Atom>,
         parallel: bool,
     ) where
         R: Renamer,
@@ -294,17 +258,16 @@ impl Scope {
         reverse: &mut ReverseMap,
         queue: Vec<Id>,
         preserved: &FxHashSet<Id>,
-        preserved_symbols: &FxHashSet<JsWord>,
+        preserved_symbols: &FxHashSet<Atom>,
     ) where
         R: Renamer,
     {
         let mut n = 0;
 
         for id in queue {
-            let fid = fast_id(id.clone());
             if preserved.contains(&id)
-                || to.get(&fid).is_some()
-                || previous.get(&fid).is_some()
+                || to.get(&id).is_some()
+                || previous.get(&id).is_some()
                 || id.0 == "eval"
             {
                 continue;
@@ -318,17 +281,14 @@ impl Scope {
                     continue;
                 }
 
-                let sym = FastJsWord::new(sym);
-
                 if self.can_rename(&id, &sym, reverse) {
                     #[cfg(debug_assertions)]
                     {
                         debug!("mangle: `{}{:?}` -> {}", id.0, id.1, sym);
                     }
 
-                    let fid = fast_id(id.clone());
-                    reverse.push_entry(sym.clone(), fid.clone());
-                    to.insert(fid.clone(), sym.into_inner());
+                    reverse.push_entry(sym.clone(), id.clone());
+                    to.insert(id.clone(), sym);
                     // self.data.decls.remove(&id);
                     // self.data.usages.remove(&id);
 
@@ -342,8 +302,4 @@ impl Scope {
         let children = &self.children;
         self.data.queue.len() + children.iter().map(|v| v.rename_cost()).sum::<usize>()
     }
-}
-
-fn fast_id(id: Id) -> FastId {
-    (FastJsWord::new(id.0), id.1)
 }

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -184,9 +184,7 @@ where
             );
         }
 
-        map.into_iter()
-            .map(|((s, ctxt), v)| ((s.into_inner(), ctxt), v))
-            .collect()
+        map
     }
 }
 


### PR DESCRIPTION
**Description:**

Actually it was slower.

```
Starting recording with the Time Profiler template. Launching process: full-4ec72b7d24d0fcd8.
Ctrl-C to stop the recording
Gnuplot not found, using plotters backend
Benchmarking es/minify/libraries/antd
Benchmarking es/minify/libraries/antd: Warming up for 3.0000 s


Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.2s.
Benchmarking es/minify/libraries/antd: Collecting 10 samples in estimated 5.1501 s (10 iterations)
Benchmarking es/minify/libraries/antd: Analyzing
es/minify/libraries/antd
                        time:   [517.09 ms 521.65 ms 527.04 ms]
                        change: [-5.0960% -4.1320% -3.0084%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/d3
Benchmarking es/minify/libraries/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 7.3s or enable flat sampling.
Benchmarking es/minify/libraries/d3: Collecting 10 samples in estimated 7.3000 s (55 iterations)
Benchmarking es/minify/libraries/d3: Analyzing
es/minify/libraries/d3  time:   [132.42 ms 132.66 ms 132.93 ms]
                        change: [-5.0809% -4.6687% -4.2423%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/echarts
Benchmarking es/minify/libraries/echarts: Warming up for 3.0000 s
Benchmarking es/minify/libraries/echarts: Collecting 10 samples in estimated 8.8664 s (20 iterations)
Benchmarking es/minify/libraries/echarts: Analyzing
es/minify/libraries/echarts
                        time:   [441.89 ms 442.98 ms 444.21 ms]
                        change: [-5.8436% -5.4580% -5.0604%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/jquery
Benchmarking es/minify/libraries/jquery: Warming up for 3.0000 s
Benchmarking es/minify/libraries/jquery: Collecting 10 samples in estimated 7.2124 s (165 iterations)
Benchmarking es/minify/libraries/jquery: Analyzing
es/minify/libraries/jquery
                        time:   [43.549 ms 43.624 ms 43.703 ms]
                        change: [-3.3699% -3.0686% -2.7597%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/lodash
Benchmarking es/minify/libraries/lodash: Warming up for 3.0000 s
Benchmarking es/minify/libraries/lodash: Collecting 10 samples in estimated 6.5048 s (110 iterations)
Benchmarking es/minify/libraries/lodash: Analyzing
es/minify/libraries/lodash
                        time:   [58.951 ms 59.114 ms 59.290 ms]
                        change: [-1.2723% -0.7019% -0.0217%] (p = 0.06 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/moment
Benchmarking es/minify/libraries/moment: Warming up for 3.0000 s
Benchmarking es/minify/libraries/moment: Collecting 10 samples in estimated 5.5497 s (220 iterations)
Benchmarking es/minify/libraries/moment: Analyzing
es/minify/libraries/moment
                        time:   [25.261 ms 25.313 ms 25.355 ms]
                        change: [-1.4771% -0.9851% -0.5957%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minify/libraries/react
Benchmarking es/minify/libraries/react: Warming up for 3.0000 s
Benchmarking es/minify/libraries/react: Collecting 10 samples in estimated 5.1132 s (605 iterations)
Benchmarking es/minify/libraries/react: Analyzing
es/minify/libraries/react
                        time:   [8.4265 ms 8.4431 ms 8.4624 ms]
                        change: [-1.3741% -1.0134% -0.6710%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minify/libraries/terser
Benchmarking es/minify/libraries/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.6s or enable flat sampling.
Benchmarking es/minify/libraries/terser: Collecting 10 samples in estimated 5.5614 s (55 iterations)
Benchmarking es/minify/libraries/terser: Analyzing
es/minify/libraries/terser
                        time:   [100.87 ms 100.98 ms 101.15 ms]
                        change: [-6.7656% -6.1477% -5.4618%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/three
Benchmarking es/minify/libraries/three: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.3s or enable flat sampling.
Benchmarking es/minify/libraries/three: Collecting 10 samples in estimated 9.3499 s (55 iterations)
Benchmarking es/minify/libraries/three: Analyzing
es/minify/libraries/three
                        time:   [170.12 ms 170.44 ms 170.81 ms]
                        change: [-6.9164% -6.4564% -5.9450%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minify/libraries/typescript
Benchmarking es/minify/libraries/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.3s.
Benchmarking es/minify/libraries/typescript: Collecting 10 samples in estimated 9.2642 s (10 iterations)
Benchmarking es/minify/libraries/typescript: Analyzing
es/minify/libraries/typescript
                        time:   [927.57 ms 929.26 ms 930.85 ms]
                        change: [-4.4792% -4.1803% -3.9000%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/victory
Benchmarking es/minify/libraries/victory: Warming up for 3.0000 s
Benchmarking es/minify/libraries/victory: Collecting 10 samples in estimated 7.0301 s (30 iterations)
Benchmarking es/minify/libraries/victory: Analyzing
es/minify/libraries/victory
                        time:   [233.98 ms 234.44 ms 234.96 ms]
                        change: [-7.2681% -6.7396% -6.2554%] (p = 0.00 < 0.05)
                        Performance has improved.
Benchmarking es/minify/libraries/vue
Benchmarking es/minify/libraries/vue: Warming up for 3.0000 s
Benchmarking es/minify/libraries/vue: Collecting 10 samples in estimated 6.7241 s (110 iterations)
Benchmarking es/minify/libraries/vue: Analyzing
es/minify/libraries/vue time:   [61.051 ms 61.124 ms 61.225 ms]
                        change: [-2.3890% -2.1697% -1.9536%] (p = 0.00 < 0.05)
                        Performance has improved.
```


**Related issue:**

 - Closes #9126