### PR TITLE
perf(es/minifier): Parallelize handling of class members

### DIFF
--- a/.changeset/calm-frogs-search.md
+++ b/.changeset/calm-frogs-search.md
@@ -1,6 +1,8 @@
 ---
 swc_core: patch
 swc_ecma_lints: patch
+swc_ecma_transforms_base: patch
+swc_ecma_transforms_optimization: patch
 swc_ecma_minifier: patch
 ---
 

--- a/.changeset/calm-frogs-search.md
+++ b/.changeset/calm-frogs-search.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_lints: patch
+swc_ecma_minifier: patch
+---
+
+perf(es/minifier): Parallelize handling of class members

--- a/crates/swc_ecma_lints/src/rules/const_assign.rs
+++ b/crates/swc_ecma_lints/src/rules/const_assign.rs
@@ -108,6 +108,12 @@ impl Visit for ConstAssign<'_> {
         self.check(&Ident::from(n));
     }
 
+    fn visit_class_members(&mut self, members: &[ClassMember]) {
+        self.maybe_par(cpu_count(), members, |v, member| {
+            member.visit_with(v);
+        });
+    }
+
     fn visit_expr_or_spreads(&mut self, n: &[ExprOrSpread]) {
         self.maybe_par(cpu_count(), n, |v, n| {
             n.visit_with(v);

--- a/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
+++ b/crates/swc_ecma_lints/src/rules/no_dupe_args.rs
@@ -111,6 +111,12 @@ impl Visit for NoDupeArgs {
         f.visit_children_with(self);
     }
 
+    fn visit_class_members(&mut self, members: &[ClassMember]) {
+        self.maybe_par(cpu_count(), members, |v, member| {
+            member.visit_with(v);
+        });
+    }
+
     fn visit_constructor(&mut self, f: &Constructor) {
         check!(&f.params);
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -308,24 +308,6 @@ enum FinalizerMode {
 impl VisitMut for Finalizer<'_> {
     noop_visit_mut_type!();
 
-    fn visit_mut_callee(&mut self, e: &mut Callee) {
-        e.visit_mut_children_with(self);
-
-        if let Callee::Expr(e) = e {
-            self.check(e, FinalizerMode::Callee);
-        }
-    }
-
-    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
-        e.visit_mut_children_with(self);
-
-        if let MemberProp::Computed(ref mut prop) = e.prop {
-            if let Expr::Lit(Lit::Num(..)) = &*prop.expr {
-                self.check(&mut e.obj, FinalizerMode::MemberAccess);
-            }
-        }
-    }
-
     fn visit_mut_bin_expr(&mut self, e: &mut BinExpr) {
         e.visit_mut_children_with(self);
 
@@ -342,65 +324,17 @@ impl VisitMut for Finalizer<'_> {
         }
     }
 
-    fn visit_mut_var_declarators(&mut self, n: &mut Vec<VarDeclarator>) {
-        n.visit_mut_children_with(self);
+    fn visit_mut_callee(&mut self, e: &mut Callee) {
+        e.visit_mut_children_with(self);
 
-        n.retain(|v| !v.name.is_invalid());
-    }
-
-    fn visit_mut_var_declarator(&mut self, n: &mut VarDeclarator) {
-        n.visit_mut_children_with(self);
-
-        if n.init.is_none() {
-            if let Pat::Ident(i) = &n.name {
-                if self.vars_to_remove.contains(&i.to_id()) {
-                    n.name.take();
-                }
-            }
+        if let Callee::Expr(e) = e {
+            self.check(e, FinalizerMode::Callee);
         }
     }
 
-    fn visit_mut_opt_var_decl_or_expr(&mut self, n: &mut Option<VarDeclOrExpr>) {
-        n.visit_mut_children_with(self);
-
-        if let Some(VarDeclOrExpr::VarDecl(v)) = n {
-            if v.decls.is_empty() {
-                *n = None;
-            }
-        }
-    }
-
-    fn visit_mut_stmt(&mut self, n: &mut Stmt) {
-        n.visit_mut_children_with(self);
-
-        if let Stmt::Decl(Decl::Var(v)) = n {
-            if v.decls.is_empty() {
-                n.take();
-            }
-        }
-    }
-
-    fn visit_mut_prop_or_spreads(&mut self, n: &mut Vec<PropOrSpread>) {
-        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
-            n.visit_mut_with(v);
-        });
-    }
-
-    fn visit_mut_expr_or_spreads(&mut self, n: &mut Vec<ExprOrSpread>) {
-        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
-            n.visit_mut_with(v);
-        });
-    }
-
-    fn visit_mut_opt_vec_expr_or_spreads(&mut self, n: &mut Vec<Option<ExprOrSpread>>) {
-        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
-            n.visit_mut_with(v);
-        });
-    }
-
-    fn visit_mut_exprs(&mut self, n: &mut Vec<Box<Expr>>) {
-        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
-            n.visit_mut_with(v);
+    fn visit_mut_class_members(&mut self, members: &mut Vec<ClassMember>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, members, |v, member| {
+            member.visit_mut_with(v);
         });
     }
 
