### PR TITLE
fix(es/parser): Do not parse empty stmt after using decl

### DIFF
--- a/.changeset/lucky-hotels-grow.md
+++ b/.changeset/lucky-hotels-grow.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+fix(es/parser): Do not parse empty stmt after using decl

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -839,6 +839,8 @@ impl<'a, I: Tokens> Parser<I> {
             }
         }
 
+        eat!(self, ';');
+
         Ok(Some(Box::new(UsingDecl {
             span: span!(self, start),
             is_await,

--- a/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-basic/input.js.json
+++ b/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-basic/input.js.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 5,
-            "end": 30
+            "end": 31
           },
           "isAwait": false,
           "decls": [
@@ -61,13 +61,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 30,
-            "end": 31
-          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-escaped/input.js.json
+++ b/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-escaped/input.js.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 3,
-            "end": 20
+            "end": 21
           },
           "isAwait": false,
           "decls": [
@@ -51,13 +51,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 20,
-            "end": 21
-          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-non-bmp/input.js.json
+++ b/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-non-bmp/input.js.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 3,
-            "end": 21
+            "end": 22
           },
           "isAwait": false,
           "decls": [
@@ -61,13 +61,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 21,
-            "end": 22
-          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-using/input.js.json
+++ b/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-using/input.js.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 5,
-            "end": 21
+            "end": 22
           },
           "isAwait": false,
           "decls": [
@@ -51,13 +51,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 21,
-            "end": 22
-          }
         },
         {
           "type": "ForOfStatement",

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.1.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 109,
-        "end": 162
+        "end": 163
       },
       "isAwait": true,
       "decls": [
@@ -99,13 +99,6 @@
       ]
     },
     {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 162,
-        "end": 163
-      }
-    },
-    {
       "type": "FunctionDeclaration",
       "identifier": {
         "type": "Identifier",
@@ -137,7 +130,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 191,
-              "end": 244
+              "end": 245
             },
             "isAwait": true,
             "decls": [
@@ -227,13 +220,6 @@
             ]
           },
           {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 244,
-              "end": 245
-            }
-          },
-          {
             "type": "ExpressionStatement",
             "span": {
               "start": 250,
@@ -293,7 +279,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 293,
-              "end": 346
+              "end": 347
             },
             "isAwait": true,
             "decls": [
@@ -381,13 +367,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 346,
-              "end": 347
-            }
           },
           {
             "type": "ExpressionStatement",
@@ -480,7 +459,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 406,
-                    "end": 459
+                    "end": 460
                   },
                   "isAwait": true,
                   "decls": [
@@ -568,13 +547,6 @@
                       "definite": false
                     }
                   ]
-                },
-                {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 459,
-                    "end": 460
-                  }
                 }
               ]
             },
@@ -641,7 +613,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 506,
-                    "end": 559
+                    "end": 560
                   },
                   "isAwait": true,
                   "decls": [
@@ -729,13 +701,6 @@
                       "definite": false
                     }
                   ]
-                },
-                {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 559,
-                    "end": 560
-                  }
                 }
               ]
             },
@@ -789,7 +754,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 594,
-                    "end": 648
+                    "end": 649
                   },
                   "isAwait": true,
                   "decls": [
@@ -879,13 +844,6 @@
                   ]
                 },
                 {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 648,
-                    "end": 649
-                  }
-                },
-                {
                   "type": "ExpressionStatement",
                   "span": {
                     "start": 658,
@@ -954,7 +912,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 704,
-                    "end": 758
+                    "end": 759
                   },
                   "isAwait": true,
                   "decls": [
@@ -1044,13 +1002,6 @@
                   ]
                 },
                 {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 758,
-                    "end": 759
-                  }
-                },
-                {
                   "type": "ExpressionStatement",
                   "span": {
                     "start": 768,
@@ -1120,7 +1071,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 810,
-            "end": 864
+            "end": 865
           },
           "isAwait": true,
           "decls": [
@@ -1208,13 +1159,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 864,
-            "end": 865
-          }
         }
       ]
     },
