### PR TITLE
chore(es): Bump `unicode-id-start` to `v1.2.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5846,9 +5846,9 @@ checksum = "b1b6def86329695390197b82c1e244a54a131ceb66c996f2088a3876e2ae083f"
 
 [[package]]
 name = "unicode-id-start"
-version = "1.0.4"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02aebfa694eccbbbffdd92922c7de136b9fe764396d2f10e21bce1681477cfc1"
+checksum = "bc3882f69607a2ac8cc4de3ee7993d8f68bb06f2974271195065b3bd07f2edea"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,7 @@ resolver = "2"
   tracing-subscriber       = "0.3.18"
   typed-arena              = "2.0.1"
   unicode-id               = "0.3"
-  unicode-id-start         = "=1.0.4"
+  unicode-id-start         = "1.2.0"
   unicode-width            = "0.1.4"
   url                      = "2.4.0"
   vergen                   = { version = "8.0.0", default-features = false }


### PR DESCRIPTION
This bumps unicode support to unicode v15.1.0

The crate version is unpinned by removing the katana middle dot problem occured in unicode v15.1.0

See https://github.com/oxc-project/unicode-id-start/pull/3

relates https://github.com/swc-project/swc/issues/8940