### PR TITLE
perf(es/minifier): Use `FastId` for DCE

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,7 +124,8 @@ resolver = "2"
   wasmer-wasix              = { version = "0.31.0", default-features = false }
 
 [profile.release]
-lto = true
+debug = true
+lto   = true
 
 # We use CARGO_PROFILE_RELEASE_LTO for production builds
 # lto = "fat"

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Display,
     mem::{transmute_copy, ManuallyDrop},
     ops::Deref,
 };
@@ -14,6 +15,12 @@ use crate::Atom;
 /// future without a semver bump.**
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FastAtom(ManuallyDrop<Atom>);
+
+impl Display for FastAtom {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &*self.0)
+    }
+}
 
 impl FastAtom {
     /// # Safety

--- a/crates/swc_ecma_minifier/benches/full.rs
+++ b/crates/swc_ecma_minifier/benches/full.rs
@@ -46,6 +46,7 @@ pub fn bench_files(c: &mut Criterion) {
     bench_file("typescript");
     bench_file("victory");
     bench_file("vue");
+    bench_file("rspack");
 }
 
 criterion_group!(files, bench_files);

--- a/crates/swc_ecma_minifier/src/compress/optimize/props.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/props.rs
@@ -166,7 +166,7 @@ impl Optimizer<'_> {
 
                 self.vars
                     .hoisted_props
-                    .insert((name.to_id(), key), new_var_name);
+                    .insert((unsafe { fast_id_from_ident(&name.id) }, key), new_var_name);
 
                 new_vars.push(new_var);
             }
@@ -201,7 +201,7 @@ impl Optimizer<'_> {
             if let Some(value) = self
                 .vars
                 .hoisted_props
-                .get(&(obj.to_id(), sym.clone()))
+                .get(&(unsafe { fast_id_from_ident(obj) }, sym.clone()))
                 .cloned()
             {
                 report_change!("hoist_props: Inlining `{}.{}`", obj.sym, sym);

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -2555,7 +2555,9 @@ impl Optimizer<'_> {
 
         if can_remove {
             report_change!("sequences: Removed variable ({})", left_id);
-            self.vars.removed.insert(left_id.to_id());
+            self.vars
+                .removed
+                .insert(unsafe { fast_id_from_ident(&left_id) });
         }
 
         dump_change_detail!("sequences: {}", dump(&*b, false));

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -219,13 +219,13 @@ pub(crate) fn is_valid_for_lhs(e: &Expr) -> bool {
 /// handle all edge cases and this type is the complement for it.
 #[derive(Clone, Copy)]
 pub(crate) struct Finalizer<'a> {
-    pub simple_functions: &'a FxHashMap<Id, Box<Expr>>,
-    pub lits: &'a FxHashMap<Id, Box<Expr>>,
-    pub lits_for_cmp: &'a FxHashMap<Id, Box<Expr>>,
-    pub lits_for_array_access: &'a FxHashMap<Id, Box<Expr>>,
-    pub hoisted_props: &'a FxHashMap<(Id, JsWord), Ident>,
+    pub simple_functions: &'a FxHashMap<FastId, Box<Expr>>,
+    pub lits: &'a FxHashMap<FastId, Box<Expr>>,
+    pub lits_for_cmp: &'a FxHashMap<FastId, Box<Expr>>,
+    pub lits_for_array_access: &'a FxHashMap<FastId, Box<Expr>>,
+    pub hoisted_props: &'a FxHashMap<(FastId, JsWord), Ident>,
 
-    pub vars_to_remove: &'a FxHashSet<Id>,
+    pub vars_to_remove: &'a FxHashSet<FastId>,
 
     pub changed: bool,
 }
@@ -241,10 +241,13 @@ impl Parallel for Finalizer<'_> {
 }
 
 impl Finalizer<'_> {
