### PR TITLE
feat(es/ast): Add `ShrinkToFit` implementation

### DIFF
--- a/.changeset/strange-crabs-argue.md
+++ b/.changeset/strange-crabs-argue.md
@@ -1,0 +1,8 @@
+---
+swc_atoms: minor
+swc_common: minor
+swc_ecma_ast: minor
+swc_core: minor
+---
+
+feat(es/ast): Add `ShrinkToFit` implementation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4602,6 +4602,7 @@ dependencies = [
  "rkyv",
  "rustc-hash 2.1.0",
  "serde",
+ "shrink-to-fit",
 ]
 
 [[package]]
@@ -4707,6 +4708,7 @@ dependencies = [
  "rustc-hash 2.1.0",
  "serde",
  "serde_json",
+ "shrink-to-fit",
  "siphasher 0.3.11",
  "sourcemap",
  "swc_allocator",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,18 +4258,18 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "shrink-to-fit"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2b490099e05858ca56c40431fea42f88bc74b45fdc877cab149f79e239f8e2"
+checksum = "040f84743f19cf4a481c2580f4d9d12beab78f401773314ff18835ef78c930ea"
 dependencies = [
  "shrink-to-fit-macro",
 ]
 
 [[package]]
 name = "shrink-to-fit-macro"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e6ce0923372a4afb6b15537fc52d1d9000575197d911e80dfaa76000022d21"
+checksum = "a5e9bca0d4a99ce6c7296fea5972a9327a5e70c062b73f38e11c7894cf7ec72c"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4257,6 +4257,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "shrink-to-fit"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2b490099e05858ca56c40431fea42f88bc74b45fdc877cab149f79e239f8e2"
+dependencies = [
+ "shrink-to-fit-macro",
+]
+
+[[package]]
+name = "shrink-to-fit-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e6ce0923372a4afb6b15537fc52d1d9000575197d911e80dfaa76000022d21"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "simd-abstraction"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5011,6 +5031,7 @@ dependencies = [
  "scoped-tls",
  "serde",
  "serde_json",
+ "shrink-to-fit",
  "string_enum",
  "swc_atoms",
  "swc_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,6 +126,7 @@ resolver = "2"
   wasm-bindgen-futures      = "0.4.41"
   wasmer                    = { version = "=5.0.5-rc1", default-features = false }
   wasmer-wasix              = { version = "0.35.0", default-features = false }
+shrink-to-fit = "0.2.0"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ resolver = "2"
   serde_json                = "1.0.115"
   sha1                      = "0.10.6"
   sha2                      = "0.10.8"
+  shrink-to-fit             = "0.2.1"
   siphasher                 = "0.3.9"
   smallvec                  = "1.8.0"
   smartstring               = "1.0.1"
@@ -126,7 +127,6 @@ resolver = "2"
   wasm-bindgen-futures      = "0.4.41"
   wasmer                    = { version = "=5.0.5-rc1", default-features = false }
   wasmer-wasix              = { version = "0.35.0", default-features = false }
-shrink-to-fit = "0.2.0"
 
 [profile.release]
 lto = true

--- a/crates/swc_atoms/Cargo.toml
+++ b/crates/swc_atoms/Cargo.toml
@@ -12,8 +12,9 @@ version       = "3.0.5"
 bench = false
 
 [features]
-__rkyv    = []
-rkyv-impl = ["__rkyv", "rkyv", "bytecheck", "rancor"]
+__rkyv        = []
+rkyv-impl     = ["__rkyv", "rkyv", "bytecheck", "rancor"]
+shrink-to-fit = ["dep:shrink-to-fit"]
 
 [dependencies]
 # bytecheck version should be in sync with rkyv version. Do not bump individually.
@@ -24,6 +25,6 @@ rancor        = { workspace = true, optional = true }
 rkyv          = { workspace = true, optional = true }
 rustc-hash    = { workspace = true }
 serde         = { workspace = true }
-shrink-to-fit = { workspace = true }
+shrink-to-fit = { workspace = true, optional = true }
 
 hstr = { version = "0.2.17", path = "../hstr" }

--- a/crates/swc_atoms/Cargo.toml
+++ b/crates/swc_atoms/Cargo.toml
@@ -17,12 +17,13 @@ rkyv-impl = ["__rkyv", "rkyv", "bytecheck", "rancor"]
 
 [dependencies]
 # bytecheck version should be in sync with rkyv version. Do not bump individually.
-arbitrary  = { workspace = true, optional = true }
-bytecheck  = { workspace = true, optional = true }
-once_cell  = { workspace = true }
-rancor     = { workspace = true, optional = true }
-rkyv       = { workspace = true, optional = true }
-rustc-hash = { workspace = true }
-serde      = { workspace = true }
+arbitrary     = { workspace = true, optional = true }
+bytecheck     = { workspace = true, optional = true }
+once_cell     = { workspace = true }
+rancor        = { workspace = true, optional = true }
+rkyv          = { workspace = true, optional = true }
+rustc-hash    = { workspace = true }
+serde         = { workspace = true }
+shrink-to-fit = { workspace = true }
 
 hstr = { version = "0.2.17", path = "../hstr" }

--- a/crates/swc_atoms/src/lib.rs
+++ b/crates/swc_atoms/src/lib.rs
@@ -271,3 +271,10 @@ impl AtomStoreCell {
         unsafe { (*self.0.get()).atom(s) }
     }
 }
+
+/// noop
+#[cfg(feature = "shrink-to-fit")]
+impl shrink_to_fit::ShrinkToFit for Atom {
+    #[inline(always)]
+    fn shrink_to_fit(&mut self) {}
+}

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -49,6 +49,7 @@ rancor                = { workspace = true, optional = true }
 rkyv                  = { workspace = true, optional = true }
 rustc-hash            = { workspace = true }
 serde                 = { workspace = true, features = ["derive"] }
+shrink-to-fit         = { workspace = true }
 siphasher             = { workspace = true }
 sourcemap             = { workspace = true, optional = true }
 termcolor             = { workspace = true, optional = true }

--- a/crates/swc_common/Cargo.toml
+++ b/crates/swc_common/Cargo.toml
@@ -35,6 +35,9 @@ tty-emitter = ["termcolor"]
 __rkyv    = []
 rkyv-impl = ["__rkyv", "rkyv", "swc_atoms/rkyv-impl", "bytecheck", "rancor"]
 
+shrink-to-fit = ["dep:shrink-to-fit", "swc_atoms/shrink-to-fit"]
+
+
 [dependencies]
 anyhow                = { workspace = true, optional = true }
 arbitrary             = { workspace = true, features = ["derive"], optional = true }
@@ -49,7 +52,7 @@ rancor                = { workspace = true, optional = true }
 rkyv                  = { workspace = true, optional = true }
 rustc-hash            = { workspace = true }
 serde                 = { workspace = true, features = ["derive"] }
-shrink-to-fit         = { workspace = true }
+shrink-to-fit         = { workspace = true, optional = true }
 siphasher             = { workspace = true }
 sourcemap             = { workspace = true, optional = true }
 termcolor             = { workspace = true, optional = true }

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -38,6 +38,7 @@ pub mod hygiene;
 )]
 #[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "rkyv-impl", repr(C))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Span {
     #[serde(rename = "start")]
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -1061,6 +1061,7 @@ pub trait SmallPos {
 )]
 #[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "rkyv-impl", repr(C))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BytePos(#[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))] pub u32);
 
 impl BytePos {

--- a/crates/swc_common/src/syntax_pos/hygiene.rs
+++ b/crates/swc_common/src/syntax_pos/hygiene.rs
@@ -37,6 +37,7 @@ use crate::EqIgnoreSpan;
 )]
 #[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "rkyv-impl", repr(C))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SyntaxContext(#[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))] u32);
 
 #[cfg(feature = "arbitrary")]

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -132,8 +132,9 @@ testing_transform = ["__ecma", "__testing_transform"]
 
 # Enable swc_ecma_ast / swc_atoms support.
 # TODO: currently both are enabled at once, we may want to separate them.
-ecma_ast       = ["__ecma", "swc_ecma_ast", "swc_atoms"]
-ecma_ast_serde = ["ecma_ast", "swc_ecma_ast/serde-impl"]
+ecma_ast        = ["__ecma", "swc_ecma_ast", "swc_atoms"]
+ecma_ast_serde  = ["ecma_ast", "swc_ecma_ast/serde-impl"]
+ecma_ast_shrink = ["ecma_ast", "swc_ecma_ast/shrink-to-fit"]
 
 # Enable swc_ecma_parser support.
 ecma_parser            = ["__parser"]

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -40,11 +40,13 @@ rancor           = { workspace = true, optional = true }
 rkyv             = { workspace = true, optional = true }
 scoped-tls       = { workspace = true }
 serde            = { workspace = true, features = ["derive"], optional = true }
-string_enum      = { version = "1.0.0", path = "../string_enum" }
-swc_atoms        = { version = "3.0.5", path = "../swc_atoms" }
-swc_common       = { version = "6.0.0", path = "../swc_common" }
-swc_visit        = { version = "2.0.0", path = "../swc_visit" }
+shrink-to-fit    = { workspace = true }
 unicode-id-start = { workspace = true }
