### PR TITLE
fix(common): Require newer version of allocator

### DIFF
--- a/.changeset/three-ways-smell.md
+++ b/.changeset/three-ways-smell.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix(common): Require newer version of allocator

--- a/.changeset/three-ways-smell.md
+++ b/.changeset/three-ways-smell.md
@@ -1,5 +1,6 @@
 ---
-"@fake-scope/fake-pkg": patch
+swc_common: patch
+swc_core: patch
 ---
 
 fix(common): Require newer version of allocator

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -64,7 +64,7 @@ url = { workspace = true }
 ast_node             = { version = "0.9.8", path = "../ast_node" }
 better_scoped_tls    = { version = "0.1.1", path = "../better_scoped_tls" }
 from_variant         = { version = "0.1.8", path = "../from_variant" }
-swc_allocator        = { version = "0.1.1", path = "../swc_allocator", default-features = false }
+swc_allocator        = { version = "0.1.7", path = "../swc_allocator", default-features = false }
 swc_atoms            = { version = "0.6.5", path = "../swc_atoms" }
 swc_eq_ignore_macros = { version = "0.1.3", path = "../swc_eq_ignore_macros" }
 swc_visit            = { version = "0.6.0", path = "../swc_visit" }


### PR DESCRIPTION
[EqIgnoreSpan](https://github.com/swc-project/swc/blob/ec03d1ec54fc7f3acfddbb5061c2f0c75a574e91/crates/swc_common/src/eq.rs#L4) uses the nightly_only macro, which was introduced in version 0.1.7 of swc_allocator. When building with the older version of the allocator, the following error results:

    error[E0432]: unresolved import `swc_allocator::nightly_only`
     --> /home/user/.cargo/registry/.../swc_common-0.36.3/src/eq.rs:4:5
      |
    4 | use swc_allocator::nightly_only;
      |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ no `nightly_only` in the root