### PR TITLE
fix(es/minifier): Revert #10006

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashSet;
 use swc_common::{pass::Either, util::take::Take, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_usage_analyzer::{
-    alias::{try_collect_infects_from, AccessKind, AliasConfig},
+    alias::{collect_infects_from, AccessKind, AliasConfig},
     util::is_global_var_with_pure_property_access,
 };
 use swc_ecma_utils::{

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashSet;
 use swc_common::{pass::Either, util::take::Take, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_usage_analyzer::{
-    alias::{collect_infects_from, AccessKind, AliasConfig},
+    alias::{try_collect_infects_from, AccessKind, AliasConfig},
     util::is_global_var_with_pure_property_access,
 };
 use swc_ecma_utils::{

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -118,9 +118,7 @@ pub(crate) struct VarUsageInfo {
 
     /// `infects_to`. This should be renamed, but it will be done with another
     /// PR. (because it's hard to review)
-    ///
-    /// [None] means that we have too many accesses to collect.
-    infects_to: Option<Vec<Access>>,
+    infects_to: Vec<Access>,
     /// Only **string** properties.
     pub(crate) accessed_props: Box<FxHashMap<JsWord, u32>>,
 
@@ -157,7 +155,7 @@ impl Default for VarUsageInfo {
             used_as_arg: Default::default(),
             indexed_with_dynamic_key: Default::default(),
             pure_fn: Default::default(),
-            infects_to: Some(vec![]),
+            infects_to: Default::default(),
             used_in_non_child_fn: Default::default(),
             accessed_props: Default::default(),
             used_recursively: Default::default(),
@@ -170,7 +168,7 @@ impl Default for VarUsageInfo {
 
 impl VarUsageInfo {
     pub(crate) fn is_infected(&self) -> bool {
-        self.infects_to.as_deref().map_or(true, |v| !v.is_empty())
+        !self.infects_to.is_empty()
     }
 
     /// The variable itself or a property of it is modified.
@@ -276,16 +274,7 @@ impl Storage for ProgramData {
                     e.get_mut().assign_count += var_info.assign_count;
                     e.get_mut().usage_count += var_info.usage_count;
 
-                    match var_info.infects_to {
-                        Some(v) => {
-                            if let Some(l) = &mut e.get_mut().infects_to {
-                                l.extend(v);
-                            }
-                        }
-                        None => {
-                            e.get_mut().infects_to = None;
-                        }
-                    }
+                    e.get_mut().infects_to.extend(var_info.infects_to);
 
                     e.get_mut().no_side_effect_for_member_access =
                         e.get_mut().no_side_effect_for_member_access
@@ -395,7 +384,7 @@ impl Storage for ProgramData {
         }
 
         let mut to_visit: IndexSet<Id, FxBuildHasher> =
-            IndexSet::from_iter(e.infects_to.iter().flatten().cloned().map(|i| i.0));
+            IndexSet::from_iter(e.infects_to.iter().cloned().map(|i| i.0));
 
         let mut idx = 0;
 
@@ -411,7 +400,7 @@ impl Storage for ProgramData {
                     usage.usage_count += 1;
                 }
 
-                to_visit.extend(usage.infects_to.iter().flatten().cloned().map(|i| i.0));
+                to_visit.extend(usage.infects_to.iter().cloned().map(|i| i.0))
             }
 
             idx += 1;
@@ -490,7 +479,6 @@ impl Storage for ProgramData {
         let to_mark_mutate = e
             .infects_to
             .iter()
-            .flatten()
             .filter(|(_, kind)| *kind == AccessKind::Reference)
             .map(|(id, _)| id.clone())
             .collect::<Vec<_>>();
@@ -568,13 +556,7 @@ impl VarDataLike for VarUsageInfo {
     }
 
     fn add_infects_to(&mut self, other: Access) {
-        if let Some(v) = &mut self.infects_to {
-            v.push(other);
-        }
-    }
-
-    fn give_up_infect_analysis(&mut self) {
-        self.infects_to = None;
+        self.infects_to.push(other);
     }
 
     fn prevent_inline(&mut self) {

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
@@ -10,7 +10,7 @@ use swc_timer::timer;
 pub use self::ctx::Ctx;
 use self::storage::*;
 use crate::{
-    alias::{try_collect_infects_from, AliasConfig},
+    alias::{collect_infects_from, AliasConfig},
     marks::Marks,
     util::can_end_conditionally,
 };
@@ -302,22 +302,15 @@ where
             };
 
             if let Some(left) = left {
-                let Ok(iter) = try_collect_infects_from(
+                let mut v = None;
+                for id in collect_infects_from(
                     &n.right,
                     AliasConfig {
                         marks: self.marks,
                         ignore_named_child_scope: true,
                         ..Default::default()
                     },
-                    8,
-                ) else {
-                    self.data
-                        .var_or_default(left.to_id())
-                        .give_up_infect_analysis();
-                    return;
-                };
-                let mut v = None;
-                for id in iter {
+                ) {
                     if v.is_none() {
                         v = Some(self.data.var_or_default(left.to_id()));
                     }
@@ -763,21 +756,14 @@ where
 
         {
             let mut v = None;
-            let Ok(iter) = try_collect_infects_from(
+            for id in collect_infects_from(
                 &n.function,
                 AliasConfig {
                     marks: self.marks,
                     ignore_named_child_scope: true,
                     ..Default::default()
                 },
-                8,
-            ) else {
-                self.data
-                    .var_or_default(n.ident.to_id())
-                    .give_up_infect_analysis();
-                return;
-            };
-            for id in iter {
+            ) {
                 if v.is_none() {
                     v = Some(self.data.var_or_default(n.ident.to_id()));
                 }
@@ -801,21 +787,14 @@ where
 
             {
                 let mut v = None;
-                let Ok(iter) = try_collect_infects_from(
+                for id in collect_infects_from(
                     &n.function,
                     AliasConfig {
                         marks: self.marks,
                         ignore_named_child_scope: true,
                         ..Default::default()
                     },
-                    8,
-                ) else {
-                    self.data
-                        .var_or_default(n_id.to_id())
-                        .give_up_infect_analysis();
-                    return;
-                };
-                for id in iter {
+                ) {
                     if v.is_none() {
                         v = Some(self.data.var_or_default(n_id.to_id()));
                     }
@@ -1306,21 +1285,14 @@ where
         for decl in &n.decls {
             if let (Pat::Ident(var), Some(init)) = (&decl.name, decl.init.as_deref()) {
                 let mut v = None;
-                let Ok(iter) = try_collect_infects_from(
+                for id in collect_infects_from(
                     init,
                     AliasConfig {
                         marks: self.marks,
                         ignore_named_child_scope: true,
                         ..Default::default()
                     },
-                    8,
-                ) else {
-                    self.data
-                        .var_or_default(var.to_id())
-                        .give_up_infect_analysis();
-                    return;
-                };
-                for id in iter {
+                ) {
                     if v.is_none() {
                         v = Some(self.data.var_or_default(var.to_id()));
                     }

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/storage.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/storage.rs
@@ -72,8 +72,6 @@ pub trait VarDataLike: Sized {
 
     fn add_infects_to(&mut self, other: Access);
 
-    fn give_up_infect_analysis(&mut self) {}
-
     fn prevent_inline(&mut self);
 
     fn mark_as_exported(&mut self);


### PR DESCRIPTION
**Description:**

Invert #10006 because the analyzer should not give up analyzing the aliases because it uses the aliasing information to modify `VarUsageInfo` of aliases.