### PR TITLE
fix(es/parser): Do not drop semicolon after using declarations

### DIFF
--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -839,8 +839,6 @@ impl<'a, I: Tokens> Parser<I> {
             }
         }
 
-        eat!(self, ';');
-
         Ok(Some(Box::new(UsingDecl {
             span: span!(self, start),
             is_await,

--- a/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-basic/input.js.json
+++ b/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-basic/input.js.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 5,
-            "end": 31
+            "end": 30
           },
           "isAwait": false,
           "decls": [
@@ -61,6 +61,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 30,
+            "end": 31
+          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-escaped/input.js.json
+++ b/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-escaped/input.js.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 3,
-            "end": 21
+            "end": 20
           },
           "isAwait": false,
           "decls": [
@@ -51,6 +51,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 20,
+            "end": 21
+          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-non-bmp/input.js.json
+++ b/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-non-bmp/input.js.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 3,
-            "end": 22
+            "end": 21
           },
           "isAwait": false,
           "decls": [
@@ -61,6 +61,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 21,
+            "end": 22
+          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-using/input.js.json
+++ b/crates/swc_ecma_parser/tests/js/explicit-resource-management/valid-using-binding-using/input.js.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 5,
-            "end": 22
+            "end": 21
           },
           "isAwait": false,
           "decls": [
@@ -51,6 +51,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 21,
+            "end": 22
+          }
         },
         {
           "type": "ForOfStatement",

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.1.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 109,
-        "end": 163
+        "end": 162
       },
       "isAwait": true,
       "decls": [
@@ -99,6 +99,13 @@
       ]
     },
     {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 162,
+        "end": 163
+      }
+    },
+    {
       "type": "FunctionDeclaration",
       "identifier": {
         "type": "Identifier",
@@ -130,7 +137,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 191,
-              "end": 245
+              "end": 244
             },
             "isAwait": true,
             "decls": [
@@ -220,6 +227,13 @@
             ]
           },
           {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 244,
+              "end": 245
+            }
+          },
+          {
             "type": "ExpressionStatement",
             "span": {
               "start": 250,
@@ -279,7 +293,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 293,
-              "end": 347
+              "end": 346
             },
             "isAwait": true,
             "decls": [
@@ -367,6 +381,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 346,
+              "end": 347
+            }
           },
           {
             "type": "ExpressionStatement",
@@ -459,7 +480,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 406,
-                    "end": 460
+                    "end": 459
                   },
                   "isAwait": true,
                   "decls": [
@@ -547,6 +568,13 @@
                       "definite": false
                     }
                   ]
+                },
+                {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 459,
+                    "end": 460
+                  }
                 }
               ]
             },
@@ -613,7 +641,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 506,
-                    "end": 560
+                    "end": 559
                   },
                   "isAwait": true,
                   "decls": [
@@ -701,6 +729,13 @@
                       "definite": false
                     }
                   ]
+                },
+                {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 559,
+                    "end": 560
+                  }
                 }
               ]
             },
@@ -754,7 +789,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 594,
-                    "end": 649
+                    "end": 648
                   },
                   "isAwait": true,
                   "decls": [
@@ -844,6 +879,13 @@
                   ]
                 },
                 {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 648,
+                    "end": 649
+                  }
+                },
+                {
                   "type": "ExpressionStatement",
                   "span": {
                     "start": 658,
@@ -912,7 +954,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 704,
-                    "end": 759
+                    "end": 758
                   },
                   "isAwait": true,
                   "decls": [
@@ -1002,6 +1044,13 @@
                   ]
                 },
                 {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 758,
+                    "end": 759
+                  }
+                },
+                {
                   "type": "ExpressionStatement",
                   "span": {
                     "start": 768,
@@ -1071,7 +1120,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 810,
-            "end": 865
+            "end": 864
           },
           "isAwait": true,
           "decls": [
@@ -1159,6 +1208,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 864,
+            "end": 865
+          }
         }
       ]
     },
