### PR TITLE
fix(es/minifier): Improve DCE

### DIFF
--- a/crates/swc/tests/tsc-references/accessorsOverrideProperty3.2.minified.js
+++ b/crates/swc/tests/tsc-references/accessorsOverrideProperty3.2.minified.js
@@ -1,1 +1,2 @@
 //// [accessorsOverrideProperty3.ts]
+Animal;

--- a/crates/swc/tests/tsc-references/accessorsOverrideProperty4.2.minified.js
+++ b/crates/swc/tests/tsc-references/accessorsOverrideProperty4.2.minified.js
@@ -1,1 +1,2 @@
 //// [accessorsOverrideProperty4.ts]
+Animal;

--- a/crates/swc/tests/tsc-references/asyncGeneratorParameterEvaluation(target=es2015).2.minified.js
+++ b/crates/swc/tests/tsc-references/asyncGeneratorParameterEvaluation(target=es2015).2.minified.js
@@ -1,4 +1,5 @@
 //// [asyncGeneratorParameterEvaluation.ts]
-import "@swc/helpers/_/_extends";
-import "@swc/helpers/_/_object_destructuring_empty";
-import "@swc/helpers/_/_wrap_async_generator";
+import { _ as _extends } from "@swc/helpers/_/_extends";
+import { _ as _object_destructuring_empty } from "@swc/helpers/_/_object_destructuring_empty";
+import { _ as _wrap_async_generator } from "@swc/helpers/_/_wrap_async_generator";
+Super;

--- a/crates/swc/tests/tsc-references/asyncGeneratorParameterEvaluation(target=es2017).2.minified.js
+++ b/crates/swc/tests/tsc-references/asyncGeneratorParameterEvaluation(target=es2017).2.minified.js
@@ -1,3 +1,4 @@
 //// [asyncGeneratorParameterEvaluation.ts]
-import "@swc/helpers/_/_extends";
-import "@swc/helpers/_/_object_destructuring_empty";
+import { _ as _extends } from "@swc/helpers/_/_extends";
+import { _ as _object_destructuring_empty } from "@swc/helpers/_/_object_destructuring_empty";
+Super;

--- a/crates/swc/tests/tsc-references/asyncGeneratorParameterEvaluation(target=es2018).2.minified.js
+++ b/crates/swc/tests/tsc-references/asyncGeneratorParameterEvaluation(target=es2018).2.minified.js
@@ -1,1 +1,2 @@
 //// [asyncGeneratorParameterEvaluation.ts]
+Super;

--- a/crates/swc/tests/tsc-references/override19.2.minified.js
+++ b/crates/swc/tests/tsc-references/override19.2.minified.js
@@ -1,1 +1,7 @@
 //// [override19.ts]
+class Context {
+}
+class A {
+    doSomething() {}
+}
+CreateMixin(Context, A), CreateMixin(Context, A);

--- a/crates/swc/tests/tsc-references/overrideInterfaceProperty.2.minified.js
+++ b/crates/swc/tests/tsc-references/overrideInterfaceProperty.2.minified.js
@@ -1,1 +1,2 @@
 //// [overrideInterfaceProperty.ts]
+Mup, Mup;

--- a/crates/swc/tests/tsc-references/thisPropertyOverridesAccessors.2.minified.js
+++ b/crates/swc/tests/tsc-references/thisPropertyOverridesAccessors.2.minified.js
@@ -1,2 +1,3 @@
 //// [foo.ts]
 //// [bar.js]
+Foo;

--- a/crates/swc_bundler/tests/fixture/deno-9591/output/entry.inlined.ts
+++ b/crates/swc_bundler/tests/fixture/deno-9591/output/entry.inlined.ts
@@ -1827,6 +1827,13 @@ function copyBytes(src, dst, off = 0) {
     return src.byteLength;
 }
 const DEFAULT_BUF_SIZE = 4096;
+class PartialReadError extends Deno.errors.UnexpectedEof {
+    name = "PartialReadError";
+    partial;
+    constructor(){
+        super("Encountered UnexpectedEof, data only partially read");
+    }
+}
 class AbstractBufBase {
     buf;
     usedBufferBytes = 0;

--- a/crates/swc_bundler/tests/fixture/deno-9591/output/entry.ts
+++ b/crates/swc_bundler/tests/fixture/deno-9591/output/entry.ts
@@ -1837,6 +1837,13 @@ function copyBytes(src, dst, off = 0) {
     return src.byteLength;
 }
 const DEFAULT_BUF_SIZE = 4096;
+class PartialReadError extends Deno.errors.UnexpectedEof {
+    name = "PartialReadError";
+    partial;
+    constructor(){
+        super("Encountered UnexpectedEof, data only partially read");
+    }
+}
 class AbstractBufBase {
     buf;
     usedBufferBytes = 0;

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/input.js
@@ -1,1 +1,5 @@
-class Element { }
+
+
+(function () {
+    class Element { }
+})()

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/input.js
@@ -20,5 +20,7 @@
         chart_elements,
         chart_plugins,
     ]);
