### PR TITLE
fix(es/preset-env): Disable all class passes for target with native class support

### DIFF
--- a/crates/swc/tests/fixture/issues-1xxx/1456/case1/output/index.ts
+++ b/crates/swc/tests/fixture/issues-1xxx/1456/case1/output/index.ts
@@ -3,6 +3,7 @@ var _ts_decorate = require("@swc/helpers/_/_ts_decorate");
 var _ts_metadata = require("@swc/helpers/_/_ts_metadata");
 var _ts_param = require("@swc/helpers/_/_ts_param");
 class MyClass1 {
+    param1;
     constructor(param1){
         this.param1 = param1;
     }
@@ -15,6 +16,7 @@ MyClass1 = _ts_decorate._([
     ])
 ], MyClass1);
 class MyClass2 {
+    param1;
     constructor(param1){
         this.param1 = param1;
     }
@@ -27,6 +29,7 @@ MyClass2 = _ts_decorate._([
     ])
 ], MyClass2);
 class MyClass3 {
+    param1;
     constructor(param1){
         this.param1 = param1;
     }
@@ -39,6 +42,7 @@ MyClass3 = _ts_decorate._([
     ])
 ], MyClass3);
 class MyClass4 {
+    param1;
     constructor(param1){
         this.param1 = param1;
     }
@@ -51,6 +55,7 @@ MyClass4 = _ts_decorate._([
     ])
 ], MyClass4);
 class MyClass5 {
+    param1;
     constructor(param1){
         this.param1 = param1;
     }
@@ -63,6 +68,8 @@ MyClass5 = _ts_decorate._([
     ])
 ], MyClass5);
 class MyClass6 {
+    param1;
+    param2;
     constructor(param1, param2){
         this.param1 = param1;
         this.param2 = param2;

--- a/crates/swc/tests/fixture/issues-1xxx/1456/case2/output/index.ts
+++ b/crates/swc/tests/fixture/issues-1xxx/1456/case2/output/index.ts
@@ -13,6 +13,7 @@ MyClass1 = _ts_decorate._([
     ])
 ], MyClass1);
 class MyClass2 {
+    param1;
     constructor(param1, param2){
         this.param1 = param1;
     }
@@ -27,6 +28,7 @@ MyClass2 = _ts_decorate._([
     ])
 ], MyClass2);
 class MyClass3 {
+    param2;
     constructor(param1, param2){
         this.param2 = param2;
     }

--- a/crates/swc/tests/fixture/issues-9xxx/9743/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-9xxx/9743/input/.swcrc
@@ -1,0 +1,21 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": false
+        },
+        "loose": true,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": false,
+    "isModule": true,
+    "env": {
+        "targets": "node >= 18.18"
+    }
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9743/input/1.js
+++ b/crates/swc/tests/fixture/issues-9xxx/9743/input/1.js
@@ -1,0 +1,3 @@
+class Foo extends Bar {
+    handleScroll = () => { }
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9743/output/1.js
+++ b/crates/swc/tests/fixture/issues-9xxx/9743/output/1.js
@@ -1,0 +1,3 @@
+class Foo extends Bar {
+    handleScroll = ()=>{};
+}

--- a/crates/swc_ecma_preset_env/src/lib.rs
+++ b/crates/swc_ecma_preset_env/src/lib.rs
@@ -90,7 +90,7 @@ where
         pass,
         Optional::new(
             class_fields_use_set(assumptions.pure_getters),
-            assumptions.set_public_class_fields,
+            assumptions.set_public_class_fields && should_enable!(ClassProperties, true),
         ),
     );
 


### PR DESCRIPTION
**Description:**

This is just PoC to ask for opinion @magic-akari. I think it sounds reasonable to disable all class properties transform where it's natively supported. So I made this, but I want to hear opinion about it.


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/9743