### PR TITLE
perf(hstr): Use thin arc for hash and length

### DIFF
--- a/.changeset/eight-steaks-yawn.md
+++ b/.changeset/eight-steaks-yawn.md
@@ -1,0 +1,6 @@
+---
+swc_core: minor
+hstr: minor
+---
+
+perf(hstr): Use thin arc for hash and length

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -1,6 +1,5 @@
 use std::{
     borrow::Cow,
-    ffi::c_void,
     fmt::Debug,
     hash::{BuildHasherDefault, Hash, Hasher},
     ptr::NonNull,

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -79,7 +79,7 @@ where
 
     let hash = calc_hash(&text);
     let entry = storage.insert_entry(text, hash);
-    let entry = Arc::into_raw(entry);
+    let entry = Arc::into_raw(entry) as *mut Entry;
 
     let ptr: NonNull<Entry> = unsafe {
         // Safety: Arc::into_raw returns a non-null pointer

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -2,6 +2,7 @@ use std::{
     borrow::Cow,
     ffi::c_void,
     hash::{BuildHasherDefault, Hash, Hasher},
+    mem::ManuallyDrop,
     ops::Deref,
     ptr::NonNull,
 };
@@ -38,14 +39,10 @@ impl Hash for Item {
     }
 }
 
-pub(crate) type Entry = <Item as Deref>::Target;
+pub(crate) unsafe fn deref_from(ptr: TaggedValue) -> ManuallyDrop<Item> {
+    let item = restore_arc(ptr);
 
-pub(crate) unsafe fn cast(ptr: TaggedValue) -> *const Item {
-    ptr.get_ptr().cast()
-}
-
-pub(crate) unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i Entry {
-    &*cast(ptr)
+    ManuallyDrop::new(item)
 }
 
 pub(crate) unsafe fn restore_arc(v: TaggedValue) -> Item {

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -18,7 +18,7 @@ struct Metadata {
     hash: u64,
 }
 
-type Entry = HeaderSlice<HeaderWithLength<Metadata>, [u8; 0]>;
+type Entry = HeaderSlice<HeaderWithLength<Metadata>, [u8]>;
 
 pub(crate) unsafe fn cast(ptr: TaggedValue) -> *const Entry {
     ptr.get_ptr().cast()

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -7,11 +7,18 @@ use std::{
 };
 
 use rustc_hash::FxHasher;
+use triomphe::ThinArc;
 
 use crate::{
     tagged_value::{TaggedValue, MAX_INLINE_LEN},
     Atom, INLINE_TAG_INIT, LEN_OFFSET, TAG_MASK,
 };
+
+struct Metadata {
+    hash: u64,
+}
+
+type Item = ThinArc<Metadata, u8>;
 
 #[derive(Debug)]
 pub(crate) struct Entry {

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -15,9 +15,14 @@ use crate::{
 };
 
 /// TODO: Remove `Hash` impl
-#[derive(Hash)]
 pub(crate) struct Metadata {
     pub hash: u64,
+}
+
+impl Hash for Metadata {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u64(self.hash);
+    }
 }
 
 pub(crate) type Item = ThinArc<HeaderWithLength<Metadata>, u8>;

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 use rustc_hash::FxHasher;
-use triomphe::ThinArc;
+use triomphe::{HeaderSlice, HeaderWithLength};
 
 use crate::{
     tagged_value::{TaggedValue, MAX_INLINE_LEN},
@@ -19,44 +19,19 @@ struct Metadata {
     hash: u64,
 }
 
-pub(crate) type Item = ThinArc<Metadata, u8>;
+type Entry = HeaderSlice<HeaderWithLength<Metadata>, [u8; 0]>;
 
-#[derive(Debug)]
-pub(crate) struct Entry {
-    pub string: Box<str>,
-    pub hash: u64,
+pub(crate) unsafe fn cast(ptr: TaggedValue) -> *const Entry {
+    ptr.get_ptr().cast()
 }
 
-impl Entry {
-    pub unsafe fn cast(ptr: TaggedValue) -> *const Entry {
-        ptr.get_ptr().cast()
-    }
-
-    pub unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i Entry {
-        &*Self::cast(ptr)
-    }
-
-    pub unsafe fn restore_arc(v: TaggedValue) -> Item {
-        let ptr = v.get_ptr() as *const Item as *const c_void;
-        Item::from_raw(ptr)
-    }
+pub(crate) unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i Entry {
+    &*cast(ptr)
 }
 
-impl PartialEq for Entry {
-    fn eq(&self, other: &Self) -> bool {
-        // Assumption: `store_id` and `alias` don't matter for equality within a single
-        // store (what we care about here). Compare hash first because that's cheaper.
-        self.hash == other.hash && self.string == other.string
-    }
-}
-
-impl Eq for Entry {}
-
-impl Hash for Entry {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // Assumption: type H is an EntryHasher
-        state.write_u64(self.hash);
-    }
+pub(crate) unsafe fn restore_arc(v: TaggedValue) -> Arc<Entry> {
+    let ptr = v.get_ptr() as *const Entry;
+    Arc::from_raw(ptr)
 }
 
 /// A store that stores [Atom]s. Can be merged with other [AtomStore]s for
@@ -104,9 +79,9 @@ where
 
     let hash = calc_hash(&text);
     let entry = storage.insert_entry(text, hash);
-    let entry = Item::into_raw(entry) as *mut c_void;
+    let entry = Arc::into_raw(entry);
 
-    let ptr: NonNull<c_void> = unsafe {
+    let ptr: NonNull<Entry> = unsafe {
         // Safety: Arc::into_raw returns a non-null pointer
         NonNull::new_unchecked(entry)
     };
@@ -117,12 +92,12 @@ where
 }
 
 pub(crate) trait Storage {
-    fn insert_entry(self, text: Cow<str>, hash: u64) -> Item;
+    fn insert_entry(self, text: Cow<str>, hash: u64) -> Arc<Entry>;
 }
 
 impl Storage for &'_ mut AtomStore {
     #[inline(never)]
-    fn insert_entry(self, text: Cow<str>, hash: u64) -> Item {
+    fn insert_entry(self, text: Cow<str>, hash: u64) -> Arc<Entry> {
         let (entry, _) = self
             .data
             .raw_entry_mut()

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -3,10 +3,10 @@ use std::{
     fmt::Debug,
     hash::{BuildHasherDefault, Hash, Hasher},
     ptr::NonNull,
+    sync::{Arc, Weak},
 };
 
 use rustc_hash::FxHasher;
-use triomphe::Arc;
 
 use crate::{
     tagged_value::{TaggedValue, MAX_INLINE_LEN},
@@ -58,7 +58,7 @@ impl Hash for Entry {
 /// # Merging [AtomStore]
 #[derive(Debug)]
 pub struct AtomStore {
-    pub(crate) data: hashbrown::HashMap<Arc<Entry>, (), BuildEntryHasher>,
+    pub(crate) data: hashbrown::HashMap<Weak<Entry>, (), BuildEntryHasher>,
 }
 
 impl Default for AtomStore {

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -16,8 +16,8 @@ use crate::{
 
 /// TODO: Remove `Hash` impl
 #[derive(Hash)]
-struct Metadata {
-    hash: u64,
+pub(crate) struct Metadata {
+    pub hash: u64,
 }
 
 pub(crate) type Item = ThinArc<HeaderWithLength<Metadata>, u8>;
@@ -36,7 +36,7 @@ pub(crate) unsafe fn deref_from<'i>(ptr: TaggedValue) -> &'i Entry {
 }
 
 pub(crate) unsafe fn restore_arc(v: TaggedValue) -> Item {
-    let ptr = v.get_ptr() as *const c_void;
+    let ptr = v.get_ptr();
     ThinArc::from_raw(ptr)
 }
 

--- a/crates/hstr/src/lib.rs
+++ b/crates/hstr/src/lib.rs
@@ -11,10 +11,9 @@ use std::{
 
 use debug_unreachable::debug_unreachable;
 use once_cell::sync::Lazy;
-use tagged_value::TaggedValue;
 
 pub use crate::dynamic::AtomStore;
-use crate::dynamic::Entry;
+use crate::{dynamic::Entry, tagged_value::TaggedValue};
 
 mod dynamic;
 mod global_store;

--- a/crates/hstr/src/lib.rs
+++ b/crates/hstr/src/lib.rs
@@ -5,7 +5,7 @@ use core::str;
 use std::{
     fmt::{Debug, Display},
     hash::Hash,
-    mem::{self, forget},
+    mem::{self, forget, transmute},
     num::NonZeroU8,
     ops::Deref,
     str::from_utf8_unchecked,
@@ -257,7 +257,8 @@ impl Atom {
     fn as_str(&self) -> &str {
         match self.tag() {
             DYNAMIC_TAG => unsafe {
-                from_utf8_unchecked(&crate::dynamic::deref_from(self.unsafe_data).slice)
+                let item = crate::dynamic::deref_from(self.unsafe_data);
+                from_utf8_unchecked(transmute::<&[u8], &'static [u8]>(&item.slice))
             },
             STATIC_TAG => {
                 todo!("static as_str")


### PR DESCRIPTION
**Description:**

This would improve performance and reduce allocation.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/10030