### PR TITLE
perf(es/codegen): Remove needless string comparison

### DIFF
--- a/crates/swc_ecma_codegen/src/text_writer.rs
+++ b/crates/swc_ecma_codegen/src/text_writer.rs
@@ -33,7 +33,12 @@ pub trait WriteJs {
 
     fn write_symbol(&mut self, span: Span, s: &str) -> Result;
 
-    fn write_punct(&mut self, span: Option<Span>, s: &'static str) -> Result;
+    fn write_punct(
+        &mut self,
+        span: Option<Span>,
+        s: &'static str,
+        should_commit_semi: bool,
+    ) -> Result;
 
     fn care_about_srcmap(&self) -> bool;
 


### PR DESCRIPTION
**Description:**

This shows up in the profiling result, so I made it explicit about whether we should commit the pending semicolon or drop it. I think it showed up in the profiling result because I used `&dyn`, but using `&dyn` is a useful technique for reducing the binary size.