### PR TITLE
feat(es/minifier): Implement optional catch binding

### DIFF
--- a/.changeset/plenty-frogs-live.md
+++ b/.changeset/plenty-frogs-live.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_minifier: patch
+swc_core: patch
+---
+
+feat(es/minifier): Implement optional catch binding

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -2876,15 +2876,17 @@ impl VisitMut for Optimizer<'_> {
         n.finalizer.visit_mut_with(self);
     }
 
-    fn visit_mut_catch_clause(&mut self, node: &mut CatchClause) {
+    fn visit_mut_catch_clause(&mut self, n: &mut CatchClause) {
+        n.visit_mut_children_with(self);
+
         if self.options.ecma < EsVersion::Es2019 || !self.options.unused {
             return;
         }
 
-        if let Some(param) = &mut node.param {
+        if let Some(param) = &mut n.param {
             self.take_pat_if_unused(param, None, false);
             if param.is_invalid() {
-                node.param = None;
+                n.param = None;
             }
         }
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -2876,6 +2876,19 @@ impl VisitMut for Optimizer<'_> {
         n.finalizer.visit_mut_with(self);
     }
 
+    fn visit_mut_catch_clause(&mut self, node: &mut CatchClause) {
+        if self.options.ecma < EsVersion::Es2019 || !self.options.unused {
+            return;
+        }
+
+        if let Some(param) = &mut node.param {
+            self.take_pat_if_unused(param, None, false);
+            if param.is_invalid() {
+                node.param = None;
+            }
+        }
+    }
+
     #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
     fn visit_mut_unary_expr(&mut self, n: &mut UnaryExpr) {
         let ctx = Ctx {

--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -178,7 +178,6 @@ impl Optimizer<'_> {
                 && v.usage_count == 0
                 && !v.reassigned
                 && v.property_mutation_count == 0
-                && !v.declared_as_catch_param
             {
                 self.changed = true;
                 report_change!(

--- a/crates/swc_ecma_minifier/tests/terser/compress/collapse_vars/collapse_vars_try/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/collapse_vars/collapse_vars_try/output.js
@@ -3,7 +3,7 @@ function f1() {
         return 1;
     } catch (ex) {
         return 2;
-    } finally {
+    } finally{
         return 3;
     }
 }

--- a/crates/swc_ecma_minifier/tests/terser/compress/drop_unused/issue_1715_1/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/drop_unused/issue_1715_1/output.js
@@ -2,9 +2,7 @@ var a = 1;
 function f() {
     try {
         x();
-    } catch (a) {
-        var a;
-    }
+    } catch (a) {}
 }
 f();
 console.log(a);

--- a/crates/swc_ecma_minifier/tests/terser/compress/drop_unused/issue_1715_4/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/drop_unused/issue_1715_4/output.js
@@ -2,8 +2,6 @@ var a = 1;
 !function() {
     try {
         x();
-    } catch (a) {
-        var a;
-    }
+    } catch (a) {}
 }();
 console.log(a);

--- a/crates/swc_ecma_minifier/tests/terser/compress/functions/issue_2604_2/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/functions/issue_2604_2/output.js
@@ -1,5 +1,5 @@
 var a = "FAIL";
-(function () {
+(function() {
     try {
         throw 1;
     } catch (o) {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
closes https://github.com/swc-project/swc/issues/8966

I think removing `!v.declared_as_catch_param` is safe, since I can't think of a bad case:
1. for the vars in the params of catch-clause, we prevent the removal if `self.options.ecma < EsVersion::Es2019 || !self.options.unused` is not satisfied.
2. for the usages or re-declarations with the same var name in the body of catch-clause, I think it's safe to remove them.