### PR TITLE
fix(es/minifier): Iterate object properties in reverse direction while inlining property access

### DIFF
--- a/.changeset/real-bugs-double.md
+++ b/.changeset/real-bugs-double.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_transforms_optimization: patch
+swc_core: patch
+---
+
+fix(es/minifier): Iterate object properties in reverse direction while inlining property access

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -11351,3 +11351,14 @@ fn issue_9184_2() {
 fn issue_9356() {
     run_default_exec_test("console.log((function ({ } = 42) { }).length)");
 }
+
+#[test]
+fn isssue_9498() {
+    run_default_exec_test(
+        "
+        const x = {a: 1};
+        const y = {...x, a: 2};
+        console.log(y.a);
+",
+    )
+}

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -1734,7 +1734,7 @@ fn get_key_value(key: &str, props: &mut Vec<PropOrSpread>) -> Option<Box<Expr>> 
         return None;
     }
 
-    for (i, prop) in props.iter_mut().enumerate() {
+    for (i, prop) in props.iter_mut().enumerate().rev() {
         let prop = match prop {
             PropOrSpread::Prop(x) => &mut **x,
             PropOrSpread::Spread(_) => unreachable!(),


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/9498