### PR TITLE
perf(es/lints): Disable lints by default

### DIFF
--- a/.changeset/poor-tools-arrive.md
+++ b/.changeset/poor-tools-arrive.md
@@ -1,0 +1,6 @@
+---
+swc: patch
+swc_core: patch
+---
+
+perf(es/lints): Disable lints by default

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1249,7 +1249,7 @@ pub struct JscExperimental {
     pub emit_isolated_dts: BoolConfig<false>,
 
     #[serde(default)]
-    pub disable_all_lints: BoolConfig<false>,
+    pub disable_all_lints: BoolConfig<true>,
 }
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]

--- a/crates/swc/tests/error_msg.rs
+++ b/crates/swc/tests/error_msg.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use swc::{
-    config::{Config, IsModule, Options},
+    config::{Config, IsModule, JscConfig, JscExperimental, Options},
     try_with_handler, Compiler, HandlerOpts,
 };
 use swc_common::{errors::ColorConfig, sync::Lrc, FilePathMapping, SourceMap, GLOBALS};
@@ -61,6 +61,13 @@ fn fixture(input: PathBuf) {
                     &Options {
                         config: Config {
                             is_module: Some(IsModule::Unknown),
+                            jsc: JscConfig {
+                                experimental: JscExperimental {
+                                    disable_all_lints: false.into(),
+                                    ..Default::default()
+                                },
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
                         swcrc: true,

--- a/crates/swc/tests/tsc.rs
+++ b/crates/swc/tests/tsc.rs
@@ -14,7 +14,9 @@ use regex::Regex;
 use serde::de::DeserializeOwned;
 use serde_json::from_str;
 use swc::{
-    config::{Config, JsMinifyOptions, JscConfig, ModuleConfig, Options, TransformConfig},
+    config::{
+        Config, JsMinifyOptions, JscConfig, JscExperimental, ModuleConfig, Options, TransformConfig,
+    },
     try_with_handler, Compiler,
 };
 use swc_common::{
@@ -401,6 +403,10 @@ fn matrix(input: &Path) -> Vec<TestUnitData> {
                                 ..Default::default()
                             })
                             .into(),
+                            experimental: JscExperimental {
+                                disable_all_lints: false.into(),
+                                ..Default::default()
+                            },
                             ..Default::default()
                         },
                         module: Some(module.into()),


### PR DESCRIPTION
**Description:**

This is a footgun for users of `swc` crate. So I changed the default value of `jsc.experimental.disableAllLints` to `true`.


**Related issue (if exists):**
