### PR TITLE
perf(es/minifier): Limit infection analysis by the entry size

### DIFF
--- a/.changeset/proud-adults-roll.md
+++ b/.changeset/proud-adults-roll.md
@@ -1,0 +1,7 @@
+---
+swc_ecma_minifier: minor
+swc_ecma_usage_analyzer: minor
+swc_core: minor
+---
+
+perf(es/minifier): Limit infection analysis by the entry size

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -118,7 +118,9 @@ pub(crate) struct VarUsageInfo {
 
     /// `infects_to`. This should be renamed, but it will be done with another
     /// PR. (because it's hard to review)
-    infects_to: Vec<Access>,
+    ///
+    /// [None] means that we have too many accesses to collect.
+    infects_to: Option<Vec<Access>>,
     /// Only **string** properties.
     pub(crate) accessed_props: Box<FxHashMap<JsWord, u32>>,
 
@@ -155,7 +157,7 @@ impl Default for VarUsageInfo {
             used_as_arg: Default::default(),
             indexed_with_dynamic_key: Default::default(),
             pure_fn: Default::default(),
-            infects_to: Default::default(),
+            infects_to: Some(vec![]),
             used_in_non_child_fn: Default::default(),
             accessed_props: Default::default(),
             used_recursively: Default::default(),
@@ -168,7 +170,7 @@ impl Default for VarUsageInfo {
 
 impl VarUsageInfo {
     pub(crate) fn is_infected(&self) -> bool {
-        !self.infects_to.is_empty()
+        self.infects_to.as_deref().map_or(true, |v| !v.is_empty())
     }
 
     /// The variable itself or a property of it is modified.
@@ -274,7 +276,16 @@ impl Storage for ProgramData {
                     e.get_mut().assign_count += var_info.assign_count;
                     e.get_mut().usage_count += var_info.usage_count;
 
-                    e.get_mut().infects_to.extend(var_info.infects_to);
+                    match var_info.infects_to {
+                        Some(v) => {
+                            if let Some(l) = &mut e.get_mut().infects_to {
+                                l.extend(v);
+                            }
+                        }
+                        None => {
+                            e.get_mut().infects_to = None;
+                        }
+                    }
 
                     e.get_mut().no_side_effect_for_member_access =
                         e.get_mut().no_side_effect_for_member_access
@@ -384,7 +395,7 @@ impl Storage for ProgramData {
         }
 
         let mut to_visit: IndexSet<Id, FxBuildHasher> =
-            IndexSet::from_iter(e.infects_to.clone().into_iter().map(|i| i.0));
+            IndexSet::from_iter(e.infects_to.iter().flatten().cloned().map(|i| i.0));
 
         let mut idx = 0;
 
@@ -400,7 +411,7 @@ impl Storage for ProgramData {
                     usage.usage_count += 1;
                 }
 
-                to_visit.extend(usage.infects_to.clone().into_iter().map(|i| i.0))
+                to_visit.extend(usage.infects_to.iter().flatten().cloned().map(|i| i.0));
             }
 
             idx += 1;
@@ -479,6 +490,7 @@ impl Storage for ProgramData {
         let to_mark_mutate = e
             .infects_to
             .iter()
+            .flatten()
             .filter(|(_, kind)| *kind == AccessKind::Reference)
             .map(|(id, _)| id.clone())
             .collect::<Vec<_>>();
@@ -556,7 +568,9 @@ impl VarDataLike for VarUsageInfo {
     }
 
     fn add_infects_to(&mut self, other: Access) {
-        self.infects_to.push(other);
+        if let Some(v) = &mut self.infects_to {
+            v.push(other);
+        }
     }
 
     fn prevent_inline(&mut self) {

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -573,6 +573,10 @@ impl VarDataLike for VarUsageInfo {
         }
     }
 
+    fn give_up_infect_analysis(&mut self) {
+        self.infects_to = None;
+    }
+
     fn prevent_inline(&mut self) {
         self.inline_prevented = true;
     }

--- a/crates/swc_ecma_usage_analyzer/src/alias/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/alias/mod.rs
@@ -3,7 +3,6 @@
 use rustc_hash::FxHashSet;
 use swc_common::SyntaxContext;
 use swc_ecma_ast::*;
-use swc_ecma_utils::BindingCollector;
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use self::ctx::Ctx;
@@ -85,7 +84,7 @@ pub type Access = (Id, AccessKind);
 
 pub fn collect_infects_from<N>(node: &N, config: AliasConfig) -> FxHashSet<Access>
 where
-    N: InfectableNode + VisitWith<BindingCollector<Id>> + VisitWith<InfectionCollector>,
+    N: InfectableNode + VisitWith<InfectionCollector>,
 {
     if config.ignore_nested && node.is_fn_or_arrow_expr() {
         return Default::default();

--- a/crates/swc_ecma_usage_analyzer/src/alias/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/alias/mod.rs
@@ -152,7 +152,7 @@ where
     node.visit_with(&mut visitor);
 
     if visitor.accesses.len() > max_entries {
-        return Err(());
+        return Err(TooManyAccesses);
     }
 
     Ok(visitor.accesses)

--- a/crates/swc_ecma_usage_analyzer/src/alias/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/alias/mod.rs
@@ -311,6 +311,12 @@ impl Visit for InfectionCollector {
     }
 
     fn visit_expr(&mut self, e: &Expr) {
+        if let Some(max_entries) = self.max_entries {
+            if self.accesses.len() >= max_entries {
+                return;
+            }
+        }
+
         match e {
             Expr::Ident(i) => {
                 if self.ctx.track_expr_ident {
@@ -343,6 +349,16 @@ impl Visit for InfectionCollector {
         if self.config.ignore_named_child_scope && n.ident.is_some() {
             return;
         }
+        n.visit_children_with(self);
+    }
+
+    fn visit_function(&mut self, n: &Function) {
+        if let Some(max_entries) = self.max_entries {
+            if self.accesses.len() >= max_entries {
+                return;
+            }
+        }
+
         n.visit_children_with(self);
     }
 
@@ -401,6 +417,16 @@ impl Visit for InfectionCollector {
                 ..self.ctx
             }));
         }
+    }
+
+    fn visit_stmt(&mut self, n: &Stmt) {
+        if let Some(max_entries) = self.max_entries {
+            if self.accesses.len() >= max_entries {
+                return;
+            }
+        }
+
+        n.visit_children_with(self);
     }
 
     fn visit_super_prop_expr(&mut self, n: &SuperPropExpr) {

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/storage.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/storage.rs
@@ -72,6 +72,8 @@ pub trait VarDataLike: Sized {
 
     fn add_infects_to(&mut self, other: Access);
 
+    fn give_up_infect_analysis(&mut self) {}
+
     fn prevent_inline(&mut self);
 
     fn mark_as_exported(&mut self);


### PR DESCRIPTION
**Description:**

In most real-world inputs, many infected identifiers typically mean we can't optimize it anyway. Because of the variable usage analysis result of the infected variable, we can't do any optimization to the original variable in most cases. So this PR stops the infection analyzer at a specific threshold.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/10000