@@ -1280,7 +1224,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 914,
-                "end": 968
+                "end": 969
               },
               "isAwait": true,
               "decls": [
@@ -1370,13 +1314,6 @@
               ]
             },
             {
-              "type": "EmptyStatement",
-              "span": {
-                "start": 968,
-                "end": 969
-              }
-            },
-            {
               "type": "BreakStatement",
               "span": {
                 "start": 978,
@@ -1406,7 +1343,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 1006,
-                "end": 1060
+                "end": 1061
               },
               "isAwait": true,
               "decls": [
@@ -1496,13 +1433,6 @@
               ]
             },
             {
-              "type": "EmptyStatement",
-              "span": {
-                "start": 1060,
-                "end": 1061
-              }
-            },
-            {
               "type": "BreakStatement",
               "span": {
                 "start": 1070,
@@ -1564,7 +1494,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 1135,
-                  "end": 1189
+                  "end": 1190
                 },
                 "isAwait": true,
                 "decls": [
@@ -1654,13 +1584,6 @@
                 ]
               },
               {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 1189,
-                  "end": 1190
-                }
-              },
-              {
                 "type": "BreakStatement",
                 "span": {
                   "start": 1203,
@@ -1692,7 +1615,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1227,
-              "end": 1281
+              "end": 1282
             },
             "isAwait": true,
             "decls": [
@@ -1780,13 +1703,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 1281,
-              "end": 1282
-            }
           }
         ]
       },
@@ -1809,7 +1725,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 1297,
-                "end": 1351
+                "end": 1352
               },
               "isAwait": true,
               "decls": [
@@ -1897,13 +1813,6 @@
                   "definite": false
                 }
               ]
-            },
-            {
-              "type": "EmptyStatement",
-              "span": {
-                "start": 1351,
-                "end": 1352
-              }
             }
           ]
         }
@@ -1920,7 +1829,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1369,
-              "end": 1423
+              "end": 1424
             },
             "isAwait": true,
             "decls": [
@@ -2008,13 +1917,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 1423,
-              "end": 1424
-            }
           }
         ]
       }
@@ -2045,7 +1947,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1444,
-              "end": 1498
+              "end": 1499
             },
             "isAwait": true,
             "decls": [
@@ -2133,13 +2035,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 1498,
-              "end": 1499
-            }
           }
         ]
       },
@@ -2155,7 +2050,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1513,
-              "end": 1567
+              "end": 1568
             },
             "isAwait": true,
             "decls": [
@@ -2243,13 +2138,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 1567,
-              "end": 1568
-            }
           }
         ]
       }
@@ -2280,7 +2168,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1591,
-              "end": 1645
+              "end": 1646
             },
             "isAwait": true,
             "decls": [
@@ -2370,13 +2258,6 @@
             ]
           },
           {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 1645,
-              "end": 1646
-            }
-          },
-          {
             "type": "BreakStatement",
             "span": {
               "start": 1651,
@@ -2413,7 +2294,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1670,
-              "end": 1724
+              "end": 1725
             },
             "isAwait": true,
             "decls": [
@@ -2503,13 +2384,6 @@
             ]
           },
           {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 1724,
-              "end": 1725
-            }
-          },
-          {
             "type": "BreakStatement",
             "span": {
               "start": 1730,
@@ -2541,7 +2415,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1769,
-              "end": 1823
+              "end": 1824
             },
             "isAwait": true,
             "decls": [
@@ -2631,13 +2505,6 @@
             ]
           },
           {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 1823,
-              "end": 1824
-            }
-          },
-          {
             "type": "BreakStatement",
             "span": {
               "start": 1829,
@@ -2706,7 +2573,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1865,
-              "end": 1919
+              "end": 1920
             },
             "isAwait": true,
             "decls": [
@@ -2794,13 +2661,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 1919,
-              "end": 1920
-            }
           }
         ]
       }
