### PR TITLE
fix(es/decorator): Add support for private access expressions in legacy decorators

### DIFF
--- a/.changeset/nasty-ligers-reflect.md
+++ b/.changeset/nasty-ligers-reflect.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_transforms_proposal: patch
+swc_core: patch
+---
+
+fix(es/decorator): Add support for private access expressions in legacy decorators

--- a/crates/swc/tests/fixture/issues-9xxx/9429/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-9xxx/9429/input/.swcrc
@@ -1,0 +1,20 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true,
+      "decorators": true
+    },
+    "target": "es2022",
+    "loose": false,
+    "minify": {
+      "compress": false,
+      "mangle": false
+    }
+  },
+  "module": {
+    "type": "es6"
+  },
+  "minify": false,
+  "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9429/input/index.ts
+++ b/crates/swc/tests/fixture/issues-9xxx/9429/input/index.ts
@@ -1,0 +1,25 @@
+class Foo {
+  static #loggedMethod<Args extends unknown[], Ret>(
+    _prototype: typeof Foo.prototype,
+    _propertyKey: string,
+    descriptor: TypedPropertyDescriptor<(this: Foo, ...args: Args) => Promise<Ret>>,
+  ) {
+    const method = descriptor.value!;
+    descriptor.value = function (...args) {
+      try {
+        console.log("before");
+        return method.apply(this, args);
+      } finally {
+        console.log("after");
+      }
+    };
+  }
+
+  @(Foo.#loggedMethod)
+  public greet(): any {
+    console.log("hi");
+  }
+}
+
+const foo = new Foo();
+foo.greet();

--- a/crates/swc/tests/fixture/issues-9xxx/9429/input/test.ts
+++ b/crates/swc/tests/fixture/issues-9xxx/9429/input/test.ts
@@ -1,0 +1,24 @@
+class Foo {
+    static {
+        class Bar {
+            static #x() {}
+
+            @Bar.#x
+            foo() {}
+        }
+    }
+
+    static #y() {}
+
+    @Foo.#y
+    public foo() {}
+
+    static {
+        class Bar {
+            static #x() {}
+
+            @Bar.#x
+            foo() {}
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9429/output/index.ts
+++ b/crates/swc/tests/fixture/issues-9xxx/9429/output/index.ts
@@ -1,0 +1,24 @@
+var _ts_decorate = require("@swc/helpers/_/_ts_decorate");
+class Foo {
+    static #loggedMethod(_prototype, _propertyKey, descriptor) {
+        const method = descriptor.value;
+        descriptor.value = function(...args) {
+            try {
+                console.log("before");
+                return method.apply(this, args);
+            } finally{
+                console.log("after");
+            }
+        };
+    }
+    greet() {
+        console.log("hi");
+    }
+    static{
+        _ts_decorate._([
+            Foo.#loggedMethod
+        ], Foo.prototype, "greet", null);
+    }
+}
+const foo = new Foo();
+foo.greet();

--- a/crates/swc/tests/fixture/issues-9xxx/9429/output/test.ts
+++ b/crates/swc/tests/fixture/issues-9xxx/9429/output/test.ts
@@ -1,0 +1,32 @@
+var _ts_decorate = require("@swc/helpers/_/_ts_decorate");
+class Foo {
+    static{
+        class Bar {
+            static #x() {}
+            foo() {}
+            static{
+                _ts_decorate._([
+                    Bar.#x
+                ], Bar.prototype, "foo", null);
+            }
+        }
+    }
+    static #y() {}
+    foo() {}
+    static{
+        class Bar {
+            static #x() {}
+            foo() {}
+            static{
+                _ts_decorate._([
+                    Bar.#x
+                ], Bar.prototype, "foo", null);
+            }
+        }
+    }
+    static{
+        _ts_decorate._([
+            Foo.#y
+        ], Foo.prototype, "foo", null);
+    }
+}

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
@@ -255,7 +255,7 @@ impl Visit for TscDecorator {
 
 impl VisitMut for TscDecorator {
     fn visit_mut_class(&mut self, n: &mut Class) {
-        debug_assert!(self.appended_private_access_exprs.is_empty());
+        let appended_private = self.appended_private_access_exprs.take();
 
         n.visit_mut_with(&mut ParamMetadata);
 
@@ -267,13 +267,15 @@ impl VisitMut for TscDecorator {
 
         n.visit_mut_children_with(self);
 
-        let appended_private_access_exprs = self.appended_private_access_exprs.take();
-        if !appended_private_access_exprs.is_empty() {
-            let expr = if appended_private_access_exprs.len() == 1 {
-                *appended_private_access_exprs.into_iter().next().unwrap()
+        let appended_private =
+            mem::replace(&mut self.appended_private_access_exprs, appended_private);
+
+        if !appended_private.is_empty() {
+            let expr = if appended_private.len() == 1 {
+                *appended_private.into_iter().next().unwrap()
             } else {
                 SeqExpr {
-                    exprs: appended_private_access_exprs,
+                    exprs: appended_private,
                     ..Default::default()
                 }
                 .into()

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
@@ -182,7 +182,10 @@ impl TscDecorator {
             elems: decorators
                 .into_iter()
                 .inspect(|e| {
-                    has_private_access |= Self::has_private_access(e);
+                    if has_private_access {
+                        return;
+                    }
+                    has_private_access = Self::has_private_access(e);
                 })
                 .map(|mut v| {
                     remove_span(&mut v);


### PR DESCRIPTION
**Related issue :**

- Closes: #9429 
