### PR TITLE
feat(typescript): Port deno `isolatedDeclarations` updates

### DIFF
--- a/.changeset/witty-bears-attend.md
+++ b/.changeset/witty-bears-attend.md
@@ -1,0 +1,5 @@
+---
+swc_typescript: major
+---
+
+feat(typescript): port deno `isolatedDeclarations` updates

--- a/crates/swc_typescript/tests/fast_dts_deno.rs
+++ b/crates/swc_typescript/tests/fast_dts_deno.rs
@@ -239,6 +239,49 @@ fn dts_class_abstract_method_test() {
 }
 
 #[test]
+fn dts_class_params_initializers_test() {
+    transform_dts_test(
+        r#"export class Object {
+    constructor(
+        values: {},
+        {
+            a,
+            b,
+        }: {
+            a?: A;
+            b?: B;
+        } = {}
+    ) {}
+
+    method(
+        values: {},
+        {
+            a,
+            b,
+        }: {
+            a?: A;
+            b?: B;
+        } = {},
+        value = 1
+    ) {}
+}
+"#,
+        r#"export declare class Object {
+    constructor(values: {
+    }, { a, b }?: {
+        a?: A;
+        b?: B;
+    });
+    method(values: {
+    }, { a, b }?: {
+        a?: A;
+        b?: B;
+    }, value?: number);
+}"#,
+    );
+}
+
+#[test]
 fn dts_var_decl_test() {
     transform_dts_test(
         r#"export const foo: number = 42;"#,

--- a/crates/swc_typescript/tests/fast_dts_deno.rs
+++ b/crates/swc_typescript/tests/fast_dts_deno.rs
@@ -282,6 +282,24 @@ fn dts_class_params_initializers_test() {
 }
 
 #[test]
+fn dts_class_properties_computed_test() {
+    transform_dts_test(
+        r#"export class Test {
+  [Symbol.for("nodejs.util.inspect.custom")]() {
+  }
+  ["string"]: string;
+  ["string2" as string]: string;
+  [1 as number]: string;
+}"#,
+        r#"export declare class Test {
+    "string": string;
+    "string2": string;
+    1: string;
+}"#,
+    );
+}
+
+#[test]
 fn dts_var_decl_test() {
     transform_dts_test(
         r#"export const foo: number = 42;"#,

--- a/crates/swc_typescript/tests/fast_dts_deno.rs
+++ b/crates/swc_typescript/tests/fast_dts_deno.rs
@@ -183,6 +183,32 @@ fn dts_class_decl_overloads_test() {
     foo(arg: number);
 }"#,
     );
+
+    transform_dts_test(
+        r#"export abstract class Value {
+    protected body?(): string | undefined | Promise<string | undefined>;
+    protected footer(): string | undefined {
+        return "";
+    }
+}
+function overloadsNonExportDecl(args: string): void;
+function overloadsNonExportDecl(args: number): void;
+function overloadsNonExportDecl(args: any): void {}
+export { overloadsNonExportDecl };
+export default function defaultExport(args: string): void;
+export default function defaultExport(args: number): void;
+export default function defaultExport(args: any): void {}
+"#,
+        r#"export declare abstract class Value {
+    protected body?(): string | undefined | Promise<string | undefined>;
+    protected footer(): string | undefined;
+}
+declare function overloadsNonExportDecl(args: string): void;
+declare function overloadsNonExportDecl(args: number): void;
+export { overloadsNonExportDecl };
+export default function defaultExport(args: string): void;
+export default function defaultExport(args: number): void;"#,
+    );
 }
 
 #[test]

--- a/crates/swc_typescript/tests/fast_dts_deno.rs
+++ b/crates/swc_typescript/tests/fast_dts_deno.rs
@@ -2,7 +2,7 @@
 
 use swc_ecma_ast::EsVersion;
 use swc_ecma_codegen::to_code;
-use swc_ecma_parser::{parse_file_as_module, Syntax, TsSyntax};
+use swc_ecma_parser::{parse_file_as_program, Syntax, TsSyntax};
 use swc_typescript::fast_dts::FastDts;
 
 #[track_caller]
@@ -15,7 +15,7 @@ fn transform_dts_test(source: &str, expected: &str) {
 
         let mut checker = FastDts::new(fm.name.clone());
 
-        let mut module = parse_file_as_module(
+        let mut program = parse_file_as_program(
             &fm,
             Syntax::Typescript(TsSyntax {
                 ..Default::default()
@@ -26,9 +26,9 @@ fn transform_dts_test(source: &str, expected: &str) {
         )
         .unwrap();
 
-        let _issues = checker.transform(&mut module);
+        let _issues = checker.transform(&mut program);
 
-        let code = to_code(&module);
+        let code = to_code(&program);
 
         assert_eq!(
             code.trim(),


### PR DESCRIPTION
In https://github.com/denoland/deno_graph/commits/main/src/fast_check/transform_dts.rs:
From https://github.com/denoland/deno_graph/commit/7f38d56de34f9a4ef7542db69db4a34157893dc3 to https://github.com/denoland/deno_graph/commit/258186c4296a933a068f3df53aff1118928e4ccc

PR list:
- [x] ~https://github.com/denoland/deno_graph/pull/508~. I don't port this pr because swc doesn't resolve `public_ranges`. However, I refer to https://github.com/oxc-project/oxc/blob/fac5042afafc6e1acd6953150f3857d086ba945d/crates/oxc_isolated_declarations/src/lib.rs#L421C24-L421C33 to fix the bugs.
- [x] https://github.com/denoland/deno_graph/pull/521
- [x] https://github.com/denoland/deno_graph/pull/522
- [x] https://github.com/denoland/deno_graph/pull/540

I will port the tests if I have spare time.