### PR TITLE
fix(es/parser): Remove wrong check about `const` without init

### DIFF
--- a/.changeset/cuddly-rocks-cross.md
+++ b/.changeset/cuddly-rocks-cross.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): Remove wrong check about `const` without init

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1006,7 +1006,7 @@ impl<'a, I: Tokens> Parser<I> {
                 // typescript allows `declare` vars not to have initializers.
                 if self.ctx().in_declare {
                     None
-                } else if kind == VarDeclKind::Const && !self.ctx().in_declare {
+                } else if kind == VarDeclKind::Const && !for_loop && !self.ctx().in_declare {
                     self.emit_err(
                         span!(self, start),
                         SyntaxError::ConstDeclarationsRequireInitialization,

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1006,8 +1006,7 @@ impl<'a, I: Tokens> Parser<I> {
                 // typescript allows `declare` vars not to have initializers.
                 if self.ctx().in_declare {
                     None
-                } else if kind == VarDeclKind::Const && self.ctx().strict && !self.ctx().in_declare
-                {
+                } else if kind == VarDeclKind::Const && !self.ctx().in_declare {
                     self.emit_err(
                         span!(self, start),
                         SyntaxError::ConstDeclarationsRequireInitialization,

--- a/crates/swc_ecma_parser/tests/typescript-errors/issue-1170-1/input.ts.swc-stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/issue-1170-1/input.ts.swc-stderr
@@ -1,3 +1,8 @@
+  x 'const' declarations must be initialized
+   ,-[$DIR/tests/typescript-errors/issue-1170-1/input.ts:1:1]
+ 1 | const toString: (local)(this: Function) => string) = undefined;
+   :       ^^^^^^^^^^^^^^^^^
+   `----
   x Expected a semicolon
    ,-[$DIR/tests/typescript-errors/issue-1170-1/input.ts:1:1]
  1 | const toString: (local)(this: Function) => string) = undefined;

--- a/crates/swc_ecma_parser/tests/typescript-errors/issue-1391/case1/input.ts.swc-stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/issue-1391/case1/input.ts.swc-stderr
@@ -1,3 +1,9 @@
+  x 'const' declarations must be initialized
+   ,-[$DIR/tests/typescript-errors/issue-1391/case1/input.ts:1:1]
+ 1 | const Methods {
+   :       ^^^^^^^
+ 2 |     f: (x, y) => x + y,
+   `----
   x Expected a semicolon
    ,-[$DIR/tests/typescript-errors/issue-1391/case1/input.ts:1:1]
  1 | const Methods {

--- a/crates/swc_fast_ts_strip/tests/errors/invalid-syntax-1.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/invalid-syntax-1.swc-stderr
@@ -1,0 +1,5 @@
+  x 'const' declarations must be initialized
+   ,----
+ 1 | interface Foo { }; const foo;
+   :                          ^^^
+   `----

--- a/crates/swc_fast_ts_strip/tests/errors/invalid-syntax-1.ts
+++ b/crates/swc_fast_ts_strip/tests/errors/invalid-syntax-1.ts
@@ -1,0 +1,1 @@
+interface Foo { }; const foo;


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/9883