### PR TITLE
fix(es/codegen): Print the missing `abstract` in class expression

### DIFF
--- a/.changeset/modern-bears-flash.md
+++ b/.changeset/modern-bears-flash.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_codegen: patch
+---
+
+fix(es/codegen): Print the missing `abstract` in class expression

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1342,6 +1342,11 @@ where
             emit!(dec);
         }
 
+        if node.class.is_abstract {
+            keyword!("abstract");
+            space!();
+        }
+
         keyword!("class");
 
         if let Some(ref i) = node.ident {

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_abstract/input.ts
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_abstract/input.ts
@@ -1,0 +1,7 @@
+export default abstract class Predictor {
+    abstract _type: string;
+}
+
+export abstract class Foo {
+    abstract _type: string;
+}

--- a/crates/swc_ecma_codegen/tests/fixture/typescript/class_abstract/output.ts
+++ b/crates/swc_ecma_codegen/tests/fixture/typescript/class_abstract/output.ts
@@ -1,0 +1,6 @@
+export default abstract class Predictor {
+    abstract _type: string;
+}
+export abstract class Foo {
+    abstract _type: string;
+}


### PR DESCRIPTION
- Closes: #9370