### PR TITLE
refactor(allocator): Feature gate `nightly`

### DIFF
--- a/crates/swc_allocator/Cargo.toml
+++ b/crates/swc_allocator/Cargo.toml
@@ -17,7 +17,7 @@ version       = "0.1.6"
 default = ["scoped"]
 nightly = []
 rkyv    = ["dep:rkyv"]
-scoped  = []
+scoped  = ["nightly"]
 serde   = ["dep:serde", "dep:serde_derive"]
 
 [dependencies]

--- a/crates/swc_allocator/Cargo.toml
+++ b/crates/swc_allocator/Cargo.toml
@@ -15,6 +15,7 @@ version       = "0.1.6"
 
 [features]
 default = ["scoped"]
+nightly = []
 rkyv    = ["dep:rkyv"]
 scoped  = []
 serde   = ["dep:serde", "dep:serde_derive"]


### PR DESCRIPTION
**Description:**

Feature gate `nightly`, and make it **really identical to types from `std`** if it's not enabled.

We need to use `#[fundamental]` for `swc_allocator::boxed::Box`. Without it, it will be very hard to use the type. But it's not stabilized. So we feature gate them under a cargo feature flag.


**Related issue:**

 - Blocks https://github.com/swc-project/swc/pull/9262