### PR TITLE
perf(es/minifier): Invert cache to be really a cache

### DIFF
--- a/.changeset/selfish-coats-shave.md
+++ b/.changeset/selfish-coats-shave.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+perf(es/minifier): Invert cache to be really a cache


### PR DESCRIPTION
**Description:**

Previous PR may decrease the performance if the result of `collect_infects_to` is empty.

**Related issue:**

 - Inverts https://github.com/swc-project/swc/pull/9909