@@ -1224,7 +1280,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 914,
-                "end": 969
+                "end": 968
               },
               "isAwait": true,
               "decls": [
@@ -1314,6 +1370,13 @@
               ]
             },
             {
+              "type": "EmptyStatement",
+              "span": {
+                "start": 968,
+                "end": 969
+              }
+            },
+            {
               "type": "BreakStatement",
               "span": {
                 "start": 978,
@@ -1343,7 +1406,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 1006,
-                "end": 1061
+                "end": 1060
               },
               "isAwait": true,
               "decls": [
@@ -1433,6 +1496,13 @@
               ]
             },
             {
+              "type": "EmptyStatement",
+              "span": {
+                "start": 1060,
+                "end": 1061
+              }
+            },
+            {
               "type": "BreakStatement",
               "span": {
                 "start": 1070,
@@ -1494,7 +1564,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 1135,
-                  "end": 1190
+                  "end": 1189
                 },
                 "isAwait": true,
                 "decls": [
@@ -1584,6 +1654,13 @@
                 ]
               },
               {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 1189,
+                  "end": 1190
+                }
+              },
+              {
                 "type": "BreakStatement",
                 "span": {
                   "start": 1203,
@@ -1615,7 +1692,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1227,
-              "end": 1282
+              "end": 1281
             },
             "isAwait": true,
             "decls": [
@@ -1703,6 +1780,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 1281,
+              "end": 1282
+            }
           }
         ]
       },
@@ -1725,7 +1809,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 1297,
-                "end": 1352
+                "end": 1351
               },
               "isAwait": true,
               "decls": [
@@ -1813,6 +1897,13 @@
                   "definite": false
                 }
               ]
+            },
+            {
+              "type": "EmptyStatement",
+              "span": {
+                "start": 1351,
+                "end": 1352
+              }
             }
           ]
         }
@@ -1829,7 +1920,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1369,
-              "end": 1424
+              "end": 1423
             },
             "isAwait": true,
             "decls": [
@@ -1917,6 +2008,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 1423,
+              "end": 1424
+            }
           }
         ]
       }
@@ -1947,7 +2045,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1444,
-              "end": 1499
+              "end": 1498
             },
             "isAwait": true,
             "decls": [
@@ -2035,6 +2133,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 1498,
+              "end": 1499
+            }
           }
         ]
       },
@@ -2050,7 +2155,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1513,
-              "end": 1568
+              "end": 1567
             },
             "isAwait": true,
             "decls": [
@@ -2138,6 +2243,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 1567,
+              "end": 1568
+            }
           }
         ]
       }
@@ -2168,7 +2280,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1591,
-              "end": 1646
+              "end": 1645
             },
             "isAwait": true,
             "decls": [
@@ -2258,6 +2370,13 @@
             ]
           },
           {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 1645,
+              "end": 1646
+            }
+          },
+          {
             "type": "BreakStatement",
             "span": {
               "start": 1651,
@@ -2294,7 +2413,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1670,
-              "end": 1725
+              "end": 1724
             },
             "isAwait": true,
             "decls": [
@@ -2384,6 +2503,13 @@
             ]
           },
           {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 1724,
+              "end": 1725
+            }
+          },
+          {
             "type": "BreakStatement",
             "span": {
               "start": 1730,
@@ -2415,7 +2541,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1769,
-              "end": 1824
+              "end": 1823
             },
             "isAwait": true,
             "decls": [
@@ -2505,6 +2631,13 @@
             ]
           },
           {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 1823,
+              "end": 1824
+            }
+          },
+          {
             "type": "BreakStatement",
             "span": {
               "start": 1829,
@@ -2573,7 +2706,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1865,
-              "end": 1920
+              "end": 1919
             },
             "isAwait": true,
             "decls": [
@@ -2661,6 +2794,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 1919,
+              "end": 1920
+            }
           }
         ]
       }
@@ -2724,7 +2864,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1950,
-              "end": 2005
+              "end": 2004
             },
             "isAwait": true,
             "decls": [
@@ -2812,6 +2952,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 2004,
+              "end": 2005
+            }
           }
         ]
       }

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.12.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.12.json
@@ -37,7 +37,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 109,
-              "end": 128
+              "end": 127
             },
             "isAwait": true,
             "decls": [
@@ -69,6 +69,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 127,
+              "end": 128
+            }
           }
         ]
       },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.13.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.13.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 84,
