### PR TITLE
feat(allocator): Implement `default` mode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,12 +28,14 @@
         // We use this to make IDE faster
         "rust-analyzer",
         "rkyv-impl",
-        "debug"
+        "debug",
+        "scoped"
     ],
     "rust-analyzer.cargo.features": [
         // We use this to make IDE faster
         "rust-analyzer",
         "rkyv-impl",
-        "debug"
+        "debug",
+        "scoped"
     ]
 }

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -72,6 +72,7 @@ impl FastAlloc {
 
     /// `true` is passed to `f` if the box is allocated with a custom allocator.
     #[cfg(not(feature = "scoped"))]
+    #[inline(always)]
     fn with_allocator<T>(&self, f: impl FnOnce(allocator_api2::alloc::Global, bool) -> T) -> T {
         f(allocator_api2::alloc::Global, false)
     }
@@ -82,6 +83,7 @@ fn mark_ptr_as_arena_mode(ptr: NonNull<[u8]>) -> NonNull<[u8]> {
 }
 
 unsafe impl allocator_api2::alloc::Allocator for FastAlloc {
+    #[inline]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, allocator_api2::alloc::AllocError> {
         self.with_allocator(|a, is_arena_mode| {
             let ptr = a.allocate(layout)?;
@@ -94,6 +96,7 @@ unsafe impl allocator_api2::alloc::Allocator for FastAlloc {
         })
     }
 
+    #[inline]
     fn allocate_zeroed(
         &self,
         layout: Layout,
@@ -109,6 +112,7 @@ unsafe impl allocator_api2::alloc::Allocator for FastAlloc {
         })
     }
 
+    #[inline]
     unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
         #[cfg(feature = "scoped")]
         if self.alloc.is_some() {
@@ -124,6 +128,7 @@ unsafe impl allocator_api2::alloc::Allocator for FastAlloc {
         Global.deallocate(ptr, layout)
     }
 
+    #[inline]
     unsafe fn grow(
         &self,
         ptr: NonNull<u8>,
@@ -141,6 +146,7 @@ unsafe impl allocator_api2::alloc::Allocator for FastAlloc {
         })
     }
 
+    #[inline]
     unsafe fn grow_zeroed(
         &self,
         ptr: NonNull<u8>,
@@ -158,6 +164,7 @@ unsafe impl allocator_api2::alloc::Allocator for FastAlloc {
         })
     }
 
+    #[inline]
     unsafe fn shrink(
         &self,
         ptr: NonNull<u8>,
@@ -175,6 +182,7 @@ unsafe impl allocator_api2::alloc::Allocator for FastAlloc {
         })
     }
 
+    #[inline(always)]
     fn by_ref(&self) -> &Self
     where
         Self: Sized,

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -55,11 +55,11 @@ impl Default for FastAlloc {
 
 impl FastAlloc {
     /// `true` is passed to `f` if the box is allocated with a custom allocator.
+    #[cfg(feature = "scoped")]
     fn with_allocator<T>(
         &self,
         f: impl FnOnce(&dyn allocator_api2::alloc::Allocator, bool) -> T,
     ) -> T {
-        #[cfg(feature = "scoped")]
         if let Some(arena) = &self.alloc {
             return f(
                 (&&arena.alloc) as &dyn allocator_api2::alloc::Allocator,
@@ -68,6 +68,12 @@ impl FastAlloc {
         }
 
         f(&allocator_api2::alloc::Global, false)
+    }
+
+    /// `true` is passed to `f` if the box is allocated with a custom allocator.
+    #[cfg(not(feature = "scoped"))]
+    fn with_allocator<T>(&self, f: impl FnOnce(allocator_api2::alloc::Global, bool) -> T) -> T {
+        f(allocator_api2::alloc::Global, false)
     }
 }
 

--- a/crates/swc_allocator/src/alloc.rs
+++ b/crates/swc_allocator/src/alloc.rs
@@ -61,11 +61,10 @@ impl FastAlloc {
     ) -> T {
         #[cfg(feature = "scoped")]
         if let Some(arena) = &self.alloc {
-            f(
+            return f(
                 (&&arena.alloc) as &dyn allocator_api2::alloc::Allocator,
                 true,
             );
-            return;
         }
 
         f(&allocator_api2::alloc::Global, false)

--- a/crates/swc_allocator/src/boxed/mod.rs
+++ b/crates/swc_allocator/src/boxed/mod.rs
@@ -252,12 +252,14 @@ impl<T: ?Sized> BorrowMut<T> for Box<T> {
 impl<T: ?Sized> Deref for Box<T> {
     type Target = T;
 
+    #[inline(always)]
     fn deref(&self) -> &T {
         &self.0
     }
 }
 
 impl<T: ?Sized> DerefMut for Box<T> {
+    #[inline(always)]
     fn deref_mut(&mut self) -> &mut T {
         &mut self.0
     }

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -5,6 +5,7 @@
 #![allow(clippy::needless_doctest_main)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(missing_docs)]
+#![allow(clippy::derivable_impls)]
 
 pub use crate::alloc::Allocator;
 
@@ -34,5 +35,6 @@ pub mod vec;
 /// original types.
 #[derive(Clone, Copy)]
 pub struct FastAlloc {
+    #[cfg(feature = "scoped")]
     alloc: Option<&'static Allocator>,
 }

--- a/crates/swc_allocator/src/lib.rs
+++ b/crates/swc_allocator/src/lib.rs
@@ -1,6 +1,29 @@
 //! Allocator for swc.
 //!
-//! API designed after [`oxc_allocator`](https://github.com/oxc-project/oxc/tree/725571aad193ec6ba779c820baeb4a7774533ed7/crates/oxc_allocator/src).
+//! # Features
+//!
+//! - `scoped`: Enable `scoped` mode.
+//!
+//! # Modes
+//!
+//! ## Default mode
+//!
+//! In default mode, [crate::boxed::Box] and [crate::vec::Vec] are identical to
+//! the original types in [std].
+//!
+//! ## Scoped mode
+//!
+//! - You need to enable `scoped` feature to use this mode.
+//!
+//! In `scoped` mode you can use [FastAlloc] to make [crate::boxed::Box] and
+//! [crate::vec::Vec] very fast.
+//!
+//! In this mode, you need to be careful while using [crate::boxed::Box] and
+//! [crate::vec::Vec]. Be sure to use same [Allocator] for allocation and
+//! deallocation.
+//!
+//! Recommened way to use this mode is to wrap the whole operations in
+//! a call to [Allocator::scope].
 
 #![allow(clippy::needless_doctest_main)]
 #![cfg_attr(docsrs, feature(doc_cfg))]

--- a/crates/swc_allocator/src/vec/mod.rs
+++ b/crates/swc_allocator/src/vec/mod.rs
@@ -279,12 +279,14 @@ impl<T> Vec<T> {
 impl<T> Deref for Vec<T> {
     type Target = allocator_api2::vec::Vec<T, FastAlloc>;
 
+    #[inline(always)]
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
 impl<T> DerefMut for Vec<T> {
+    #[inline(always)]
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.0
     }


### PR DESCRIPTION
**Description:**

In the default mode, `Box<T>` and `Vec<T>` should work just like them from std.

**Related issue:**

 - This PR is part of https://github.com/swc-project/swc/pull/9230