### PR TITLE
fix(@swc/types): tsc build file ignored by npm

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -16,6 +16,10 @@
         "registry": "https://registry.npmjs.org/",
         "access": "public"
     },
+    "files": [
+        "*.js",
+        "*.d.ts"
+    ],
     "keywords": [
         "swc",
         "types"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@swc/types",
     "packageManager": "yarn@4.0.2",
-    "version": "0.1.16",
+    "version": "0.1.17",
     "description": "Typings for the swc project.",
     "sideEffects": false,
     "scripts": {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
JS and DTS files in `@swc/types` are automatically ignored by npm. Add the `files` attribute in `package.json` to make it work.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Here's the result of `npm publish --dry-run`:
```
> @swc/types@0.1.16 prepublishOnly
> yarn build

npm notice
npm notice 📦  @swc/types@0.1.16
npm notice Tarball Contents
npm notice 10.8kB LICENSE
npm notice 219B README.md
npm notice 2.6kB assumptions.d.ts
npm notice 77B assumptions.js
npm notice 61.8kB index.d.ts
npm notice 77B index.js
npm notice 902B package.json
npm notice Tarball Details
npm notice name: @swc/types
npm notice version: 0.1.16
npm notice filename: swc-types-0.1.16.tgz
npm notice package size: 18.5 kB
npm notice unpacked size: 76.6 kB
npm notice shasum: 0740c566a7f6eca97d02d03a0f4a059b0b5903e7
npm notice integrity: sha512-pcVB4Cnv1hS/s[...]quwePgoVn6Lmg==
npm notice total files: 7
```


**BREAKING CHANGE:**
Nothing.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
