### PR TITLE
feat(bindings/ts): Add transform/strip-only mode

### DIFF
--- a/bindings/binding_typescript_wasm/Cargo.toml
+++ b/bindings/binding_typescript_wasm/Cargo.toml
@@ -13,9 +13,6 @@ bench      = false
 crate-type = ["cdylib"]
 
 [features]
-default = ["swc_v1"]
-swc_v1  = []
-swc_v2  = []
 
 [dependencies]
 anyhow = "1.0.66"

--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`transform in strip-only mode should throw an error when it encounters an enum 1`] = `
+"
+  x TypeScript enum is not supported in strip-only mode
+   ,----
+ 1 | enum Foo {}
+   : ^^^^^^^^^^^
+   \`----
+"
+`;
+
+exports[`transform in transform mode should transpile enum 1`] = `
+"var Foo;
+(function(Foo) {})(Foo || (Foo = {}));
+"
+`;
+
+exports[`transform should strip types 1`] = `
+"export const foo = 1;
+"
+`;

--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -10,6 +10,16 @@ exports[`transform in strip-only mode should throw an error when it encounters a
 "
 `;
 
+exports[`transform in strip-only mode should throw an error with a descriptive message when it encounters a decorator 1`] = `
+"
+  x Decorators are not supported
+   ,----
+ 1 | class Foo { @decorator foo() {} }
+   :             ^^^^^^^^^^
+   \`----
+"
+`;
+
 exports[`transform in transform mode should transpile enum 1`] = `
 "var Foo;
 (function(Foo) {})(Foo || (Foo = {}));

--- a/bindings/binding_typescript_wasm/__tests__/transform.js
+++ b/bindings/binding_typescript_wasm/__tests__/transform.js
@@ -6,7 +6,7 @@ it("properly reports error", function () {
     }).toThrow();
 });
 
-describe("trannsform", () => {
+describe("transform", () => {
     it("should strip types", async () => {
         const { code } = await swc.transform(
             `
@@ -15,26 +15,28 @@ describe("trannsform", () => {
     `,
             {}
         );
-        expect(code).toMatchInlineSnapshot(`
-            "export const foo = 1;
-            "
-        `);
+        expect(code).toMatchSnapshot();
     });
 
-    it("should preserve enum", async () => {
-        const { code } = await swc.transform(
-            `
-            enum Foo {
-                Bar
-            }
-                `,
-            {}
-        );
-        await expect(code).toMatchInlineSnapshot(`
-            "enum Foo {
-                Bar
-            }
-            "
-        `);
+    describe("in strip-only mode", () => {
+        it("should throw an error when it encounters an enum", async () => {
+            await expect(
+                swc.transform("enum Foo {}", {
+                    mode: "strip-only",
+                })
+            ).rejects.toMatchSnapshot();
+        });
+    });
+
+    describe("in transform mode", () => {
+        it("should transpile enum", async () => {
+            const { code } = await swc.transform("enum Foo {}", {
+                mode: "transform",
+            });
+
+            expect(code).toMatchSnapshot();
+        });
+
+
     });
 });

--- a/bindings/binding_typescript_wasm/__tests__/transform.js
+++ b/bindings/binding_typescript_wasm/__tests__/transform.js
@@ -26,6 +26,14 @@ describe("transform", () => {
                 })
             ).rejects.toMatchSnapshot();
         });
+
+        it('should throw an error with a descriptive message when it encounters a decorator', async () => {
+            await expect(
+                swc.transform("class Foo { @decorator foo() {} }", {
+                    mode: "strip-only",
+                })
+            ).rejects.toMatchSnapshot();
+        })
     });
 
     describe("in transform mode", () => {

--- a/bindings/binding_typescript_wasm/package.json
+++ b/bindings/binding_typescript_wasm/package.json
@@ -1,5 +1,5 @@
 {
     "devDependencies": {
-        "jest": "^25.1.0"
+        "jest": "^29.7.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6327,7 +6327,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "binding_typescript_wasm-2142ce@workspace:bindings/binding_typescript_wasm"
   dependencies:
-    jest: "npm:^25.1.0"
+    jest: "npm:^29.7.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
**Description:**

This PR adds `strip-only`/`transform` mode to `@swc/wasm-typescript`.

- Both mode errors on decorator usages.
- In `strip-only` mode, `enum` and TypeScript parameter properties are treated as an invalid syntax.
- In `transform` mode, those are transpiled.