### PR TITLE
feat(allocator): Introduce scoped allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,6 +67,9 @@ name = "allocator-api2"
 version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "android-tzdata"
@@ -3319,9 +3322,9 @@ checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -3349,9 +3352,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3700,6 +3703,8 @@ dependencies = [
  "allocator-api2",
  "bumpalo",
  "scoped-tls",
+ "serde",
+ "serde_derive",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
 dependencies = [
  "bytecheck_derive",
- "ptr_meta",
+ "ptr_meta 0.1.4",
  "simdutf8",
 ]
 
@@ -2870,7 +2870,16 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
 dependencies = [
- "ptr_meta_derive",
+ "ptr_meta_derive 0.1.4",
+]
+
+[[package]]
+name = "ptr_meta"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcada80daa06c42ed5f48c9a043865edea5dc44cbf9ac009fda3b89526e28607"
+dependencies = [
+ "ptr_meta_derive 0.2.0",
 ]
 
 [[package]]
@@ -2878,6 +2887,17 @@ name = "ptr_meta_derive"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca9224df2e20e7c5548aeb5f110a0f3b77ef05f8585139b7148b59056168ed2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3115,7 +3135,7 @@ dependencies = [
  "bytes",
  "hashbrown 0.12.3",
  "indexmap 1.9.3",
- "ptr_meta",
+ "ptr_meta 0.1.4",
  "rend",
  "rkyv_derive",
  "seahash",
@@ -3702,6 +3722,7 @@ version = "0.1.1"
 dependencies = [
  "allocator-api2",
  "bumpalo",
+ "ptr_meta 0.2.0",
  "rkyv",
  "scoped-tls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3848,6 +3848,7 @@ dependencies = [
  "serde_json",
  "siphasher",
  "sourcemap",
+ "swc_allocator",
  "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3702,6 +3702,7 @@ version = "0.1.1"
 dependencies = [
  "allocator-api2",
  "bumpalo",
+ "rkyv",
  "scoped-tls",
  "serde",
  "serde_derive",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -406,6 +412,9 @@ name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "bytecheck"
@@ -3688,6 +3697,7 @@ dependencies = [
 name = "swc_allocator"
 version = "0.1.1"
 dependencies = [
+ "allocator-api2",
  "bumpalo",
  "scoped-tls",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3689,6 +3689,7 @@ name = "swc_allocator"
 version = "0.1.1"
 dependencies = [
  "bumpalo",
+ "scoped-tls",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,7 +426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6372023ac861f6e6dc89c8344a8f398fb42aaba2b5dbc649ca0c0e9dbcb627"
 dependencies = [
  "bytecheck_derive",
- "ptr_meta 0.1.4",
+ "ptr_meta",
  "simdutf8",
 ]
 
@@ -2870,16 +2870,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
 dependencies = [
- "ptr_meta_derive 0.1.4",
-]
-
-[[package]]
-name = "ptr_meta"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcada80daa06c42ed5f48c9a043865edea5dc44cbf9ac009fda3b89526e28607"
-dependencies = [
- "ptr_meta_derive 0.2.0",
+ "ptr_meta_derive",
 ]
 
 [[package]]
@@ -2887,17 +2878,6 @@ name = "ptr_meta_derive"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca9224df2e20e7c5548aeb5f110a0f3b77ef05f8585139b7148b59056168ed2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3135,7 +3115,7 @@ dependencies = [
  "bytes",
  "hashbrown 0.12.3",
  "indexmap 1.9.3",
- "ptr_meta 0.1.4",
+ "ptr_meta",
  "rend",
  "rkyv_derive",
  "seahash",
@@ -3722,7 +3702,7 @@ version = "0.1.1"
 dependencies = [
  "allocator-api2",
  "bumpalo",
- "ptr_meta 0.2.0",
+ "ptr_meta",
  "rkyv",
  "scoped-tls",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4134,6 +4134,7 @@ dependencies = [
  "serde",
  "serde_json",
  "string_enum",
+ "swc_allocator",
  "swc_atoms",
  "swc_common",
  "unicode-id-start",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -138,6 +138,7 @@ resolver = "2"
   wasmer                    = { version = "4.2.5", default-features = false }
   wasmer-wasix              = { version = "0.18.0", default-features = false }
 allocator-api2 = "0.2.18"
+ptr_meta = "0.2.0"
 
 [profile.release]
 # lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ resolver = "2"
 
   Inflector                 = "0.11.4"
   ahash                     = "0.8.8"
+  allocator-api2            = "0.2.18"
   ansi_term                 = "0.12.1"
   anyhow                    = "1.0.81"
   arbitrary                 = "1"
@@ -95,6 +96,7 @@ resolver = "2"
   phf                       = "0.11.2"
   pretty_assertions         = "1.3"
   proc-macro2               = "1.0.24"
+  ptr_meta                  = "0.1.4"
   quote                     = "1.0.7"
   rayon                     = "1.7.0"
   regex                     = "1.5.4"
@@ -137,8 +139,6 @@ resolver = "2"
   wasm-bindgen-futures      = "0.4.41"
   wasmer                    = { version = "4.2.5", default-features = false }
   wasmer-wasix              = { version = "0.18.0", default-features = false }
-allocator-api2 = "0.2.18"
-ptr_meta = "0.2.0"
 
 [profile.release]
 # lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,7 @@ resolver = "2"
   wasm-bindgen-futures      = "0.4.41"
   wasmer                    = { version = "4.2.5", default-features = false }
   wasmer-wasix              = { version = "0.18.0", default-features = false }
+allocator-api2 = "0.2.18"
 
 [profile.release]
 # lto = true

--- a/crates/swc_allocator/Cargo.toml
+++ b/crates/swc_allocator/Cargo.toml
@@ -15,6 +15,7 @@ bumpalo = { workspace = true, features = [
     "boxed",
     "collections",
 ] }
+rkyv = { workspace = true }
 scoped-tls = { workspace = true }
 serde = { workspace = true }
 serde_derive = { workspace = true }

--- a/crates/swc_allocator/Cargo.toml
+++ b/crates/swc_allocator/Cargo.toml
@@ -9,4 +9,5 @@ repository    = { workspace = true }
 version       = "0.1.1"
 
 [dependencies]
-bumpalo = { workspace = true, features = ["boxed", "collections"] }
+bumpalo    = { workspace = true, features = ["boxed", "collections"] }
+scoped-tls = { workspace = true }

--- a/crates/swc_allocator/Cargo.toml
+++ b/crates/swc_allocator/Cargo.toml
@@ -9,5 +9,10 @@ repository    = { workspace = true }
 version       = "0.1.1"
 
 [dependencies]
-bumpalo    = { workspace = true, features = ["boxed", "collections"] }
+allocator-api2 = { workspace = true }
+bumpalo = { workspace = true, features = [
+    "allocator-api2",
+    "boxed",
+    "collections",
+] }
 scoped-tls = { workspace = true }

--- a/crates/swc_allocator/Cargo.toml
+++ b/crates/swc_allocator/Cargo.toml
@@ -16,3 +16,5 @@ bumpalo = { workspace = true, features = [
     "collections",
 ] }
 scoped-tls = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }

--- a/crates/swc_allocator/Cargo.toml
+++ b/crates/swc_allocator/Cargo.toml
@@ -9,7 +9,7 @@ repository    = { workspace = true }
 version       = "0.1.1"
 
 [dependencies]
-allocator-api2 = { workspace = true }
+allocator-api2 = { workspace = true, features = ["serde"] }
 bumpalo = { workspace = true, features = [
     "allocator-api2",
     "boxed",

--- a/crates/swc_allocator/Cargo.toml
+++ b/crates/swc_allocator/Cargo.toml
@@ -15,6 +15,7 @@ bumpalo = { workspace = true, features = [
     "boxed",
     "collections",
 ] }
+ptr_meta = { workspace = true }
 rkyv = { workspace = true }
 scoped-tls = { workspace = true }
 serde = { workspace = true }

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -1,1 +1,9 @@
+use scoped_tls::scoped_thread_local;
+
+use crate::Allocator;
+
+scoped_thread_local!(pub(crate) static ALLOC: Allocator);
+
 pub(crate) struct SwcAlloc;
+
+impl allocator_api2::alloc::Allocator for SwcAlloc {}

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -1,0 +1,5 @@
+use scoped_tls::scoped_thread_local;
+
+use crate::Allocator;
+
+scoped_thread_local!(pub(crate) static ALLOC: Allocator);

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -6,34 +6,38 @@ use crate::Allocator;
 
 scoped_thread_local!(pub(crate) static ALLOC: Allocator);
 
-/// `true` is passed to `f` if the box is allocated with a custom allocator.
-fn with_allocator<T>(f: impl FnOnce(&dyn allocator_api2::alloc::Allocator, bool) -> T) -> T {
-    if ALLOC.is_set() {
-        ALLOC.with(|a| {
-            //
-            f(&&**a as &dyn allocator_api2::alloc::Allocator, true)
-        })
-    } else {
-        f(&allocator_api2::alloc::Global, false)
+pub(crate) struct SwcAlloc {
+    pub is_custom: bool,
+}
+
+impl SwcAlloc {
+    /// `true` is passed to `f` if the box is allocated with a custom allocator.
+    fn with_allocator<T>(&self, f: impl FnOnce(&dyn allocator_api2::alloc::Allocator) -> T) -> T {
+        if self.is_custom {
+            ALLOC.with(|a| {
+                //
+                f(&&**a as &dyn allocator_api2::alloc::Allocator)
+            })
+        } else {
+            f(&allocator_api2::alloc::Global)
+        }
     }
 }
 
-pub(crate) struct SwcAlloc;
-
 unsafe impl allocator_api2::alloc::Allocator for SwcAlloc {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
-        with_allocator(|a, _custom| a.allocate(layout))
+        self.with_allocator(|a| a.allocate(layout))
     }
 
     fn allocate_zeroed(
         &self,
         layout: Layout,
     ) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
-        with_allocator(|a, _custom| a.allocate_zeroed(layout))
+        self.with_allocator(|a| a.allocate_zeroed(layout))
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        with_allocator(|a, _custom| a.deallocate(ptr, layout))
+        self.with_allocator(|a| a.deallocate(ptr, layout))
     }
 
     unsafe fn grow(
@@ -42,7 +46,7 @@ unsafe impl allocator_api2::alloc::Allocator for SwcAlloc {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
-        with_allocator(|a, _custom| a.grow(ptr, old_layout, new_layout))
+        self.with_allocator(|a| a.grow(ptr, old_layout, new_layout))
     }
 
     unsafe fn grow_zeroed(
@@ -51,7 +55,7 @@ unsafe impl allocator_api2::alloc::Allocator for SwcAlloc {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
-        with_allocator(|a, _custom| a.grow_zeroed(ptr, old_layout, new_layout))
+        self.with_allocator(|a| a.grow_zeroed(ptr, old_layout, new_layout))
     }
 
     unsafe fn shrink(
@@ -60,7 +64,7 @@ unsafe impl allocator_api2::alloc::Allocator for SwcAlloc {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
-        with_allocator(|a, _custom| a.shrink(ptr, old_layout, new_layout))
+        self.with_allocator(|a| a.shrink(ptr, old_layout, new_layout))
     }
 
     fn by_ref(&self) -> &Self

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -6,7 +6,7 @@ use crate::Allocator;
 
 scoped_thread_local!(pub(crate) static ALLOC: Allocator);
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Default)]
 pub struct SwcAlloc {
     pub(crate) is_custom: bool,
 }

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -6,12 +6,14 @@ use crate::Allocator;
 
 scoped_thread_local!(pub(crate) static ALLOC: Allocator);
 
+pub(crate) struct SwcAlloc {}
+
 #[derive(Clone, Copy)]
-pub struct SwcAlloc {
+pub struct CachedAlloc {
     pub(crate) is_custom: bool,
 }
 
-impl Default for SwcAlloc {
+impl Default for CachedAlloc {
     fn default() -> Self {
         Self {
             is_custom: ALLOC.is_set(),
@@ -19,7 +21,7 @@ impl Default for SwcAlloc {
     }
 }
 
-impl SwcAlloc {
+impl CachedAlloc {
     /// `true` is passed to `f` if the box is allocated with a custom allocator.
     fn with_allocator<T>(&self, f: impl FnOnce(&dyn allocator_api2::alloc::Allocator) -> T) -> T {
         if self.is_custom {
@@ -33,7 +35,7 @@ impl SwcAlloc {
     }
 }
 
-unsafe impl allocator_api2::alloc::Allocator for SwcAlloc {
+unsafe impl allocator_api2::alloc::Allocator for CachedAlloc {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
         self.with_allocator(|a| a.allocate(layout))
     }

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -6,6 +6,7 @@ use crate::Allocator;
 
 scoped_thread_local!(pub(crate) static ALLOC: Allocator);
 
+#[derive(Clone, Copy)]
 pub(crate) struct SwcAlloc {
     pub is_custom: bool,
 }

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -7,8 +7,8 @@ use crate::Allocator;
 scoped_thread_local!(pub(crate) static ALLOC: Allocator);
 
 #[derive(Clone, Copy)]
-pub(crate) struct SwcAlloc {
-    pub is_custom: bool,
+pub struct SwcAlloc {
+    pub(crate) is_custom: bool,
 }
 
 impl SwcAlloc {

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -6,9 +6,17 @@ use crate::Allocator;
 
 scoped_thread_local!(pub(crate) static ALLOC: Allocator);
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Copy)]
 pub struct SwcAlloc {
     pub(crate) is_custom: bool,
+}
+
+impl Default for SwcAlloc {
+    fn default() -> Self {
+        Self {
+            is_custom: ALLOC.is_set(),
+        }
+    }
 }
 
 impl SwcAlloc {

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -4,6 +4,17 @@ use crate::Allocator;
 
 scoped_thread_local!(pub(crate) static ALLOC: Allocator);
 
+fn with_allocator(f: impl FnOnce(&dyn allocator_api2::alloc::Allocator)) {
+    if ALLOC.is_set() {
+        ALLOC.with(|a| {
+            //
+            f(&&**a as &dyn allocator_api2::alloc::Allocator)
+        });
+    } else {
+        f(&allocator_api2::alloc::Global);
+    }
+}
+
 pub(crate) struct SwcAlloc;
 
 impl allocator_api2::alloc::Allocator for SwcAlloc {}

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -1,5 +1,1 @@
-use scoped_tls::scoped_thread_local;
-
-use crate::Allocator;
-
-scoped_thread_local!(pub(crate) static ALLOC: Allocator);
+pub(crate) struct SwcAlloc;

--- a/crates/swc_allocator/src/boxed.rs
+++ b/crates/swc_allocator/src/boxed.rs
@@ -7,4 +7,5 @@ use crate::alloc::SwcAlloc;
 /// # Representation
 ///
 /// The last bit is 1 if the box is allocated with a custom allocator.
+#[repr(transparent)]
 pub struct Box<T: ?Sized>(allocator_api2::boxed::Box<T, SwcAlloc>);

--- a/crates/swc_allocator/src/boxed.rs
+++ b/crates/swc_allocator/src/boxed.rs
@@ -1,8 +1,12 @@
-use std::{marker::PhantomData, ptr::NonNull};
+use std::ptr::NonNull;
 
 /// A special `Box` which has size of [`std::boxed::Box`] but **may** be
 /// allocated with a custom allocator.
+///
+///
+/// # Representation
+///
+/// The last bit is 1 if the box is allocated with a custom allocator.
 pub struct Box<T: ?Sized> {
     data: NonNull<T>,
-    marker: PhantomData<&mut T>,
 }

--- a/crates/swc_allocator/src/boxed.rs
+++ b/crates/swc_allocator/src/boxed.rs
@@ -1,5 +1,7 @@
 use std::{marker::PhantomData, ptr::NonNull};
 
+/// A special `Box` which has size of [`std::boxed::Box`] but **may** be
+/// allocated with a custom allocator.
 pub struct Box<T: ?Sized> {
     data: NonNull<T>,
     marker: PhantomData<&mut T>,

--- a/crates/swc_allocator/src/boxed.rs
+++ b/crates/swc_allocator/src/boxed.rs
@@ -1,4 +1,4 @@
-use std::ptr::NonNull;
+use crate::alloc::SwcAlloc;
 
 /// A special `Box` which has size of [`std::boxed::Box`] but **may** be
 /// allocated with a custom allocator.
@@ -7,6 +7,4 @@ use std::ptr::NonNull;
 /// # Representation
 ///
 /// The last bit is 1 if the box is allocated with a custom allocator.
-pub struct Box<T: ?Sized> {
-    data: NonNull<T>,
-}
+pub struct Box<T: ?Sized>(allocator_api2::boxed::Box<T, SwcAlloc>);

--- a/crates/swc_allocator/src/boxed.rs
+++ b/crates/swc_allocator/src/boxed.rs
@@ -1,4 +1,6 @@
-use crate::alloc::SwcAlloc;
+use std::ops::{Deref, DerefMut};
+
+use crate::alloc::{SwcAlloc, ALLOC};
 
 /// A special `Box` which has size of [`std::boxed::Box`] but **may** be
 /// allocated with a custom allocator.
@@ -8,4 +10,31 @@ use crate::alloc::SwcAlloc;
 ///
 /// The last bit is 1 if the box is allocated with a custom allocator.
 #[repr(transparent)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Box<T: ?Sized>(allocator_api2::boxed::Box<T, SwcAlloc>);
+
+impl<T> Box<T> {
+    #[inline(always)]
+    pub fn new(value: T) -> Self {
+        let is_custom = ALLOC.is_set();
+
+        Self(allocator_api2::boxed::Box::new_in(
+            value,
+            SwcAlloc { is_custom },
+        ))
+    }
+}
+
+impl<T: ?Sized> Deref for Box<T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &self.0
+    }
+}
+
+impl<T: ?Sized> DerefMut for Box<T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}

--- a/crates/swc_allocator/src/boxed.rs
+++ b/crates/swc_allocator/src/boxed.rs
@@ -1,0 +1,6 @@
+use std::{marker::PhantomData, ptr::NonNull};
+
+pub struct Box<T: ?Sized> {
+    data: NonNull<T>,
+    marker: PhantomData<&mut T>,
+}

--- a/crates/swc_allocator/src/boxed.rs
+++ b/crates/swc_allocator/src/boxed.rs
@@ -13,7 +13,7 @@ use crate::alloc::SwcAlloc;
 /// The last bit is 1 if the box is allocated with a custom allocator.
 #[repr(transparent)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Box<T: ?Sized>(allocator_api2::boxed::Box<T, SwcAlloc>);
+pub struct Box<T: ?Sized>(pub(crate) allocator_api2::boxed::Box<T, SwcAlloc>);
 
 impl<T> Box<T> {
     #[inline(always)]

--- a/crates/swc_allocator/src/boxed.rs
+++ b/crates/swc_allocator/src/boxed.rs
@@ -10,7 +10,7 @@ use crate::alloc::{SwcAlloc, ALLOC};
 ///
 /// The last bit is 1 if the box is allocated with a custom allocator.
 #[repr(transparent)]
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Box<T: ?Sized>(allocator_api2::boxed::Box<T, SwcAlloc>);
 
 impl<T> Box<T> {
@@ -22,6 +22,10 @@ impl<T> Box<T> {
             value,
             SwcAlloc { is_custom },
         ))
+    }
+
+    pub fn unbox(self) -> T {
+        allocator_api2::boxed::Box::into_inner(self.0)
     }
 }
 

--- a/crates/swc_allocator/src/boxed.rs
+++ b/crates/swc_allocator/src/boxed.rs
@@ -42,3 +42,27 @@ impl<T: ?Sized> DerefMut for Box<T> {
         &mut self.0
     }
 }
+
+impl<T> serde::Serialize for Box<T>
+where
+    T: serde::Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T> serde::Deserialize<'de> for Box<T>
+where
+    T: serde::Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Box<T>, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        Ok(Box(allocator_api2::boxed::Box::deserialize(deserializer)?))
+    }
+}

--- a/crates/swc_allocator/src/boxed/mod.rs
+++ b/crates/swc_allocator/src/boxed/mod.rs
@@ -54,6 +54,12 @@ impl<T: ?Sized> AsRef<T> for Box<T> {
     }
 }
 
+impl<T: ?Sized> AsMut<T> for Box<T> {
+    fn as_mut(&mut self) -> &mut T {
+        &mut self.0
+    }
+}
+
 impl<T: ?Sized> Deref for Box<T> {
     type Target = T;
 

--- a/crates/swc_allocator/src/boxed/mod.rs
+++ b/crates/swc_allocator/src/boxed/mod.rs
@@ -1,9 +1,9 @@
 use std::ops::{Deref, DerefMut};
 
+use crate::alloc::SwcAlloc;
+
 mod rkyv;
 mod serde;
-
-use crate::alloc::CachedAlloc;
 
 /// A special `Box` which has size of [`std::boxed::Box`] but **may** be
 /// allocated with a custom allocator.
@@ -14,7 +14,7 @@ use crate::alloc::CachedAlloc;
 /// The last bit is 1 if the box is allocated with a custom allocator.
 #[repr(transparent)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Box<T: ?Sized>(pub(crate) allocator_api2::boxed::Box<T, CachedAlloc>);
+pub struct Box<T: ?Sized>(pub(crate) allocator_api2::boxed::Box<T, SwcAlloc>);
 
 impl<T> From<T> for Box<T> {
     #[inline(always)]
@@ -64,7 +64,7 @@ impl<T: ?Sized> Box<T> {
     pub unsafe fn from_raw(raw: *mut T) -> Self {
         Self(allocator_api2::boxed::Box::from_raw_in(
             raw,
-            CachedAlloc::default(),
+            SwcAlloc::default(),
         ))
     }
 }

--- a/crates/swc_allocator/src/boxed/mod.rs
+++ b/crates/swc_allocator/src/boxed/mod.rs
@@ -23,6 +23,20 @@ impl<T> From<T> for Box<T> {
     }
 }
 
+pub trait IntoBox<T>: Sized {
+    fn boxed(self) -> Box<T>;
+}
+
+impl<T, V> IntoBox<T> for V
+where
+    V: Into<T>,
+{
+    #[inline(always)]
+    fn boxed(self) -> Box<T> {
+        Box::new(self.into())
+    }
+}
+
 impl<T> Default for Box<T>
 where
     T: Default,

--- a/crates/swc_allocator/src/boxed/mod.rs
+++ b/crates/swc_allocator/src/boxed/mod.rs
@@ -37,8 +37,10 @@ impl<T: ?Sized> Box<T> {
             SwcAlloc::default(),
         ))
     }
+}
 
-    pub fn as_ref(&self) -> &T {
+impl<T: ?Sized> AsRef<T> for Box<T> {
+    fn as_ref(&self) -> &T {
         &self.0
     }
 }

--- a/crates/swc_allocator/src/boxed/mod.rs
+++ b/crates/swc_allocator/src/boxed/mod.rs
@@ -49,10 +49,7 @@ where
 impl<T> Box<T> {
     #[inline(always)]
     pub fn new(value: T) -> Self {
-        Self(allocator_api2::boxed::Box::new_in(
-            value,
-            CachedAlloc::default(),
-        ))
+        Self(allocator_api2::boxed::Box::new_in(value, SwcAlloc))
     }
 
     pub fn unbox(self) -> T {

--- a/crates/swc_allocator/src/boxed/mod.rs
+++ b/crates/swc_allocator/src/boxed/mod.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 mod rkyv;
 mod serde;
 
-use crate::alloc::SwcAlloc;
+use crate::alloc::CachedAlloc;
 
 /// A special `Box` which has size of [`std::boxed::Box`] but **may** be
 /// allocated with a custom allocator.
@@ -14,7 +14,7 @@ use crate::alloc::SwcAlloc;
 /// The last bit is 1 if the box is allocated with a custom allocator.
 #[repr(transparent)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Box<T: ?Sized>(pub(crate) allocator_api2::boxed::Box<T, SwcAlloc>);
+pub struct Box<T: ?Sized>(pub(crate) allocator_api2::boxed::Box<T, CachedAlloc>);
 
 impl<T> From<T> for Box<T> {
     #[inline(always)]
@@ -51,7 +51,7 @@ impl<T> Box<T> {
     pub fn new(value: T) -> Self {
         Self(allocator_api2::boxed::Box::new_in(
             value,
-            SwcAlloc::default(),
+            CachedAlloc::default(),
         ))
     }
 
@@ -64,7 +64,7 @@ impl<T: ?Sized> Box<T> {
     pub unsafe fn from_raw(raw: *mut T) -> Self {
         Self(allocator_api2::boxed::Box::from_raw_in(
             raw,
-            SwcAlloc::default(),
+            CachedAlloc::default(),
         ))
     }
 }

--- a/crates/swc_allocator/src/boxed/mod.rs
+++ b/crates/swc_allocator/src/boxed/mod.rs
@@ -16,6 +16,13 @@ use crate::alloc::SwcAlloc;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Box<T: ?Sized>(pub(crate) allocator_api2::boxed::Box<T, SwcAlloc>);
 
+impl<T> From<T> for Box<T> {
+    #[inline(always)]
+    fn from(v: T) -> Self {
+        Box::new(v)
+    }
+}
+
 impl<T> Default for Box<T>
 where
     T: Default,

--- a/crates/swc_allocator/src/boxed/mod.rs
+++ b/crates/swc_allocator/src/boxed/mod.rs
@@ -16,6 +16,15 @@ use crate::alloc::SwcAlloc;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Box<T: ?Sized>(pub(crate) allocator_api2::boxed::Box<T, SwcAlloc>);
 
+impl<T> Default for Box<T>
+where
+    T: Default,
+{
+    fn default() -> Self {
+        Box::new(Default::default())
+    }
+}
+
 impl<T> Box<T> {
     #[inline(always)]
     pub fn new(value: T) -> Self {

--- a/crates/swc_allocator/src/boxed/rkyv.rs
+++ b/crates/swc_allocator/src/boxed/rkyv.rs
@@ -1,0 +1,24 @@
+use rkyv::{
+    boxed::{ArchivedBox, BoxResolver},
+    Archive, ArchivePointee, ArchiveUnsized, Archived, Deserialize, DeserializeUnsized, Fallible,
+    Serialize, SerializeUnsized,
+};
+
+use super::Box;
+
+impl<T: ArchiveUnsized + ?Sized> Archive for Box<T> {
+    type Archived = ArchivedBox<T::Archived>;
+    type Resolver = BoxResolver<T::MetadataResolver>;
+
+    #[inline]
+    unsafe fn resolve(&self, pos: usize, resolver: Self::Resolver, out: *mut Self::Archived) {
+        ArchivedBox::resolve_from_ref(self.as_ref(), pos, resolver, out);
+    }
+}
+
+impl<T: SerializeUnsized<S> + ?Sized, S: Fallible + ?Sized> Serialize<S> for Box<T> {
+    #[inline]
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        ArchivedBox::serialize_from_ref(self.as_ref(), serializer)
+    }
+}

--- a/crates/swc_allocator/src/boxed/rkyv.rs
+++ b/crates/swc_allocator/src/boxed/rkyv.rs
@@ -1,6 +1,9 @@
+use std::{alloc, cmp};
+
 use rkyv::{
     boxed::{ArchivedBox, BoxResolver},
-    Archive, ArchiveUnsized, Fallible, Serialize, SerializeUnsized,
+    Archive, ArchivePointee, ArchiveUnsized, Deserialize, DeserializeUnsized, Fallible, Serialize,
+    SerializeUnsized,
 };
 
 use super::Box;
@@ -19,5 +22,38 @@ impl<T: SerializeUnsized<S> + ?Sized, S: Fallible + ?Sized> Serialize<S> for Box
     #[inline]
     fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
         ArchivedBox::serialize_from_ref(self.as_ref(), serializer)
+    }
+}
+
+impl<T, D> Deserialize<Box<T>, D> for ArchivedBox<T::Archived>
+where
+    T: ArchiveUnsized + ?Sized,
+    T::Archived: DeserializeUnsized<T, D>,
+    D: Fallible + ?Sized,
+{
+    #[inline]
+    fn deserialize(&self, deserializer: &mut D) -> Result<Box<T>, D::Error> {
+        unsafe {
+            let data_address = self
+                .get()
+                .deserialize_unsized(deserializer, |layout| alloc::alloc(layout))?;
+            let metadata = self.get().deserialize_metadata(deserializer)?;
+            let ptr = ptr_meta::from_raw_parts_mut(data_address, metadata);
+            Ok(Box::from_raw(ptr))
+        }
+    }
+}
+
+impl<T: ArchivePointee + PartialEq<U> + ?Sized, U: ?Sized> PartialEq<Box<U>> for ArchivedBox<T> {
+    #[inline]
+    fn eq(&self, other: &Box<U>) -> bool {
+        self.get().eq(other.as_ref())
+    }
+}
+
+impl<T: ArchivePointee + PartialOrd<U> + ?Sized, U: ?Sized> PartialOrd<Box<U>> for ArchivedBox<T> {
+    #[inline]
+    fn partial_cmp(&self, other: &Box<U>) -> Option<cmp::Ordering> {
+        self.get().partial_cmp(other.as_ref())
     }
 }

--- a/crates/swc_allocator/src/boxed/rkyv.rs
+++ b/crates/swc_allocator/src/boxed/rkyv.rs
@@ -1,7 +1,6 @@
 use rkyv::{
     boxed::{ArchivedBox, BoxResolver},
-    Archive, ArchivePointee, ArchiveUnsized, Archived, Deserialize, DeserializeUnsized, Fallible,
-    Serialize, SerializeUnsized,
+    Archive, ArchiveUnsized, Fallible, Serialize, SerializeUnsized,
 };
 
 use super::Box;

--- a/crates/swc_allocator/src/boxed/serde.rs
+++ b/crates/swc_allocator/src/boxed/serde.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+use super::Box;
+
+impl<T> Serialize for Box<T>
+where
+    T: Serialize,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<'de, T> Deserialize<'de> for Box<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Box<T>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Box(allocator_api2::boxed::Box::deserialize(deserializer)?))
+    }
+}

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! API designed after [`oxc_allocator`](https://github.com/oxc-project/oxc/tree/725571aad193ec6ba779c820baeb4a7774533ed7/crates/oxc_allocator/src).
 
-use alloc::ALLOC;
+use alloc::{SwcAlloc, ALLOC};
 use std::ops::{Deref, DerefMut};
 
 use bumpalo::Bump;
@@ -46,23 +46,11 @@ impl DerefMut for Allocator {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
-pub struct Vec<'alloc, T>(bumpalo::collections::Vec<'alloc, T>);
+pub struct Vec<T>(allocator_api2::vec::Vec<T, SwcAlloc>);
 
-impl<'alloc, T> Vec<'alloc, T> {
-    #[inline(always)]
-    pub fn new(alloc: &'alloc Allocator) -> Self {
-        Self(bumpalo::collections::Vec::new_in(alloc))
-    }
-
-    #[inline(always)]
-    pub fn with_capacity(alloc: &'alloc Allocator, capacity: usize) -> Self {
-        Self(bumpalo::collections::Vec::with_capacity_in(capacity, alloc))
-    }
-}
-
-impl<'alloc, T> Deref for Vec<'alloc, T> {
+impl<T> Deref for Vec<T> {
     type Target = [T];
 
     fn deref(&self) -> &[T] {
@@ -70,14 +58,14 @@ impl<'alloc, T> Deref for Vec<'alloc, T> {
     }
 }
 
-impl<'alloc, T> DerefMut for Vec<'alloc, T> {
+impl<T> DerefMut for Vec<T> {
     fn deref_mut(&mut self) -> &mut [T] {
         &mut self.0
     }
 }
 
-impl<'alloc, T> IntoIterator for Vec<'alloc, T> {
-    type IntoIter = bumpalo::collections::vec::IntoIter<'alloc, T>;
+impl<T> IntoIterator for Vec<T> {
+    type IntoIter = allocator_api2::vec::IntoIter<T, SwcAlloc>;
     type Item = T;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -6,6 +6,8 @@ use std::ops::{Deref, DerefMut};
 
 use bumpalo::Bump;
 
+pub mod boxed;
+
 #[derive(Default)]
 pub struct Allocator {
     alloc: Bump,

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! API designed after [`oxc_allocator`](https://github.com/oxc-project/oxc/tree/725571aad193ec6ba779c820baeb4a7774533ed7/crates/oxc_allocator/src).
 
+use alloc::ALLOC;
 use std::ops::{Deref, DerefMut};
 
 use bumpalo::Bump;
@@ -12,6 +13,17 @@ pub mod boxed;
 #[derive(Default)]
 pub struct Allocator {
     alloc: Bump,
+}
+
+impl Allocator {
+    /// Invokes `f` in a scope where the allocations are done in this allocator.
+    #[inline(always)]
+    pub fn scope<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        ALLOC.set(self, f)
+    }
 }
 
 impl From<Bump> for Allocator {

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -36,31 +36,6 @@ impl DerefMut for Allocator {
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
-pub struct Box<'alloc, T>(bumpalo::boxed::Box<'alloc, T>);
-
-impl<'alloc, T> Box<'alloc, T> {
-    #[inline(always)]
-    pub fn new(alloc: &'alloc Allocator, value: T) -> Self {
-        Self(bumpalo::boxed::Box::new_in(value, alloc))
-    }
-}
-
-impl<'alloc, T> Deref for Box<'alloc, T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
-        &self.0
-    }
-}
-
-impl<'alloc, T> DerefMut for Box<'alloc, T> {
-    fn deref_mut(&mut self) -> &mut T {
-        &mut self.0
-    }
-}
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[repr(transparent)]
 pub struct Vec<'alloc, T>(bumpalo::collections::Vec<'alloc, T>);
 
 impl<'alloc, T> Vec<'alloc, T> {

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -5,10 +5,7 @@
 use std::ops::{Deref, DerefMut};
 
 use bumpalo::Bump;
-use rkyv::{
-    vec::{ArchivedVec, VecResolver},
-    DeserializeUnsized,
-};
+use rkyv::{vec::ArchivedVec, DeserializeUnsized};
 use serde_derive::{Deserialize, Serialize};
 
 use crate::{
@@ -85,6 +82,12 @@ impl<T> IntoIterator for Vec<T> {
 
     fn into_iter(self) -> Self::IntoIter {
         self.0.into_iter()
+    }
+}
+
+impl<T> From<Box<[T]>> for Vec<T> {
+    fn from(v: Box<[T]>) -> Self {
+        Self(allocator_api2::vec::Vec::from(v.0))
     }
 }
 

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -121,7 +121,7 @@ where
     fn deserialize(&self, deserializer: &mut D) -> Result<Vec<T>, D::Error> {
         unsafe {
             let data_address =
-                (&**self).deserialize_unsized(deserializer, |layout| std::alloc::alloc(layout))?;
+                (**self).deserialize_unsized(deserializer, |layout| std::alloc::alloc(layout))?;
             let metadata = self.as_slice().deserialize_metadata(deserializer)?;
             let ptr = ptr_meta::from_raw_parts_mut(data_address, metadata);
             Ok(Box::<[T]>::from_raw(ptr).into())

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -5,16 +5,12 @@
 use std::ops::{Deref, DerefMut};
 
 use bumpalo::Bump;
-use rkyv::{vec::ArchivedVec, DeserializeUnsized};
-use serde_derive::{Deserialize, Serialize};
 
-use crate::{
-    alloc::{SwcAlloc, ALLOC},
-    boxed::Box,
-};
+use crate::alloc::ALLOC;
 
 mod alloc;
 pub mod boxed;
+pub mod vec;
 
 #[derive(Default)]
 pub struct Allocator {
@@ -49,82 +45,5 @@ impl Deref for Allocator {
 impl DerefMut for Allocator {
     fn deref_mut(&mut self) -> &mut Bump {
         &mut self.alloc
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-#[repr(transparent)]
-pub struct Vec<T>(allocator_api2::vec::Vec<T, SwcAlloc>);
-
-impl<T> Deref for Vec<T> {
-    type Target = [T];
-
-    fn deref(&self) -> &[T] {
-        &self.0
-    }
-}
-
-impl<T> DerefMut for Vec<T> {
-    fn deref_mut(&mut self) -> &mut [T] {
-        &mut self.0
-    }
-}
-
-impl<T> Default for Vec<T> {
-    fn default() -> Self {
-        Self(allocator_api2::vec::Vec::new_in(SwcAlloc::default()))
-    }
-}
-
-impl<T> IntoIterator for Vec<T> {
-    type IntoIter = allocator_api2::vec::IntoIter<T, SwcAlloc>;
-    type Item = T;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
-
-impl<T> From<Box<[T]>> for Vec<T> {
-    fn from(v: Box<[T]>) -> Self {
-        Self(allocator_api2::vec::Vec::from(v.0))
-    }
-}
-
-impl<T> rkyv::Archive for Vec<T>
-where
-    T: rkyv::Archive,
-{
-    type Archived = rkyv::vec::ArchivedVec<T::Archived>;
-    type Resolver = rkyv::vec::VecResolver;
-
-    unsafe fn resolve(&self, pos: usize, resolver: Self::Resolver, out: *mut Self::Archived) {
-        rkyv::vec::ArchivedVec::resolve_from_slice(self, pos, resolver, out);
-    }
-}
-
-impl<T: rkyv::Serialize<S>, S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer + ?Sized>
-    rkyv::Serialize<S> for Vec<T>
-{
-    #[inline]
-    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
-        ArchivedVec::<T::Archived>::serialize_from_slice(self, serializer)
-    }
-}
-
-impl<T: rkyv::Archive, D: rkyv::Fallible + ?Sized> rkyv::Deserialize<Vec<T>, D>
-    for ArchivedVec<T::Archived>
-where
-    [T::Archived]: rkyv::DeserializeUnsized<[T], D>,
-{
-    #[inline]
-    fn deserialize(&self, deserializer: &mut D) -> Result<Vec<T>, D::Error> {
-        unsafe {
-            let data_address =
-                (**self).deserialize_unsized(deserializer, |layout| std::alloc::alloc(layout))?;
-            let metadata = self.as_slice().deserialize_metadata(deserializer)?;
-            let ptr = ptr_meta::from_raw_parts_mut(data_address, metadata);
-            Ok(Box::<[T]>::from_raw(ptr).into())
-        }
     }
 }

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -6,6 +6,7 @@ use alloc::{SwcAlloc, ALLOC};
 use std::ops::{Deref, DerefMut};
 
 use bumpalo::Bump;
+use serde_derive::{Deserialize, Serialize};
 
 mod alloc;
 pub mod boxed;
@@ -46,7 +47,7 @@ impl DerefMut for Allocator {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[repr(transparent)]
 pub struct Vec<T>(allocator_api2::vec::Vec<T, SwcAlloc>);
 

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -65,6 +65,12 @@ impl<T> DerefMut for Vec<T> {
     }
 }
 
+impl<T> Default for Vec<T> {
+    fn default() -> Self {
+        Self(allocator_api2::vec::Vec::new_in(SwcAlloc::default()))
+    }
+}
+
 impl<T> IntoIterator for Vec<T> {
     type IntoIter = allocator_api2::vec::IntoIter<T, SwcAlloc>;
     type Item = T;

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -6,6 +6,7 @@ use std::ops::{Deref, DerefMut};
 
 use bumpalo::Bump;
 
+mod alloc;
 pub mod boxed;
 
 #[derive(Default)]

--- a/crates/swc_allocator/src/vec/mod.rs
+++ b/crates/swc_allocator/src/vec/mod.rs
@@ -3,11 +3,11 @@ use std::ops::{Deref, DerefMut};
 use rkyv::{vec::ArchivedVec, DeserializeUnsized};
 use serde_derive::{Deserialize, Serialize};
 
-use crate::{alloc::CachedAlloc, boxed::Box};
+use crate::{alloc::SwcAlloc, boxed::Box};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[repr(transparent)]
-pub struct Vec<T>(allocator_api2::vec::Vec<T, CachedAlloc>);
+pub struct Vec<T>(allocator_api2::vec::Vec<T, SwcAlloc>);
 
 impl<T> Vec<T> {
     pub fn new() -> Self {
@@ -16,7 +16,7 @@ impl<T> Vec<T> {
 }
 
 impl<T> Deref for Vec<T> {
-    type Target = allocator_api2::vec::Vec<T, CachedAlloc>;
+    type Target = allocator_api2::vec::Vec<T, SwcAlloc>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -31,12 +31,12 @@ impl<T> DerefMut for Vec<T> {
 
 impl<T> Default for Vec<T> {
     fn default() -> Self {
-        Self(allocator_api2::vec::Vec::new_in(CachedAlloc::default()))
+        Self(allocator_api2::vec::Vec::new_in(SwcAlloc::default()))
     }
 }
 
 impl<T> IntoIterator for Vec<T> {
-    type IntoIter = allocator_api2::vec::IntoIter<T, CachedAlloc>;
+    type IntoIter = allocator_api2::vec::IntoIter<T, SwcAlloc>;
     type Item = T;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/crates/swc_allocator/src/vec/mod.rs
+++ b/crates/swc_allocator/src/vec/mod.rs
@@ -10,15 +10,15 @@ use crate::{alloc::SwcAlloc, boxed::Box};
 pub struct Vec<T>(allocator_api2::vec::Vec<T, SwcAlloc>);
 
 impl<T> Deref for Vec<T> {
-    type Target = [T];
+    type Target = allocator_api2::vec::Vec<T, SwcAlloc>;
 
-    fn deref(&self) -> &[T] {
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
 impl<T> DerefMut for Vec<T> {
-    fn deref_mut(&mut self) -> &mut [T] {
+    fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }
 }

--- a/crates/swc_allocator/src/vec/mod.rs
+++ b/crates/swc_allocator/src/vec/mod.rs
@@ -55,6 +55,14 @@ impl<'a, T> IntoIterator for &'a mut Vec<T> {
     }
 }
 
+impl<T> FromIterator<T> for Vec<T> {
+    fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
+        let mut vec = Vec::default();
+        vec.extend(iter);
+        vec
+    }
+}
+
 impl<T> From<Box<[T]>> for Vec<T> {
     fn from(v: Box<[T]>) -> Self {
         Self(allocator_api2::vec::Vec::from(v.0))

--- a/crates/swc_allocator/src/vec/mod.rs
+++ b/crates/swc_allocator/src/vec/mod.rs
@@ -37,6 +37,23 @@ impl<T> IntoIterator for Vec<T> {
         self.0.into_iter()
     }
 }
+impl<'a, T> IntoIterator for &'a Vec<T> {
+    type IntoIter = std::slice::Iter<'a, T>;
+    type Item = &'a T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut Vec<T> {
+    type IntoIter = std::slice::IterMut<'a, T>;
+    type Item = &'a mut T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
 
 impl<T> From<Box<[T]>> for Vec<T> {
     fn from(v: Box<[T]>) -> Self {

--- a/crates/swc_allocator/src/vec/mod.rs
+++ b/crates/swc_allocator/src/vec/mod.rs
@@ -3,11 +3,11 @@ use std::ops::{Deref, DerefMut};
 use rkyv::{vec::ArchivedVec, DeserializeUnsized};
 use serde_derive::{Deserialize, Serialize};
 
-use crate::{alloc::SwcAlloc, boxed::Box};
+use crate::{alloc::CachedAlloc, boxed::Box};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[repr(transparent)]
-pub struct Vec<T>(allocator_api2::vec::Vec<T, SwcAlloc>);
+pub struct Vec<T>(allocator_api2::vec::Vec<T, CachedAlloc>);
 
 impl<T> Vec<T> {
     pub fn new() -> Self {
@@ -16,7 +16,7 @@ impl<T> Vec<T> {
 }
 
 impl<T> Deref for Vec<T> {
-    type Target = allocator_api2::vec::Vec<T, SwcAlloc>;
+    type Target = allocator_api2::vec::Vec<T, CachedAlloc>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -31,12 +31,12 @@ impl<T> DerefMut for Vec<T> {
 
 impl<T> Default for Vec<T> {
     fn default() -> Self {
-        Self(allocator_api2::vec::Vec::new_in(SwcAlloc::default()))
+        Self(allocator_api2::vec::Vec::new_in(CachedAlloc::default()))
     }
 }
 
 impl<T> IntoIterator for Vec<T> {
-    type IntoIter = allocator_api2::vec::IntoIter<T, SwcAlloc>;
+    type IntoIter = allocator_api2::vec::IntoIter<T, CachedAlloc>;
     type Item = T;
 
     fn into_iter(self) -> Self::IntoIter {

--- a/crates/swc_allocator/src/vec/mod.rs
+++ b/crates/swc_allocator/src/vec/mod.rs
@@ -1,0 +1,83 @@
+use std::ops::{Deref, DerefMut};
+
+use rkyv::{vec::ArchivedVec, DeserializeUnsized};
+use serde_derive::{Deserialize, Serialize};
+
+use crate::{alloc::SwcAlloc, boxed::Box};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[repr(transparent)]
+pub struct Vec<T>(allocator_api2::vec::Vec<T, SwcAlloc>);
+
+impl<T> Deref for Vec<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        &self.0
+    }
+}
+
+impl<T> DerefMut for Vec<T> {
+    fn deref_mut(&mut self) -> &mut [T] {
+        &mut self.0
+    }
+}
+
+impl<T> Default for Vec<T> {
+    fn default() -> Self {
+        Self(allocator_api2::vec::Vec::new_in(SwcAlloc::default()))
+    }
+}
+
+impl<T> IntoIterator for Vec<T> {
+    type IntoIter = allocator_api2::vec::IntoIter<T, SwcAlloc>;
+    type Item = T;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<T> From<Box<[T]>> for Vec<T> {
+    fn from(v: Box<[T]>) -> Self {
+        Self(allocator_api2::vec::Vec::from(v.0))
+    }
+}
+
+impl<T> rkyv::Archive for Vec<T>
+where
+    T: rkyv::Archive,
+{
+    type Archived = rkyv::vec::ArchivedVec<T::Archived>;
+    type Resolver = rkyv::vec::VecResolver;
+
+    unsafe fn resolve(&self, pos: usize, resolver: Self::Resolver, out: *mut Self::Archived) {
+        rkyv::vec::ArchivedVec::resolve_from_slice(self, pos, resolver, out);
+    }
+}
+
+impl<T: rkyv::Serialize<S>, S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer + ?Sized>
+    rkyv::Serialize<S> for Vec<T>
+{
+    #[inline]
+    fn serialize(&self, serializer: &mut S) -> Result<Self::Resolver, S::Error> {
+        ArchivedVec::<T::Archived>::serialize_from_slice(self, serializer)
+    }
+}
+
+impl<T: rkyv::Archive, D: rkyv::Fallible + ?Sized> rkyv::Deserialize<Vec<T>, D>
+    for ArchivedVec<T::Archived>
+where
+    [T::Archived]: rkyv::DeserializeUnsized<[T], D>,
+{
+    #[inline]
+    fn deserialize(&self, deserializer: &mut D) -> Result<Vec<T>, D::Error> {
+        unsafe {
+            let data_address =
+                (**self).deserialize_unsized(deserializer, |layout| std::alloc::alloc(layout))?;
+            let metadata = self.as_slice().deserialize_metadata(deserializer)?;
+            let ptr = ptr_meta::from_raw_parts_mut(data_address, metadata);
+            Ok(Box::<[T]>::from_raw(ptr).into())
+        }
+    }
+}

--- a/crates/swc_allocator/src/vec/mod.rs
+++ b/crates/swc_allocator/src/vec/mod.rs
@@ -9,6 +9,12 @@ use crate::{alloc::SwcAlloc, boxed::Box};
 #[repr(transparent)]
 pub struct Vec<T>(allocator_api2::vec::Vec<T, SwcAlloc>);
 
+impl<T> Vec<T> {
+    pub fn new() -> Self {
+        Default::default()
+    }
+}
+
 impl<T> Deref for Vec<T> {
     type Target = allocator_api2::vec::Vec<T, SwcAlloc>;
 

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -65,6 +65,7 @@ url = { workspace = true }
 ast_node             = { version = "0.9.8", path = "../ast_node" }
 better_scoped_tls    = { version = "0.1.1", path = "../better_scoped_tls" }
 from_variant         = { version = "0.1.8", path = "../from_variant" }
+swc_allocator        = { version = "0.1.1", path = "../swc_allocator" }
 swc_atoms            = { version = "0.6.5", path = "../swc_atoms" }
 swc_eq_ignore_macros = { version = "0.1.3", path = "../swc_eq_ignore_macros" }
 swc_visit            = { version = "0.5.14", path = "../swc_visit" }

--- a/crates/swc_common/src/eq.rs
+++ b/crates/swc_common/src/eq.rs
@@ -63,6 +63,19 @@ where
     }
 }
 
+impl<T> EqIgnoreSpan for swc_allocator::Vec<T>
+where
+    T: EqIgnoreSpan,
+{
+    fn eq_ignore_span(&self, other: &Self) -> bool {
+        self.len() == other.len()
+            && self
+                .iter()
+                .zip(other.iter())
+                .all(|(a, b)| a.eq_ignore_span(b))
+    }
+}
+
 /// Derive with `#[derive(TypeEq)]`.
 pub trait TypeEq {
     /// **Note**: This method should return `true` for non-type values.
@@ -171,6 +184,26 @@ macro_rules! deref {
 }
 
 deref!(Box, Rc, Arc);
+
+impl<N> EqIgnoreSpan for swc_allocator::boxed::Box<N>
+where
+    N: EqIgnoreSpan,
+{
+    #[inline]
+    fn eq_ignore_span(&self, other: &Self) -> bool {
+        (**self).eq_ignore_span(&**other)
+    }
+}
+
+impl<N> TypeEq for swc_allocator::boxed::Box<N>
+where
+    N: TypeEq,
+{
+    #[inline]
+    fn type_eq(&self, other: &Self) -> bool {
+        (**self).type_eq(&**other)
+    }
+}
 
 impl<'a, N> EqIgnoreSpan for &'a N
 where

--- a/crates/swc_common/src/eq.rs
+++ b/crates/swc_common/src/eq.rs
@@ -63,7 +63,7 @@ where
     }
 }
 
-impl<T> EqIgnoreSpan for swc_allocator::Vec<T>
+impl<T> EqIgnoreSpan for swc_allocator::vec::Vec<T>
 where
     T: EqIgnoreSpan,
 {

--- a/crates/swc_common/src/pos.rs
+++ b/crates/swc_common/src/pos.rs
@@ -190,3 +190,12 @@ where
         }
     }
 }
+
+impl<T> Spanned for swc_allocator::boxed::Box<T>
+where
+    T: Spanned,
+{
+    fn span(&self) -> Span {
+        self.as_ref().span()
+    }
+}

--- a/crates/swc_common/src/util/take.rs
+++ b/crates/swc_common/src/util/take.rs
@@ -54,3 +54,18 @@ impl Take for Span {
         DUMMY_SP
     }
 }
+
+impl<T> Take for swc_allocator::boxed::Box<T>
+where
+    T: Take,
+{
+    fn dummy() -> Self {
+        swc_allocator::boxed::Box::new(T::dummy())
+    }
+}
+
+impl<T> Take for swc_allocator::Vec<T> {
+    fn dummy() -> Self {
+        swc_allocator::Vec::default()
+    }
+}

--- a/crates/swc_common/src/util/take.rs
+++ b/crates/swc_common/src/util/take.rs
@@ -64,8 +64,8 @@ where
     }
 }
 
-impl<T> Take for swc_allocator::Vec<T> {
+impl<T> Take for swc_allocator::vec::Vec<T> {
     fn dummy() -> Self {
-        swc_allocator::Vec::default()
+        Default::default()
     }
 }

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -42,10 +42,12 @@ rkyv = { workspace = true, features = [
 ], optional = true }
 scoped-tls = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
-string_enum = { version = "0.4.4", path = "../string_enum" }
-swc_atoms = { version = "0.6.5", path = "../swc_atoms" }
-swc_common = { version = "0.35.0", path = "../swc_common" }
 unicode-id-start = { workspace = true }
+
+string_enum   = { version = "0.4.4", path = "../string_enum" }
+swc_allocator = { version = "0.1.1", path = "../swc_allocator" }
+swc_atoms     = { version = "0.6.5", path = "../swc_atoms" }
+swc_common    = { version = "0.35.0", path = "../swc_common" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/swc_ecma_ast/src/class.rs
+++ b/crates/swc_ecma_ast/src/class.rs
@@ -1,5 +1,5 @@
 use is_macro::Is;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, SyntaxContext, DUMMY_SP};
 
 use crate::{

--- a/crates/swc_ecma_ast/src/class.rs
+++ b/crates/swc_ecma_ast/src/class.rs
@@ -1,4 +1,5 @@
 use is_macro::Is;
+use swc_allocator::{boxed::Box, Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, SyntaxContext, DUMMY_SP};
 
 use crate::{

--- a/crates/swc_ecma_ast/src/decl.rs
+++ b/crates/swc_ecma_ast/src/decl.rs
@@ -1,6 +1,6 @@
 use is_macro::Is;
 use string_enum::StringEnum;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, SyntaxContext, DUMMY_SP};
 
 use crate::{

--- a/crates/swc_ecma_ast/src/decl.rs
+++ b/crates/swc_ecma_ast/src/decl.rs
@@ -71,8 +71,6 @@ decl_from!(
 macro_rules! decl_from_boxed {
     ($($variant_ty:ty),*) => {
         $(
-            bridge_from!(Box<crate::Stmt>, Decl, $variant_ty);
-            bridge_from!(Box<crate::Stmt>, Decl, Box<$variant_ty>);
             bridge_from!(crate::Stmt, Decl, Box<$variant_ty>);
             bridge_from!(crate::ModuleItem, crate::Stmt, Box<$variant_ty>);
         )*

--- a/crates/swc_ecma_ast/src/decl.rs
+++ b/crates/swc_ecma_ast/src/decl.rs
@@ -1,5 +1,6 @@
 use is_macro::Is;
 use string_enum::StringEnum;
+use swc_allocator::{boxed::Box, Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, SyntaxContext, DUMMY_SP};
 
 use crate::{

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, mem::transmute};
 
 use is_macro::Is;
 use string_enum::StringEnum;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_atoms::Atom;
 use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Span, Spanned, SyntaxContext, DUMMY_SP,

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -529,7 +529,7 @@ impl ObjectLit {
     ///
     /// Returns [None] if this is not a valid for `with` of [crate::ImportDecl].
     pub fn as_import_with(&self) -> Option<ImportWith> {
-        let mut values = vec![];
+        let mut values = Vec::default();
         for prop in &self.props {
             match prop {
                 PropOrSpread::Spread(..) => return None,
@@ -1402,7 +1402,7 @@ impl TryFrom<Box<Pat>> for AssignTarget {
     type Error = Box<Pat>;
 
     fn try_from(p: Box<Pat>) -> Result<Self, Self::Error> {
-        (*p).try_into().map_err(Box::new)
+        p.unbox().try_into().map_err(Box::new)
     }
 }
 

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -169,7 +169,7 @@ pub enum Expr {
     Invalid(Invalid),
 }
 
-bridge_from!(Box<Expr>, Box<JSXElement>, JSXElement);
+bridge_from!(Expr, Box<JSXElement>, JSXElement);
 
 // Memory layout depends on the version of rustc.
 // #[cfg(target_pointer_width = "64")]
@@ -468,7 +468,6 @@ boxed_expr!(ParenExpr);
 boxed_expr!(JSXMemberExpr);
 boxed_expr!(JSXNamespacedName);
 boxed_expr!(JSXEmptyExpr);
-boxed_expr!(Box<JSXElement>);
 boxed_expr!(JSXFragment);
 boxed_expr!(TsTypeAssertion);
 boxed_expr!(TsSatisfiesExpr);

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -3,6 +3,7 @@ use std::{borrow::Cow, mem::transmute};
 
 use is_macro::Is;
 use string_enum::StringEnum;
+use swc_allocator::{boxed::Box, Vec};
 use swc_atoms::Atom;
 use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Span, Spanned, SyntaxContext, DUMMY_SP,

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -437,7 +437,7 @@ bridge_expr_from!(ClassExpr, Class);
 
 macro_rules! boxed_expr {
     ($T:ty) => {
-        bridge_from!(Box<Expr>, Expr, $T);
+        bridge_into!(Box<Expr>, Expr, $T);
     };
 }
 

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -1503,7 +1503,8 @@ impl TryFrom<Box<Expr>> for SimpleAssignTarget {
     type Error = Box<Expr>;
 
     fn try_from(e: Box<Expr>) -> Result<Self, Self::Error> {
-        Ok(match *e {
+        let e = e.unbox();
+        Ok(match e {
             Expr::Ident(i) => SimpleAssignTarget::Ident(i.into()),
             Expr::Member(m) => SimpleAssignTarget::Member(m),
             Expr::SuperProp(s) => SimpleAssignTarget::SuperProp(s),
@@ -1514,7 +1515,7 @@ impl TryFrom<Box<Expr>> for SimpleAssignTarget {
             Expr::TsNonNull(n) => SimpleAssignTarget::TsNonNull(n),
             Expr::TsTypeAssertion(a) => SimpleAssignTarget::TsTypeAssertion(a),
             Expr::TsInstantiation(a) => SimpleAssignTarget::TsInstantiation(a),
-            _ => return Err(e),
+            _ => return Err(Box::new(e)),
         })
     }
 }

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -437,7 +437,7 @@ bridge_expr_from!(ClassExpr, Class);
 
 macro_rules! boxed_expr {
     ($T:ty) => {
-        bridge_into!(Box<Expr>, Expr, $T);
+        bridge_from!(Box<Expr>, Expr, $T);
     };
 }
 

--- a/crates/swc_ecma_ast/src/function.rs
+++ b/crates/swc_ecma_ast/src/function.rs
@@ -1,5 +1,5 @@
 use is_macro::Is;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, SyntaxContext, DUMMY_SP};
 
 use crate::{

--- a/crates/swc_ecma_ast/src/function.rs
+++ b/crates/swc_ecma_ast/src/function.rs
@@ -1,4 +1,5 @@
 use is_macro::Is;
+use swc_allocator::{boxed::Box, Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, SyntaxContext, DUMMY_SP};
 
 use crate::{

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use phf::phf_set;
-use swc_allocator::{boxed::Box, vec::Vec};
+use swc_allocator::boxed::Box;
 use swc_atoms::{js_word, Atom};
 use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Mark, Span, Spanned, SyntaxContext, DUMMY_SP,

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use phf::phf_set;
+use swc_allocator::{boxed::Box, Vec};
 use swc_atoms::{js_word, Atom};
 use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Mark, Span, Spanned, SyntaxContext, DUMMY_SP,

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use phf::phf_set;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_atoms::{js_word, Atom};
 use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Mark, Span, Spanned, SyntaxContext, DUMMY_SP,

--- a/crates/swc_ecma_ast/src/jsx.rs
+++ b/crates/swc_ecma_ast/src/jsx.rs
@@ -1,4 +1,5 @@
 use is_macro::Is;
+use swc_allocator::{boxed::Box, Vec};
 use swc_atoms::Atom;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 

--- a/crates/swc_ecma_ast/src/jsx.rs
+++ b/crates/swc_ecma_ast/src/jsx.rs
@@ -1,5 +1,5 @@
 use is_macro::Is;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_atoms::Atom;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use num_bigint::BigInt as BigIntValue;
+use swc_allocator::{boxed::Box, Vec};
 use swc_atoms::{js_word, Atom};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use num_bigint::BigInt as BigIntValue;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_atoms::{js_word, Atom};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -214,18 +214,6 @@ macro_rules! bridge_from {
     };
 }
 
-macro_rules! bridge_into {
-    ($dst:ty, $bridge:ty, $src:ty) => {
-        impl Into<$dst> for $src {
-            #[cfg_attr(not(debug_assertions), inline(always))]
-            fn into(self) -> $dst {
-                let src: $bridge = self.into();
-                src.into()
-            }
-        }
-    };
-}
-
 macro_rules! bridge_expr_from {
     ($bridge:ty, $src:ty) => {
         bridge_from!(crate::Expr, $bridge, $src);

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -214,10 +214,22 @@ macro_rules! bridge_from {
     };
 }
 
+macro_rules! bridge_into {
+    ($dst:ty, $bridge:ty, $src:ty) => {
+        impl Into<$dst> for $src {
+            #[cfg_attr(not(debug_assertions), inline(always))]
+            fn into(src: $src) -> $dst {
+                let src: $bridge = src.into();
+                src.into()
+            }
+        }
+    };
+}
+
 macro_rules! bridge_expr_from {
     ($bridge:ty, $src:ty) => {
         bridge_from!(crate::Expr, $bridge, $src);
-        bridge_from!(Box<crate::Expr>, crate::Expr, $src);
+        bridge_into!(Box<crate::Expr>, crate::Expr, $src);
     };
 }
 
@@ -225,6 +237,6 @@ macro_rules! bridge_pat_from {
     ($bridge:ty, $src:ty) => {
         bridge_from!(crate::Pat, $bridge, $src);
         bridge_from!(crate::Param, crate::Pat, $src);
-        bridge_from!(Box<crate::Pat>, crate::Pat, $src);
+        bridge_into!(Box<crate::Pat>, crate::Pat, $src);
     };
 }

--- a/crates/swc_ecma_ast/src/macros.rs
+++ b/crates/swc_ecma_ast/src/macros.rs
@@ -218,8 +218,8 @@ macro_rules! bridge_into {
     ($dst:ty, $bridge:ty, $src:ty) => {
         impl Into<$dst> for $src {
             #[cfg_attr(not(debug_assertions), inline(always))]
-            fn into(src: $src) -> $dst {
-                let src: $bridge = src.into();
+            fn into(self) -> $dst {
+                let src: $bridge = self.into();
                 src.into()
             }
         }
@@ -229,7 +229,7 @@ macro_rules! bridge_into {
 macro_rules! bridge_expr_from {
     ($bridge:ty, $src:ty) => {
         bridge_from!(crate::Expr, $bridge, $src);
-        bridge_into!(Box<crate::Expr>, crate::Expr, $src);
+        // bridge_into!(Box<crate::Expr>, crate::Expr, $src);
     };
 }
 
@@ -237,6 +237,6 @@ macro_rules! bridge_pat_from {
     ($bridge:ty, $src:ty) => {
         bridge_from!(crate::Pat, $bridge, $src);
         bridge_from!(crate::Param, crate::Pat, $src);
-        bridge_into!(Box<crate::Pat>, crate::Pat, $src);
+        // bridge_into!(Box<crate::Pat>, crate::Pat, $src);
     };
 }

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -1,4 +1,5 @@
 use is_macro::Is;
+use swc_allocator::{boxed::Box, Vec};
 use swc_atoms::Atom;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -1,5 +1,5 @@
 use is_macro::Is;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_atoms::Atom;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 

--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -1,4 +1,5 @@
 use is_macro::Is;
+use swc_allocator::{boxed::Box, Vec};
 use swc_atoms::Atom;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 

--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -1,5 +1,5 @@
 use is_macro::Is;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_atoms::Atom;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 

--- a/crates/swc_ecma_ast/src/operators.rs
+++ b/crates/swc_ecma_ast/src/operators.rs
@@ -1,4 +1,5 @@
 use string_enum::StringEnum;
+use swc_allocator::{boxed::Box, Vec};
 use swc_common::EqIgnoreSpan;
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]

--- a/crates/swc_ecma_ast/src/operators.rs
+++ b/crates/swc_ecma_ast/src/operators.rs
@@ -1,5 +1,5 @@
 use string_enum::StringEnum;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_common::EqIgnoreSpan;
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -1,4 +1,5 @@
 use is_macro::Is;
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 
 use crate::{

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -72,7 +72,7 @@ bridge_pat_from!(BindingIdent, Id);
 macro_rules! pat_to_other {
     ($T:ty) => {
         bridge_from!(crate::Param, crate::Pat, $T);
-        bridge_from!(Box<crate::Pat>, crate::Pat, $T);
+        bridge_into!(Box<crate::Pat>, crate::Pat, $T);
     };
 }
 

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -72,7 +72,7 @@ bridge_pat_from!(BindingIdent, Id);
 macro_rules! pat_to_other {
     ($T:ty) => {
         bridge_from!(crate::Param, crate::Pat, $T);
-        bridge_into!(Box<crate::Pat>, crate::Pat, $T);
+        // bridge_into!(Box<crate::Pat>, crate::Pat, $T);
     };
 }
 

--- a/crates/swc_ecma_ast/src/prop.rs
+++ b/crates/swc_ecma_ast/src/prop.rs
@@ -1,5 +1,8 @@
 use is_macro::Is;
-use swc_allocator::{boxed::Box, vec::Vec};
+use swc_allocator::{
+    boxed::{Box, IntoBox},
+    vec::Vec,
+};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 
 use crate::{
@@ -133,15 +136,15 @@ impl From<PropName> for MemberProp {
             PropName::Computed(p) => MemberProp::Computed(p),
             PropName::Str(p) => MemberProp::Computed(ComputedPropName {
                 span: DUMMY_SP,
-                expr: p.into(),
+                expr: p.boxed(),
             }),
             PropName::Num(p) => MemberProp::Computed(ComputedPropName {
                 span: DUMMY_SP,
-                expr: p.into(),
+                expr: p.boxed(),
             }),
             PropName::BigInt(p) => MemberProp::Computed(ComputedPropName {
                 span: DUMMY_SP,
-                expr: p.into(),
+                expr: p.boxed(),
             }),
         }
     }

--- a/crates/swc_ecma_ast/src/prop.rs
+++ b/crates/swc_ecma_ast/src/prop.rs
@@ -1,5 +1,5 @@
 use is_macro::Is;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 
 use crate::{

--- a/crates/swc_ecma_ast/src/prop.rs
+++ b/crates/swc_ecma_ast/src/prop.rs
@@ -1,4 +1,5 @@
 use is_macro::Is;
+use swc_allocator::{boxed::Box, Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 
 use crate::{

--- a/crates/swc_ecma_ast/src/source_map.rs
+++ b/crates/swc_ecma_ast/src/source_map.rs
@@ -1,5 +1,6 @@
 use std::{rc::Rc, sync::Arc};
 
+use swc_allocator::{boxed::Box, Vec};
 use swc_common::{BytePos, SourceMap, SourceMapper, SourceMapperDyn, Span, Spanned};
 
 use crate::list::ListFormat;

--- a/crates/swc_ecma_ast/src/source_map.rs
+++ b/crates/swc_ecma_ast/src/source_map.rs
@@ -1,6 +1,6 @@
 use std::{rc::Rc, sync::Arc};
 
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_common::{BytePos, SourceMap, SourceMapper, SourceMapperDyn, Span, Spanned};
 
 use crate::list::ListFormat;

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -1,5 +1,5 @@
 use is_macro::Is;
-use swc_allocator::{boxed::Box, Vec};
+use swc_allocator::{boxed::Box, vec::Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, SyntaxContext, DUMMY_SP};
 
 use crate::{

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -24,11 +24,7 @@ pub struct BlockStmt {
 
 impl Take for BlockStmt {
     fn dummy() -> Self {
-        BlockStmt {
-            span: DUMMY_SP,
-            stmts: vec![],
-            ctxt: Default::default(),
-        }
+        Default::default()
     }
 }
 

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -1,4 +1,5 @@
 use is_macro::Is;
+use swc_allocator::{boxed::Box, Vec};
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, SyntaxContext, DUMMY_SP};
 
 use crate::{


### PR DESCRIPTION
**Description:**

We don't need to add lifetimes to everywhere! 

<img width="360" height="360" src="https://github.com/user-attachments/assets/92d34e7d-b1ca-4af0-b60e-f62ad025e6f6"/>


 - [x] ~`swc_allocator::boxed::Box<T>` is `std::boxed::Box<T>` or `bumpalo::boxed::Box<T>`, but in a compact form by using pointer magic. The size of `Box<T>` is 8 bytes.~ It's 16 bytes to avoid the cost of thread-local accesses.
 - [x] How it is allocated is determined based on the context. Namely, using `scoped_tls`.
 - [x] `FastAlloc` will be used to cache the context because accessing a thread-local variable is an expensive operation.
 - [ ] Parser should use `FastAlloc` instead of `Box::new()` wherever possible.
 - [x] It should be behind a feature flag. `swc_allocator/scoped`.
 - [x] If the feature is disabled, `Box<T>` and `Vec<T>` should work identically as ones from `std`.
 - [x] If the features is enabled, `swc_allocator::scope()` that enables allocations using `bumpalo`.
 - [x] `swc_core` should reexport the feature.
 - [x] `swc_core` should reexport the allocator crate.
 - [x] Document downside: User should use same allocator while allocating/deallocating using scoped API. 
 - [x] Document that recommendation is enabling it only for fully single threaded tasks.
 - [ ] Use it from `@swc/core`
 - [ ] Test multi-threaded usecase. Namely, there should be a test about dropping `Box<T>` allocated from another thread.
 - [ ] 