### PR TITLE
fix(es/plugin): Migrate `swc plugin new` to use `.cargo/config.toml`

### DIFF
--- a/.changeset/sixty-walls-hang.md
+++ b/.changeset/sixty-walls-hang.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_cli_impl: patch
+---
+
+Migrate  to config.toml to fix warning

--- a/crates/swc_cli_impl/src/commands/plugin.rs
+++ b/crates/swc_cli_impl/src/commands/plugin.rs
@@ -165,7 +165,7 @@ lto = true
 serde = "1"
 swc_core = {{ version = "{}", features = ["ecma_plugin_transform"] }}
 
-# .cargo/config defines few alias to build plugin.
+# .cargo/config.toml defines few alias to build plugin.
 # cargo build-wasi generates wasm-wasi32 binary
 # cargo build-wasm32 generates wasm32-unknown-unknown binary.
 "#,
@@ -185,11 +185,11 @@ swc_core = {{ version = "{}", features = ["ecma_plugin_transform"] }}
             PluginTargetType::Wasm32Wasi => "build-wasi",
         };
 
-        // Create cargo config for build target
+        // Create `.cargo/config.toml` file for build target
         let cargo_config_path = path.join(".cargo");
         create_dir_all(&cargo_config_path).context("`create_dir_all` failed")?;
         fs::write(
-            cargo_config_path.join("config"),
+            cargo_config_path.join("config.toml"),
             r#"# These command aliases are not final, may change
 [alias]
 # Alias to build actual plugin binary for the specified target.


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
As per https://doc.rust-lang.org/cargo/reference/config.html we should be generating a `.cargo/config.toml` instead of `.cargo/config` when creating a new plugin

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Motivation - console warnings 😆 

**BREAKING CHANGE:**
Technically this means users **must** have a toolchain > 1.38 (released september, 2019 - so five years ago). 
Given that:
 - the [public documentation for swc plugins](https://swc.rs/docs/plugin/ecmascript/getting-started#install-rust) link directly to the latest version of the rust toolchain (currently 1.81)
 - 1.38 was > **five years ago** 
 - This only impacts **new** usages of `swc plugin new ..`
 - README.md specifies that the `swc-project/swc` MSRV is 1.73 anyways - whilst that doesn't **specifically** refer to **generated** code, it shows the intent of the project :)

I don't believe it will have material impact. 

I will raise a separate PR to generate the correct MSRV for both `swc-project/swc` **and** the generated plugin itself.

**Related issue (if exists):**
