### PR TITLE
refactor(atoms): Rename `FastAtom` to `UnsafeAtom`

### DIFF
--- a/.changeset/two-jeans-itch.md
+++ b/.changeset/two-jeans-itch.md
@@ -1,0 +1,5 @@
+---
+swc_atoms: major
+---
+
+refactor(atoms): Rename `FastAtom` to `UnsafeAtom`

--- a/crates/swc_atoms/src/fast.rs
+++ b/crates/swc_atoms/src/fast.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::Atom;
 
-/// FastAtom is a wrapper around [Atom] that does not allocate, but extremely
+/// UnsafeAtom is a wrapper around [Atom] that does not allocate, but extremely
 /// unsafe.
 ///
 /// Do not use this unless you know what you are doing.
@@ -13,9 +13,9 @@ use crate::Atom;
 /// **Currently, it's considered as a unstable API and may be changed in the
 /// future without a semver bump.**
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FastAtom(ManuallyDrop<Atom>);
+pub struct UnsafeAtom(ManuallyDrop<Atom>);
 
-impl FastAtom {
+impl UnsafeAtom {
     /// # Safety
     ///
     ///  - You should ensure that the passed `atom` is not freed.
@@ -23,8 +23,8 @@ impl FastAtom {
     /// Some simple solutions to ensure this are
     ///
     ///  - Collect all [Atom] and store them somewhere while you are using
-    ///    [FastAtom]
-    ///  - Use [FastAtom] only for short-lived operations where all [Atom] is
+    ///    [UnsafeAtom]
+    ///  - Use [UnsafeAtom] only for short-lived operations where all [Atom] is
     ///    stored in AST and ensure that the AST is not dropped.
     #[inline]
     pub unsafe fn new(atom: &Atom) -> Self {
@@ -32,7 +32,7 @@ impl FastAtom {
     }
 }
 
-impl Deref for FastAtom {
+impl Deref for UnsafeAtom {
     type Target = Atom;
 
     #[inline]
@@ -41,14 +41,14 @@ impl Deref for FastAtom {
     }
 }
 
-impl Clone for FastAtom {
+impl Clone for UnsafeAtom {
     #[inline]
     fn clone(&self) -> Self {
         unsafe { Self::new(&self.0) }
     }
 }
 
-impl PartialEq<Atom> for FastAtom {
+impl PartialEq<Atom> for UnsafeAtom {
     #[inline]
     fn eq(&self, other: &Atom) -> bool {
         *self.0 == *other

--- a/crates/swc_atoms/src/lib.rs
+++ b/crates/swc_atoms/src/lib.rs
@@ -22,8 +22,9 @@ use once_cell::sync::Lazy;
 use serde::Serializer;
 
 pub use self::{atom as js_word, Atom as JsWord};
+pub use crate::fast::UnsafeAtom;
 
-pub mod fast;
+mod fast;
 
 /// Clone-on-write string.
 ///

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use phf::phf_set;
-use swc_atoms::{fast::FastAtom, js_word, Atom};
+use swc_atoms::{js_word, Atom, UnsafeAtom};
 use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Mark, Span, Spanned, SyntaxContext, DUMMY_SP,
 };
@@ -475,30 +475,30 @@ impl From<IdentName> for BindingIdent {
 ///
 /// **Currently, it's considered as a unstable API and may be changed in the
 /// future without a semver bump.**
-pub type UnsafeId = (FastAtom, SyntaxContext);
+pub type UnsafeId = (UnsafeAtom, SyntaxContext);
 
 /// This is extremely unsafe so don't use it unless you know what you are doing.
 ///
 /// # Safety
 ///
-/// See [`FastAtom::new`] for constraints.
+/// See [`UnsafeAtom::new`] for constraints.
 ///
 /// **Currently, it's considered as a unstable API and may be changed in the
 /// future without a semver bump.**
 pub unsafe fn unsafe_id(id: &Id) -> UnsafeId {
-    (FastAtom::new(&id.0), id.1)
+    (UnsafeAtom::new(&id.0), id.1)
 }
 
 /// This is extremely unsafe so don't use it unless you know what you are doing.
 ///
 /// # Safety
 ///
-/// See [`FastAtom::new`] for constraints.
+/// See [`UnsafeAtom::new`] for constraints.
 ///
 /// **Currently, it's considered as a unstable API and may be changed in the
 /// future without a semver bump.**
 pub unsafe fn unsafe_id_from_ident(id: &Ident) -> UnsafeId {
-    (FastAtom::new(&id.sym), id.ctxt)
+    (UnsafeAtom::new(&id.sym), id.ctxt)
 }
 
 /// See [Ident] for documentation.


### PR DESCRIPTION
**Description:**

`UnsafeAtom` is a better name, because it's not only fast.