### PR TITLE
fix(bindings/node): Add `VisitTsPropertySignature`

### DIFF
--- a/packages/core/src/Visitor.ts
+++ b/packages/core/src/Visitor.ts
@@ -797,7 +797,6 @@ export class Visitor {
         return n;
     }
     visitTsPropertySignature(n: TsPropertySignature): TsPropertySignature {
-        n.params = this.visitTsFnParameters(n.params);
         n.typeAnnotation = this.visitTsTypeAnnotation(n.typeAnnotation);
         return n;
     }

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -2426,11 +2426,7 @@ export interface TsPropertySignature extends Node, HasSpan {
     computed: boolean;
     optional: boolean;
 
-    init?: Expression;
-    params: TsFnParameter[];
-
     typeAnnotation?: TsTypeAnnotation;
-    typeParams?: TsTypeParameterDeclaration;
 }
 
 export interface TsGetterSignature extends Node, HasSpan {


### PR DESCRIPTION
**Description:**

As per PR #8955
> TsPropertySignature can not have params, type params, or an initializer.

This PR clean up these fields from ts definition and visitor 