### PR TITLE
fix(es/codegen): Use raw value for emitting JSX text

### DIFF
--- a/.changeset/little-scissors-join.md
+++ b/.changeset/little-scissors-join.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_codegen: patch
+swc_core: patch
+---
+
+fix(es/codegen): use raw value for emitting JSX text

--- a/crates/swc_ecma_codegen/src/jsx.rs
+++ b/crates/swc_ecma_codegen/src/jsx.rs
@@ -174,7 +174,7 @@ where
 
     #[emitter]
     fn emit_jsx_text(&mut self, node: &JSXText) -> Result {
-        self.emit_atom(node.span(), &node.value)?;
+        self.emit_atom(node.span(), &node.raw)?;
     }
 
     #[emitter]

--- a/crates/swc_ecma_codegen/tests/fixture.rs
+++ b/crates/swc_ecma_codegen/tests/fixture.rs
@@ -74,6 +74,7 @@ fn ts(input: PathBuf) {
 }
 
 #[testing::fixture("tests/fixture/**/input.js")]
+#[testing::fixture("tests/fixture/**/input.jsx")]
 fn js(input: PathBuf) {
     run(&input, false);
     run(&input, true);

--- a/crates/swc_ecma_codegen/tests/fixture/issue-9758/input.jsx
+++ b/crates/swc_ecma_codegen/tests/fixture/issue-9758/input.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export function Test() {
+  return (
+    <div className={test}>
+      <span>&gt; 右上角设置</span>
+      <span>&gt; 保证金管理</span>
+    </div>
+  );
+}

--- a/crates/swc_ecma_codegen/tests/fixture/issue-9758/output.jsx
+++ b/crates/swc_ecma_codegen/tests/fixture/issue-9758/output.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+export function Test() {
+    return (<div className={test}>
+      <span>&gt; 右上角设置</span>
+      <span>&gt; 保证金管理</span>
+    </div>);
+}

--- a/crates/swc_ecma_codegen/tests/fixture/issue-9758/output.min.jsx
+++ b/crates/swc_ecma_codegen/tests/fixture/issue-9758/output.min.jsx
@@ -1,0 +1,4 @@
+import React from"react";export function Test(){return(<div className={test}>
+      <span>&gt; 右上角设置</span>
+      <span>&gt; 保证金管理</span>
+    </div>)}


### PR DESCRIPTION
**Related issue:**
- Closes: #9758 