-        "end": 105
+        "end": 104
       },
       "isAwait": true,
       "decls": [
@@ -40,6 +40,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 104,
+        "end": 105
+      }
     },
     {
       "type": "FunctionDeclaration",
@@ -73,7 +80,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 126,
-              "end": 147
+              "end": 146
             },
             "isAwait": true,
             "decls": [
@@ -104,6 +111,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 146,
+              "end": 147
+            }
           }
         ]
       },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.15.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.15.json
@@ -37,7 +37,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 134,
-              "end": 187
+              "end": 186
             },
             "isAwait": true,
             "decls": [
@@ -125,6 +125,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 186,
+              "end": 187
+            }
           }
         ]
       },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.2.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 115,
-            "end": 228
+            "end": 227
           },
           "isAwait": true,
           "decls": [
@@ -188,6 +188,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 227,
+            "end": 228
+          }
         }
       ]
     },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.3.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.3.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 115,
-            "end": 276
+            "end": 275
           },
           "isAwait": true,
           "decls": [
@@ -243,6 +243,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 275,
+            "end": 276
+          }
         }
       ]
     },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.9.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarations.9.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 90,
-            "end": 111
+            "end": 110
           },
           "isAwait": true,
           "decls": [
@@ -48,6 +48,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 110,
+            "end": 111
+          }
         }
       ]
     },

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarationsTopLevelOfModule.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarationsTopLevelOfModule.1.json
@@ -87,7 +87,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 154,
-        "end": 207
+        "end": 206
       },
       "isAwait": true,
       "decls": [
@@ -175,6 +175,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 206,
+        "end": 207
+      }
     },
     {
       "type": "VariableDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarationsWithImportHelpers.json
+++ b/crates/swc_ecma_parser/tests/tsc/awaitUsingDeclarationsWithImportHelpers.json
@@ -48,7 +48,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 145,
-              "end": 166
+              "end": 165
             },
             "isAwait": true,
             "decls": [
@@ -79,6 +79,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 165,
+              "end": 166
+            }
           }
         ]
       },

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.1.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 109,
-        "end": 146
+        "end": 145
       },
       "isAwait": false,
       "decls": [
@@ -99,6 +99,13 @@
       ]
     },
     {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 145,
+        "end": 146
+      }
+    },
+    {
       "type": "FunctionDeclaration",
       "identifier": {
         "type": "Identifier",
@@ -130,7 +137,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 167,
-              "end": 204
+              "end": 203
             },
             "isAwait": false,
             "decls": [
@@ -218,6 +225,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 203,
+              "end": 204
+            }
           }
         ]
       },
@@ -258,7 +272,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 234,
-              "end": 271
+              "end": 270
             },
             "isAwait": false,
             "decls": [
@@ -348,6 +362,13 @@
             ]
           },
           {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 270,
+              "end": 271
+            }
+          },
+          {
             "type": "ExpressionStatement",
             "span": {
               "start": 276,
@@ -407,7 +428,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 312,
-              "end": 349
+              "end": 348
             },
             "isAwait": false,
             "decls": [
@@ -497,6 +518,13 @@
             ]
           },
           {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 348,
+              "end": 349
+            }
+          },
+          {
             "type": "ExpressionStatement",
             "span": {
               "start": 354,
@@ -551,7 +579,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 392,
-              "end": 429
+              "end": 428
             },
             "isAwait": false,
             "decls": [
@@ -639,6 +667,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 428,
+              "end": 429
+            }
           },
           {
             "type": "ExpressionStatement",
@@ -731,7 +766,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 482,
-                    "end": 519
+                    "end": 518
                   },
                   "isAwait": false,
                   "decls": [
@@ -819,6 +854,13 @@
                       "definite": false
                     }
                   ]
+                },
+                {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 518,
+                    "end": 519
+                  }
                 }
               ]
             },
