### PR TITLE
perf(es/minifier): Make DCE analyzer parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5650,6 +5650,7 @@ dependencies = [
  "swc_ecma_visit",
  "swc_fast_graph",
  "testing",
+ "thread_local",
  "tracing",
 ]
 
@@ -6571,9 +6572,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5627,6 +5627,7 @@ dependencies = [
 name = "swc_ecma_transforms_optimization"
 version = "10.0.0"
 dependencies = [
+ "ahash",
  "dashmap 5.5.3",
  "indexmap 2.7.1",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5627,7 +5627,6 @@ dependencies = [
 name = "swc_ecma_transforms_optimization"
 version = "10.0.0"
 dependencies = [
- "ahash",
  "dashmap 5.5.3",
  "indexmap 2.7.1",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5650,6 +5650,7 @@ dependencies = [
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_fast_graph",
+ "swc_parallel",
  "testing",
  "thread_local",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ resolver = "2"
   tempfile                  = "3.6.0"
   termcolor                 = "1.0"
   thiserror                 = "1.0.30"
+  thread_local              = "1.1.8"
   tokio                     = { version = "1", default-features = false }
   toml                      = "0.8.2"
   tracing                   = "0.1.40"
@@ -127,7 +128,6 @@ resolver = "2"
   wasm-bindgen-futures      = "0.4.41"
   wasmer                    = { version = "=5.0.5-rc1", default-features = false }
   wasmer-wasix              = { version = "0.35.0", default-features = false }
-thread_local = "1.1.8"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ resolver = "2"
   wasm-bindgen-futures      = "0.4.41"
   wasmer                    = { version = "=5.0.5-rc1", default-features = false }
   wasmer-wasix              = { version = "0.35.0", default-features = false }
+thread_local = "1.1.8"
 
 [profile.release]
 lto = true

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -22,6 +22,7 @@ concurrent = [
 debug = []
 
 [dependencies]
+ahash        = { workspace = true }
 dashmap      = { workspace = true }
 indexmap     = { workspace = true }
 once_cell    = { workspace = true }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -33,16 +33,18 @@ serde_json   = { workspace = true }
 thread_local = { workspace = true }
 tracing      = { workspace = true }
 
-swc_atoms                  = { version = "4.0.0", path = "../swc_atoms" }
-swc_common                 = { version = "7.0.0", path = "../swc_common" }
-swc_ecma_ast               = { version = "7.0.0", path = "../swc_ecma_ast" }
-swc_ecma_parser            = { version = "9.0.0", path = "../swc_ecma_parser" }
-swc_ecma_transforms_base   = { version = "10.0.0", path = "../swc_ecma_transforms_base" }
+swc_atoms = { version = "4.0.0", path = "../swc_atoms" }
+swc_common = { version = "7.0.0", path = "../swc_common" }
+swc_ecma_ast = { version = "7.0.0", path = "../swc_ecma_ast" }
+swc_ecma_parser = { version = "9.0.0", path = "../swc_ecma_parser" }
+swc_ecma_transforms_base = { version = "10.0.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_macros = { version = "1.0.0", path = "../swc_ecma_transforms_macros" }
-swc_ecma_utils             = { version = "10.0.0", path = "../swc_ecma_utils" }
-swc_ecma_visit             = { version = "7.0.0", path = "../swc_ecma_visit" }
-swc_fast_graph             = { version = "8.0.0", path = "../swc_fast_graph" }
-swc_parallel               = { version = "1.0.0", path = "../swc_parallel" }
+swc_ecma_utils = { version = "10.0.0", path = "../swc_ecma_utils" }
+swc_ecma_visit = { version = "7.0.0", path = "../swc_ecma_visit" }
+swc_fast_graph = { version = "8.0.0", path = "../swc_fast_graph" }
+swc_parallel = { version = "1.0.0", path = "../swc_parallel", default-features = false, features = [
+  "indexmap",
+] }
 
 [dev-dependencies]
 swc_ecma_transforms_compat     = { version = "11.0.0", path = "../swc_ecma_transforms_compat" }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -22,14 +22,15 @@ concurrent = [
 debug = []
 
 [dependencies]
-dashmap    = { workspace = true }
-indexmap   = { workspace = true }
-once_cell  = { workspace = true }
-petgraph   = { workspace = true }
-rayon      = { workspace = true, optional = true }
-rustc-hash = { workspace = true }
-serde_json = { workspace = true }
-tracing    = { workspace = true }
+dashmap      = { workspace = true }
+indexmap     = { workspace = true }
+once_cell    = { workspace = true }
+petgraph     = { workspace = true }
+rayon        = { workspace = true, optional = true }
+rustc-hash   = { workspace = true }
+serde_json   = { workspace = true }
+thread_local = { workspace = true }
+tracing      = { workspace = true }
 
 swc_atoms                  = { version = "4.0.0", path = "../swc_atoms" }
 swc_common                 = { version = "7.0.0", path = "../swc_common" }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -42,6 +42,7 @@ swc_ecma_transforms_macros = { version = "1.0.0", path = "../swc_ecma_transforms
 swc_ecma_utils             = { version = "10.0.0", path = "../swc_ecma_utils" }
 swc_ecma_visit             = { version = "7.0.0", path = "../swc_ecma_visit" }
 swc_fast_graph             = { version = "8.0.0", path = "../swc_fast_graph" }
+swc_parallel               = { version = "1.0.0", path = "../swc_parallel" }
 
 [dev-dependencies]
 swc_ecma_transforms_compat     = { version = "11.0.0", path = "../swc_ecma_transforms_compat" }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -22,7 +22,6 @@ concurrent = [
 debug = []
 
 [dependencies]
-ahash        = { workspace = true }
 dashmap      = { workspace = true }
 indexmap     = { workspace = true }
 once_cell    = { workspace = true }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -262,7 +262,14 @@ impl Parallel for Analyzer<'_> {
 
         self.scope
             .bindings_affected_by_eval
+            .reserve(other.scope.bindings_affected_by_eval.len());
+        self.scope
+            .bindings_affected_by_eval
             .extend(other.scope.bindings_affected_by_eval);
+
+        self.scope
+            .bindings_affected_by_arguements
+            .reserve(other.scope.bindings_affected_by_arguements.len());
         self.scope
             .bindings_affected_by_arguements
             .extend(other.scope.bindings_affected_by_arguements);
@@ -1233,6 +1240,8 @@ where
     S: BuildHasher,
 {
     fn merge(&mut self, other: Self) {
+        self.reserve(other.len());
+
         for (k, v) in other {
             match self.entry(k) {
                 std::collections::hash_map::Entry::Occupied(mut e) => {
@@ -1253,6 +1262,8 @@ where
     S: BuildHasher,
 {
     fn merge(&mut self, other: Self) {
+        self.reserve(other.len());
+
         for (k, v) in other {
             match self.entry(k) {
                 indexmap::map::Entry::Occupied(mut e) => {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1,13 +1,8 @@
 use std::{borrow::Cow, cell::RefCell, mem::take, sync::Arc};
 
-use ahash::RandomState;
 use indexmap::{IndexMap, IndexSet};
 use petgraph::{algo::tarjan_scc, Direction::Incoming};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
-use swc_atoms::{atom, JsWord};
-use swc_common::{
-use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
-use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{atom, JsWord};
 use swc_common::{
     collections::AHashSet,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -39,7 +39,7 @@ pub fn dce(
             in_strict: false,
             remaining_depth: 2,
         },
-        config,
+        config: Arc::new(config),
         changed: false,
         pass: 0,
         in_fn: false,
@@ -85,7 +85,7 @@ impl Default for Config {
 struct TreeShaker {
     expr_ctx: ExprCtx,
 
-    config: Config,
+    config: Arc<Config>,
     changed: bool,
     pass: u16,
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -152,6 +152,7 @@ impl Data {
     }
 
     /// Traverse the graph and subtract usages from `used_names`.
+    #[allow(unused)]
     fn subtract_cycles(&mut self) {
         let edges = take(&mut self.edges);
 
@@ -1228,7 +1229,7 @@ fn merge_data(data: Arc<ThreadLocal<RefCell<Data>>>) -> Data {
         merged.merge(data);
     }
 
-    merged.subtract_cycles();
+    // merged.subtract_cycles();
 
     merged
 }
@@ -1292,7 +1293,7 @@ impl Merge for Data {
     fn merge(&mut self, other: Self) {
         self.used_names.merge(other.used_names);
         self.entry_ids.extend(other.entry_ids);
-        self.edges.0.merge(other.edges.0);
+        // self.edges.0.merge(other.edges.0);
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -120,7 +120,7 @@ impl CompilerPass for TreeShaker {
 struct Data {
     used_names: FxHashMap<Id, VarInfo>,
 
-    edges: IndexMap<(Id, Id), VarInfo, RandomState>,
+    edges: Edges,
     /// Entrypoints.
     entry_ids: FxHashSet<Id>,
 
@@ -128,10 +128,13 @@ struct Data {
     graph_ix: IndexSet<Id, BuildHasherDefault<FxHasher>>,
 }
 
+#[derive(Default)]
+struct Edges(IndexMap<(Id, Id), VarInfo, RandomState>);
+
 impl Data {
     /// Add an edge to dependency graph
     fn add_dep_edge(&mut self, from: Id, to: Id, assign: bool) {
-        match self.edges.entry((from, to)) {
+        match self.edges.0.entry((from, to)) {
             indexmap::map::Entry::Occupied(mut info) => {
                 if assign {
                     info.get_mut().assign += 1;
@@ -169,7 +172,7 @@ impl Data {
             .map(|id| get_node(id.clone()))
             .collect::<IndexSet<_, RandomState>>();
 
-        for ((src, dst), info) in edges {
+        for ((src, dst), info) in edges.0 {
             let src = get_node(src);
             let dst = get_node(dst);
 
@@ -1288,7 +1291,7 @@ impl Merge for Data {
     fn merge(&mut self, other: Self) {
         self.used_names.merge(other.used_names);
         self.entry_ids.extend(other.entry_ids);
-        self.edges.merge(other.edges);
+        self.edges.0.merge(other.edges.0);
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -624,31 +624,31 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_opt_vec_expr_or_spreads(&mut self, n: &[Option<ExprOrSpread>]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_prop_or_spreads(&mut self, n: &[PropOrSpread]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_expr_or_spreads(&mut self, n: &[ExprOrSpread]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_exprs(&mut self, n: &[Box<Expr>]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_stmts(&mut self, n: &[Stmt]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_module_items(&mut self, n: &[ModuleItem]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_var_declarators(&mut self, n: &[VarDeclarator]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -156,7 +156,8 @@ impl Data {
         let edges = take(&mut self.edges);
 
         let mut graph = FastDiGraphMap::with_capacity(self.used_names.len(), self.edges.0.len());
-        let mut graph_ix = IndexMap::<Id, u32, RandomState>::default();
+        let mut graph_ix: IndexMap<(JsWord, SyntaxContext), u32, RandomState> =
+            IndexMap::with_capacity_and_hasher(self.used_names.len(), Default::default());
 
         let mut get_node = |id: Id| -> u32 {
             let len = graph_ix.len();

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -231,7 +231,10 @@ impl Parallel for Analyzer<'_> {
             data: self.data.clone(),
             scope: Scope {
                 parent: self.scope.parent,
-                ..Default::default()
+                ast_path: self.scope.ast_path.clone(),
+                bindings_affected_by_arguements: Default::default(),
+                bindings_affected_by_eval: Default::default(),
+                ..self.scope
             },
             cur_class_id: self.cur_class_id.clone(),
             cur_fn_id: self.cur_fn_id.clone(),
@@ -239,7 +242,16 @@ impl Parallel for Analyzer<'_> {
         }
     }
 
-    fn merge(&mut self, _: Self) {}
+    fn merge(&mut self, other: Self) {
+        self.scope.ast_path = other.scope.ast_path;
+
+        self.scope
+            .bindings_affected_by_eval
+            .extend(other.scope.bindings_affected_by_eval);
+        self.scope
+            .bindings_affected_by_arguements
+            .extend(other.scope.bindings_affected_by_arguements);
+    }
 }
 
 #[derive(Debug, Default)]
@@ -259,7 +271,7 @@ struct Scope<'a> {
     ast_path: Vec<Id>,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum ScopeKind {
     Fn,
     ArrowFn,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -155,7 +155,7 @@ impl Data {
     fn subtract_cycles(&mut self) {
         let edges = take(&mut self.edges);
 
-        let mut graph = FastDiGraphMap::default();
+        let mut graph = FastDiGraphMap::with_capacity(self.used_names.len(), self.edges.0.len());
         let mut graph_ix = IndexMap::<Id, u32, RandomState>::default();
 
         let mut get_node = |id: Id| -> u32 {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -155,7 +155,7 @@ impl Data {
     fn subtract_cycles(&mut self) {
         let edges = take(&mut self.edges);
 
-        let mut graph = FastDiGraphMap::with_capacity(self.used_names.len(), self.edges.0.len());
+        let mut graph = FastDiGraphMap::with_capacity(self.used_names.len(), edges.0.len());
         let mut graph_ix: IndexMap<(JsWord, SyntaxContext), u32, RandomState> =
             IndexMap::with_capacity_and_hasher(self.used_names.len(), Default::default());
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1,10 +1,14 @@
-use std::{borrow::Cow, cell::RefCell, sync::Arc};
+use std::{borrow::Cow, cell::RefCell, hash::BuildHasherDefault, sync::Arc};
 
 use indexmap::IndexSet;
 use petgraph::{algo::tarjan_scc, Direction::Incoming};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use swc_atoms::{atom, JsWord};
 use swc_common::{
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+use swc_atoms::{atom, JsWord};
+use swc_common::{
+    collections::AHashSet,
     pass::{CompilerPass, Repeated},
     util::take::Take,
     Mark, SyntaxContext, DUMMY_SP,
@@ -117,6 +121,7 @@ struct Data {
     entry_ids: FxHashSet<Id>,
 
     graph_ix: IndexSet<Id, FxBuildHasher>,
+    graph_ix: IndexSet<Id, BuildHasherDefault<FxHasher>>,
 }
 
 impl Data {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1217,11 +1217,6 @@ fn merge_data(data: Arc<ThreadLocal<RefCell<Data>>>) -> Data {
         .into_iter()
         .map(|d| d.into_inner())
         .collect::<Vec<_>>();
-    let mut merged = Data::default();
-
-    for data in data {
-        merged.merge(data);
-    }
 
     // merged.subtract_cycles();
     let mut merged = merge_in_parallel(data);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -980,24 +980,8 @@ impl VisitMut for TreeShaker {
                 };
                 m.visit_with(&mut analyzer);
             }
-            let data = Arc::try_unwrap(data)
-                .map_err(|_| {})
-                .unwrap()
-                .into_iter()
-                .map(|d| d.into_inner())
-                .map(|mut data| {
-                    data.subtract_cycles();
-                    data
-                })
-                .collect::<Vec<_>>();
-            let mut merged = Data::default();
 
-            for data in data {
-                merged.used_names.extend(data.used_names);
-                merged.entry_ids.extend(data.entry_ids);
-            }
-
-            self.data = Arc::new(merged);
+            self.data = Arc::new(merge_data(data));
 
             m.visit_mut_children_with(self);
         })
@@ -1059,24 +1043,8 @@ impl VisitMut for TreeShaker {
                 };
                 m.visit_with(&mut analyzer);
             }
-            let data = Arc::try_unwrap(data)
-                .map_err(|_| {})
-                .unwrap()
-                .into_iter()
-                .map(|d| d.into_inner())
-                .map(|mut data| {
-                    data.subtract_cycles();
-                    data
-                })
-                .collect::<Vec<_>>();
-            let mut merged = Data::default();
 
-            for data in data {
-                merged.used_names.extend(data.used_names);
-                merged.entry_ids.extend(data.entry_ids);
-            }
-
-            self.data = Arc::new(merged);
+            self.data = Arc::new(merge_data(data));
 
             m.visit_mut_children_with(self);
         })
@@ -1209,6 +1177,27 @@ impl VisitMut for TreeShaker {
     fn visit_mut_with_stmt(&mut self, n: &mut WithStmt) {
         n.obj.visit_mut_with(self);
     }
+}
+
+fn merge_data(data: Arc<ThreadLocal<RefCell<Data>>>) -> Data {
+    let data = Arc::try_unwrap(data)
+        .map_err(|_| {})
+        .unwrap()
+        .into_iter()
+        .map(|d| d.into_inner())
+        .map(|mut data| {
+            data.subtract_cycles();
+            data
+        })
+        .collect::<Vec<_>>();
+    let mut merged = Data::default();
+
+    for data in data {
+        merged.used_names.extend(data.used_names);
+        merged.entry_ids.extend(data.entry_ids);
+    }
+
+    merged
 }
 
 impl Scope<'_> {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1214,9 +1214,7 @@ fn merge_data(data: Arc<ThreadLocal<RefCell<Data>>>) -> Data {
     let mut merged = Data::default();
 
     for data in data {
-        merged.used_names.merge(data.used_names);
-        merged.entry_ids.extend(data.entry_ids);
-        merged.edges.merge(data.edges);
+        merged.merge(data);
     }
 
     merged.subtract_cycles();
@@ -1272,6 +1270,14 @@ impl Merge for VarInfo {
     fn merge(&mut self, other: Self) {
         self.usage += other.usage;
         self.assign += other.assign;
+    }
+}
+
+impl Merge for Data {
+    fn merge(&mut self, other: Self) {
+        self.used_names.merge(other.used_names);
+        self.entry_ids.extend(other.entry_ids);
+        self.edges.merge(other.edges);
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -191,7 +191,7 @@ impl Data {
 
             for &i in &cycle {
                 for &j in &cycle {
-                    if i == j {
+                    if i <= j {
                         continue;
                     }
 


### PR DESCRIPTION
**Description:**

The analyzer of the DCE pass can be parallelized in a similar way to mark-sweep GC. It currently uses `&mut petgraph::DiGraphMap` to find reachable bindings, but we can split the graph creation into multiple threads.

Also, I decided to amort allocations because `swc_parallel::join` is called an enormous amount of time, meaning that it will be slower if I allocate one hashmap from each closure. I'll use [thread_local **crate**](https://docs.rs/thread_local/latest/thread_local/) to reuse the hashmap and collect all of them after the traversal is done.

### Profiling result
```
```