### PR TITLE
perf(es/utils): Optimize `maybe_par_idx_raw`

### DIFF
--- a/crates/swc_ecma_utils/src/parallel.rs
+++ b/crates/swc_ecma_utils/src/parallel.rs
@@ -86,27 +86,23 @@ where
                 }
 
                 let (na, nb) = nodes.split_at(len / 2);
+                let mut vb = Parallel::create(&*self);
 
-                let (va, vb) = join(
+                let (_, vb) = join(
                     || {
                         GLOBALS.set(globals, || {
-                            let mut visitor = Parallel::create(&*self);
-                            visitor.maybe_par_idx_raw(threshold, na, op);
-
-                            visitor
+                            self.maybe_par_idx_raw(threshold, na, op);
                         })
                     },
                     || {
                         GLOBALS.set(globals, || {
-                            let mut visitor = Parallel::create(&*self);
-                            visitor.maybe_par_idx_raw(threshold, nb, op);
+                            vb.maybe_par_idx_raw(threshold, nb, op);
 
-                            visitor
+                            vb
                         })
                     },
                 );
 
-                Parallel::merge(self, va);
                 Parallel::merge(self, vb);
             });
 


### PR DESCRIPTION
**Description:**

I was not sure if two create in parallel are faster thana  single create in the original thread at the moment of writing the function, but when I tried single create was faster.