### PR TITLE
fix(typescript): Allow references to the global Symbol in computed property names under `isolatedDeclarations`

### DIFF
--- a/.changeset/long-turtles-grow.md
+++ b/.changeset/long-turtles-grow.md
@@ -1,0 +1,6 @@
+---
+swc: major
+swc_typescript: major
+---
+
+fix(typescript): Allow references to the global Symbol in computed property names under isolatedDeclarations

--- a/crates/swc/benches/isolated_declarations.rs
+++ b/crates/swc/benches/isolated_declarations.rs
@@ -36,6 +36,7 @@ fn bench_isolated_declarations(criterion: &mut Criterion) {
                 let internal_annotations = FastDts::get_internal_annotations(&comments);
                 let mut checker = FastDts::new(
                     fm.name.clone(),
+                    unresolved_mark,
                     FastDtsOptions {
                         internal_annotations: Some(internal_annotations),
                     },

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -812,6 +812,7 @@ impl Options {
                 .into_bool(),
             codegen_inline_script,
             emit_isolated_dts: experimental.emit_isolated_dts.into_bool(),
+            unresolved_mark,
             resolver,
         })
     }
@@ -1124,6 +1125,7 @@ pub struct BuiltInput<P: Pass> {
     pub codegen_inline_script: bool,
 
     pub emit_isolated_dts: bool,
+    pub unresolved_mark: Mark,
     pub resolver: Option<(FileName, Arc<dyn ImportResolver>)>,
 }
 
@@ -1156,6 +1158,7 @@ where
             emit_assert_for_import_attributes: self.emit_assert_for_import_attributes,
             codegen_inline_script: self.codegen_inline_script,
             emit_isolated_dts: self.emit_isolated_dts,
