### PR TITLE
doc(es/parallel): Improve document of `Parallel`

### DIFF
--- a/.changeset/friendly-crews-breathe.md
+++ b/.changeset/friendly-crews-breathe.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_utils: patch
+---
+
+doc(es/parallel): Improve document of `Parallel`

--- a/crates/swc_ecma_utils/src/parallel.rs
+++ b/crates/swc_ecma_utils/src/parallel.rs
@@ -22,9 +22,15 @@ pub trait Parallel: swc_common::sync::Send + swc_common::sync::Sync {
     fn merge(&mut self, other: Self);
 
     /// Invoked after visiting all [Stmt]s, possibly in parallel.
+    ///
+    ///
+    /// Note: `visit_*_par` never calls this.
     fn after_stmts(&mut self, _stmts: &mut Vec<Stmt>) {}
 
     /// Invoked after visiting all [ModuleItem]s, possibly in parallel.
+    ///
+    ///
+    /// Note: `visit_*_par` never calls this.
     fn after_module_items(&mut self, _stmts: &mut Vec<ModuleItem>) {}
 }
 


### PR DESCRIPTION
**Description:**

Document that `after_*` is not used for `visit_*_par`