-    fn var(&mut self, i: &Id, mode: FinalizerMode) -> Option<Box<Expr>> {
+    fn var(&mut self, i: &Ident, mode: FinalizerMode) -> Option<Box<Expr>> {
         let mut e = match mode {
             FinalizerMode::Callee => {
-                let mut value = self.simple_functions.get(i).cloned()?;
+                let mut value = self
+                    .simple_functions
+                    .get(&unsafe { fast_id_from_ident(i) })
+                    .cloned()?;
                 let mut cache = FxHashMap::default();
                 let mut remap = FxHashMap::default();
                 let bindings: AHashSet<Id> = collect_decls(&*value);
@@ -268,8 +271,14 @@ impl Finalizer<'_> {
 
                 value
             }
-            FinalizerMode::ComparisonWithLit => self.lits_for_cmp.get(i).cloned()?,
-            FinalizerMode::MemberAccess => self.lits_for_array_access.get(i).cloned()?,
+            FinalizerMode::ComparisonWithLit => self
+                .lits_for_cmp
+                .get(&unsafe { fast_id_from_ident(i) })
+                .cloned()?,
+            FinalizerMode::MemberAccess => self
+                .lits_for_array_access
+                .get(&unsafe { fast_id_from_ident(i) })
+                .cloned()?,
         };
 
         e.visit_mut_children_with(self);
@@ -288,8 +297,8 @@ impl Finalizer<'_> {
 
     fn check(&mut self, e: &mut Expr, mode: FinalizerMode) {
         if let Expr::Ident(i) = e {
-            if let Some(new) = self.var(&i.to_id(), mode) {
-                debug!("multi-replacer: Replaced `{}`", i);
+            if let Some(new) = self.var(i, mode) {
+                debug!("multi-replacer: Replaced `{}`", i.sym);
                 self.changed = true;
 
                 *e = *new;
@@ -353,7 +362,10 @@ impl VisitMut for Finalizer<'_> {
 
         if n.init.is_none() {
             if let Pat::Ident(i) = &n.name {
-                if self.vars_to_remove.contains(&i.to_id()) {
+                if self
+                    .vars_to_remove
+                    .contains(&unsafe { fast_id_from_ident(i) })
+                {
                     n.name.take();
                 }
             }
@@ -407,7 +419,7 @@ impl VisitMut for Finalizer<'_> {
     fn visit_mut_expr(&mut self, n: &mut Expr) {
         match n {
             Expr::Ident(i) => {
-                if let Some(expr) = self.lits.get(&i.to_id()) {
+                if let Some(expr) = self.lits.get(&unsafe { fast_id_from_ident(i) }) {
                     *n = *expr.clone();
                     return;
                 }
@@ -423,7 +435,10 @@ impl VisitMut for Finalizer<'_> {
                         _ => return,
                     };
 
-                    if let Some(ident) = self.hoisted_props.get(&(obj.to_id(), sym.clone())) {
+                    if let Some(ident) = self
+                        .hoisted_props
+                        .get(&(unsafe { fast_id_from_ident(obj) }, sym.clone()))
+                    {
                         self.changed = true;
                         *n = ident.clone().into();
                         return;
@@ -450,21 +465,21 @@ impl VisitMut for Finalizer<'_> {
 }
 
 pub(crate) struct NormalMultiReplacer<'a> {
-    pub vars: &'a mut FxHashMap<Id, Box<Expr>>,
+    pub vars: &'a mut FxHashMap<FastId, Box<Expr>>,
     pub changed: bool,
 }
 
 impl<'a> NormalMultiReplacer<'a> {
     /// `worked` will be changed to `true` if any replacement is done
-    pub fn new(vars: &'a mut FxHashMap<Id, Box<Expr>>) -> Self {
+    pub fn new(vars: &'a mut FxHashMap<FastId, Box<Expr>>) -> Self {
         NormalMultiReplacer {
             vars,
             changed: false,
         }
     }
 
-    fn var(&mut self, i: &Id) -> Option<Box<Expr>> {
-        let mut e = self.vars.remove(i)?;
+    fn var(&mut self, i: FastId) -> Option<Box<Expr>> {
+        let mut e = self.vars.remove(&i)?;
 
         e.visit_mut_children_with(self);
 
@@ -495,7 +510,7 @@ impl VisitMut for NormalMultiReplacer<'_> {
         }
 
         if let Expr::Ident(i) = e {
-            if let Some(new) = self.var(&i.to_id()) {
+            if let Some(new) = self.var(unsafe { fast_id_from_ident(i) }) {
                 debug!("multi-replacer: Replaced `{}`", i);
                 self.changed = true;
 
@@ -521,8 +536,8 @@ impl VisitMut for NormalMultiReplacer<'_> {
         p.visit_mut_children_with(self);
 
         if let Prop::Shorthand(i) = p {
-            if let Some(value) = self.var(&i.to_id()) {
-                debug!("multi-replacer: Replaced `{}` as shorthand", i);
+            if let Some(value) = self.var(unsafe { fast_id_from_ident(i) }) {
+                debug!("multi-replacer: Replaced `{}` as shorthand", i.sym);
                 self.changed = true;
 
                 *p = Prop::KeyValue(KeyValueProp {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -665,7 +665,7 @@ impl VisitMut for TreeShaker {
 
         if let Some(id) = n.left.as_ident() {
             // TODO: `var`
-            if self.can_drop_assignment_to(unsafe { fast_id_from_ident(&id) }, false)
+            if self.can_drop_assignment_to(unsafe { fast_id_from_ident(id) }, false)
                 && !n.right.may_have_side_effects(&self.expr_ctx)
             {
                 self.changed = true;
@@ -978,7 +978,7 @@ impl VisitMut for TreeShaker {
             if cnt != 0
                 && v.decls.iter().all(|vd| match &vd.name {
                     Pat::Ident(i) => self.can_drop_binding(
-                        unsafe { fast_id_from_ident(&i) },
+                        unsafe { fast_id_from_ident(i) },
                         v.kind == VarDeclKind::Var,
                     ),
                     _ => false,


### PR DESCRIPTION
**Description:**

I'll split this PR after finishing migration.

### `main`:

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/4a341c0a-44f3-4e96-b86a-02ecb07bbdf0" />



### Afte patching DCE:

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/b1535b3f-8843-4cbb-aeb3-876993e24a43" />

### After patching inlining part of `Optimizer`

<img width="1383" alt="image" src="https://github.com/user-attachments/assets/2b544888-e91c-4c80-953e-1ccc49edca3f" />


**Related issue:**

 - Follow-up of https://github.com/swc-project/swc/pull/9826