### PR TITLE
perf(es/minifier): Box `VarUsageInfo` of `ProgramData`

### DIFF
--- a/.changeset/late-maps-jump.md
+++ b/.changeset/late-maps-jump.md
@@ -1,0 +1,6 @@
+---
+swc_core: minor
+swc_ecma_minifier: minor
+---
+
+perf(es/minifier): Reduce memory allocations

--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -272,7 +272,7 @@ impl Optimizer<'_> {
                     used_recursively,
                     no_side_effect_for_member_access,
                     ..
-                } = *usage;
+                } = **usage;
                 let mut inc_usage = || {
                     if let Expr::Ident(i) = &*init {
                         if let Some(u) = self.data.vars.get_mut(&i.to_id()) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -319,7 +319,9 @@ impl From<&Function> for FnMetadata {
 
 impl Optimizer<'_> {
     fn may_remove_ident(&self, id: &Ident) -> bool {
-        if let Some(VarUsageInfo { exported: true, .. }) = self.data.vars.get(&id.clone().to_id()) {
+        if let Some(VarUsageInfo { exported: true, .. }) =
+            self.data.vars.get(&id.clone().to_id()).map(|v| &**v)
+        {
             return false;
         }
 

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -31,7 +31,7 @@ where
 /// Analyzed info of a whole program we are working on.
 #[derive(Debug, Default)]
 pub(crate) struct ProgramData {
-    pub(crate) vars: FxHashMap<Id, VarUsageInfo>,
+    pub(crate) vars: FxHashMap<Id, Box<VarUsageInfo>>,
 
     pub(crate) top: ScopeData,
 
@@ -338,9 +338,11 @@ impl Storage for ProgramData {
     fn report_usage(&mut self, ctx: Ctx, i: Id) {
         let inited = self.initialized_vars.contains(&i);
 
-        let e = self.vars.entry(i.clone()).or_insert_with(|| VarUsageInfo {
-            used_above_decl: true,
-            ..Default::default()
+        let e = self.vars.entry(i.clone()).or_insert_with(|| {
+            Box::new(VarUsageInfo {
+                used_above_decl: true,
+                ..Default::default()
+            })
         });
 
         e.used_as_ref |= ctx.is_id_ref;


### PR DESCRIPTION
**Description:**

As the `ProgramData.vars` is re-allocated lots of time, we can reduce `memmove` operations by boxing the `VarUsageInfo`. This is because the hash map would need to allocate, e.g., `1024 * size_of<Box<T>>` instead of `1024 * size_of<VarUsageInfo>`  while incrementing the size of the hash map from 512 to 1024.


```
Benchmarking es/minifier/libs/es/minifier/libs/antd
Benchmarking es/minifier/libs/es/minifier/libs/antd: Warming up for 3.0000 s
Benchmarking es/minifier/libs/es/minifier/libs/antd: Collecting 10 samples in estimated 9.7340 s (20 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/antd: Analyzing
es/minifier/libs/es/minifier/libs/antd
                        time:   [489.01 ms 490.05 ms 490.97 ms]
                        change: [-1.5287% -1.2158% -0.9269%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minifier/libs/es/minifier/libs/d3
Benchmarking es/minifier/libs/es/minifier/libs/d3: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 6.4s or enable flat sampling.
Benchmarking es/minifier/libs/es/minifier/libs/d3: Collecting 10 samples in estimated 6.4406 s (55 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/d3: Analyzing
es/minifier/libs/es/minifier/libs/d3
                        time:   [116.67 ms 117.18 ms 117.78 ms]
                        change: [-0.3332% +0.5408% +1.3860%] (p = 0.27 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) low mild
Benchmarking es/minifier/libs/es/minifier/libs/echarts
Benchmarking es/minifier/libs/es/minifier/libs/echarts: Warming up for 3.0000 s
Benchmarking es/minifier/libs/es/minifier/libs/echarts: Collecting 10 samples in estimated 8.4715 s (20 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/echarts: Analyzing
es/minifier/libs/es/minifier/libs/echarts
                        time:   [424.80 ms 425.63 ms 426.53 ms]
                        change: [-0.8302% -0.5287% -0.2551%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minifier/libs/es/minifier/libs/jquery
Benchmarking es/minifier/libs/es/minifier/libs/jquery: Warming up for 3.0000 s
Benchmarking es/minifier/libs/es/minifier/libs/jquery: Collecting 10 samples in estimated 6.4860 s (165 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/jquery: Analyzing
es/minifier/libs/es/minifier/libs/jquery
                        time:   [39.416 ms 39.525 ms 39.635 ms]
                        change: [-1.1709% -0.3682% +0.3550%] (p = 0.37 > 0.05)
                        No change in performance detected.
Found 2 outliers among 10 measurements (20.00%)
  1 (10.00%) low mild
  1 (10.00%) high mild
Benchmarking es/minifier/libs/es/minifier/libs/lodash
Benchmarking es/minifier/libs/es/minifier/libs/lodash: Warming up for 3.0000 s
Benchmarking es/minifier/libs/es/minifier/libs/lodash: Collecting 10 samples in estimated 5.4512 s (110 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/lodash: Analyzing
es/minifier/libs/es/minifier/libs/lodash
                        time:   [48.916 ms 49.027 ms 49.132 ms]
                        change: [-0.3397% +0.1751% +0.7892%] (p = 0.55 > 0.05)
                        No change in performance detected.
Found 3 outliers among 10 measurements (30.00%)
  1 (10.00%) low severe
  1 (10.00%) high mild
  1 (10.00%) high severe
Benchmarking es/minifier/libs/es/minifier/libs/moment
Benchmarking es/minifier/libs/es/minifier/libs/moment: Warming up for 3.0000 s
Benchmarking es/minifier/libs/es/minifier/libs/moment: Collecting 10 samples in estimated 6.0985 s (275 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/moment: Analyzing
es/minifier/libs/es/minifier/libs/moment
                        time:   [21.975 ms 22.097 ms 22.180 ms]
                        change: [-0.5825% -0.0376% +0.4977%] (p = 0.89 > 0.05)
                        No change in performance detected.
Benchmarking es/minifier/libs/es/minifier/libs/react
Benchmarking es/minifier/libs/es/minifier/libs/react: Warming up for 3.0000 s
Benchmarking es/minifier/libs/es/minifier/libs/react: Collecting 10 samples in estimated 5.2885 s (770 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/react: Analyzing
es/minifier/libs/es/minifier/libs/react
                        time:   [6.8318 ms 6.8407 ms 6.8490 ms]
                        change: [-0.9893% -0.4427% +0.0059%] (p = 0.12 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high severe
Benchmarking es/minifier/libs/es/minifier/libs/terser
Benchmarking es/minifier/libs/es/minifier/libs/terser: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 5.2s or enable flat sampling.
Benchmarking es/minifier/libs/es/minifier/libs/terser: Collecting 10 samples in estimated 5.2464 s (55 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/terser: Analyzing
es/minifier/libs/es/minifier/libs/terser
                        time:   [94.771 ms 95.388 ms 96.051 ms]
                        change: [-0.1542% +0.7131% +1.6361%] (p = 0.15 > 0.05)
                        No change in performance detected.
Benchmarking es/minifier/libs/es/minifier/libs/three
Benchmarking es/minifier/libs/es/minifier/libs/three: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 8.5s or enable flat sampling.
Benchmarking es/minifier/libs/es/minifier/libs/three: Collecting 10 samples in estimated 8.4619 s (55 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/three: Analyzing
es/minifier/libs/es/minifier/libs/three
                        time:   [153.14 ms 153.68 ms 154.43 ms]
                        change: [-0.9029% -0.0544% +0.8860%] (p = 0.92 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minifier/libs/es/minifier/libs/typescript
Benchmarking es/minifier/libs/es/minifier/libs/typescript: Warming up for 3.0000 s

Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 9.7s.
Benchmarking es/minifier/libs/es/minifier/libs/typescript: Collecting 10 samples in estimated 9.7210 s (10 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/typescript: Analyzing
es/minifier/libs/es/minifier/libs/typescript
                        time:   [967.74 ms 972.37 ms 976.98 ms]
                        change: [-1.5382% -0.6114% +0.2760%] (p = 0.22 > 0.05)
                        No change in performance detected.
Benchmarking es/minifier/libs/es/minifier/libs/victory
Benchmarking es/minifier/libs/es/minifier/libs/victory: Warming up for 3.0000 s
Benchmarking es/minifier/libs/es/minifier/libs/victory: Collecting 10 samples in estimated 6.7932 s (30 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/victory: Analyzing
es/minifier/libs/es/minifier/libs/victory
                        time:   [226.69 ms 227.27 ms 227.88 ms]
                        change: [-1.1037% -0.7390% -0.3683%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Benchmarking es/minifier/libs/es/minifier/libs/vue
Benchmarking es/minifier/libs/es/minifier/libs/vue: Warming up for 3.0000 s
Benchmarking es/minifier/libs/es/minifier/libs/vue: Collecting 10 samples in estimated 5.9418 s (110 iterations)
Benchmarking es/minifier/libs/es/minifier/libs/vue: Analyzing
es/minifier/libs/es/minifier/libs/vue
                        time:   [53.880 ms 53.961 ms 54.118 ms]
                        change: [-1.2002% -0.0320% +0.9082%] (p = 0.96 > 0.05)
                        No change in performance detected.
Found 1 outliers among 10 measurements (10.00%)
```