### PR TITLE
fix(es/ts_strip): Handle ASI hazard in return statement

### DIFF
--- a/.changeset/curly-poems-dance.md
+++ b/.changeset/curly-poems-dance.md
@@ -1,0 +1,5 @@
+---
+swc_fast_ts_strip: minor
+---
+
+fix(es/ts_strip): Handle ASI hazard in return statement

--- a/crates/swc_fast_ts_strip/tests/fixture/issue-9878.js
+++ b/crates/swc_fast_ts_strip/tests/fixture/issue-9878.js
@@ -1,0 +1,18 @@
+function f() {
+	return (  
+		 x   )=>x;
+}
+
+function f2() {
+	return ( 
+	 
+		 x   )=>x;
+}
+
+
+function f3() {
+	return ( 
+	 
+		 x              
+         )=>x;
+}

--- a/crates/swc_fast_ts_strip/tests/fixture/issue-9878.transform.js
+++ b/crates/swc_fast_ts_strip/tests/fixture/issue-9878.transform.js
@@ -1,0 +1,9 @@
+function f() {
+    return (x)=>x;
+}
+function f2() {
+    return (x)=>x;
+}
+function f3() {
+    return (x)=>x;
+}

--- a/crates/swc_fast_ts_strip/tests/fixture/issue-9878.ts
+++ b/crates/swc_fast_ts_strip/tests/fixture/issue-9878.ts
@@ -1,0 +1,18 @@
+function f() {
+	return <T>
+		(x: T)=>x;
+}
+
+function f2() {
+	return <T
+	>
+		(x: T)=>x;
+}
+
+
+function f3() {
+	return <T
+	>
+		(x: T): Promise<
+        T>=>x;
+}


### PR DESCRIPTION
**Related issue:**

- Closes: #9878 