@@ -436,16 +370,88 @@ impl VisitMut for Finalizer<'_> {
         n.visit_mut_children_with(self);
     }
 
-    fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
+    fn visit_mut_expr_or_spreads(&mut self, n: &mut Vec<ExprOrSpread>) {
         self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
             n.visit_mut_with(v);
         });
+    }
+
+    fn visit_mut_exprs(&mut self, n: &mut Vec<Box<Expr>>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
+            n.visit_mut_with(v);
+        });
+    }
+
+    fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
+        e.visit_mut_children_with(self);
+
+        if let MemberProp::Computed(ref mut prop) = e.prop {
+            if let Expr::Lit(Lit::Num(..)) = &*prop.expr {
+                self.check(&mut e.obj, FinalizerMode::MemberAccess);
+            }
+        }
     }
 
     fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
         self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
             n.visit_mut_with(v);
         });
+    }
+
+    fn visit_mut_opt_var_decl_or_expr(&mut self, n: &mut Option<VarDeclOrExpr>) {
+        n.visit_mut_children_with(self);
+
+        if let Some(VarDeclOrExpr::VarDecl(v)) = n {
+            if v.decls.is_empty() {
+                *n = None;
+            }
+        }
+    }
+
+    fn visit_mut_opt_vec_expr_or_spreads(&mut self, n: &mut Vec<Option<ExprOrSpread>>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
+            n.visit_mut_with(v);
+        });
+    }
+
+    fn visit_mut_prop_or_spreads(&mut self, n: &mut Vec<PropOrSpread>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
+            n.visit_mut_with(v);
+        });
+    }
+
+    fn visit_mut_stmt(&mut self, n: &mut Stmt) {
+        n.visit_mut_children_with(self);
+
+        if let Stmt::Decl(Decl::Var(v)) = n {
+            if v.decls.is_empty() {
+                n.take();
+            }
+        }
+    }
+
+    fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
+        self.maybe_par(*HEAVY_TASK_PARALLELS, n, |v, n| {
+            n.visit_mut_with(v);
+        });
+    }
+
+    fn visit_mut_var_declarator(&mut self, n: &mut VarDeclarator) {
+        n.visit_mut_children_with(self);
+
+        if n.init.is_none() {
+            if let Pat::Ident(i) = &n.name {
+                if self.vars_to_remove.contains(&i.to_id()) {
+                    n.name.take();
+                }
+            }
+        }
+    }
+
+    fn visit_mut_var_declarators(&mut self, n: &mut Vec<VarDeclarator>) {
+        n.visit_mut_children_with(self);
+
+        n.retain(|v| !v.name.is_invalid());
     }
 }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -184,7 +184,7 @@ impl Pure<'_> {
     where
         N: for<'aa> VisitMutWith<Pure<'aa>> + Send + Sync,
     {
-        self.maybe_par(cpu_count() * 8, nodes, |v, node| {
+        self.maybe_par(cpu_count() * 2, nodes, |v, node| {
             node.visit_mut_with(v);
         });
     }

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -243,20 +243,6 @@ impl VisitMut for Pure<'_> {
         self.drop_arguments_of_symbol_call(e);
     }
 
-    fn visit_mut_opt_call(&mut self, opt_call: &mut OptCall) {
-        {
-            let ctx = Ctx {
-                is_callee: true,
-                ..self.ctx
-            };
-            opt_call.callee.visit_mut_with(&mut *self.with_ctx(ctx));
-        }
-
-        opt_call.args.visit_mut_with(self);
-
-        self.eval_spread_array(&mut opt_call.args);
-    }
-
     fn visit_mut_class_member(&mut self, m: &mut ClassMember) {
         m.visit_mut_children_with(self);
 
@@ -268,7 +254,7 @@ impl VisitMut for Pure<'_> {
     }
 
     fn visit_mut_class_members(&mut self, m: &mut Vec<ClassMember>) {
-        m.visit_mut_children_with(self);
+        self.visit_par(m);
 
         m.retain(|m| {
             if let ClassMember::Empty(..) = m {
@@ -671,6 +657,20 @@ impl VisitMut for Pure<'_> {
         }
 
         e.args.visit_mut_with(self);
+    }
+
+    fn visit_mut_opt_call(&mut self, opt_call: &mut OptCall) {
+        {
+            let ctx = Ctx {
+                is_callee: true,
+                ..self.ctx
+            };
+            opt_call.callee.visit_mut_with(&mut *self.with_ctx(ctx));
+        }
+
+        opt_call.args.visit_mut_with(self);
+
+        self.eval_spread_array(&mut opt_call.args);
     }
 
     fn visit_mut_opt_var_decl_or_expr(&mut self, n: &mut Option<VarDeclOrExpr>) {

--- a/crates/swc_ecma_transforms_base/src/rename/ops.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/ops.rs
@@ -522,6 +522,12 @@ where
         }
     }
 
+    fn visit_mut_class_members(&mut self, members: &mut Vec<ClassMember>) {
+        self.maybe_par(cpu_count(), members, |v, member| {
+            member.visit_mut_with(v);
+        });
+    }
+
     fn visit_mut_prop_or_spreads(&mut self, n: &mut Vec<PropOrSpread>) {
         self.maybe_par(cpu_count() * 100, n, |v, n| {
             n.visit_mut_with(v);

--- a/crates/swc_ecma_transforms_optimization/src/inline_globals.rs
+++ b/crates/swc_ecma_transforms_optimization/src/inline_globals.rs
@@ -65,6 +65,10 @@ impl Parallel for InlineGlobals {
 impl VisitMut for InlineGlobals {
     noop_visit_mut_type!(fail);
 
+    fn visit_mut_class_members(&mut self, members: &mut Vec<ClassMember>) {
+        self.visit_mut_par(cpu_count(), members);
+    }
+
     fn visit_mut_expr(&mut self, expr: &mut Expr) {
         if let Expr::Ident(Ident { ref sym, ctxt, .. }) = expr {
             if self.bindings.contains(&(sym.clone(), *ctxt)) {
@@ -151,10 +155,22 @@ impl VisitMut for InlineGlobals {
         }
     }
 
+    fn visit_mut_expr_or_spreads(&mut self, n: &mut Vec<ExprOrSpread>) {
+        self.visit_mut_par(cpu_count(), n);
+    }
+
+    fn visit_mut_exprs(&mut self, n: &mut Vec<Box<Expr>>) {
+        self.visit_mut_par(cpu_count(), n);
+    }
+
     fn visit_mut_module(&mut self, module: &mut Module) {
         self.bindings = Lrc::new(collect_decls(&*module));
 
         module.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_opt_vec_expr_or_spreads(&mut self, n: &mut Vec<Option<ExprOrSpread>>) {
+        self.visit_mut_par(cpu_count(), n);
     }
 
     fn visit_mut_prop(&mut self, p: &mut Prop) {
@@ -176,26 +192,14 @@ impl VisitMut for InlineGlobals {
         }
     }
 
-    fn visit_mut_script(&mut self, script: &mut Script) {
-        self.bindings = Lrc::new(collect_decls(&*script));
-
-        script.visit_mut_children_with(self);
-    }
-
     fn visit_mut_prop_or_spreads(&mut self, n: &mut Vec<PropOrSpread>) {
         self.visit_mut_par(cpu_count(), n);
     }
 
-    fn visit_mut_expr_or_spreads(&mut self, n: &mut Vec<ExprOrSpread>) {
-        self.visit_mut_par(cpu_count(), n);
-    }
+    fn visit_mut_script(&mut self, script: &mut Script) {
+        self.bindings = Lrc::new(collect_decls(&*script));
 
-    fn visit_mut_opt_vec_expr_or_spreads(&mut self, n: &mut Vec<Option<ExprOrSpread>>) {
-        self.visit_mut_par(cpu_count(), n);
-    }
-
-    fn visit_mut_exprs(&mut self, n: &mut Vec<Box<Expr>>) {
-        self.visit_mut_par(cpu_count(), n);
+        script.visit_mut_children_with(self);
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -74,6 +74,12 @@ impl Parallel for Remover {
 impl VisitMut for Remover {
     noop_visit_mut_type!();
 
+    fn visit_mut_class_members(&mut self, members: &mut Vec<ClassMember>) {
+        self.maybe_par(cpu_count(), members, |v, member| {
+            member.visit_mut_with(v);
+        });
+    }
+
     fn visit_mut_expr(&mut self, e: &mut Expr) {
         e.visit_mut_children_with(self);
 
@@ -175,6 +181,18 @@ impl VisitMut for Remover {
 
             _ => {}
         }
+    }
+
+    fn visit_mut_expr_or_spreads(&mut self, n: &mut Vec<ExprOrSpread>) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_mut_with(v);
+        })
+    }
+
+    fn visit_mut_exprs(&mut self, n: &mut Vec<Box<Expr>>) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_mut_with(v);
+        })
     }
 
     fn visit_mut_for_stmt(&mut self, s: &mut ForStmt) {
@@ -296,6 +314,12 @@ impl VisitMut for Remover {
         }
     }
 
+    fn visit_mut_opt_vec_expr_or_spreads(&mut self, n: &mut Vec<Option<ExprOrSpread>>) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_mut_with(v);
+        })
+    }
+
     fn visit_mut_pat(&mut self, p: &mut Pat) {
         p.visit_mut_children_with(self);
 
@@ -316,6 +340,12 @@ impl VisitMut for Remover {
 
             _ => {}
         }
+    }
+
+    fn visit_mut_prop_or_spreads(&mut self, n: &mut Vec<PropOrSpread>) {
+        self.maybe_par(cpu_count() * 8, n, |v, n| {
+            n.visit_mut_with(v);
+        })
     }
 
     fn visit_mut_seq_expr(&mut self, e: &mut SeqExpr) {
@@ -1216,30 +1246,6 @@ impl VisitMut for Remover {
         }) {
             s.cases.clear();
         }
-    }
-
-    fn visit_mut_prop_or_spreads(&mut self, n: &mut Vec<PropOrSpread>) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
-            n.visit_mut_with(v);
-        })
-    }
-
-    fn visit_mut_expr_or_spreads(&mut self, n: &mut Vec<ExprOrSpread>) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
-            n.visit_mut_with(v);
-        })
-    }
-
-    fn visit_mut_opt_vec_expr_or_spreads(&mut self, n: &mut Vec<Option<ExprOrSpread>>) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
-            n.visit_mut_with(v);
-        })
-    }
-
-    fn visit_mut_exprs(&mut self, n: &mut Vec<Box<Expr>>) {
-        self.maybe_par(cpu_count() * 8, n, |v, n| {
-            n.visit_mut_with(v);
-        })
     }
 
     fn visit_mut_var_declarators(&mut self, n: &mut Vec<VarDeclarator>) {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -701,6 +701,10 @@ impl VisitMut for TreeShaker {
         self.in_block_stmt = old_in_block_stmt;
     }
 
+    fn visit_mut_class_members(&mut self, members: &mut Vec<ClassMember>) {
+        self.visit_par(members);
+    }
+
     fn visit_mut_decl(&mut self, n: &mut Decl) {
         n.visit_mut_children_with(self);
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -702,7 +702,7 @@ impl VisitMut for TreeShaker {
     }
 
     fn visit_mut_class_members(&mut self, members: &mut Vec<ClassMember>) {
-        self.visit_par(members);
+        self.visit_mut_par(cpu_count() * 8, members);
     }
 
     fn visit_mut_decl(&mut self, n: &mut Decl) {


### PR DESCRIPTION
**Description:**

These methods were missing and it makes the minification of some files needlessly slow.