### PR TITLE
chore(ci): Disable `miri` for `swc` as it fails with OOM

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -499,7 +499,7 @@ jobs:
         crate:
           - better_scoped_tls
           - string_enum
-          - swc
+          # - swc
           - swc_bundler
           # - swc_ecma_codegen
           # - swc_ecma_minifier


### PR DESCRIPTION
**Description:**

It may work with custom runners, but I don't think we can afford it.