### PR TITLE
perf(es/minifier): Do heavy operation only if required

### DIFF
--- a/.changeset/old-foxes-train.md
+++ b/.changeset/old-foxes-train.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_minifier: minor
+swc_core: minor
+---
+
+perf(es/minifier): Do heavy operation only if required


### PR DESCRIPTION
**Description:**

In `store_var_for_inlining`, we had called `inline_with_multi_replacer` needlessly. This PR fixes it.