### PR TITLE
fix(es/typescript): Strip exported default overload function declaration

### DIFF
--- a/.changeset/soft-plants-prove.md
+++ b/.changeset/soft-plants-prove.md
@@ -1,0 +1,5 @@
+---
+swc_fast_ts_strip: patch
+---
+
+fix(es/typescript): Strip exported default overload function declaration

--- a/crates/swc_fast_ts_strip/src/lib.rs
+++ b/crates/swc_fast_ts_strip/src/lib.rs
@@ -12,13 +12,13 @@ use swc_common::{
 };
 use swc_ecma_ast::{
     ArrayPat, ArrowExpr, AutoAccessor, BindingIdent, Class, ClassDecl, ClassMethod, ClassProp,
-    Constructor, Decl, DoWhileStmt, EsVersion, ExportAll, ExportDecl, ExportDefaultDecl,
-    ExportSpecifier, FnDecl, ForInStmt, ForOfStmt, ForStmt, IfStmt, ImportDecl, ImportSpecifier,
-    NamedExport, ObjectPat, Param, Pat, PrivateMethod, PrivateProp, Program, Stmt, TsAsExpr,
-    TsConstAssertion, TsEnumDecl, TsExportAssignment, TsImportEqualsDecl, TsIndexSignature,
-    TsInstantiation, TsModuleDecl, TsModuleName, TsNamespaceDecl, TsNonNullExpr, TsParamPropParam,
-    TsSatisfiesExpr, TsTypeAliasDecl, TsTypeAnn, TsTypeAssertion, TsTypeParamDecl,
-    TsTypeParamInstantiation, VarDeclarator, WhileStmt,
+    Constructor, Decl, DefaultDecl, DoWhileStmt, EsVersion, ExportAll, ExportDecl,
+    ExportDefaultDecl, ExportSpecifier, FnDecl, ForInStmt, ForOfStmt, ForStmt, IfStmt, ImportDecl,
+    ImportSpecifier, NamedExport, ObjectPat, Param, Pat, PrivateMethod, PrivateProp, Program, Stmt,
+    TsAsExpr, TsConstAssertion, TsEnumDecl, TsExportAssignment, TsImportEqualsDecl,
+    TsIndexSignature, TsInstantiation, TsModuleDecl, TsModuleName, TsNamespaceDecl, TsNonNullExpr,
+    TsParamPropParam, TsSatisfiesExpr, TsTypeAliasDecl, TsTypeAnn, TsTypeAssertion,
+    TsTypeParamDecl, TsTypeParamInstantiation, VarDeclarator, WhileStmt,
 };
 use swc_ecma_parser::{
     lexer::Lexer,
@@ -775,7 +775,7 @@ impl Visit for TsStrip {
     }
 
     fn visit_export_default_decl(&mut self, n: &ExportDefaultDecl) {
-        if n.decl.is_ts_interface_decl() {
+        if n.decl.is_ts_declare() {
             self.add_replacement(n.span);
             self.fix_asi(n.span);
             return;
@@ -1097,6 +1097,16 @@ impl IsTsDecl for Decl {
 impl IsTsDecl for Stmt {
     fn is_ts_declare(&self) -> bool {
         self.as_decl().map_or(false, IsTsDecl::is_ts_declare)
+    }
+}
+
+impl IsTsDecl for DefaultDecl {
+    fn is_ts_declare(&self) -> bool {
+        match self {
+            Self::Class(..) => false,
+            DefaultDecl::Fn(r#fn) => r#fn.function.body.is_none(),
+            DefaultDecl::TsInterfaceDecl(..) => true,
+        }
     }
 }
 

--- a/crates/swc_fast_ts_strip/tests/tsc/defaultExportWithOverloads01.strip.broken
+++ b/crates/swc_fast_ts_strip/tests/tsc/defaultExportWithOverloads01.strip.broken
@@ -1,7 +1,0 @@
-  x Expected '{', got ';'
-   ,-[$DIR/tests/tsc/defaultExportWithOverloads01.strip.js:4:1]
- 3 | 
- 4 | export default function f();
-   :                            ^
- 5 | export default function f(x        );
-   `----

--- a/crates/swc_fast_ts_strip/tests/tsc/defaultExportWithOverloads01.strip.js
+++ b/crates/swc_fast_ts_strip/tests/tsc/defaultExportWithOverloads01.strip.js
@@ -1,7 +1,0 @@
-// @module: commonjs
-// @target: ES5
-
-export default function f();
-export default function f(x        );
-export default function f(...args       ) {
-}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
