### PR TITLE
fix(es/parser): Make `UnterminatedBlockComment` stick to the EOF

### DIFF
--- a/.changeset/thin-cobras-taste.md
+++ b/.changeset/thin-cobras-taste.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): Make `UnterminatedBlockComment` stick to the EOF

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -290,7 +290,8 @@ impl<'a> Lexer<'a> {
             self.bump();
         }
 
-        let span = Span::new(start, self.input.end_pos());
+        let end = self.input.end_pos();
+        let span = Span::new(end, end);
         self.emit_error_span(span, SyntaxError::UnterminatedBlockComment)
     }
 

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/025560435ed0b9a6.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/025560435ed0b9a6.js.swc-stderr
@@ -1,6 +1,4 @@
   x Unterminated block comment
-   ,-[$DIR/tests/test262-parser/fail/025560435ed0b9a6.js:1:1]
- 1 | ,-> /*
- 2 | |   
- 3 | `-> 
+   ,-[$DIR/tests/test262-parser/fail/025560435ed0b9a6.js:3:2]
+ 3 | 
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/100c329e6dd70e5a.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/100c329e6dd70e5a.js.swc-stderr
@@ -1,5 +1,4 @@
   x Unterminated block comment
    ,-[$DIR/tests/test262-parser/fail/100c329e6dd70e5a.js:1:1]
  1 | /* 
-   : ^^^
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/1c6ba8177a9624f0.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/1c6ba8177a9624f0.js.swc-stderr
@@ -1,5 +1,4 @@
   x Unterminated block comment
-   ,-[$DIR/tests/test262-parser/fail/1c6ba8177a9624f0.js:1:1]
+   ,-[$DIR/tests/test262-parser/fail/1c6ba8177a9624f0.js:1:5]
  1 | /*
-   : ^^^
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/65a7e95d594ad7ad.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/65a7e95d594ad7ad.js.swc-stderr
@@ -1,6 +1,5 @@
   x Unterminated block comment
-   ,-[$DIR/tests/test262-parser/fail/65a7e95d594ad7ad.js:1:1]
- 1 | ,-> /*
- 2 | |   
- 3 | `-> *
+   ,-[$DIR/tests/test262-parser/fail/65a7e95d594ad7ad.js:3:1]
+ 2 | 
+ 3 | *
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/766e0153d3f7ec95.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/766e0153d3f7ec95.js.swc-stderr
@@ -1,5 +1,4 @@
   x Unterminated block comment
    ,-[$DIR/tests/test262-parser/fail/766e0153d3f7ec95.js:1:1]
  1 | /*
-   : ^^
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/86308fd40fa95e9d.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/86308fd40fa95e9d.js.swc-stderr
@@ -1,5 +1,4 @@
   x Unterminated block comment
    ,-[$DIR/tests/test262-parser/fail/86308fd40fa95e9d.js:1:1]
  1 | /*hello
-   : ^^^^^^^
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/8d64a30d9de151b6.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/8d64a30d9de151b6.js.swc-stderr
@@ -1,5 +1,4 @@
   x Unterminated block comment
    ,-[$DIR/tests/test262-parser/fail/8d64a30d9de151b6.js:1:1]
  1 | /**
-   : ^^^
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/ac1ee2739ad30d66.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/ac1ee2739ad30d66.js.swc-stderr
@@ -1,5 +1,4 @@
   x Unterminated block comment
    ,-[$DIR/tests/test262-parser/fail/ac1ee2739ad30d66.js:1:1]
  0 | /*
-   : ^^
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/d056300d8658429f.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/d056300d8658429f.js.swc-stderr
@@ -1,5 +1,4 @@
   x Unterminated block comment
    ,-[$DIR/tests/test262-parser/fail/d056300d8658429f.js:1:1]
  1 | /* 
-   : ^^^
    `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/e2cdddda85e8ffe1.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/e2cdddda85e8ffe1.js.swc-stderr
@@ -1,5 +1,4 @@
   x Unterminated block comment
    ,-[$DIR/tests/test262-parser/fail/e2cdddda85e8ffe1.js:1:1]
  1 | /*hello  *
-   : ^^^^^^^^^^
    `----


### PR DESCRIPTION
**Description:**


**Related issue:**

 - https://github.com/wooorm/markdown-rs/pull/120