### PR TITLE
fix(es/minifier): Fix minification of `framer-motion` by checking `cons.termniates()`

### DIFF
--- a/.changeset/gold-shoes-cross.md
+++ b/.changeset/gold-shoes-cross.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): Add failing test case for an example in `framer-motion`

--- a/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
@@ -121,7 +121,9 @@ impl Optimizer<'_> {
                     (
                         Some(Stmt::If(l @ IfStmt { alt: None, .. })),
                         Some(Stmt::If(r @ IfStmt { alt: None, .. })),
-                    ) => SyntaxContext::within_ignored_ctxt(|| l.cons.eq_ignore_span(&r.cons)),
+                    ) => SyntaxContext::within_ignored_ctxt(|| {
+                        l.cons.eq_ignore_span(&r.cons) && l.cons.terminates()
+                    }),
                     _ => false,
                 });
         if !has_work {

--- a/crates/swc_ecma_minifier/tests/fixture/issues/framer-motion/1/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/framer-motion/1/input.js
@@ -1,0 +1,28 @@
+// `resolveVariantFromProps` in framer-motion
+// https://github.com/motiondivision/motion/blob/ecd97f7dce8954be300aa73ab6a96208437941c5/packages/framer-motion/src/render/utils/resolve-variants.ts#L31-L72
+
+export function resolveVariantFromProps(props, definition, custom, visualElement) {
+    if (typeof definition === "function") {
+        const [current, velocity] = getValueState(visualElement)
+        definition = definition(
+            custom !== undefined ? custom : props.custom,
+            current,
+            velocity
+        )
+    }
+
+    if (typeof definition === "string") {
+        definition = props.variants && props.variants[definition]
+    }
+
+    if (typeof definition === "function") {
+        const [current, velocity] = getValueState(visualElement)
+        definition = definition(
+            custom !== undefined ? custom : props.custom,
+            current,
+            velocity
+        )
+    }
+
+    return definition
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/framer-motion/1/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/framer-motion/1/output.js
@@ -1,0 +1,13 @@
+// `resolveVariantFromProps` in framer-motion
+// https://github.com/motiondivision/motion/blob/ecd97f7dce8954be300aa73ab6a96208437941c5/packages/framer-motion/src/render/utils/resolve-variants.ts#L31-L72
+export function resolveVariantFromProps(props, definition, custom, visualElement) {
+    if ("function" == typeof definition) {
+      const [current, velocity] = getValueState(visualElement)
+      definition = definition(void 0 !== custom ? custom : props.custom, current, velocity)
+    }
+    if (("string" == typeof definition && (definition = props.variants && props.variants[definition]), "function" == typeof definition)) {
+        const [current, velocity] = getValueState(visualElement);
+        definition = definition(void 0 !== custom ? custom : props.custom, current, velocity);
+    }
+    return definition
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/framer-motion/1/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/framer-motion/1/output.js
@@ -2,12 +2,12 @@
 // https://github.com/motiondivision/motion/blob/ecd97f7dce8954be300aa73ab6a96208437941c5/packages/framer-motion/src/render/utils/resolve-variants.ts#L31-L72
 export function resolveVariantFromProps(props, definition, custom, visualElement) {
     if ("function" == typeof definition) {
-      const [current, velocity] = getValueState(visualElement)
-      definition = definition(void 0 !== custom ? custom : props.custom, current, velocity)
-    }
-    if (("string" == typeof definition && (definition = props.variants && props.variants[definition]), "function" == typeof definition)) {
         const [current, velocity] = getValueState(visualElement);
         definition = definition(void 0 !== custom ? custom : props.custom, current, velocity);
     }
-    return definition
+    if ("string" == typeof definition && (definition = props.variants && props.variants[definition]), "function" == typeof definition) {
+        const [current, velocity] = getValueState(visualElement);
+        definition = definition(void 0 !== custom ? custom : props.custom, current, velocity);
+    }
+    return definition;
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Next.js 15 seems to minify parts of `framer-motion`'s code in an invalid way, changing the meaning. The original function modifies the single `definition` variable as it changes meaning (see `input.js`):
- if `definition` is a function, it calls it and saves the return value as `definition`
- if `definition` is a string, it resolves animation variant based on value as name and saves the variant as `definition`
- if `definition` is again a function, it calls it again and saves the return value as `definition` again

However, `swc` seems to be not noticing that `definition` may be mutated between the calls and collapses all `if`s into one:

```
// `resolveVariantFromProps` in framer-motion
// https://github.com/motiondivision/motion/blob/ecd97f7dce8954be300aa73ab6a96208437941c5/packages/framer-motion/src/render/utils/resolve-variants.ts#L31-L72
export function resolveVariantFromProps(props, definition, custom, visualElement) {
    if ("function" == typeof definition || ("string" == typeof definition && (definition = props.variants && props.variants[definition]), "function" == typeof definition)) {
        const [current, velocity] = getValueState(visualElement);
        definition = definition(void 0 !== custom ? custom : props.custom, current, velocity);
    }
    return definition;
}
```

which skips the first call to `definition`, first "resolution" step.

Note: I suspect the `output.js` may not be precisely what SWC may output as minified code (maybe there is a way to minify it further). It definitely differs from the current output though by the initial call and reassignment to `definition`.