### PR TITLE
chore(es/codegen): Bump minimum required swc_allocator version to 0.1.8

### DIFF
--- a/.changeset/bright-olives-sell.md
+++ b/.changeset/bright-olives-sell.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_codegen: patch
+swc_core: patch
+---
+
+chore(es/codegen): bump minimum required swc_allocator version to 0.1.8

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -24,7 +24,7 @@ serde      = { workspace = true }
 sourcemap  = { workspace = true }
 tracing    = { workspace = true }
 
-swc_allocator           = { version = "0.1.7", path = "../swc_allocator", default-features = false }
+swc_allocator           = { version = "0.1.8", path = "../swc_allocator", default-features = false }
 swc_atoms               = { version = "0.6.5", path = "../swc_atoms" }
 swc_common              = { version = "0.37.0", path = "../swc_common" }
 swc_ecma_ast            = { version = "0.118.0", path = "../swc_ecma_ast" }


### PR DESCRIPTION
**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`swc_ecma_codegen` uses `swc_allocator::collections` modules:

https://github.com/swc-project/swc/blob/f500dd4530a1e214d787151689ef9ddb64fb7510/crates/swc_ecma_codegen/src/text_writer/basic_impl.rs#L3

https://github.com/swc-project/swc/blob/f500dd4530a1e214d787151689ef9ddb64fb7510/crates/swc_ecma_codegen/tests/sourcemap.rs#L5

`collections` module was added to `swc_allocator` in 0.1.8. However, `swc_ecma_codegen` still says that the minimum required version of `swc_allocator` is 0.1.7:

https://github.com/swc-project/swc/blob/f500dd4530a1e214d787151689ef9ddb64fb7510/crates/swc_ecma_codegen/Cargo.toml#L27

This can cause a compile error when someone has a lockfile that pins `swc_allocator` 0.1.7, which is supposed to work with `swc_ecma_codegen` according to the manifest, but actually not.

**BREAKING CHANGE:**

N/A

**Related issue (if exists):**

N/A