@@ -2864,7 +2724,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1950,
-              "end": 2004
+              "end": 2005
             },
             "isAwait": true,
             "decls": [
@@ -2952,13 +2812,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 2004,
-              "end": 2005
-            }
           }
         ]
       }

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.12.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.12.json
@@ -37,7 +37,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 109,
-              "end": 127
+              "end": 128
             },
             "isAwait": true,
             "decls": [
@@ -69,13 +69,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 127,
-              "end": 128
-            }
           }
         ]
       },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.13.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.13.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 84,
-        "end": 104
+        "end": 105
       },
       "isAwait": true,
       "decls": [
@@ -40,13 +40,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 104,
-        "end": 105
-      }
     },
     {
       "type": "FunctionDeclaration",
@@ -80,7 +73,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 126,
-              "end": 146
+              "end": 147
             },
             "isAwait": true,
             "decls": [
@@ -111,13 +104,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 146,
-              "end": 147
-            }
           }
         ]
       },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.15.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.15.json
@@ -37,7 +37,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 134,
-              "end": 186
+              "end": 187
             },
             "isAwait": true,
             "decls": [
@@ -125,13 +125,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 186,
-              "end": 187
-            }
           }
         ]
       },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.2.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 115,
-            "end": 227
+            "end": 228
           },
           "isAwait": true,
           "decls": [
@@ -188,13 +188,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 227,
-            "end": 228
-          }
         }
       ]
     },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.3.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.3.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 115,
-            "end": 275
+            "end": 276
           },
           "isAwait": true,
           "decls": [
@@ -243,13 +243,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 275,
-            "end": 276
-          }
         }
       ]
     },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.9.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.9.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 90,
-            "end": 110
+            "end": 111
           },
           "isAwait": true,
           "decls": [
@@ -48,13 +48,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 110,
-            "end": 111
-          }
         }
       ]
     },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarationsTopLevelOfModule.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarationsTopLevelOfModule.1.json
@@ -87,7 +87,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 154,
-        "end": 206
+        "end": 207
       },
       "isAwait": true,
       "decls": [
@@ -175,13 +175,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 206,
-        "end": 207
-      }
     },
     {
       "type": "VariableDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarationsWithImportHelpers.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarationsWithImportHelpers.json
@@ -48,7 +48,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 145,
-              "end": 165
+              "end": 166
             },
             "isAwait": true,
             "decls": [
@@ -79,13 +79,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 165,
-              "end": 166
-            }
           }
         ]
       },

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.1.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 109,
-        "end": 145
+        "end": 146
       },
       "isAwait": false,
       "decls": [
@@ -99,13 +99,6 @@
       ]
     },
     {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 145,
-        "end": 146
-      }
-    },
-    {
       "type": "FunctionDeclaration",
       "identifier": {
         "type": "Identifier",
@@ -137,7 +130,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 167,
-              "end": 203
+              "end": 204
             },
             "isAwait": false,
             "decls": [
@@ -225,13 +218,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 203,
-              "end": 204
-            }
           }
         ]
       },
@@ -272,7 +258,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 234,
-              "end": 270
+              "end": 271
             },
             "isAwait": false,
             "decls": [
@@ -362,13 +348,6 @@
             ]
           },
           {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 270,
-              "end": 271
-            }
-          },
-          {
             "type": "ExpressionStatement",
             "span": {
               "start": 276,
@@ -428,7 +407,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 312,
-              "end": 348
+              "end": 349
             },
             "isAwait": false,
             "decls": [
@@ -518,13 +497,6 @@
             ]
           },
           {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 348,
-              "end": 349
-            }
-          },
-          {
             "type": "ExpressionStatement",
             "span": {
               "start": 354,
@@ -579,7 +551,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 392,
-              "end": 428
+              "end": 429
             },
             "isAwait": false,
             "decls": [
@@ -667,13 +639,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 428,
-              "end": 429
-            }
           },
           {
             "type": "ExpressionStatement",
@@ -766,7 +731,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 482,
-                    "end": 518
+                    "end": 519
                   },
                   "isAwait": false,
                   "decls": [
@@ -854,13 +819,6 @@
                       "definite": false
                     }
                   ]
