### PR TITLE
chore: Use `cargo fmt --` instead of `rustfmt --`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
             "taplo format"
         ],
         "*.rs": [
-            "rustfmt --"
+            "cargo fmt --"
         ],
         "*.json": [
             "prettier --write"


### PR DESCRIPTION
**Description:**