@@ -885,7 +927,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 558,
-                    "end": 595
+                    "end": 594
                   },
                   "isAwait": false,
                   "decls": [
@@ -973,6 +1015,13 @@
                       "definite": false
                     }
                   ]
+                },
+                {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 594,
+                    "end": 595
+                  }
                 }
               ]
             },
@@ -1020,7 +1069,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 631,
-                  "end": 668
+                  "end": 667
                 },
                 "isAwait": false,
                 "decls": [
@@ -1108,6 +1157,13 @@
                     "definite": false
                   }
                 ]
+              },
+              {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 667,
+                  "end": 668
+                }
               }
             ]
           },
@@ -1132,7 +1188,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 697,
-                  "end": 734
+                  "end": 733
                 },
                 "isAwait": false,
                 "decls": [
@@ -1220,6 +1276,13 @@
                     "definite": false
                   }
                 ]
+              },
+              {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 733,
+                  "end": 734
+                }
               }
             ]
           }
@@ -1258,7 +1321,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 760,
-                    "end": 798
+                    "end": 797
                   },
                   "isAwait": false,
                   "decls": [
@@ -1346,6 +1409,13 @@
                       "definite": false
                     }
                   ]
+                },
+                {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 797,
+                    "end": 798
+                  }
                 }
               ]
             },
@@ -1395,7 +1465,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 828,
-                    "end": 866
+                    "end": 865
                   },
                   "isAwait": false,
                   "decls": [
@@ -1485,6 +1555,13 @@
                   ]
                 },
                 {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 865,
+                    "end": 866
+                  }
+                },
+                {
                   "type": "ReturnStatement",
                   "span": {
                     "start": 875,
@@ -1568,7 +1645,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 915,
-                    "end": 953
+                    "end": 952
                   },
                   "isAwait": false,
                   "decls": [
@@ -1656,6 +1733,13 @@
                       "definite": false
                     }
                   ]
+                },
+                {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 952,
+                    "end": 953
+                  }
                 }
               ]
             },
@@ -1705,7 +1789,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 986,
-                    "end": 1024
+                    "end": 1023
                   },
                   "isAwait": false,
                   "decls": [
@@ -1795,6 +1879,13 @@
                   ]
                 },
                 {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 1023,
+                    "end": 1024
+                  }
+                },
+                {
                   "type": "ExpressionStatement",
                   "span": {
                     "start": 1033,
@@ -1863,7 +1954,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 1072,
-                    "end": 1110
+                    "end": 1109
                   },
                   "isAwait": false,
                   "decls": [
@@ -1953,6 +2044,13 @@
                   ]
                 },
                 {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 1109,
+                    "end": 1110
+                  }
+                },
+                {
                   "type": "ExpressionStatement",
                   "span": {
                     "start": 1119,
@@ -2016,7 +2114,7 @@
                   "type": "UsingDeclaration",
                   "span": {
                     "start": 1160,
-                    "end": 1198
+                    "end": 1197
                   },
                   "isAwait": false,
                   "decls": [
@@ -2104,6 +2202,13 @@
                       "definite": false
                     }
                   ]
+                },
+                {
+                  "type": "EmptyStatement",
+                  "span": {
+                    "start": 1197,
+                    "end": 1198
+                  }
                 },
                 {
                   "type": "ExpressionStatement",
@@ -2211,7 +2316,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 1293,
-                  "end": 1331
+                  "end": 1330
                 },
                 "isAwait": false,
                 "decls": [
@@ -2299,6 +2404,13 @@
                     "definite": false
                   }
                 ]
+              },
+              {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 1330,
+                  "end": 1331
+                }
               },
               {
                 "type": "ExpressionStatement",
@@ -2427,7 +2539,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 1419,
-                  "end": 1457
+                  "end": 1456
                 },
                 "isAwait": false,
                 "decls": [
@@ -2517,6 +2629,13 @@
                 ]
               },
               {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 1456,
+                  "end": 1457
+                }
+              },
+              {
                 "type": "ExpressionStatement",
                 "span": {
                   "start": 1466,
@@ -2590,7 +2709,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1502,
-              "end": 1540
+              "end": 1539
             },
             "isAwait": false,
             "decls": [
@@ -2678,6 +2797,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 1539,
+              "end": 1540
+            }
           }
         ]
       }
