### PR TITLE
perf(hstr): Skip interning if the text is long enough

### DIFF
--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -113,6 +113,14 @@ pub(crate) trait Storage {
 impl Storage for &'_ mut AtomStore {
     #[inline(never)]
     fn insert_entry(self, text: Cow<str>, hash: u64) -> Item {
+        // If the text is too long, interning is not worth it.
+        if text.len() > 512 {
+            return Item(ThinArc::from_header_and_slice(
+                HeaderWithLength::new(Metadata { hash }, text.len()),
+                text.as_bytes(),
+            ));
+        }
+
         let (entry, _) = self
             .data
             .raw_entry_mut()


### PR DESCRIPTION
**Description:**

Almost all long strings are likely to differ, so there's no worth interning them. Those are mostly template literals in the case of SWC, but I didn't see any instance of very long text being identical to other instances.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/10031