### PR TITLE
feat(es/minifier): Optimize switch with side effect and termination tests

### DIFF
--- a/.changeset/happy-planes-dance.md
+++ b/.changeset/happy-planes-dance.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_utils: major
+---
+
+feat(es/minifier): Optimize switch and replace empty test with side effect and termination tests

--- a/crates/swc/tests/tsc-references/stringLiteralsWithSwitchStatements03.2.minified.js
+++ b/crates/swc/tests/tsc-references/stringLiteralsWithSwitchStatements03.2.minified.js
@@ -1,6 +1,2 @@
 //// [stringLiteralsWithSwitchStatements03.ts]
-var z;
-switch(void 0){
-    case randBool() ? "foo" : "baz":
-    case z || "baz":
-}
+randBool();

--- a/crates/swc/tests/tsc-references/switchStatements.2.minified.js
+++ b/crates/swc/tests/tsc-references/switchStatements.2.minified.js
@@ -25,7 +25,6 @@ switch((M || (M = {})).fn = function(x) {
     case void 0 === x ? "undefined" : _type_of(x):
     case void 0 === M ? "undefined" : _type_of(M):
     case M.fn(1):
-    default:
 }
 var x, M, C = function C() {
     _class_call_check(this, C);

--- a/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
@@ -21,7 +21,12 @@ impl Optimizer<'_> {
         expr: &mut Expr,
         is_ret_val_ignored: bool,
     ) -> bool {
-        let cost = negate_cost(&self.expr_ctx, expr, is_ret_val_ignored, is_ret_val_ignored);
+        let cost = negate_cost(
+            &self.ctx.expr_ctx,
+            expr,
+            is_ret_val_ignored,
+            is_ret_val_ignored,
+        );
         if cost >= 0 {
             return false;
         }
@@ -72,11 +77,12 @@ impl Optimizer<'_> {
 
         let ctx = Ctx {
             in_bool_ctx: true,
-            ..self.ctx
+            ..self.ctx.clone()
         };
 
-        self.with_ctx(ctx).negate(&mut e.left, false);
-        self.with_ctx(ctx).negate(&mut e.right, is_ret_val_ignored);
+        self.with_ctx(ctx.clone()).negate(&mut e.left, false);
+        self.with_ctx(ctx.clone())
+            .negate(&mut e.right, is_ret_val_ignored);
 
         dump_change_detail!("{} => {}", start, dump(&*e, false));
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
@@ -30,11 +30,11 @@ impl Optimizer<'_> {
             _ => {}
         }
 
-        if negate_cost(&self.expr_ctx, &stmt.test, true, false) < 0 {
+        if negate_cost(&self.ctx.expr_ctx, &stmt.test, true, false) < 0 {
             report_change!("if_return: Negating `cond` of an if statement which has cons and alt");
             let ctx = Ctx {
                 in_bool_ctx: true,
-                ..self.ctx
+                ..self.ctx.clone()
             };
             self.with_ctx(ctx).negate(&mut stmt.test, false);
             swap(alt, &mut *stmt.cons);
@@ -63,7 +63,7 @@ impl Optimizer<'_> {
             _ => return,
         };
 
-        if !cond.cons.may_have_side_effects(&self.expr_ctx) {
+        if !cond.cons.may_have_side_effects(&self.ctx.expr_ctx) {
             self.changed = true;
             report_change!("conditionals: `cond ? useless : alt` => `cond || alt`");
             *e = BinExpr {
@@ -76,7 +76,7 @@ impl Optimizer<'_> {
             return;
         }
 
-        if !cond.alt.may_have_side_effects(&self.expr_ctx) {
+        if !cond.alt.may_have_side_effects(&self.ctx.expr_ctx) {
             self.changed = true;
             report_change!("conditionals: `cond ? cons : useless` => `cond && cons`");
             *e = BinExpr {
@@ -878,7 +878,7 @@ impl Optimizer<'_> {
                         ) = (&*cons, &*alt)
                         {
                             // I don't know why, but terser behaves differently
-                            negate(&self.expr_ctx, &mut test, true, false);
+                            negate(&self.ctx.expr_ctx, &mut test, true, false);
 
                             swap(&mut cons, &mut alt);
                         }

--- a/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
@@ -163,7 +163,7 @@ impl Optimizer<'_> {
         //
 
         for arg in &*args {
-            if arg.spread.is_some() || arg.expr.may_have_side_effects(&self.expr_ctx) {
+            if arg.spread.is_some() || arg.expr.may_have_side_effects(&self.ctx.expr_ctx) {
                 return;
             }
         }
@@ -233,7 +233,7 @@ impl Optimizer<'_> {
                             return;
                         }
 
-                        if let Known(char_code) = args[0].expr.as_pure_number(&self.expr_ctx) {
+                        if let Known(char_code) = args[0].expr.as_pure_number(&self.ctx.expr_ctx) {
                             let v = char_code.floor() as u32;
 
                             if let Some(v) = char::from_u32(v) {
@@ -341,7 +341,7 @@ impl Optimizer<'_> {
         }
 
         if let Expr::Call(..) = e {
-            if let Some(value) = eval_as_number(&self.expr_ctx, e) {
+            if let Some(value) = eval_as_number(&self.ctx.expr_ctx, e) {
                 self.changed = true;
                 report_change!("evaluate: Evaluated an expression as `{}`", value);
 
@@ -367,8 +367,8 @@ impl Optimizer<'_> {
 
         match e {
             Expr::Bin(bin @ BinExpr { op: op!("**"), .. }) => {
-                let l = bin.left.as_pure_number(&self.expr_ctx);
-                let r = bin.right.as_pure_number(&self.expr_ctx);
+                let l = bin.left.as_pure_number(&self.ctx.expr_ctx);
+                let r = bin.right.as_pure_number(&self.ctx.expr_ctx);
 
                 if let Known(l) = l {
                     if let Known(r) = r {
@@ -395,9 +395,9 @@ impl Optimizer<'_> {
             }
 
             Expr::Bin(bin @ BinExpr { op: op!("/"), .. }) => {
-                let ln = bin.left.as_pure_number(&self.expr_ctx);
+                let ln = bin.left.as_pure_number(&self.ctx.expr_ctx);
 
-                let rn = bin.right.as_pure_number(&self.expr_ctx);
+                let rn = bin.right.as_pure_number(&self.ctx.expr_ctx);
                 if let (Known(ln), Known(rn)) = (ln, rn) {
                     // Prefer `0/0` over NaN.
                     if ln == 0.0 && rn == 0.0 {
@@ -477,7 +477,7 @@ impl Optimizer<'_> {
             }
             // Remove rhs of lhs if possible.
 
-            let v = left.right.as_pure_bool(&self.expr_ctx);
+            let v = left.right.as_pure_bool(&self.ctx.expr_ctx);
             if let Known(v) = v {
                 // As we used as_pure_bool, we can drop it.
                 if v && e.op == op!("&&") {

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -1,7 +1,7 @@
 use swc_common::{util::take::Take, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_optimization::debug_assert_valid;
-use swc_ecma_utils::{StmtExt, StmtLike};
+use swc_ecma_utils::StmtLike;
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use super::Optimizer;
@@ -570,7 +570,7 @@ fn always_terminates_with_return_arg(s: &Stmt) -> bool {
 fn can_merge_as_if_return(s: &Stmt) -> bool {
     fn cost(s: &Stmt) -> Option<isize> {
         if let Stmt::Block(..) = s {
-            if !s.terminates() {
+            if !swc_ecma_utils::StmtExt::terminates(s) {
                 return None;
             }
         }

--- a/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/if_return.rs
@@ -116,7 +116,7 @@ impl Optimizer<'_> {
         // for stmt in stmts.iter_mut() {
         //     let ctx = Ctx {
         //         is_nested_if_return_merging: true,
-        //         ..self.ctx
+        //         ..self.ctx.clone()
         //     };
         //     self.with_ctx(ctx).merge_nested_if_returns(stmt, terminate);
         // }
@@ -396,7 +396,7 @@ impl Optimizer<'_> {
                         && seq
                             .exprs
                             .last()
-                            .map(|v| is_pure_undefined(&self.expr_ctx, v))
+                            .map(|v| is_pure_undefined(&self.ctx.expr_ctx, v))
                             .unwrap_or(true) =>
                 {
                     let expr = self.ignore_return_value(&mut cur);

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -293,7 +293,7 @@ impl Optimizer<'_> {
             let ctx = Ctx {
                 in_fn_like: true,
                 top_level: false,
-                ..self.ctx
+                ..self.ctx.clone()
             };
             let mut optimizer = self.with_ctx(ctx);
             match find_body(callee) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -77,7 +77,7 @@ impl Optimizer<'_> {
             if ref_count == 0 {
                 self.mode.store(ident.to_id(), &*init);
 
-                if init.may_have_side_effects(&self.expr_ctx) {
+                if init.may_have_side_effects(&self.ctx.expr_ctx) {
                     // TODO: Inline partially
                     return;
                 }
@@ -494,7 +494,7 @@ impl Optimizer<'_> {
                     }
                 }
 
-                if init.may_have_side_effects(&self.expr_ctx) {
+                if init.may_have_side_effects(&self.ctx.expr_ctx) {
                     return;
                 }
 
@@ -531,13 +531,13 @@ impl Optimizer<'_> {
         if body.stmts.len() == 1 {
             match &body.stmts[0] {
                 Stmt::Expr(ExprStmt { expr, .. })
-                    if expr.size(self.expr_ctx.unresolved_ctxt) < cost_limit =>
+                    if expr.size(self.ctx.expr_ctx.unresolved_ctxt) < cost_limit =>
                 {
                     return true
                 }
 
                 Stmt::Return(ReturnStmt { arg: Some(arg), .. })
-                    if arg.size(self.expr_ctx.unresolved_ctxt) < cost_limit =>
+                    if arg.size(self.ctx.expr_ctx.unresolved_ctxt) < cost_limit =>
                 {
                     return true
                 }
@@ -719,7 +719,7 @@ impl Optimizer<'_> {
                 })
             {
                 if let Decl::Class(ClassDecl { class, .. }) = decl {
-                    if class_has_side_effect(&self.expr_ctx, class, self.ctx.in_strict) {
+                    if class_has_side_effect(&self.ctx.expr_ctx, class) {
                         return;
                     }
                 }

--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -719,7 +719,7 @@ impl Optimizer<'_> {
                 })
             {
                 if let Decl::Class(ClassDecl { class, .. }) = decl {
-                    if class_has_side_effect(&self.expr_ctx, class) {
+                    if class_has_side_effect(&self.expr_ctx, class, self.ctx.in_strict) {
                         return;
                     }
                 }

--- a/crates/swc_ecma_minifier/src/compress/optimize/loops.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/loops.rs
@@ -65,7 +65,7 @@ impl Optimizer<'_> {
 
         match stmt {
             Stmt::While(w) => {
-                let (purity, val) = w.test.cast_to_bool(&self.expr_ctx);
+                let (purity, val) = w.test.cast_to_bool(&self.ctx.expr_ctx);
                 if let Known(false) = val {
                     if purity.is_pure() {
                         let changed = UnreachableHandler::preserve_vars(stmt);
@@ -86,7 +86,7 @@ impl Optimizer<'_> {
             }
             Stmt::For(f) => {
                 if let Some(test) = &mut f.test {
-                    let (purity, val) = test.cast_to_bool(&self.expr_ctx);
+                    let (purity, val) = test.cast_to_bool(&self.ctx.expr_ctx);
                     if let Known(false) = val {
                         let changed = UnreachableHandler::preserve_vars(&mut f.body);
                         self.changed |= changed;

--- a/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
@@ -132,20 +132,20 @@ impl Optimizer<'_> {
             (lt, rt) if lt != rt => {}
             (Type::Obj, Type::Obj) => {}
             (Type::Num, Type::Num) => {
-                let l = n.left.as_pure_number(&self.expr_ctx).opt()?;
-                let r = n.right.as_pure_number(&self.expr_ctx).opt()?;
+                let l = n.left.as_pure_number(&self.ctx.expr_ctx).opt()?;
+                let r = n.right.as_pure_number(&self.ctx.expr_ctx).opt()?;
                 report_change!("Optimizing: literal comparison => num");
                 return make_lit_bool(l == r);
             }
             (Type::Str, Type::Str) => {
-                let l = &n.left.as_pure_string(&self.expr_ctx).opt()?;
-                let r = &n.right.as_pure_string(&self.expr_ctx).opt()?;
+                let l = &n.left.as_pure_string(&self.ctx.expr_ctx).opt()?;
+                let r = &n.right.as_pure_string(&self.ctx.expr_ctx).opt()?;
                 report_change!("Optimizing: literal comparison => str");
                 return make_lit_bool(l == r);
             }
             (_, _) => {
-                let l = n.left.as_pure_bool(&self.expr_ctx).opt()?;
-                let r = n.right.as_pure_bool(&self.expr_ctx).opt()?;
+                let l = n.left.as_pure_bool(&self.ctx.expr_ctx).opt()?;
+                let r = n.right.as_pure_bool(&self.ctx.expr_ctx).opt()?;
                 report_change!("Optimizing: literal comparison => bool");
                 return make_lit_bool(l == r);
             }
@@ -201,7 +201,12 @@ impl Optimizer<'_> {
     }
 
     pub(super) fn negate(&mut self, e: &mut Expr, is_ret_val_ignored: bool) {
-        negate(&self.expr_ctx, e, self.ctx.in_bool_ctx, is_ret_val_ignored)
+        negate(
+            &self.ctx.expr_ctx,
+            e,
+            self.ctx.in_bool_ctx,
+            is_ret_val_ignored,
+        )
     }
 
     /// This method does
@@ -309,7 +314,7 @@ impl Optimizer<'_> {
 
         match bin.op {
             op!("&&") => {
-                let rb = bin.right.as_pure_bool(&self.expr_ctx);
+                let rb = bin.right.as_pure_bool(&self.ctx.expr_ctx);
                 let rb = match rb {
                     Value::Known(v) => v,
                     _ => return,
@@ -324,7 +329,7 @@ impl Optimizer<'_> {
                 }
             }
             op!("||") => {
-                let rb = bin.right.as_pure_bool(&self.expr_ctx);
+                let rb = bin.right.as_pure_bool(&self.ctx.expr_ctx);
                 let rb = match rb {
                     Value::Known(v) => v,
                     _ => return,

--- a/crates/swc_ecma_minifier/src/compress/optimize/props.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/props.rs
@@ -299,11 +299,11 @@ impl Optimizer<'_> {
                 Prop::Shorthand(..) => false,
                 Prop::KeyValue(p) => {
                     p.key.is_computed()
-                        || p.value.may_have_side_effects(&self.expr_ctx)
+                        || p.value.may_have_side_effects(&self.ctx.expr_ctx)
                         || deeply_contains_this_expr(&p.value)
                 }
                 Prop::Assign(p) => {
-                    p.value.may_have_side_effects(&self.expr_ctx)
+                    p.value.may_have_side_effects(&self.ctx.expr_ctx)
                         || deeply_contains_this_expr(&p.value)
                 }
                 Prop::Getter(p) => p.key.is_computed(),

--- a/crates/swc_ecma_minifier/src/compress/optimize/strings.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/strings.rs
@@ -18,7 +18,7 @@ impl Optimizer<'_> {
         {
             if args
                 .iter()
-                .any(|arg| arg.expr.may_have_side_effects(&self.expr_ctx))
+                .any(|arg| arg.expr.may_have_side_effects(&self.ctx.expr_ctx))
             {
                 return;
             }
@@ -57,7 +57,7 @@ impl Optimizer<'_> {
             _ => {}
         }
 
-        let value = n.as_pure_string(&self.expr_ctx);
+        let value = n.as_pure_string(&self.ctx.expr_ctx);
         if let Known(value) = value {
             let span = n.span();
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
@@ -1,6 +1,6 @@
 use swc_common::{util::take::Take, EqIgnoreSpan, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{prepend_stmt, ExprExt, ExprFactory, StmtExt};
+use swc_ecma_utils::{extract_var_ids, prepend_stmt, ExprExt, ExprFactory, StmtExt};
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use super::Optimizer;
@@ -55,7 +55,7 @@ impl Optimizer<'_> {
                         exact = Some(idx);
                         break;
                     } else {
-                        var_ids.extend(case.cons.extract_var_ids())
+                        var_ids.extend(extract_var_ids(&case.cons))
                     }
                 } else {
                     if !may_match_other_than_exact
@@ -74,12 +74,12 @@ impl Optimizer<'_> {
 
         if let Some(exact) = exact {
             let exact_case = cases.last_mut().unwrap();
-            let mut terminate = exact_case.cons.terminates();
+            let mut terminate = exact_case.cons.iter().rev().any(|s| s.terminates());
             for case in stmt.cases[(exact + 1)..].iter_mut() {
                 if terminate {
-                    var_ids.extend(case.cons.extract_var_ids())
+                    var_ids.extend(extract_var_ids(&case.cons))
                 } else {
-                    terminate |= case.cons.terminates();
+                    terminate |= case.cons.iter().rev().any(|s| s.terminates());
                     exact_case.cons.extend(case.cons.take())
                 }
             }
@@ -90,7 +90,7 @@ impl Optimizer<'_> {
                     if case.test.is_some() {
                         true
                     } else {
-                        var_ids.extend(case.cons.extract_var_ids());
+                        var_ids.extend(extract_var_ids(&case.cons));
                         false
                     }
                 });
@@ -202,12 +202,16 @@ impl Optimizer<'_> {
         self.merge_cases_with_same_cons(cases);
 
         // last case with no empty body
-        let mut last = cases.len();
+        let mut last = 0;
 
         for (idx, case) in cases.iter_mut().enumerate().rev() {
             self.changed |= remove_last_break(&mut case.cons);
 
-            if !case.cons.is_empty() {
+            if case
+                .cons
+                .iter()
+                .any(|stmt| stmt.may_have_side_effects(&self.expr_ctx) || stmt.terminates())
+            {
                 last = idx + 1;
                 break;
             }
@@ -234,10 +238,18 @@ impl Optimizer<'_> {
         }
 
         if let Some(default) = default {
+            if cases.is_empty() {
+                return;
+            }
+
             let end = cases
                 .iter()
                 .skip(default)
-                .position(|case| !case.cons.is_empty())
+                .position(|case| {
+                    case.cons
+                        .iter()
+                        .any(|stmt| stmt.may_have_side_effects(&self.expr_ctx) || stmt.terminates())
+                })
                 .unwrap_or(0)
                 + default;
 
@@ -249,7 +261,10 @@ impl Optimizer<'_> {
                     .as_deref()
                     .map(|test| test.may_have_side_effects(&self.expr_ctx))
                     .unwrap_or(false)
-                    || (idx != end && !case.cons.is_empty())
+                    || (idx != end
+                        && case.cons.iter().any(|stmt| {
+                            stmt.may_have_side_effects(&self.expr_ctx) || stmt.terminates()
+                        }))
             });
 
             let start = start.map(|s| s + 1).unwrap_or(0);
@@ -292,7 +307,7 @@ impl Optimizer<'_> {
                     .map(|test| is_primitive(&self.expr_ctx, test).is_none())
                     .unwrap_or(false)
                     || !(cases[j].cons.is_empty()
-                        || cases[j].cons.terminates()
+                        || cases[j].cons.iter().rev().any(|s| s.terminates())
                         || j == cases.len() - 1);
 
                 if cases[j].cons.is_empty() {
@@ -419,7 +434,7 @@ impl Optimizer<'_> {
                     }
                     self.changed = true;
                     report_change!("switches: Turn two cases switch into if else");
-                    let terminate = first.cons.terminates();
+                    let terminate = first.cons.iter().rev().any(|s| s.terminates());
 
                     if terminate {
                         remove_last_break(&mut first.cons);

--- a/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
@@ -207,11 +207,9 @@ impl Optimizer<'_> {
         for (idx, case) in cases.iter_mut().enumerate().rev() {
             self.changed |= remove_last_break(&mut case.cons);
 
-            if case
-                .cons
-                .iter()
-                .any(|stmt| stmt.may_have_side_effects(&self.expr_ctx) || stmt.terminates())
-            {
+            if case.cons.iter().any(|stmt| {
+                stmt.may_have_side_effects(&self.expr_ctx, self.ctx.in_strict) || stmt.terminates()
+            }) {
                 last = idx + 1;
                 break;
             }
@@ -246,9 +244,10 @@ impl Optimizer<'_> {
                 .iter()
                 .skip(default)
                 .position(|case| {
-                    case.cons
-                        .iter()
-                        .any(|stmt| stmt.may_have_side_effects(&self.expr_ctx) || stmt.terminates())
+                    case.cons.iter().any(|stmt| {
+                        stmt.may_have_side_effects(&self.expr_ctx, self.ctx.in_strict)
+                            || stmt.terminates()
+                    })
                 })
                 .unwrap_or(0)
                 + default;
@@ -263,7 +262,8 @@ impl Optimizer<'_> {
                     .unwrap_or(false)
                     || (idx != end
                         && case.cons.iter().any(|stmt| {
-                            stmt.may_have_side_effects(&self.expr_ctx) || stmt.terminates()
+                            stmt.may_have_side_effects(&self.expr_ctx, self.ctx.in_strict)
+                                || stmt.terminates()
                         }))
             });
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/switches.rs
@@ -30,7 +30,7 @@ impl Optimizer<'_> {
 
         let discriminant = &mut stmt.discriminant;
 
-        let tail = if let Some(e) = is_primitive(&self.expr_ctx, tail_expr(discriminant)) {
+        let tail = if let Some(e) = is_primitive(&self.ctx.expr_ctx, tail_expr(discriminant)) {
             e
         } else {
             return;
@@ -43,7 +43,7 @@ impl Optimizer<'_> {
 
         for (idx, case) in stmt.cases.iter_mut().enumerate() {
             if let Some(test) = case.test.as_ref() {
-                if let Some(e) = is_primitive(&self.expr_ctx, tail_expr(test)) {
+                if let Some(e) = is_primitive(&self.ctx.expr_ctx, tail_expr(test)) {
                     if match (e, tail) {
                         (Expr::Lit(Lit::Num(e)), Expr::Lit(Lit::Num(tail))) => {
                             e.value == tail.value
@@ -207,9 +207,11 @@ impl Optimizer<'_> {
         for (idx, case) in cases.iter_mut().enumerate().rev() {
             self.changed |= remove_last_break(&mut case.cons);
 
-            if case.cons.iter().any(|stmt| {
-                stmt.may_have_side_effects(&self.expr_ctx, self.ctx.in_strict) || stmt.terminates()
-            }) {
+            if case
+                .cons
+                .iter()
+                .any(|stmt| stmt.may_have_side_effects(&self.ctx.expr_ctx) || stmt.terminates())
+            {
                 last = idx + 1;
                 break;
             }
@@ -218,7 +220,7 @@ impl Optimizer<'_> {
         let has_side_effect = cases.iter().skip(last).rposition(|case| {
             case.test
                 .as_deref()
-                .map(|test| test.may_have_side_effects(&self.expr_ctx))
+                .map(|test| test.may_have_side_effects(&self.ctx.expr_ctx))
                 .unwrap_or(false)
         });
 
@@ -245,8 +247,7 @@ impl Optimizer<'_> {
                 .skip(default)
                 .position(|case| {
                     case.cons.iter().any(|stmt| {
-                        stmt.may_have_side_effects(&self.expr_ctx, self.ctx.in_strict)
-                            || stmt.terminates()
+                        stmt.may_have_side_effects(&self.ctx.expr_ctx) || stmt.terminates()
                     })
                 })
                 .unwrap_or(0)
@@ -258,12 +259,11 @@ impl Optimizer<'_> {
             let start = cases.iter().enumerate().rposition(|(idx, case)| {
                 case.test
                     .as_deref()
-                    .map(|test| test.may_have_side_effects(&self.expr_ctx))
+                    .map(|test| test.may_have_side_effects(&self.ctx.expr_ctx))
                     .unwrap_or(false)
                     || (idx != end
                         && case.cons.iter().any(|stmt| {
-                            stmt.may_have_side_effects(&self.expr_ctx, self.ctx.in_strict)
-                                || stmt.terminates()
+                            stmt.may_have_side_effects(&self.ctx.expr_ctx) || stmt.terminates()
                         }))
             });
 
@@ -304,7 +304,7 @@ impl Optimizer<'_> {
                 cannot_cross_block |= cases[j]
                     .test
                     .as_deref()
-                    .map(|test| is_primitive(&self.expr_ctx, test).is_none())
+                    .map(|test| is_primitive(&self.ctx.expr_ctx, test).is_none())
                     .unwrap_or(false)
                     || !(cases[j].cons.is_empty()
                         || cases[j].cons.iter().rev().any(|s| s.terminates())

--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -503,7 +503,8 @@ impl Optimizer<'_> {
                     );
                     // This will remove the declaration.
                     let class = decl.take().class().unwrap();
-                    let mut side_effects = extract_class_side_effect(&self.expr_ctx, *class.class);
+                    let mut side_effects =
+                        extract_class_side_effect(&self.ctx.expr_ctx, *class.class);
 
                     if !side_effects.is_empty() {
                         self.prepend_stmts.push(
@@ -687,7 +688,7 @@ impl Optimizer<'_> {
                     && !var.exported
                     && var.usage_count == 0
                     && var.declared
-                    && (!var.declared_as_fn_param || !used_arguments || self.ctx.in_strict)
+                    && (!var.declared_as_fn_param || !used_arguments || self.ctx.expr_ctx.in_strict)
                 {
                     report_change!(
                         "unused: Dropping assignment to var '{}{:?}', which is never used",
@@ -827,7 +828,7 @@ impl Optimizer<'_> {
             PropOrSpread::Prop(p) => match &**p {
                 Prop::Shorthand(_) => false,
                 Prop::KeyValue(p) => {
-                    p.key.is_computed() || p.value.may_have_side_effects(&self.expr_ctx)
+                    p.key.is_computed() || p.value.may_have_side_effects(&self.ctx.expr_ctx)
                 }
                 Prop::Assign(_) => true,
                 Prop::Getter(p) => p.key.is_computed(),

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -95,8 +95,7 @@ impl<'b> Optimizer<'b> {
             }
         }
 
-        let orig_ctx = self.ctx;
-        self.ctx = ctx;
+        let orig_ctx = std::mem::replace(&mut self.ctx, ctx);
         WithCtx {
             reducer: self,
             orig_ctx,
@@ -158,7 +157,7 @@ impl DerefMut for WithCtx<'_, '_> {
 
 impl Drop for WithCtx<'_, '_> {
     fn drop(&mut self) {
-        self.reducer.ctx = self.orig_ctx;
+        self.reducer.ctx = self.orig_ctx.clone();
     }
 }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/bools.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/bools.rs
@@ -195,7 +195,7 @@ impl Pure<'_> {
 
         if delete.arg.may_have_side_effects(&ExprCtx {
             is_unresolved_ref_safe: true,
-            ..self.expr_ctx.clone()
+            ..self.expr_ctx
         }) {
             return;
         }

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -59,6 +59,7 @@ pub(crate) fn pure_optimizer<'a>(
         expr_ctx: ExprCtx {
             unresolved_ctxt: SyntaxContext::empty().apply_mark(marks.unresolved_mark),
             is_unresolved_ref_safe: false,
+            in_strict: options.module,
         },
         ctx: Default::default(),
         changed: Default::default(),

--- a/crates/swc_ecma_minifier/src/compress/util/tests.rs
+++ b/crates/swc_ecma_minifier/src/compress/util/tests.rs
@@ -48,6 +48,7 @@ fn assert_negate_cost(s: &str, in_bool_ctx: bool, is_ret_val_ignored: bool, expe
         let expr_ctx = ExprCtx {
             unresolved_ctxt: SyntaxContext::empty().apply_mark(Mark::new()),
             is_unresolved_ref_safe: false,
+            in_strict: false,
         };
 
         let real = {

--- a/crates/swc_ecma_minifier/src/eval.rs
+++ b/crates/swc_ecma_minifier/src/eval.rs
@@ -31,6 +31,7 @@ impl Evaluator {
             expr_ctx: ExprCtx {
                 unresolved_ctxt: SyntaxContext::empty().apply_mark(marks.unresolved_mark),
                 is_unresolved_ref_safe: false,
+                in_strict: true,
             },
 
             module,

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8813/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8813/output.js
@@ -13,7 +13,6 @@
     switch(x){
         case x:
         case y = "FAIL":
-        default:
     }
     console.log(y);
 })(), console.log("PASS 3"), console.log("PASS 4"), (()=>{
@@ -21,7 +20,6 @@
     switch('asdf'){
         case y = "PASS 5":
         case z = "PASS 5":
-        default:
     }
     console.log(y, z);
 })();

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8953/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8953/input.js
@@ -1,0 +1,10 @@
+"use strict";
+const k = (() => {
+    let x = 1;
+    switch (x) {
+        case x:
+            async function x() {}
+    }
+    return x;
+})();
+console.log(k);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8953/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8953/output.js
@@ -1,0 +1,2 @@
+"use strict";
+console.log(1);

--- a/crates/swc_ecma_minifier/tests/terser/compress/issue_1750/case_2/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/issue_1750/case_2/output.js
@@ -1,4 +1,3 @@
-var a = 0,
-    b = 1;
-if (0 === a) a = 3;
+var a = 0, b = 1;
+a = 3;
 console.log(a, b);

--- a/crates/swc_ecma_minifier/tests/terser/compress/switch/gut_entire_switch_2/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/switch/gut_entire_switch_2/output.js
@@ -1,2 +1,2 @@
-if (1 === id(123)) "no side effect";
+id(123);
 console.log("PASS");

--- a/crates/swc_ecma_minifier/tests/terser/compress/switch/issue_1680_2/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/switch/issue_1680_2/output.js
@@ -1,6 +1,5 @@
-var a = 100,
-    b = 10;
-switch (b) {
+var a = 100, b = 10;
+switch(b){
     case a--:
         break;
     case b:

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -32,6 +32,7 @@ pub fn dead_branch_remover(unresolved_mark: Mark) -> impl RepeatedJsPass + Visit
         expr_ctx: ExprCtx {
             unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
             is_unresolved_ref_safe: false,
+            in_strict: false,
         },
     })
 }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/tests.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/tests.rs
@@ -25,6 +25,7 @@ macro_rules! test_stmt {
                             unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
                             // This is hack
                             is_unresolved_ref_safe: true,
+                            in_strict: false,
                         },
                     })
                 )

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -35,6 +35,7 @@ pub fn dce(
         expr_ctx: ExprCtx {
             unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
             is_unresolved_ref_safe: false,
+            in_strict: false,
         },
         config,
         changed: false,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -48,6 +48,7 @@ pub fn expr_simplifier(
         expr_ctx: ExprCtx {
             unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
             is_unresolved_ref_safe: false,
+            in_strict: false,
         },
         config,
         changed: false,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/tests.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/tests.rs
@@ -22,6 +22,7 @@ fn fold(src: &str, expected: &str) {
                         unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
                         // This is hack
                         is_unresolved_ref_safe: true,
+                        in_strict: false,
                     },
                     config: super::Config {},
                     changed: false,

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
@@ -35,6 +35,7 @@ where
             unresolved_ctxt: SyntaxContext::empty()
                 .apply_mark(marks.map(|m| m.unresolved_mark).unwrap_or_default()),
             is_unresolved_ref_safe: false,
+            in_strict: false,
         },
         used_recursively: AHashMap::default(),
     };

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
@@ -1188,7 +1188,7 @@ where
             } else {
                 self.with_ctx(ctx).visit_in_cond(case);
             }
-            fallthrough = !case.cons.terminates()
+            fallthrough = !case.cons.iter().rev().any(|s| s.terminates())
         }
     }
 

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -514,9 +514,7 @@ pub trait StmtExt {
             Stmt::Decl(decl) => match decl {
                 Decl::Class(class_decl) => class_has_side_effect(ctx, &class_decl.class, in_strict),
                 Decl::Fn(_) => !in_strict,
-                Decl::Var(var_decl) if var_decl.kind == VarDeclKind::Var => {
-                    var_decl.decls.iter().any(|decl| decl.init.is_some())
-                }
+                Decl::Var(var_decl) => var_decl.kind == VarDeclKind::Var,
                 _ => false,
             },
             Stmt::Expr(expr_stmt) => expr_stmt.expr.may_have_side_effects(ctx),


### PR DESCRIPTION
**Description:**

This is learnt from https://github.com/terser/terser/pull/1044
**Key point:** all the cases (statements) after the last side-effect and non-terminated one are useless.

There are also some points on whether a statement is side-effect free:
- **Var declaration:** I think var declaration always contains side effect. 
- **Function declaration:** In non-strict mode, function declaration is same as var declaration. In strict mode, function is declared in enclosing block scope, so it's side-effect free. But there is a bad case when we call the function before it is declared in the switch case:
```js
"use strict";
const k = (() => {
    let x = 1;
    switch (x) {
        case y():
        case x: {
            async function y() {
                console.log(123);
            }
        }
    }
    return x;
})();
```

**This is an existing bug.** I'm not sure whether we should fix it since it is a very bad code and I also find some similar bad cases with terser.

~I'm also not sure it's appropriate to introduce context variable `in_strict` for `StmtExt:: may_have_side_effects`, because `in_strict` could change from `false` to `true`. But this is a **conservative** mistake and does not break the program. Maybe we should use visitor for context-aware side effect checker in the future.~

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/8953