### PR TITLE
fix(plugin): Don't panic when ast byte not match

### DIFF
--- a/.changeset/four-tips-impress.md
+++ b/.changeset/four-tips-impress.md
@@ -1,0 +1,8 @@
+---
+ast_node: major
+swc_atoms: major
+swc_common: minor
+swc_plugin_proxy: minor
+---
+
+fix(swc_common): don't panic when ast byte not match

--- a/crates/ast_node/src/lib.rs
+++ b/crates/ast_node/src/lib.rs
@@ -138,6 +138,8 @@ impl VisitMut for AddAttr {
     fn visit_field_mut(&mut self, f: &mut Field) {
         f.attrs
             .push(parse_quote!(#[cfg_attr(feature = "__rkyv", omit_bounds)]));
+        f.attrs
+            .push(parse_quote!(#[cfg_attr(feature = "__rkyv", archive_attr(omit_bounds))]));
     }
 }
 
@@ -203,14 +205,13 @@ pub fn ast_node(
                     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
                 )]
                 #[cfg_attr(feature = "rkyv-impl", archive(check_bytes))]
+                #[cfg_attr(feature = "rkyv-impl", archive_attr(check_bytes(
+                    bound = "__C: rkyv::validation::ArchiveContext, <__C as rkyv::Fallible>::Error: std::error::Error"
+                )))]
                 #[cfg_attr(feature = "rkyv-impl", archive_attr(repr(u32)))]
-                #[cfg_attr(
-                    feature = "rkyv-impl",
-                    archive(bound(
-                        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + rkyv::ser::SharedSerializeRegistry",
-                        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-                    ))
-                )]
+                #[cfg_attr(feature = "rkyv-impl", archive(
+                    bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer")
+                ))]
                 #[cfg_attr(
                     feature = "serde-impl",
                     serde(untagged)
@@ -267,16 +268,13 @@ pub fn ast_node(
                     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
                 )]
                 #[cfg_attr(feature = "rkyv-impl", archive(check_bytes))]
+                #[cfg_attr(feature = "rkyv-impl", archive_attr(check_bytes(
+                    bound = "__C: rkyv::validation::ArchiveContext, <__C as rkyv::Fallible>::Error: std::error::Error"
+                )))]
                 #[cfg_attr(feature = "rkyv-impl", archive_attr(repr(C)))]
-                #[cfg_attr(
-                    feature = "rkyv-impl",
-                    archive(
-                        bound(
-                            serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + rkyv::ser::SharedSerializeRegistry",
-                            deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-                        )
-                    )
-                )]
+                #[cfg_attr(feature = "rkyv-impl", archive(
+                    bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer")
+                ))]
                 #serde_tag
                 #[cfg_attr(
                     feature = "serde-impl",

--- a/crates/swc_atoms/Cargo.toml
+++ b/crates/swc_atoms/Cargo.toml
@@ -23,8 +23,4 @@ hstr       = { workspace = true }
 once_cell  = { workspace = true }
 rustc-hash = { workspace = true }
 serde      = { workspace = true }
-
-  [dependencies.rkyv]
-  features  = ["strict", "validation"]
-  optional  = true
-  workspace = true
+rkyv       = { workspace = true, features  = ["validation"], optional = true }

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -48,10 +48,7 @@ new_debug_unreachable = { workspace = true }
 num-bigint = { workspace = true }
 once_cell = { workspace = true }
 parking_lot = { workspace = true, optional = true }
-rkyv = { workspace = true, features = [
-  "strict",
-  "validation",
-], optional = true }
+rkyv = { workspace = true, features = ["validation"], optional = true }
 rustc-hash = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 siphasher = { workspace = true }

--- a/crates/swc_css_ast/Cargo.toml
+++ b/crates/swc_css_ast/Cargo.toml
@@ -25,7 +25,4 @@ string_enum = { version = "0.4.4", path = "../string_enum/" }
 swc_atoms  = { version = "0.6.5", path = "../swc_atoms" }
 swc_common = { version = "0.38.0", path = "../swc_common" }
 
