### PR TITLE
fix(es/codegen): Fix wrong sourcemap when there are new lines in tpl

### DIFF
--- a/.changeset/gentle-cycles-repair.md
+++ b/.changeset/gentle-cycles-repair.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_codegen: patch
+swc_core: patch
+---
+
+fix(es/codegen): fix wrong sourcemap when there are new lines in tpl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4400,6 +4400,7 @@ dependencies = [
  "memchr",
  "num-bigint",
  "once_cell",
+ "regex",
  "serde",
  "serde_json",
  "sourcemap",

--- a/crates/swc/tests/fixture/sourcemap/issue-9567/input/.swcrc
+++ b/crates/swc/tests/fixture/sourcemap/issue-9567/input/.swcrc
@@ -1,0 +1,22 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "target": "es2015",
+        "externalHelpers": true,
+        "loose": false,
+        "minify": {
+            "compress": true,
+            "mangle": {
+                "toplevel": true
+            }
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": true,
+    "sourceMaps": true
+}

--- a/crates/swc/tests/fixture/sourcemap/issue-9567/input/index.js
+++ b/crates/swc/tests/fixture/sourcemap/issue-9567/input/index.js
@@ -1,6 +1,12 @@
 function foo(span, error) {
   span.setStatus({
-      message: `${error.message} ${error.code ? `\nMongoose Error Code: ${error.code}` : ''}`,
+      message: `${error.message} ${
+          error.code
+              ? `\nMon\tgo\nos
+e Error\n C
+od\ne: ${error.code}`
+              : "1\n23"
+      }`,
   });
 }
 foo();

--- a/crates/swc/tests/fixture/sourcemap/issue-9567/input/index.js
+++ b/crates/swc/tests/fixture/sourcemap/issue-9567/input/index.js
@@ -1,0 +1,6 @@
+function foo(span, error) {
+  span.setStatus({
+      message: `${error.message} ${error.code ? `\nMongoose Error Code: ${error.code}` : ''}`,
+  });
+}
+foo();

--- a/crates/swc/tests/fixture/sourcemap/issue-9567/output/index.js
+++ b/crates/swc/tests/fixture/sourcemap/issue-9567/output/index.js
@@ -1,2 +1,7 @@
 function e(e,o){e.setStatus({message:`${o.message} ${o.code?`
-Mongoose Error Code: ${o.code}`:""}`})}e();
+Mon	go
+os
+e Error
+ C
+od
+e: ${o.code}`:"1\n23"}`})}e();

--- a/crates/swc/tests/fixture/sourcemap/issue-9567/output/index.js
+++ b/crates/swc/tests/fixture/sourcemap/issue-9567/output/index.js
@@ -1,0 +1,2 @@
+function e(e,o){e.setStatus({message:`${o.message} ${o.code?`
+Mongoose Error Code: ${o.code}`:""}`})}e();

--- a/crates/swc/tests/fixture/sourcemap/issue-9567/output/index.map
+++ b/crates/swc/tests/fixture/sourcemap/issue-9567/output/index.map
@@ -1,5 +1,5 @@
 {
-  "mappings": "AAAA,SAASA,EAAIC,CAAI,CAAEC,CAAK,EACtBD,EAAKE,SAAS,CAAC,CACXC,QAAS,GAAGF,EAAME,OAAO,CAAC,CAAC,EAAEF,EAAMG,IAAI,CAAG,CAAC;AAAC,qBAAsB,EAAEH,EAAMG,IAAI,EAAE,CAAG,IAAI,AAC3F,EACF,CACAL",
+  "mappings": "AAAA,SAASA,EAAIC,CAAI,CAAEC,CAAK,EACtBD,EAAKE,SAAS,CAAC,CACXC,QAAS,CAAC,EAAEF,EAAME,OAAO,CAAC,CAAC,EACvBF,EAAMG,IAAI,CACJ,CAAC;AAAE;AAAS;AAC5B;AAAS;AACT;AAAI,GAAG,EAAEH,EAAMG,IAAI,CAAC,CAAC,CACL,QACT,CAAC,AACN,EACF,CACAL",
   "names": [
     "foo",
     "span",
@@ -12,7 +12,7 @@
     "../../input/index.js"
   ],
   "sourcesContent": [
-    "function foo(span, error) {\n  span.setStatus({\n      message: `${error.message} ${error.code ? `\\nMongoose Error Code: ${error.code}` : ''}`,\n  });\n}\nfoo();"
+    "function foo(span, error) {\n  span.setStatus({\n      message: `${error.message} ${\n          error.code\n              ? `\\nMon\\tgo\\nos\ne Error\\n C\nod\\ne: ${error.code}`\n              : \"1\\n23\"\n      }`,\n  });\n}\nfoo();\n"
   ],
   "version": 3
 }

--- a/crates/swc/tests/fixture/sourcemap/issue-9567/output/index.map
+++ b/crates/swc/tests/fixture/sourcemap/issue-9567/output/index.map
@@ -1,0 +1,18 @@
+{
+  "mappings": "AAAA,SAASA,EAAIC,CAAI,CAAEC,CAAK,EACtBD,EAAKE,SAAS,CAAC,CACXC,QAAS,GAAGF,EAAME,OAAO,CAAC,CAAC,EAAEF,EAAMG,IAAI,CAAG,CAAC;AAAC,qBAAsB,EAAEH,EAAMG,IAAI,EAAE,CAAG,IAAI,AAC3F,EACF,CACAL",
+  "names": [
+    "foo",
+    "span",
+    "error",
+    "setStatus",
+    "message",
+    "code"
+  ],
+  "sources": [
+    "../../input/index.js"
+  ],
+  "sourcesContent": [
+    "function foo(span, error) {\n  span.setStatus({\n      message: `${error.message} ${error.code ? `\\nMongoose Error Code: ${error.code}` : ''}`,\n  });\n}\nfoo();"
+  ],
+  "version": 3
+}

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -20,6 +20,7 @@ bench = false
 memchr     = { workspace = true }
 num-bigint = { workspace = true, features = ["serde"] }
 once_cell  = { workspace = true }
+regex      = { workspace = true }
 serde      = { workspace = true }
 sourcemap  = { workspace = true }
 tracing    = { workspace = true }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

1. split quasi by '\n' 
2. add the mapping between original string and generated string one by one.

<img width="873" alt="image" src="https://github.com/user-attachments/assets/8a03da7f-2d22-4dd5-9bac-220418b10911">

**Related issue (if exists):**

closes https://github.com/swc-project/swc/issues/9567