### PR TITLE
feat(es/utils): Support for arrays using `cast_to_number`

### DIFF
--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/tests.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/tests.rs
@@ -489,6 +489,27 @@ fn test_unary_ops_4() {
 }
 
 #[test]
+fn test_unary_ops_5() {
+    // Empty arrays
+    fold("+[]", "0");
+    fold("+[[]]", "0");
+    fold("+[[[]]]", "0");
+    
+    // Arrays with one element
+    fold("+[1]", "1");
+    fold("+[[1]]", "1");
+    fold("+[undefined]", "0");
+    fold("+[null]", "0");
+    fold("+[,]", "0");
+    
+    // Arrays with more than one element
+    fold("+[1, 2]", "NaN");
+    fold("+[[1], 2]", "NaN");
+    fold("+[,1]", "NaN");
+    fold("+[,,]", "NaN");
+}
+
+#[test]
 fn test_unary_ops_string_compare() {
     fold_same("a = -1");
     fold("a = ~0", "a = -1");

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/tests.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/tests.rs
@@ -494,14 +494,14 @@ fn test_unary_ops_5() {
     fold("+[]", "0");
     fold("+[[]]", "0");
     fold("+[[[]]]", "0");
-    
+
     // Arrays with one element
     fold("+[1]", "1");
     fold("+[[1]]", "1");
     fold("+[undefined]", "0");
     fold("+[null]", "0");
     fold("+[,]", "0");
-    
+
     // Arrays with more than one element
     fold("+[1, 2]", "NaN");
     fold("+[[1], 2]", "NaN");

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -894,9 +894,9 @@ pub trait ExprExt {
                 let Known(s) = self.as_pure_string(ctx) else {
                     return (Pure, Unknown);
                 };
-                
+
                 return (Pure, num_from_str(&s));
-            },
+            }
             Expr::Ident(Ident { sym, span, .. }) => match &**sym {
                 "undefined" | "NaN" if span.ctxt == ctx.unresolved_ctxt => f64::NAN,
                 "Infinity" if span.ctxt == ctx.unresolved_ctxt => f64::INFINITY,

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -890,6 +890,39 @@ pub trait ExprExt {
                 Lit::Str(Str { value, .. }) => return (Pure, num_from_str(value)),
                 _ => return (Pure, Unknown),
             },
+            Expr::Array(array) => {
+                if array.elems.len() != 1 {
+                    // Can only be converted to a number if there's exactly one element.
+                    return (Pure, Known(if array.elems.is_empty() {
+                        // Empty array is treated as zero.
+                        0.0
+                    } else {
+                        // More than one element is treated as NaN.
+                        f64::NAN
+                    }));
+                }
+
+                let Some(elem) = array.elems.get(0) else {
+                    return (Pure, Unknown);
+                };
+
+                // [,] is treated as zero.
+                let Some(e) = elem else {
+                    return (Pure, Known(0.0));
+                };
+                
+                // Ignore spread if it exists.
+                if e.spread.is_some() {
+                    return (Pure, Unknown);
+                }
+                
+                // Special case: undefined is treated as zero in arrays (e.g. +[undefined])
+                if e.expr.is_undefined(ctx) {
+                    return (Pure, Known(0.0));
+                }
+                
+                return e.expr.cast_to_number(ctx);
+            },
             Expr::Ident(Ident { sym, span, .. }) => match &**sym {
                 "undefined" | "NaN" if span.ctxt == ctx.unresolved_ctxt => f64::NAN,
                 "Infinity" if span.ctxt == ctx.unresolved_ctxt => f64::INFINITY,

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -1572,7 +1572,6 @@ pub fn num_from_str(s: &str) -> Value<f64> {
         return Unknown;
     }
 
-    // TODO: Check if this is correct
     let s = s.trim();
 
     if s.is_empty() {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
This PR allows `ArrayLit`s to be converted to numbers in the `cast_to_number` function. This allows expressions using arrays to be converted to numbers. See some example expressions below that were previously not able to be computed, but are now able to due to this change.

```js
+[] // 0
+[[]] // 0
+[1] // 1
+[undefined] // 0
+[null] // 0
+[[1]] // 1
+[,] // 0
+[,,] // NaN
```

Regarding the implementation, arrays are converted to strings, and the string is then parsed as a number. So arrays like `[]` and `[undefined]` return `""` which then return `0` when parsed as a string. This is also why arrays with more than one element can't be parsed because e.g. `[1, 2]` returns `"1,2"`. This procedure follows the ECMAScript specification.
https://262.ecma-international.org/6.0/#sec-tonumber
https://262.ecma-international.org/6.0/#sec-toprimitive

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
