### PR TITLE
perf(es/lints): Make lint rules parallel

### DIFF
--- a/.changeset/red-coats-melt.md
+++ b/.changeset/red-coats-melt.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_utils: patch
+swc_ecma_lints: patch
+---
+
+perf(es/lints): Make lint rules parallel

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5120,7 +5120,6 @@ dependencies = [
  "dashmap 5.5.3",
  "parking_lot",
  "pretty_assertions",
- "rayon",
  "regex",
  "serde",
  "swc_atoms",
@@ -5134,6 +5133,7 @@ dependencies = [
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_malloc",
+ "swc_parallel",
  "testing",
  "walkdir",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5602,6 +5602,7 @@ dependencies = [
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_ecma_visit",
+ "swc_parallel",
  "testing",
  "tracing",
  "unicode-id",

--- a/crates/swc_ecma_lints/Cargo.toml
+++ b/crates/swc_ecma_lints/Cargo.toml
@@ -16,7 +16,6 @@ bench = false
 auto_impl   = { workspace = true }
 dashmap     = { workspace = true }
 parking_lot = { workspace = true }
-rayon       = { workspace = true }
 regex       = { workspace = true }
 serde       = { workspace = true, features = ["derive"] }
 
@@ -30,6 +29,7 @@ swc_ecma_ast = { version = "5.0.1", path = "../swc_ecma_ast", features = [
 ] }
 swc_ecma_utils = { version = "6.0.1", path = "../swc_ecma_utils" }
 swc_ecma_visit = { version = "5.0.0", path = "../swc_ecma_visit" }
+swc_parallel = { version = "1.0.0", path = "../swc_parallel", default-features = false }
 
 [dev-dependencies]
 anyhow                    = { workspace = true }

--- a/crates/swc_ecma_lints/src/rule.rs
+++ b/crates/swc_ecma_lints/src/rule.rs
@@ -5,7 +5,6 @@ use parking_lot::Mutex;
 use swc_common::errors::{Diagnostic, DiagnosticBuilder, Emitter, Handler, HANDLER};
 use swc_ecma_ast::{Module, Script};
 use swc_ecma_visit::{Visit, VisitWith};
-use swc_parallel::join;
 
 /// A lint rule.
 ///

--- a/crates/swc_ecma_lints/src/rule.rs
+++ b/crates/swc_ecma_lints/src/rule.rs
@@ -49,7 +49,9 @@ fn lint_rules<N: LintNode<R>, R: Rule>(rules: &mut Vec<R>, program: &N) {
         {
             let handler = Handler::with_emitter(true, false, Box::new(emitter.clone()));
             HANDLER.set(&handler, || {
-                program.lint(&mut rules[0]);
+                for rule in rules {
+                    program.lint(rule);
+                }
             });
         }
         let errors = Arc::try_unwrap(emitter.errors).unwrap().into_inner();

--- a/crates/swc_ecma_lints/src/rules/const_assign.rs
+++ b/crates/swc_ecma_lints/src/rules/const_assign.rs
@@ -109,37 +109,37 @@ impl Visit for ConstAssign<'_> {
     }
 
     fn visit_expr_or_spreads(&mut self, n: &[ExprOrSpread]) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
+        self.maybe_par(cpu_count(), n, |v, n| {
             n.visit_with(v);
         });
     }
 
     fn visit_exprs(&mut self, exprs: &[Box<Expr>]) {
-        self.maybe_par(cpu_count() * 8, exprs, |v, expr| {
+        self.maybe_par(cpu_count(), exprs, |v, expr| {
             expr.visit_with(v);
         });
     }
 
     fn visit_module_items(&mut self, items: &[ModuleItem]) {
-        self.maybe_par(cpu_count() * 8, items, |v, item| {
+        self.maybe_par(cpu_count(), items, |v, item| {
             item.visit_with(v);
         });
     }
 
     fn visit_opt_vec_expr_or_spreads(&mut self, n: &[Option<ExprOrSpread>]) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
+        self.maybe_par(cpu_count(), n, |v, n| {
             n.visit_with(v);
         });
     }
 
     fn visit_prop_or_spreads(&mut self, n: &[PropOrSpread]) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
+        self.maybe_par(cpu_count(), n, |v, n| {
             n.visit_with(v);
         });
     }
 
     fn visit_stmts(&mut self, stmts: &[Stmt]) {
-        self.maybe_par(cpu_count() * 8, stmts, |v, stmt| {
+        self.maybe_par(cpu_count(), stmts, |v, stmt| {
             stmt.visit_with(v);
         });
     }

--- a/crates/swc_ecma_lints/src/rules/const_assign.rs
+++ b/crates/swc_ecma_lints/src/rules/const_assign.rs
@@ -108,6 +108,12 @@ impl Visit for ConstAssign<'_> {
         self.check(&Ident::from(n));
     }
 
+    fn visit_expr_or_spreads(&mut self, n: &[ExprOrSpread]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        });
+    }
+
     fn visit_exprs(&mut self, exprs: &[Box<Expr>]) {
         self.maybe_par(cpu_count() * 8, exprs, |v, expr| {
             expr.visit_with(v);
@@ -117,6 +123,18 @@ impl Visit for ConstAssign<'_> {
     fn visit_module_items(&mut self, items: &[ModuleItem]) {
         self.maybe_par(cpu_count() * 8, items, |v, item| {
             item.visit_with(v);
+        });
+    }
+
+    fn visit_opt_vec_expr_or_spreads(&mut self, n: &[Option<ExprOrSpread>]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        });
+    }
+
+    fn visit_prop_or_spreads(&mut self, n: &[PropOrSpread]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
         });
     }
 

--- a/crates/swc_ecma_lints/src/rules/const_assign.rs
+++ b/crates/swc_ecma_lints/src/rules/const_assign.rs
@@ -1,5 +1,6 @@
 use swc_common::{collections::AHashMap, errors::HANDLER, Span};
 use swc_ecma_ast::*;
+use swc_ecma_utils::parallel::{cpu_count, Parallel, ParallelExt};
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::rule::Rule;
@@ -49,11 +50,20 @@ impl Rule for ConstAssignRule {
     }
 }
 
+#[derive(Clone, Copy)]
 struct ConstAssign<'a> {
     const_vars: &'a AHashMap<Id, Span>,
     import_binding: &'a AHashMap<Id, Span>,
 
     is_pat_decl: bool,
+}
+
+impl Parallel for ConstAssign<'_> {
+    fn create(&self) -> Self {
+        *self
+    }
+
+    fn merge(&mut self, _: Self) {}
 }
 
 impl ConstAssign<'_> {
