### PR TITLE
fix(es/compat): Skip `getter` and `setter` as FlowHelper `function` do

### DIFF
--- a/.changeset/shy-eagles-shake.md
+++ b/.changeset/shy-eagles-shake.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_compat_es2015: patch
+swc_core: patch
+---
+
+fix(es/compat): Skip `getter` and `setter` as FlowHelper `function` do

--- a/crates/swc/tests/fixture/issues-9xxx/9579/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-9xxx/9579/input/.swcrc
@@ -1,0 +1,19 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "tsx": true
+    },
+    "target": "es5",
+    "loose": false,
+    "minify": {
+      "compress": false,
+      "mangle": false
+    }
+  },
+  "module": {
+    "type": "es6"
+  },
+  "minify": false,
+  "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9579/input/index.js
+++ b/crates/swc/tests/fixture/issues-9xxx/9579/input/index.js
@@ -1,0 +1,21 @@
+function expectA(a) {
+    console.log(a.b === 1)
+}
+
+export function test() {
+    // any loop
+    for (let i = 0; i < 1; i++) {
+        const a = {
+            get b() {
+                return 1
+            }
+        }
+        const c = 2
+            ; () => {
+                // create any arrow function that references value in loop
+                c
+            }
+        // We expect a.b to be 1
+        expectA(a)
+    }
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9579/output/index.js
+++ b/crates/swc/tests/fixture/issues-9xxx/9579/output/index.js
@@ -1,0 +1,18 @@
+function expectA(a) {
+    console.log(a.b === 1);
+}
+export function test() {
+    var _loop = function(i) {
+        var a = {
+            get b () {
+                return 1;
+            }
+        };
+        var c = 2;
+        (function() {
+            c;
+        });
+        expectA(a);
+    };
+    for(var i = 0; i < 1; i++)_loop(i);
+}

--- a/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
+++ b/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
@@ -750,6 +750,12 @@ impl VisitMut for FlowHelper<'_> {
     /// noop
     fn visit_mut_function(&mut self, _f: &mut Function) {}
 
+    /// noop
+    fn visit_mut_getter_prop(&mut self, _f: &mut GetterProp) {}
+
+    /// noop
+    fn visit_mut_setter_prop(&mut self, _f: &mut SetterProp) {}
+
     fn visit_mut_labeled_stmt(&mut self, l: &mut LabeledStmt) {
         self.inner_label.insert(l.label.sym.clone());
 


### PR DESCRIPTION
**Related issue:**

- Closes: #9579 
- https://github.com/swc-project/swc/issues/9161#issuecomment-2211641985