### PR TITLE
refactor(allocator): Use `&` instead of a thread-local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,6 +3710,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "swc_malloc",
+ "triomphe",
 ]
 
 [[package]]
@@ -5876,9 +5877,9 @@ dependencies = [
 
 [[package]]
 name = "triomphe"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859eb650cfee7434994602c3a68b25d77ad9e68c8a6cd491616ef86661382eb3"
+checksum = "e6631e42e10b40c0690bf92f404ebcfe6e1fdb480391d15f17cc8e96eeed5369"
 dependencies = [
  "serde",
  "stable_deref_trait",

--- a/crates/swc_allocator/Cargo.toml
+++ b/crates/swc_allocator/Cargo.toml
@@ -24,6 +24,7 @@ rkyv = { workspace = true, optional = true }
 scoped-tls = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
+triomphe = "0.1.13"
 
 
 [dev-dependencies]

--- a/crates/swc_allocator/benches/bench.rs
+++ b/crates/swc_allocator/benches/bench.rs
@@ -1,7 +1,7 @@
 extern crate swc_malloc;
 
 use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Bencher, Criterion};
-use swc_allocator::{FastAlloc, MemorySpace};
+use swc_allocator::{FastAlloc, SwcAllocator};
 
 fn bench_alloc(c: &mut Criterion) {
     fn direct_alloc_std(b: &mut Bencher, times: usize) {
@@ -40,7 +40,7 @@ fn bench_alloc(c: &mut Criterion) {
 
     fn direct_alloc_scoped(b: &mut Bencher, times: usize) {
         b.iter(|| {
-            let allocator = MemorySpace::default();
+            let allocator = SwcAllocator::default();
 
             allocator.scope(|| {
                 let mut vec = swc_allocator::vec::Vec::new();
@@ -56,7 +56,7 @@ fn bench_alloc(c: &mut Criterion) {
 
     fn fast_alloc_scoped(b: &mut Bencher, times: usize) {
         b.iter(|| {
-            MemorySpace::default().scope(|| {
+            SwcAllocator::default().scope(|| {
                 let allocator = FastAlloc::default();
 
                 let mut vec = allocator.vec();

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -13,17 +13,16 @@ pub struct SwcAllocator(MemorySpace);
 impl SwcAllocator {
     /// Invokes `f` in a scope where the allocations are done in this allocator.
     #[inline(always)]
-    pub fn scope<F, R>(&self, f: F) -> R
+    pub fn scope<'a, F, R>(&'a self, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        ALLOC.set(
-            unsafe {
-                // Safery: We are using a scoped API
-                transmute::<&SwcAllocator, &&'static SwcAllocator>(&self)
-            },
-            f,
-        )
+        let s = unsafe {
+            // Safery: We are using a scoped API
+            transmute::<&'a SwcAllocator, &'static SwcAllocator>(self)
+        };
+
+        ALLOC.set(&s, f)
     }
 }
 

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -2,43 +2,46 @@ use std::{alloc::Layout, ptr::NonNull};
 
 use allocator_api2::alloc::Global;
 use scoped_tls::scoped_thread_local;
+use triomphe::Arc;
 
 use crate::{FastAlloc, MemorySpace};
 
-scoped_thread_local!(pub(crate) static ALLOC: MemorySpace);
+scoped_thread_local!(pub(crate) static ALLOC: SwcAllocator);
 
-#[derive(Debug, Clone, Copy)]
-pub struct SwcAlloc {
-    pub(crate) is_arena_mode: bool,
+#[derive(Clone, Default)]
+pub struct SwcAllocator(Arc<MemorySpace>);
+
+impl SwcAllocator {
+    /// Invokes `f` in a scope where the allocations are done in this allocator.
+    #[inline(always)]
+    pub fn scope<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        ALLOC.set(self, f)
+    }
 }
 
 impl Default for FastAlloc {
     fn default() -> Self {
         Self {
-            is_arena_mode: ALLOC.is_set(),
+            alloc: if ALLOC.is_set() {
+                Some(ALLOC.with(|v| v.clone()))
+            } else {
+                None
+            },
         }
     }
 }
 
-impl Default for SwcAlloc {
-    fn default() -> Self {
-        SwcAlloc {
-            is_arena_mode: ALLOC.is_set(),
-        }
-    }
-}
-
-impl SwcAlloc {
+impl FastAlloc {
     /// `true` is passed to `f` if the box is allocated with a custom allocator.
     fn with_allocator<T>(
         &self,
         f: impl FnOnce(&dyn allocator_api2::alloc::Allocator, bool) -> T,
     ) -> T {
-        if self.is_arena_mode {
-            ALLOC.with(|a| {
-                //
-                f(&&**a as &dyn allocator_api2::alloc::Allocator, true)
-            })
+        if let Some(arena) = &self.alloc {
+            f((&&**arena.0) as &dyn allocator_api2::alloc::Allocator, true)
         } else {
             f(&allocator_api2::alloc::Global, false)
         }
@@ -49,7 +52,7 @@ fn mark_ptr_as_arena_mode(ptr: NonNull<[u8]>) -> NonNull<[u8]> {
     ptr
 }
 
-unsafe impl allocator_api2::alloc::Allocator for SwcAlloc {
+unsafe impl allocator_api2::alloc::Allocator for FastAlloc {
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
         self.with_allocator(|a, is_arena_mode| {
             let ptr = a.allocate(layout)?;
@@ -78,18 +81,13 @@ unsafe impl allocator_api2::alloc::Allocator for SwcAlloc {
     }
 
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        if self.is_arena_mode {
+        if self.alloc.is_some() {
             debug_assert!(
                 ALLOC.is_set(),
                 "Deallocating a pointer allocated with arena mode with a non-arena mode allocator"
             );
 
-            ALLOC.with(|alloc| {
-                unsafe {
-                    // Safety: We are in unsafe fn
-                    (&**alloc).deallocate(ptr, layout)
-                }
-            })
+            self.with_allocator(|alloc, _| alloc.deallocate(ptr, layout))
         } else {
             Global.deallocate(ptr, layout)
         }
@@ -101,16 +99,15 @@ unsafe impl allocator_api2::alloc::Allocator for SwcAlloc {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
-        if self.is_arena_mode {
-            debug_assert!(
-                ALLOC.is_set(),
-                "Growing a pointer allocated with arena mode with a non-arena mode allocator"
-            );
+        self.with_allocator(|alloc, is_arena_mode| {
+            let ptr = alloc.grow(ptr, old_layout, new_layout)?;
 
-            ALLOC.with(|alloc| (&**alloc).grow(ptr, old_layout, new_layout))
-        } else {
-            Global.grow(ptr, old_layout, new_layout)
-        }
+            if is_arena_mode {
+                Ok(mark_ptr_as_arena_mode(ptr))
+            } else {
+                Ok(ptr)
+            }
+        })
     }
 
     unsafe fn grow_zeroed(
@@ -119,16 +116,15 @@ unsafe impl allocator_api2::alloc::Allocator for SwcAlloc {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
-        if self.is_arena_mode {
-            debug_assert!(
-                ALLOC.is_set(),
-                "Growing a pointer allocated with arena mode with a non-arena mode allocator"
-            );
+        self.with_allocator(|alloc, is_arena_mode| {
+            let ptr = alloc.grow_zeroed(ptr, old_layout, new_layout)?;
 
-            ALLOC.with(|alloc| (&**alloc).grow_zeroed(ptr, old_layout, new_layout))
-        } else {
-            Global.grow_zeroed(ptr, old_layout, new_layout)
-        }
+            if is_arena_mode {
+                Ok(mark_ptr_as_arena_mode(ptr))
+            } else {
+                Ok(ptr)
+            }
+        })
     }
 
     unsafe fn shrink(
@@ -137,16 +133,15 @@ unsafe impl allocator_api2::alloc::Allocator for SwcAlloc {
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
-        if self.is_arena_mode {
-            debug_assert!(
-                ALLOC.is_set(),
-                "Shrinking a pointer allocated with arena mode with a non-arena mode allocator"
-            );
+        self.with_allocator(|alloc, is_arena_mode| {
+            let ptr = alloc.shrink(ptr, old_layout, new_layout)?;
 
-            ALLOC.with(|alloc| (&**alloc).shrink(ptr, old_layout, new_layout))
-        } else {
-            Global.shrink(ptr, old_layout, new_layout)
-        }
+            if is_arena_mode {
+                Ok(mark_ptr_as_arena_mode(ptr))
+            } else {
+                Ok(ptr)
+            }
+        })
     }
 
     fn by_ref(&self) -> &Self

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -20,7 +20,7 @@ impl SwcAllocator {
         ALLOC.set(
             unsafe {
                 // Safery: We are using a scoped API
-                transmute::<&_, &'static _>(self)
+                transmute::<&SwcAllocator, &&'static SwcAllocator>(&self)
             },
             f,
         )

--- a/crates/swc_allocator/src/boxed/mod.rs
+++ b/crates/swc_allocator/src/boxed/mod.rs
@@ -7,7 +7,7 @@ use std::{
     pin::Pin,
 };
 
-use crate::{alloc::SwcAlloc, FastAlloc};
+use crate::FastAlloc;
 
 #[cfg(feature = "rkyv")]
 mod rkyv;
@@ -23,7 +23,7 @@ mod serde;
 /// The last bit is 1 if the box is allocated with a custom allocator.
 #[repr(transparent)]
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Box<T: ?Sized>(pub(crate) allocator_api2::boxed::Box<T, SwcAlloc>);
+pub struct Box<T: ?Sized>(pub(crate) allocator_api2::boxed::Box<T, FastAlloc>);
 
 impl<T> From<T> for Box<T> {
     #[inline(always)]
@@ -32,9 +32,9 @@ impl<T> From<T> for Box<T> {
     }
 }
 
-impl<T: ?Sized> From<allocator_api2::boxed::Box<T, SwcAlloc>> for Box<T> {
+impl<T: ?Sized> From<allocator_api2::boxed::Box<T, FastAlloc>> for Box<T> {
     #[inline(always)]
-    fn from(v: allocator_api2::boxed::Box<T, SwcAlloc>) -> Self {
+    fn from(v: allocator_api2::boxed::Box<T, FastAlloc>) -> Self {
         Box(v)
     }
 }
@@ -56,7 +56,7 @@ impl<T> Box<T> {
     pub fn new(value: T) -> Self {
         Self(allocator_api2::boxed::Box::new_in(
             value,
-            SwcAlloc::default(),
+            FastAlloc::default(),
         ))
     }
 
@@ -111,7 +111,7 @@ impl<T: ?Sized> Box<T> {
     pub unsafe fn from_raw(raw: *mut T) -> Self {
         Self(allocator_api2::boxed::Box::from_raw_in(
             raw,
-            SwcAlloc::default(),
+            FastAlloc::default(),
         ))
     }
 
@@ -629,7 +629,7 @@ where
 }
 
 impl FastAlloc {
-    pub fn alloc<T>(self, t: T) -> Box<T> {
-        Box(allocator_api2::boxed::Box::new_in(t, self.swc_alloc()))
+    pub fn alloc<T>(&self, t: T) -> Box<T> {
+        Box(allocator_api2::boxed::Box::new_in(t, self.clone()))
     }
 }

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -4,7 +4,7 @@
 
 #![allow(clippy::needless_doctest_main)]
 
-use alloc::SwcAlloc;
+use alloc::SwcAllocator;
 use std::ops::{Deref, DerefMut};
 
 use bumpalo::Bump;
@@ -15,33 +15,14 @@ mod alloc;
 pub mod boxed;
 pub mod vec;
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Clone)]
 pub struct FastAlloc {
-    is_arena_mode: bool,
-}
-
-impl FastAlloc {
-    fn swc_alloc(self) -> SwcAlloc {
-        SwcAlloc {
-            is_arena_mode: self.is_arena_mode,
-        }
-    }
+    alloc: Option<SwcAllocator>,
 }
 
 #[derive(Default)]
 pub struct MemorySpace {
     alloc: Bump,
-}
-
-impl MemorySpace {
-    /// Invokes `f` in a scope where the allocations are done in this allocator.
-    #[inline(always)]
-    pub fn scope<F, R>(&self, f: F) -> R
-    where
-        F: FnOnce() -> R,
-    {
-        ALLOC.set(self, f)
-    }
 }
 
 impl From<Bump> for MemorySpace {

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -4,12 +4,11 @@
 
 #![allow(clippy::needless_doctest_main)]
 
-use alloc::SwcAllocator;
 use std::ops::{Deref, DerefMut};
 
 use bumpalo::Bump;
 
-use crate::alloc::ALLOC;
+pub use crate::alloc::SwcAllocator;
 
 mod alloc;
 pub mod boxed;
@@ -21,7 +20,7 @@ pub struct FastAlloc {
 }
 
 #[derive(Default)]
-pub struct MemorySpace {
+struct MemorySpace {
     alloc: Bump,
 }
 

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -16,7 +16,7 @@ pub mod vec;
 
 #[derive(Clone)]
 pub struct FastAlloc {
-    alloc: Option<SwcAllocator>,
+    alloc: Option<&'static SwcAllocator>,
 }
 
 #[derive(Default)]

--- a/crates/swc_allocator/src/vec/mod.rs
+++ b/crates/swc_allocator/src/vec/mod.rs
@@ -3,7 +3,7 @@ use std::ops::{Deref, DerefMut};
 #[cfg(feature = "rkyv")]
 mod rkyv;
 
-use crate::{alloc::SwcAlloc, boxed::Box, FastAlloc};
+use crate::{boxed::Box, FastAlloc};
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[repr(transparent)]
@@ -11,7 +11,7 @@ use crate::{alloc::SwcAlloc, boxed::Box, FastAlloc};
     feature = "serde",
     derive(serde_derive::Serialize, serde_derive::Deserialize)
 )]
-pub struct Vec<T>(allocator_api2::vec::Vec<T, SwcAlloc>);
+pub struct Vec<T>(allocator_api2::vec::Vec<T, FastAlloc>);
 
 impl<T> Vec<T> {
     pub fn new() -> Self {
@@ -21,7 +21,7 @@ impl<T> Vec<T> {
     pub fn with_capacity(capacity: usize) -> Self {
         Self(allocator_api2::vec::Vec::with_capacity_in(
             capacity,
-            SwcAlloc::default(),
+            FastAlloc::default(),
         ))
     }
 
@@ -167,13 +167,13 @@ impl<T> Vec<T> {
             ptr,
             length,
             capacity,
-            SwcAlloc::default(),
+            FastAlloc::default(),
         ))
     }
 }
 
 impl<T> Deref for Vec<T> {
-    type Target = allocator_api2::vec::Vec<T, SwcAlloc>;
+    type Target = allocator_api2::vec::Vec<T, FastAlloc>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -188,12 +188,12 @@ impl<T> DerefMut for Vec<T> {
 
 impl<T> Default for Vec<T> {
     fn default() -> Self {
-        Self(allocator_api2::vec::Vec::new_in(SwcAlloc::default()))
+        Self(allocator_api2::vec::Vec::new_in(FastAlloc::default()))
     }
 }
 
 impl<T> IntoIterator for Vec<T> {
-    type IntoIter = allocator_api2::vec::IntoIter<T, SwcAlloc>;
+    type IntoIter = allocator_api2::vec::IntoIter<T, FastAlloc>;
     type Item = T;
 
     fn into_iter(self) -> Self::IntoIter {
@@ -245,14 +245,14 @@ impl<T> Extend<T> for Vec<T> {
 }
 
 impl FastAlloc {
-    pub fn vec<T>(self) -> Vec<T> {
-        Vec(allocator_api2::vec::Vec::new_in(self.swc_alloc()))
+    pub fn vec<T>(&self) -> Vec<T> {
+        Vec(allocator_api2::vec::Vec::new_in(self.clone()))
     }
 
-    pub fn vec_with_capacity<T>(self, capacity: usize) -> Vec<T> {
+    pub fn vec_with_capacity<T>(&self, capacity: usize) -> Vec<T> {
         Vec(allocator_api2::vec::Vec::with_capacity_in(
             capacity,
-            self.swc_alloc(),
+            self.clone(),
         ))
     }
 }

--- a/crates/swc_allocator/tests/apis.rs
+++ b/crates/swc_allocator/tests/apis.rs
@@ -1,5 +1,5 @@
 use criterion::black_box;
-use swc_allocator::MemorySpace;
+use swc_allocator::SwcAllocator;
 
 #[test]
 fn direct_alloc_std() {
@@ -22,7 +22,7 @@ fn direct_alloc_no_scope() {
 
 #[test]
 fn direct_alloc_in_scope() {
-    let allocator = MemorySpace::default();
+    let allocator = SwcAllocator::default();
 
     allocator.scope(|| {
         let mut vec = swc_allocator::vec::Vec::new();


### PR DESCRIPTION
**Description:**

This is a part of https://github.com/swc-project/swc/pull/9230. I profiled the performance, and `thread_local` took too long to get the address of the thread-local variable. So, I inlined the reference into the allocator.

# Benchmark result

```

Gnuplot not found, using plotters backend
common/allocator/alloc/std/1000000
                        time:   [4.9478 ms 4.9653 ms 4.9922 ms]
Found 17 outliers among 100 measurements (17.00%)
  4 (4.00%) high mild
  13 (13.00%) high severe

common/allocator/alloc/no-scope/1000000
                        time:   [5.4821 ms 5.4938 ms 5.5068 ms]
Found 17 outliers among 100 measurements (17.00%)
  2 (2.00%) high mild
  15 (15.00%) high severe

common/allocator/alloc/scoped/1000000
                        time:   [3.1401 ms 3.1456 ms 3.1518 ms]
Found 12 outliers among 100 measurements (12.00%)
  3 (3.00%) high mild
  9 (9.00%) high severe

common/allocator/alloc/cached-no-scope/1000000
                        time:   [5.0992 ms 5.1090 ms 5.1198 ms]
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe

common/allocator/alloc/cached-scoped/1000000
                        time:   [3.0191 ms 3.0230 ms 3.0273 ms]
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) low mild
  1 (1.00%) high mild
  8 (8.00%) high severe
```

