### PR TITLE
feat(es/transforms): Add `module.outFileExtension`

### DIFF
--- a/.changeset/heavy-apes-collect.md
+++ b/.changeset/heavy-apes-collect.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_transforms_module: major
+---
+
+Feat out file extension resolution

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -48,7 +48,7 @@ use swc_ecma_transforms::{
         self,
         path::{ImportResolver, NodeImportResolver, Resolver},
         rewriter::import_rewriter,
-        EsModuleConfig,
+        util, EsModuleConfig,
     },
     optimization::{const_modules, json_parse, simplifier},
     proposals::{
@@ -1400,7 +1400,7 @@ impl ModuleConfig {
 
         let base_url = base_url.to_path_buf();
         let resolver = match config {
-            None => build_resolver(base_url, paths, false, &"js".to_string()),
+            None => build_resolver(base_url, paths, false, &util::Config::default_js_ext()),
             Some(ModuleConfig::Es6(config)) | Some(ModuleConfig::NodeNext(config)) => {
                 build_resolver(
                     base_url,
@@ -1750,7 +1750,7 @@ fn build_resolver(
     mut base_url: PathBuf,
     paths: CompiledPaths,
     resolve_fully: bool,
-    file_extension: &String,
+    file_extension: &str,
 ) -> SwcImportResolver {
     static CACHE: Lazy<DashMap<(PathBuf, CompiledPaths, bool), SwcImportResolver, ARandomState>> =
         Lazy::new(Default::default);

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1405,7 +1405,7 @@ impl ModuleConfig {
                 build_resolver(
                     base_url,
                     paths,
-                    config.resolve_fully,
+                    config.config.resolve_fully,
                     &config.config.out_file_extension,
                 )
             }
@@ -1430,7 +1430,7 @@ impl ModuleConfig {
             Some(ModuleConfig::SystemJs(config)) => build_resolver(
                 base_url,
                 paths,
-                config.resolve_fully,
+                config.config.resolve_fully,
                 &config.config.out_file_extension,
             ),
         };

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1400,22 +1400,39 @@ impl ModuleConfig {
 
         let base_url = base_url.to_path_buf();
         let resolver = match config {
-            None => build_resolver(base_url, paths, false),
+            None => build_resolver(base_url, paths, false, &"js".to_string()),
             Some(ModuleConfig::Es6(config)) | Some(ModuleConfig::NodeNext(config)) => {
-                build_resolver(base_url, paths, config.resolve_fully)
+                build_resolver(
+                    base_url,
+                    paths,
+                    config.resolve_fully,
+                    &config.config.out_file_extension,
+                )
             }
-            Some(ModuleConfig::CommonJs(config)) => {
-                build_resolver(base_url, paths, config.resolve_fully)
-            }
-            Some(ModuleConfig::Umd(config)) => {
-                build_resolver(base_url, paths, config.config.resolve_fully)
-            }
-            Some(ModuleConfig::Amd(config)) => {
-                build_resolver(base_url, paths, config.config.resolve_fully)
-            }
-            Some(ModuleConfig::SystemJs(config)) => {
-                build_resolver(base_url, paths, config.resolve_fully)
-            }
+            Some(ModuleConfig::CommonJs(config)) => build_resolver(
+                base_url,
+                paths,
+                config.resolve_fully,
+                &config.out_file_extension,
+            ),
+            Some(ModuleConfig::Umd(config)) => build_resolver(
+                base_url,
+                paths,
+                config.config.resolve_fully,
+                &config.config.out_file_extension,
+            ),
+            Some(ModuleConfig::Amd(config)) => build_resolver(
+                base_url,
+                paths,
+                config.config.resolve_fully,
+                &config.config.out_file_extension,
+            ),
+            Some(ModuleConfig::SystemJs(config)) => build_resolver(
+                base_url,
+                paths,
+                config.resolve_fully,
+                &config.config.out_file_extension,
+            ),
         };
 
         Some((base, resolver))
@@ -1733,6 +1750,7 @@ fn build_resolver(
     mut base_url: PathBuf,
     paths: CompiledPaths,
     resolve_fully: bool,
+    file_extension: &String,
 ) -> SwcImportResolver {
     static CACHE: Lazy<DashMap<(PathBuf, CompiledPaths, bool), SwcImportResolver, ARandomState>> =
         Lazy::new(Default::default);
@@ -1772,6 +1790,7 @@ fn build_resolver(
             swc_ecma_transforms::modules::path::Config {
                 base_dir: Some(base_url.clone()),
                 resolve_fully,
+                file_extension: file_extension.to_owned(),
             },
         );
         Arc::new(r)

--- a/crates/swc/tests/fixture/issues-3xxx/3067/amd/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/amd/input/.swcrc
@@ -1,0 +1,21 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "dynamicImport": true,
+        },
+        "target": "es2020",
+        "baseUrl": ".",
+        "paths": {
+            "@print/c": ["./packages/c/src/index.js"],
+        },
+        "externalHelpers": true,
+    },
+    "module": {
+        "type": "amd",
+        "resolveFully": true,
+        // This should say "resolve this fully to .mjs".
+        // Normally should be paired with --out-file-extension in the cli
+        "outFileExtension": "mjs",
+    },
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/amd/input/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/amd/input/packages/c/src/index.ts
@@ -1,0 +1,6 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+import something from 'lodash/dist/something.js'
+export function displayC(): string {
+    something()
+    return 'Display C'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/amd/input/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/amd/input/src/index.ts
@@ -1,0 +1,14 @@
+
+import { displayB } from './inner/b'
+import { displayC } from '@print/c'
+import { merge } from 'lodash'
+
+async function display() {
+    const displayA = await import('./inner/a').then(c => c.displayA)
+    console.log(displayA())
+    console.log(displayB())
+    console.log(displayC())
+    const foo = merge({}, { a: 22 })
+}
+
+display()

--- a/crates/swc/tests/fixture/issues-3xxx/3067/amd/input/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/amd/input/src/inner/a/index.ts
@@ -1,0 +1,3 @@
+export function displayA() {
+    return 'Display A'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/amd/input/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/amd/input/src/inner/b/index.ts
@@ -1,0 +1,3 @@
+export function displayB() {
+    return 'Display B'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/amd/output/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/amd/output/packages/c/src/index.ts
@@ -1,0 +1,23 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+define([
+    "require",
+    "exports",
+    "@swc/helpers/_/_interop_require_default",
+    "lodash/dist/something.js"
+], function(require, exports, _interop_require_default, _something) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    Object.defineProperty(exports, "displayC", {
+        enumerable: true,
+        get: function() {
+            return displayC;
+        }
+    });
+    _something = /*#__PURE__*/ _interop_require_default._(_something);
+    function displayC() {
+        (0, _something.default)();
+        return 'Display C';
+    }
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/amd/output/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/amd/output/src/index.ts
@@ -1,0 +1,25 @@
+define([
+    "require",
+    "exports",
+    "@swc/helpers/_/_interop_require_wildcard",
+    "./inner/b/index.mjs",
+    "../packages/c/src/index.mjs",
+    "lodash"
+], function(require, exports, _interop_require_wildcard, _b, _c, _lodash) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    async function display() {
+        const displayA = await new Promise((resolve, reject)=>require([
+                "./inner/a/index.mjs"
+            ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard._(m)), reject)).then((c)=>c.displayA);
+        console.log(displayA());
+        console.log((0, _b.displayB)());
+        console.log((0, _c.displayC)());
+        const foo = (0, _lodash.merge)({}, {
+            a: 22
+        });
+    }
+    display();
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/amd/output/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/amd/output/src/inner/a/index.ts
@@ -1,0 +1,18 @@
+define([
+    "require",
+    "exports"
+], function(require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    Object.defineProperty(exports, "displayA", {
+        enumerable: true,
+        get: function() {
+            return displayA;
+        }
+    });
+    function displayA() {
+        return 'Display A';
+    }
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/amd/output/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/amd/output/src/inner/b/index.ts
@@ -1,0 +1,18 @@
+define([
+    "require",
+    "exports"
+], function(require, exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    Object.defineProperty(exports, "displayB", {
+        enumerable: true,
+        get: function() {
+            return displayB;
+        }
+    });
+    function displayB() {
+        return 'Display B';
+    }
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/input/.swcrc
@@ -1,0 +1,21 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "dynamicImport": true,
+        },
+        "target": "es2020",
+        "baseUrl": ".",
+        "paths": {
+            "@print/c": ["./packages/c/src/index.js"],
+        },
+        "externalHelpers": true,
+    },
+    "module": {
+        "type": "commonjs",
+        "resolveFully": true,
+        // This should say "resolve this fully to .mjs".
+        // Normally should be paired with --out-file-extension in the cli
+        "outFileExtension": "mjs",
+    },
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/input/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/input/packages/c/src/index.ts
@@ -1,0 +1,6 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+import something from 'lodash/dist/something.js'
+export function displayC(): string {
+    something()
+    return 'Display C'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/input/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/input/src/index.ts
@@ -1,0 +1,14 @@
+
+import { displayB } from './inner/b'
+import { displayC } from '@print/c'
+import { merge } from 'lodash'
+
+async function display() {
+    const displayA = await import('./inner/a').then(c => c.displayA)
+    console.log(displayA())
+    console.log(displayB())
+    console.log(displayC())
+    const foo = merge({}, { a: 22 })
+}
+
+display()

--- a/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/input/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/input/src/inner/a/index.ts
@@ -1,0 +1,3 @@
+export function displayA() {
+    return 'Display A'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/input/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/input/src/inner/b/index.ts
@@ -1,0 +1,3 @@
+export function displayB() {
+    return 'Display B'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/output/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/output/packages/c/src/index.ts
@@ -1,0 +1,17 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "displayC", {
+    enumerable: true,
+    get: function() {
+        return displayC;
+    }
+});
+const _interop_require_default = require("@swc/helpers/_/_interop_require_default");
+const _something = /*#__PURE__*/ _interop_require_default._(require("lodash/dist/something.js"));
+function displayC() {
+    (0, _something.default)();
+    return 'Display C';
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/output/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/output/src/index.ts
@@ -1,0 +1,18 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+const _interop_require_wildcard = require("@swc/helpers/_/_interop_require_wildcard");
+const _b = require("./inner/b/index.mjs");
+const _c = require("../packages/c/src/index.mjs");
+const _lodash = require("lodash");
+async function display() {
+    const displayA = await Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard._(require("./inner/a/index.mjs"))).then((c)=>c.displayA);
+    console.log(displayA());
+    console.log((0, _b.displayB)());
+    console.log((0, _c.displayC)());
+    const foo = (0, _lodash.merge)({}, {
+        a: 22
+    });
+}
+display();

--- a/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/output/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/output/src/inner/a/index.ts
@@ -1,0 +1,13 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "displayA", {
+    enumerable: true,
+    get: function() {
+        return displayA;
+    }
+});
+function displayA() {
+    return 'Display A';
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/output/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/commonjs/output/src/inner/b/index.ts
@@ -1,0 +1,13 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "displayB", {
+    enumerable: true,
+    get: function() {
+        return displayB;
+    }
+});
+function displayB() {
+    return 'Display B';
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/es6/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/es6/input/.swcrc
@@ -1,0 +1,21 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "dynamicImport": true,
+        },
+        "target": "es2020",
+        "baseUrl": ".",
+        "paths": {
+            "@print/c": ["./packages/c/src/index.js"],
+        },
+        "externalHelpers": true,
+    },
+    "module": {
+        "type": "es6",
+        "resolveFully": true,
+        // This should say "resolve this fully to .mjs".
+        // Normally should be paired with --out-file-extension in the cli
+        "outFileExtension": "mjs",
+    },
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/es6/input/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/es6/input/packages/c/src/index.ts
@@ -1,0 +1,6 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+import something from 'lodash/dist/something.js'
+export function displayC(): string {
+    something()
+    return 'Display C'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/es6/input/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/es6/input/src/index.ts
@@ -1,0 +1,14 @@
+
+import { displayB } from './inner/b'
+import { displayC } from '@print/c'
+import { merge } from 'lodash'
+
+async function display() {
+    const displayA = await import('./inner/a').then(c => c.displayA)
+    console.log(displayA())
+    console.log(displayB())
+    console.log(displayC())
+    const foo = merge({}, { a: 22 })
+}
+
+display()

--- a/crates/swc/tests/fixture/issues-3xxx/3067/es6/input/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/es6/input/src/inner/a/index.ts
@@ -1,0 +1,3 @@
+export function displayA() {
+    return 'Display A'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/es6/input/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/es6/input/src/inner/b/index.ts
@@ -1,0 +1,3 @@
+export function displayB() {
+    return 'Display B'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/es6/output/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/es6/output/packages/c/src/index.ts
@@ -1,0 +1,6 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+import something from "lodash/dist/something.js";
+export function displayC() {
+    something();
+    return 'Display C';
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/es6/output/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/es6/output/src/index.ts
@@ -1,0 +1,13 @@
+import { displayB } from "./inner/b/index.mjs";
+import { displayC } from "../packages/c/src/index.mjs";
+import { merge } from "lodash";
+async function display() {
+    const displayA = await import("./inner/a/index.mjs").then((c)=>c.displayA);
+    console.log(displayA());
+    console.log(displayB());
+    console.log(displayC());
+    const foo = merge({}, {
+        a: 22
+    });
+}
+display();

--- a/crates/swc/tests/fixture/issues-3xxx/3067/es6/output/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/es6/output/src/inner/a/index.ts
@@ -1,0 +1,3 @@
+export function displayA() {
+    return 'Display A';
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/es6/output/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/es6/output/src/inner/b/index.ts
@@ -1,0 +1,3 @@
+export function displayB() {
+    return 'Display B';
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/input/.swcrc
@@ -1,0 +1,21 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "dynamicImport": true,
+        },
+        "target": "es2020",
+        "baseUrl": ".",
+        "paths": {
+            "@print/c": ["./packages/c/src/index.js"],
+        },
+        "externalHelpers": true,
+    },
+    "module": {
+        "type": "nodenext",
+        "resolveFully": true,
+        // This should say "resolve this fully to .mjs".
+        // Normally should be paired with --out-file-extension in the cli
+        "outFileExtension": "mjs",
+    },
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/input/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/input/packages/c/src/index.ts
@@ -1,0 +1,6 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+import something from 'lodash/dist/something.js'
+export function displayC(): string {
+    something()
+    return 'Display C'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/input/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/input/src/index.ts
@@ -1,0 +1,14 @@
+
+import { displayB } from './inner/b'
+import { displayC } from '@print/c'
+import { merge } from 'lodash'
+
+async function display() {
+    const displayA = await import('./inner/a').then(c => c.displayA)
+    console.log(displayA())
+    console.log(displayB())
+    console.log(displayC())
+    const foo = merge({}, { a: 22 })
+}
+
+display()

--- a/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/input/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/input/src/inner/a/index.ts
@@ -1,0 +1,3 @@
+export function displayA() {
+    return 'Display A'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/input/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/input/src/inner/b/index.ts
@@ -1,0 +1,3 @@
+export function displayB() {
+    return 'Display B'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/output/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/output/packages/c/src/index.ts
@@ -1,0 +1,6 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+import something from "lodash/dist/something.js";
+export function displayC() {
+    something();
+    return 'Display C';
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/output/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/output/src/index.ts
@@ -1,0 +1,13 @@
+import { displayB } from "./inner/b/index.mjs";
+import { displayC } from "../packages/c/src/index.mjs";
+import { merge } from "lodash";
+async function display() {
+    const displayA = await import("./inner/a/index.mjs").then((c)=>c.displayA);
+    console.log(displayA());
+    console.log(displayB());
+    console.log(displayC());
+    const foo = merge({}, {
+        a: 22
+    });
+}
+display();

--- a/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/output/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/output/src/inner/a/index.ts
@@ -1,0 +1,3 @@
+export function displayA() {
+    return 'Display A';
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/output/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/nodenext/output/src/inner/b/index.ts
@@ -1,0 +1,3 @@
+export function displayB() {
+    return 'Display B';
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/input/.swcrc
@@ -1,0 +1,21 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "dynamicImport": true,
+        },
+        "target": "es2020",
+        "baseUrl": ".",
+        "paths": {
+            "@print/c": ["./packages/c/src/index.js"],
+        },
+        "externalHelpers": true,
+    },
+    "module": {
+        "type": "systemjs",
+        "resolveFully": true,
+        // This should say "resolve this fully to .mjs".
+        // Normally should be paired with --out-file-extension in the cli
+        "outFileExtension": "mjs",
+    },
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/input/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/input/packages/c/src/index.ts
@@ -1,0 +1,6 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+import something from 'lodash/dist/something.js'
+export function displayC(): string {
+    something()
+    return 'Display C'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/input/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/input/src/index.ts
@@ -1,0 +1,14 @@
+
+import { displayB } from './inner/b'
+import { displayC } from '@print/c'
+import { merge } from 'lodash'
+
+async function display() {
+    const displayA = await import('./inner/a').then(c => c.displayA)
+    console.log(displayA())
+    console.log(displayB())
+    console.log(displayC())
+    const foo = merge({}, { a: 22 })
+}
+
+display()

--- a/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/input/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/input/src/inner/a/index.ts
@@ -1,0 +1,3 @@
+export function displayA() {
+    return 'Display A'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/input/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/input/src/inner/b/index.ts
@@ -1,0 +1,3 @@
+export function displayB() {
+    return 'Display B'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/output/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/output/packages/c/src/index.ts
@@ -1,0 +1,20 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+System.register([
+    "lodash/dist/something.js"
+], function(_export, _context) {
+    "use strict";
+    var something;
+    function displayC() {
+        something();
+        return 'Display C';
+    }
+    _export("displayC", displayC);
+    return {
+        setters: [
+            function(_something) {
+                something = _something.default;
+            }
+        ],
+        execute: function() {}
+    };
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/output/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/output/src/index.ts
@@ -1,0 +1,33 @@
+System.register([
+    "./inner/b/index.mjs",
+    "../packages/c/src/index.mjs",
+    "lodash"
+], function(_export, _context) {
+    "use strict";
+    var displayB, displayC, merge;
+    async function display() {
+        const displayA = await _context.import('./inner/a').then((c)=>c.displayA);
+        console.log(displayA());
+        console.log(displayB());
+        console.log(displayC());
+        const foo = merge({}, {
+            a: 22
+        });
+    }
+    return {
+        setters: [
+            function(_index) {
+                displayB = _index.displayB;
+            },
+            function(_index) {
+                displayC = _index.displayC;
+            },
+            function(_lodash) {
+                merge = _lodash.merge;
+            }
+        ],
+        execute: function() {
+            display();
+        }
+    };
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/output/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/output/src/inner/a/index.ts
@@ -1,0 +1,11 @@
+System.register([], function(_export, _context) {
+    "use strict";
+    function displayA() {
+        return 'Display A';
+    }
+    _export("displayA", displayA);
+    return {
+        setters: [],
+        execute: function() {}
+    };
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/output/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/systemjs/output/src/inner/b/index.ts
@@ -1,0 +1,11 @@
+System.register([], function(_export, _context) {
+    "use strict";
+    function displayB() {
+        return 'Display B';
+    }
+    _export("displayB", displayB);
+    return {
+        setters: [],
+        execute: function() {}
+    };
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/umd/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/umd/input/.swcrc
@@ -1,0 +1,21 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "dynamicImport": true,
+        },
+        "target": "es2020",
+        "baseUrl": ".",
+        "paths": {
+            "@print/c": ["./packages/c/src/index.js"],
+        },
+        "externalHelpers": true,
+    },
+    "module": {
+        "type": "umd",
+        "resolveFully": true,
+        // This should say "resolve this fully to .mjs".
+        // Normally should be paired with --out-file-extension in the cli
+        "outFileExtension": "mjs",
+    },
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/umd/input/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/umd/input/packages/c/src/index.ts
@@ -1,0 +1,6 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+import something from 'lodash/dist/something.js'
+export function displayC(): string {
+    something()
+    return 'Display C'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/umd/input/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/umd/input/src/index.ts
@@ -1,0 +1,14 @@
+
+import { displayB } from './inner/b'
+import { displayC } from '@print/c'
+import { merge } from 'lodash'
+
+async function display() {
+    const displayA = await import('./inner/a').then(c => c.displayA)
+    console.log(displayA())
+    console.log(displayB())
+    console.log(displayC())
+    const foo = merge({}, { a: 22 })
+}
+
+display()

--- a/crates/swc/tests/fixture/issues-3xxx/3067/umd/input/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/umd/input/src/inner/a/index.ts
@@ -1,0 +1,3 @@
+export function displayA() {
+    return 'Display A'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/umd/input/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/umd/input/src/inner/b/index.ts
@@ -1,0 +1,3 @@
+export function displayB() {
+    return 'Display B'
+}

--- a/crates/swc/tests/fixture/issues-3xxx/3067/umd/output/packages/c/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/umd/output/packages/c/src/index.ts
@@ -1,0 +1,26 @@
+// Simulate accessing a .js file in a third party package that shouldn't be edited
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("@swc/helpers/_/_interop_require_default"), require("lodash/dist/something.js"));
+    else if (typeof define === "function" && define.amd) define([
+        "exports",
+        "@swc/helpers/_/_interop_require_default",
+        "lodash/dist/something.js"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.index = {}, global.interopRequireDefault, global.somethingJs);
+})(this, function(exports, _interop_require_default, _something) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    Object.defineProperty(exports, "displayC", {
+        enumerable: true,
+        get: function() {
+            return displayC;
+        }
+    });
+    _something = /*#__PURE__*/ _interop_require_default._(_something);
+    function displayC() {
+        (0, _something.default)();
+        return 'Display C';
+    }
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/umd/output/src/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/umd/output/src/index.ts
@@ -1,0 +1,26 @@
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("@swc/helpers/_/_interop_require_wildcard"), require("./inner/b/index.mjs"), require("../packages/c/src/index.mjs"), require("lodash"));
+    else if (typeof define === "function" && define.amd) define([
+        "exports",
+        "@swc/helpers/_/_interop_require_wildcard",
+        "./inner/b/index.mjs",
+        "../packages/c/src/index.mjs",
+        "lodash"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.index = {}, global.interopRequireWildcard, global.indexMjs, global.indexMjs, global.lodash);
+})(this, function(exports, _interop_require_wildcard, _b, _c, _lodash) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    async function display() {
+        const displayA = await import('./inner/a').then((c)=>c.displayA);
+        console.log(displayA());
+        console.log((0, _b.displayB)());
+        console.log((0, _c.displayC)());
+        const foo = (0, _lodash.merge)({}, {
+            a: 22
+        });
+    }
+    display();
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/umd/output/src/inner/a/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/umd/output/src/inner/a/index.ts
@@ -1,0 +1,21 @@
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports);
+    else if (typeof define === "function" && define.amd) define([
+        "exports"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.index = {});
+})(this, function(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    Object.defineProperty(exports, "displayA", {
+        enumerable: true,
+        get: function() {
+            return displayA;
+        }
+    });
+    function displayA() {
+        return 'Display A';
+    }
+});

--- a/crates/swc/tests/fixture/issues-3xxx/3067/umd/output/src/inner/b/index.ts
+++ b/crates/swc/tests/fixture/issues-3xxx/3067/umd/output/src/inner/b/index.ts
@@ -1,0 +1,21 @@
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports);
+    else if (typeof define === "function" && define.amd) define([
+        "exports"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.index = {});
+})(this, function(exports) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    Object.defineProperty(exports, "displayB", {
+        enumerable: true,
+        get: function() {
+            return displayB;
+        }
+    });
+    function displayB() {
+        return 'Display B';
+    }
+});

--- a/crates/swc/tests/fixture/jsc-paths/vercel-site/1/input/.swcrc
+++ b/crates/swc/tests/fixture/jsc-paths/vercel-site/1/input/.swcrc
@@ -9,5 +9,10 @@
                 "./*"
             ]
         }
+    },
+    "module": {
+        "type": "es6",
+        "resolveFully": true,
+        "outFileExtension": "mjs"
     }
 }

--- a/crates/swc_ecma_transforms_module/src/lib.rs
+++ b/crates/swc_ecma_transforms_module/src/lib.rs
@@ -25,8 +25,6 @@ pub mod umd;
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EsModuleConfig {
-    #[serde(default)]
-    pub resolve_fully: bool,
     #[serde(flatten, default)]
     pub config: Config,
 }

--- a/crates/swc_ecma_transforms_module/src/lib.rs
+++ b/crates/swc_ecma_transforms_module/src/lib.rs
@@ -5,6 +5,7 @@
 
 use serde::{Deserialize, Serialize};
 use swc_common::{Span, SyntaxContext};
+use util::Config;
 
 pub use self::{amd::amd, common_js::common_js, system_js::system_js, umd::umd};
 
@@ -26,6 +27,8 @@ pub mod umd;
 pub struct EsModuleConfig {
     #[serde(default)]
     pub resolve_fully: bool,
+    #[serde(flatten, default)]
+    pub config: Config,
 }
 
 type SpanCtx = (Span, SyntaxContext);

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -17,6 +17,8 @@ use swc_ecma_loader::resolve::{Resolution, Resolve};
 use swc_ecma_utils::{quote_ident, ExprFactory};
 use tracing::{debug, info, warn, Level};
 
+use crate::util::default_js_ext;
+
 #[derive(Default)]
 pub enum Resolver {
     Real {
@@ -96,10 +98,21 @@ where
     config: Config,
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 pub struct Config {
     pub base_dir: Option<PathBuf>,
     pub resolve_fully: bool,
+    pub file_extension: String,
+}
+
+impl Default for Config {
+    fn default() -> Config {
+        Config {
+            file_extension: default_js_ext(),
+            resolve_fully: bool::default(),
+            base_dir: Option::default(),
+        }
+    }
 }
 
 impl<R> NodeImportResolver<R>
@@ -162,13 +175,13 @@ where
             };
 
             let is_resolved_as_non_js = if let Some(ext) = target_path.extension() {
-                ext != "js"
+                ext.to_string_lossy() != self.config.file_extension
             } else {
                 false
             };
 
             let is_resolved_as_js = if let Some(ext) = target_path.extension() {
-                ext == "js"
+                ext.to_string_lossy() == self.config.file_extension
             } else {
                 false
             };
@@ -191,27 +204,30 @@ where
                 // Resolved: `./foo/index.js`
 
                 if self.config.resolve_fully {
-                    target_path.set_file_name("index.js");
+                    target_path.set_file_name(format!("index.{}", self.config.file_extension));
                 } else {
                     target_path.set_file_name("index");
                 }
-            } else if is_resolved_as_index && is_resolved_as_js && orig_filename != "index.js" {
+            } else if is_resolved_as_index
+                && is_resolved_as_js
+                && orig_filename != format!("index{}", self.config.file_extension)
+            {
                 // Import: `./foo`
                 // Resolved: `./foo/index.js`
 
                 target_path.pop();
             } else if is_resolved_as_non_js && self.config.resolve_fully && file_stem_matches {
-                target_path.set_extension("js");
+                target_path.set_extension(self.config.file_extension.clone());
             } else if !is_resolved_as_js && !is_resolved_as_index && !is_exact {
                 target_path.set_file_name(orig_filename);
             } else if is_resolved_as_non_js && is_exact {
                 if let Some(ext) = Path::new(orig_filename).extension() {
                     target_path.set_extension(ext);
                 } else {
-                    target_path.set_extension("js");
+                    target_path.set_extension(self.config.file_extension.clone());
                 }
             } else if self.config.resolve_fully && is_resolved_as_non_js {
-                target_path.set_extension("js");
+                target_path.set_extension(self.config.file_extension.clone());
             } else if is_resolved_as_non_js && is_resolved_as_index {
                 if orig_filename == "index" {
                     target_path.set_extension("");

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -210,7 +210,7 @@ where
                 }
             } else if is_resolved_as_index
                 && is_resolved_as_js
-                && orig_filename != format!("index{}", self.config.file_extension)
+                && orig_filename != format!("index.{}", self.config.file_extension)
             {
                 // Import: `./foo`
                 // Resolved: `./foo/index.js`

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -17,8 +17,6 @@ use swc_ecma_loader::resolve::{Resolution, Resolve};
 use swc_ecma_utils::{quote_ident, ExprFactory};
 use tracing::{debug, info, warn, Level};
 
-use crate::util::default_js_ext;
-
 #[derive(Default)]
 pub enum Resolver {
     Real {
@@ -108,7 +106,7 @@ pub struct Config {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            file_extension: default_js_ext(),
+            file_extension: crate::util::Config::default_js_ext(),
             resolve_fully: bool::default(),
             base_dir: Option::default(),
         }

--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -20,9 +20,6 @@ pub struct Config {
     #[serde(default)]
     pub allow_top_level_this: bool,
 
-    #[serde(default)]
-    pub resolve_fully: bool,
-
     #[serde(flatten, default)]
     pub config: InnerConfig,
 }

--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -8,6 +8,7 @@ use swc_ecma_utils::{
 };
 use swc_ecma_visit::{fold_pass, standard_only_fold, Fold, FoldWith, VisitWith};
 
+pub use super::util::Config as InnerConfig;
 use crate::{
     path::Resolver,
     top_level_this::top_level_this,
@@ -21,6 +22,9 @@ pub struct Config {
 
     #[serde(default)]
     pub resolve_fully: bool,
+
+    #[serde(flatten, default)]
+    pub config: InnerConfig,
 }
 
 struct SystemJs {

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -46,6 +46,13 @@ pub struct Config {
 
     #[serde(default)]
     pub resolve_fully: bool,
+
+    #[serde(default = "default_js_ext")]
+    pub out_file_extension: String,
+}
+
+pub fn default_js_ext() -> String {
+    "js".to_string()
 }
 
 impl Default for Config {
@@ -61,6 +68,7 @@ impl Default for Config {
             ignore_dynamic: false,
             preserve_import_meta: false,
             resolve_fully: false,
+            out_file_extension: "js".to_string(),
         }
     }
 }

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -47,12 +47,14 @@ pub struct Config {
     #[serde(default)]
     pub resolve_fully: bool,
 
-    #[serde(default = "default_js_ext")]
+    #[serde(default = "Config::default_js_ext")]
     pub out_file_extension: String,
 }
 
-pub fn default_js_ext() -> String {
-    "js".to_string()
+impl Config {
+    pub fn default_js_ext() -> String {
+        "js".to_string()
+    }
 }
 
 impl Default for Config {

--- a/crates/swc_ecma_transforms_module/tests/path_node.rs
+++ b/crates/swc_ecma_transforms_module/tests/path_node.rs
@@ -11,6 +11,7 @@ use swc_ecma_parser::Syntax;
 use swc_ecma_transforms_module::{
     path::{ImportResolver, NodeImportResolver},
     rewriter::import_rewriter,
+    util::default_js_ext,
 };
 use swc_ecma_transforms_testing::{test_fixture, FixtureTestConfig};
 use testing::run_test2;
@@ -106,6 +107,7 @@ fn paths_resolver(base_dir: &Path, rules: Vec<(String, Vec<String>)>) -> JscPath
         swc_ecma_transforms_module::path::Config {
             base_dir: Some(base_dir),
             resolve_fully: true,
+            file_extension: default_js_ext(),
         },
     )
 }

--- a/crates/swc_ecma_transforms_module/tests/path_node.rs
+++ b/crates/swc_ecma_transforms_module/tests/path_node.rs
@@ -11,7 +11,6 @@ use swc_ecma_parser::Syntax;
 use swc_ecma_transforms_module::{
     path::{ImportResolver, NodeImportResolver},
     rewriter::import_rewriter,
-    util::default_js_ext,
 };
 use swc_ecma_transforms_testing::{test_fixture, FixtureTestConfig};
 use testing::run_test2;
@@ -107,7 +106,7 @@ fn paths_resolver(base_dir: &Path, rules: Vec<(String, Vec<String>)>) -> JscPath
         swc_ecma_transforms_module::path::Config {
             base_dir: Some(base_dir),
             resolve_fully: true,
-            file_extension: default_js_ext(),
+            file_extension: swc_ecma_transforms_module::util::Config::default_js_ext(),
         },
     )
 }

--- a/packages/core/__tests__/transform/issue_3067_test.mjs
+++ b/packages/core/__tests__/transform/issue_3067_test.mjs
@@ -1,0 +1,294 @@
+import swc from "../..";
+import { dirname, join, resolve } from "path";
+import { platform } from "os";
+import { fileURLToPath } from "url";
+import { writeFileSync } from "fs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+it("should work with outFileExtension (commonjs)", async () => {
+    if (process.platform === "win32") {
+        expect(true).toBeTruthy();
+        return;
+    }
+
+    const dir = join(__dirname, "..", "..", "tests", "issue-3067");
+    const filename = join(dir, "src", "index.ts");
+    console.log(filename);
+    const { code } = await swc.transformFile(filename, {
+        jsc: {
+            parser: {
+                syntax: "typescript",
+                dynamicImport: true,
+            },
+            target: "es2020",
+            baseUrl: resolve("."),
+            paths: {
+                "@print/c": [join(dir, "./packages/c/src/index.js")],
+            },
+            externalHelpers: true,
+        },
+        module: {
+            type: "commonjs",
+            resolveFully: true,
+            outFileExtension: "mjs",
+        },
+    });
+    expect(code).toMatchInlineSnapshot(`
+        ""use strict";
+        Object.defineProperty(exports, "__esModule", {
+            value: true
+        });
+        const _interop_require_wildcard = require("@swc/helpers/_/_interop_require_wildcard");
+        const _b = require("./inner/b/index.mjs");
+        const _c = require("../packages/c/src/index.mjs");
+        const _lodash = require("lodash");
+        async function display() {
+            const displayA = await Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard._(require("./inner/a/index.mjs"))).then((c)=>c.displayA);
+            console.log(displayA());
+            console.log((0, _b.displayB)());
+            console.log((0, _c.displayC)());
+            const foo = (0, _lodash.merge)({}, {
+                a: 22
+            });
+        }
+        display();
+        "
+    `);
+});
+
+// ESM Types
+it.each([
+    ['es6'],
+    ['nodenext']
+])("should work with outFileExtension (%s)", async (type) => {
+    if (process.platform === "win32") {
+        expect(true).toBeTruthy();
+        return;
+    }
+
+    const dir = join(__dirname, "..", "..", "tests", "issue-3067");
+    const filename = join(dir, "src", "index.ts");
+    console.log(filename);
+    const { code } = await swc.transformFile(filename, {
+        jsc: {
+            parser: {
+                syntax: "typescript",
+                dynamicImport: true,
+            },
+            target: "es2020",
+            baseUrl: resolve("."),
+            paths: {
+                "@print/c": [join(dir, "./packages/c/src/index.js")],
+            },
+            externalHelpers: true,
+        },
+        module: {
+            type,
+            resolveFully: true,
+            outFileExtension: "mjs",
+        },
+    });
+    expect(code).toMatchInlineSnapshot(`
+        "import { displayB } from "./inner/b/index.mjs";
+        import { displayC } from "../packages/c/src/index.mjs";
+        import { merge } from "lodash";
+        async function display() {
+            const displayA = await import("./inner/a/index.mjs").then((c)=>c.displayA);
+            console.log(displayA());
+            console.log(displayB());
+            console.log(displayC());
+            const foo = merge({}, {
+                a: 22
+            });
+        }
+        display();
+        "
+    `);
+});
+
+it("should work with outFileExtension (umd)", async () => {
+    if (process.platform === "win32") {
+        expect(true).toBeTruthy();
+        return;
+    }
+
+    const dir = join(__dirname, "..", "..", "tests", "issue-3067");
+    const filename = join(dir, "src", "index.ts");
+    console.log(filename);
+    const { code } = await swc.transformFile(filename, {
+        jsc: {
+            parser: {
+                syntax: "typescript",
+                dynamicImport: true,
+            },
+            target: "es2020",
+            baseUrl: resolve("."),
+            paths: {
+                "@print/c": [join(dir, "./packages/c/src/index.js")],
+            },
+            externalHelpers: true,
+        },
+        module: {
+            type: "umd",
+            resolveFully: true,
+            outFileExtension: "mjs",
+        },
+    });
+    // TODO: it seems like dynamic import does not do a full resolve - this might be a fix for a different PR
+    expect(code).toMatchInlineSnapshot(`
+"(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("@swc/helpers/_/_interop_require_wildcard"), require("./inner/b/index.mjs"), require("../packages/c/src/index.mjs"), require("lodash"));
+    else if (typeof define === "function" && define.amd) define([
+        "exports",
+        "@swc/helpers/_/_interop_require_wildcard",
+        "./inner/b/index.mjs",
+        "../packages/c/src/index.mjs",
+        "lodash"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.index = {}, global.interopRequireWildcard, global.indexMjs, global.indexMjs, global.lodash);
+})(this, function(exports, _interop_require_wildcard, _b, _c, _lodash) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    async function display() {
+        const displayA = await import('./inner/a').then((c)=>c.displayA);
+        console.log(displayA());
+        console.log((0, _b.displayB)());
+        console.log((0, _c.displayC)());
+        const foo = (0, _lodash.merge)({}, {
+            a: 22
+        });
+    }
+    display();
+});
+"
+`);
+});
+
+it("should work with outFileExtension (amd)", async () => {
+    if (process.platform === "win32") {
+        expect(true).toBeTruthy();
+        return;
+    }
+
+    const dir = join(__dirname, "..", "..", "tests", "issue-3067");
+    const filename = join(dir, "src", "index.ts");
+    console.log(filename);
+    const { code } = await swc.transformFile(filename, {
+        jsc: {
+            parser: {
+                syntax: "typescript",
+                dynamicImport: true,
+            },
+            target: "es2020",
+            baseUrl: resolve("."),
+            paths: {
+                "@print/c": [join(dir, "./packages/c/src/index.js")],
+            },
+            externalHelpers: true,
+        },
+        module: {
+            type: "amd",
+            resolveFully: true,
+            outFileExtension: "mjs",
+        },
+    });
+    expect(code).toMatchInlineSnapshot(`
+"define([
+    "require",
+    "exports",
+    "@swc/helpers/_/_interop_require_wildcard",
+    "./inner/b/index.mjs",
+    "../packages/c/src/index.mjs",
+    "lodash"
+], function(require, exports, _interop_require_wildcard, _b, _c, _lodash) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    async function display() {
+        const displayA = await new Promise((resolve, reject)=>require([
+                "./inner/a/index.mjs"
+            ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard._(m)), reject)).then((c)=>c.displayA);
+        console.log(displayA());
+        console.log((0, _b.displayB)());
+        console.log((0, _c.displayC)());
+        const foo = (0, _lodash.merge)({}, {
+            a: 22
+        });
+    }
+    display();
+});
+"
+`);
+});
+
+it("should work with outFileExtension (systemjs)", async () => {
+    if (process.platform === "win32") {
+        expect(true).toBeTruthy();
+        return;
+    }
+
+    const dir = join(__dirname, "..", "..", "tests", "issue-3067");
+    const filename = join(dir, "src", "index.ts");
+    console.log(filename);
+    const { code } = await swc.transformFile(filename, {
+        jsc: {
+            parser: {
+                syntax: "typescript",
+                dynamicImport: true,
+            },
+            target: "es2020",
+            baseUrl: resolve("."),
+            paths: {
+                "@print/c": [join(dir, "./packages/c/src/index.js")],
+            },
+            externalHelpers: true,
+        },
+        module: {
+            type: "systemjs",
+            resolveFully: true,
+            outFileExtension: "mjs",
+        },
+    });
+    writeFileSync('foo2.txt', code)
+    // TODO: it seems like dynamic import does not do a full resolve - this might be a fix for a different PR
+    expect(code).toMatchInlineSnapshot(`
+"System.register([
+    "./inner/b/index.mjs",
+    "../packages/c/src/index.mjs",
+    "lodash"
+], function(_export, _context) {
+    "use strict";
+    var displayB, displayC, merge;
+    async function display() {
+        const displayA = await _context.import('./inner/a').then((c)=>c.displayA);
+        console.log(displayA());
+        console.log(displayB());
+        console.log(displayC());
+        const foo = merge({}, {
+            a: 22
+        });
+    }
+    return {
+        setters: [
+            function(_index) {
+                displayB = _index.displayB;
+            },
+            function(_index) {
+                displayC = _index.displayC;
+            },
+            function(_lodash) {
+                merge = _lodash.merge;
+            }
+        ],
+        execute: function() {
+            display();
+        }
+    };
+});
+"
+`);
+});

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -25,6 +25,7 @@ module.exports = {
             : {
                   displayName: "e2e tests",
                   testMatch: ["**/e2e/**/?(*.)+(spec|test).[jt]s?(x)"],
+                  moduleFileExtensions: ["js", "jsx", "mjs"],
               },
     ].filter(Boolean),
 };

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,7 +54,7 @@
         "build:wasm": "npm-run-all \"pack -- build ../../bindings/binding_core_wasm --scope swc {1} -t {2} --features plugin\" --",
         "build": "tsc -d && napi build --manifest-path ../../bindings/Cargo.toml --platform -p binding_core_node --js ./binding.js --dts ./binding.d.ts --release -o .",
         "build:dev": "tsc -d && napi build --manifest-path ../../bindings/Cargo.toml --platform -p binding_core_node --js ./binding.js --dts ./binding.d.ts -o .",
-        "test": "cross-env NODE_OPTIONS='--experimental-vm-modules' jest --config ./jest.config.js",
+        "test": "cross-env NODE_OPTIONS='--experimental-vm-modules ${NODE_OPTIONS}' jest --config ./jest.config.js",
         "version": "napi version --npm-dir scripts/npm"
     },
     "peerDependencies": {

--- a/packages/core/tests/issue-3067/packages/c/src/index.ts
+++ b/packages/core/tests/issue-3067/packages/c/src/index.ts
@@ -1,0 +1,3 @@
+export function displayC() {
+    return 'Display C'
+}

--- a/packages/core/tests/issue-3067/src/index.ts
+++ b/packages/core/tests/issue-3067/src/index.ts
@@ -1,0 +1,14 @@
+
+import { displayB } from './inner/b'
+import { displayC } from '@print/c'
+import { merge } from 'lodash'
+
+async function display() {
+    const displayA = await import('./inner/a').then(c => c.displayA)
+    console.log(displayA())
+    console.log(displayB())
+    console.log(displayC())
+    const foo = merge({}, { a: 22 })
+}
+
+display()

--- a/packages/core/tests/issue-3067/src/inner/a/index.ts
+++ b/packages/core/tests/issue-3067/src/inner/a/index.ts
@@ -1,0 +1,3 @@
+export function displayA() {
+    return 'Display A'
+}

--- a/packages/core/tests/issue-3067/src/inner/b/index.ts
+++ b/packages/core/tests/issue-3067/src/inner/b/index.ts
@@ -1,0 +1,3 @@
+export function displayB() {
+    return 'Display B'
+}


### PR DESCRIPTION
**Description:**

Summary of Changes:

1. Adds an `outFileExtension` property to every module configuration option struct
2. passes this configuration through to the resolver function and changes all hard-coded `"js"` checks to use the new parameter
3. As a matter of backwards compatibility, structures default to "js" if nothing is provided
4. `@swc/core` snapshot tests for each module using `resolveFully` and `outFileExtension` (Please check the rendered output of the snapshots to make sure you don't have any issues with it).
1. QOL - updates `@swc/core` jest config to use explicit module names (this was because the mapping util in jest was exploding when it would try to load in the .node files that were over 512MB)
5. QOL - updates the test script to pass through any existing NODE_OPTIONS - this allows debugging tools to add their own inspect configurations while preserving our esm module flag

**Note**

This is a rudimentary fix to:  https://github.com/swc-project/swc/issues/3067#issuecomment-2516108434.  I had to implement it locally since I could not find a workaround in my timeline.

I do know that @kdy1 said they would work on it a few days ago, so I am opening this to either provide some visibility to a solution that works for me if they haven't started or to let them switch to PR critique if that feels more valuable for their time on this issue.  Let me know if this should be closed due to a better implementation already being in the works.


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/3067
