### PR TITLE
fix(html/minifier): Fix HTML minifier TS types

### DIFF
--- a/packages/html/index.ts
+++ b/packages/html/index.ts
@@ -16,10 +16,13 @@ export type Options = {
         | "only-metadata";
     removeEmptyMetadataElements?: boolean;
     removeComments?: boolean;
-    preserveComments: string[];
+    preserveComments?: string[];
     minifyConditionalComments?: boolean;
     removeEmptyAttributes?: boolean;
-    removeRedundantAttributes?: boolean;
+    removeRedundantAttributes?:
+        | "none"
+        | "all"
+        | "smart";
     collapseBooleanAttributes?: boolean;
     normalizeAttributes?: boolean;
     minifyJson?: boolean | { pretty?: boolean };


### PR DESCRIPTION
**Description:**

`preserveComments` is optional but required in the TS type

`removeRedundantAttributes` is an enum and passing a boolean leads to errors

See https://github.com/swc-project/swc/blob/main/crates/swc_html_minifier/src/option.rs#L54

Sync HTML minifier TS options with Rust options.

I'm not sure if I'm supposed to edit this file manually or if it's generated, but let's figure it out together 😄 

**BREAKING CHANGE:** no, type bugfix

**Related issue (if exists):** https://github.com/facebook/docusaurus/pull/10554