-                },
-                {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 518,
-                    "end": 519
-                  }
                 }
               ]
             },
@@ -927,7 +885,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 558,
-                    "end": 594
+                    "end": 595
                   },
                   "isAwait": false,
                   "decls": [
@@ -1015,13 +973,6 @@
                       "definite": false
                     }
                   ]
-                },
-                {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 594,
-                    "end": 595
-                  }
                 }
               ]
             },
@@ -1069,7 +1020,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 631,
-                  "end": 667
+                  "end": 668
                 },
                 "isAwait": false,
                 "decls": [
@@ -1157,13 +1108,6 @@
                     "definite": false
                   }
                 ]
-              },
-              {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 667,
-                  "end": 668
-                }
               }
             ]
           },
@@ -1188,7 +1132,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 697,
-                  "end": 733
+                  "end": 734
                 },
                 "isAwait": false,
                 "decls": [
@@ -1276,13 +1220,6 @@
                     "definite": false
                   }
                 ]
-              },
-              {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 733,
-                  "end": 734
-                }
               }
             ]
           }
@@ -1321,7 +1258,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 760,
-                    "end": 797
+                    "end": 798
                   },
                   "isAwait": false,
                   "decls": [
@@ -1409,13 +1346,6 @@
                       "definite": false
                     }
                   ]
-                },
-                {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 797,
-                    "end": 798
-                  }
                 }
               ]
             },
@@ -1465,7 +1395,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 828,
-                    "end": 865
+                    "end": 866
                   },
                   "isAwait": false,
                   "decls": [
@@ -1555,13 +1485,6 @@
                   ]
                 },
                 {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 865,
-                    "end": 866
-                  }
-                },
-                {
                   "type": "ReturnStatement",
                   "span": {
                     "start": 875,
@@ -1645,7 +1568,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 915,
-                    "end": 952
+                    "end": 953
                   },
                   "isAwait": false,
                   "decls": [
@@ -1733,13 +1656,6 @@
                       "definite": false
                     }
                   ]
-                },
-                {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 952,
-                    "end": 953
-                  }
                 }
               ]
             },
@@ -1789,7 +1705,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 986,
-                    "end": 1023
+                    "end": 1024
                   },
                   "isAwait": false,
                   "decls": [
@@ -1879,13 +1795,6 @@
                   ]
                 },
                 {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 1023,
-                    "end": 1024
-                  }
-                },
-                {
                   "type": "ExpressionStatement",
                   "span": {
                     "start": 1033,
@@ -1954,7 +1863,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 1072,
-                    "end": 1109
+                    "end": 1110
                   },
                   "isAwait": false,
                   "decls": [
@@ -2044,13 +1953,6 @@
                   ]
                 },
                 {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 1109,
-                    "end": 1110
-                  }
-                },
-                {
                   "type": "ExpressionStatement",
                   "span": {
                     "start": 1119,
@@ -2114,7 +2016,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 1160,
-                    "end": 1197
+                    "end": 1198
                   },
                   "isAwait": false,
                   "decls": [
@@ -2202,13 +2104,6 @@
                       "definite": false
                     }
                   ]
-                },
-                {
-                  "type": "EmptyStatement",
-                  "span": {
-                    "start": 1197,
-                    "end": 1198
-                  }
                 },
                 {
                   "type": "ExpressionStatement",
@@ -2316,7 +2211,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 1293,
-                  "end": 1330
+                  "end": 1331
                 },
                 "isAwait": false,
                 "decls": [
@@ -2404,13 +2299,6 @@
                     "definite": false
                   }
                 ]
