### PR TITLE
feat(es/minifier): Drop redundant function parameters

### DIFF
--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -520,10 +520,10 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_param(&mut self, param: &Param) {
-        let old_is_in_param = self.in_param;
+        let old_in_param = self.in_param;
         self.in_param = true;
         param.visit_children_with(self);
-        self.in_param = old_is_in_param;
+        self.in_param = old_in_param;
     }
 
     fn visit_pat(&mut self, p: &Pat) {

--- a/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/issue_763_4.js
+++ b/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/issue_763_4.js
@@ -13,7 +13,7 @@ const resources = [
         label: 'Instagram'
     }
 ];
-export function foo(websites) {
+export function foo() {
     const a = resources.map((resource)=>({
             value: resource.value
         }));

--- a/crates/swc_ecma_transforms_optimization/tests/simplify.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/simplify.rs
@@ -489,6 +489,24 @@ fn test_template_strings_known_methods() {
     test("x = parseFloat(`1.23`)", "x = 1.23");
 }
 
+#[test]
+fn test_redundant_params() {
+    // One or more parameters can be dropped
+    test("x = function(a, b) {}", "x = function() {}");
+    test(
+        "x = function(a, b, c, d) {f(b);}",
+        "x = function(a, b) {f(b);}",
+    );
+    test(
+        "x = function(a, b, c, d) {f(c);}",
+        "x = function(a, b, c) {f(c);}",
+    );
+
+    // No parameters can be dropped
+    test_same("x = function(a, b) {f(b);}");
+    test_same("x = function(a) {f(a);}");
+}
+
 test!(
     Syntax::Typescript(TsSyntax {
         decorators: true,

--- a/crates/swc_node_bundler/tests/pass/cjs/conditional/output/entry.js
+++ b/crates/swc_node_bundler/tests/pass/cjs/conditional/output/entry.js
@@ -31,7 +31,7 @@ function __swcpack_require__(mod) {
     cache = interop(module.exports);
     return cache;
 }
-var load = __swcpack_require__.bind(void 0, function(module, exports) {
+var load = __swcpack_require__.bind(void 0, function() {
     console.log("foo");
     console.log("bar");
 });

--- a/crates/swc_node_bundler/tests/pass/cjs/issue-967-no-recursive-require/output/entry.js
+++ b/crates/swc_node_bundler/tests/pass/cjs/issue-967-no-recursive-require/output/entry.js
@@ -31,13 +31,13 @@ function __swcpack_require__(mod) {
     cache = interop(module.exports);
     return cache;
 }
-var load = __swcpack_require__.bind(void 0, function(module, exports) {
+var load = __swcpack_require__.bind(void 0, function() {
     console.log("a");
 });
-var load1 = __swcpack_require__.bind(void 0, function(module, exports) {
+var load1 = __swcpack_require__.bind(void 0, function() {
     console.log("b");
 });
-var load2 = __swcpack_require__.bind(void 0, function(module, exports) {
+var load2 = __swcpack_require__.bind(void 0, function() {
     console.log("c");
 });
 load();

--- a/crates/swc_node_bundler/tests/pass/cjs/issue-967-recursive-require/output/entry.js
+++ b/crates/swc_node_bundler/tests/pass/cjs/issue-967-recursive-require/output/entry.js
@@ -56,7 +56,7 @@ var load4 = __swcpack_require__.bind(void 0, function(module, exports) {
         bb: bb
     };
 });
-var load5 = __swcpack_require__.bind(void 0, function(module, exports) {
+var load5 = __swcpack_require__.bind(void 0, function() {
     console.log("c");
 });
 load4();

--- a/crates/swc_node_bundler/tests/pass/deno-001/full/output/entry.js
+++ b/crates/swc_node_bundler/tests/pass/deno-001/full/output/entry.js
@@ -421,7 +421,7 @@ class MuxAsyncIterator {
 }
 function emptyReader() {
     return {
-        read (_) {
+        read () {
             return Promise.resolve(null);
         }
     };

--- a/crates/swc_node_bundler/tests/pass/deno-001/simple-1/output/entry.js
+++ b/crates/swc_node_bundler/tests/pass/deno-001/simple-1/output/entry.js
@@ -52,7 +52,7 @@ class MuxAsyncIterator {
 }
 function emptyReader() {
     return {
-        read (_) {
+        read () {
             return Promise.resolve(null);
         }
     };

--- a/crates/swc_node_bundler/tests/pass/deno-001/simple-2/output/entry.js
+++ b/crates/swc_node_bundler/tests/pass/deno-001/simple-2/output/entry.js
@@ -23,10 +23,10 @@ class ServerRequest {
     }
 }
 console.log(ServerRequest);
-async function writeResponse(w, r) {}
-async function readRequest(conn, bufr) {}
+async function writeResponse() {}
+async function readRequest() {}
 console.log(deferred, writeResponse, readRequest, MuxAsyncIterator);
-async function listenAndServe(addr, handler) {}
+async function listenAndServe() {}
 listenAndServe({
     port: 8080
 }, async (req)=>{});

--- a/crates/swc_node_bundler/tests/pass/issue-1328/case1/output/entry.js
+++ b/crates/swc_node_bundler/tests/pass/issue-1328/case1/output/entry.js
@@ -127,7 +127,7 @@ function foo() {
 }
 function _foo() {
     _foo = _async_to_generator(function() {
-        return _ts_generator(this, function(_state) {
+        return _ts_generator(this, function() {
             return [
                 2
             ];

--- a/crates/swc_node_bundler/tests/pass/issue-2124/named-export/output/entry.js
+++ b/crates/swc_node_bundler/tests/pass/issue-2124/named-export/output/entry.js
@@ -32,7 +32,7 @@ function __swcpack_require__(mod) {
     return cache;
 }
 var load = __swcpack_require__.bind(void 0, function(module, exports) {
-    function lodash(value) {
+    function lodash() {
         console.log("lodash");
     }
     function memoize() {

--- a/crates/swc_node_bundler/tests/pass/regenerator/1/output/entry.js
+++ b/crates/swc_node_bundler/tests/pass/regenerator/1/output/entry.js
@@ -127,7 +127,7 @@ function foo() {
 }
 function _foo() {
     _foo = _async_to_generator(function() {
-        return _ts_generator(this, function(_state) {
+        return _ts_generator(this, function() {
             return [
                 2
             ];


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
Trailing parameters in functions/arrow expressions can be dropped if they're not referenced inside the function body without introducing side effects. e.g. `function f(a, b, c) {f(a);}` -> `function f(a) {f(a);}`.

This simply iterates (reverse) through the parameters and once it encounters a parameter that is used, it stops and drops the ones it found. If no referenced parameters are found then all parameters can be dropped.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