@@ -2694,7 +2820,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 1550,
-            "end": 1588
+            "end": 1587
           },
           "isAwait": false,
           "decls": [
@@ -2782,6 +2908,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 1587,
+            "end": 1588
+          }
         }
       ]
     },
@@ -2847,7 +2980,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 1637,
-                "end": 1675
+                "end": 1674
               },
               "isAwait": false,
               "decls": [
@@ -2937,6 +3070,13 @@
               ]
             },
             {
+              "type": "EmptyStatement",
+              "span": {
+                "start": 1674,
+                "end": 1675
+              }
+            },
+            {
               "type": "BreakStatement",
               "span": {
                 "start": 1684,
@@ -2966,7 +3106,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 1712,
-                "end": 1750
+                "end": 1749
               },
               "isAwait": false,
               "decls": [
@@ -3056,6 +3196,13 @@
               ]
             },
             {
+              "type": "EmptyStatement",
+              "span": {
+                "start": 1749,
+                "end": 1750
+              }
+            },
+            {
               "type": "BreakStatement",
               "span": {
                 "start": 1759,
@@ -3117,7 +3264,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 1824,
-                  "end": 1862
+                  "end": 1861
                 },
                 "isAwait": false,
                 "decls": [
@@ -3207,6 +3354,13 @@
                 ]
               },
               {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 1861,
+                  "end": 1862
+                }
+              },
+              {
                 "type": "BreakStatement",
                 "span": {
                   "start": 1875,
@@ -3238,7 +3392,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 1899,
-              "end": 1937
+              "end": 1936
             },
             "isAwait": false,
             "decls": [
@@ -3326,6 +3480,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 1936,
+              "end": 1937
+            }
           }
         ]
       },
@@ -3348,7 +3509,7 @@
               "type": "UsingDeclaration",
               "span": {
                 "start": 1952,
-                "end": 1990
+                "end": 1989
               },
               "isAwait": false,
               "decls": [
@@ -3436,6 +3597,13 @@
                   "definite": false
                 }
               ]
+            },
+            {
+              "type": "EmptyStatement",
+              "span": {
+                "start": 1989,
+                "end": 1990
+              }
             }
           ]
         }
@@ -3452,7 +3620,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2007,
-              "end": 2045
+              "end": 2044
             },
             "isAwait": false,
             "decls": [
@@ -3540,6 +3708,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 2044,
+              "end": 2045
+            }
           }
         ]
       }
@@ -3570,7 +3745,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2065,
-              "end": 2103
+              "end": 2102
             },
             "isAwait": false,
             "decls": [
@@ -3658,6 +3833,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 2102,
+              "end": 2103
+            }
           }
         ]
       },
@@ -3673,7 +3855,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2117,
-              "end": 2155
+              "end": 2154
             },
             "isAwait": false,
             "decls": [
@@ -3761,6 +3943,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 2154,
+              "end": 2155
+            }
           }
         ]
       }
@@ -3791,7 +3980,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2178,
-              "end": 2216
+              "end": 2215
             },
             "isAwait": false,
             "decls": [
@@ -3881,6 +4070,13 @@
             ]
           },
           {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 2215,
+              "end": 2216
+            }
+          },
+          {
             "type": "BreakStatement",
             "span": {
               "start": 2221,
@@ -3917,7 +4113,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2240,
-              "end": 2278
+              "end": 2277
             },
             "isAwait": false,
             "decls": [
@@ -4007,6 +4203,13 @@
             ]
           },
           {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 2277,
+              "end": 2278
+            }
+          },
+          {
             "type": "BreakStatement",
             "span": {
               "start": 2283,
@@ -4038,7 +4241,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2322,
-              "end": 2360
+              "end": 2359
             },
             "isAwait": false,
             "decls": [
@@ -4128,6 +4331,13 @@
             ]
           },
           {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 2359,
+              "end": 2360
+            }
+          },
+          {
             "type": "BreakStatement",
             "span": {
               "start": 2365,
@@ -4196,7 +4406,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2401,
-              "end": 2439
+              "end": 2438
             },
             "isAwait": false,
             "decls": [
@@ -4284,6 +4494,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 2438,
+              "end": 2439
+            }
           }
         ]
       }