+
+    console.log('Done 1')
 })()
     ;

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/input.js
@@ -1,0 +1,1 @@
+class Element { }

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/input.js
@@ -1,8 +1,24 @@
-
-
-(function () {
+(() => {
+    "use strict";
     class Element { }
+    class PointElement extends Element {
+        static id = 'point';
+        constructor(cfg) {
+            super();
+        }
+    }
 
-    console.log('Done')
+    // var chart_elements = /*#__PURE__*/ Object.freeze({
+    // PointElement: PointElement
+    // });
 
+    var chart_elements = /*#__PURE__*/(null && (Object.freeze({
+        PointElement: PointElement
+    })));
+
+    const registerables = null && ([
+        chart_elements,
+        chart_plugins,
+    ]);
 })()
+    ;

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/input.js
@@ -2,4 +2,7 @@
 
 (function () {
     class Element { }
+
+    console.log('Done')
+
 })()

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/output.js
@@ -1,0 +1,1 @@
+console.log('Done');

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/1-class/output.js
@@ -1,1 +1,1 @@
-console.log('Done');
+console.log('Done 1');

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/input.js
@@ -1,7 +1,11 @@
-class Element { }
-class PointElement extends Element {
-    static id = 'point';
-    constructor(cfg) {
-        super();
+
+
+(function () {
+    class Element { }
+    class PointElement extends Element {
+        static id = 'point';
+        constructor(cfg) {
+            super();
+        }
     }
-}
+})()

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/input.js
@@ -8,4 +8,7 @@
             super();
         }
     }
+
+    console.log('Done')
+
 })()

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/input.js
@@ -15,5 +15,7 @@
         chart_elements,
         chart_plugins
     ]);
+
+    console.log('Done 2')
 })()
     ;

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/input.js
@@ -1,0 +1,7 @@
+class Element { }
+class PointElement extends Element {
+    static id = 'point';
+    constructor(cfg) {
+        super();
+    }
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/input.js
@@ -1,14 +1,19 @@
-
-
-(function () {
+(() => {
+    "use strict";
     class Element { }
-    class PointElement extends Element {
-        static id = 'point';
-        constructor(cfg) {
-            super();
-        }
-    }
 
-    console.log('Done')
 
+    // var chart_elements = /*#__PURE__*/ Object.freeze({
+    // PointElement: PointElement
+    // });
+
+    var chart_elements = /*#__PURE__*/(null && (Object.freeze({
+        Element: Element
+    })));
+
+    const registerables = null && ([
+        chart_elements,
+        chart_plugins
+    ]);
 })()
+    ;

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/output.js
@@ -1,0 +1,1 @@
+console.log('Done');

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/2-class-extends/output.js
@@ -1,1 +1,1 @@
-console.log('Done');
+console.log('Done 2');

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/3/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/3/input.js
@@ -1,0 +1,3 @@
+function foo() {
+
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/3/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/3/input.js
@@ -1,3 +1,5 @@
-function foo() {
+(function () {
+    function foo() {
 
-}
+    }
+})()

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/3/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/3/input.js
@@ -2,4 +2,6 @@
     function foo() {
 
     }
+
+    console.log('Done')
 })()

--- a/crates/swc_ecma_minifier/tests/fixture/issues/9823/3/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/9823/3/output.js
@@ -1,0 +1,1 @@
+console.log('Done');

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -700,7 +700,7 @@ impl VisitMut for TreeShaker {
                     && c.class
                         .super_class
                         .as_deref()
-                        .map_or(true, |e| e.may_have_side_effects(&self.expr_ctx))
+                        .map_or(true, |e| !e.may_have_side_effects(&self.expr_ctx))
                     && c.class.body.iter().all(|m| match m {
                         ClassMember::Method(m) => !matches!(m.key, PropName::Computed(..)),
                         ClassMember::ClassProp(m) => {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -16,7 +16,7 @@ use swc_ecma_transforms_base::{
     perf::{cpu_count, ParVisitMut, Parallel},
 };
 use swc_ecma_utils::{
-    collect_decls, find_pat_ids, ExprCtx, ExprExt, IsEmpty, ModuleItemLike, StmtLike,
+    collect_decls, find_pat_ids, ExprCtx, ExprExt, IsEmpty, ModuleItemLike, StmtLike, Value::Known,
 };
 use swc_ecma_visit::{
     noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith, VisitWith,
@@ -655,6 +655,24 @@ impl TreeShaker {
                 .map(|v| v.usage == 0)
                 .unwrap_or_default()
     }
+
+    /// Drops RHS from `null && foo`
+    fn optimize_bin_expr(&mut self, n: &mut Expr) {
+        let Expr::Bin(b) = n else {
+            return;
+        };
+
+        if b.op == op!("&&") && b.left.as_pure_bool(&self.expr_ctx) == Known(false) {
+            *n = *b.left.take();
+            self.changed = true;
+            return;
+        }
+
+        if b.op == op!("||") && b.left.as_pure_bool(&self.expr_ctx) == Known(true) {
+            *n = *b.left.take();
+            self.changed = true;
+        }
+    }
 }
 
 impl VisitMut for TreeShaker {
@@ -760,6 +778,8 @@ impl VisitMut for TreeShaker {
 
     fn visit_mut_expr(&mut self, n: &mut Expr) {
         n.visit_mut_children_with(self);
+
+        self.optimize_bin_expr(n);
 
         if let Expr::Call(CallExpr {
             callee: Callee::Expr(callee),

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -697,6 +697,10 @@ impl VisitMut for TreeShaker {
             }
             Decl::Class(c) => {
                 if self.can_drop_binding(c.ident.to_id(), false)
+                    && c.class
+                        .super_class
+                        .as_deref()
+                        .map_or(true, |e| e.may_have_side_effects(&self.expr_ctx))
                     && c.class.body.iter().all(|m| match m {
                         ClassMember::Method(m) => !matches!(m.key, PropName::Computed(..)),
                         ClassMember::ClassProp(m) => {


### PR DESCRIPTION
**Description:**

 - We should check for the super class while dropping class declarations. 
 - Add early-check for `null && foo` and `true || foo`.




**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/9823