### PR TITLE
fix(es/typescript): Handle multiline type parameters in async arrow functions

### DIFF
--- a/.changeset/swift-hairs-bow.md
+++ b/.changeset/swift-hairs-bow.md
@@ -1,0 +1,6 @@
+---
+swc_fast_ts_strip: patch
+swc_core: patch
+---
+
+fix(es/typescript): Handle multiline type parameters in async arrow functions

--- a/crates/swc_fast_ts_strip/tests/fixture/issue-9698.js
+++ b/crates/swc_fast_ts_strip/tests/fixture/issue-9698.js
@@ -1,0 +1,9 @@
+let f = async (
+     
+  v   ) => v;
+
+let g = async (
+     
+  v    
+                 ) => 
+        v;

--- a/crates/swc_fast_ts_strip/tests/fixture/issue-9698.transform.js
+++ b/crates/swc_fast_ts_strip/tests/fixture/issue-9698.transform.js
@@ -1,0 +1,2 @@
+let f = async (v)=>v;
+let g = async (v)=>v;

--- a/crates/swc_fast_ts_strip/tests/fixture/issue-9698.ts
+++ b/crates/swc_fast_ts_strip/tests/fixture/issue-9698.ts
@@ -1,0 +1,9 @@
+let f = async <
+    T
+>(v: T) => v;
+
+let g = async <
+    T
+>(v: T)
+    : Promise<any> => 
+        v;


### PR DESCRIPTION
**Related issue:**

- Closes: #9698 
