### PR TITLE
fix(swc_core): Remove unused `preset_env`

### DIFF
--- a/.changeset/rare-brooms-serve.md
+++ b/.changeset/rare-brooms-serve.md
@@ -1,0 +1,5 @@
+---
+swc_core: patch
+---
+
+fix: remove unused preset env usage

--- a/crates/swc_core/src/lib.rs
+++ b/crates/swc_core/src/lib.rs
@@ -32,12 +32,6 @@ pub extern crate swc_ecma_quote_macros;
 )]
 pub mod plugin;
 
-#[cfg(feature = "ecma_preset_env")]
-#[cfg_attr(docsrs, doc(cfg(feature = "preset_env")))]
-pub mod preset_env {
-    pub use preset_env_base::*;
-}
-
 #[cfg(feature = "__ecma")]
 #[cfg_attr(docsrs, doc(cfg(feature = "__ecma")))]
 pub mod ecma {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

While upgrading to 0.99.4, we encounter a compile error with the `ecma_preset_env` feature on `swc_core`. Seems that the preset_env_base package is not a dependency of [swc_core](https://github.com/swc-project/swc/blob/95af17ff917a6ec3d1420f6bc089585f89a8cd31/crates/swc_core/Cargo.toml#L336-L387)

[Repro](https://github.com/LingyuCoder/swc-ecma-preset-env-error)

**Related issue (if exists):**
