### PR TITLE
fix: correct option types of wasm-typescript functions

### DIFF
--- a/crates/swc_fast_ts_strip/src/lib.rs
+++ b/crates/swc_fast_ts_strip/src/lib.rs
@@ -64,7 +64,7 @@ interface Options {
     module?: boolean;
     filename?: string;
     mode?: Mode;
-    transform?; TransformConfig;
+    transform?: TransformConfig;
     sourceMap?: boolean;
 }
 


### PR DESCRIPTION

<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

The types for the wasm-typescript functions are incorrect due to a typo.

Without this fix:

```
Property 'TransformConfig' is missing in type '{ module: true; filename: any; sourceMap:   • 
 true; mode: "transform"; transform: { verbatimModuleSyntax: boolean; nativeClassProperties:       
 boolean; importNotUsedAsValues: string; importExportAssignConfig: string; }; }' but required in   
 type 'Options'. [2345]  
```
