### PR TITLE
refactor(es/minifier): Move `Pure` optimizer to another crate

### DIFF
--- a/crates/swc_ecma_transforms_optimization/src/simplify/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/mod.rs
@@ -15,6 +15,7 @@ pub mod const_propagation;
 pub mod dce;
 mod expr;
 pub mod inlining;
+mod pure;
 
 #[derive(Debug, Default)]
 pub struct Config {


### PR DESCRIPTION
**Description:**

This is a groundwork to merge expression simplifier and dead branch remover into the pure optimizer

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/9926