### PR TITLE
fix(es/minifier): Collect raw str values for new Tpl element

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/pure/strings.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/strings.rs
@@ -127,8 +127,8 @@ impl Pure<'_> {
         for idx in 0..(tpl.quasis.len() + tpl.exprs.len()) {
             if idx % 2 == 0 {
                 let q = tpl.quasis[idx / 2].take();
-
-                cur_cooked_str.push_str(q.cooked.as_deref().unwrap_or(&*q.raw));
+                
+                cur_cooked_str.push_str(&Str::from_tpl_raw(&q.raw));
                 cur_raw_str.push_str(&q.raw);
             } else {
                 let mut e = tpl.exprs[idx / 2].take();
@@ -143,7 +143,7 @@ impl Pure<'_> {
                             if idx % 2 == 0 {
                                 let q = e.quasis[idx / 2].take();
 
-                                cur_cooked_str.push_str(q.cooked.as_deref().unwrap_or(&*q.raw));
+                                cur_cooked_str.push_str(Str::from_tpl_raw(&q.raw).as_ref());
                                 cur_raw_str.push_str(&q.raw);
                             } else {
                                 let cooked = Atom::from(&*cur_cooked_str);

--- a/crates/swc_ecma_minifier/src/compress/pure/strings.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/strings.rs
@@ -121,13 +121,13 @@ impl Pure<'_> {
             quasis: Default::default(),
             exprs: Default::default(),
         };
-        let mut cur_str_value = String::new();
+        let mut cur_cooked_str = String::new();
 
         for idx in 0..(tpl.quasis.len() + tpl.exprs.len()) {
             if idx % 2 == 0 {
                 let q = tpl.quasis[idx / 2].take();
 
-                cur_str_value.push_str(q.cooked.as_deref().unwrap_or(&*q.raw));
+                cur_cooked_str.push_str(q.cooked.as_deref().unwrap_or(&*q.raw));
             } else {
                 let mut e = tpl.exprs[idx / 2].take();
                 self.eval_nested_tpl(&mut e);
@@ -141,16 +141,17 @@ impl Pure<'_> {
                             if idx % 2 == 0 {
                                 let q = e.quasis[idx / 2].take();
 
-                                cur_str_value.push_str(q.cooked.as_deref().unwrap_or(&*q.raw));
+                                cur_cooked_str.push_str(q.cooked.as_deref().unwrap_or(&*q.raw));
                             } else {
-                                let s = Atom::from(&*cur_str_value);
-                                cur_str_value.clear();
+                                let cooked = Atom::from(&*cur_cooked_str);
+                                let raw = Atom::from(convert_str_value_to_tpl_raw(&cooked));
+                                cur_cooked_str.clear();
 
                                 new_tpl.quasis.push(TplElement {
                                     span: DUMMY_SP,
                                     tail: false,
-                                    cooked: Some(s.clone()),
-                                    raw: s,
+                                    cooked: Some(cooked),
+                                    raw,
                                 });
 
                                 let e = e.exprs[idx / 2].take();
@@ -160,14 +161,15 @@ impl Pure<'_> {
                         }
                     }
                     _ => {
-                        let s = Atom::from(&*cur_str_value);
-                        cur_str_value.clear();
+                        let cooked = Atom::from(&*cur_cooked_str);
+                        let raw = Atom::from(convert_str_value_to_tpl_raw(&cooked));
+                        cur_cooked_str.clear();
 
                         new_tpl.quasis.push(TplElement {
                             span: DUMMY_SP,
                             tail: false,
-                            cooked: Some(s.clone()),
-                            raw: s,
+                            cooked: Some(cooked),
+                            raw,
                         });
 
                         new_tpl.exprs.push(e);
@@ -176,12 +178,13 @@ impl Pure<'_> {
             }
         }
 
-        let s = Atom::from(&*cur_str_value);
+        let cooked = Atom::from(&*cur_cooked_str);
+        let raw = Atom::from(convert_str_value_to_tpl_raw(&cooked));
         new_tpl.quasis.push(TplElement {
             span: DUMMY_SP,
             tail: false,
-            cooked: Some(s.clone()),
-            raw: s,
+            cooked: Some(cooked),
+            raw,
         });
 
         *e = new_tpl.into();

--- a/crates/swc_ecma_minifier/src/compress/pure/strings.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/strings.rs
@@ -122,12 +122,14 @@ impl Pure<'_> {
             exprs: Default::default(),
         };
         let mut cur_cooked_str = String::new();
+        let mut cur_raw_str = String::new();
 
         for idx in 0..(tpl.quasis.len() + tpl.exprs.len()) {
             if idx % 2 == 0 {
                 let q = tpl.quasis[idx / 2].take();
 
                 cur_cooked_str.push_str(q.cooked.as_deref().unwrap_or(&*q.raw));
+                cur_raw_str.push_str(&q.raw);
             } else {
                 let mut e = tpl.exprs[idx / 2].take();
                 self.eval_nested_tpl(&mut e);
@@ -142,10 +144,12 @@ impl Pure<'_> {
                                 let q = e.quasis[idx / 2].take();
 
                                 cur_cooked_str.push_str(q.cooked.as_deref().unwrap_or(&*q.raw));
+                                cur_raw_str.push_str(&q.raw);
                             } else {
                                 let cooked = Atom::from(&*cur_cooked_str);
-                                let raw = Atom::from(convert_str_value_to_tpl_raw(&cooked));
+                                let raw = Atom::from(&*cur_raw_str);
                                 cur_cooked_str.clear();
+                                cur_raw_str.clear();
 
                                 new_tpl.quasis.push(TplElement {
                                     span: DUMMY_SP,
@@ -162,8 +166,9 @@ impl Pure<'_> {
                     }
                     _ => {
                         let cooked = Atom::from(&*cur_cooked_str);
-                        let raw = Atom::from(convert_str_value_to_tpl_raw(&cooked));
+                        let raw = Atom::from(&*cur_raw_str);
                         cur_cooked_str.clear();
+                        cur_raw_str.clear();
 
                         new_tpl.quasis.push(TplElement {
                             span: DUMMY_SP,
@@ -179,7 +184,7 @@ impl Pure<'_> {
         }
 
         let cooked = Atom::from(&*cur_cooked_str);
-        let raw = Atom::from(convert_str_value_to_tpl_raw(&cooked));
+        let raw = Atom::from(&*cur_raw_str);
         new_tpl.quasis.push(TplElement {
             span: DUMMY_SP,
             tail: false,

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -11333,5 +11333,5 @@ fn issue_9184() {
         let pi= Math.random() >1.1 ? "foo": "bar";
         console.log(`(${`${pi}`} - ${`\\*${pi}`})`)
 "#,
-    ); 
+    );
 }

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -11325,3 +11325,13 @@ fn issue_9010() {
         "#,
     );
 }
+
+#[test]
+fn issue_9184() {
+    run_default_exec_test(
+        r#"
+        let pi= Math.random() >1.1 ? "foo": "bar";
+        console.log(`(${`${pi}`} - ${`\\*${pi}`})`)
+"#,
+    ); 
+}

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -11335,3 +11335,13 @@ fn issue_9184() {
 "#,
     );
 }
+
+#[test]
+fn issue_9184_2() {
+    run_default_exec_test(
+        r#"
+        let pi= Math.random() < -1 ? "foo": "bar";
+        console.log(`(${`${pi}`} - ${`\\*${pi}`})`)
+"#,
+    );
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
convert `raw` value  to `cooked` for creating new Tpl element.

<del>
while optimizing nested tpl, after concatenating some cooked strs to assemble a new tpl element,
the `raw` of the tpl should be escaped cooked string value.
</del>


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

None
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
https://github.com/swc-project/swc/issues/9184