### PR TITLE
fix(es/codegen): Emit question token for class methods

### DIFF
--- a/.changeset/tall-cooks-speak.md
+++ b/.changeset/tall-cooks-speak.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_codegen: patch
+swc_ecma_transforms_typescript: patch
+---
+
+fix(es/codegen): Emit question token for class methods

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1599,6 +1599,10 @@ where
             }
         }
 
+        if n.is_optional {
+            punct!("?");
+        }
+
         if let Some(type_params) = &n.function.type_params {
             emit!(type_params);
         }

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_method/input.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_method/input.js
@@ -1,5 +1,5 @@
 class MyClass extends Base {
     public override method(param: number): string {
     }
-    public abstract override log(msg: string): void;
+    public abstract override log?<TValue>(msg: string): TValue;
 }

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_method/output.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_method/output.js
@@ -1,4 +1,4 @@
 class MyClass extends Base {
     public override method(param: number): string {}
-    public abstract override log(msg: string): void;
+    public abstract override log?<TValue>(msg: string): TValue;
 }

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_method/output.min.js
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_method/output.min.js
@@ -1,1 +1,1 @@
-class MyClass extends Base{public override method(param:number):string{}public abstract override log(msg:string):void}
+class MyClass extends Base{public override method(param:number):string{}public abstract override log?<TValue>(msg:string):TValue}

--- a/crates/swc_ecma_transforms_typescript/src/strip_type.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip_type.rs
@@ -84,6 +84,7 @@ impl VisitMut for StripType {
         n.accessibility = None;
         n.is_override = false;
         n.is_abstract = false;
+        n.is_optional = false;
         n.visit_mut_children_with(self);
     }
 


### PR DESCRIPTION
I'm in the process of upgrading swc and stumbled on this one.

**Description:** Regression in emitting class methods that are optional.

**Related issue (if exists):** None
