### PR TITLE
fix: Remove `Caused by: 'failed to parse'` from TS blank space

### DIFF
--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -1,5 +1,14 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`transform in strip-only mode should not emit 'Caused by: failed to parse' 1`] = `
+"  x await isn't allowed in non-async function
+   ,----
+ 1 | function foo() { await Promise.resolve(1); }
+   :                        ^^^^^^^
+   \`----
+"
+`;
+
 exports[`transform in strip-only mode should remove declare enum 1`] = `
 {
   "code": "                   ",

--- a/bindings/binding_typescript_wasm/__tests__/transform.js
+++ b/bindings/binding_typescript_wasm/__tests__/transform.js
@@ -136,7 +136,7 @@ describe("transform", () => {
                 swc.transform("function foo() { await Promise.resolve(1); }", {
                     mode: "strip-only",
                 })
-            ).rejects.not.toMatchSnapshot();
+            ).rejects.toMatchSnapshot();
         });
     });
 });

--- a/bindings/binding_typescript_wasm/__tests__/transform.js
+++ b/bindings/binding_typescript_wasm/__tests__/transform.js
@@ -130,5 +130,13 @@ describe("transform", () => {
                 })
             ).rejects.toMatchSnapshot();
         });
+
+        it("should not emit 'Caused by: failed to parse'", async () => {
+            await expect(
+                swc.transform("function foo() { await Promise.resolve(1); }", {
+                    mode: "strip-only",
+                })
+            ).rejects.not.toMatchSnapshot();
+        });
     });
 });

--- a/bindings/binding_typescript_wasm/src/lib.rs
+++ b/bindings/binding_typescript_wasm/src/lib.rs
@@ -53,5 +53,5 @@ fn operate(input: String, options: Options) -> Result<TransformOutput, Error> {
 }
 
 pub fn convert_err(err: Error) -> wasm_bindgen::prelude::JsValue {
-    format!("{:?}", err).into()
+    format!("{}", err).into()
 }


### PR DESCRIPTION
**Description:**


**Related issue (if exists):**
