### PR TITLE
fix(es/parser): Correct `>` and `<` when exit type context

### DIFF
--- a/.changeset/fluffy-lizards-allow.md
+++ b/.changeset/fluffy-lizards-allow.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): Correct `>` and `<` when exit type context

--- a/crates/swc/tests/fixture/issues-9xxx/9471/input/index.ts
+++ b/crates/swc/tests/fixture/issues-9xxx/9471/input/index.ts
@@ -1,0 +1,7 @@
+const x0 = testNum as number > 0;
+const x1 = testNum as number >> 0;
+const x2 = testNum as number >= 0;
+const x3 = testNum as number >>> 0;
+const x4 = testNum as number < 0;
+const x5 = testNum as number << 0;
+const x6 = testNum as number <= 0;

--- a/crates/swc/tests/fixture/issues-9xxx/9471/output/index.ts
+++ b/crates/swc/tests/fixture/issues-9xxx/9471/output/index.ts
@@ -1,0 +1,7 @@
+var x0 = testNum > 0;
+var x1 = testNum >> 0;
+var x2 = testNum >= 0;
+var x3 = testNum >>> 0;
+var x4 = testNum < 0;
+var x5 = testNum << 0;
+var x6 = testNum <= 0;

--- a/crates/swc_ecma_parser/src/macros.rs
+++ b/crates/swc_ecma_parser/src/macros.rs
@@ -113,14 +113,29 @@ macro_rules! tok {
     ("<<") => {
         crate::token::Token::BinOp(crate::token::BinOpToken::LShift)
     };
+    ("<=") => {
+        crate::token::Token::BinOp(crate::token::BinOpToken::LtEq)
+    };
+    ("<<=") => {
+        crate::token::Token::AssignOp(crate::token::AssignOp::LShiftAssign)
+    };
     ('>') => {
         crate::token::Token::BinOp(crate::token::BinOpToken::Gt)
     };
     (">>") => {
         crate::token::Token::BinOp(crate::token::BinOpToken::RShift)
     };
+    (">>>") => {
+        crate::token::Token::BinOp(crate::token::BinOpToken::ZeroFillRShift)
+    };
     (">=") => {
         crate::token::Token::BinOp(crate::token::BinOpToken::GtEq)
+    };
+    (">>=") => {
+        crate::token::Token::AssignOp(crate::AssignOp::RShiftAssign)
+    };
+    (">>>=") => {
+        crate::token::Token::AssignOp(crate::AssignOp::ZeroFillRShiftAssign)
     };
 
     ("++") => {

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -414,6 +414,53 @@ impl<I: Tokens> Buffer<I> {
         });
     }
 
+    pub fn merge_lt_gt(&mut self) {
+        debug_assert!(
+            self.is(&tok!('<')) || self.is(&tok!('>')),
+            "parser should only call merge_lt_gt when encountering '<' or '>' token"
+        );
+
+        let span = self.cur_span();
+
+        if self.peek().is_none() {
+            return;
+        }
+
+        let next = self.next.as_ref().unwrap();
+
+        if span.hi != next.span.lo {
+            return;
+        }
+
+        let cur = self.cur.take().unwrap();
+        let next = self.next.take().unwrap();
+
+        let token = match (&cur.token, &next.token) {
+            (tok!('>'), tok!('>')) => tok!(">>"),
+            (tok!('>'), tok!('=')) => tok!(">="),
+            (tok!('>'), tok!(">>")) => tok!(">>>"),
+            (tok!('>'), tok!(">=")) => tok!(">>="),
+            (tok!('>'), tok!(">>=")) => tok!(">>>="),
+            (tok!('<'), tok!('<')) => tok!("<<"),
+            (tok!('<'), tok!('=')) => tok!("<="),
+            (tok!('<'), tok!("<=")) => tok!("<<="),
+
+            _ => {
+                self.cur = Some(cur);
+                self.next = Some(next);
+                return;
+            }
+        };
+        let span = span.with_hi(next.span.hi);
+
+        self.cur = Some(TokenAndSpan {
+            token,
+            span,
+            had_line_break: cur.had_line_break,
+        });
+        self.next = None;
+    }
+
     #[inline]
     pub fn is(&mut self, expected: &Token) -> bool {
         match self.cur() {

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -458,7 +458,6 @@ impl<I: Tokens> Buffer<I> {
             span,
             had_line_break: cur.had_line_break,
         });
-        self.next = None;
     }
 
     #[inline]

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -713,11 +713,17 @@ impl<I: Tokens> Parser<I> {
     pub(super) fn next_then_parse_ts_type(&mut self) -> PResult<Box<TsType>> {
         debug_assert!(self.input.syntax().typescript());
 
-        self.in_type().parse_with(|p| {
+        let result = self.in_type().parse_with(|p| {
             bump!(p);
 
             p.parse_ts_type()
-        })
+        });
+
+        if !self.ctx().in_type && is_one_of!(self, '>', '<') {
+            self.input.merge_lt_gt();
+        }
+
+        result
     }
 
     /// `tsParseEnumMember`

--- a/crates/swc_ecma_parser/src/token.rs
+++ b/crates/swc_ecma_parser/src/token.rs
@@ -9,7 +9,7 @@ use std::{
 use num_bigint::BigInt as BigIntValue;
 use swc_atoms::{atom, Atom, AtomStore};
 use swc_common::{Span, Spanned};
-use swc_ecma_ast::{AssignOp, BinaryOp};
+pub(crate) use swc_ecma_ast::{AssignOp, BinaryOp};
 
 pub(crate) use self::{Keyword::*, Token::*};
 use crate::{error::Error, lexer::LexResult};


### PR DESCRIPTION
**Related issue:**

- Closes: #9471 
