### PR TITLE
fix(es/module): Drop the level of a few tracing events

### DIFF
--- a/.changeset/few-rules-cough.md
+++ b/.changeset/few-rules-cough.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_loader: patch
+---
+
+fix(es/module): drop the priority of a few tracing events

--- a/crates/swc_ecma_loader/src/resolvers/node.rs
+++ b/crates/swc_ecma_loader/src/resolvers/node.rs
@@ -157,7 +157,7 @@ impl NodeModulesResolver {
         let _tracing = if cfg!(debug_assertions) {
             Some(
                 tracing::span!(
-                    Level::ERROR,
+                    Level::TRACE,
                     "resolve_as_file",
                     path = tracing::field::display(path.display())
                 )
@@ -239,7 +239,7 @@ impl NodeModulesResolver {
         let _tracing = if cfg!(debug_assertions) {
             Some(
                 tracing::span!(
-                    Level::ERROR,
+                    Level::TRACE,
                     "resolve_as_directory",
                     path = tracing::field::display(path.display())
                 )
@@ -279,7 +279,7 @@ impl NodeModulesResolver {
         let _tracing = if cfg!(debug_assertions) {
             Some(
                 tracing::span!(
-                    Level::ERROR,
+                    Level::TRACE,
                     "resolve_package_entry",
                     pkg_dir = tracing::field::display(pkg_dir.display()),
                     pkg_path = tracing::field::display(pkg_path.display()),


### PR DESCRIPTION
**Description:**

These events don't represent an error condition -- they're informative -- and they're making our logs a little noisy.