-              },
-              {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 1330,
-                  "end": 1331
-                }
               },
               {
                 "type": "ExpressionStatement",
@@ -2539,7 +2427,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 1419,
-                  "end": 1456
+                  "end": 1457
                 },
                 "isAwait": false,
                 "decls": [
@@ -2629,13 +2517,6 @@
                 ]
               },
               {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 1456,
-                  "end": 1457
-                }
-              },
-              {
                 "type": "ExpressionStatement",
                 "span": {
                   "start": 1466,
@@ -2709,7 +2590,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1502,
-              "end": 1539
+              "end": 1540
             },
             "isAwait": false,
             "decls": [
@@ -2797,13 +2678,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 1539,
-              "end": 1540
-            }
           }
         ]
       }
@@ -2820,7 +2694,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 1550,
-            "end": 1587
+            "end": 1588
           },
           "isAwait": false,
           "decls": [
@@ -2908,13 +2782,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 1587,
-            "end": 1588
-          }
         }
       ]
     },
@@ -2980,7 +2847,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 1637,
-                "end": 1674
+                "end": 1675
               },
               "isAwait": false,
               "decls": [
@@ -3070,13 +2937,6 @@
               ]
             },
             {
-              "type": "EmptyStatement",
-              "span": {
-                "start": 1674,
-                "end": 1675
-              }
-            },
-            {
               "type": "BreakStatement",
               "span": {
                 "start": 1684,
@@ -3106,7 +2966,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 1712,
-                "end": 1749
+                "end": 1750
               },
               "isAwait": false,
               "decls": [
@@ -3196,13 +3056,6 @@
               ]
             },
             {
-              "type": "EmptyStatement",
-              "span": {
-                "start": 1749,
-                "end": 1750
-              }
-            },
-            {
               "type": "BreakStatement",
               "span": {
                 "start": 1759,
@@ -3264,7 +3117,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 1824,
-                  "end": 1861
+                  "end": 1862
                 },
                 "isAwait": false,
                 "decls": [
@@ -3354,13 +3207,6 @@
                 ]
               },
               {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 1861,
-                  "end": 1862
-                }
-              },
-              {
                 "type": "BreakStatement",
                 "span": {
                   "start": 1875,
@@ -3392,7 +3238,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1899,
-              "end": 1936
+              "end": 1937
             },
             "isAwait": false,
             "decls": [
@@ -3480,13 +3326,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 1936,
-              "end": 1937
-            }
           }
         ]
       },
@@ -3509,7 +3348,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 1952,
-                "end": 1989
+                "end": 1990
               },
               "isAwait": false,
               "decls": [
@@ -3597,13 +3436,6 @@
                   "definite": false
                 }
               ]
-            },
-            {
-              "type": "EmptyStatement",
-              "span": {
-                "start": 1989,
-                "end": 1990
-              }
             }
           ]
         }
@@ -3620,7 +3452,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2007,
-              "end": 2044
+              "end": 2045
             },
             "isAwait": false,
             "decls": [
@@ -3708,13 +3540,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 2044,
-              "end": 2045
-            }
           }
         ]
       }
@@ -3745,7 +3570,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2065,
-              "end": 2102
+              "end": 2103
             },
             "isAwait": false,
             "decls": [
@@ -3833,13 +3658,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 2102,
-              "end": 2103
-            }
           }
         ]
       },
@@ -3855,7 +3673,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2117,
-              "end": 2154
+              "end": 2155
             },
             "isAwait": false,
             "decls": [
@@ -3943,13 +3761,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 2154,
-              "end": 2155
-            }
           }
         ]
       }
