### PR TITLE
perf(allocator): Drop `scoped_tls`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3706,7 +3706,6 @@ dependencies = [
  "criterion",
  "ptr_meta",
  "rkyv",
- "scoped-tls",
  "serde",
  "serde_derive",
  "swc_malloc",

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Also, SWC tries to ensure that
 
 for rust users.
 
-MSRV of crates is currently `1.71`.
+MSRV of crates is currently `1.73`.
 
 To update all SWC crates you use, you can run `curl https://raw.githubusercontent.com/swc-project/swc/main/scripts/update-all-swc-crates.sh | bash -s`. This script will update all dependencies to the latest version and run `cargo build` to ensure that everything works.
 Note that you need

--- a/clippy.toml
+++ b/clippy.toml
@@ -22,5 +22,5 @@ ignore-interior-mutability = [
   "swc_atoms::JsWord",
   "swc_ecma_ast::Id",
 ]
-msrv = "1.71"
+msrv = "1.73"
 type-complexity-threshold = 25000

--- a/crates/swc_allocator/Cargo.toml
+++ b/crates/swc_allocator/Cargo.toml
@@ -21,7 +21,6 @@ bumpalo = { workspace = true, features = [
 ] }
 ptr_meta = { workspace = true }
 rkyv = { workspace = true, optional = true }
-scoped-tls = { workspace = true }
 serde = { workspace = true, optional = true }
 serde_derive = { workspace = true, optional = true }
 triomphe = "0.1.13"

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -1,11 +1,12 @@
-use std::{alloc::Layout, mem::transmute, ptr::NonNull};
+use std::{alloc::Layout, cell::Cell, mem::transmute, ptr::NonNull};
 
 use allocator_api2::alloc::Global;
-use scoped_tls::scoped_thread_local;
 
 use crate::{FastAlloc, MemorySpace};
 
-scoped_thread_local!(pub(crate) static ALLOC: &'static SwcAllocator);
+thread_local! {
+  static ALLOC: Cell<Option<&'static SwcAllocator>> = const { Cell::new(None) };
+}
 
 #[derive(Default)]
 pub struct SwcAllocator(MemorySpace);
@@ -22,15 +23,18 @@ impl SwcAllocator {
             transmute::<&'a SwcAllocator, &'static SwcAllocator>(self)
         };
 
-        ALLOC.set(&s, f)
+        ALLOC.set(Some(s));
+        let ret = f();
+        ALLOC.set(None);
+        ret
     }
 }
 
 impl Default for FastAlloc {
     fn default() -> Self {
         Self {
-            alloc: if ALLOC.is_set() {
-                Some(ALLOC.with(|v| *v))
+            alloc: if let Some(v) = ALLOC.get() {
+                Some(v)
             } else {
                 None
             },
@@ -87,7 +91,7 @@ unsafe impl allocator_api2::alloc::Allocator for FastAlloc {
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         if self.alloc.is_some() {
             debug_assert!(
-                ALLOC.is_set(),
+                ALLOC.get().is_some(),
                 "Deallocating a pointer allocated with arena mode with a non-arena mode allocator"
             );
 


### PR DESCRIPTION
**Description:**

The performance is much better without it.