@@ -4347,7 +4564,7 @@
             "type": "UsingDeclaration",
             "span": {
               "start": 2469,
-              "end": 2507
+              "end": 2506
             },
             "isAwait": false,
             "decls": [
@@ -4435,6 +4652,13 @@
                 "definite": false
               }
             ]
+          },
+          {
+            "type": "EmptyStatement",
+            "span": {
+              "start": 2506,
+              "end": 2507
+            }
           }
         ]
       }

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.11.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.11.json
@@ -79,7 +79,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 141,
-                  "end": 156
+                  "end": 155
                 },
                 "isAwait": false,
                 "decls": [
@@ -110,6 +110,13 @@
                     "definite": false
                   }
                 ]
+              },
+              {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 155,
+                  "end": 156
+                }
               },
               {
                 "type": "ExpressionStatement",
@@ -228,7 +235,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 248,
-                  "end": 263
+                  "end": 262
                 },
                 "isAwait": false,
                 "decls": [
@@ -259,6 +266,13 @@
                     "definite": false
                   }
                 ]
+              },
+              {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 262,
+                  "end": 263
+                }
               }
             ]
           },
@@ -363,7 +377,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 332,
-                  "end": 347
+                  "end": 346
                 },
                 "isAwait": false,
                 "decls": [
@@ -394,6 +408,13 @@
                     "definite": false
                   }
                 ]
+              },
+              {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 346,
+                  "end": 347
+                }
               },
               {
                 "type": "ExpressionStatement",
@@ -525,7 +546,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 438,
-                  "end": 453
+                  "end": 452
                 },
                 "isAwait": false,
                 "decls": [
@@ -556,6 +577,13 @@
                     "definite": false
                   }
                 ]
+              },
+              {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 452,
+                  "end": 453
+                }
               },
               {
                 "type": "ExpressionStatement",
@@ -721,7 +749,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 555,
-                  "end": 570
+                  "end": 569
                 },
                 "isAwait": false,
                 "decls": [
@@ -752,6 +780,13 @@
                     "definite": false
                   }
                 ]
+              },
+              {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 569,
+                  "end": 570
+                }
               },
               {
                 "type": "ExpressionStatement",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.12.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.12.json
@@ -166,7 +166,7 @@
                 "type": "UsingDeclaration",
                 "span": {
                   "start": 228,
-                  "end": 266
+                  "end": 265
                 },
                 "isAwait": false,
                 "decls": [
@@ -254,6 +254,13 @@
                     "definite": false
                   }
                 ]