@@ -3980,7 +3791,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2178,
-              "end": 2215
+              "end": 2216
             },
             "isAwait": false,
             "decls": [
@@ -4070,13 +3881,6 @@
             ]
           },
           {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 2215,
-              "end": 2216
-            }
-          },
-          {
             "type": "BreakStatement",
             "span": {
               "start": 2221,
@@ -4113,7 +3917,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2240,
-              "end": 2277
+              "end": 2278
             },
             "isAwait": false,
             "decls": [
@@ -4203,13 +4007,6 @@
             ]
           },
           {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 2277,
-              "end": 2278
-            }
-          },
-          {
             "type": "BreakStatement",
             "span": {
               "start": 2283,
@@ -4241,7 +4038,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2322,
-              "end": 2359
+              "end": 2360
             },
             "isAwait": false,
             "decls": [
@@ -4331,13 +4128,6 @@
             ]
           },
           {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 2359,
-              "end": 2360
-            }
-          },
-          {
             "type": "BreakStatement",
             "span": {
               "start": 2365,
@@ -4406,7 +4196,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2401,
-              "end": 2438
+              "end": 2439
             },
             "isAwait": false,
             "decls": [
@@ -4494,13 +4284,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 2438,
-              "end": 2439
-            }
           }
         ]
       }
@@ -4564,7 +4347,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2469,
-              "end": 2506
+              "end": 2507
             },
             "isAwait": false,
             "decls": [
@@ -4652,13 +4435,6 @@
                 "definite": false
               }
             ]
-          },
-          {
-            "type": "EmptyStatement",
-            "span": {
-              "start": 2506,
-              "end": 2507
-            }
           }
         ]
       }

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.11.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.11.json
@@ -79,7 +79,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 141,
-                  "end": 155
+                  "end": 156
                 },
                 "isAwait": false,
                 "decls": [
@@ -110,13 +110,6 @@
                     "definite": false
                   }
                 ]
-              },
-              {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 155,
-                  "end": 156
-                }
               },
               {
                 "type": "ExpressionStatement",
@@ -235,7 +228,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 248,
-                  "end": 262
+                  "end": 263
                 },
                 "isAwait": false,
                 "decls": [
@@ -266,13 +259,6 @@
                     "definite": false
                   }
                 ]
-              },
-              {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 262,
-                  "end": 263
-                }
               }
             ]
           },
@@ -377,7 +363,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 332,
-                  "end": 346
+                  "end": 347
                 },
                 "isAwait": false,
                 "decls": [
@@ -408,13 +394,6 @@
                     "definite": false
                   }
                 ]
-              },
-              {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 346,
-                  "end": 347
-                }
               },
               {
                 "type": "ExpressionStatement",
@@ -546,7 +525,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 438,
-                  "end": 452
+                  "end": 453
                 },
                 "isAwait": false,
                 "decls": [
@@ -577,13 +556,6 @@
                     "definite": false
                   }
                 ]
-              },
-              {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 452,
-                  "end": 453
-                }
               },
               {
                 "type": "ExpressionStatement",
@@ -749,7 +721,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 555,
-                  "end": 569
+                  "end": 570
                 },
                 "isAwait": false,
                 "decls": [
@@ -780,13 +752,6 @@
                     "definite": false
                   }
                 ]
-              },
-              {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 569,
-                  "end": 570
-                }
               },
               {
                 "type": "ExpressionStatement",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.12.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.12.json
@@ -166,7 +166,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 228,
-                  "end": 265
+                  "end": 266
                 },
                 "isAwait": false,
                 "decls": [
@@ -254,13 +254,6 @@
                     "definite": false
                   }
                 ]