+
+string_enum = { version = "1.0.0", path = "../string_enum" }
+swc_atoms   = { version = "3.0.5", path = "../swc_atoms" }
+swc_common  = { version = "6.0.0", path = "../swc_common" }
+swc_visit   = { version = "2.0.0", path = "../swc_visit" }
 
 [dev-dependencies]
 serde_json = { workspace = true }

--- a/crates/swc_ecma_ast/Cargo.toml
+++ b/crates/swc_ecma_ast/Cargo.toml
@@ -28,6 +28,12 @@ rkyv-impl = [
   "swc_common/rkyv-impl",
 ]
 serde-impl = ["serde"]
+shrink-to-fit = [
+  "dep:shrink-to-fit",
+  "swc_atoms/shrink-to-fit",
+  "swc_common/shrink-to-fit",
+]
+
 
 [dependencies]
 arbitrary        = { workspace = true, features = ["derive"], optional = true }
@@ -40,7 +46,7 @@ rancor           = { workspace = true, optional = true }
 rkyv             = { workspace = true, optional = true }
 scoped-tls       = { workspace = true }
 serde            = { workspace = true, features = ["derive"], optional = true }
-shrink-to-fit    = { workspace = true }
+shrink-to-fit    = { workspace = true, optional = true }
 unicode-id-start = { workspace = true }
 
 string_enum = { version = "1.0.0", path = "../string_enum" }

