### PR TITLE
refactor(allocator): Use RAII guard instead of `scope`

### DIFF
--- a/crates/swc_allocator/benches/bench.rs
+++ b/crates/swc_allocator/benches/bench.rs
@@ -39,30 +39,30 @@ fn bench_alloc(c: &mut Criterion) {
     fn direct_alloc_scoped(b: &mut Bencher, times: usize) {
         b.iter(|| {
             let allocator = Allocator::default();
+            let _guard = unsafe { allocator.guard() };
 
-            allocator.scope(|| {
-                let mut vec = SwcVec::new();
+            let mut vec = SwcVec::new();
 
-                for i in 0..times {
-                    let item: SwcBox<usize> = black_box(SwcBox::new(black_box(i)));
-                    vec.push(item);
-                }
-            });
+            for i in 0..times {
+                let item: SwcBox<usize> = black_box(SwcBox::new(black_box(i)));
+                vec.push(item);
+            }
         })
     }
 
     fn fast_alloc_scoped(b: &mut Bencher, times: usize) {
         b.iter(|| {
-            Allocator::default().scope(|| {
-                let alloc = FastAlloc::default();
+            let alloc = Allocator::default();
+            let _guard = unsafe { alloc.guard() };
 
-                let mut vec = SwcVec::new_in(alloc);
+            let alloc = FastAlloc::default();
 
-                for i in 0..times {
-                    let item: SwcBox<usize> = black_box(SwcBox::new_in(black_box(i), alloc));
-                    vec.push(item);
-                }
-            });
+            let mut vec = SwcVec::new_in(alloc);
+
+            for i in 0..times {
+                let item: SwcBox<usize> = black_box(SwcBox::new_in(black_box(i), alloc));
+                vec.push(item);
+            }
         })
     }
 

--- a/crates/swc_allocator/src/vec/mod.rs
+++ b/crates/swc_allocator/src/vec/mod.rs
@@ -1,6 +1,9 @@
 //! Faster vec type.
 
-use std::ops::{Deref, DerefMut};
+use std::{
+    fmt, io,
+    ops::{Deref, DerefMut},
+};
 
 #[cfg(feature = "rkyv")]
 mod rkyv;
@@ -347,5 +350,34 @@ impl<T> From<Vec<T>> for Box<[T]> {
 impl<T> Extend<T> for Vec<T> {
     fn extend<I: IntoIterator<Item = T>>(&mut self, iter: I) {
         self.0.extend(iter)
+    }
+}
+
+impl io::Write for Vec<u8> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        io::Write::write(&mut self.0, buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        io::Write::flush(&mut self.0)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> io::Result<()> {
+        io::Write::write_all(&mut self.0, buf)
+    }
+
+    fn write_vectored(&mut self, bufs: &[io::IoSlice<'_>]) -> io::Result<usize> {
+        io::Write::write_vectored(&mut self.0, bufs)
+    }
+
+    fn write_fmt(&mut self, fmt: fmt::Arguments<'_>) -> io::Result<()> {
+        io::Write::write_fmt(&mut self.0, fmt)
+    }
+
+    fn by_ref(&mut self) -> &mut Self
+    where
+        Self: Sized,
+    {
+        self
     }
 }

--- a/crates/swc_allocator/tests/apis.rs
+++ b/crates/swc_allocator/tests/apis.rs
@@ -23,14 +23,13 @@ fn direct_alloc_no_scope() {
 #[test]
 fn direct_alloc_in_scope() {
     let allocator = Allocator::default();
+    let _guard = unsafe { allocator.guard() };
 
-    allocator.scope(|| {
-        let mut vec = swc_allocator::vec::Vec::new();
+    let mut vec = swc_allocator::vec::Vec::new();
 
-        for i in 0..1000 {
-            let item: swc_allocator::boxed::Box<usize> =
-                black_box(swc_allocator::boxed::Box::new(black_box(i)));
-            vec.push(item);
-        }
-    });
+    for i in 0..1000 {
+        let item: swc_allocator::boxed::Box<usize> =
+            black_box(swc_allocator::boxed::Box::new(black_box(i)));
+        vec.push(item);
+    }
 }

--- a/crates/swc_allocator/tests/escape.rs
+++ b/crates/swc_allocator/tests/escape.rs
@@ -4,7 +4,10 @@ use swc_allocator::{boxed::Box, Allocator, FastAlloc};
 fn escape() {
     let allocator = Allocator::default();
 
-    let obj = allocator.scope(|| Box::new(1234));
+    let obj = {
+        let _guard = unsafe { allocator.guard() };
+        Box::new(1234)
+    };
 
     assert_eq!(*obj, 1234);
     // It should not segfault, because the allocator is still alive.
@@ -14,8 +17,10 @@ fn escape() {
 #[test]
 fn global_allocator() {
     let allocator = Allocator::default();
-
-    let obj = allocator.scope(|| Box::new_in(1234, FastAlloc::global()));
+    let obj = {
+        let _guard = unsafe { allocator.guard() };
+        Box::new_in(1234, FastAlloc::global())
+    };
 
     assert_eq!(*obj, 1234);
     drop(allocator);


### PR DESCRIPTION
**Description:**


**Related issue:**

- https://github.com/swc-project/swc/issues/9253