-              },
-              {
-                "type": "EmptyStatement",
-                "span": {
-                  "start": 265,
-                  "end": 266
-                }
               }
             ]
           },

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.14.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.14.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 84,
-        "end": 96
+        "end": 97
       },
       "isAwait": false,
       "decls": [
@@ -41,13 +41,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 96,
-        "end": 97
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.15.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.15.json
@@ -20,7 +20,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 121,
-        "end": 156
+        "end": 157
       },
       "isAwait": false,
       "decls": [
@@ -108,13 +108,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 156,
-        "end": 157
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.2.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 115,
-            "end": 193
+            "end": 194
           },
           "isAwait": false,
           "decls": [
@@ -188,13 +188,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 193,
-            "end": 194
-          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.3.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.3.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 115,
-            "end": 240
+            "end": 241
           },
           "isAwait": false,
           "decls": [
@@ -243,13 +243,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 240,
-            "end": 241
-          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.9.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.9.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 90,
-            "end": 104
+            "end": 105
           },
           "isAwait": false,
           "decls": [
@@ -48,13 +48,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 104,
-            "end": 105
-          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsDeclarationEmit.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsDeclarationEmit.1.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 90,
-        "end": 126
+        "end": 127
       },
       "isAwait": false,
       "decls": [
@@ -99,13 +99,6 @@
       ]
     },
     {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 126,
-        "end": 127
-      }
-    },
-    {
       "type": "ExportNamedDeclaration",
       "span": {
         "start": 128,
@@ -140,7 +133,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 144,
-        "end": 197
+        "end": 198
       },
       "isAwait": true,
       "decls": [
@@ -228,13 +221,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 197,
-        "end": 198
-      }
     },
     {
       "type": "ExportNamedDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsDeclarationEmit.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsDeclarationEmit.2.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 90,
-        "end": 126
+        "end": 127
       },
       "isAwait": false,
       "decls": [
@@ -99,13 +99,6 @@
       ]
     },
     {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 126,
-        "end": 127
-      }
-    },
-    {
       "type": "ExportDeclaration",
       "span": {
         "start": 128,
@@ -153,7 +146,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 157,
-        "end": 210
+        "end": 211
       },
       "isAwait": true,
       "decls": [
@@ -241,13 +234,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 210,
-        "end": 211
-      }
     },
     {
       "type": "ExportDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 119,
-        "end": 172
+        "end": 173
       },
       "isAwait": false,
       "decls": [
@@ -176,17 +176,10 @@
       ]
     },
     {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 172,
-        "end": 173
-      }
-    },
-    {
       "type": "UsingDeclaration",
       "span": {
         "start": 175,
-        "end": 246
+        "end": 247
       },
       "isAwait": false,
       "decls": [
@@ -330,17 +323,10 @@
       ]
     },
     {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 246,
-        "end": 247
-      }
-    },
-    {
       "type": "UsingDeclaration",
       "span": {
         "start": 249,
-        "end": 307
+        "end": 308
       },
       "isAwait": false,
       "decls": [
@@ -468,17 +454,10 @@
       ]
     },
     {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 307,
-        "end": 308
-      }
-    },
-    {
       "type": "UsingDeclaration",
       "span": {
         "start": 310,
-        "end": 386
+        "end": 387
       },
       "isAwait": false,
       "decls": [
@@ -638,13 +617,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 386,
-        "end": 387
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.1.json
@@ -87,7 +87,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 167,
-        "end": 202
+        "end": 203
       },
       "isAwait": false,
       "decls": [
@@ -175,13 +175,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 202,
-        "end": 203
-      }
     },
     {
       "type": "VariableDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.2.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 118,
-        "end": 153
+        "end": 154
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 153,
-        "end": 154
-      }
     },
     {
       "type": "VariableDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.3.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.3.json
@@ -40,7 +40,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 147,
-        "end": 182
+        "end": 183
       },
       "isAwait": false,
       "decls": [
@@ -128,13 +128,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 182,
-        "end": 183
-      }
     },
     {
       "type": "IfStatement",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.1.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 222
+        "end": 223
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 222,
-        "end": 223
-      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.10.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.10.json
@@ -107,7 +107,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 234,
-        "end": 252
+        "end": 253
       },
       "isAwait": false,
       "decls": [
@@ -138,13 +138,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 252,
-        "end": 253
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.11.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.11.json
@@ -141,7 +141,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 236,
-        "end": 254
+        "end": 255
       },
       "isAwait": false,
       "decls": [
@@ -172,13 +172,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 254,
-        "end": 255
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.12.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.12.json
@@ -150,7 +150,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 241,
-        "end": 259
+        "end": 260
       },
       "isAwait": false,
       "decls": [
@@ -181,13 +181,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 259,
-        "end": 260
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.2.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 222
+        "end": 223
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 222,
-        "end": 223
-      }
     },
     {
       "type": "ExportDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.3.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.3.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 222
+        "end": 223
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 222,
-        "end": 223
-      }
     },
     {
       "type": "ExportDefaultDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.4.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.4.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 222
+        "end": 223
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 222,
-        "end": 223
-      }
     },
     {
       "type": "ExportDefaultDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.5.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.5.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 222
+        "end": 223
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 222,
-        "end": 223
-      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.6.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.6.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 222
+        "end": 223
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 222,
-        "end": 223
-      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.7.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.7.json
@@ -110,7 +110,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 221,
-        "end": 239
+        "end": 240
       },
       "isAwait": false,
       "decls": [
@@ -141,13 +141,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 239,
-        "end": 240
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.8.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.8.json
@@ -117,7 +117,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 228,
-        "end": 246
+        "end": 247
       },
       "isAwait": false,
       "decls": [
@@ -148,13 +148,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 246,
-        "end": 247
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.9.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.9.json
@@ -141,7 +141,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 245,
-        "end": 263
+        "end": 264
       },
       "isAwait": false,
       "decls": [
@@ -172,13 +172,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 263,
-        "end": 264
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithImportHelpers.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithImportHelpers.json
@@ -28,7 +28,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 126,
-            "end": 140
+            "end": 141
           },
           "isAwait": false,
           "decls": [
@@ -59,13 +59,6 @@
               "definite": false
             }
           ]
