### PR TITLE
fix(es/transforms): Avoid adding `__self` in constructors of derived class in the `jsx_self` react transform

### DIFF
--- a/crates/swc_ecma_transforms_react/src/jsx_self/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx_self/mod.rs
@@ -2,7 +2,7 @@ use swc_common::DUMMY_SP;
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::perf::Parallel;
 use swc_ecma_utils::quote_ident;
-use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut};
+use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
 
 #[cfg(test)]
 mod tests;
@@ -11,12 +11,32 @@ mod tests;
 ///
 /// Add a __self prop to all JSX Elements
 pub fn jsx_self(dev: bool) -> impl Pass {
-    visit_mut_pass(JsxSelf { dev })
+    visit_mut_pass(JsxSelf {
+        dev,
+        ctx: Default::default(),
+    })
+}
+
+/// See <https://github.com/babel/babel/blob/1bdb1a4175ed1fc40751fb84dc4ad1900260f28f/packages/babel-plugin-transform-react-jsx-self/src/index.ts#L27>
+#[derive(Clone, Copy, Default)]
+struct Context {
+    in_constructor: bool,
+    in_derived_class: bool,
 }
 
 #[derive(Clone, Copy)]
 struct JsxSelf {
     dev: bool,
+    ctx: Context,
+}
+
+impl JsxSelf {
+    fn with_in_constructor<N: VisitMutWith<JsxSelf>>(&mut self, in_constructor: bool, n: &mut N) {
+        let old = self.ctx;
+        self.ctx.in_constructor = in_constructor;
+        n.visit_mut_children_with(self);
+        self.ctx = old;
+    }
 }
 
 impl Parallel for JsxSelf {
@@ -30,8 +50,47 @@ impl Parallel for JsxSelf {
 impl VisitMut for JsxSelf {
     noop_visit_mut_type!();
 
+    fn visit_mut_class(&mut self, n: &mut Class) {
+        let old = self.ctx;
+        self.ctx.in_derived_class = n.super_class.is_some();
+        n.visit_mut_children_with(self);
+        self.ctx = old;
+    }
+
+    fn visit_mut_fn_decl(&mut self, n: &mut FnDecl) {
+        self.with_in_constructor(false, n);
+    }
+
+    fn visit_mut_fn_expr(&mut self, n: &mut FnExpr) {
+        self.with_in_constructor(false, n);
+    }
+
+    fn visit_mut_prop(&mut self, n: &mut Prop) {
+        match n {
+            Prop::Getter(_) | Prop::Setter(_) | Prop::Method(_) => {
+                self.with_in_constructor(false, n)
+            }
+            _ => n.visit_mut_children_with(self),
+        }
+    }
+
+    fn visit_mut_class_member(&mut self, n: &mut ClassMember) {
+        match n {
+            ClassMember::Constructor(_) => self.with_in_constructor(true, n),
+            ClassMember::Method(_)
+            | ClassMember::PrivateMethod(_)
+            | ClassMember::StaticBlock(_) => self.with_in_constructor(false, n),
+            _ => n.visit_mut_children_with(self),
+        }
+    }
+
     fn visit_mut_jsx_opening_element(&mut self, n: &mut JSXOpeningElement) {
         if !self.dev {
+            return;
+        }
+
+        // https://github.com/babel/babel/blob/1bdb1a4175ed1fc40751fb84dc4ad1900260f28f/packages/babel-plugin-transform-react-jsx-self/src/index.ts#L50
+        if self.ctx.in_constructor && self.ctx.in_derived_class {
             return;
         }
 

--- a/crates/swc_ecma_transforms_react/src/jsx_self/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx_self/tests.rs
@@ -1,3 +1,6 @@
+use swc_common::Mark;
+use swc_ecma_transforms_base::resolver;
+use swc_ecma_transforms_compat::es2015::arrow;
 use swc_ecma_transforms_testing::test;
 
 use super::*;
@@ -15,4 +18,90 @@ test!(
     |_| tr(),
     basic_sample,
     r#"var x = <sometag />"#
+);
+
+test!(
+    module,
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
+        jsx: true,
+        ..Default::default()
+    }),
+    |_| tr(),
+    disable_with_super,
+    r#"class A { }
+
+class B extends A {
+  constructor() {
+    <sometag1 />;
+    super(<sometag2 />);
+    <sometag3 />;
+  }
+}
+
+class C {
+  constructor() {
+    <sometag4 />;
+    class D extends A {
+      constructor() {
+        super();
+      }
+    }
+    const E = class extends A {
+      constructor() {
+        super();
+      }
+    };
+  }
+}
+
+class E extends A {
+  constructor() {
+    this.x = () => <sometag5 />;
+    this.y = function () {
+      return <sometag6 />;
+    };
+    function z() {
+      return <sometag7 />;
+    }
+    { <sometag8 /> }
+    super();
+  }
+}
+
+class F {
+  constructor() {
+    <sometag9 />
+  }
+}
+
+class G extends A {
+  constructor() {
+    return <sometag10 />;
+  }
+}"#
+);
+
+test!(
+    module,
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
+        jsx: true,
+        ..Default::default()
+    }),
+    |_| {
+        let unresolved_mark = Mark::new();
+        let top_level_mark = Mark::new();
+        (
+            resolver(unresolved_mark, top_level_mark, false),
+            tr(),
+            arrow(unresolved_mark),
+        )
+    },
+    arrow_function,
+    r#"<div />;
+() => <div />;
+
+function fn() {
+  <div />;
+  () => <div />;
+}"#
 );

