### PR TITLE
perf(es/ast): Drop `raw` fields from AST

### DIFF
--- a/crates/swc_ecma_ast/src/jsx.rs
+++ b/crates/swc_ecma_ast/src/jsx.rs
@@ -195,22 +195,10 @@ pub enum JSXAttrValue {
 
 #[ast_node("JSXText")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub struct JSXText {
     pub span: Span,
     pub value: Atom,
-    pub raw: Atom,
-}
-
-#[cfg(feature = "arbitrary")]
-#[cfg_attr(docsrs, doc(cfg(feature = "arbitrary")))]
-impl<'a> arbitrary::Arbitrary<'a> for JSXText {
-    fn arbitrary(u: &mut arbitrary::Unstructured<'_>) -> arbitrary::Result<Self> {
-        let span = u.arbitrary()?;
-        let value = u.arbitrary::<String>()?.into();
-        let raw = u.arbitrary::<String>()?.into();
-
-        Ok(Self { span, value, raw })
-    }
 }
 
 #[ast_node("JSXElement")]

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use num_bigint::BigInt as BigIntValue;
-use swc_atoms::{js_word, Atom};
+use swc_atoms::Atom;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 
 use crate::jsx::JSXText;
@@ -30,7 +30,7 @@ pub enum Lit {
     BigInt(BigInt),
 
     #[tag("RegExpLiteral")]
-    Regex(Regex),
+    Regex(Box<Regex>),
 
     #[tag("JSXText")]
     JSXText(JSXText),

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -172,24 +172,16 @@ impl From<BigIntValue> for BigInt {
 
 /// A string literal.
 #[ast_node("StringLiteral")]
-#[derive(Eq, Hash)]
+#[derive(Eq, Hash, Default)]
 pub struct Str {
     pub span: Span,
 
     pub value: Atom,
-
-    /// Use `None` value only for transformations to avoid recalculate escaped
-    /// characters in strings
-    pub raw: Option<Atom>,
 }
 
 impl Take for Str {
     fn dummy() -> Self {
-        Str {
-            span: DUMMY_SP,
-            value: js_word!(""),
-            raw: None,
-        }
+        Default::default()
     }
 }
 
@@ -270,9 +262,8 @@ impl From<Atom> for Str {
     #[inline]
     fn from(value: Atom) -> Self {
         Str {
-            span: DUMMY_SP,
             value,
-            raw: None,
+            ..Default::default()
         }
     }
 }

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -36,6 +36,8 @@ pub enum Lit {
     JSXText(JSXText),
 }
 
+boxed_variants!(Lit, [Regex]);
+
 macro_rules! bridge_lit_from {
     ($bridge: ty, $src:ty) => {
         bridge_expr_from!(crate::Lit, $src);

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -206,6 +206,15 @@ macro_rules! bridge_from {
     };
 }
 
+macro_rules! boxed_variants {
+    ($e:ident, [$($variant:ident),*]) => {
+        $(
+            bridge_from!(Box<$e>, $e,$variant);
+            bridge_from!($e, Box<$variant>, $variant);
+        )*
+    };
+}
+
 macro_rules! bridge_expr_from {
     ($bridge:ty, $src:ty) => {
         bridge_from!(crate::Expr, $bridge, $src);

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -122,12 +122,7 @@ pub struct Directive {
 impl Stmt {
     pub fn is_use_strict(&self) -> bool {
         match self {
-            Stmt::Expr(expr) => match *expr.expr {
-                Expr::Lit(Lit::Str(Str { ref raw, .. })) => {
-                    matches!(raw, Some(value) if value == "\"use strict\"" || value == "'use strict'")
-                }
-                _ => false,
-            },
+            Stmt::Directive(d) => d.value.value == "use strict",
             _ => false,
         }
     }

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -35,6 +35,9 @@ impl Take for BlockStmt {
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 pub enum Stmt {
+    #[tag("Directive")]
+    Directive(Directive),
+
     #[tag("BlockStatement")]
     Block(BlockStmt),
 
@@ -106,6 +109,14 @@ pub enum Stmt {
 
     #[tag("ExpressionStatement")]
     Expr(ExprStmt),
+}
+
+#[ast_node("Directive")]
+#[derive(Eq, Hash, EqIgnoreSpan)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+pub struct Directive {
+    pub span: Span,
+    pub value: Str,
 }
 
 impl Stmt {

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -152,6 +152,7 @@ impl Clone for Stmt {
     fn clone(&self) -> Self {
         use Stmt::*;
         match self {
+            Directive(s) => Directive(s.clone()),
             Block(s) => Block(s.clone()),
             Empty(s) => Empty(s.clone()),
             Debugger(s) => Debugger(s.clone()),


### PR DESCRIPTION
**Description:**

 - Remove `raw` fields from literals in favor of `span`.
 - Add `Stmt::Directive` to preserve APIs.