### PR TITLE
perf(es/minifier): Make character frequency calculation more parallel

### DIFF
--- a/.changeset/quick-teachers-watch.md
+++ b/.changeset/quick-teachers-watch.md
@@ -1,0 +1,6 @@
+---
+swc_core: minor
+swc_ecma_minifier: minor
+---
+
+perf(es/minifier): Make character frequency calculation more parallel


### PR DESCRIPTION
**Description:**

We join two operations. The first operation is codegen, and the second operation is visiting. The second operation is done in parallel, but it may stall in some cases. If we perform codegen in parallel, the threads that have nothing to do while visiting will get some tasks of codegen.