### PR TITLE
fix: undefined params if using by stauren/vite-plugin-deadfile

### DIFF
--- a/packages/core/src/Visitor.ts
+++ b/packages/core/src/Visitor.ts
@@ -885,7 +885,7 @@ export class Visitor {
         return n;
     }
 
-    visitTsFnParameters(params: TsFnParameter[]): TsFnParameter[] {
+    visitTsFnParameters(params: TsFnParameter[] = []): TsFnParameter[] {
         return params.map(this.visitTsFnParameter.bind(this));
     }
 


### PR DESCRIPTION
**Description:**

I use this library indirectly through stauren/vite-plugin-deadfile. I noticed an exception which occurs with every build due to an undefined array.

**BREAKING CHANGE:**

**Related issue (if exists):**
```
error during build:
[vite-plugin-pwa:build] Cannot read properties of undefined (reading 'map')
file: /projectfolder/src/main.ts
    at ImportVisitor.visitTsFnParameters (/projectfolder/node_modules/@swc/core/Visitor.js:589:23)
    at ImportVisitor.visitTsPropertySignature (/projectfolder/node_modules/@swc/core/Visitor.js:511:25)
    at ImportVisitor.visitTsTypeElement (/projectfolder/node_modules/@swc/core/Visitor.js:489:29)
    at Array.map (<anonymous>)
    at ImportVisitor.visitTsTypeElements (/projectfolder/node_modules/@swc/core/Visitor.js:480:22)
    at ImportVisitor.visitTsInterfaceBody (/projectfolder/node_modules/@swc/core/Visitor.js:476:23)
    at ImportVisitor.visitTsInterfaceDeclaration (/projectfolder/node_modules/@swc/core/Visitor.js:472:23)
    at ImportVisitor.visitDeclaration (/projectfolder/node_modules/@swc/core/Visitor.js:404:29)
    at ImportVisitor.visitStatement (/projectfolder/node_modules/@swc/core/Visitor.js:235:29)
    at ImportVisitor.visitModuleItem (/projectfolder/node_modules/@swc/core/Visitor.js:40:29)
```