### PR TITLE
fix(cli): Exclude non-files from get_files_list

### DIFF
--- a/.changeset/weak-papayas-deliver.md
+++ b/.changeset/weak-papayas-deliver.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_cli_impl: patch
+---
+
+fix(cli): Exclude non-files from get_files_list

--- a/crates/swc_cli_impl/src/commands/compile.rs
+++ b/crates/swc_cli_impl/src/commands/compile.rs
@@ -146,6 +146,7 @@ fn get_files_list(
             .into_iter()
             .filter_map(|e| e.ok())
             .map(|e| e.into_path())
+            .filter(|e| e.is_file())
             .filter(|e| {
                 extensions
                     .iter()

--- a/crates/swc_cli_impl/tests/issues.rs
+++ b/crates/swc_cli_impl/tests/issues.rs
@@ -144,6 +144,20 @@ fn issue_8667_1() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn issue_9559() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    fs::write(sandbox.path().join("index.ts"), r"console.log('Hello')")?;
+    fs::create_dir(sandbox.path().join("chart.js"))?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox).arg("compile").arg(sandbox.path());
+
+    cmd.assert().success();
+
+    Ok(())
+}
+
 /// ln -s $a $b
 fn symlink(a: &Path, b: &Path) {
     #[cfg(unix)]


### PR DESCRIPTION
**Description:**

`get_files_list` does not check if a path with the `extensions` is really a file.


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/9559