+            unresolved_mark: self.unresolved_mark,
             resolver: self.resolver,
         }
     }

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -983,7 +983,8 @@ impl Compiler {
                 let trailing = std::rc::Rc::new(RefCell::new(trailing.clone()));
 
                 let comments = SingleThreadedComments::from_leading_and_trailing(leading, trailing);
-                let mut checker = FastDts::new(fm.name.clone(), Default::default());
+                let mut checker =
+                    FastDts::new(fm.name.clone(), config.unresolved_mark, Default::default());
                 let mut program = program.clone();
 
                 if let Some((base, resolver)) = config.resolver {

--- a/crates/swc_typescript/examples/isolated_declarations.rs
+++ b/crates/swc_typescript/examples/isolated_declarations.rs
@@ -34,6 +34,7 @@ pub fn main() {
         let internal_annotations = FastDts::get_internal_annotations(&comments);
         let mut checker = FastDts::new(
             fm.name.clone(),
+            unresolved_mark,
             FastDtsOptions {
                 internal_annotations: Some(internal_annotations),
             },

--- a/crates/swc_typescript/src/fast_dts/class.rs
+++ b/crates/swc_typescript/src/fast_dts/class.rs
@@ -512,18 +512,22 @@ impl FastDts {
     }
 
     pub(crate) fn is_global_symbol_object(&self, expr: &Expr) -> bool {
-        let Some(member_expr) = expr.as_member() else {
+        let Some(obj) = (match expr {
+            Expr::Member(member) => Some(&member.obj),
+            Expr::OptChain(opt_chain) => opt_chain.base.as_member().map(|member| &member.obj),
+            _ => None,
+        }) else {
             return false;
         };
 
         // https://github.com/microsoft/TypeScript/blob/cbac1ddfc73ca3b9d8741c1b51b74663a0f24695/src/compiler/transformers/declarations.ts#L1011
-        if let Some(ident) = member_expr.obj.as_ident() {
+        if let Some(ident) = obj.as_ident() {
             // Exactly `Symbol.something` and `Symbol` either does not resolve
             // or definitely resolves to the global Symbol
             return ident.sym.as_str() == "Symbol" && ident.ctxt.has_mark(self.unresolved_mark);
         }
 
-        if let Some(member_expr) = member_expr.obj.as_member() {
+        if let Some(member_expr) = obj.as_member() {
             // Exactly `globalThis.Symbol.something` and `globalThis` resolves
             // to the global `globalThis`
             if let Some(ident) = member_expr.obj.as_ident() {

--- a/crates/swc_typescript/src/fast_dts/mod.rs
+++ b/crates/swc_typescript/src/fast_dts/mod.rs
@@ -3,7 +3,8 @@ use std::{borrow::Cow, mem::take, sync::Arc};
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::Atom;
 use swc_common::{
-    comments::SingleThreadedComments, util::take::Take, BytePos, FileName, Span, Spanned, DUMMY_SP,
+    comments::SingleThreadedComments, util::take::Take, BytePos, FileName, Mark, Span, Spanned,
+    DUMMY_SP,
 };
 use swc_ecma_ast::{
     BindingIdent, Decl, DefaultDecl, ExportDefaultExpr, Id, Ident, ImportSpecifier, ModuleDecl,
@@ -38,6 +39,7 @@ mod visitors;
 /// The original code is MIT licensed.
 pub struct FastDts {
     filename: Arc<FileName>,
+    unresolved_mark: Mark,
     diagnostics: Vec<DtsIssue>,
     // states
     id_counter: u32,
@@ -53,10 +55,11 @@ pub struct FastDtsOptions {
 
 /// Diagnostics
 impl FastDts {
-    pub fn new(filename: Arc<FileName>, options: FastDtsOptions) -> Self {
+    pub fn new(filename: Arc<FileName>, unresolved_mark: Mark, options: FastDtsOptions) -> Self {
         let internal_annotations = options.internal_annotations;
         Self {
             filename,
+            unresolved_mark,
             diagnostics: Vec::new(),
             id_counter: 0,
             is_top_level: true,

--- a/crates/swc_typescript/src/fast_dts/types.rs
+++ b/crates/swc_typescript/src/fast_dts/types.rs
@@ -352,10 +352,6 @@ impl FastDts {
 
         let is_not_allowed = match key {
             Expr::Ident(_) | Expr::Member(_) | Expr::OptChain(_) => key.get_root_ident().is_none(),
-            Expr::Ident(_) => false,
-            Expr::Member(member) => {
-                !member.get_first_object().is_ident() && !self.is_global_symbol_object(key)
-            }
             _ => !Self::is_literal(key),
         };
 

--- a/crates/swc_typescript/src/fast_dts/types.rs
+++ b/crates/swc_typescript/src/fast_dts/types.rs
@@ -352,6 +352,10 @@ impl FastDts {
 
         let is_not_allowed = match key {
             Expr::Ident(_) | Expr::Member(_) | Expr::OptChain(_) => key.get_root_ident().is_none(),
+            Expr::Ident(_) => false,
+            Expr::Member(member) => {
+                !member.get_first_object().is_ident() && !self.is_global_symbol_object(key)
+            }
             _ => !Self::is_literal(key),
         };
 

--- a/crates/swc_typescript/tests/fixture/issues/9859.snap
+++ b/crates/swc_typescript/tests/fixture/issues/9859.snap
@@ -1,0 +1,10 @@
+```==================== .D.TS ====================
+
+export declare class NumberRange implements Iterable<number> {
+    private start;
+    private end;
+    constructor(start: number, end: number);
+    [Symbol.iterator](): Iterator<number>;
+}
+
+

--- a/crates/swc_typescript/tests/fixture/issues/9859.ts
+++ b/crates/swc_typescript/tests/fixture/issues/9859.ts
@@ -1,0 +1,24 @@
+export class NumberRange implements Iterable<number> {
+    private start: number;
+    private end: number;
+
+    constructor(start: number, end: number) {
+        this.start = start;
+        this.end = end;
+    }
+
+    [Symbol.iterator](): Iterator<number> {
+        let current = this.start;
+        const end = this.end;
+
+        return {
+            next(): IteratorResult<number> {
+                if (current <= end) {
+                    return { value: current++, done: false };
+                } else {
+                    return { value: undefined, done: true };
+                }
+            },
+        };
+    }
+}

--- a/crates/swc_typescript/tests/fixture/symbol-properties.snap
+++ b/crates/swc_typescript/tests/fixture/symbol-properties.snap
@@ -1,0 +1,58 @@
+```==================== .D.TS ====================
+
+// Correct
+export declare const foo: {
+    [Symbol.iterator]: () => void;
+    [Symbol.asyncIterator]: () => Promise<void>;
+    [globalThis.Symbol.iterator]: () => void;
+    [Symbol.toStringTag]: string;
+};
+export declare abstract class Foo {
+    [Symbol.iterator](): void;
+    [Symbol.asyncIterator](): Promise<void>;
+    [globalThis.Symbol.iterator](): void;
+    get [Symbol.toStringTag](): string;
+}
+// Incorrect
+export declare namespace Foo {
+    const foo: {
+    };
+}
+export declare function bar(Symbol: {
+}, globalThis: {
+}): {
+};
+
+
+==================== Errors ====================
+  x TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/symbol-properties.ts:46:1]
+ 45 |     export const foo = {
+ 46 |         [Symbol.iterator]: (): void => {},
+    :         ^^^^^^^^^^^^^^^^^
+ 47 |         [globalThis.Symbol.iterator]: (): void => {},
+    `----
+  x TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/symbol-properties.ts:47:1]
+ 46 |         [Symbol.iterator]: (): void => {},
+ 47 |         [globalThis.Symbol.iterator]: (): void => {},
+    :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 48 |     };
+    `----
+  x TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/symbol-properties.ts:53:1]
+ 52 |     return {
+ 53 |         [Symbol.iterator]: (): void => {},
+    :         ^^^^^^^^^^^^^^^^^
+ 54 |         [globalThis.Symbol.iterator]: (): void => {},
+    `----
+  x TS9038: Computed property names on class or object literals cannot be inferred with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/symbol-properties.ts:54:1]
+ 53 |         [Symbol.iterator]: (): void => {},
+ 54 |         [globalThis.Symbol.iterator]: (): void => {},
+    :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 55 |     };
+    `----
+
+
+```

--- a/crates/swc_typescript/tests/fixture/symbol-properties.ts
+++ b/crates/swc_typescript/tests/fixture/symbol-properties.ts
@@ -1,0 +1,56 @@
+// Correct
+export const foo = {
+    [Symbol.iterator]: (): void => {},
+    [Symbol.asyncIterator]: async (): Promise<void> => {},
+    [globalThis.Symbol.iterator]: (): void => {},
+    get [Symbol.toStringTag]() {
+        return "foo";
+    },
+};
+
+export abstract class Foo {
+    [Symbol.iterator](): void {}
+    async [Symbol.asyncIterator](): Promise<void> {}
+    [globalThis.Symbol.iterator](): void {}
+    get [Symbol.toStringTag]() {
+        return "Foo";
+    }
+}
+
+// OK because these are not exported
+
+namespace Foo {
+    const Symbol = {};
+    const globalThis = {};
+
+    export const foo = {
+        [Symbol.iterator]: (): void => {},
+        [globalThis.Symbol.iterator]: (): void => {},
+    };
+}
+
+function bar(Symbol: {}, globalThis: {}) {
+    return {
+        [Symbol.iterator]: (): void => {},
+        [globalThis.Symbol.iterator]: (): void => {},
+    };
+}
+
+// Incorrect
+
+export namespace Foo {
+    const Symbol = {};
+    const globalThis = {};
+
+    export const foo = {
+        [Symbol.iterator]: (): void => {},
+        [globalThis.Symbol.iterator]: (): void => {},
+    };
+}
+
+export function bar(Symbol: {}, globalThis: {}) {
+    return {
+        [Symbol.iterator]: (): void => {},
+        [globalThis.Symbol.iterator]: (): void => {},
+    };
+}

--- a/crates/swc_typescript/tests/typescript.rs
+++ b/crates/swc_typescript/tests/typescript.rs
@@ -35,6 +35,7 @@ fn fixture(input: PathBuf) {
         let internal_annotations = FastDts::get_internal_annotations(&comments);
         let mut checker = FastDts::new(
             fm.name.clone(),
+            unresolved_mark,
             FastDtsOptions {
                 internal_annotations: Some(internal_annotations),
             },


### PR DESCRIPTION
fixes https://github.com/swc-project/swc/issues/9859
ref: https://github.com/microsoft/TypeScript/pull/58771

Pass `unresolved_mark` to FastDts so it can check whether a `Symbol` ident refs to global Symbol.