### PR TITLE
fix(es/parser): Parse `yield<T> (v: T)=>v`

### DIFF
--- a/.changeset/pink-kids-perform.md
+++ b/.changeset/pink-kids-perform.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+fix(es/parser): Parse `yield<T> (v: T)=>v`

--- a/crates/swc_ecma_parser/tests/typescript/issue-9914/1/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/issue-9914/1/input.ts
@@ -1,0 +1,3 @@
+(function* () {
+    yield <T>(v: T) => v;
+});

--- a/crates/swc_ecma_parser/tests/typescript/issue-9914/1/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/issue-9914/1/input.ts.json
@@ -1,0 +1,153 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 46
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 1,
+        "end": 46
+      },
+      "expression": {
+        "type": "ParenthesisExpression",
+        "span": {
+          "start": 1,
+          "end": 45
+        },
+        "expression": {
+          "type": "FunctionExpression",
+          "identifier": null,
+          "params": [],
+          "decorators": [],
+          "span": {
+            "start": 2,
+            "end": 44
+          },
+          "ctxt": 0,
+          "body": {
+            "type": "BlockStatement",
+            "span": {
+              "start": 15,
+              "end": 44
+            },
+            "ctxt": 0,
+            "stmts": [
+              {
+                "type": "ExpressionStatement",
+                "span": {
+                  "start": 21,
+                  "end": 42
+                },
+                "expression": {
+                  "type": "YieldExpression",
+                  "span": {
+                    "start": 21,
+                    "end": 41
+                  },
+                  "argument": {
+                    "type": "ArrowFunctionExpression",
+                    "span": {
+                      "start": 27,
+                      "end": 41
+                    },
+                    "ctxt": 0,
+                    "params": [
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 31,
+                          "end": 35
+                        },
+                        "ctxt": 0,
+                        "value": "v",
+                        "optional": false,
+                        "typeAnnotation": {
+                          "type": "TsTypeAnnotation",
+                          "span": {
+                            "start": 32,
+                            "end": 35
+                          },
+                          "typeAnnotation": {
+                            "type": "TsTypeReference",
+                            "span": {
+                              "start": 34,
+                              "end": 35
+                            },
+                            "typeName": {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 34,
+                                "end": 35
+                              },
+                              "ctxt": 0,
+                              "value": "T",
+                              "optional": false
+                            },
+                            "typeParams": null
+                          }
+                        }
+                      }
+                    ],
+                    "body": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 40,
+                        "end": 41
+                      },
+                      "ctxt": 0,
+                      "value": "v",
+                      "optional": false
+                    },
+                    "async": false,
+                    "generator": false,
+                    "typeParameters": {
+                      "type": "TsTypeParameterDeclaration",
+                      "span": {
+                        "start": 27,
+                        "end": 30
+                      },
+                      "parameters": [
+                        {
+                          "type": "TsTypeParameter",
+                          "span": {
+                            "start": 28,
+                            "end": 29
+                          },
+                          "name": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 28,
+                              "end": 29
+                            },
+                            "ctxt": 0,
+                            "value": "T",
+                            "optional": false
+                          },
+                          "in": false,
+                          "out": false,
+                          "const": false,
+                          "constraint": null,
+                          "default": null
+                        }
+                      ]
+                    },
+                    "returnType": null
+                  },
+                  "delegate": false
+                }
+              }
+            ]
+          },
+          "generator": true,
+          "async": false,
+          "typeParameters": null,
+          "returnType": null
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/typescript/issue-9914/2/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/issue-9914/2/input.ts
@@ -1,0 +1,3 @@
+(function* () {
+    yield <T,>(v: T) => v;
+});

--- a/crates/swc_ecma_parser/tests/typescript/issue-9914/2/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/issue-9914/2/input.ts.json
@@ -1,0 +1,153 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 47
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 1,
+        "end": 47
+      },
+      "expression": {
+        "type": "ParenthesisExpression",
+        "span": {
+          "start": 1,
+          "end": 46
+        },
+        "expression": {
+          "type": "FunctionExpression",
+          "identifier": null,
+          "params": [],
+          "decorators": [],
+          "span": {
+            "start": 2,
+            "end": 45
+          },
+          "ctxt": 0,
+          "body": {
+            "type": "BlockStatement",
+            "span": {
+              "start": 15,
+              "end": 45
+            },
+            "ctxt": 0,
+            "stmts": [
+              {
+                "type": "ExpressionStatement",
+                "span": {
+                  "start": 21,
+                  "end": 43
+                },
+                "expression": {
+                  "type": "YieldExpression",
+                  "span": {
+                    "start": 21,
+                    "end": 42
+                  },
+                  "argument": {
+                    "type": "ArrowFunctionExpression",
+                    "span": {
+                      "start": 27,
+                      "end": 42
+                    },
+                    "ctxt": 0,
+                    "params": [
+                      {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 32,
+                          "end": 36
+                        },
+                        "ctxt": 0,
+                        "value": "v",
+                        "optional": false,
+                        "typeAnnotation": {
+                          "type": "TsTypeAnnotation",
+                          "span": {
+                            "start": 33,
+                            "end": 36
+                          },
+                          "typeAnnotation": {
+                            "type": "TsTypeReference",
+                            "span": {
+                              "start": 35,
+                              "end": 36
+                            },
+                            "typeName": {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 35,
+                                "end": 36
+                              },
+                              "ctxt": 0,
+                              "value": "T",
+                              "optional": false
+                            },
+                            "typeParams": null
+                          }
+                        }
+                      }
+                    ],
+                    "body": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 41,
+                        "end": 42
+                      },
+                      "ctxt": 0,
+                      "value": "v",
+                      "optional": false
+                    },
+                    "async": false,
+                    "generator": false,
+                    "typeParameters": {
+                      "type": "TsTypeParameterDeclaration",
+                      "span": {
+                        "start": 27,
+                        "end": 31
+                      },
+                      "parameters": [
+                        {
+                          "type": "TsTypeParameter",
+                          "span": {
+                            "start": 28,
+                            "end": 29
+                          },
+                          "name": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 28,
+                              "end": 29
+                            },
+                            "ctxt": 0,
+                            "value": "T",
+                            "optional": false
+                          },
+                          "in": false,
+                          "out": false,
+                          "const": false,
+                          "constraint": null,
+                          "default": null
+                        }
+                      ]
+                    },
+                    "returnType": null
+                  },
+                  "delegate": false
+                }
+              }
+            ]
+          },
+          "generator": true,
+          "async": false,
+          "typeParameters": null,
+          "returnType": null
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Related issue:**

- Closes: #9914
