### PR TITLE
fix(es/typescript): Fix tricky cases in TS fast strip

### DIFF
--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -168,6 +168,10 @@ impl<I: Tokens> Capturing<I> {
         }
     }
 
+    pub fn tokens(&self) -> Rc<RefCell<Vec<TokenAndSpan>>> {
+        self.captured.clone()
+    }
+
     /// Take captured tokens
     pub fn take(&mut self) -> Vec<TokenAndSpan> {
         mem::take(&mut *self.captured.borrow_mut())

--- a/crates/swc_fast_ts_strip/src/lib.rs
+++ b/crates/swc_fast_ts_strip/src/lib.rs
@@ -99,8 +99,9 @@ pub fn operate(
     program.visit_with(&mut ts_strip);
 
     let replacements = ts_strip.replacements;
+    let removals = ts_strip.removals;
 
-    if replacements.is_empty() {
+    if replacements.is_empty() && removals.is_empty() {
         return Ok(fm.src.to_string());
     }
 
@@ -112,8 +113,8 @@ pub fn operate(
 
     // Assert that removal does not overlap with each other
 
-    for removal in ts_strip.removals.iter() {
-        for r in &ts_strip.removals {
+    for removal in removals.iter() {
+        for r in &removals {
             if removal == r {
                 continue;
             }
@@ -127,7 +128,7 @@ pub fn operate(
         }
     }
 
-    for removal in ts_strip.removals.iter().copied().rev() {
+    for removal in removals.iter().copied().rev() {
         code.drain((removal.0 .0 - 1) as usize..(removal.1 .0 - 1) as usize);
     }
 

--- a/crates/swc_fast_ts_strip/src/lib.rs
+++ b/crates/swc_fast_ts_strip/src/lib.rs
@@ -105,7 +105,7 @@ pub fn operate(
     let mut replacements = ts_strip.replacements;
     let removals = ts_strip.removals;
 
-    for pos in ts_strip.remove_question_mark_after {
+    for pos in ts_strip.remove_token_after {
         let index = tokens.binary_search_by_key(&pos, |t| t.span.lo);
         let index = match index {
             Ok(index) => index,
@@ -161,7 +161,7 @@ struct TsStrip {
     /// Applied after replacements. Used for arrow functions.
     removals: Vec<(BytePos, BytePos)>,
 
-    remove_question_mark_after: Vec<BytePos>,
+    remove_token_after: Vec<BytePos>,
 }
 
 impl TsStrip {
@@ -171,7 +171,7 @@ impl TsStrip {
             src,
             replacements: Default::default(),
             removals: Default::default(),
-            remove_question_mark_after: Default::default(),
+            remove_token_after: Default::default(),
         }
     }
 }
@@ -207,7 +207,7 @@ impl Visit for TsStrip {
         n.visit_children_with(self);
 
         if n.optional {
-            self.remove_question_mark_after
+            self.remove_token_after
                 .push(n.id.span.lo + BytePos(n.id.sym.len() as u32));
         }
     }

--- a/crates/swc_fast_ts_strip/tests/fixture/tricky.js
+++ b/crates/swc_fast_ts_strip/tests/fixture/tricky.js
@@ -1,0 +1,5 @@
+
+
+export const foo = (id/** Why? */         ) => {
+
+}

--- a/crates/swc_fast_ts_strip/tests/fixture/tricky.ts
+++ b/crates/swc_fast_ts_strip/tests/fixture/tricky.ts
@@ -1,0 +1,5 @@
+
+
+export const foo = (id/** Why? */?: string) => {
+
+}


### PR DESCRIPTION
**Description:**

We can leverage lexer information to handle tricky cases.