### PR TITLE
fix(es/module): Fix `jsc.paths` using absolute paths with dots in a filename for an alias

### DIFF
--- a/.changeset/dirty-panthers-reflect.md
+++ b/.changeset/dirty-panthers-reflect.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_loader: patch
+---
+
+fix(es/module): Fix jsc.paths using absolute paths with dots in a filename for an alias

--- a/crates/swc_ecma_loader/src/resolvers/tsc.rs
+++ b/crates/swc_ecma_loader/src/resolvers/tsc.rs
@@ -302,7 +302,7 @@ where
                         .split([std::path::MAIN_SEPARATOR, '/'])
                         .last()
                         .filter(|&slug| slug != "index.ts" && slug != "index.tsx")
-                        .map(|v| v.split_once('.').map(|v| v.0).unwrap_or(v))
+                        .map(|v| v.rsplit_once('.').map(|v| v.0).unwrap_or(v))
                         .map(From::from);
 
                     if tp.is_absolute() {

--- a/crates/swc_ecma_loader/tests/tsc_resolver.rs
+++ b/crates/swc_ecma_loader/tests/tsc_resolver.rs
@@ -98,6 +98,62 @@ fn pattern_1() {
 }
 
 #[test]
+fn base_url_works_for_resolves_full_filenames_with_dot_suffix() {
+    let mut map = HashMap::default();
+    map.insert(
+        "./common/folder1/file1.suffix1.ts".to_string(),
+        "suffix1".to_string(),
+    );
+    map.insert(
+        "./common/folder2/file2-suffix2.ts".to_string(),
+        "suffix2".to_string(),
+    );
+
+    let r = TsConfigResolver::new(
+        TestResolver(map),
+        ".".into(),
+        vec![
+            (
+                "@common/file1-suffix1".into(),
+                vec!["common/folder1/file1.suffix1.ts".into()],
+            ),
+            (
+                "@common/file2-suffix2".into(),
+                vec!["common/folder2/file2-suffix2.ts".into()],
+            ),
+        ],
+    );
+
+    {
+        let resolved = r
+            .resolve(&FileName::Anon, "@common/file1-suffix1")
+            .expect("should resolve");
+
+        assert_eq!(
+            resolved,
+            Resolution {
+                filename: FileName::Custom("suffix1".into()),
+                slug: Some("file1.suffix1".into())
+            }
+        );
+    }
+
+    {
+        let resolved = r
+            .resolve(&FileName::Anon, "@common/file2-suffix2")
+            .expect("should resolve");
+
+        assert_eq!(
+            resolved,
+            Resolution {
+                filename: FileName::Custom("suffix2".into()),
+                slug: Some("file2-suffix2".into())
+            }
+        );
+    }
+}
+
+#[test]
 fn base_url_works_for_bare_specifier() {
     let mut map = HashMap::default();
     map.insert("./src/common/helper".to_string(), "helper".to_string());


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

- Resolves `jsc.paths` using an absolute filename with dots

**Related issue:**

- Closes https://github.com/swc-project/swc/issues/9591
