### PR TITLE
chore: Fix Typo

### DIFF
--- a/bindings/binding_typescript_wasm/README.md
+++ b/bindings/binding_typescript_wasm/README.md
@@ -1,4 +1,4 @@
-# @swc/wasm-tyescript
+# @swc/wasm-typescript
 
 This package provides a Wasm binding for the TypeScript transform.
 


### PR DESCRIPTION
**Description:**

`tyescript` ->  `typescript` !

Found in <https://github.com/nodejs/amaro/tree/main/lib/swc>, <https://www.npmjs.com/package/@swc/wasm-typescript>, ...

**BREAKING CHANGE:**

None

**Related issue (if exists):**

None