### PR TITLE
chore(es/minifier): Print slow files from `minify-all` example

### DIFF
--- a/crates/swc_ecma_minifier/examples/minify-all.rs
+++ b/crates/swc_ecma_minifier/examples/minify-all.rs
@@ -138,6 +138,10 @@ fn minify_all(files: &[PathBuf]) {
                 worker.total_size += code.len();
                 worker.max_duration = worker.max_duration.max(duration);
 
+                if duration > Duration::from_secs(1) {
+                    eprintln!("{}: {:?}", path.display(), duration);
+                }
+
                 Ok(())
             })
             .unwrap()


### PR DESCRIPTION
**Description:**

I got

```
1970 files
Total size after minification: 46586141
Max duration (per file): 1.861938125s
Total run: Took 2.089914291s
```

This means that one single file is time-consuming and we should optimize for the large files to reduce the total time.