+              },
+              {
+                "type": "EmptyStatement",
+                "span": {
+                  "start": 265,
+                  "end": 266
+                }
               }
             ]
           },

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.14.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.14.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 84,
-        "end": 97
+        "end": 96
       },
       "isAwait": false,
       "decls": [
@@ -41,6 +41,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 96,
+        "end": 97
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.15.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.15.json
@@ -20,7 +20,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 121,
-        "end": 157
+        "end": 156
       },
       "isAwait": false,
       "decls": [
@@ -108,6 +108,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 156,
+        "end": 157
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.2.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 115,
-            "end": 194
+            "end": 193
           },
           "isAwait": false,
           "decls": [
@@ -188,6 +188,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 193,
+            "end": 194
+          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.3.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.3.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 115,
-            "end": 241
+            "end": 240
           },
           "isAwait": false,
           "decls": [
@@ -243,6 +243,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 240,
+            "end": 241
+          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarations.9.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarations.9.json
@@ -17,7 +17,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 90,
-            "end": 105
+            "end": 104
           },
           "isAwait": false,
           "decls": [
@@ -48,6 +48,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 104,
+            "end": 105
+          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsDeclarationEmit.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsDeclarationEmit.1.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 90,
-        "end": 127
+        "end": 126
       },
       "isAwait": false,
       "decls": [
@@ -99,6 +99,13 @@
       ]
     },
     {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 126,
+        "end": 127
+      }
+    },
+    {
       "type": "ExportNamedDeclaration",
       "span": {
         "start": 128,
@@ -133,7 +140,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 144,
-        "end": 198
+        "end": 197
       },
       "isAwait": true,
       "decls": [
@@ -221,6 +228,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 197,
+        "end": 198
+      }
     },
     {
       "type": "ExportNamedDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsDeclarationEmit.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsDeclarationEmit.2.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 90,
-        "end": 127
+        "end": 126
       },
       "isAwait": false,
       "decls": [
@@ -99,6 +99,13 @@
       ]
     },
     {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 126,
+        "end": 127
+      }
+    },
+    {
       "type": "ExportDeclaration",
       "span": {
         "start": 128,
@@ -146,7 +153,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 157,
-        "end": 211
+        "end": 210
       },
       "isAwait": true,
       "decls": [
@@ -234,6 +241,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 210,
+        "end": 211
+      }
     },
     {
       "type": "ExportDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsNamedEvaluationDecoratorsAndClassFields.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 119,
-        "end": 173
+        "end": 172
       },
       "isAwait": false,
       "decls": [
@@ -176,10 +176,17 @@
       ]
     },
     {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 172,
+        "end": 173
+      }
+    },
+    {
       "type": "UsingDeclaration",
       "span": {
         "start": 175,
-        "end": 247
+        "end": 246
       },
       "isAwait": false,
       "decls": [
@@ -323,10 +330,17 @@
       ]
     },
     {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 246,
+        "end": 247
+      }
+    },
+    {
       "type": "UsingDeclaration",
       "span": {
         "start": 249,
-        "end": 308
+        "end": 307
       },
       "isAwait": false,
       "decls": [
@@ -454,10 +468,17 @@
       ]
     },
     {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 307,
+        "end": 308
+      }
+    },
+    {
       "type": "UsingDeclaration",
       "span": {
         "start": 310,
-        "end": 387
+        "end": 386
       },
       "isAwait": false,
       "decls": [
@@ -617,6 +638,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 386,
+        "end": 387
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.1.json
@@ -87,7 +87,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 167,
-        "end": 203
+        "end": 202
       },
       "isAwait": false,
       "decls": [
@@ -175,6 +175,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 202,
+        "end": 203
+      }
     },
     {
       "type": "VariableDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.2.json
@@ -9,7 +9,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 118,
-        "end": 154
+        "end": 153
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 153,
+        "end": 154
+      }
     },
     {
       "type": "VariableDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.3.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsTopLevelOfModule.3.json
@@ -40,7 +40,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 147,
-        "end": 183
+        "end": 182
       },
       "isAwait": false,
       "decls": [
@@ -128,6 +128,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 182,
+        "end": 183
+      }
     },
     {
       "type": "IfStatement",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.1.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 223
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 222,
+        "end": 223
+      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.10.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.10.json
@@ -107,7 +107,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 234,
-        "end": 253
+        "end": 252
       },
       "isAwait": false,
       "decls": [
@@ -138,6 +138,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 252,
+        "end": 253
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.11.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.11.json
@@ -141,7 +141,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 236,
-        "end": 255
+        "end": 254
       },
       "isAwait": false,
       "decls": [
@@ -172,6 +172,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 254,
+        "end": 255
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.12.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.12.json
@@ -150,7 +150,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 241,
-        "end": 260
+        "end": 259
       },
       "isAwait": false,
       "decls": [
@@ -181,6 +181,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 259,
+        "end": 260
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.2.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 223
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 222,
+        "end": 223
+      }
     },
     {
       "type": "ExportDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.3.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.3.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 223
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 222,
+        "end": 223
+      }
     },
     {
       "type": "ExportDefaultDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.4.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.4.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 223
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 222,
+        "end": 223
+      }
     },
     {
       "type": "ExportDefaultDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.5.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.5.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 223
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 222,
+        "end": 223
+      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.6.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.6.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 203,
-        "end": 223
+        "end": 222
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 222,
+        "end": 223
+      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.7.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.7.json
@@ -110,7 +110,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 221,
-        "end": 240
+        "end": 239
       },
       "isAwait": false,
       "decls": [
@@ -141,6 +141,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 239,
+        "end": 240
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.8.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.8.json
@@ -117,7 +117,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 228,
-        "end": 247
+        "end": 246
       },
       "isAwait": false,
       "decls": [
@@ -148,6 +148,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 246,
+        "end": 247
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.9.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithESClassDecorators.9.json
@@ -141,7 +141,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 245,
-        "end": 264
+        "end": 263
       },
       "isAwait": false,
       "decls": [
@@ -172,6 +172,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 263,
+        "end": 264
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithImportHelpers.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithImportHelpers.json
@@ -28,7 +28,7 @@
           "type": "UsingDeclaration",
           "span": {
             "start": 126,
-            "end": 141
+            "end": 140
           },
           "isAwait": false,
           "decls": [
@@ -59,6 +59,13 @@
               "definite": false
             }
           ]
