### PR TITLE
fix(ci/publish): Do not tag stable if `onlyNightly` is on

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -173,6 +173,7 @@ jobs:
   git-tag-stable:
     name: "Git tag stable"
     runs-on: ubuntu-latest
+    if: inputs.onlyNightly == false
     needs:
       - publish-cargo
       - run-ecosystem-ci-with-nightly


### PR DESCRIPTION
**Description:**

We should not create a git tag if we want to publish only nightly.