### PR TITLE
refactor(atoms): Rename `FastAtom` to `UnsafeAtom`

### DIFF
--- a/.changeset/swift-experts-dance.md
+++ b/.changeset/swift-experts-dance.md
@@ -1,0 +1,6 @@
+---
+swc_atoms: patch
+swc_ecma_utils: patch
+---
+
+refactor(atoms): Rename `FastAtom` to `UnsafeAtom`

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -465,14 +465,14 @@ impl From<IdentName> for BindingIdent {
     }
 }
 
-/// FastId is a wrapper around [Id] that does not allocate, but extremely
+/// UnsafeId is a wrapper around [Id] that does not allocate, but extremely
 /// unsafe.
 ///
 /// Do not use this unless you know what you are doing.
 ///
 /// **Currently, it's considered as a unstable API and may be changed in the
 /// future without a semver bump.**
-pub type FastId = (FastAtom, SyntaxContext);
+pub type UnsafeId = (FastAtom, SyntaxContext);
 
 /// This is extremely unsafe so don't use it unless you know what you are doing.
 ///
@@ -482,7 +482,7 @@ pub type FastId = (FastAtom, SyntaxContext);
 ///
 /// **Currently, it's considered as a unstable API and may be changed in the
 /// future without a semver bump.**
-pub unsafe fn fast_id(id: &Id) -> FastId {
+pub unsafe fn unsafe_id(id: &Id) -> UnsafeId {
     (FastAtom::new(&id.0), id.1)
 }
 
@@ -494,7 +494,7 @@ pub unsafe fn fast_id(id: &Id) -> FastId {
 ///
 /// **Currently, it's considered as a unstable API and may be changed in the
 /// future without a semver bump.**
-pub unsafe fn fast_id_from_ident(id: &Ident) -> FastId {
+pub unsafe fn unsafe_id_from_ident(id: &Ident) -> UnsafeId {
     (FastAtom::new(&id.sym), id.ctxt)
 }
 

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -23,8 +23,8 @@ pub use self::{
     expr::*,
     function::{Function, Param, ParamOrTsParamProp},
     ident::{
-        fast_id, fast_id_from_ident, BindingIdent, EsReserved, FastId, Id, Ident, IdentName,
-        PrivateName,
+        unsafe_id, unsafe_id_from_ident, BindingIdent, EsReserved, Id, Ident, IdentName,
+        PrivateName, UnsafeId,
     },
     jsx::{
         JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXClosingElement, JSXClosingFragment,

--- a/crates/swc_ecma_utils/src/ident.rs
+++ b/crates/swc_ecma_utils/src/ident.rs
@@ -1,6 +1,6 @@
 use swc_atoms::JsWord;
 use swc_common::SyntaxContext;
-use swc_ecma_ast::{fast_id, BindingIdent, FastId, Id, Ident};
+use swc_ecma_ast::{unsafe_id, BindingIdent, Id, Ident, UnsafeId};
 
 pub trait IdentLike: Sized + Send + Sync + 'static {
     fn from_ident(i: &Ident) -> Self;
@@ -70,17 +70,17 @@ impl IdentLike for Ident {
     }
 }
 
-impl IdentLike for FastId {
+impl IdentLike for UnsafeId {
     fn from_ident(i: &Ident) -> Self {
-        unsafe { fast_id(&i.to_id()) }
+        unsafe { unsafe_id(&i.to_id()) }
     }
 
     fn to_id(&self) -> Id {
-        unreachable!("FastId.to_id() is not allowed because it is very likely to be unsafe")
+        unreachable!("UnsafeId.to_id() is not allowed because it is very likely to be unsafe")
     }
 
     fn into_id(self) -> Id {
-        unreachable!("FastId.into_id() is not allowed because it is very likely to be unsafe")
+        unreachable!("UnsafeId.into_id() is not allowed because it is very likely to be unsafe")
     }
 }
 

--- a/crates/swc_ecma_utils/src/ident.rs
+++ b/crates/swc_ecma_utils/src/ident.rs
@@ -1,6 +1,6 @@
 use swc_atoms::JsWord;
 use swc_common::SyntaxContext;
-use swc_ecma_ast::{unsafe_id, BindingIdent, Id, Ident, UnsafeId};
+use swc_ecma_ast::{unsafe_id_from_ident, BindingIdent, Id, Ident, UnsafeId};
 
 pub trait IdentLike: Sized + Send + Sync + 'static {
     fn from_ident(i: &Ident) -> Self;
@@ -72,7 +72,7 @@ impl IdentLike for Ident {
 
 impl IdentLike for UnsafeId {
     fn from_ident(i: &Ident) -> Self {
-        unsafe { unsafe_id(&i.to_id()) }
+        unsafe { unsafe_id_from_ident(i) }
     }
 
     fn to_id(&self) -> Id {


### PR DESCRIPTION
**Description:**

`UnsafeAtom` is the correct name of the type.