### PR TITLE
fix(common): Remove unused import

### DIFF
--- a/.changeset/slow-forks-brake.md
+++ b/.changeset/slow-forks-brake.md
@@ -1,5 +1,6 @@
 ---
-"@fake-scope/fake-pkg": patch
+swc_common: patch
+swc_core: patch
 ---
 
 fix(common): Remove unused import

--- a/.changeset/slow-forks-brake.md
+++ b/.changeset/slow-forks-brake.md
@@ -1,0 +1,5 @@
+---
+"@fake-scope/fake-pkg": patch
+---
+
+fix(common): Remove unused import

--- a/crates/swc_common/src/errors/emitter.rs
+++ b/crates/swc_common/src/errors/emitter.rs
@@ -12,7 +12,7 @@ use std::{
     borrow::Cow,
     cmp::{min, Reverse},
     collections::HashMap,
-    io::{self, prelude::*, IsTerminal},
+    io::{self, prelude::*},
 };
 
 #[cfg(feature = "tty-emitter")]
@@ -116,6 +116,8 @@ pub enum ColorConfig {
 impl ColorConfig {
     #[cfg(feature = "tty-emitter")]
     fn to_color_choice(self) -> ColorChoice {
+        use std::io::IsTerminal;
+
         let stderr = io::stderr();
 
         match self {


### PR DESCRIPTION
Moving the import under the tty-emitter feature fixes the following:

    warning: unused import: `IsTerminal`
      --> /home/user/swc/crates/swc_common/src/errors/emitter.rs:15:28
       |
    15 |     io::{self, prelude::*, IsTerminal},
       |                            ^^^^^^^^^^
       |
       = note: `#[warn(unused_imports)]` on by default