### PR TITLE
fix(es/utils): Use `$crate` for `quote_ident!()`

### DIFF
--- a/.changeset/unlucky-planets-laugh.md
+++ b/.changeset/unlucky-planets-laugh.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_utils: patch
+swc_core: patch
+---
+
+fix(es/utils): Use `$crate` for `quote_ident!()`

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  merge_group:
   pull_request:
     types: ["opened", "reopened", "synchronize"]
   push:

--- a/crates/swc_ecma_utils/src/macros.rs
+++ b/crates/swc_ecma_utils/src/macros.rs
@@ -24,7 +24,7 @@ macro_rules! quote_ident {
     ($ctxt:expr, $s:expr) => {{
         let sym: $crate::swc_atoms::Atom = $s.into();
         let id: $crate::swc_ecma_ast::Ident =
-            $crate::swc_ecma_ast::Ident::new(sym, DUMMY_SP, $ctxt);
+            $crate::swc_ecma_ast::Ident::new(sym, $crate::swc_common::DUMMY_SP, $ctxt);
 
         id
     }};


### PR DESCRIPTION
**Related issue:**

  - Closes https://github.com/swc-project/swc/issues/9299