--- a/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/jsx_self/tests.rs/arrow_function.js
+++ b/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/jsx_self/tests.rs/arrow_function.js
@@ -1,0 +1,12 @@
+var _this = this;
+<div __self={this}/>;
+(function() {
+    return <div __self={_this}/>;
+});
+function fn() {
+    var _this = this;
+    <div __self={this}/>;
+    (function() {
+        return <div __self={_this}/>;
+    });
+}

--- a/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/jsx_self/tests.rs/disable_with_super.js
+++ b/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/jsx_self/tests.rs/disable_with_super.js
@@ -2,9 +2,9 @@ class A {
 }
 class B extends A {
     constructor(){
-        <sometag1 __self={this}/>;
-        super(<sometag2 __self={this}/>);
-        <sometag3 __self={this}/>;
+        <sometag1/>;
+        super(<sometag2/>);
+        <sometag3/>;
     }
 }
 class C {
@@ -24,7 +24,7 @@ class C {
 }
 class E extends A {
     constructor(){
-        this.x = ()=><sometag5 __self={this}/>;
+        this.x = ()=><sometag5/>;
         this.y = function() {
             return <sometag6 __self={this}/>;
         };
@@ -32,7 +32,7 @@ class E extends A {
             return <sometag7 __self={this}/>;
         }
         {
-            <sometag8 __self={this}/>;
+            <sometag8/>;
         }
         super();
     }
@@ -44,6 +44,6 @@ class F {
 }
 class G extends A {
     constructor(){
-        return <sometag10 __self={this}/>;
+        return <sometag10/>;
     }
 }

--- a/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/jsx_self/tests.rs/disable_with_super.js
+++ b/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/jsx_self/tests.rs/disable_with_super.js
@@ -1,0 +1,49 @@
+class A {
+}
+class B extends A {
+    constructor(){
+        <sometag1 __self={this}/>;
+        super(<sometag2 __self={this}/>);
+        <sometag3 __self={this}/>;
+    }
+}
+class C {
+    constructor(){
+        <sometag4 __self={this}/>;
+        class D extends A {
+            constructor(){
+                super();
+            }
+        }
+        const E = class extends A {
+            constructor(){
+                super();
+            }
+        };
+    }
+}
+class E extends A {
+    constructor(){
+        this.x = ()=><sometag5 __self={this}/>;
+        this.y = function() {
+            return <sometag6 __self={this}/>;
+        };
+        function z() {
+            return <sometag7 __self={this}/>;
+        }
+        {
+            <sometag8 __self={this}/>;
+        }
+        super();
+    }
+}
+class F {
+    constructor(){
+        <sometag9 __self={this}/>;
+    }
+}
+class G extends A {
+    constructor(){
+        return <sometag10 __self={this}/>;
+    }
+}


### PR DESCRIPTION
fixes https://github.com/swc-project/swc/issues/9904

1. port babel test: https://github.com/babel/babel/tree/main/packages/babel-plugin-transform-react-jsx-self/test/fixtures/react-source
2. check if the jsx is in a constructor of a derived class: https://github.com/babel/babel/blob/main/packages/babel-plugin-transform-react-jsx-self/src/index.ts#L77