### PR TITLE
fix(es/codegen): Emit space after div if rhs has leading comment

### DIFF
--- a/.changeset/neat-ties-smoke.md
+++ b/.changeset/neat-ties-smoke.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_codegen: patch
+swc_core: patch
+---
+
+fix(es/codegen): Emit space after div if rhs has leading comment

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1267,6 +1267,13 @@ where
         let need_post_space = if self.cfg.minify {
             if is_kwd_op {
                 node.right.starts_with_alpha_num()
+            } else if node.op == op!("/") {
+                let span = node.right.span();
+
+                span.is_pure()
+                    || self
+                        .comments
+                        .map_or(false, |comments| comments.has_leading(node.right.span().lo))
             } else {
                 require_space_before_rhs(&node.right, &node.op)
             }

--- a/crates/swc_ecma_codegen/src/tests.rs
+++ b/crates/swc_ecma_codegen/src/tests.rs
@@ -962,6 +962,19 @@ fn issue_8491_2() {
     );
 }
 
+#[test]
+fn issue_9630() {
+    test_from_to_custom_config(
+        "console.log(1 / /* @__PURE__ */ something())",
+        "console.log(1/ /* @__PURE__ */something())",
+        Config {
+            minify: true,
+            ..Default::default()
+        },
+        Default::default(),
+    );
+}
+
 #[testing::fixture("tests/str-lits/**/*.txt")]
 fn test_str_lit(input: PathBuf) {
     test_str_lit_inner(input)


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
Closes #9630 