-  [dependencies.rkyv]
-  features  = ["strict", "validation"]
-  optional  = true
-  workspace = true
+rkyv       = { workspace = true, features  = ["validation"], optional = true }

--- a/crates/swc_css_ast/src/at_rule.rs
+++ b/crates/swc_css_ast/src/at_rule.rs
@@ -453,11 +453,7 @@ pub struct MediaFeatureBoolean {
 #[cfg_attr(feature = "rkyv", archive_attr(repr(u32)))]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 pub enum MediaFeatureRangeComparison {
     /// `<`
@@ -783,11 +779,7 @@ pub struct SizeFeatureBoolean {
 #[cfg_attr(feature = "rkyv", archive_attr(repr(u32)))]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 pub enum SizeFeatureRangeComparison {
     /// `<`

--- a/crates/swc_css_ast/src/selector.rs
+++ b/crates/swc_css_ast/src/selector.rs
@@ -125,11 +125,7 @@ pub struct Combinator {
 )]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 #[cfg_attr(feature = "rkyv", archive(check_bytes))]
 #[cfg_attr(feature = "rkyv", archive_attr(repr(u32)))]
@@ -270,11 +266,7 @@ pub struct AttributeSelector {
 #[cfg_attr(feature = "rkyv", archive_attr(repr(u32)))]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 pub enum AttributeSelectorMatcherValue {
     /// `=`

--- a/crates/swc_css_ast/src/token.rs
+++ b/crates/swc_css_ast/src/token.rs
@@ -44,11 +44,7 @@ pub struct UrlKeyValue(pub Atom, pub Atom);
 #[cfg_attr(feature = "rkyv", archive_attr(repr(u32)))]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 #[cfg_attr(feature = "serde-impl", derive(Serialize, Deserialize))]
 pub enum NumberType {
@@ -86,11 +82,7 @@ pub struct DimensionToken {
 #[cfg_attr(feature = "rkyv", archive_attr(repr(u32)))]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
 pub enum Token {

--- a/crates/swc_css_ast/src/value.rs
+++ b/crates/swc_css_ast/src/value.rs
@@ -121,11 +121,7 @@ impl EqIgnoreSpan for Str {
 )]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 #[cfg_attr(feature = "rkyv", archive(check_bytes))]
 #[cfg_attr(feature = "rkyv", archive_attr(repr(u32)))]
@@ -401,11 +397,7 @@ pub struct Ratio {
 )]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 #[cfg_attr(feature = "rkyv", archive(check_bytes))]
 #[cfg_attr(feature = "rkyv", archive_attr(repr(u32)))]
@@ -511,11 +503,7 @@ pub struct CalcOperator {
 )]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 #[cfg_attr(feature = "rkyv-impl", archive(check_bytes))]
 #[cfg_attr(feature = "rkyv-impl", archive_attr(repr(u32)))]

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -36,10 +36,7 @@ bytecheck = { workspace = true, optional = true }
 is-macro = { workspace = true }
 num-bigint = { workspace = true, features = ["serde"] }
 phf = { workspace = true, features = ["macros"] }
-rkyv = { workspace = true, features = [
-  "strict",
-  "validation",
-], optional = true }
+rkyv = { workspace = true, features = ["validation"], optional = true }
 scoped-tls = { workspace = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 string_enum = { version = "0.4.4", path = "../string_enum" }

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -1273,12 +1273,8 @@ impl Take for Import {
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
 #[cfg_attr(
-    any(feature = "rkyv-impl"),
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    feature = "rkyv",
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 #[cfg_attr(feature = "rkyv-impl", archive(check_bytes))]
 #[cfg_attr(feature = "rkyv-impl", archive_attr(repr(C)))]

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -20,12 +20,8 @@ use crate::{typescript::TsTypeAnn, Expr};
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
 )]
 #[cfg_attr(
-    any(feature = "rkyv-impl"),
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    feature = "rkyv",
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 #[cfg_attr(feature = "rkyv-impl", archive(check_bytes))]
 #[cfg_attr(feature = "rkyv-impl", archive_attr(repr(C)))]

--- a/crates/swc_html_ast/Cargo.toml
+++ b/crates/swc_html_ast/Cargo.toml
@@ -21,10 +21,7 @@ serde-impl = ["serde"]
 
 [dependencies]
 is-macro = { workspace = true }
-rkyv = { workspace = true, features = [
-  "strict",
-  "validation",
-], optional = true }
+rkyv = { workspace = true, features = ["validation"], optional = true }
 serde = { workspace = true, features = ["derive"], optional = true }
 
 string_enum = { version = "0.4.4", path = "../string_enum/" }

--- a/crates/swc_html_ast/src/base.rs
+++ b/crates/swc_html_ast/src/base.rs
@@ -25,11 +25,7 @@ pub struct DocumentFragment {
 )]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 pub enum DocumentMode {
     /// `no-quirks`
@@ -81,11 +77,7 @@ impl EqIgnoreSpan for DocumentType {
 )]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 pub enum Namespace {
     /// `http://www.w3.org/1999/xhtml`

--- a/crates/swc_html_ast/src/token.rs
+++ b/crates/swc_html_ast/src/token.rs
@@ -27,11 +27,7 @@ pub struct AttributeToken {
 )]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
 pub enum Raw {
@@ -46,11 +42,7 @@ pub enum Raw {
 )]
 #[cfg_attr(
     feature = "rkyv",
-    archive(bound(
-        serialize = "__S: rkyv::ser::Serializer + rkyv::ser::ScratchSpace + \
-                     rkyv::ser::SharedSerializeRegistry",
-        deserialize = "__D: rkyv::de::SharedDeserializeRegistry"
-    ))
+    archive(bound(serialize = "__S: rkyv::ser::ScratchSpace + rkyv::ser::Serializer"))
 )]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
 pub enum Token {

--- a/crates/swc_plugin_proxy/Cargo.toml
+++ b/crates/swc_plugin_proxy/Cargo.toml
@@ -22,10 +22,7 @@ plugin-rt   = ["__plugin_rt", "swc_common/plugin-base", "rkyv-impl"]
 
 [dependencies]
 
-rkyv = { workspace = true, features = [
-  "strict",
-  "validation",
-], optional = true }
+rkyv = { workspace = true, features = ["validation"], optional = true }
 tracing = { workspace = true }
 
 better_scoped_tls = { version = "0.1.1", path = "../better_scoped_tls" }

--- a/crates/swc_plugin_proxy/src/memory_interop/read_returned_result_from_host.rs
+++ b/crates/swc_plugin_proxy/src/memory_interop/read_returned_result_from_host.rs
@@ -92,7 +92,8 @@ pub fn read_returned_result_from_host<F, R>(f: F) -> Option<R>
 where
     F: FnOnce(u32) -> u32,
     R: rkyv::Archive,
-    R::Archived: rkyv::Deserialize<R, rkyv::de::deserializers::SharedDeserializeMap>,
+    R::Archived: rkyv::Deserialize<R, rkyv::de::deserializers::SharedDeserializeMap>
+        + for<'a> rkyv::CheckBytes<rkyv::validation::validators::DefaultValidator<'a>>,
 {
     let allocated_returned_value_ptr = read_returned_result_from_host_inner(f);
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

1. Disable rkyv strict feature, it is useless in swc.
2. Archived_root will panic if the wasm plugin ast binary not match core ast, so use safe api to avoid panic when mismatch. Implementation reference: https://github.com/rkyv/rkyv/blob/v0.7.43/examples/json/src/main.rs#L57-L76

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

No

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
