### PR TITLE
feat(es/parser): Ability to get script's potential module errors

### DIFF
--- a/.changeset/fifty-goats-beg.md
+++ b/.changeset/fifty-goats-beg.md
@@ -1,0 +1,6 @@
+---
+swc_core: breaking
+swc_ecma_parser: breaking
+---
+
+feat(es/parser): Ability to get script's potential module errors

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -192,6 +192,10 @@ impl Tokens for Lexer<'_> {
         take(&mut self.errors.borrow_mut())
     }
 
+    fn take_script_module_errors(&mut self) -> Vec<Error> {
+        take(&mut self.module_errors.borrow_mut())
+    }
+
     fn end_pos(&self) -> BytePos {
         self.input.end_pos()
     }

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -49,6 +49,10 @@ pub trait Tokens: Clone + Iterator<Item = TokenAndSpan> {
     fn end_pos(&self) -> BytePos;
 
     fn take_errors(&mut self) -> Vec<Error>;
+
+    /// If the program was parsed as a script, this contains the module
+    /// errors should the program be identified as a module in the future.
+    fn take_script_module_errors(&mut self) -> Vec<Error>;
 }
 
 #[derive(Clone)]
@@ -143,6 +147,10 @@ impl Tokens for TokensInput {
 
     fn take_errors(&mut self) -> Vec<Error> {
         take(&mut self.errors.borrow_mut())
+    }
+
+    fn take_script_module_errors(&mut self) -> Vec<Error> {
+        take(&mut self.module_errors.borrow_mut())
     }
 
     fn end_pos(&self) -> BytePos {
@@ -267,6 +275,10 @@ impl<I: Tokens> Tokens for Capturing<I> {
 
     fn take_errors(&mut self) -> Vec<Error> {
         self.inner.take_errors()
+    }
+
+    fn take_script_module_errors(&mut self) -> Vec<Error> {
+        self.inner.take_script_module_errors()
     }
 
     fn end_pos(&self) -> BytePos {

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -90,6 +90,10 @@ impl<I: Tokens> Parser<I> {
         self.input().take_errors()
     }
 
+    pub fn take_script_module_errors(&mut self) -> Vec<Error> {
+        self.input().take_script_module_errors()
+    }
+
     pub fn parse_script(&mut self) -> PResult<Script> {
         trace_cur!(self, parse_script);
 

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -350,26 +350,22 @@ fn parse_non_strict_for_loop() {
 
 #[test]
 fn parse_program_take_script_module_errors() {
-    test_parser(
-        r#"077;"#,
-        Default::default(),
-        |p| {
-            let program = p.parse_program()?;
+    test_parser(r#"077;"#, Default::default(), |p| {
+        let program = p.parse_program()?;
 
-            assert_eq!(p.take_errors(), vec![]);
-            // will contain the script's potential module errors
-            assert_eq!(
-                p.take_script_module_errors(),
-                vec![Error::new(
-                    Span {
-                        lo: BytePos(1),
-                        hi: BytePos(4),
-                    },
-                    crate::parser::SyntaxError::LegacyOctal
-                )]
-            );
+        assert_eq!(p.take_errors(), vec![]);
+        // will contain the script's potential module errors
+        assert_eq!(
+            p.take_script_module_errors(),
+            vec![Error::new(
+                Span {
+                    lo: BytePos(1),
+                    hi: BytePos(4),
+                },
+                crate::parser::SyntaxError::LegacyOctal
+            )]
+        );
 
-            Ok(program)
-        },
-    );
+        Ok(program)
+    });
 }

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -317,6 +317,7 @@ fn illegal_language_mode_directive1() {
         },
     );
 }
+
 #[test]
 fn illegal_language_mode_directive2() {
     test_parser(
@@ -345,4 +346,30 @@ fn illegal_language_mode_directive2() {
 #[test]
 fn parse_non_strict_for_loop() {
     script("for (var v1 = 1 in v3) {}");
+}
+
+#[test]
+fn parse_program_take_script_module_errors() {
+    test_parser(
+        r#"077;"#,
+        Default::default(),
+        |p| {
+            let program = p.parse_program()?;
+
+            assert_eq!(p.take_errors(), vec![]);
+            // will contain the script's potential module errors
+            assert_eq!(
+                p.take_script_module_errors(),
+                vec![Error::new(
+                    Span {
+                        lo: BytePos(1),
+                        hi: BytePos(4),
+                    },
+                    crate::parser::SyntaxError::LegacyOctal
+                )]
+            );
+
+            Ok(program)
+        },
+    );
 }


### PR DESCRIPTION
**Description:**

In Deno I'm now parsing stuff as a program more often because I sometimes now need to discover if something is a script or es module by looking at the contents. A problem is that the module errors are discarded when parsing as a script, but I still might need them later if I discover the program the program should be treated as an ES module.

**BREAKING CHANGE:**

Adds a new method to the `Tokens` trait.

**Related issue (if exists):** None
