### PR TITLE
feat(typescript): Check computed property names of ts signatures

### DIFF
--- a/.changeset/twelve-colts-call.md
+++ b/.changeset/twelve-colts-call.md
@@ -1,0 +1,6 @@
+---
+swc_core: minor
+swc_typescript: minor
+---
+
+feat(typescript): Check computed property names of ts signatures

--- a/crates/swc_typescript/src/fast_dts/class.rs
+++ b/crates/swc_typescript/src/fast_dts/class.rs
@@ -8,7 +8,7 @@ use swc_ecma_ast::{
 
 use super::{
     type_ann,
-    util::ast_ext::{PatExt, PropNameExit},
+    util::ast_ext::{MemberExprExt, PatExt, PropNameExit},
     FastDts,
 };
 
@@ -17,25 +17,7 @@ impl FastDts {
         if let Some(super_class) = &class.super_class {
             let is_not_allowed = match super_class.as_ref() {
                 Expr::Ident(_) => false,
-                Expr::Member(member_expr) => {
-                    let mut object = &member_expr.obj;
-                    loop {
-                        match object.as_ref() {
-                            Expr::Member(member_expr) => {
-                                object = &member_expr.obj;
-                                continue;
-                            }
-                            Expr::OptChain(opt_chain) => {
-                                if let Some(member_expr) = opt_chain.base.as_member() {
-                                    object = &member_expr.obj;
-                                    continue;
-                                }
-                            }
-                            _ => {}
-                        }
-                        break !object.is_ident();
-                    }
-                }
+                Expr::Member(member_expr) => !member_expr.get_first_object().is_ident(),
                 _ => true,
             };
 

--- a/crates/swc_typescript/src/fast_dts/decl.rs
+++ b/crates/swc_typescript/src/fast_dts/decl.rs
@@ -101,11 +101,26 @@ impl FastDts {
                     );
                 }
             }
-            Decl::TsInterface(_) | Decl::TsTypeAlias(_) => {
+            Decl::TsInterface(ts_interface) => {
                 if let Some(internal_annotations) = self.internal_annotations.as_ref() {
-                    decl.visit_mut_children_with(&mut InternalAnnotationTransformer::new(
+                    ts_interface.visit_mut_children_with(&mut InternalAnnotationTransformer::new(
                         internal_annotations,
                     ))
+                }
+                for type_element in ts_interface.body.body.iter() {
+                    self.check_ts_signature(type_element);
+                }
+            }
+            Decl::TsTypeAlias(ts_type_alias) => {
+                if let Some(internal_annotations) = self.internal_annotations.as_ref() {
+                    ts_type_alias.visit_mut_children_with(&mut InternalAnnotationTransformer::new(
+                        internal_annotations,
+                    ))
+                }
+                if let Some(ts_lit) = ts_type_alias.type_ann.as_ts_type_lit() {
+                    for type_element in ts_lit.members.iter() {
+                        self.check_ts_signature(type_element);
+                    }
                 }
             }
         }

--- a/crates/swc_typescript/src/fast_dts/types.rs
+++ b/crates/swc_typescript/src/fast_dts/types.rs
@@ -10,7 +10,7 @@ use super::{
     inferrer::ReturnTypeInferrer,
     type_ann,
     util::{
-        ast_ext::PatExt,
+        ast_ext::{MemberExprExt, PatExt},
         types::{ts_keyword_type, ts_lit_type},
     },
     FastDts,
@@ -312,6 +312,52 @@ impl FastDts {
             PropName::Num(num) => (Lit::Num(num.clone()).into(), true),
             PropName::Computed(computed) => (*computed.expr.clone(), true),
             PropName::BigInt(big_int) => (Lit::BigInt(big_int.clone()).into(), true),
+        }
+    }
+
+    pub(crate) fn check_ts_signature(&mut self, signature: &TsTypeElement) {
+        match signature {
+            TsTypeElement::TsPropertySignature(ts_property_signature) => {
+                self.report_signature_property_key(
+                    &ts_property_signature.key,
+                    ts_property_signature.computed,
+                );
+            }
+            TsTypeElement::TsGetterSignature(ts_getter_signature) => {
+                self.report_signature_property_key(
+                    &ts_getter_signature.key,
+                    ts_getter_signature.computed,
+                );
+            }
+            TsTypeElement::TsSetterSignature(ts_setter_signature) => {
+                self.report_signature_property_key(
+                    &ts_setter_signature.key,
+                    ts_setter_signature.computed,
+                );
+            }
+            TsTypeElement::TsMethodSignature(ts_method_signature) => {
+                self.report_signature_property_key(
+                    &ts_method_signature.key,
+                    ts_method_signature.computed,
+                );
+            }
+            _ => {}
+        }
+    }
+
+    pub(crate) fn report_signature_property_key(&mut self, key: &Expr, computed: bool) {
+        if !computed {
+            return;
+        }
+
+        let is_not_allowed = match key {
+            Expr::Ident(_) => false,
+            Expr::Member(member) => !member.get_first_object().is_ident(),
+            _ => !Self::is_literal(key),
+        };
+
+        if is_not_allowed {
+            self.signature_computed_property_name(key.span());
         }
     }
 

--- a/crates/swc_typescript/tests/fixture/signature-computed-property-name.snap
+++ b/crates/swc_typescript/tests/fixture/signature-computed-property-name.snap
@@ -1,0 +1,44 @@
+```==================== .D.TS ====================
+
+export interface A {
+    ["foo" as string]: number;
+    ["bar" as string](a: number): string;
+}
+export type B = {
+    ["foo" as string]: number;
+    ["bar" as string](a: number): string;
+};
+
+
+==================== Errors ====================
+  x TS9014: Computed properties must be number or string literals, variables or dotted expressions with --isolatedDeclarations.
+   ,-[$DIR/tests/fixture/signature-computed-property-name.ts:2:1]
+ 1 | export interface A {
+ 2 |     ["foo" as string]: number;
+   :      ^^^^^^^^^^^^^^^
+ 3 |     ["bar" as string](a: number): string;
+   `----
+  x TS9014: Computed properties must be number or string literals, variables or dotted expressions with --isolatedDeclarations.
+   ,-[$DIR/tests/fixture/signature-computed-property-name.ts:3:1]
+ 2 |     ["foo" as string]: number;
+ 3 |     ["bar" as string](a: number): string;
+   :      ^^^^^^^^^^^^^^^
+ 4 | }
+   `----
+  x TS9014: Computed properties must be number or string literals, variables or dotted expressions with --isolatedDeclarations.
+   ,-[$DIR/tests/fixture/signature-computed-property-name.ts:7:1]
+ 6 | export type B = {
+ 7 |     ["foo" as string]: number;
+   :      ^^^^^^^^^^^^^^^
+ 8 |     ["bar" as string](a: number): string;
+   `----
+  x TS9014: Computed properties must be number or string literals, variables or dotted expressions with --isolatedDeclarations.
+   ,-[$DIR/tests/fixture/signature-computed-property-name.ts:8:1]
+ 7 |     ["foo" as string]: number;
+ 8 |     ["bar" as string](a: number): string;
+   :      ^^^^^^^^^^^^^^^
+ 9 | };
+   `----
+
+
+```

--- a/crates/swc_typescript/tests/fixture/signature-computed-property-name.ts
+++ b/crates/swc_typescript/tests/fixture/signature-computed-property-name.ts
@@ -1,0 +1,9 @@
+export interface A {
+    ["foo" as string]: number;
+    ["bar" as string](a: number): string;
+}
+
+export type B = {
+    ["foo" as string]: number;
+    ["bar" as string](a: number): string;
+};


### PR DESCRIPTION
I find this missing part when I check https://github.com/swc-project/swc/issues/9859

swc: https://play.swc.rs/?version=1.10.6&code=H4sIAAAAAAAAA0utKMgvKlHIzCtJLUpLTE5VcFSo5lIAgmiltPx8JYXEYoXikqLMvPRYK4W80tyk1CJrqHRSYhGytEYiTIGmFVTMmquWiysVYkFJZUGqgpOCLVVNt%2BYCAA%2Bn8R2%2FAAAA&config=H4sIAAAAAAAAA1WMOQ6AMAwEe14RueYF1DQUPCIKLoI4LNtIQYi%2FY64Iut0Z7W6Fc9BLgMptFq2QZ0HO3Yisk%2FpkBHQllMCRFMrXqpxKecGL7LcATIQcR7Tp8Dk7zRi1kXnwil2t8hsXzwHIvHDA1lP2%2BwE5e0RDqwAAAA%3D%3D

ts playground: https://www.typescriptlang.org/play/?isolatedDeclarations=true&isolatedModules=true#code/KYDwDg9gTgLgBASwHY2FAZgQwMbDgQTgG8AoOcuAbQCJ0IJq5MBnOZmKZAcwF0AuOEgCuAWwBGaANxkKNMZiiMWbDtx4AKTAOHi0ASgHtOSLtIC+JEqEiw4MAJ5g8AITgBeYjPI06DJqyM1bVEJKGkKKmp5RX8VY15NYN0oAzjuc2kgA