### PR TITLE
test(ts/fast-strip): Add tests for `declare module` error cases

### DIFF
--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -129,6 +129,18 @@ exports[`transform in strip-only mode should throw an error when it encounters a
 }
 `;
 
+exports[`transform in strip-only mode should throw an error when it encounters a module 2`] = `
+{
+  "code": "UnsupportedSyntax",
+  "message": "  x \`module\` keyword is not supported. Use \`namespace\` instead.
+   ,----
+ 1 | declare module foo { }
+   :         ^^^^^^
+   \`----
+",
+}
+`;
+
 exports[`transform in strip-only mode should throw an error when it encounters a namespace 1`] = `
 {
   "code": "UnsupportedSyntax",
@@ -151,6 +163,15 @@ exports[`transform in strip-only mode should throw an error when it encounters a
    \`----
 ",
 }
+`;
+
+exports[`transform in transform mode should throw an error when it encounters a declared module 1`] = `
+"  x \`module\` keyword is not supported. Use \`namespace\` instead.
+   ,----
+ 1 | declare module foo { }
+   :         ^^^^^^
+   \`----
+"
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a module 1`] = `

--- a/bindings/binding_typescript_wasm/__tests__/transform.js
+++ b/bindings/binding_typescript_wasm/__tests__/transform.js
@@ -132,6 +132,15 @@ describe("transform", () => {
             ).rejects.toMatchSnapshot();
         });
 
+        it("should throw an error when it encounters a module", async () => {
+            await expect(
+                swc.transform("declare module foo { }", {
+                    mode: "strip-only",
+                    deprecatedTsModuleAsError: true,
+                }),
+            ).rejects.toMatchSnapshot();
+        });
+
         it("should not emit 'Caused by: failed to parse'", async () => {
             await expect(
                 swc.transform("function foo() { await Promise.resolve(1); }", {
@@ -166,6 +175,15 @@ describe("transform", () => {
         it("should throw an error when it encounters a module", async () => {
             await expect(
                 swc.transform("module foo { }", {
+                    mode: "transform",
+                    deprecatedTsModuleAsError: true,
+                }),
+            ).rejects.toMatchSnapshot();
+        });
+
+        it("should throw an error when it encounters a declared module", async () => {
+            await expect(
+                swc.transform("declare module foo { }", {
                     mode: "transform",
                     deprecatedTsModuleAsError: true,
                 }),

--- a/crates/swc_fast_ts_strip/tests/errors/ts-module.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/ts-module.swc-stderr
@@ -5,6 +5,19 @@
    : ^^^^^^
  4 |     export const foo = 1;
    `----
+  x `module` keyword is not supported. Use `namespace` instead.
+   ,-[7:1]
+ 6 | 
+ 7 | module Foo { }
+   : ^^^^^^
+ 8 | declare module Bar { }
+   `----
+  x `module` keyword is not supported. Use `namespace` instead.
+   ,-[8:1]
+ 7 | module Foo { }
+ 8 | declare module Bar { }
+   :         ^^^^^^
+   `----
   x TypeScript namespace declaration is not supported in strip-only mode
    ,-[3:1]
  2 |     

--- a/crates/swc_fast_ts_strip/tests/errors/ts-module.ts
+++ b/crates/swc_fast_ts_strip/tests/errors/ts-module.ts
@@ -3,3 +3,6 @@
 module Foo {
     export const foo = 1;
 }
+
+module Foo { }
+declare module Bar { }


### PR DESCRIPTION
**Related issue:**
- https://github.com/nodejs/amaro/pull/174