### PR TITLE
fix: don't panic when wasm bytecheck faild

### DIFF
--- a/.changeset/new-apricots-exercise.md
+++ b/.changeset/new-apricots-exercise.md
@@ -1,0 +1,6 @@
+---
+swc: patch
+swc_core: patch
+---
+
+fix: don't panic when wasm bytecheck faild

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -7,6 +7,7 @@
 )]
 
 use serde::{Deserialize, Serialize};
+use swc_common::errors::HANDLER;
 use swc_ecma_ast::Pass;
 #[cfg(feature = "plugin")]
 use swc_ecma_ast::*;
@@ -165,15 +166,27 @@ impl Fold for RustPlugins {
 
     #[cfg(feature = "plugin")]
     fn fold_module(&mut self, n: Module) -> Module {
-        self.apply(Program::Module(n))
-            .expect("failed to invoke plugin")
-            .expect_module()
+        match self.apply(Program::Module(n)) {
+            Ok(program) => program.expect_module(),
+            Err(err) => {
+                HANDLER.with(|handler| {
+                    handler.err(&err.to_string());
+                });
+                Module::default()
+            }
+        }
     }
 
     #[cfg(feature = "plugin")]
     fn fold_script(&mut self, n: Script) -> Script {
-        self.apply(Program::Script(n))
-            .expect("failed to invoke plugin")
-            .expect_script()
+        match self.apply(Program::Script(n)) {
+            Ok(program) => program.expect_script(),
+            Err(err) => {
+                HANDLER.with(|handler| {
+                    handler.err(&err.to_string());
+                });
+                Script::default()
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
Currently when wasm plugin is not compatible with swc version it will panic which cause it hard to report useful error info from caller except use catch_unwind.
change the behavior to not panic and let the user to decide error handling 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
No
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
