### PR TITLE
fix(es/resolver): Skip resolving lowercase `JSXIdentifiers`

### DIFF
--- a/.changeset/fluffy-eyes-hope.md
+++ b/.changeset/fluffy-eyes-hope.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_transforms_base: patch
+swc_core: patch
+---
+
+fix(es/resolver): Skip resolving lowercase JSXIdentifiers

--- a/crates/swc/tests/fixture/issues-9xxx/9685/input/index.tsx
+++ b/crates/swc/tests/fixture/issues-9xxx/9685/input/index.tsx
@@ -1,0 +1,4 @@
+export namespace form {
+    export const input = null;
+    export const test = <input />
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9685/output/index.tsx
+++ b/crates/swc/tests/fixture/issues-9xxx/9685/output/index.tsx
@@ -1,0 +1,5 @@
+(function(form) {
+    form.input = null;
+    form.test = /*#__PURE__*/ React.createElement("input", null);
+})(form || (form = {}));
+export var form;

--- a/crates/swc_ecma_transforms_base/src/resolver/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/resolver/mod.rs
@@ -923,6 +923,18 @@ impl VisitMut for Resolver<'_> {
     fn visit_mut_jsx_element_name(&mut self, node: &mut JSXElementName) {
         if let JSXElementName::Ident(i) = node {
             if i.as_ref().starts_with(|c: char| c.is_ascii_lowercase()) {
+                if cfg!(debug_assertions) && LOG {
+                    debug!("\t -> JSXElementName");
+                }
+
+                let ctxt = i.ctxt.apply_mark(self.config.unresolved_mark);
+
+                if cfg!(debug_assertions) && LOG {
+                    debug!("\t -> {:?}", ctxt);
+                }
+
+                i.ctxt = ctxt;
+
                 return;
             }
         }

--- a/crates/swc_ecma_transforms_base/src/resolver/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/resolver/mod.rs
@@ -922,7 +922,7 @@ impl VisitMut for Resolver<'_> {
 
     fn visit_mut_jsx_element_name(&mut self, node: &mut JSXElementName) {
         if let JSXElementName::Ident(i) = node {
-            if i.as_ref().starts_with(|c: char| c.is_ascii_lowercase()) {
+            if i.as_ref().starts_with(char::is_ascii_lowercase) {
                 if cfg!(debug_assertions) && LOG {
                     debug!("\t -> JSXElementName");
                 }

--- a/crates/swc_ecma_transforms_base/src/resolver/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/resolver/mod.rs
@@ -922,7 +922,7 @@ impl VisitMut for Resolver<'_> {
 
     fn visit_mut_jsx_element_name(&mut self, node: &mut JSXElementName) {
         if let JSXElementName::Ident(i) = node {
-            if i.as_ref().starts_with(char::is_ascii_lowercase) {
+            if i.as_ref().starts_with(|c: char| c.is_ascii_lowercase()) {
                 if cfg!(debug_assertions) && LOG {
                     debug!("\t -> JSXElementName");
                 }

--- a/crates/swc_ecma_transforms_base/src/resolver/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/resolver/mod.rs
@@ -920,6 +920,16 @@ impl VisitMut for Resolver<'_> {
         f.body.visit_mut_with(self);
     }
 
+    fn visit_mut_jsx_element_name(&mut self, node: &mut JSXElementName) {
+        if let JSXElementName::Ident(i) = node {
+            if i.as_ref().starts_with(|c: char| c.is_ascii_lowercase()) {
+                return;
+            }
+        }
+
+        node.visit_mut_children_with(self);
+    }
+
     fn visit_mut_ident(&mut self, i: &mut Ident) {
         if i.ctxt != SyntaxContext::empty() {
             return;

--- a/crates/swc_ecma_transforms_base/tests/fixture.rs
+++ b/crates/swc_ecma_transforms_base/tests/fixture.rs
@@ -84,10 +84,12 @@ fn test_resolver(input: PathBuf) {
 }
 
 #[fixture("tests/ts-resolver/**/input.ts")]
+#[fixture("tests/ts-resolver/**/input.tsx")]
 fn test_ts_resolver(input: PathBuf) {
     run(
         Syntax::Typescript(TsSyntax {
             decorators: true,
+            tsx: input.extension().filter(|ext| *ext == "tsx").is_some(),
             ..Default::default()
         }),
         &input,

--- a/crates/swc_ecma_transforms_base/tests/resolver/issues/2854/1/output.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/issues/2854/1/output.js
@@ -2,7 +2,7 @@ export function App__2() {
     return <Form__2/>;
 }
 export function Form__2({ onChange__4 = function() {} }) {
-    return <input__0 onChange={function() {
+    return <input onChange={function() {
         onChange__4();
     }}/>;
 }

--- a/crates/swc_ecma_transforms_base/tests/resolver/issues/2854/1/output.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/issues/2854/1/output.js
@@ -2,7 +2,7 @@ export function App__2() {
     return <Form__2/>;
 }
 export function Form__2({ onChange__4 = function() {} }) {
-    return <input onChange={function() {
+    return <input__0 onChange={function() {
         onChange__4();
     }}/>;
 }

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/issue-9685/1/input.tsx
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/issue-9685/1/input.tsx
@@ -1,0 +1,4 @@
+export namespace form {
+    export const input = null;
+    export const test = <input />;
+}

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/issue-9685/1/output.tsx
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/issue-9685/1/output.tsx
@@ -1,4 +1,4 @@
 export namespace form__2 {
     export const input__3 = null;
-    export const test__3 = <input__0/>;
+    export const test__3 = <input/>;
 }

--- a/crates/swc_ecma_transforms_base/tests/ts-resolver/issue-9685/1/output.tsx
+++ b/crates/swc_ecma_transforms_base/tests/ts-resolver/issue-9685/1/output.tsx
@@ -1,0 +1,4 @@
+export namespace form__2 {
+    export const input__3 = null;
+    export const test__3 = <input__0/>;
+}


### PR DESCRIPTION
**Related issue:**

- Closes: #9685 