@@ -96,6 +106,24 @@ impl Visit for ConstAssign<'_> {
 
     fn visit_binding_ident(&mut self, n: &BindingIdent) {
         self.check(&Ident::from(n));
+    }
+
+    fn visit_exprs(&mut self, exprs: &[Box<Expr>]) {
+        self.maybe_par(cpu_count() * 8, exprs, |v, expr| {
+            expr.visit_with(v);
+        });
+    }
+
+    fn visit_module_items(&mut self, items: &[ModuleItem]) {
+        self.maybe_par(cpu_count() * 8, items, |v, item| {
+            item.visit_with(v);
+        });
+    }
+
+    fn visit_stmts(&mut self, stmts: &[Stmt]) {
+        self.maybe_par(cpu_count() * 8, stmts, |v, stmt| {
+            stmt.visit_with(v);
+        });
     }
 
     fn visit_update_expr(&mut self, n: &UpdateExpr) {

--- a/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
+++ b/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
@@ -118,13 +118,13 @@ impl Visit for NoDupeArgs {
     }
 
     fn visit_expr_or_spreads(&mut self, n: &[ExprOrSpread]) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
+        self.maybe_par(cpu_count(), n, |v, n| {
             n.visit_with(v);
         });
     }
 
     fn visit_exprs(&mut self, exprs: &[Box<Expr>]) {
-        self.maybe_par(cpu_count() * 8, exprs, |v, expr| {
+        self.maybe_par(cpu_count(), exprs, |v, expr| {
             expr.visit_with(v);
         });
     }
@@ -136,25 +136,25 @@ impl Visit for NoDupeArgs {
     }
 
     fn visit_module_items(&mut self, items: &[ModuleItem]) {
-        self.maybe_par(cpu_count() * 8, items, |v, item| {
+        self.maybe_par(cpu_count(), items, |v, item| {
             item.visit_with(v);
         });
     }
 
     fn visit_opt_vec_expr_or_spreads(&mut self, n: &[Option<ExprOrSpread>]) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
+        self.maybe_par(cpu_count(), n, |v, n| {
             n.visit_with(v);
         });
     }
 
     fn visit_prop_or_spreads(&mut self, n: &[PropOrSpread]) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
+        self.maybe_par(cpu_count(), n, |v, n| {
             n.visit_with(v);
         });
     }
 
     fn visit_stmts(&mut self, stmts: &[Stmt]) {
-        self.maybe_par(cpu_count() * 8, stmts, |v, stmt| {
+        self.maybe_par(cpu_count(), stmts, |v, stmt| {
             stmt.visit_with(v);
         });
     }

--- a/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
+++ b/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
@@ -105,30 +105,6 @@ macro_rules! check {
 impl Visit for NoDupeArgs {
     noop_visit_type!();
 
-    fn visit_exprs(&mut self, exprs: &[Box<Expr>]) {
-        self.maybe_par(cpu_count() * 8, exprs, |v, expr| {
-            expr.visit_with(v);
-        });
-    }
-
-    fn visit_module_items(&mut self, items: &[ModuleItem]) {
-        self.maybe_par(cpu_count() * 8, items, |v, item| {
-            item.visit_with(v);
-        });
-    }
-
-    fn visit_stmts(&mut self, stmts: &[Stmt]) {
-        self.maybe_par(cpu_count() * 8, stmts, |v, stmt| {
-            stmt.visit_with(v);
-        });
-    }
-
-    fn visit_function(&mut self, f: &Function) {
-        check!(&f.params);
-
-        f.visit_children_with(self);
-    }
-
     fn visit_arrow_expr(&mut self, f: &ArrowExpr) {
         check!(&f.params);
 
@@ -139,5 +115,47 @@ impl Visit for NoDupeArgs {
         check!(&f.params);
 
         f.visit_children_with(self);
+    }
+
+    fn visit_expr_or_spreads(&mut self, n: &[ExprOrSpread]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        });
+    }
+
+    fn visit_exprs(&mut self, exprs: &[Box<Expr>]) {
+        self.maybe_par(cpu_count() * 8, exprs, |v, expr| {
+            expr.visit_with(v);
+        });
+    }
+
+    fn visit_function(&mut self, f: &Function) {
+        check!(&f.params);
+
+        f.visit_children_with(self);
+    }
+
+    fn visit_module_items(&mut self, items: &[ModuleItem]) {
+        self.maybe_par(cpu_count() * 8, items, |v, item| {
+            item.visit_with(v);
+        });
+    }
+
+    fn visit_opt_vec_expr_or_spreads(&mut self, n: &[Option<ExprOrSpread>]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        });
+    }
+
+    fn visit_prop_or_spreads(&mut self, n: &[PropOrSpread]) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_with(v);
+        });
+    }
+
+    fn visit_stmts(&mut self, stmts: &[Stmt]) {
+        self.maybe_par(cpu_count() * 8, stmts, |v, stmt| {
+            stmt.visit_with(v);
+        });
     }
 }

