### PR TITLE
fix(es/parser): Fix span for unterminated block comments

### DIFF
--- a/.changeset/large-glasses-move.md
+++ b/.changeset/large-glasses-move.md
@@ -1,0 +1,6 @@
+---
+swc_common: patch
+swc_ecma_parser: patch
+---
+
+fix(es/parser): Fix span for unterminated block comments

--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -49,6 +49,14 @@ impl<'a> StringInput<'a> {
             self.reset_to(self.last_pos + BytePos(n as u32));
         }
     }
+
+    pub fn start_pos(&self) -> BytePos {
+        self.orig_start
+    }
+
+    pub fn end_pos(&self) -> BytePos {
+        self.last_pos
+    }
 }
 
 /// Creates an [Input] from [SourceFile]. This is an alias for

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -290,7 +290,8 @@ impl<'a> Lexer<'a> {
             self.bump();
         }
 
-        self.emit_error(start, SyntaxError::UnterminatedBlockComment)
+        let span = Span::new(start, self.input.end_pos());
+        self.emit_error_span(span, SyntaxError::UnterminatedBlockComment)
     }
 
     #[inline(never)]


### PR DESCRIPTION
**Description:**


**Related issue:**

 - https://github.com/wooorm/mdxjs-rs/pull/49