### PR TITLE
perf(es/minifier): Make DCE analyzer parallel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5704,7 +5704,6 @@ dependencies = [
 name = "swc_ecma_transforms_optimization"
 version = "11.1.0"
 dependencies = [
- "ahash",
  "dashmap 5.5.3",
  "indexmap 2.7.1",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5704,6 +5704,7 @@ dependencies = [
 name = "swc_ecma_transforms_optimization"
 version = "11.1.0"
 dependencies = [
+ "ahash",
  "dashmap 5.5.3",
  "indexmap 2.7.1",
  "once_cell",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5726,6 +5726,7 @@ dependencies = [
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_fast_graph",
+ "swc_par_iter",
  "swc_parallel",
  "testing",
  "thread_local",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5728,6 +5728,7 @@ dependencies = [
  "swc_fast_graph",
  "swc_parallel",
  "testing",
+ "thread_local",
  "tracing",
 ]
 
@@ -6639,9 +6640,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.7"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ resolver = "2"
   tempfile                  = "3.6.0"
   termcolor                 = "1.0"
   thiserror                 = "1.0.30"
+  thread_local              = "1.1.8"
   tokio                     = { version = "1", default-features = false }
   toml                      = "0.8.2"
   tracing                   = "0.1.40"

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -22,6 +22,7 @@ concurrent = [
 debug = []
 
 [dependencies]
+ahash        = { workspace = true }
 dashmap      = { workspace = true }
 indexmap     = { workspace = true }
 once_cell    = { workspace = true }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -22,7 +22,6 @@ concurrent = [
 debug = []
 
 [dependencies]
-ahash        = { workspace = true }
 dashmap      = { workspace = true }
 indexmap     = { workspace = true }
 once_cell    = { workspace = true }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -41,6 +41,7 @@ swc_ecma_transforms_macros = { version = "1.0.0", path = "../swc_ecma_transforms
 swc_ecma_utils             = { version = "11.0.0", path = "../swc_ecma_utils" }
 swc_ecma_visit             = { version = "8.0.0", path = "../swc_ecma_visit" }
 swc_fast_graph             = { version = "9.0.0", path = "../swc_fast_graph" }
+swc_par_iter               = { version = "1.0.0", path = "../swc_par_iter" }
 swc_parallel               = { version = "1.3.0", path = "../swc_parallel", default-features = false }
 
 

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -22,14 +22,15 @@ concurrent = [
 debug = []
 
 [dependencies]
-dashmap    = { workspace = true }
-indexmap   = { workspace = true }
-once_cell  = { workspace = true }
-petgraph   = { workspace = true }
-rayon      = { workspace = true, optional = true }
-rustc-hash = { workspace = true }
-serde_json = { workspace = true }
-tracing    = { workspace = true }
+dashmap      = { workspace = true }
+indexmap     = { workspace = true }
+once_cell    = { workspace = true }
+petgraph     = { workspace = true }
+rayon        = { workspace = true, optional = true }
+rustc-hash   = { workspace = true }
+serde_json   = { workspace = true }
+thread_local = { workspace = true }
+tracing      = { workspace = true }
 
 swc_atoms                  = { version = "5.0.0", path = "../swc_atoms" }
 swc_common                 = { version = "8.0.1", path = "../swc_common" }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -264,7 +264,14 @@ impl Parallel for Analyzer<'_> {
 
         self.scope
             .bindings_affected_by_eval
+            .reserve(other.scope.bindings_affected_by_eval.len());
+        self.scope
+            .bindings_affected_by_eval
             .extend(other.scope.bindings_affected_by_eval);
+
+        self.scope
+            .bindings_affected_by_arguements
+            .reserve(other.scope.bindings_affected_by_arguements.len());
         self.scope
             .bindings_affected_by_arguements
             .extend(other.scope.bindings_affected_by_arguements);
@@ -1322,6 +1329,8 @@ where
     S: BuildHasher,
 {
     fn merge(&mut self, other: Self) {
+        self.reserve(other.len());
+
         for (k, v) in other {
             match self.entry(k) {
                 std::collections::hash_map::Entry::Occupied(mut e) => {
@@ -1342,6 +1351,8 @@ where
     S: BuildHasher,
 {
     fn merge(&mut self, other: Self) {
+        self.reserve(other.len());
+
         for (k, v) in other {
             match self.entry(k) {
                 indexmap::map::Entry::Occupied(mut e) => {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -157,7 +157,7 @@ impl Data {
     fn subtract_cycles(&mut self) {
         let edges = take(&mut self.edges);
 
-        let mut graph = FastDiGraphMap::with_capacity(self.used_names.len(), self.edges.0.len());
+        let mut graph = FastDiGraphMap::with_capacity(self.used_names.len(), edges.0.len());
         let mut graph_ix: IndexMap<(JsWord, SyntaxContext), u32, RandomState> =
             IndexMap::with_capacity_and_hasher(self.used_names.len(), Default::default());
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, sync::Arc};
+use std::{borrow::Cow, cell::RefCell, sync::Arc};
 
 use indexmap::IndexSet;
 use petgraph::{algo::tarjan_scc, Direction::Incoming};
@@ -19,6 +19,7 @@ use swc_ecma_visit::{
     noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 use swc_fast_graph::digraph::FastDiGraphMap;
+use thread_local::ThreadLocal;
 use tracing::{debug, span, Level};
 
 use crate::debug_assert_valid;
@@ -111,6 +112,7 @@ struct Data {
     graph: FastDiGraphMap<u32, VarInfo>,
     /// Entrypoints.
     entries: FxHashSet<u32>,
+    entry_ids: FxHashSet<Id>,
 
     graph_ix: IndexSet<Id, FxBuildHasher>,
 }
@@ -211,7 +213,7 @@ struct Analyzer<'a> {
     config: &'a Config,
     in_var_decl: bool,
     scope: Scope<'a>,
-    data: &'a mut Data,
+    data: Arc<ThreadLocal<RefCell<Data>>>,
     cur_class_id: Option<Id>,
     cur_fn_id: Option<Id>,
 }
@@ -271,7 +273,7 @@ impl Analyzer<'_> {
 
             let mut v = Analyzer {
                 scope: child,
-                data: self.data,
+                data: self.data.clone(),
                 cur_fn_id: self.cur_fn_id.clone(),
                 cur_class_id: self.cur_class_id.clone(),
                 ..*self
@@ -288,7 +290,13 @@ impl Analyzer<'_> {
         // If we found eval, mark all declarations in scope and upper as used
         if child_scope.found_direct_eval {
             for id in child_scope.bindings_affected_by_eval {
-                self.data.used_names.entry(id).or_default().usage += 1;
+                self.data
+                    .get_or_default()
+                    .borrow_mut()
+                    .used_names
+                    .entry(id)
+                    .or_default()
+                    .usage += 1;
             }
 
             self.scope.found_direct_eval = true;
@@ -298,7 +306,13 @@ impl Analyzer<'_> {
             // Parameters
 
             for id in child_scope.bindings_affected_by_arguements {
-                self.data.used_names.entry(id).or_default().usage += 1;
+                self.data
+                    .get_or_default()
+                    .borrow_mut()
+                    .used_names
+                    .entry(id)
+                    .or_default()
+                    .usage += 1;
             }
 
             if !matches!(kind, ScopeKind::Fn) {
@@ -324,16 +338,19 @@ impl Analyzer<'_> {
             }
         }
 
+        let mut data = self.data.get_or_default().borrow_mut();
+
         if self.scope.is_ast_path_empty() {
             // Add references from top level items into graph
-            let idx = self.data.node(&id);
-            self.data.entries.insert(idx);
+            let idx = data.node(&id);
+            data.entries.insert(idx);
+            data.entry_ids.insert(id.clone());
         } else {
             let mut scope = Some(&self.scope);
 
             while let Some(s) = scope {
                 for component in &s.ast_path {
-                    self.data.add_dep_edge(component, &id, assign);
+                    data.add_dep_edge(component, &id, assign);
                 }
 
                 if s.kind == ScopeKind::Fn && !s.ast_path.is_empty() {
@@ -345,9 +362,9 @@ impl Analyzer<'_> {
         }
 
         if assign {
-            self.data.used_names.entry(id).or_default().assign += 1;
+            data.used_names.entry(id).or_default().assign += 1;
         } else {
-            self.data.used_names.entry(id).or_default().usage += 1;
+            data.used_names.entry(id).or_default().usage += 1;
         }
     }
 }
@@ -633,11 +650,8 @@ impl TreeShaker {
             }
 
             // Abort if the variable is declared on top level scope.
-            let ix = self.data.graph_ix.get_index_of(&name);
-            if let Some(ix) = ix {
-                if self.data.entries.contains(&(ix as u32)) {
-                    return false;
-                }
+            if self.data.entry_ids.contains(&name) {
+                return false;
             }
         }
 
@@ -907,21 +921,37 @@ impl VisitMut for TreeShaker {
             self.bindings = Arc::new(collect_decls(&*m))
         }
 
-        let mut data = Default::default();
+        let data: Arc<ThreadLocal<RefCell<Data>>> = Default::default();
 
         {
             let mut analyzer = Analyzer {
                 config: &self.config,
                 in_var_decl: false,
                 scope: Default::default(),
-                data: &mut data,
+                data: data.clone(),
                 cur_class_id: Default::default(),
                 cur_fn_id: Default::default(),
             };
             m.visit_with(&mut analyzer);
         }
-        data.subtract_cycles();
-        self.data = Arc::new(data);
+        let data = Arc::try_unwrap(data)
+            .map_err(|_| {})
+            .unwrap()
+            .into_iter()
+            .map(|d| d.into_inner())
+            .map(|mut data| {
+                data.subtract_cycles();
+                data
+            })
+            .collect::<Vec<_>>();
+        let mut merged = Data::default();
+
+        for data in data {
+            merged.used_names.extend(data.used_names);
+            merged.entry_ids.extend(data.entry_ids);
+        }
+
+        self.data = Arc::new(merged);
 
         m.visit_mut_children_with(self);
     }
@@ -968,21 +998,37 @@ impl VisitMut for TreeShaker {
             self.bindings = Arc::new(collect_decls(&*m))
         }
 
-        let mut data = Default::default();
+        let data: Arc<ThreadLocal<RefCell<Data>>> = Default::default();
 
         {
             let mut analyzer = Analyzer {
                 config: &self.config,
                 in_var_decl: false,
                 scope: Default::default(),
-                data: &mut data,
+                data: data.clone(),
                 cur_class_id: Default::default(),
                 cur_fn_id: Default::default(),
             };
             m.visit_with(&mut analyzer);
         }
-        data.subtract_cycles();
-        self.data = Arc::new(data);
+        let data = Arc::try_unwrap(data)
+            .map_err(|_| {})
+            .unwrap()
+            .into_iter()
+            .map(|d| d.into_inner())
+            .map(|mut data| {
+                data.subtract_cycles();
+                data
+            })
+            .collect::<Vec<_>>();
+        let mut merged = Data::default();
+
+        for data in data {
+            merged.used_names.extend(data.used_names);
+            merged.entry_ids.extend(data.entry_ids);
+        }
+
+        self.data = Arc::new(merged);
 
         m.visit_mut_children_with(self);
     }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -193,7 +193,7 @@ impl Data {
 
             for &i in &cycle {
                 for &j in &cycle {
-                    if i == j {
+                    if i <= j {
                         continue;
                     }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -5,7 +5,6 @@ use petgraph::{algo::tarjan_scc, Direction::Incoming};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use swc_atoms::{atom, Atom};
 use swc_common::{
-    collections::AHashSet,
     pass::{CompilerPass, Repeated},
     util::take::Take,
     Mark, SyntaxContext, DUMMY_SP,
@@ -114,13 +113,10 @@ struct Data {
     edges: Edges,
     /// Entrypoints.
     entry_ids: FxHashSet<Id>,
-
-    graph_ix: IndexSet<Id, FxBuildHasher>,
-    graph_ix: IndexSet<Id, BuildHasherDefault<FxHasher>>,
 }
 
 #[derive(Default)]
-struct Edges(IndexMap<(Id, Id), VarInfo, RandomState>);
+struct Edges(IndexMap<(Id, Id), VarInfo, FxBuildHasher>);
 
 impl Data {
     /// Add an edge to dependency graph
@@ -148,7 +144,7 @@ impl Data {
         let edges = take(&mut self.edges);
 
         let mut graph = FastDiGraphMap::with_capacity(self.used_names.len(), edges.0.len());
-        let mut graph_ix: IndexMap<(JsWord, SyntaxContext), u32, RandomState> =
+        let mut graph_ix: IndexMap<(JsWord, SyntaxContext), u32, FxBuildHasher> =
             IndexMap::with_capacity_and_hasher(self.used_names.len(), Default::default());
 
         let mut get_node = |id: Id| -> u32 {
@@ -163,7 +159,7 @@ impl Data {
             .entry_ids
             .iter()
             .map(|id| get_node(id.clone()))
-            .collect::<IndexSet<_, RandomState>>();
+            .collect::<IndexSet<_, FxBuildHasher>>();
 
         for ((src, dst), info) in edges.0 {
             let src = get_node(src);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1,11 +1,4 @@
-use std::{
-    borrow::Cow,
-    cell::RefCell,
-    collections::HashMap,
-    hash::{BuildHasher, Hash},
-    mem::take,
-    sync::Arc,
-};
+use std::{borrow::Cow, cell::RefCell, mem::take, sync::Arc};
 
 use ahash::RandomState;
 use indexmap::{IndexMap, IndexSet};
@@ -36,6 +29,7 @@ use swc_ecma_visit::{
     noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 use swc_fast_graph::digraph::FastDiGraphMap;
+use swc_parallel::merge::{merge_in_parallel, Merge};
 use thread_local::ThreadLocal;
 use tracing::{debug, span, Level};
 
@@ -1319,56 +1313,11 @@ fn merge_data(data: Arc<ThreadLocal<RefCell<Data>>>) -> Data {
     }
 
     // merged.subtract_cycles();
+    let mut merged = merge_in_parallel(data);
+
+    merged.subtract_cycles();
 
     merged
-}
-
-trait Merge {
-    fn merge(&mut self, other: Self);
-}
-
-impl<K, V, S> Merge for HashMap<K, V, S>
-where
-    K: Eq + Hash,
-    V: Merge,
-    S: BuildHasher,
-{
-    fn merge(&mut self, other: Self) {
-        self.reserve(other.len());
-
-        for (k, v) in other {
-            match self.entry(k) {
-                std::collections::hash_map::Entry::Occupied(mut e) => {
-                    e.get_mut().merge(v);
-                }
-                std::collections::hash_map::Entry::Vacant(e) => {
-                    e.insert(v);
-                }
-            }
-        }
-    }
-}
-
-impl<K, V, S> Merge for IndexMap<K, V, S>
-where
-    K: Eq + Hash,
-    V: Merge,
-    S: BuildHasher,
-{
-    fn merge(&mut self, other: Self) {
-        self.reserve(other.len());
-
-        for (k, v) in other {
-            match self.entry(k) {
-                indexmap::map::Entry::Occupied(mut e) => {
-                    e.get_mut().merge(v);
-                }
-                indexmap::map::Entry::Vacant(e) => {
-                    e.insert(v);
-                }
-            }
-        }
-    }
 }
 
 impl Merge for VarInfo {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1,11 +1,20 @@
-use std::{borrow::Cow, cell::RefCell, hash::BuildHasherDefault, sync::Arc};
+use std::{
+    borrow::Cow,
+    cell::RefCell,
+    collections::HashMap,
+    hash::{BuildHasher, Hash},
+    mem::take,
+    sync::Arc,
+};
 
-use indexmap::IndexSet;
+use ahash::RandomState;
+use indexmap::{IndexMap, IndexSet};
 use petgraph::{algo::tarjan_scc, Direction::Incoming};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use swc_atoms::{atom, Atom};
 use swc_common::{
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{atom, JsWord};
 use swc_common::{
     collections::AHashSet,
@@ -113,13 +122,8 @@ impl CompilerPass for TreeShaker {
 struct Data {
     used_names: FxHashMap<Id, VarInfo>,
 
-    /// Variable usage graph
-    ///
-    /// We use `u32` because [FastDiGraphMap] stores types as `(N, 1 bit)` so if
-    /// we use u32 it fits into the cache line of cpu.
-    graph: FastDiGraphMap<u32, VarInfo>,
+    edges: IndexMap<(Id, Id), VarInfo, RandomState>,
     /// Entrypoints.
-    entries: FxHashSet<u32>,
     entry_ids: FxHashSet<Id>,
 
     graph_ix: IndexSet<Id, FxBuildHasher>,
@@ -127,43 +131,54 @@ struct Data {
 }
 
 impl Data {
-    fn node(&mut self, id: &Id) -> u32 {
-        self.graph_ix.get_index_of(id).unwrap_or_else(|| {
-            let ix = self.graph_ix.len();
-            self.graph_ix.insert_full(id.clone());
-            ix
-        }) as _
-    }
-
     /// Add an edge to dependency graph
-    fn add_dep_edge(&mut self, from: &Id, to: &Id, assign: bool) {
-        let from = self.node(from);
-        let to = self.node(to);
-
-        match self.graph.edge_weight_mut(from, to) {
-            Some(info) => {
+    fn add_dep_edge(&mut self, from: Id, to: Id, assign: bool) {
+        match self.edges.entry((from, to)) {
+            indexmap::map::Entry::Occupied(mut info) => {
                 if assign {
-                    info.assign += 1;
+                    info.get_mut().assign += 1;
                 } else {
-                    info.usage += 1;
+                    info.get_mut().usage += 1;
                 }
             }
-            None => {
-                self.graph.add_edge(
-                    from,
-                    to,
-                    VarInfo {
-                        usage: u32::from(!assign),
-                        assign: u32::from(assign),
-                    },
-                );
+            indexmap::map::Entry::Vacant(info) => {
+                info.insert(VarInfo {
+                    usage: u32::from(!assign),
+                    assign: u32::from(assign),
+                });
             }
-        };
+        }
     }
 
     /// Traverse the graph and subtract usages from `used_names`.
     fn subtract_cycles(&mut self) {
-        let cycles = tarjan_scc(&self.graph);
+        let edges = take(&mut self.edges);
+
+        let mut graph = FastDiGraphMap::default();
+        let mut graph_ix = IndexMap::<Id, u32, RandomState>::default();
+
+        let mut get_node = |id: Id| -> u32 {
+            let len = graph_ix.len();
+
+            let id = *graph_ix.entry(id).or_insert(len as u32);
+
+            id as _
+        };
+
+        let entries = self
+            .entry_ids
+            .iter()
+            .map(|id| get_node(id.clone()))
+            .collect::<IndexSet<_, RandomState>>();
+
+        for ((src, dst), info) in edges {
+            let src = get_node(src);
+            let dst = get_node(dst);
+
+            graph.add_edge(src, dst, info);
+        }
+
+        let cycles = tarjan_scc(&graph);
 
         'c: for cycle in cycles {
             if cycle.len() == 1 {
@@ -174,11 +189,11 @@ impl Data {
             // of cycle.
             for &node in &cycle {
                 // It's referenced by an outer node.
-                if self.entries.contains(&node) {
+                if entries.contains(&node) {
                     continue 'c;
                 }
 
-                if self.graph.neighbors_directed(node, Incoming).any(|node| {
+                if graph.neighbors_directed(node, Incoming).any(|node| {
                     // Node in cycle does not matter
                     !cycle.contains(&node)
                 }) {
@@ -192,13 +207,13 @@ impl Data {
                         continue;
                     }
 
-                    let id = self.graph_ix.get_index(j as _);
+                    let id = graph_ix.get_index(j as _);
                     let id = match id {
-                        Some(id) => id,
+                        Some(id) => id.0,
                         None => continue,
                     };
 
-                    if let Some(w) = self.graph.edge_weight(i, j) {
+                    if let Some(w) = graph.edge_weight(i, j) {
                         let e = self.used_names.entry(id.clone()).or_default();
                         e.usage -= w.usage;
                         e.assign -= w.assign;
@@ -380,15 +395,13 @@ impl Analyzer<'_> {
 
         if self.scope.is_ast_path_empty() {
             // Add references from top level items into graph
-            let idx = data.node(&id);
-            data.entries.insert(idx);
             data.entry_ids.insert(id.clone());
         } else {
             let mut scope = Some(&self.scope);
 
             while let Some(s) = scope {
                 for component in &s.ast_path {
-                    data.add_dep_edge(component, &id, assign);
+                    data.add_dep_edge(component.clone(), id.clone(), assign);
                 }
 
                 if s.kind == ScopeKind::Fn && !s.ast_path.is_empty() {
@@ -1286,19 +1299,69 @@ fn merge_data(data: Arc<ThreadLocal<RefCell<Data>>>) -> Data {
         .unwrap()
         .into_iter()
         .map(|d| d.into_inner())
-        .map(|mut data| {
-            data.subtract_cycles();
-            data
-        })
         .collect::<Vec<_>>();
     let mut merged = Data::default();
 
     for data in data {
-        merged.used_names.extend(data.used_names);
+        merged.used_names.merge(data.used_names);
         merged.entry_ids.extend(data.entry_ids);
+        merged.edges.merge(data.edges);
     }
 
+    merged.subtract_cycles();
+
     merged
+}
+
+trait Merge {
+    fn merge(&mut self, other: Self);
+}
+
+impl<K, V, S> Merge for HashMap<K, V, S>
+where
+    K: Eq + Hash,
+    V: Merge,
+    S: BuildHasher,
+{
+    fn merge(&mut self, other: Self) {
+        for (k, v) in other {
+            match self.entry(k) {
+                std::collections::hash_map::Entry::Occupied(mut e) => {
+                    e.get_mut().merge(v);
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(v);
+                }
+            }
+        }
+    }
+}
+
+impl<K, V, S> Merge for IndexMap<K, V, S>
+where
+    K: Eq + Hash,
+    V: Merge,
+    S: BuildHasher,
+{
+    fn merge(&mut self, other: Self) {
+        for (k, v) in other {
+            match self.entry(k) {
+                indexmap::map::Entry::Occupied(mut e) => {
+                    e.get_mut().merge(v);
+                }
+                indexmap::map::Entry::Vacant(e) => {
+                    e.insert(v);
+                }
+            }
+        }
+    }
+}
+
+impl Merge for VarInfo {
+    fn merge(&mut self, other: Self) {
+        self.usage += other.usage;
+        self.assign += other.assign;
+    }
 }
 
 impl Scope<'_> {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -10,10 +10,7 @@ use swc_common::{
     Mark, SyntaxContext, DUMMY_SP,
 };
 use swc_ecma_ast::*;
-use swc_ecma_transforms_base::{
-    helpers::{Helpers, HELPERS},
-    perf::{cpu_count, Parallel},
-};
+use swc_ecma_transforms_base::perf::{cpu_count, Parallel};
 use swc_ecma_utils::{
     collect_decls, find_pat_ids, parallel::ParallelExt, ExprCtx, ExprExt, IsEmpty, ModuleItemLike,
     StmtLike, Value::Known,
@@ -996,31 +993,29 @@ impl VisitMut for TreeShaker {
     }
 
     fn visit_mut_module(&mut self, m: &mut Module) {
-        HELPERS.set(&Helpers::new(true), || {
-            let _tracing = span!(Level::ERROR, "tree-shaker", pass = self.pass).entered();
+        let _tracing = span!(Level::ERROR, "tree-shaker", pass = self.pass).entered();
 
-            if self.bindings.is_empty() {
-                self.bindings = Arc::new(collect_decls(&*m))
-            }
+        if self.bindings.is_empty() {
+            self.bindings = Arc::new(collect_decls(&*m))
+        }
 
-            let data: Arc<ThreadLocal<RefCell<Data>>> = Default::default();
+        let data: Arc<ThreadLocal<RefCell<Data>>> = Default::default();
 
-            {
-                let mut analyzer = Analyzer {
-                    config: &self.config,
-                    in_var_decl: false,
-                    scope: Default::default(),
-                    data: data.clone(),
-                    cur_class_id: Default::default(),
-                    cur_fn_id: Default::default(),
-                };
-                m.visit_with(&mut analyzer);
-            }
+        {
+            let mut analyzer = Analyzer {
+                config: &self.config,
+                in_var_decl: false,
+                scope: Default::default(),
+                data: data.clone(),
+                cur_class_id: Default::default(),
+                cur_fn_id: Default::default(),
+            };
+            m.visit_with(&mut analyzer);
+        }
 
-            self.data = Arc::new(merge_data(data));
+        self.data = Arc::new(merge_data(data));
 
-            m.visit_mut_children_with(self);
-        })
+        m.visit_mut_children_with(self);
     }
 
     fn visit_mut_module_item(&mut self, n: &mut ModuleItem) {
@@ -1059,31 +1054,29 @@ impl VisitMut for TreeShaker {
     }
 
     fn visit_mut_script(&mut self, m: &mut Script) {
-        HELPERS.set(&Helpers::new(true), || {
-            let _tracing = span!(Level::ERROR, "tree-shaker", pass = self.pass).entered();
+        let _tracing = span!(Level::ERROR, "tree-shaker", pass = self.pass).entered();
 
-            if self.bindings.is_empty() {
-                self.bindings = Arc::new(collect_decls(&*m))
-            }
+        if self.bindings.is_empty() {
+            self.bindings = Arc::new(collect_decls(&*m))
+        }
 
-            let data: Arc<ThreadLocal<RefCell<Data>>> = Default::default();
+        let data: Arc<ThreadLocal<RefCell<Data>>> = Default::default();
 
-            {
-                let mut analyzer = Analyzer {
-                    config: &self.config,
-                    in_var_decl: false,
-                    scope: Default::default(),
-                    data: data.clone(),
-                    cur_class_id: Default::default(),
-                    cur_fn_id: Default::default(),
-                };
-                m.visit_with(&mut analyzer);
-            }
+        {
+            let mut analyzer = Analyzer {
+                config: &self.config,
+                in_var_decl: false,
+                scope: Default::default(),
+                data: data.clone(),
+                cur_class_id: Default::default(),
+                cur_fn_id: Default::default(),
+            };
+            m.visit_with(&mut analyzer);
+        }
 
-            self.data = Arc::new(merge_data(data));
+        self.data = Arc::new(merge_data(data));
 
-            m.visit_mut_children_with(self);
-        })
+        m.visit_mut_children_with(self);
     }
 
     fn visit_mut_stmt(&mut self, s: &mut Stmt) {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -233,7 +233,10 @@ impl Parallel for Analyzer<'_> {
             data: self.data.clone(),
             scope: Scope {
                 parent: self.scope.parent,
-                ..Default::default()
+                ast_path: self.scope.ast_path.clone(),
+                bindings_affected_by_arguements: Default::default(),
+                bindings_affected_by_eval: Default::default(),
+                ..self.scope
             },
             cur_class_id: self.cur_class_id.clone(),
             cur_fn_id: self.cur_fn_id.clone(),
@@ -241,7 +244,16 @@ impl Parallel for Analyzer<'_> {
         }
     }
 
-    fn merge(&mut self, _: Self) {}
+    fn merge(&mut self, other: Self) {
+        self.scope.ast_path = other.scope.ast_path;
+
+        self.scope
+            .bindings_affected_by_eval
+            .extend(other.scope.bindings_affected_by_eval);
+        self.scope
+            .bindings_affected_by_arguements
+            .extend(other.scope.bindings_affected_by_arguements);
+    }
 }
 
 #[derive(Debug, Default)]
@@ -261,7 +273,7 @@ struct Scope<'a> {
     ast_path: Vec<Id>,
 }
 
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum ScopeKind {
     Fn,
     ArrowFn,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -157,7 +157,7 @@ impl Data {
     fn subtract_cycles(&mut self) {
         let edges = take(&mut self.edges);
 
-        let mut graph = FastDiGraphMap::default();
+        let mut graph = FastDiGraphMap::with_capacity(self.used_names.len(), self.edges.0.len());
         let mut graph_ix = IndexMap::<Id, u32, RandomState>::default();
 
         let mut get_node = |id: Id| -> u32 {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -10,10 +10,9 @@ use swc_common::{
     Mark, SyntaxContext, DUMMY_SP,
 };
 use swc_ecma_ast::*;
-use swc_ecma_transforms_base::perf::{cpu_count, Parallel};
 use swc_ecma_transforms_base::{
     helpers::{Helpers, HELPERS},
-    perf::{cpu_count, ParVisit, ParVisitMut, Parallel},
+    perf::{cpu_count, ParVisit, Parallel},
 };
 use swc_ecma_utils::{
     collect_decls, find_pat_ids, parallel::ParallelExt, ExprCtx, ExprExt, IsEmpty, ModuleItemLike,
@@ -144,7 +143,7 @@ impl Data {
         let edges = take(&mut self.edges);
 
         let mut graph = FastDiGraphMap::with_capacity(self.used_names.len(), edges.0.len());
-        let mut graph_ix: IndexMap<(JsWord, SyntaxContext), u32, FxBuildHasher> =
+        let mut graph_ix: IndexMap<(Atom, SyntaxContext), u32, FxBuildHasher> =
             IndexMap::with_capacity_and_hasher(self.used_names.len(), Default::default());
 
         let mut get_node = |id: Id| -> u32 {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -158,7 +158,8 @@ impl Data {
         let edges = take(&mut self.edges);
 
         let mut graph = FastDiGraphMap::with_capacity(self.used_names.len(), self.edges.0.len());
-        let mut graph_ix = IndexMap::<Id, u32, RandomState>::default();
+        let mut graph_ix: IndexMap<(JsWord, SyntaxContext), u32, RandomState> =
+            IndexMap::with_capacity_and_hasher(self.used_names.len(), Default::default());
 
         let mut get_node = |id: Id| -> u32 {
             let len = graph_ix.len();

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1306,11 +1306,6 @@ fn merge_data(data: Arc<ThreadLocal<RefCell<Data>>>) -> Data {
         .into_iter()
         .map(|d| d.into_inner())
         .collect::<Vec<_>>();
-    let mut merged = Data::default();
-
-    for data in data {
-        merged.merge(data);
-    }
 
     // merged.subtract_cycles();
     let mut merged = merge_in_parallel(data);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1303,9 +1303,7 @@ fn merge_data(data: Arc<ThreadLocal<RefCell<Data>>>) -> Data {
     let mut merged = Data::default();
 
     for data in data {
-        merged.used_names.merge(data.used_names);
-        merged.entry_ids.extend(data.entry_ids);
-        merged.edges.merge(data.edges);
+        merged.merge(data);
     }
 
     merged.subtract_cycles();
@@ -1361,6 +1359,14 @@ impl Merge for VarInfo {
     fn merge(&mut self, other: Self) {
         self.usage += other.usage;
         self.assign += other.assign;
+    }
+}
+
+impl Merge for Data {
+    fn merge(&mut self, other: Self) {
+        self.used_names.merge(other.used_names);
+        self.entry_ids.extend(other.entry_ids);
+        self.edges.merge(other.edges);
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1,10 +1,14 @@
-use std::{borrow::Cow, cell::RefCell, sync::Arc};
+use std::{borrow::Cow, cell::RefCell, hash::BuildHasherDefault, sync::Arc};
 
 use indexmap::IndexSet;
 use petgraph::{algo::tarjan_scc, Direction::Incoming};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use swc_atoms::{atom, Atom};
 use swc_common::{
+use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
+use swc_atoms::{atom, JsWord};
+use swc_common::{
+    collections::AHashSet,
     pass::{CompilerPass, Repeated},
     util::take::Take,
     Mark, SyntaxContext, DUMMY_SP,
@@ -119,6 +123,7 @@ struct Data {
     entry_ids: FxHashSet<Id>,
 
     graph_ix: IndexSet<Id, FxBuildHasher>,
+    graph_ix: IndexSet<Id, BuildHasherDefault<FxHasher>>,
 }
 
 impl Data {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1,14 +1,9 @@
 use std::{borrow::Cow, cell::RefCell, mem::take, sync::Arc};
 
-use ahash::RandomState;
 use indexmap::{IndexMap, IndexSet};
 use petgraph::{algo::tarjan_scc, Direction::Incoming};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use swc_atoms::{atom, Atom};
-use swc_common::{
-use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
-use rustc_hash::{FxHashMap, FxHashSet};
-use swc_atoms::{atom, JsWord};
 use swc_common::{
     collections::AHashSet,
     pass::{CompilerPass, Repeated},

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -41,7 +41,7 @@ pub fn dce(
             in_strict: false,
             remaining_depth: 2,
         },
-        config,
+        config: Arc::new(config),
         changed: false,
         pass: 0,
         in_fn: false,
@@ -87,7 +87,7 @@ impl Default for Config {
 struct TreeShaker {
     expr_ctx: ExprCtx,
 
-    config: Config,
+    config: Arc<Config>,
     changed: bool,
     pass: u16,
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -12,7 +12,7 @@ use swc_common::{
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{
     helpers::{Helpers, HELPERS},
-    perf::{cpu_count, ParVisit, Parallel},
+    perf::{cpu_count, Parallel},
 };
 use swc_ecma_utils::{
     collect_decls, find_pat_ids, parallel::ParallelExt, ExprCtx, ExprExt, IsEmpty, ModuleItemLike,
@@ -414,6 +414,13 @@ impl Analyzer<'_> {
         } else {
             data.used_names.entry(id).or_default().usage += 1;
         }
+    }
+
+    fn visit_par<N>(&mut self, threshold: usize, nodes: &[N])
+    where
+        N: Send + Sync + VisitWith<Self>,
+    {
+        self.maybe_par(threshold, nodes, |v, n| n.visit_with(v));
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -154,6 +154,7 @@ impl Data {
     }
 
     /// Traverse the graph and subtract usages from `used_names`.
+    #[allow(unused)]
     fn subtract_cycles(&mut self) {
         let edges = take(&mut self.edges);
 
@@ -1317,7 +1318,7 @@ fn merge_data(data: Arc<ThreadLocal<RefCell<Data>>>) -> Data {
         merged.merge(data);
     }
 
-    merged.subtract_cycles();
+    // merged.subtract_cycles();
 
     merged
 }
@@ -1381,7 +1382,7 @@ impl Merge for Data {
     fn merge(&mut self, other: Self) {
         self.used_names.merge(other.used_names);
         self.entry_ids.extend(other.entry_ids);
-        self.edges.0.merge(other.edges.0);
+        // self.edges.0.merge(other.edges.0);
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -626,31 +626,31 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_opt_vec_expr_or_spreads(&mut self, n: &[Option<ExprOrSpread>]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_prop_or_spreads(&mut self, n: &[PropOrSpread]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_expr_or_spreads(&mut self, n: &[ExprOrSpread]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_exprs(&mut self, n: &[Box<Expr>]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_stmts(&mut self, n: &[Stmt]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_module_items(&mut self, n: &[ModuleItem]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 
     fn visit_var_declarators(&mut self, n: &[VarDeclarator]) {
-        self.visit_par(cpu_count(), n);
+        self.visit_par(cpu_count() * 8, n);
     }
 }
 


### PR DESCRIPTION
**Description:**

The analyzer of the DCE pass can be parallelized in a similar way to mark-sweep GC. It currently uses `&mut petgraph::DiGraphMap` to find reachable bindings, but we can split the graph creation into multiple threads.

Also, I decided to amort allocations because `swc_parallel::join` is called an enormous amount of time, meaning that it will be slower if I allocate one hashmap from each closure. I'll use [thread_local **crate**](https://docs.rs/thread_local/latest/thread_local/) to reuse the hashmap and collect all of them after the traversal is done.