-        },
-        {
-          "type": "EmptyStatement",
-          "span": {
-            "start": 140,
-            "end": 141
-          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.1.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 221
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 221,
-        "end": 222
-      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.10.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.10.json
@@ -107,7 +107,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 233,
-        "end": 251
+        "end": 252
       },
       "isAwait": false,
       "decls": [
@@ -138,13 +138,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 251,
-        "end": 252
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.11.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.11.json
@@ -141,7 +141,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 235,
-        "end": 253
+        "end": 254
       },
       "isAwait": false,
       "decls": [
@@ -172,13 +172,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 253,
-        "end": 254
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.12.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.12.json
@@ -150,7 +150,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 240,
-        "end": 258
+        "end": 259
       },
       "isAwait": false,
       "decls": [
@@ -181,13 +181,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 258,
-        "end": 259
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.2.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 221
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 221,
-        "end": 222
-      }
     },
     {
       "type": "ExportDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.3.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.3.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 221
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 221,
-        "end": 222
-      }
     },
     {
       "type": "ExportDefaultDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.4.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.4.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 221
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 221,
-        "end": 222
-      }
     },
     {
       "type": "ExportDefaultDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.5.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.5.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 221
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 221,
-        "end": 222
-      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.6.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.6.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 221
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,13 +97,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 221,
-        "end": 222
-      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.7.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.7.json
@@ -110,7 +110,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 220,
-        "end": 238
+        "end": 239
       },
       "isAwait": false,
       "decls": [
@@ -141,13 +141,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 238,
-        "end": 239
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.8.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.8.json
@@ -117,7 +117,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 227,
-        "end": 245
+        "end": 246
       },
       "isAwait": false,
       "decls": [
@@ -148,13 +148,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 245,
-        "end": 246
-      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.9.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.9.json
@@ -116,7 +116,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 235,
-        "end": 253
+        "end": 254
       },
       "isAwait": false,
       "decls": [
@@ -147,13 +147,6 @@
           "definite": false
         }
       ]
-    },
-    {
-      "type": "EmptyStatement",
-      "span": {
-        "start": 253,
-        "end": 254
-      }
     }
   ],
   "interpreter": null


### PR DESCRIPTION
**Description:**

See test output. It was parsing an empty statement after a using declaration.

**Related issue (if exists):** None