--- a/crates/swc_ecma_ast/src/class.rs
+++ b/crates/swc_ecma_ast/src/class.rs
@@ -57,6 +57,7 @@ impl Take for Class {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ClassMember {
     #[tag("Constructor")]
     Constructor(Constructor),
@@ -179,6 +180,7 @@ pub struct PrivateProp {
 #[ast_node("ClassMethod")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ClassMethod {
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub span: Span,
@@ -225,6 +227,7 @@ pub struct PrivateMethod {
 #[ast_node("Constructor")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Constructor {
     pub span: Span,
 
@@ -247,6 +250,7 @@ pub struct Constructor {
 #[ast_node("Decorator")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Decorator {
     pub span: Span,
 
@@ -327,6 +331,7 @@ impl Default for Key {
 #[ast_node("AutoAccessor")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AutoAccessor {
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub span: Span,

--- a/crates/swc_ecma_ast/src/class.rs
+++ b/crates/swc_ecma_ast/src/class.rs
@@ -94,6 +94,7 @@ impl Take for ClassMember {
 #[ast_node("ClassProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ClassProp {
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub span: Span,
@@ -139,6 +140,7 @@ pub struct ClassProp {
 #[ast_node("PrivateProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct PrivateProp {
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub span: Span,
@@ -204,6 +206,7 @@ pub struct ClassMethod {
 #[ast_node("PrivateMethod")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct PrivateMethod {
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub span: Span,
@@ -267,6 +270,7 @@ pub struct Decorator {
 #[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "rkyv-impl", repr(u32))]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum MethodKind {
     #[default]
     #[cfg_attr(feature = "serde-impl", serde(rename = "method"))]
@@ -280,6 +284,7 @@ pub enum MethodKind {
 #[ast_node("StaticBlock")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct StaticBlock {
     pub span: Span,
     pub body: BlockStmt,
@@ -298,6 +303,7 @@ impl Take for StaticBlock {
 #[ast_node]
 #[derive(Is, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Key {
     #[tag("PrivateName")]
     Private(PrivateName),

--- a/crates/swc_ecma_ast/src/class.rs
+++ b/crates/swc_ecma_ast/src/class.rs
@@ -17,6 +17,7 @@ use crate::{
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Class {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/decl.rs
+++ b/crates/swc_ecma_ast/src/decl.rs
@@ -178,6 +178,7 @@ impl Take for VarDecl {
 )]
 #[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "rkyv-impl", repr(u32))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum VarDeclKind {
     /// `var`
     #[default]

--- a/crates/swc_ecma_ast/src/decl.rs
+++ b/crates/swc_ecma_ast/src/decl.rs
@@ -14,6 +14,7 @@ use crate::{
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Decl {
     #[tag("ClassDeclaration")]
     Class(ClassDecl),
@@ -96,6 +97,7 @@ impl Take for Decl {
 #[ast_node("FunctionDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct FnDecl {
     #[cfg_attr(feature = "serde-impl", serde(rename = "identifier"))]
     pub ident: Ident,
@@ -121,6 +123,7 @@ impl Take for FnDecl {
 #[ast_node("ClassDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ClassDecl {
     #[cfg_attr(feature = "serde-impl", serde(rename = "identifier"))]
     pub ident: Ident,
@@ -146,6 +149,7 @@ impl Take for ClassDecl {
 #[ast_node("VariableDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct VarDecl {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/decl.rs
+++ b/crates/swc_ecma_ast/src/decl.rs
@@ -191,6 +191,7 @@ pub enum VarDeclKind {
 #[ast_node("VariableDeclarator")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct VarDeclarator {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "id"))]
@@ -219,6 +220,7 @@ impl Take for VarDeclarator {
 #[ast_node("UsingDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct UsingDecl {
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub span: Span,

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -517,6 +517,7 @@ impl Take for ArrayLit {
 #[ast_node("ObjectExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ObjectLit {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -29,6 +29,7 @@ use crate::{
 #[ast_node(no_clone)]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Expr {
     #[tag("ThisExpression")]
     This(ThisExpr),
@@ -483,6 +484,7 @@ boxed_expr!(Invalid);
 #[ast_node("ThisExpression")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ThisExpr {
     pub span: Span,
 }
@@ -497,6 +499,7 @@ impl Take for ThisExpr {
 #[ast_node("ArrayExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ArrayLit {
     pub span: Span,
 
@@ -620,6 +623,7 @@ impl Take for ObjectLit {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum PropOrSpread {
     /// Spread properties, e.g., `{a: 1, ...obj, b: 2}`.
     #[tag("SpreadElement")]
@@ -643,6 +647,7 @@ impl Take for PropOrSpread {
 #[ast_node("SpreadElement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SpreadElement {
     #[cfg_attr(feature = "serde-impl", serde(rename = "spread"))]
     #[span(lo)]
@@ -688,6 +693,7 @@ impl Take for UnaryExpr {
 #[ast_node("UpdateExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct UpdateExpr {
     pub span: Span,
 
@@ -740,6 +746,7 @@ impl Take for BinExpr {
 #[ast_node("FunctionExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct FnExpr {
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "identifier"))]
     pub ident: Option<Ident>,

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -781,6 +781,7 @@ bridge_expr_from!(FnExpr, Box<Function>);
 #[ast_node("ClassExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ClassExpr {
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "identifier"))]
     pub ident: Option<Ident>,
@@ -811,6 +812,7 @@ bridge_expr_from!(ClassExpr, Box<Class>);
 #[ast_node("AssignmentExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignExpr {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -1081,6 +1081,7 @@ impl Take for YieldExpr {
 #[ast_node("MetaProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct MetaPropExpr {
     pub span: Span,
     pub kind: MetaPropKind,
@@ -1094,6 +1095,7 @@ pub struct MetaPropExpr {
 )]
 #[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "rkyv-impl", repr(u32))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum MetaPropKind {
     /// `new.target`
     NewTarget,

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -670,6 +670,7 @@ impl Take for SpreadElement {
 #[ast_node("UnaryExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct UnaryExpr {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -721,6 +721,7 @@ impl Take for UpdateExpr {
 #[ast_node("BinaryExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BinExpr {
     pub span: Span,
 
@@ -845,6 +846,7 @@ impl AssignExpr {
 #[ast_node("MemberExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct MemberExpr {
     pub span: Span,
 
@@ -858,6 +860,7 @@ pub struct MemberExpr {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum MemberProp {
     #[tag("Identifier")]
     Ident(IdentName),
@@ -876,6 +879,7 @@ impl MemberProp {
 #[ast_node("SuperPropExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SuperPropExpr {
     pub span: Span,
 
@@ -888,6 +892,7 @@ pub struct SuperPropExpr {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum SuperProp {
     #[tag("Identifier")]
     Ident(IdentName),
@@ -932,6 +937,7 @@ impl Default for SuperProp {
 #[ast_node("ConditionalExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct CondExpr {
     pub span: Span,
 
@@ -958,6 +964,7 @@ impl Take for CondExpr {
 #[ast_node("CallExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct CallExpr {
     pub span: Span,
     pub ctxt: SyntaxContext,
@@ -981,6 +988,7 @@ impl Take for CallExpr {
 #[ast_node("NewExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct NewExpr {
     pub span: Span,
 
@@ -1025,6 +1033,7 @@ impl Take for SeqExpr {
 #[ast_node("ArrowFunctionExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ArrowExpr {
     pub span: Span,
 
@@ -1059,6 +1068,7 @@ impl Take for ArrowExpr {
 #[ast_node("YieldExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct YieldExpr {
     pub span: Span,
 
@@ -1107,6 +1117,7 @@ pub enum MetaPropKind {
 #[ast_node("AwaitExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AwaitExpr {
     pub span: Span,
 
@@ -1140,6 +1151,7 @@ impl Take for Tpl {
 #[ast_node("TaggedTemplateExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TaggedTpl {
     pub span: Span,
 
@@ -1211,6 +1223,7 @@ impl<'a> arbitrary::Arbitrary<'a> for TplElement {
 #[ast_node("ParenthesisExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ParenExpr {
     pub span: Span,
 
@@ -1229,6 +1242,7 @@ impl Take for ParenExpr {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Callee {
     #[tag("Super")]
     #[is(name = "super_")]
@@ -1256,6 +1270,7 @@ impl Take for Callee {
 #[ast_node("Super")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Super {
     pub span: Span,
 }
@@ -1269,6 +1284,7 @@ impl Take for Super {
 #[ast_node("Import")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Import {
     pub span: Span,
     pub phase: ImportPhase,
@@ -1285,6 +1301,7 @@ impl Take for Import {
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -1353,6 +1370,7 @@ bridge_from!(ExprOrSpread, Box<Expr>, Expr);
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum BlockStmtOrExpr {
     #[tag("BlockStatement")]
     BlockStmt(BlockStmt),
@@ -1441,6 +1459,7 @@ impl TryFrom<Box<Expr>> for AssignTarget {
 #[ast_node]
 #[derive(Is, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum AssignTargetPat {
     #[tag("ArrayPattern")]
     Array(ArrayPat),
@@ -1495,6 +1514,7 @@ impl TryFrom<Pat> for AssignTargetPat {
 #[ast_node]
 #[derive(Is, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum SimpleAssignTarget {
     /// Note: This type is to help implementing visitor and the field `type_ann`
     /// is always [None].
@@ -1619,6 +1639,7 @@ impl Take for AssignTarget {
 #[ast_node("OptionalChainingExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct OptChainExpr {
     pub span: Span,
     pub optional: bool,
@@ -1629,6 +1650,7 @@ pub struct OptChainExpr {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum OptChainBase {
     #[tag("MemberExpression")]
     Member(MemberExpr),
@@ -1645,6 +1667,7 @@ impl Default for OptChainBase {
 #[ast_node("CallExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct OptCall {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -1005,6 +1005,7 @@ impl Take for NewExpr {
 #[ast_node("SequenceExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SeqExpr {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -1116,6 +1116,7 @@ pub struct AwaitExpr {
 #[ast_node("TemplateLiteral")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Tpl {
     pub span: Span,
 
@@ -1161,6 +1162,7 @@ impl Take for TaggedTpl {
 
 #[ast_node("TemplateElement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TplElement {
     pub span: Span,
     pub tail: bool,
@@ -1381,6 +1383,7 @@ impl Take for BlockStmtOrExpr {
 #[ast_node]
 #[derive(Is, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum AssignTarget {
     #[tag("Identifier")]
     #[tag("MemberExpression")]

--- a/crates/swc_ecma_ast/src/function.rs
+++ b/crates/swc_ecma_ast/src/function.rs
@@ -52,6 +52,7 @@ impl Take for Function {
 #[ast_node("Parameter")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Param {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -72,6 +73,7 @@ impl From<Pat> for Param {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ParamOrTsParamProp {
     #[tag("TsParameterProperty")]
     TsParamProp(TsParamProp),

--- a/crates/swc_ecma_ast/src/function.rs
+++ b/crates/swc_ecma_ast/src/function.rs
@@ -12,6 +12,7 @@ use crate::{
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Function {
     pub params: Vec<Param>,
 

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -168,6 +168,7 @@ bridge_from!(BindingIdent, Ident, Id);
 /// distinguish identifiers.
 #[ast_node("Identifier")]
 #[derive(Eq, Hash, Default)]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Ident {
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
     pub span: Span,

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -37,6 +37,7 @@ use crate::{typescript::TsTypeAnn, Expr};
 )]
 #[cfg_attr(feature = "rkyv-impl", repr(C))]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BindingIdent {
     #[cfg_attr(feature = "serde-impl", serde(flatten))]
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -386,6 +386,7 @@ impl Ident {
 #[ast_node("Identifier")]
 #[derive(Eq, Hash, Default, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct IdentName {
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
     pub span: Span,
@@ -547,6 +548,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Ident {
 #[ast_node("PrivateName")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct PrivateName {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "value"))]

--- a/crates/swc_ecma_ast/src/jsx.rs
+++ b/crates/swc_ecma_ast/src/jsx.rs
@@ -49,6 +49,7 @@ pub struct JSXNamespacedName {
 #[ast_node("JSXEmptyExpression")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXEmptyExpr {
     pub span: Span,
 }
@@ -56,6 +57,7 @@ pub struct JSXEmptyExpr {
 #[ast_node("JSXExpressionContainer")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXExprContainer {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -66,6 +68,7 @@ pub struct JSXExprContainer {
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXExpr {
     #[tag("JSXEmptyExpression")]
     JSXEmptyExpr(JSXEmptyExpr),
@@ -217,6 +220,7 @@ impl<'a> arbitrary::Arbitrary<'a> for JSXText {
 #[ast_node("JSXElement")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXElement {
     pub span: Span,
     pub opening: JSXOpeningElement,
@@ -238,6 +242,7 @@ impl Take for JSXElement {
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXElementChild {
     #[tag("JSXText")]
     JSXText(JSXText),
@@ -258,6 +263,7 @@ pub enum JSXElementChild {
 #[ast_node("JSXFragment")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXFragment {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/jsx.rs
+++ b/crates/swc_ecma_ast/src/jsx.rs
@@ -14,7 +14,8 @@ use crate::{
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXObject {
     #[tag("JSXMemberExpression")]
     JSXMemberExpr(Box<JSXMemberExpr>),
@@ -24,7 +25,8 @@ pub enum JSXObject {
 
 #[ast_node("JSXMemberExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXMemberExpr {
     pub span: Span,
 
@@ -38,7 +40,8 @@ pub struct JSXMemberExpr {
 /// XML-based namespace syntax:
 #[ast_node("JSXNamespacedName")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXNamespacedName {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "namespace"))]
@@ -48,14 +51,16 @@ pub struct JSXNamespacedName {
 
 #[ast_node("JSXEmptyExpression")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXEmptyExpr {
     pub span: Span,
 }
 
 #[ast_node("JSXExpressionContainer")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXExprContainer {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -65,7 +70,8 @@ pub struct JSXExprContainer {
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXExpr {
     #[tag("JSXEmptyExpression")]
     JSXEmptyExpr(JSXEmptyExpr),
@@ -75,7 +81,8 @@ pub enum JSXExpr {
 
 #[ast_node("JSXSpreadChild")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXSpreadChild {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -84,7 +91,8 @@ pub struct JSXSpreadChild {
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXElementName {
     #[tag("Identifier")]
     Ident(Ident),
@@ -102,7 +110,8 @@ impl Take for JSXElementName {
 
 #[ast_node("JSXOpeningElement")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXOpeningElement {
     pub name: JSXElementName,
 
@@ -135,7 +144,8 @@ impl Take for JSXOpeningElement {
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXAttrOrSpread {
     #[tag("JSXAttribute")]
     JSXAttr(JSXAttr),
@@ -145,7 +155,8 @@ pub enum JSXAttrOrSpread {
 
 #[ast_node("JSXClosingElement")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXClosingElement {
     pub span: Span,
     pub name: JSXElementName,
@@ -153,7 +164,8 @@ pub struct JSXClosingElement {
 
 #[ast_node("JSXAttribute")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXAttr {
     pub span: Span,
     pub name: JSXAttrName,
@@ -163,7 +175,8 @@ pub struct JSXAttr {
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXAttrName {
     #[tag("Identifier")]
     Ident(IdentName),
@@ -173,7 +186,8 @@ pub enum JSXAttrName {
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXAttrValue {
     #[tag("StringLiteral")]
     #[tag("BooleanLiteral")]
@@ -216,7 +230,8 @@ impl<'a> arbitrary::Arbitrary<'a> for JSXText {
 
 #[ast_node("JSXElement")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXElement {
     pub span: Span,
     pub opening: JSXOpeningElement,
@@ -237,7 +252,8 @@ impl Take for JSXElement {
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXElementChild {
     #[tag("JSXText")]
     JSXText(JSXText),
@@ -257,7 +273,8 @@ pub enum JSXElementChild {
 
 #[ast_node("JSXFragment")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXFragment {
     pub span: Span,
 
@@ -282,7 +299,8 @@ impl Take for JSXFragment {
 
 #[ast_node("JSXOpeningFragment")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXOpeningFragment {
     pub span: Span,
 }
@@ -295,7 +313,8 @@ impl Take for JSXOpeningFragment {
 
 #[ast_node("JSXClosingFragment")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXClosingFragment {
     pub span: Span,
 }

--- a/crates/swc_ecma_ast/src/jsx.rs
+++ b/crates/swc_ecma_ast/src/jsx.rs
@@ -195,6 +195,7 @@ pub enum JSXAttrValue {
 
 #[ast_node("JSXText")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXText {
     pub span: Span,
     pub value: Atom,

--- a/crates/swc_ecma_ast/src/jsx.rs
+++ b/crates/swc_ecma_ast/src/jsx.rs
@@ -14,7 +14,7 @@ use crate::{
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXObject {
     #[tag("JSXMemberExpression")]
     JSXMemberExpr(Box<JSXMemberExpr>),
@@ -24,7 +24,7 @@ pub enum JSXObject {
 
 #[ast_node("JSXMemberExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXMemberExpr {
     pub span: Span,
 
@@ -38,7 +38,7 @@ pub struct JSXMemberExpr {
 /// XML-based namespace syntax:
 #[ast_node("JSXNamespacedName")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXNamespacedName {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "namespace"))]
@@ -48,16 +48,14 @@ pub struct JSXNamespacedName {
 
 #[ast_node("JSXEmptyExpression")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXEmptyExpr {
     pub span: Span,
 }
 
 #[ast_node("JSXExpressionContainer")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXExprContainer {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -67,8 +65,7 @@ pub struct JSXExprContainer {
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXExpr {
     #[tag("JSXEmptyExpression")]
     JSXEmptyExpr(JSXEmptyExpr),
@@ -78,7 +75,7 @@ pub enum JSXExpr {
 
 #[ast_node("JSXSpreadChild")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXSpreadChild {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -87,7 +84,7 @@ pub struct JSXSpreadChild {
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXElementName {
     #[tag("Identifier")]
     Ident(Ident),
@@ -105,7 +102,7 @@ impl Take for JSXElementName {
 
 #[ast_node("JSXOpeningElement")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXOpeningElement {
     pub name: JSXElementName,
 
@@ -138,7 +135,7 @@ impl Take for JSXOpeningElement {
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXAttrOrSpread {
     #[tag("JSXAttribute")]
     JSXAttr(JSXAttr),
@@ -148,7 +145,7 @@ pub enum JSXAttrOrSpread {
 
 #[ast_node("JSXClosingElement")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXClosingElement {
     pub span: Span,
     pub name: JSXElementName,
@@ -156,7 +153,7 @@ pub struct JSXClosingElement {
 
 #[ast_node("JSXAttribute")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXAttr {
     pub span: Span,
     pub name: JSXAttrName,
@@ -166,7 +163,7 @@ pub struct JSXAttr {
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXAttrName {
     #[tag("Identifier")]
     Ident(IdentName),
@@ -176,7 +173,7 @@ pub enum JSXAttrName {
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXAttrValue {
     #[tag("StringLiteral")]
     #[tag("BooleanLiteral")]
@@ -219,8 +216,7 @@ impl<'a> arbitrary::Arbitrary<'a> for JSXText {
 
 #[ast_node("JSXElement")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXElement {
     pub span: Span,
     pub opening: JSXOpeningElement,
@@ -241,8 +237,7 @@ impl Take for JSXElement {
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXElementChild {
     #[tag("JSXText")]
     JSXText(JSXText),
@@ -262,8 +257,7 @@ pub enum JSXElementChild {
 
 #[ast_node("JSXFragment")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXFragment {
     pub span: Span,
 
@@ -288,7 +282,7 @@ impl Take for JSXFragment {
 
 #[ast_node("JSXOpeningFragment")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXOpeningFragment {
     pub span: Span,
 }
@@ -301,7 +295,7 @@ impl Take for JSXOpeningFragment {
 
 #[ast_node("JSXClosingFragment")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXClosingFragment {
     pub span: Span,
 }

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -334,6 +334,7 @@ where
 #[ast_node("Invalid")]
 #[derive(Eq, Default, Hash, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Invalid {
     pub span: Span,
 }

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -14,6 +14,7 @@ use crate::jsx::JSXText;
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan, Is)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Lit {
     #[tag("StringLiteral")]
     Str(Str),
@@ -77,6 +78,7 @@ impl Lit {
 
 #[ast_node("BigIntLiteral")]
 #[derive(Eq, Hash)]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BigInt {
     pub span: Span,
     #[cfg_attr(any(feature = "rkyv-impl"), rkyv(with = EncodeBigInt))]
@@ -174,6 +176,7 @@ impl From<BigIntValue> for BigInt {
 /// A string literal.
 #[ast_node("StringLiteral")]
 #[derive(Eq, Hash)]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Str {
     pub span: Span,
 
@@ -294,6 +297,7 @@ bridge_from!(Str, Atom, Cow<'_, str>);
 #[ast_node("BooleanLiteral")]
 #[derive(Copy, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Bool {
     pub span: Span,
     pub value: bool,
@@ -321,6 +325,7 @@ impl From<bool> for Bool {
 #[ast_node("NullLiteral")]
 #[derive(Copy, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Null {
     pub span: Span,
 }
@@ -333,6 +338,7 @@ impl Take for Null {
 
 #[ast_node("RegExpLiteral")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Regex {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -13,7 +13,8 @@ use crate::jsx::JSXText;
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan, Is)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Lit {
     #[tag("StringLiteral")]
     Str(Str),
@@ -77,7 +78,6 @@ impl Lit {
 
 #[ast_node("BigIntLiteral")]
 #[derive(Eq, Hash)]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BigInt {
     pub span: Span,
     #[cfg_attr(any(feature = "rkyv-impl"), rkyv(with = EncodeBigInt))]
@@ -86,6 +86,12 @@ pub struct BigInt {
     /// Use `None` value only for transformations to avoid recalculate
     /// characters in big integer
     pub raw: Option<Atom>,
+}
+
+#[cfg(feature = "shrink-to-fit")]
+impl shrink_to_fit::ShrinkToFit for BigInt {
+    #[inline(always)]
+    fn shrink_to_fit(&mut self) {}
 }
 
 impl EqIgnoreSpan for BigInt {
@@ -295,7 +301,8 @@ bridge_from!(Str, Atom, Cow<'_, str>);
 /// All of `Box<Expr>`, `Expr`, `Lit`, `Bool` implements `From<bool>`.
 #[ast_node("BooleanLiteral")]
 #[derive(Copy, Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Bool {
     pub span: Span,
     pub value: bool,
@@ -322,7 +329,8 @@ impl From<bool> for Bool {
 
 #[ast_node("NullLiteral")]
 #[derive(Copy, Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Null {
     pub span: Span,
 }

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -383,6 +383,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Regex {
 /// `From<usize>`.
 
 #[ast_node("NumericLiteral")]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Number {
     pub span: Span,
     /// **Note**: This should not be `NaN`. Use [crate::Ident] to represent NaN.

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -13,8 +13,7 @@ use crate::jsx::JSXText;
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan, Is)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Lit {
     #[tag("StringLiteral")]
     Str(Str),
@@ -296,8 +295,7 @@ bridge_from!(Str, Atom, Cow<'_, str>);
 /// All of `Box<Expr>`, `Expr`, `Lit`, `Bool` implements `From<bool>`.
 #[ast_node("BooleanLiteral")]
 #[derive(Copy, Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Bool {
     pub span: Span,
     pub value: bool,
@@ -324,8 +322,7 @@ impl From<bool> for Bool {
 
 #[ast_node("NullLiteral")]
 #[derive(Copy, Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Null {
     pub span: Span,
 }

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -7,6 +7,7 @@ use crate::{module_decl::ModuleDecl, stmt::Stmt};
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Program {
     #[tag("Module")]
     Module(Module),
@@ -22,6 +23,7 @@ impl Take for Program {
 
 #[ast_node("Module")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Module {
     pub span: Span,
 
@@ -57,6 +59,7 @@ impl Take for Module {
 
 #[ast_node("Script")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Script {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -96,6 +96,7 @@ impl Take for Script {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ModuleItem {
     #[tag("ImportDeclaration")]
     #[tag("ExportDeclaration")]

--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -13,7 +13,8 @@ use crate::{
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ModuleDecl {
     #[tag("ImportDeclaration")]
     Import(ImportDecl),
@@ -92,7 +93,8 @@ impl Take for ModuleDecl {
 /// is [`ExportDefaultExpr`] and it's not hoisted.
 #[ast_node("ExportDefaultExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultExpr {
     pub span: Span,
 
@@ -102,7 +104,8 @@ pub struct ExportDefaultExpr {
 
 #[ast_node("ExportDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDecl {
     pub span: Span,
 
@@ -112,7 +115,8 @@ pub struct ExportDecl {
 
 #[ast_node("ImportDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportDecl {
     pub span: Span,
 
@@ -133,7 +137,8 @@ pub struct ImportDecl {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -167,7 +172,8 @@ impl Take for ImportDecl {
 /// `export * from 'mod'`
 #[ast_node("ExportAllDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportAll {
     pub span: Span,
 
@@ -196,7 +202,8 @@ impl Take for ExportAll {
 /// `export { foo as bar } from 'mod'`
 #[ast_node("ExportNamedDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct NamedExport {
     pub span: Span,
 
@@ -226,7 +233,8 @@ impl Take for NamedExport {
 
 #[ast_node("ExportDefaultDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultDecl {
     pub span: Span,
 
@@ -235,7 +243,8 @@ pub struct ExportDefaultDecl {
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum DefaultDecl {
     #[tag("ClassExpression")]
     Class(ClassExpr),
@@ -250,7 +259,8 @@ pub enum DefaultDecl {
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ImportSpecifier {
     #[tag("ImportSpecifier")]
     Named(ImportNamedSpecifier),
@@ -288,7 +298,8 @@ impl ImportSpecifier {
 /// e.g. `import foo from 'mod.js'`
 #[ast_node("ImportDefaultSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportDefaultSpecifier {
     pub span: Span,
 
@@ -297,7 +308,8 @@ pub struct ImportDefaultSpecifier {
 /// e.g. `import * as foo from 'mod.js'`.
 #[ast_node("ImportNamespaceSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportStarAsSpecifier {
     pub span: Span,
 
@@ -308,7 +320,8 @@ pub struct ImportStarAsSpecifier {
 /// 'mod.js'`
 #[ast_node("ImportSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportNamedSpecifier {
     pub span: Span,
 
@@ -323,7 +336,8 @@ pub struct ImportNamedSpecifier {
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ExportSpecifier {
     #[tag("ExportNamespaceSpecifier")]
     Namespace(ExportNamespaceSpecifier),
@@ -338,7 +352,8 @@ pub enum ExportSpecifier {
 /// `export * as foo from 'src';`
 #[ast_node("ExportNamespaceSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportNamespaceSpecifier {
     pub span: Span,
 
@@ -348,7 +363,8 @@ pub struct ExportNamespaceSpecifier {
 // export v from 'mod';
 #[ast_node("ExportDefaultSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultSpecifier {
     #[span]
     pub exported: Ident,
@@ -356,7 +372,8 @@ pub struct ExportDefaultSpecifier {
 
 #[ast_node("ExportSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportNamedSpecifier {
     pub span: Span,
     /// `foo` in `export { foo as bar }`
@@ -371,7 +388,8 @@ pub struct ExportNamedSpecifier {
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 // https://tc39.es/ecma262/#prod-ModuleExportName
 pub enum ModuleExportName {
     #[tag("Identifier")]

--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -13,8 +13,7 @@ use crate::{
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ModuleDecl {
     #[tag("ImportDeclaration")]
     Import(ImportDecl),
@@ -93,7 +92,7 @@ impl Take for ModuleDecl {
 /// is [`ExportDefaultExpr`] and it's not hoisted.
 #[ast_node("ExportDefaultExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultExpr {
     pub span: Span,
 
@@ -103,8 +102,7 @@ pub struct ExportDefaultExpr {
 
 #[ast_node("ExportDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDecl {
     pub span: Span,
 
@@ -114,8 +112,7 @@ pub struct ExportDecl {
 
 #[ast_node("ImportDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportDecl {
     pub span: Span,
 
@@ -136,7 +133,7 @@ pub struct ImportDecl {
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -170,7 +167,7 @@ impl Take for ImportDecl {
 /// `export * from 'mod'`
 #[ast_node("ExportAllDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportAll {
     pub span: Span,
 
@@ -199,8 +196,7 @@ impl Take for ExportAll {
 /// `export { foo as bar } from 'mod'`
 #[ast_node("ExportNamedDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct NamedExport {
     pub span: Span,
 
@@ -230,7 +226,7 @@ impl Take for NamedExport {
 
 #[ast_node("ExportDefaultDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultDecl {
     pub span: Span,
 
@@ -239,7 +235,7 @@ pub struct ExportDefaultDecl {
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum DefaultDecl {
     #[tag("ClassExpression")]
     Class(ClassExpr),
@@ -254,8 +250,7 @@ pub enum DefaultDecl {
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ImportSpecifier {
     #[tag("ImportSpecifier")]
     Named(ImportNamedSpecifier),
@@ -293,8 +288,7 @@ impl ImportSpecifier {
 /// e.g. `import foo from 'mod.js'`
 #[ast_node("ImportDefaultSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportDefaultSpecifier {
     pub span: Span,
 
@@ -303,8 +297,7 @@ pub struct ImportDefaultSpecifier {
 /// e.g. `import * as foo from 'mod.js'`.
 #[ast_node("ImportNamespaceSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportStarAsSpecifier {
     pub span: Span,
 
@@ -315,8 +308,7 @@ pub struct ImportStarAsSpecifier {
 /// 'mod.js'`
 #[ast_node("ImportSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportNamedSpecifier {
     pub span: Span,
 
@@ -331,7 +323,7 @@ pub struct ImportNamedSpecifier {
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ExportSpecifier {
     #[tag("ExportNamespaceSpecifier")]
     Namespace(ExportNamespaceSpecifier),
@@ -346,7 +338,7 @@ pub enum ExportSpecifier {
 /// `export * as foo from 'src';`
 #[ast_node("ExportNamespaceSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportNamespaceSpecifier {
     pub span: Span,
 
@@ -356,7 +348,7 @@ pub struct ExportNamespaceSpecifier {
 // export v from 'mod';
 #[ast_node("ExportDefaultSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultSpecifier {
     #[span]
     pub exported: Ident,
@@ -364,7 +356,7 @@ pub struct ExportDefaultSpecifier {
 
 #[ast_node("ExportSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportNamedSpecifier {
     pub span: Span,
     /// `foo` in `export { foo as bar }`
@@ -379,7 +371,7 @@ pub struct ExportNamedSpecifier {
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 // https://tc39.es/ecma262/#prod-ModuleExportName
 pub enum ModuleExportName {
     #[tag("Identifier")]

--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -294,6 +294,7 @@ impl ImportSpecifier {
 #[ast_node("ImportDefaultSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportDefaultSpecifier {
     pub span: Span,
 
@@ -303,6 +304,7 @@ pub struct ImportDefaultSpecifier {
 #[ast_node("ImportNamespaceSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportStarAsSpecifier {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -104,6 +104,7 @@ pub struct ExportDefaultExpr {
 #[ast_node("ExportDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDecl {
     pub span: Span,
 
@@ -199,6 +200,7 @@ impl Take for ExportAll {
 #[ast_node("ExportNamedDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct NamedExport {
     pub span: Span,
 
@@ -253,6 +255,7 @@ pub enum DefaultDecl {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ImportSpecifier {
     #[tag("ImportSpecifier")]
     Named(ImportNamedSpecifier),
@@ -311,6 +314,7 @@ pub struct ImportStarAsSpecifier {
 #[ast_node("ImportSpecifier")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportNamedSpecifier {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -14,6 +14,7 @@ use crate::{
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ModuleDecl {
     #[tag("ImportDeclaration")]
     Import(ImportDecl),
@@ -113,6 +114,7 @@ pub struct ExportDecl {
 #[ast_node("ImportDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportDecl {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/operators.rs
+++ b/crates/swc_ecma_ast/src/operators.rs
@@ -2,7 +2,7 @@ use string_enum::StringEnum;
 use swc_common::EqIgnoreSpan;
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -114,7 +114,7 @@ impl BinaryOp {
 }
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -190,7 +190,7 @@ impl AssignOp {
 }
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -206,7 +206,7 @@ pub enum UpdateOp {
 }
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)

--- a/crates/swc_ecma_ast/src/operators.rs
+++ b/crates/swc_ecma_ast/src/operators.rs
@@ -2,7 +2,8 @@ use string_enum::StringEnum;
 use swc_common::EqIgnoreSpan;
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -114,7 +115,8 @@ impl BinaryOp {
 }
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -190,7 +192,8 @@ impl AssignOp {
 }
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -206,7 +209,8 @@ pub enum UpdateOp {
 }
 
 #[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -103,6 +103,7 @@ pub struct ArrayPat {
 #[ast_node("ObjectPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ObjectPat {
     pub span: Span,
 

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -11,7 +11,8 @@ use crate::{
 
 #[ast_node(no_clone)]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Pat {
     #[tag("Identifier")]
     Ident(BindingIdent),
@@ -84,7 +85,8 @@ pat_to_other!(Box<Expr>);
 
 #[ast_node("ArrayPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ArrayPat {
     pub span: Span,
 
@@ -101,7 +103,8 @@ pub struct ArrayPat {
 
 #[ast_node("ObjectPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ObjectPat {
     pub span: Span,
 
@@ -118,7 +121,8 @@ pub struct ObjectPat {
 
 #[ast_node("AssignmentPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignPat {
     pub span: Span,
 
@@ -130,7 +134,8 @@ pub struct AssignPat {
 /// EsTree `RestElement`
 #[ast_node("RestElement")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct RestPat {
     pub span: Span,
 
@@ -146,7 +151,8 @@ pub struct RestPat {
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ObjectPatProp {
     #[tag("KeyValuePatternProperty")]
     KeyValue(KeyValuePatProp),
@@ -161,7 +167,8 @@ pub enum ObjectPatProp {
 /// `{key: value}`
 #[ast_node("KeyValuePatternProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct KeyValuePatProp {
     #[span(lo)]
     pub key: PropName,
@@ -172,7 +179,8 @@ pub struct KeyValuePatProp {
 /// `{key}` or `{key = value}`
 #[ast_node("AssignmentPatternProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignPatProp {
     pub span: Span,
     /// Note: This type is to help implementing visitor and the field `type_ann`

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -12,6 +12,7 @@ use crate::{
 #[ast_node(no_clone)]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Pat {
     #[tag("Identifier")]
     Ident(BindingIdent),

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -11,8 +11,7 @@ use crate::{
 
 #[ast_node(no_clone)]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Pat {
     #[tag("Identifier")]
     Ident(BindingIdent),
@@ -85,7 +84,7 @@ pat_to_other!(Box<Expr>);
 
 #[ast_node("ArrayPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ArrayPat {
     pub span: Span,
 
@@ -102,8 +101,7 @@ pub struct ArrayPat {
 
 #[ast_node("ObjectPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ObjectPat {
     pub span: Span,
 
@@ -120,7 +118,7 @@ pub struct ObjectPat {
 
 #[ast_node("AssignmentPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignPat {
     pub span: Span,
 
@@ -132,7 +130,7 @@ pub struct AssignPat {
 /// EsTree `RestElement`
 #[ast_node("RestElement")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct RestPat {
     pub span: Span,
 
@@ -148,7 +146,7 @@ pub struct RestPat {
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ObjectPatProp {
     #[tag("KeyValuePatternProperty")]
     KeyValue(KeyValuePatProp),
@@ -163,7 +161,7 @@ pub enum ObjectPatProp {
 /// `{key: value}`
 #[ast_node("KeyValuePatternProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct KeyValuePatProp {
     #[span(lo)]
     pub key: PropName,
@@ -174,7 +172,7 @@ pub struct KeyValuePatProp {
 /// `{key}` or `{key = value}`
 #[ast_node("AssignmentPatternProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignPatProp {
     pub span: Span,
     /// Note: This type is to help implementing visitor and the field `type_ann`

--- a/crates/swc_ecma_ast/src/prop.rs
+++ b/crates/swc_ecma_ast/src/prop.rs
@@ -13,7 +13,8 @@ use crate::{
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Prop {
     /// `a` in `{ a, }`
     #[tag("Identifier")]
@@ -41,7 +42,8 @@ bridge_from!(Prop, Ident, IdentName);
 
 #[ast_node("KeyValueProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct KeyValueProp {
     #[span(lo)]
     pub key: PropName,
@@ -52,7 +54,8 @@ pub struct KeyValueProp {
 
 #[ast_node("AssignmentProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignProp {
     pub span: Span,
     pub key: Ident,
@@ -61,7 +64,8 @@ pub struct AssignProp {
 
 #[ast_node("GetterProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct GetterProp {
     pub span: Span,
     pub key: PropName,
@@ -72,7 +76,8 @@ pub struct GetterProp {
 }
 #[ast_node("SetterProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SetterProp {
     pub span: Span,
     pub key: PropName,
@@ -83,7 +88,8 @@ pub struct SetterProp {
 }
 #[ast_node("MethodProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct MethodProp {
     pub key: PropName,
 
@@ -94,7 +100,8 @@ pub struct MethodProp {
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum PropName {
     #[tag("Identifier")]
     Ident(IdentName),
@@ -148,7 +155,8 @@ impl From<PropName> for MemberProp {
 
 #[ast_node("Computed")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ComputedPropName {
     /// Span including `[` and `]`.
     pub span: Span,

--- a/crates/swc_ecma_ast/src/prop.rs
+++ b/crates/swc_ecma_ast/src/prop.rs
@@ -95,6 +95,7 @@ pub struct MethodProp {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum PropName {
     #[tag("Identifier")]
     Ident(IdentName),
@@ -149,6 +150,7 @@ impl From<PropName> for MemberProp {
 #[ast_node("Computed")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ComputedPropName {
     /// Span including `[` and `]`.
     pub span: Span,

--- a/crates/swc_ecma_ast/src/prop.rs
+++ b/crates/swc_ecma_ast/src/prop.rs
@@ -13,7 +13,7 @@ use crate::{
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Prop {
     /// `a` in `{ a, }`
     #[tag("Identifier")]
@@ -41,7 +41,7 @@ bridge_from!(Prop, Ident, IdentName);
 
 #[ast_node("KeyValueProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct KeyValueProp {
     #[span(lo)]
     pub key: PropName,
@@ -52,7 +52,7 @@ pub struct KeyValueProp {
 
 #[ast_node("AssignmentProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignProp {
     pub span: Span,
     pub key: Ident,
@@ -61,7 +61,7 @@ pub struct AssignProp {
 
 #[ast_node("GetterProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct GetterProp {
     pub span: Span,
     pub key: PropName,
@@ -72,7 +72,7 @@ pub struct GetterProp {
 }
 #[ast_node("SetterProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SetterProp {
     pub span: Span,
     pub key: PropName,
@@ -83,7 +83,7 @@ pub struct SetterProp {
 }
 #[ast_node("MethodProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct MethodProp {
     pub key: PropName,
 
@@ -94,8 +94,7 @@ pub struct MethodProp {
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum PropName {
     #[tag("Identifier")]
     Ident(IdentName),
@@ -149,8 +148,7 @@ impl From<PropName> for MemberProp {
 
 #[ast_node("Computed")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ComputedPropName {
     /// Span including `[` and `]`.
     pub span: Span,

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -11,8 +11,7 @@ use crate::{
 /// Use when only block statements are allowed.
 #[ast_node("BlockStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BlockStmt {
     /// Span including the braces.
     pub span: Span,
@@ -34,7 +33,7 @@ impl Take for BlockStmt {
 
 #[ast_node(no_clone)]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Stmt {
     #[tag("BlockStatement")]
     Block(BlockStmt),
@@ -212,7 +211,7 @@ impl Take for Stmt {
 
 #[ast_node("ExpressionStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExprStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -221,8 +220,7 @@ pub struct ExprStmt {
 
 #[ast_node("EmptyStatement")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
-#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct EmptyStmt {
     /// Span of semicolon.
     pub span: Span,
@@ -230,14 +228,14 @@ pub struct EmptyStmt {
 
 #[ast_node("DebuggerStatement")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct DebuggerStmt {
     pub span: Span,
 }
 
 #[ast_node("WithStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct WithStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "object"))]
@@ -247,7 +245,7 @@ pub struct WithStmt {
 
 #[ast_node("ReturnStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ReturnStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "argument"))]
@@ -256,7 +254,7 @@ pub struct ReturnStmt {
 
 #[ast_node("LabeledStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct LabeledStmt {
     pub span: Span,
     pub label: Ident,
@@ -265,7 +263,7 @@ pub struct LabeledStmt {
 
 #[ast_node("BreakStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BreakStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -274,7 +272,7 @@ pub struct BreakStmt {
 
 #[ast_node("ContinueStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ContinueStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -283,7 +281,7 @@ pub struct ContinueStmt {
 
 #[ast_node("IfStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct IfStmt {
     pub span: Span,
     pub test: Box<Expr>,
@@ -297,7 +295,7 @@ pub struct IfStmt {
 
 #[ast_node("SwitchStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SwitchStmt {
     pub span: Span,
     pub discriminant: Box<Expr>,
@@ -306,7 +304,7 @@ pub struct SwitchStmt {
 
 #[ast_node("ThrowStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ThrowStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "argument"))]
@@ -315,7 +313,7 @@ pub struct ThrowStmt {
 
 #[ast_node("TryStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TryStmt {
     pub span: Span,
 
@@ -330,7 +328,7 @@ pub struct TryStmt {
 
 #[ast_node("WhileStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct WhileStmt {
     pub span: Span,
     pub test: Box<Expr>,
@@ -339,7 +337,7 @@ pub struct WhileStmt {
 
 #[ast_node("DoWhileStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct DoWhileStmt {
     pub span: Span,
     pub test: Box<Expr>,
@@ -348,7 +346,7 @@ pub struct DoWhileStmt {
 
 #[ast_node("ForStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForStmt {
     pub span: Span,
 
@@ -366,7 +364,7 @@ pub struct ForStmt {
 
 #[ast_node("ForInStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForInStmt {
     pub span: Span,
     pub left: ForHead,
@@ -376,7 +374,7 @@ pub struct ForInStmt {
 
 #[ast_node("ForOfStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForOfStmt {
     pub span: Span,
     /// Span of the await token.
@@ -399,7 +397,7 @@ impl Take for ForOfStmt {
 
 #[ast_node("SwitchCase")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SwitchCase {
     pub span: Span,
 
@@ -423,7 +421,7 @@ impl Take for SwitchCase {
 
 #[ast_node("CatchClause")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct CatchClause {
     pub span: Span,
     /// es2019
@@ -439,7 +437,7 @@ pub struct CatchClause {
 /// A head for for-in and for-of loop.
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ForHead {
     #[tag("VariableDeclaration")]
     VarDecl(Box<VarDecl>),
@@ -469,7 +467,7 @@ impl Default for ForHead {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum VarDeclOrExpr {
     #[tag("VariableDeclaration")]
     VarDecl(Box<VarDecl>),

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -12,6 +12,7 @@ use crate::{
 #[ast_node("BlockStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BlockStmt {
     /// Span including the braces.
     pub span: Span,

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -222,6 +222,7 @@ pub struct ExprStmt {
 #[ast_node("EmptyStatement")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct EmptyStmt {
     /// Span of semicolon.
     pub span: Span,

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -11,7 +11,8 @@ use crate::{
 /// Use when only block statements are allowed.
 #[ast_node("BlockStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BlockStmt {
     /// Span including the braces.
     pub span: Span,
@@ -33,7 +34,8 @@ impl Take for BlockStmt {
 
 #[ast_node(no_clone)]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Stmt {
     #[tag("BlockStatement")]
     Block(BlockStmt),
@@ -211,7 +213,8 @@ impl Take for Stmt {
 
 #[ast_node("ExpressionStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExprStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -220,7 +223,8 @@ pub struct ExprStmt {
 
 #[ast_node("EmptyStatement")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct EmptyStmt {
     /// Span of semicolon.
     pub span: Span,
@@ -228,14 +232,16 @@ pub struct EmptyStmt {
 
 #[ast_node("DebuggerStatement")]
 #[derive(Eq, Hash, Copy, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct DebuggerStmt {
     pub span: Span,
 }
 
 #[ast_node("WithStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct WithStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "object"))]
@@ -245,7 +251,8 @@ pub struct WithStmt {
 
 #[ast_node("ReturnStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ReturnStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "argument"))]
@@ -254,7 +261,8 @@ pub struct ReturnStmt {
 
 #[ast_node("LabeledStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct LabeledStmt {
     pub span: Span,
     pub label: Ident,
@@ -263,7 +271,8 @@ pub struct LabeledStmt {
 
 #[ast_node("BreakStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BreakStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -272,7 +281,8 @@ pub struct BreakStmt {
 
 #[ast_node("ContinueStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ContinueStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -281,7 +291,8 @@ pub struct ContinueStmt {
 
 #[ast_node("IfStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct IfStmt {
     pub span: Span,
     pub test: Box<Expr>,
@@ -295,7 +306,8 @@ pub struct IfStmt {
 
 #[ast_node("SwitchStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SwitchStmt {
     pub span: Span,
     pub discriminant: Box<Expr>,
@@ -304,7 +316,8 @@ pub struct SwitchStmt {
 
 #[ast_node("ThrowStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ThrowStmt {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "argument"))]
@@ -313,7 +326,8 @@ pub struct ThrowStmt {
 
 #[ast_node("TryStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TryStmt {
     pub span: Span,
 
@@ -328,7 +342,8 @@ pub struct TryStmt {
 
 #[ast_node("WhileStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct WhileStmt {
     pub span: Span,
     pub test: Box<Expr>,
@@ -337,7 +352,8 @@ pub struct WhileStmt {
 
 #[ast_node("DoWhileStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct DoWhileStmt {
     pub span: Span,
     pub test: Box<Expr>,
@@ -346,7 +362,8 @@ pub struct DoWhileStmt {
 
 #[ast_node("ForStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForStmt {
     pub span: Span,
 
@@ -364,7 +381,8 @@ pub struct ForStmt {
 
 #[ast_node("ForInStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForInStmt {
     pub span: Span,
     pub left: ForHead,
@@ -374,7 +392,8 @@ pub struct ForInStmt {
 
 #[ast_node("ForOfStatement")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForOfStmt {
     pub span: Span,
     /// Span of the await token.
@@ -397,7 +416,8 @@ impl Take for ForOfStmt {
 
 #[ast_node("SwitchCase")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SwitchCase {
     pub span: Span,
 
@@ -421,7 +441,8 @@ impl Take for SwitchCase {
 
 #[ast_node("CatchClause")]
 #[derive(Eq, Hash, EqIgnoreSpan, Default)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct CatchClause {
     pub span: Span,
     /// es2019
@@ -437,7 +458,8 @@ pub struct CatchClause {
 /// A head for for-in and for-of loop.
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ForHead {
     #[tag("VariableDeclaration")]
     VarDecl(Box<VarDecl>),
@@ -467,7 +489,8 @@ impl Default for ForHead {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
-#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))] #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum VarDeclOrExpr {
     #[tag("VariableDeclaration")]
     VarDecl(Box<VarDecl>),

--- a/crates/swc_ecma_ast/src/typescript.rs
+++ b/crates/swc_ecma_ast/src/typescript.rs
@@ -827,6 +827,7 @@ pub struct TsTplLitType {
 #[ast_node("TsInterfaceDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInterfaceDecl {
     pub span: Span,
     pub id: Ident,
@@ -859,6 +860,7 @@ pub struct TsExprWithTypeArgs {
 #[ast_node("TsTypeAliasDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeAliasDecl {
     pub span: Span,
     pub declare: bool,
@@ -872,6 +874,7 @@ pub struct TsTypeAliasDecl {
 #[ast_node("TsEnumDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsEnumDecl {
     pub span: Span,
     pub declare: bool,
@@ -915,6 +918,7 @@ impl AsRef<Atom> for TsEnumMemberId {
 #[ast_node("TsModuleDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsModuleDecl {
     pub span: Span,
     pub declare: bool,

--- a/crates/swc_ecma_ast/src/typescript.rs
+++ b/crates/swc_ecma_ast/src/typescript.rs
@@ -97,6 +97,7 @@ pub struct TsParamProp {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsParamPropParam {
     #[tag("Identifier")]
     Ident(BindingIdent),
@@ -108,6 +109,7 @@ pub enum TsParamPropParam {
 #[ast_node("TsQualifiedName")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsQualifiedName {
     pub span: Span,
     pub left: TsEntityName,
@@ -118,6 +120,7 @@ pub struct TsQualifiedName {
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsEntityName {
     #[tag("TsQualifiedName")]
     TsQualifiedName(Box<TsQualifiedName>),
@@ -133,6 +136,7 @@ pub enum TsEntityName {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsTypeElement {
     #[tag("TsCallSignatureDeclaration")]
     TsCallSignatureDecl(TsCallSignatureDecl),
@@ -159,6 +163,7 @@ pub enum TsTypeElement {
 #[ast_node("TsCallSignatureDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsCallSignatureDecl {
     pub span: Span,
     pub params: Vec<TsFnParam>,
@@ -171,6 +176,7 @@ pub struct TsCallSignatureDecl {
 #[ast_node("TsConstructSignatureDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConstructSignatureDecl {
     pub span: Span,
     pub params: Vec<TsFnParam>,
@@ -183,6 +189,7 @@ pub struct TsConstructSignatureDecl {
 #[ast_node("TsPropertySignature")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsPropertySignature {
     pub span: Span,
     pub readonly: bool,
@@ -196,6 +203,7 @@ pub struct TsPropertySignature {
 #[ast_node("TsGetterSignature")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsGetterSignature {
     pub span: Span,
     pub key: Box<Expr>,
@@ -207,6 +215,7 @@ pub struct TsGetterSignature {
 #[ast_node("TsSetterSignature")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsSetterSignature {
     pub span: Span,
     pub key: Box<Expr>,
@@ -217,6 +226,7 @@ pub struct TsSetterSignature {
 #[ast_node("TsMethodSignature")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsMethodSignature {
     pub span: Span,
     pub key: Box<Expr>,
@@ -349,6 +359,7 @@ impl Clone for TsType {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsFnOrConstructorType {
     #[tag("TsFunctionType")]
     TsFnType(TsFnType),
@@ -383,6 +394,7 @@ impl From<TsIntersectionType> for TsType {
 #[ast_node("TsKeywordType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsKeywordType {
     pub span: Span,
     pub kind: TsKeywordTypeKind,
@@ -390,6 +402,7 @@ pub struct TsKeywordType {
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -441,6 +454,7 @@ pub enum TsKeywordTypeKind {
 #[ast_node("TsThisType")]
 #[derive(Copy, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsThisType {
     pub span: Span,
 }
@@ -448,6 +462,7 @@ pub struct TsThisType {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsFnParam {
     #[tag("Identifier")]
     Ident(BindingIdent),
@@ -465,6 +480,7 @@ pub enum TsFnParam {
 #[ast_node("TsFunctionType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsFnType {
     pub span: Span,
     pub params: Vec<TsFnParam>,
@@ -478,6 +494,7 @@ pub struct TsFnType {
 #[ast_node("TsConstructorType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConstructorType {
     pub span: Span,
     pub params: Vec<TsFnParam>,
@@ -491,6 +508,7 @@ pub struct TsConstructorType {
 #[ast_node("TsTypeReference")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeRef {
     pub span: Span,
     pub type_name: TsEntityName,
@@ -501,6 +519,7 @@ pub struct TsTypeRef {
 #[ast_node("TsTypePredicate")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypePredicate {
     pub span: Span,
     pub asserts: bool,
@@ -513,6 +532,7 @@ pub struct TsTypePredicate {
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsThisTypeOrIdent {
     #[tag("TsThisType")]
     TsThisType(TsThisType),
@@ -525,6 +545,7 @@ pub enum TsThisTypeOrIdent {
 #[ast_node("TsTypeQuery")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeQuery {
     pub span: Span,
     pub expr_name: TsTypeQueryExpr,
@@ -535,6 +556,7 @@ pub struct TsTypeQuery {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsTypeQueryExpr {
     #[tag("TsQualifiedName")]
     #[tag("Identifier")]
@@ -546,6 +568,7 @@ pub enum TsTypeQueryExpr {
 #[ast_node("TsImportType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsImportType {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "argument"))]
@@ -558,6 +581,7 @@ pub struct TsImportType {
 #[ast_node("TsTypeLiteral")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeLit {
     pub span: Span,
     pub members: Vec<TsTypeElement>,
@@ -566,6 +590,7 @@ pub struct TsTypeLit {
 #[ast_node("TsArrayType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsArrayType {
     pub span: Span,
     pub elem_type: Box<TsType>,
@@ -574,6 +599,7 @@ pub struct TsArrayType {
 #[ast_node("TsTupleType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTupleType {
     pub span: Span,
     pub elem_types: Vec<TsTupleElement>,
@@ -582,6 +608,7 @@ pub struct TsTupleType {
 #[ast_node("TsTupleElement")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTupleElement {
     pub span: Span,
     /// `Ident` or `RestPat { arg: Ident }`
@@ -592,6 +619,7 @@ pub struct TsTupleElement {
 #[ast_node("TsOptionalType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsOptionalType {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
@@ -601,6 +629,7 @@ pub struct TsOptionalType {
 #[ast_node("TsRestType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsRestType {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
@@ -610,6 +639,7 @@ pub struct TsRestType {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsUnionOrIntersectionType {
     #[tag("TsUnionType")]
     TsUnionType(TsUnionType),
@@ -621,6 +651,7 @@ pub enum TsUnionOrIntersectionType {
 #[ast_node("TsUnionType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsUnionType {
     pub span: Span,
     pub types: Vec<Box<TsType>>,
@@ -629,6 +660,7 @@ pub struct TsUnionType {
 #[ast_node("TsIntersectionType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsIntersectionType {
     pub span: Span,
     pub types: Vec<Box<TsType>>,
@@ -678,6 +710,7 @@ pub struct TsTypeOperator {
 
 #[derive(StringEnum, Clone, Copy, PartialEq, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -696,6 +729,7 @@ pub enum TsTypeOperatorOp {
 #[ast_node("TsIndexedAccessType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsIndexedAccessType {
     pub span: Span,
     pub readonly: bool,
@@ -706,6 +740,7 @@ pub struct TsIndexedAccessType {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
     any(feature = "rkyv-impl"),
     derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
@@ -778,6 +813,7 @@ impl<'de> Deserialize<'de> for TruePlusMinus {
 #[ast_node("TsMappedType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsMappedType {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -794,6 +830,7 @@ pub struct TsMappedType {
 #[ast_node("TsLiteralType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsLitType {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "literal"))]
@@ -803,6 +840,7 @@ pub struct TsLitType {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsLit {
     #[tag("NumericLiteral")]
     Number(Number),
@@ -823,6 +861,7 @@ pub enum TsLit {
 #[ast_node("TemplateLiteral")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTplLitType {
     pub span: Span,
 
@@ -899,6 +938,7 @@ pub struct TsEnumDecl {
 #[ast_node("TsEnumMember")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsEnumMember {
     pub span: Span,
     pub id: TsEnumMemberId,
@@ -911,6 +951,7 @@ pub struct TsEnumMember {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsEnumMemberId {
     #[tag("Identifier")]
     Ident(Ident),
@@ -947,6 +988,7 @@ pub struct TsModuleDecl {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsNamespaceBody {
     #[tag("TsModuleBlock")]
     TsModuleBlock(TsModuleBlock),
@@ -958,6 +1000,7 @@ pub enum TsNamespaceBody {
 #[ast_node("TsModuleBlock")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsModuleBlock {
     pub span: Span,
     pub body: Vec<ModuleItem>,
@@ -966,6 +1009,7 @@ pub struct TsModuleBlock {
 #[ast_node("TsNamespaceDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsNamespaceDecl {
     pub span: Span,
     pub declare: bool,
@@ -978,6 +1022,7 @@ pub struct TsNamespaceDecl {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsModuleName {
     #[tag("Identifier")]
     Ident(Ident),
@@ -989,6 +1034,7 @@ pub enum TsModuleName {
 #[ast_node("TsImportEqualsDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsImportEqualsDecl {
     pub span: Span,
     pub is_export: bool,
@@ -1000,6 +1046,7 @@ pub struct TsImportEqualsDecl {
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsModuleRef {
     #[tag("TsQualifiedName")]
     #[tag("Identifier")]
@@ -1012,6 +1059,7 @@ pub enum TsModuleRef {
 #[ast_node("TsExternalModuleReference")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsExternalModuleRef {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -1024,6 +1072,7 @@ pub struct TsExternalModuleRef {
 #[ast_node("TsExportAssignment")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsExportAssignment {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -1033,6 +1082,7 @@ pub struct TsExportAssignment {
 #[ast_node("TsNamespaceExportDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsNamespaceExportDecl {
     pub span: Span,
     pub id: Ident,

--- a/crates/swc_ecma_ast/src/typescript.rs
+++ b/crates/swc_ecma_ast/src/typescript.rs
@@ -27,6 +27,7 @@ use crate::{
 #[ast_node("TsTypeAnnotation")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeAnn {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
@@ -46,6 +47,7 @@ pub struct TsTypeParamDecl {
 #[ast_node("TsTypeParameter")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeParam {
     pub span: Span,
     pub name: Ident,
@@ -230,6 +232,7 @@ pub struct TsMethodSignature {
 #[ast_node("TsIndexSignature")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsIndexSignature {
     pub params: Vec<TsFnParam>,
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "typeAnnotation"))]
@@ -248,6 +251,7 @@ pub struct TsIndexSignature {
 #[ast_node(no_clone)]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsType {
     #[tag("TsKeywordType")]
     TsKeywordType(TsKeywordType),
@@ -1048,6 +1052,7 @@ pub struct TsAsExpr {
 #[ast_node("TsTypeAssertion")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeAssertion {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -1059,6 +1064,7 @@ pub struct TsTypeAssertion {
 #[ast_node("TsNonNullExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsNonNullExpr {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -1068,6 +1074,7 @@ pub struct TsNonNullExpr {
 #[ast_node("TsSatisfiesExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsSatisfiesExpr {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]

--- a/crates/swc_ecma_ast/src/typescript.rs
+++ b/crates/swc_ecma_ast/src/typescript.rs
@@ -637,6 +637,7 @@ pub struct TsIntersectionType {
 #[ast_node("TsConditionalType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConditionalType {
     pub span: Span,
     pub check_type: Box<TsType>,
@@ -648,6 +649,7 @@ pub struct TsConditionalType {
 #[ast_node("TsInferType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInferType {
     pub span: Span,
     pub type_param: TsTypeParam,
@@ -656,6 +658,7 @@ pub struct TsInferType {
 #[ast_node("TsParenthesizedType")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsParenthesizedType {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
@@ -665,6 +668,7 @@ pub struct TsParenthesizedType {
 #[ast_node("TsTypeOperator")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeOperator {
     pub span: Span,
     pub op: TsTypeOperatorOp,
@@ -1041,6 +1045,7 @@ pub struct TsNamespaceExportDecl {
 #[ast_node("TsAsExpression")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsAsExpr {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -1105,6 +1110,7 @@ pub enum Accessibility {
 #[ast_node("TsConstAssertion")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConstAssertion {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -1114,6 +1120,7 @@ pub struct TsConstAssertion {
 #[ast_node("TsInstantiation")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInstantiation {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]

--- a/crates/swc_ecma_ast/src/typescript.rs
+++ b/crates/swc_ecma_ast/src/typescript.rs
@@ -36,6 +36,7 @@ pub struct TsTypeAnn {
 #[ast_node("TsTypeParameterDeclaration")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeParamDecl {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "parameters"))]
@@ -68,6 +69,7 @@ pub struct TsTypeParam {
 #[ast_node("TsTypeParameterInstantiation")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeParamInstantiation {
     pub span: Span,
     pub params: Vec<Box<TsType>>,
@@ -76,6 +78,7 @@ pub struct TsTypeParamInstantiation {
 #[ast_node("TsParameterProperty")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsParamProp {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -841,6 +844,7 @@ pub struct TsInterfaceDecl {
 #[ast_node("TsInterfaceBody")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInterfaceBody {
     pub span: Span,
     pub body: Vec<TsTypeElement>,
@@ -849,6 +853,7 @@ pub struct TsInterfaceBody {
 #[ast_node("TsExpressionWithTypeArguments")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsExprWithTypeArgs {
     pub span: Span,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
@@ -1080,6 +1085,7 @@ pub struct TsSatisfiesExpr {
 #[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
 #[cfg_attr(feature = "rkyv-impl", repr(u32))]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Accessibility {
     #[cfg_attr(feature = "serde-impl", serde(rename = "public"))]
     Public,


### PR DESCRIPTION
**Description:**

This PR adds `ShrinkToFit` implementations to all ECMAScript AST nodes.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/9997
 - Depends on https://github.com/dudykr/ddbase/pull/55
 - Depends on https://github.com/dudykr/ddbase/pull/56
 - Depends on https://github.com/dudykr/ddbase/pull/57