### PR TITLE
chore(ci): Remove miri ci for `swc_ecma_codegen` and `swc_ecma_minifier`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -501,8 +501,8 @@ jobs:
           - string_enum
           - swc
           - swc_bundler
-          - swc_ecma_codegen
-          - swc_ecma_minifier
+          # - swc_ecma_codegen
+          # - swc_ecma_minifier
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

Running miri for `swc_ecma_codegen` and `swc_ecma_minifier` is too slow.
Miri on `swc_ecma_codegen` consumes up to 4 hours, and miri on `swc_ecma_minifier` consumes up to 6 hours, which exceeded github's 6 hour limit and makes ci bound to error.

Since they do not introduce too much unsafe code, I think we'd better remove the miri tests for them or run partial tests in a reasonable time. 