### PR TITLE
perf(es/minifier): Speed up `merge_sequences_in_exprs` by caching computation

### DIFF
--- a/.changeset/forty-maps-smoke.md
+++ b/.changeset/forty-maps-smoke.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+perf(es/minifier): Speed up `merge_sequences_in_exprs` by caching computation

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -987,11 +987,11 @@ impl Optimizer<'_> {
                                 if !self.is_skippable_for_seq(Some(a), e2) {
                                     break;
                                 }
-                            }
 
-                            if let Some(id) = a.id() {
-                                if merge_seq_cache.is_ident_used_by(&id, &**e2, b_idx) {
-                                    break;
+                                if let Some(id) = a.id() {
+                                    if merge_seq_cache.is_ident_used_by(&id, &**e2, b_idx) {
+                                        break;
+                                    }
                                 }
                             }
                         }

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -845,11 +845,7 @@ impl Optimizer<'_> {
 
                                     match bv.init.as_deref_mut() {
                                         Some(b_init) => {
-                                            if merge_seq_cache.is_ident_used_by(
-                                                &an.to_id(),
-                                                b_init,
-                                                b_idx,
-                                            ) {
+                                            if is_ident_used_by(an.to_id(), b_init) {
                                                 log_abort!(
                                                     "We can't duplicated binding because \
                                                      initializer uses the previous declaration of \
@@ -994,11 +990,11 @@ impl Optimizer<'_> {
                                 if !self.is_skippable_for_seq(Some(a), e2) {
                                     break;
                                 }
+                            }
 
-                                if let Some(id) = a.id() {
-                                    if merge_seq_cache.is_ident_used_by(&id, &**e2, b_idx) {
-                                        break;
-                                    }
+                            if let Some(id) = a.id() {
+                                if merge_seq_cache.is_ident_used_by(&id, &**e2, b_idx) {
+                                    break;
                                 }
                             }
                         }

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -861,6 +861,8 @@ impl Optimizer<'_> {
                                             if let Some(a_init) = av.init.take() {
                                                 let b_seq = b_init.force_seq();
                                                 b_seq.exprs.insert(0, a_init);
+                                                merge_seq_cache.invalidate(a_idx);
+                                                merge_seq_cache.invalidate(b_idx);
 
                                                 self.changed = true;
                                                 report_change!(
@@ -892,6 +894,8 @@ impl Optimizer<'_> {
                                             //
                                             // prints 5
                                             bv.init = av.init.take();
+                                            merge_seq_cache.invalidate(a_idx);
+                                            merge_seq_cache.invalidate(b_idx);
                                             self.changed = true;
                                             report_change!(
                                                 "Moving initializer to the next variable \
@@ -915,6 +919,7 @@ impl Optimizer<'_> {
                                     && self.merge_sequential_expr(a, b)?
                                 {
                                     changed = true;
+                                    merge_seq_cache.invalidate(a_idx);
                                     merge_seq_cache.invalidate(b_idx);
                                     break;
                                 }
@@ -926,6 +931,7 @@ impl Optimizer<'_> {
                                 && self.merge_sequential_expr(a, b)?
                             {
                                 changed = true;
+                                merge_seq_cache.invalidate(a_idx);
                                 merge_seq_cache.invalidate(b_idx);
                                 break;
                             }
@@ -934,6 +940,7 @@ impl Optimizer<'_> {
                         Mergable::Drop => {
                             if self.drop_mergable_seq(a)? {
                                 changed = true;
+                                merge_seq_cache.invalidate(a_idx);
                                 merge_seq_cache.invalidate(b_idx);
                                 break;
                             }

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -915,6 +915,7 @@ impl Optimizer<'_> {
                                     && self.merge_sequential_expr(a, b)?
                                 {
                                     changed = true;
+                                    merge_seq_cache.invalidate(b_idx);
                                     break;
                                 }
                             }
@@ -925,6 +926,7 @@ impl Optimizer<'_> {
                                 && self.merge_sequential_expr(a, b)?
                             {
                                 changed = true;
+                                merge_seq_cache.invalidate(b_idx);
                                 break;
                             }
                         }
@@ -932,6 +934,7 @@ impl Optimizer<'_> {
                         Mergable::Drop => {
                             if self.drop_mergable_seq(a)? {
                                 changed = true;
+                                merge_seq_cache.invalidate(b_idx);
                                 break;
                             }
                         }
@@ -998,7 +1001,6 @@ impl Optimizer<'_> {
                             }
 
                             if let Some(id) = a.id() {
-                                // TODO(kdy1): Optimize
                                 if merge_seq_cache.is_ident_used_by(&id, &**e2, b_idx) {
                                     break;
                                 }
@@ -2724,6 +2726,10 @@ impl MergeSequenceCache {
     ) -> bool {
         let idents = self.ident_usage_cache[node_id].get_or_insert_with(|| idents_used_by(node));
         idents.contains(ident)
+    }
+
+    fn invalidate(&mut self, node_id: usize) {
+        self.ident_usage_cache[node_id] = None;
     }
 
     fn is_top_retain(&mut self, optimizer: &Optimizer, a: &Mergable, node_id: usize) -> bool {

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -2737,7 +2737,7 @@ impl MergeSequenceCache {
     fn is_top_retain(&mut self, optimizer: &Optimizer, a: &Mergable, node_id: usize) -> bool {
         *self.top_retain_cache[node_id].get_or_insert_with(|| {
             if let Mergable::Drop = a {
-                return false;
+                return true;
             }
 
             if let Some(a_id) = a.id() {
@@ -2745,11 +2745,11 @@ impl MergeSequenceCache {
                     || (matches!(a, Mergable::Var(_) | Mergable::FnDecl(_))
                         && !optimizer.may_remove_ident(&Ident::from(a_id)))
                 {
-                    return false;
+                    return true;
                 }
             }
 
-            true
+            false
         })
     }
 }

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -831,15 +831,15 @@ impl Optimizer<'_> {
             let mut did_work = false;
 
             for a_idx in 0..exprs.len() {
-                for b_idx in a_idx..exprs.len() {
-                    let (a1, a2) = exprs.split_at_mut(a_idx);
+                for b_idx in (a_idx + 1)..exprs.len() {
+                    let (a1, a2) = exprs.split_at_mut(a_idx + 1);
 
                     if a1.is_empty() || a2.is_empty() {
                         break;
                     }
 
                     let a = a1.last_mut().unwrap();
-                    let b = &mut a2[b_idx - a_idx];
+                    let b = &mut a2[b_idx - a_idx - 1];
 
                     if self.options.unused && self.options.sequences() {
                         if let (Mergable::Var(av), Mergable::Var(bv)) = (&mut *a, &mut *b) {
@@ -994,7 +994,7 @@ impl Optimizer<'_> {
                                 }
                             }
 
-                            if let Some(id) = a1.last_mut().unwrap().id() {
+                            if let Some(id) = a.id() {
                                 if merge_seq_cache.is_ident_used_by(&id, &**e2, b_idx) {
                                     break;
                                 }
@@ -1005,7 +1005,7 @@ impl Optimizer<'_> {
                                 break;
                             }
 
-                            if let Some(id) = a1.last_mut().unwrap().id() {
+                            if let Some(id) = a.id() {
                                 // TODO(kdy1): Optimize
                                 if merge_seq_cache.is_ident_used_by(&id, &**e2, b_idx) {
                                     break;


### PR DESCRIPTION
## Problem

In https://github.com/chenjiahan/rspack-swc-minify-test:
Rspack + SWC minify: 15.89 s
Rspack + esbuild minify: 1.74 s

This is caused by `merge_sequences_in_exprs` which tries to merge every pair of exprs with time complexity of O(n^2). In the given example, a vec of 5003 exprs (react component declarations and other declarations) are passed to this function. 

From the profiling result below we can see `visit_children_with` takes a lot of times, which is called by `IdentUsageFinder` and `idents_used_by` to check whether an ident is used in an ast node. However, in the O(n^2) loops, this part of the result is heavily recalculated.

Example:
```js
// input.js
export function source() {
    let c = 0, a = 1;
    c += a, a += 5;
    let b = c;
    console.log(a, b, c);
}

// esbuild/terser output
export function source(){let o=0,e=1;o+=e,e+=5,console.log(e,o,o)}

// swc output
export function source(){console.log(6,1,1)}
```

## Solution

To be honest, I don't come up with a better algorithm to reduce time complexity or pruning. But caching part of the computation does work very well in this bad case. Anyway, I'm proposing this pr first.

## Result

**Before: 10128ms**  
<img width="1246" alt="image" src="https://github.com/user-attachments/assets/43d38775-e487-4f5a-a95c-8331ee85f109" />

**After: 1013ms(~10x)**
<img width="1207" alt="image" src="https://github.com/user-attachments/assets/1b0d2852-343f-4bf6-8140-2b9f2d2772a4" />
