### PR TITLE
feat(html/minifier): Support using custom css minifier

### DIFF
--- a/.changeset/ninety-tips-heal.md
+++ b/.changeset/ninety-tips-heal.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_html: patch
+swc_html_minifier: patch
+---
+
+feat(html/minifier): Support using custom css minifier

--- a/crates/swc_html/Cargo.toml
+++ b/crates/swc_html/Cargo.toml
@@ -24,6 +24,6 @@ minifier = ["swc_html_minifier"]
 [dependencies]
 swc_html_ast      = { version = "0.37.0", path = "../swc_html_ast" }
 swc_html_codegen  = { version = "0.46.0", path = "../swc_html_codegen" }
-swc_html_minifier = { version = "0.143.0", path = "../swc_html_minifier", optional = true }
+swc_html_minifier = { version = "0.143.0", path = "../swc_html_minifier", optional = true, default-features = false }
 swc_html_parser   = { version = "0.43.0", path = "../swc_html_parser" }
 swc_html_visit    = { version = "0.37.0", path = "../swc_html_visit" }

--- a/crates/swc_html_minifier/Cargo.toml
+++ b/crates/swc_html_minifier/Cargo.toml
@@ -15,6 +15,11 @@ version = "0.143.0"
 [lib]
 bench = false
 
+[features]
+default = ["default-css-minifier"]
+default-css-minifier = ["swc_css_ast", "swc_css_codegen", "swc_css_minifier", "swc_css_parser"]
+custom-css-minifier = []
+
 [dependencies]
 once_cell  = { workspace = true }
 serde      = { workspace = true, features = ["derive"] }
@@ -23,10 +28,10 @@ serde_json = { workspace = true }
 swc_atoms = { version = "0.6.5", path = "../swc_atoms" }
 swc_cached = { version = "0.3.19", path = "../swc_cached" }
 swc_common = { version = "0.37.0", path = "../swc_common" }
-swc_css_ast = { version = "0.144.0", path = "../swc_css_ast" }
-swc_css_codegen = { version = "0.155.0", path = "../swc_css_codegen" }
-swc_css_minifier = { version = "0.120.0", path = "../swc_css_minifier" }
-swc_css_parser = { version = "0.154.0", path = "../swc_css_parser" }
+swc_css_ast = { version = "0.144.0", path = "../swc_css_ast", optional = true }
+swc_css_codegen = { version = "0.155.0", path = "../swc_css_codegen", optional = true }
+swc_css_minifier = { version = "0.120.0", path = "../swc_css_minifier", optional = true }
+swc_css_parser = { version = "0.154.0", path = "../swc_css_parser", optional = true }
 swc_ecma_ast = { version = "0.118.0", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "0.155.0", path = "../swc_ecma_codegen", features = [
   "serde-impl",

--- a/crates/swc_html_minifier/src/lib.rs
+++ b/crates/swc_html_minifier/src/lib.rs
@@ -15,12 +15,12 @@ use swc_html_parser::parser::ParserConfig;
 use swc_html_utils::{HTML_ELEMENTS_AND_ATTRIBUTES, SVG_ELEMENTS_AND_ATTRIBUTES};
 use swc_html_visit::{VisitMut, VisitMutWith};
 
+#[cfg(feature = "default-css-minifier")]
+use crate::option::CssOptions;
 use crate::option::{
     CollapseWhitespaces, JsOptions, JsParserOptions, JsonOptions, MinifierType, MinifyCssOption,
     MinifyJsOption, MinifyJsonOption, MinifyOptions, RemoveRedundantAttributes,
 };
-#[cfg(feature = "default-css-minifier")]
-use crate::option::CssOptions;
 
 pub mod option;
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Support use a custom css minifier when minimizing html, add `feature = "custom-css-minifier"` to enable this and remove the dependencies of `swc_css_*`.
And `feature = "default-css-minifier"` keep the original behavior, using `swc_css` when minimizing html, and this is the default feature.
(Rspack is now using LightningCSS to minimize CSS files, but the CSS insides html is still using `swc_css` (which called by `swc_html_minifier`) to do the minify, so we want to also use LightningCSS to minify the CSS insides html to keep the consistent with CSS files)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
