### PR TITLE
perf(es/minifier): Introduce `FastJsWord` and `FastId` in `swc_atoms`

### DIFF
--- a/.changeset/loud-bottles-teach.md
+++ b/.changeset/loud-bottles-teach.md
@@ -1,0 +1,8 @@
+---
+swc_atoms: patch
+swc_core: patch
+swc_ecma_ast: patch
+swc_ecma_utils: patch
+---
+
+perf(es/minifier): Introduce `FastJsWord` and `FastId` in `swc_atoms`

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -9,6 +9,7 @@ use crate::Atom;
 /// unsafe.
 ///
 /// Do not use this unless you know what you are doing.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FastAtom(ManuallyDrop<Atom>);
 
 impl FastAtom {

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::Atom;
 
-/// FastAtom is a wrapper around [Atom] that does not allocate, but extermely
+/// FastAtom is a wrapper around [Atom] that does not allocate, but extremely
 /// unsafe.
 ///
 /// Do not use this unless you know what you are doing.

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -1,0 +1,9 @@
+use std::mem::ManuallyDrop;
+
+use crate::Atom;
+
+/// FastAtom is a wrapper around [Atom] that does not allocate, but extermely
+/// unsafe.
+///
+/// Do not use this unless you know what you are doing.
+pub struct FastAtom(ManuallyDrop<Atom>);

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -15,6 +15,13 @@ impl FastAtom {
     /// # Safety
     ///
     ///  - You should ensure that the passed `atom` is not freed.
+    ///
+    /// Some simple solutions to ensure this are
+    ///
+    ///  - Collect all [Atom] and store them somewhere while you are using
+    ///    [FastAtom]
+    ///  - Use [FastAtom] only for short-lived operations where all [Atom] is
+    ///    stored in AST and ensure that the AST is not dropped.
     pub unsafe fn new(atom: &Atom) -> Self {
         Self(ManuallyDrop::new(transmute_copy(atom)))
     }

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -9,6 +9,9 @@ use crate::Atom;
 /// unsafe.
 ///
 /// Do not use this unless you know what you are doing.
+///
+/// **Currently, it's considered as a unstable API and may be changed in the
+/// future without a semver bump.**
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FastAtom(ManuallyDrop<Atom>);
 

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -35,3 +35,9 @@ impl Deref for FastAtom {
         &self.0
     }
 }
+
+impl PartialEq<Atom> for FastAtom {
+    fn eq(&self, other: &Atom) -> bool {
+        *self.0 == *other
+    }
+}

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -23,6 +23,7 @@ impl FastAtom {
     ///    [FastAtom]
     ///  - Use [FastAtom] only for short-lived operations where all [Atom] is
     ///    stored in AST and ensure that the AST is not dropped.
+    #[inline]
     pub unsafe fn new(atom: &Atom) -> Self {
         Self(ManuallyDrop::new(transmute_copy(atom)))
     }
@@ -31,18 +32,21 @@ impl FastAtom {
 impl Deref for FastAtom {
     type Target = Atom;
 
+    #[inline]
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
 impl Clone for FastAtom {
+    #[inline]
     fn clone(&self) -> Self {
         unsafe { Self::new(&self.0) }
     }
 }
 
 impl PartialEq<Atom> for FastAtom {
+    #[inline]
     fn eq(&self, other: &Atom) -> bool {
         *self.0 == *other
     }

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -9,7 +9,7 @@ use crate::Atom;
 /// unsafe.
 ///
 /// Do not use this unless you know what you are doing.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FastAtom(ManuallyDrop<Atom>);
 
 impl FastAtom {
@@ -33,6 +33,12 @@ impl Deref for FastAtom {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Clone for FastAtom {
+    fn clone(&self) -> Self {
+        unsafe { Self::new(&self.0) }
     }
 }
 

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -1,4 +1,7 @@
-use std::mem::ManuallyDrop;
+use std::{
+    mem::{transmute_copy, ManuallyDrop},
+    ops::Deref,
+};
 
 use crate::Atom;
 
@@ -7,3 +10,20 @@ use crate::Atom;
 ///
 /// Do not use this unless you know what you are doing.
 pub struct FastAtom(ManuallyDrop<Atom>);
+
+impl FastAtom {
+    /// # Safety
+    ///
+    ///  - You should ensure that the passed `atom` is not freed.
+    pub unsafe fn new(atom: &Atom) -> Self {
+        Self(ManuallyDrop::new(transmute_copy(atom)))
+    }
+}
+
+impl Deref for FastAtom {
+    type Target = Atom;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}

--- a/crates/swc_atoms/src/lib.rs
+++ b/crates/swc_atoms/src/lib.rs
@@ -23,6 +23,8 @@ use serde::Serializer;
 
 pub use self::{atom as js_word, Atom as JsWord};
 
+pub mod fast;
+
 /// Clone-on-write string.
 ///
 ///

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -465,7 +465,7 @@ impl From<IdentName> for BindingIdent {
     }
 }
 
-/// FastId is a wrapper around [Id] that does not allocate, but extermely
+/// FastId is a wrapper around [Id] that does not allocate, but extremely
 /// unsafe.
 ///
 /// Do not use this unless you know what you are doing.

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -480,6 +480,15 @@ pub unsafe fn fast_id(id: &Id) -> FastId {
     (FastAtom::new(&id.0), id.1)
 }
 
+/// This is extremely unsafe so don't use it unless you know what you are doing.
+///
+/// # Safety
+///
+/// See [`FastAtom::new`] for constraints.
+pub unsafe fn fast_id_from_ident(id: &Ident) -> FastId {
+    (FastAtom::new(&id.sym), id.ctxt)
+}
+
 /// See [Ident] for documentation.
 pub type Id = (Atom, SyntaxContext);
 

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use phf::phf_set;
-use swc_atoms::{js_word, Atom};
+use swc_atoms::{fast::FastAtom, js_word, Atom};
 use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Mark, Span, Spanned, SyntaxContext, DUMMY_SP,
 };
@@ -463,6 +463,21 @@ impl From<IdentName> for BindingIdent {
             ..Default::default()
         }
     }
+}
+
+/// FastId is a wrapper around [Id] that does not allocate, but extermely
+/// unsafe.
+///
+/// Do not use this unless you know what you are doing.
+pub type FastId = (FastAtom, SyntaxContext);
+
+/// This is extremely unsafe so don't use it unless you know what you are doing.
+///
+/// # Safety
+///
+/// See [`FastAtom::new`] for constraints.
+pub unsafe fn fast_id(id: &Id) -> FastId {
+    (FastAtom::new(&id.0), id.1)
 }
 
 /// See [Ident] for documentation.

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -469,6 +469,9 @@ impl From<IdentName> for BindingIdent {
 /// unsafe.
 ///
 /// Do not use this unless you know what you are doing.
+///
+/// **Currently, it's considered as a unstable API and may be changed in the
+/// future without a semver bump.**
 pub type FastId = (FastAtom, SyntaxContext);
 
 /// This is extremely unsafe so don't use it unless you know what you are doing.
@@ -476,6 +479,9 @@ pub type FastId = (FastAtom, SyntaxContext);
 /// # Safety
 ///
 /// See [`FastAtom::new`] for constraints.
+///
+/// **Currently, it's considered as a unstable API and may be changed in the
+/// future without a semver bump.**
 pub unsafe fn fast_id(id: &Id) -> FastId {
     (FastAtom::new(&id.0), id.1)
 }
@@ -485,6 +491,9 @@ pub unsafe fn fast_id(id: &Id) -> FastId {
 /// # Safety
 ///
 /// See [`FastAtom::new`] for constraints.
+///
+/// **Currently, it's considered as a unstable API and may be changed in the
+/// future without a semver bump.**
 pub unsafe fn fast_id_from_ident(id: &Ident) -> FastId {
     (FastAtom::new(&id.sym), id.ctxt)
 }

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -22,7 +22,7 @@ pub use self::{
     decl::{ClassDecl, Decl, FnDecl, UsingDecl, VarDecl, VarDeclKind, VarDeclarator},
     expr::*,
     function::{Function, Param, ParamOrTsParamProp},
-    ident::{BindingIdent, EsReserved, Id, Ident, IdentName, PrivateName},
+    ident::{fast_id, BindingIdent, EsReserved, FastId, Id, Ident, IdentName, PrivateName},
     jsx::{
         JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXClosingElement, JSXClosingFragment,
         JSXElement, JSXElementChild, JSXElementName, JSXEmptyExpr, JSXExpr, JSXExprContainer,

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -22,7 +22,10 @@ pub use self::{
     decl::{ClassDecl, Decl, FnDecl, UsingDecl, VarDecl, VarDeclKind, VarDeclarator},
     expr::*,
     function::{Function, Param, ParamOrTsParamProp},
-    ident::{fast_id, BindingIdent, EsReserved, FastId, Id, Ident, IdentName, PrivateName},
+    ident::{
+        fast_id, fast_id_from_ident, BindingIdent, EsReserved, FastId, Id, Ident, IdentName,
+        PrivateName,
+    },
     jsx::{
         JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXClosingElement, JSXClosingFragment,
         JSXElement, JSXElementChild, JSXElementName, JSXEmptyExpr, JSXExpr, JSXExprContainer,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -93,7 +93,7 @@ struct TreeShaker {
 
     data: Arc<Data>,
 
-    bindings: Arc<AHashSet<FastId>>,
+    bindings: Arc<AHashSet<Id>>,
 }
 
 impl CompilerPass for TreeShaker {
@@ -104,7 +104,7 @@ impl CompilerPass for TreeShaker {
 
 #[derive(Default)]
 struct Data {
-    used_names: AHashMap<FastId, VarInfo>,
+    used_names: AHashMap<Id, VarInfo>,
 
     /// Variable usage graph
     ///
@@ -114,11 +114,11 @@ struct Data {
     /// Entrypoints.
     entries: FxHashSet<u32>,
 
-    graph_ix: IndexSet<FastId, ARandomState>,
+    graph_ix: IndexSet<Id, ARandomState>,
 }
 
 impl Data {
-    fn node(&mut self, id: &FastId) -> u32 {
+    fn node(&mut self, id: &Id) -> u32 {
         self.graph_ix.get_index_of(id).unwrap_or_else(|| {
             let ix = self.graph_ix.len();
             self.graph_ix.insert_full(id.clone());
@@ -127,7 +127,7 @@ impl Data {
     }
 
     /// Add an edge to dependency graph
-    fn add_dep_edge(&mut self, from: &FastId, to: &FastId, assign: bool) {
+    fn add_dep_edge(&mut self, from: &Id, to: &Id, assign: bool) {
         let from = self.node(from);
         let to = self.node(to);
 
@@ -214,8 +214,8 @@ struct Analyzer<'a> {
     in_var_decl: bool,
     scope: Scope<'a>,
     data: &'a mut Data,
-    cur_class_id: Option<FastId>,
-    cur_fn_id: Option<FastId>,
+    cur_class_id: Option<Id>,
+    cur_fn_id: Option<Id>,
 }
 
 #[derive(Debug, Default)]
@@ -223,16 +223,16 @@ struct Scope<'a> {
     parent: Option<&'a Scope<'a>>,
     kind: ScopeKind,
 
-    bindings_affected_by_eval: AHashSet<FastId>,
+    bindings_affected_by_eval: AHashSet<Id>,
     found_direct_eval: bool,
 
     found_arguemnts: bool,
-    bindings_affected_by_arguements: Vec<FastId>,
+    bindings_affected_by_arguements: Vec<Id>,
 
     /// Used to construct a graph.
     ///
     /// This includes all bindings to current node.
-    ast_path: Vec<FastId>,
+    ast_path: Vec<Id>,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -248,7 +248,7 @@ impl Default for ScopeKind {
 }
 
 impl Analyzer<'_> {
-    fn with_ast_path<F>(&mut self, ids: Vec<FastId>, op: F)
+    fn with_ast_path<F>(&mut self, ids: Vec<Id>, op: F)
     where
         F: for<'aa> FnOnce(&mut Analyzer<'aa>),
     {
@@ -310,7 +310,7 @@ impl Analyzer<'_> {
     }
 
     /// Mark `id` as used
-    fn add(&mut self, id: FastId, assign: bool) {
+    fn add(&mut self, id: Id, assign: bool) {
         if id.0 == atom!("arguments") {
             self.scope.found_arguemnts = true;
         }
@@ -370,18 +370,18 @@ impl Visit for Analyzer<'_> {
     fn visit_assign_pat_prop(&mut self, n: &AssignPatProp) {
         n.visit_children_with(self);
 
-        self.add(unsafe { fast_id_from_ident(&n.key) }, true);
+        self.add(n.key.to_id(), true);
     }
 
     fn visit_class_decl(&mut self, n: &ClassDecl) {
-        self.with_ast_path(vec![unsafe { fast_id_from_ident(&n.ident) }], |v| {
+        self.with_ast_path(vec![n.ident.to_id()], |v| {
             let old = v.cur_class_id.take();
-            v.cur_class_id = Some(unsafe { fast_id_from_ident(&n.ident) });
+            v.cur_class_id = Some(n.ident.to_id());
             n.visit_children_with(v);
             v.cur_class_id = old;
 
             if !n.class.decorators.is_empty() {
-                v.add(unsafe { fast_id_from_ident(&n.ident) }, false);
+                v.add(n.ident.to_id(), false);
             }
         })
     }
@@ -391,21 +391,21 @@ impl Visit for Analyzer<'_> {
 
         if !n.class.decorators.is_empty() {
             if let Some(i) = &n.ident {
-                self.add(unsafe { fast_id_from_ident(i) }, false);
+                self.add(i.to_id(), false);
             }
         }
     }
 
     fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {
         if let ModuleExportName::Ident(orig) = &n.orig {
-            self.add(unsafe { fast_id_from_ident(orig) }, false);
+            self.add(orig.to_id(), false);
         }
     }
 
     fn visit_export_decl(&mut self, n: &ExportDecl) {
         let name = match &n.decl {
-            Decl::Class(c) => vec![unsafe { fast_id_from_ident(&c.ident) }],
-            Decl::Fn(f) => vec![unsafe { fast_id_from_ident(&f.ident) }],
+            Decl::Class(c) => vec![c.ident.to_id()],
+            Decl::Fn(f) => vec![f.ident.to_id()],
             Decl::Var(v) => v
                 .decls
                 .iter()
@@ -427,7 +427,7 @@ impl Visit for Analyzer<'_> {
         e.visit_children_with(self);
 
         if let Expr::Ident(i) = e {
-            self.add(unsafe { fast_id_from_ident(i) }, false);
+            self.add(i.to_id(), false);
         }
 
         self.in_var_decl = old_in_var_decl;
@@ -437,7 +437,7 @@ impl Visit for Analyzer<'_> {
         match n.op {
             op!("=") => {
                 if let Some(i) = n.left.as_ident() {
-                    self.add(unsafe { fast_id_from_ident(i) }, true);
+                    self.add(i.to_id(), true);
                     n.right.visit_with(self);
                 } else {
                     n.visit_children_with(self);
@@ -445,8 +445,8 @@ impl Visit for Analyzer<'_> {
             }
             _ => {
                 if let Some(i) = n.left.as_ident() {
-                    self.add(unsafe { fast_id_from_ident(i) }, false);
-                    self.add(unsafe { fast_id_from_ident(i) }, true);
+                    self.add(i.to_id(), false);
+                    self.add(i.to_id(), true);
                     n.right.visit_with(self);
                 } else {
                     n.visit_children_with(self);
@@ -459,7 +459,7 @@ impl Visit for Analyzer<'_> {
         e.visit_children_with(self);
 
         if let JSXElementName::Ident(i) = e {
-            self.add(unsafe { fast_id_from_ident(i) }, false);
+            self.add(i.to_id(), false);
         }
     }
 
@@ -467,7 +467,7 @@ impl Visit for Analyzer<'_> {
         e.visit_children_with(self);
 
         if let JSXObject::Ident(i) = e {
-            self.add(unsafe { fast_id_from_ident(i) }, false);
+            self.add(i.to_id(), false);
         }
     }
 
@@ -496,14 +496,14 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_fn_decl(&mut self, n: &FnDecl) {
-        self.with_ast_path(vec![unsafe { fast_id_from_ident(&n.ident) }], |v| {
+        self.with_ast_path(vec![n.ident.to_id()], |v| {
             let old = v.cur_fn_id.take();
-            v.cur_fn_id = Some(unsafe { fast_id_from_ident(&n.ident) });
+            v.cur_fn_id = Some(n.ident.to_id());
             n.visit_children_with(v);
             v.cur_fn_id = old;
 
             if !n.function.decorators.is_empty() {
-                v.add(unsafe { fast_id_from_ident(&n.ident) }, false);
+                v.add(n.ident.to_id(), false);
             }
         })
     }
@@ -513,7 +513,7 @@ impl Visit for Analyzer<'_> {
 
         if !n.function.decorators.is_empty() {
             if let Some(i) = &n.ident {
-                self.add(unsafe { fast_id_from_ident(i) }, false);
+                self.add(i.to_id(), false);
             }
         }
     }
@@ -523,7 +523,7 @@ impl Visit for Analyzer<'_> {
 
         if !self.in_var_decl {
             if let Pat::Ident(i) = p {
-                self.add(unsafe { fast_id_from_ident(i) }, true);
+                self.add(i.to_id(), true);
             }
         }
     }
@@ -532,7 +532,7 @@ impl Visit for Analyzer<'_> {
         p.visit_children_with(self);
 
         if let Prop::Shorthand(i) = p {
-            self.add(unsafe { fast_id_from_ident(i) }, false);
+            self.add(i.to_id(), false);
         }
     }
 
@@ -603,7 +603,7 @@ impl TreeShaker {
         });
     }
 
-    fn can_drop_binding(&self, name: FastId, is_var: bool) -> bool {
+    fn can_drop_binding(&self, name: Id, is_var: bool) -> bool {
         if !self.config.top_level {
             if is_var {
                 if !self.in_fn {
@@ -624,7 +624,7 @@ impl TreeShaker {
         }
     }
 
-    fn can_drop_assignment_to(&self, name: FastId, is_var: bool) -> bool {
+    fn can_drop_assignment_to(&self, name: Id, is_var: bool) -> bool {
         if !self.config.top_level {
             if is_var {
                 if !self.in_fn {
@@ -665,7 +665,7 @@ impl VisitMut for TreeShaker {
 
         if let Some(id) = n.left.as_ident() {
             // TODO: `var`
-            if self.can_drop_assignment_to(unsafe { fast_id_from_ident(&id) }, false)
+            if self.can_drop_assignment_to(id.to_id(), false)
                 && !n.right.may_have_side_effects(&self.expr_ctx)
             {
                 self.changed = true;
@@ -688,7 +688,7 @@ impl VisitMut for TreeShaker {
 
         match n {
             Decl::Fn(f) => {
-                if self.can_drop_binding(unsafe { fast_id_from_ident(&f.ident) }, true) {
+                if self.can_drop_binding(f.ident.to_id(), true) {
                     debug!("Dropping function `{}` as it's not used", f.ident);
                     self.changed = true;
 
@@ -696,7 +696,7 @@ impl VisitMut for TreeShaker {
                 }
             }
             Decl::Class(c) => {
-                if self.can_drop_binding(unsafe { fast_id_from_ident(&c.ident) }, false)
+                if self.can_drop_binding(c.ident.to_id(), false)
                     && c.class.body.iter().all(|m| match m {
                         ClassMember::Method(m) => !matches!(m.key, PropName::Computed(..)),
                         ClassMember::ClassProp(m) => {
@@ -852,7 +852,7 @@ impl VisitMut for TreeShaker {
                 ImportSpecifier::Namespace(l) => &l.local,
             };
 
-            if self.can_drop_binding(unsafe { fast_id_from_ident(local) }, false) {
+            if self.can_drop_binding(local.to_id(), false) {
                 debug!(
                     "Dropping import specifier `{}` because it's not used",
                     local
@@ -977,10 +977,7 @@ impl VisitMut for TreeShaker {
             // If all name is droppable, do so.
             if cnt != 0
                 && v.decls.iter().all(|vd| match &vd.name {
-                    Pat::Ident(i) => self.can_drop_binding(
-                        unsafe { fast_id_from_ident(&i) },
-                        v.kind == VarDeclKind::Var,
-                    ),
+                    Pat::Ident(i) => self.can_drop_binding(i.to_id(), v.kind == VarDeclKind::Var),
                     _ => false,
                 })
             {
@@ -1064,10 +1061,7 @@ impl VisitMut for TreeShaker {
             };
 
             if can_drop
-                && self.can_drop_binding(
-                    unsafe { fast_id_from_ident(i) },
-                    self.var_decl_kind == Some(VarDeclKind::Var),
-                )
+                && self.can_drop_binding(i.to_id(), self.var_decl_kind == Some(VarDeclKind::Var))
             {
                 self.changed = true;
                 debug!("Dropping {} because it's not used", i);

--- a/crates/swc_ecma_utils/src/ident.rs
+++ b/crates/swc_ecma_utils/src/ident.rs
@@ -1,6 +1,6 @@
 use swc_atoms::JsWord;
 use swc_common::SyntaxContext;
-use swc_ecma_ast::{BindingIdent, Id, Ident};
+use swc_ecma_ast::{fast_id, BindingIdent, FastId, Id, Ident};
 
 pub trait IdentLike: Sized + Send + Sync + 'static {
     fn from_ident(i: &Ident) -> Self;
@@ -67,6 +67,20 @@ impl IdentLike for Ident {
     #[inline]
     fn into_id(self) -> Id {
         (self.sym, self.ctxt)
+    }
+}
+
+impl IdentLike for FastId {
+    fn from_ident(i: &Ident) -> Self {
+        unsafe { fast_id(&i.to_id()) }
+    }
+
+    fn to_id(&self) -> Id {
+        unreachable!("FastId.to_id() is not allowed because it is very likely to be unsafe")
+    }
+
+    fn into_id(self) -> Id {
+        unreachable!("FastId.into_id() is not allowed because it is very likely to be unsafe")
     }
 }
 


### PR DESCRIPTION
**Description**:

`FastJsWord` and `FastId` implement `Copy` and do not need to be cloned or dropped, unlike `JsWord` or `Id`.
Of course, they are inherently unsafe. But I found that I could use it for the minifier.


**Related issue:**

 - Extracted from #9813