### PR TITLE
feat(es/minifier): Support unary negate in `cast_to_number`

### DIFF
--- a/.changeset/lazy-ladybugs-jump.md
+++ b/.changeset/lazy-ladybugs-jump.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_utils: patch
+swc_core: patch
+---
+
+feat(es/minifier): Support unary negate in `cast_to_number`

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -933,17 +933,10 @@ pub trait ExprExt {
                 op: op!(unary, "-"),
                 arg,
                 ..
-            }) if matches!(
-                &**arg,
-                Expr::Ident(Ident {
-                    sym,
-                    ctxt,
-                    ..
-                }) if &**sym == "Infinity" && *ctxt == ctx.unresolved_ctxt
-            ) =>
-            {
-                -f64::INFINITY
-            }
+            }) => match arg.cast_to_number(ctx) {
+                (Pure, Known(v)) => -v,
+                _ => return (MayBeImpure, Unknown),
+            },
             Expr::Unary(UnaryExpr {
                 op: op!("!"),
                 ref arg,


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
Adds support for `-` in `cast_to_number`. Before it only worked if `arg` is `Infinity`. Now it uses a recursive call on `arg` so it works for expressions like `-5`, `-[]` etc.

This change is important because negative number literals (e.g. `-5`) are a `UnaryExpr` with `op`=`-` & `arg`=`5`, unless you apply `expr_simplifier` pass or something else that uses it.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
