### PR TITLE
perf(es): Cache `current_dir()` system calls

### DIFF
--- a/.changeset/silent-cows-brake.md
+++ b/.changeset/silent-cows-brake.md
@@ -1,0 +1,7 @@
+---
+swc: patch
+swc_common: patch
+swc_core: patch
+---
+
+perf(es): Cache `current_dir()` system calls

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -842,7 +842,9 @@ pub struct CallerOptions {
 
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 fn default_cwd() -> PathBuf {
-    ::std::env::current_dir().unwrap()
+    static CWD: Lazy<PathBuf> = Lazy::new(|| ::std::env::current_dir().unwrap());
+
+    CWD.clone()
 }
 
 /// `.swcrc` file

--- a/crates/swc_common/src/plugin/metadata.rs
+++ b/crates/swc_common/src/plugin/metadata.rs
@@ -1,5 +1,7 @@
 use std::env;
 
+use once_cell::sync::Lazy;
+
 use crate::collections::AHashMap;
 
 /// Indexable key to the metadata context for a transform plugin.
@@ -48,12 +50,16 @@ impl TransformPluginMetadataContext {
         env: String,
         experimental: Option<AHashMap<String, String>>,
     ) -> Self {
+        static CWD: Lazy<Option<String>> = Lazy::new(|| {
+            env::current_dir()
+                .map(|cwd| cwd.as_path().to_string_lossy().to_string())
+                .ok()
+        });
+
         TransformPluginMetadataContext {
             filename,
             env,
-            cwd: env::current_dir()
-                .map(|cwd| cwd.as_path().to_string_lossy().to_string())
-                .ok(),
+            cwd: CWD.clone(),
             experimental: experimental.unwrap_or_default(),
         }
     }


### PR DESCRIPTION
**Description:**

Cache `current_dir()` system calls. Those are needless because we already cache `current_dir` in some places so it will break if the user changes cwd anyway.

**Related issue:**

 - https://github.com/swc-project/swc/issues/9601