### PR TITLE
perf(bindings): Invert Wasm size shrink

### DIFF
--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -16,12 +16,11 @@ resolver = "2"
 # lto = "fat"
 
 # debug = true
-opt-level = 'z'
+# opt-level = 'z'
 
 # Strip debug symbols
 strip = "symbols"
 
-codegen-units = 1
 
 [profile.dev.package."*"]
 debug-assertions = false

--- a/bindings/binding_typescript_wasm/scripts/build.sh
+++ b/bindings/binding_typescript_wasm/scripts/build.sh
@@ -2,7 +2,7 @@
 set -eux
 
 export CARGO_PROFILE_RELEASE_LTO="fat"
-# export CARGO_PROFILE_RELEASE_OPT_LEVEL="z"
+export CARGO_PROFILE_RELEASE_OPT_LEVEL="z"
 wasm-pack build --out-name wasm --release --scope=swc --target nodejs
 ls -al ./pkg
 


### PR DESCRIPTION
Reverts swc-project/swc#9191

I'm reverting because it applies even to `@swc/core`. cc @magic-akari 
Instead, I used an environment variable.