--- a/crates/swc_ecma_utils/Cargo.toml
+++ b/crates/swc_ecma_utils/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 
 [features]
 # Process in parallel.
-concurrent = ["swc_common/concurrent", "rayon"]
+concurrent = ["swc_common/concurrent", "swc_parallel/parallel", "rayon"]
 
 [dependencies]
 indexmap   = { workspace = true }
@@ -33,6 +33,7 @@ swc_atoms      = { version = "3.0.1", path = "../swc_atoms" }
 swc_common     = { version = "5.0.0", path = "../swc_common" }
 swc_ecma_ast   = { version = "5.0.1", path = "../swc_ecma_ast" }
 swc_ecma_visit = { version = "5.0.0", path = "../swc_ecma_visit" }
+swc_parallel   = { version = "1.0.0", path = "../swc_parallel", default-features = false }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "arm")))'.dependencies]
 stacker = { version = "0.1.15", optional = true }

--- a/crates/swc_ecma_utils/src/parallel.rs
+++ b/crates/swc_ecma_utils/src/parallel.rs
@@ -94,7 +94,7 @@ where
 {
     type Elem = &'a mut T;
     #[cfg(feature = "concurrent")]
-    type SplitItems = Self;
+    type SplitItems = &'a mut [T];
 
     fn len(&self) -> usize {
         <[T]>::len(self)
@@ -114,7 +114,7 @@ where
 {
     type Elem = &'a T;
     #[cfg(feature = "concurrent")]
-    type SplitItems = Self;
+    type SplitItems = &'a [T];
 
     fn len(&self) -> usize {
         <[T]>::len(self)

--- a/crates/swc_parallel/src/lib.rs
+++ b/crates/swc_parallel/src/lib.rs
@@ -109,6 +109,7 @@ where
     RA: Send,
     RB: Send,
 {
+    #[cfg(feature = "parallel")]
     let (ra, rb) = scope.0.join(
         |scope| {
             let scope = Scope(unsafe { transmute::<&mut chili::Scope, &mut chili::Scope>(scope) });
@@ -120,6 +121,12 @@ where
 
             oper_b(scope)
         },
+    );
+
+    #[cfg(not(feature = "parallel"))]
+    let (ra, rb) = (
+        oper_a(Scope(std::marker::PhantomData)),
+        oper_b(Scope(std::marker::PhantomData)),
     );
 
     (ra, rb)


### PR DESCRIPTION
**Description:**

This PR makes ES linter much more parallel using `chili`. 


**Related issue:**
 
 - Follow-up of https://github.com/swc-project/swc/pull/9840
 - Follow-up of https://github.com/swc-project/swc/pull/9838