+        },
+        {
+          "type": "EmptyStatement",
+          "span": {
+            "start": 140,
+            "end": 141
+          }
         }
       ]
     }

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.1.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.1.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 222
+        "end": 221
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 221,
+        "end": 222
+      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.10.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.10.json
@@ -107,7 +107,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 233,
-        "end": 252
+        "end": 251
       },
       "isAwait": false,
       "decls": [
@@ -138,6 +138,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 251,
+        "end": 252
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.11.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.11.json
@@ -141,7 +141,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 235,
-        "end": 254
+        "end": 253
       },
       "isAwait": false,
       "decls": [
@@ -172,6 +172,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 253,
+        "end": 254
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.12.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.12.json
@@ -150,7 +150,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 240,
-        "end": 259
+        "end": 258
       },
       "isAwait": false,
       "decls": [
@@ -181,6 +181,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 258,
+        "end": 259
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.2.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.2.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 222
+        "end": 221
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 221,
+        "end": 222
+      }
     },
     {
       "type": "ExportDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.3.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.3.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 222
+        "end": 221
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 221,
+        "end": 222
+      }
     },
     {
       "type": "ExportDefaultDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.4.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.4.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 222
+        "end": 221
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 221,
+        "end": 222
+      }
     },
     {
       "type": "ExportDefaultDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.5.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.5.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 222
+        "end": 221
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 221,
+        "end": 222
+      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.6.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.6.json
@@ -66,7 +66,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 202,
-        "end": 222
+        "end": 221
       },
       "isAwait": false,
       "decls": [
@@ -97,6 +97,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 221,
+        "end": 222
+      }
     },
     {
       "type": "ClassDeclaration",

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.7.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.7.json
@@ -110,7 +110,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 220,
-        "end": 239
+        "end": 238
       },
       "isAwait": false,
       "decls": [
@@ -141,6 +141,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 238,
+        "end": 239
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.8.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.8.json
@@ -117,7 +117,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 227,
-        "end": 246
+        "end": 245
       },
       "isAwait": false,
       "decls": [
@@ -148,6 +148,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 245,
+        "end": 246
+      }
     }
   ],
   "interpreter": null

--- a/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.9.json
+++ b/crates/swc_ecma_parser/tests/tsc/usingDeclarationsWithLegacyClassDecorators.9.json
@@ -116,7 +116,7 @@
       "type": "UsingDeclaration",
       "span": {
         "start": 235,
-        "end": 254
+        "end": 253
       },
       "isAwait": false,
       "decls": [
@@ -147,6 +147,13 @@
           "definite": false
         }
       ]
+    },
+    {
+      "type": "EmptyStatement",
+      "span": {
+        "start": 253,
+        "end": 254
+      }
     }
   ],
   "interpreter": null


### PR DESCRIPTION
 - Reverts swc-project/swc#9798
 - https://github.com/nodejs/amaro/pull/138