### PR TITLE
perf(es/ast): Box `ArrayPat` and `ObjectPat`

### DIFF
--- a/.changeset/five-deers-jump.md
+++ b/.changeset/five-deers-jump.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_ast: major
+---
+
+perf(es/ast): Box `ArrayPat` and `ObjectPat`

--- a/crates/swc_bundler/src/bundler/chunk/cjs.rs
+++ b/crates/swc_bundler/src/bundler/chunk/cjs.rs
@@ -327,12 +327,12 @@ where
                 declare: false,
                 decls: vec![VarDeclarator {
                     span: i.span,
-                    name: Pat::Object(ObjectPat {
+                    name: Pat::Object(Box::new(ObjectPat {
                         span: DUMMY_SP,
                         props,
                         optional: false,
                         type_ann: None,
-                    }),
+                    })),
                     init: Some(Box::new(Expr::Call(CallExpr {
                         span: DUMMY_SP,
                         callee: load_var.as_callee(),

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -1462,9 +1462,9 @@ impl TryFrom<Box<Expr>> for AssignTarget {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum AssignTargetPat {
     #[tag("ArrayPattern")]
-    Array(ArrayPat),
+    Array(Box<ArrayPat>),
     #[tag("ObjectPattern")]
-    Object(ObjectPat),
+    Object(Box<ObjectPat>),
     #[tag("Invalid")]
     Invalid(Invalid),
 }
@@ -1593,8 +1593,8 @@ bridge_from!(AssignTarget, SimpleAssignTarget, TsSatisfiesExpr);
 bridge_from!(AssignTarget, SimpleAssignTarget, TsNonNullExpr);
 bridge_from!(AssignTarget, SimpleAssignTarget, TsTypeAssertion);
 
-bridge_from!(AssignTarget, AssignTargetPat, ArrayPat);
-bridge_from!(AssignTarget, AssignTargetPat, ObjectPat);
+bridge_from!(AssignTarget, AssignTargetPat, Box<ArrayPat>);
+bridge_from!(AssignTarget, AssignTargetPat, Box<ObjectPat>);
 
 impl From<SimpleAssignTarget> for Box<Expr> {
     fn from(s: SimpleAssignTarget) -> Self {

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -1595,6 +1595,10 @@ bridge_from!(AssignTarget, SimpleAssignTarget, TsTypeAssertion);
 
 bridge_from!(AssignTarget, AssignTargetPat, Box<ArrayPat>);
 bridge_from!(AssignTarget, AssignTargetPat, Box<ObjectPat>);
+bridge_from!(AssignTargetPat, Box<ArrayPat>, ArrayPat);
+bridge_from!(AssignTargetPat, Box<ObjectPat>, ObjectPat);
+bridge_from!(AssignTarget, AssignTargetPat, ArrayPat);
+bridge_from!(AssignTarget, AssignTargetPat, ObjectPat);
 
 impl From<SimpleAssignTarget> for Box<Expr> {
     fn from(s: SimpleAssignTarget) -> Self {

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -83,6 +83,9 @@ pat_to_other!(AssignPat);
 pat_to_other!(RestPat);
 pat_to_other!(Box<Expr>);
 
+bridge_from!(Pat, Box<ArrayPat>, ArrayPat);
+bridge_from!(Pat, Box<ObjectPat>, ObjectPat);
+
 #[ast_node("ArrayPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -85,6 +85,8 @@ pat_to_other!(Box<Expr>);
 
 bridge_from!(Pat, Box<ArrayPat>, ArrayPat);
 bridge_from!(Pat, Box<ObjectPat>, ObjectPat);
+bridge_from!(Box<crate::Pat>, crate::Pat, ArrayPat);
+bridge_from!(Box<crate::Pat>, crate::Pat, ObjectPat);
 
 #[ast_node("ArrayPattern")]
 #[derive(Eq, Hash, EqIgnoreSpan)]

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -18,13 +18,13 @@ pub enum Pat {
     Ident(BindingIdent),
 
     #[tag("ArrayPattern")]
-    Array(ArrayPat),
+    Array(Box<ArrayPat>),
 
     #[tag("RestElement")]
     Rest(RestPat),
 
     #[tag("ObjectPattern")]
-    Object(ObjectPat),
+    Object(Box<ObjectPat>),
 
     #[tag("AssignmentPattern")]
     Assign(AssignPat),
@@ -77,8 +77,8 @@ macro_rules! pat_to_other {
 }
 
 pat_to_other!(BindingIdent);
-pat_to_other!(ArrayPat);
-pat_to_other!(ObjectPat);
+pat_to_other!(Box<ArrayPat>);
+pat_to_other!(Box<ObjectPat>);
 pat_to_other!(AssignPat);
 pat_to_other!(RestPat);
 pat_to_other!(Box<Expr>);

--- a/crates/swc_ecma_ast/src/typescript.rs
+++ b/crates/swc_ecma_ast/src/typescript.rs
@@ -468,13 +468,13 @@ pub enum TsFnParam {
     Ident(BindingIdent),
 
     #[tag("ArrayPattern")]
-    Array(ArrayPat),
+    Array(Box<ArrayPat>),
 
     #[tag("RestElement")]
     Rest(RestPat),
 
     #[tag("ObjectPattern")]
-    Object(ObjectPat),
+    Object(Box<ObjectPat>),
 }
 
 #[ast_node("TsFunctionType")]

--- a/crates/swc_ecma_compat_es2015/src/destructuring.rs
+++ b/crates/swc_ecma_compat_es2015/src/destructuring.rs
@@ -290,7 +290,7 @@ impl AssignFolder {
                 }
             }
             Pat::Object(obj) if obj.props.is_empty() => {
-                let ObjectPat { span, props, .. } = *obj;
+                let ObjectPat { span, .. } = *obj;
 
                 // We should convert
                 //
@@ -896,14 +896,16 @@ impl VisitMut for AssignFolder {
                     }
                     .into()
                 }
-                AssignTargetPat::Object(ObjectPat { props, .. }) if props.is_empty() => {
+                AssignTargetPat::Object(obj) if obj.props.is_empty() => {
                     let mut right = right.take();
                     right.visit_mut_with(self);
 
                     *expr = helper_expr!(object_destructuring_empty)
                         .as_call(DUMMY_SP, vec![right.as_arg()]);
                 }
-                AssignTargetPat::Object(ObjectPat { span, props, .. }) => {
+                AssignTargetPat::Object(obj) => {
+                    let ObjectPat { span, props, .. } = &mut **obj;
+
                     if props.len() == 1 {
                         if let ObjectPatProp::Assign(p @ AssignPatProp { value: None, .. }) =
                             &props[0]

--- a/crates/swc_ecma_compat_es2015/src/destructuring.rs
+++ b/crates/swc_ecma_compat_es2015/src/destructuring.rs
@@ -156,7 +156,9 @@ impl AssignFolder {
                 "rest pattern should handled by array pattern handler: {:?}",
                 decl.name
             ),
-            Pat::Array(ArrayPat { elems, .. }) => {
+            Pat::Array(arr) => {
+                let ArrayPat { elems, .. } = *arr;
+
                 assert!(
                     decl.init.is_some(),
                     "destructuring pattern binding requires initializer"
@@ -287,7 +289,9 @@ impl AssignFolder {
                     decls.extend(var_decls);
                 }
             }
-            Pat::Object(ObjectPat { span, props, .. }) if props.is_empty() => {
+            Pat::Object(obj) if obj.props.is_empty() => {
+                let ObjectPat { span, props, .. } = *obj;
+
                 // We should convert
                 //
                 //      var {} = null;
@@ -316,7 +320,9 @@ impl AssignFolder {
                 decls.push(var_decl);
             }
 
-            Pat::Object(ObjectPat { props, .. }) => {
+            Pat::Object(obj) => {
+                let ObjectPat { props, .. } = *obj;
+
                 assert!(
                     decl.init.is_some(),
                     "destructuring pattern binding requires initializer"
@@ -659,7 +665,9 @@ impl VisitMut for AssignFolder {
                 //         right: right.take(),
                 //     });
                 // }
-                AssignTargetPat::Array(ArrayPat { elems, .. }) => {
+                AssignTargetPat::Array(arr) => {
+                    let ArrayPat { elems, .. } = &mut **arr;
+
                     let mut exprs = Vec::with_capacity(elems.len() + 1);
 
                     if is_literal(right) && ignore_return_value {

--- a/crates/swc_ecma_lints/src/rules/no_loop_func.rs
+++ b/crates/swc_ecma_lints/src/rules/no_loop_func.rs
@@ -96,14 +96,18 @@ impl NoLoopFunc {
                     .unwrap()
                     .insert(ident.to_id());
             }
-            Pat::Array(ArrayPat { elems, .. }) => {
+            Pat::Array(arr) => {
+                let ArrayPat { elems, .. } = &**arr;
+
                 elems.iter().for_each(|elem| {
                     if let Some(elem) = elem {
                         self.extract_vars(elem);
                     }
                 });
             }
-            Pat::Object(ObjectPat { props, .. }) => {
+            Pat::Object(obj) => {
+                let ObjectPat { props, .. } = &**obj;
+
                 props.iter().for_each(|prop| match prop {
                     ObjectPatProp::Assign(AssignPatProp { key, .. }) => {
                         self.scoped_unsafe_vars

--- a/crates/swc_ecma_lints/src/rules/no_new.rs
+++ b/crates/swc_ecma_lints/src/rules/no_new.rs
@@ -81,16 +81,22 @@ impl NoNew {
             Pat::Assign(AssignPat { right, .. }) => {
                 self.check_and_pass_new_expr(right.as_ref());
             }
-            Pat::Array(ArrayPat { elems, .. }) => elems.iter().for_each(|elem| {
-                if let Some(elem) = elem {
-                    // cases
-                    // var [ x = new A() ] = arr;
-                    // var [ a, [ y = new A() ] ] = arr;
+            Pat::Array(arr) => {
+                let ArrayPat { elems, .. } = &**arr;
 
-                    self.check_var_name(elem);
-                }
-            }),
-            Pat::Object(ObjectPat { props, .. }) => {
+                elems.iter().for_each(|elem| {
+                    if let Some(elem) = elem {
+                        // cases
+                        // var [ x = new A() ] = arr;
+                        // var [ a, [ y = new A() ] ] = arr;
+
+                        self.check_var_name(elem);
+                    }
+                });
+            }
+            Pat::Object(obj) => {
+                let ObjectPat { props, .. } = &**obj;
+
                 props.iter().for_each(|prop| match prop {
                     ObjectPatProp::KeyValue(KeyValuePatProp { value, .. }) => {
                         self.check_var_name(value.as_ref());

--- a/crates/swc_ecma_lints/src/rules/no_use_before_define.rs
+++ b/crates/swc_ecma_lints/src/rules/no_use_before_define.rs
@@ -149,14 +149,18 @@ impl NoUseBeforeDefine {
             Pat::Ident(id) => {
                 self.check_ident(es6_var_check, &Ident::from(id));
             }
-            Pat::Array(ArrayPat { elems, .. }) => {
+            Pat::Array(arr) => {
+                let ArrayPat { elems, .. } = &**arr;
+
                 elems.iter().for_each(|elem| {
                     if let Some(elem) = elem {
                         self.check_pat(es6_var_check, elem);
                     }
                 });
             }
-            Pat::Object(ObjectPat { props, .. }) => {
+            Pat::Object(obj) => {
+                let ObjectPat { props, .. } = &**obj;
+
                 props.iter().for_each(|prop| match prop {
                     ObjectPatProp::Assign(AssignPatProp { key, .. }) => {
                         self.check_ident(es6_var_check, &Ident::from(key));

--- a/crates/swc_ecma_lints/src/rules/prefer_const.rs
+++ b/crates/swc_ecma_lints/src/rules/prefer_const.rs
@@ -116,12 +116,16 @@ impl PreferConst {
             Pat::Assign(AssignPat { left, .. }) => {
                 self.collect_decl_pat(initialized, left.as_ref());
             }
-            Pat::Array(ArrayPat { elems, .. }) => {
+            Pat::Array(arr) => {
+                let ArrayPat { elems, .. } = &**arr;
+
                 elems.iter().flatten().for_each(|elem| {
                     self.collect_decl_pat(initialized, elem);
                 });
             }
-            Pat::Object(ObjectPat { props, .. }) => {
+            Pat::Object(obj) => {
+                let ObjectPat { props, .. } = &**obj;
+
                 props.iter().for_each(|prop| {
                     match prop {
                         ObjectPatProp::KeyValue(KeyValuePatProp { value, .. }) => {
@@ -169,10 +173,16 @@ impl PreferConst {
             Pat::Ident(id) => {
                 self.consider_mutation_for_ident(&Ident::from(id), destructuring_assign);
             }
-            Pat::Array(ArrayPat { elems, .. }) => elems.iter().flatten().for_each(|elem| {
-                self.consider_mutation(elem, destructuring_assign);
-            }),
-            Pat::Object(ObjectPat { props, .. }) => {
+            Pat::Array(arr) => {
+                let ArrayPat { elems, .. } = &**arr;
+
+                elems.iter().flatten().for_each(|elem| {
+                    self.consider_mutation(elem, destructuring_assign);
+                });
+            }
+            Pat::Object(obj) => {
+                let ObjectPat { props, .. } = &**obj;
+
                 props.iter().for_each(|prop| match prop {
                     ObjectPatProp::KeyValue(KeyValuePatProp { value, .. }) => {
                         self.consider_mutation(value.as_ref(), true);
@@ -241,12 +251,16 @@ impl Visit for PreferConst {
                 }
 
                 AssignTarget::Pat(pat) => match pat {
-                    AssignTargetPat::Array(ArrayPat { elems, .. }) => {
+                    AssignTargetPat::Array(arr) => {
+                        let ArrayPat { elems, .. } = &**arr;
+
                         elems.iter().flatten().for_each(|elem| {
                             self.consider_mutation(elem, true);
                         })
                     }
-                    AssignTargetPat::Object(ObjectPat { props, .. }) => {
+                    AssignTargetPat::Object(obj) => {
+                        let ObjectPat { props, .. } = &**obj;
+
                         props.iter().for_each(|prop| match prop {
                             ObjectPatProp::KeyValue(KeyValuePatProp { value, .. }) => {
                                 self.consider_mutation(value.as_ref(), true);

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -11,7 +11,7 @@ mod tests;
 mod verifier;
 
 impl<I: Tokens> Parser<I> {
-    fn get_type_ann_and_span_of_pat<'a>(
+    pub(super) fn get_type_ann_and_span_of_pat<'a>(
         &self,
         pat: &'a mut Pat,
     ) -> Option<(&'a mut Option<Box<TsTypeAnn>>, &'a mut Span)> {

--- a/crates/swc_ecma_parser/src/parser/expr/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/tests.rs
@@ -127,7 +127,7 @@ fn object_rest_pat() {
             span,
             is_async: false,
             is_generator: false,
-            params: vec![Pat::Object(ObjectPat {
+            params: vec![Pat::Object(Box::new(ObjectPat {
                 span,
                 optional: false,
                 props: vec![ObjectPatProp::Rest(RestPat {
@@ -137,7 +137,7 @@ fn object_rest_pat() {
                     type_ann: None,
                 })],
                 type_ann: None
-            })],
+            }))],
             body: Box::new(BlockStmtOrExpr::BlockStmt(BlockStmt {
                 span,
                 ..Default::default()

--- a/crates/swc_ecma_parser/src/parser/pat.rs
+++ b/crates/swc_ecma_parser/src/parser/pat.rs
@@ -966,26 +966,26 @@ mod tests {
     fn array_pat_simple() {
         assert_eq_ignore_span!(
             array_pat("[a, [b], [c]]"),
-            Pat::Array(ArrayPat {
+            Pat::Array(Box::new(ArrayPat {
                 span,
                 optional: false,
                 elems: vec![
                     Some(Pat::Ident(ident("a").into())),
-                    Some(Pat::Array(ArrayPat {
+                    Some(Pat::Array(Box::new(ArrayPat {
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("b").into()))],
                         type_ann: None
-                    })),
-                    Some(Pat::Array(ArrayPat {
+                    }))),
+                    Some(Pat::Array(Box::new(ArrayPat {
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("c").into()))],
                         type_ann: None
-                    }))
+                    })))
                 ],
                 type_ann: None
-            })
+            }))
         );
     }
 
@@ -993,27 +993,27 @@ mod tests {
     fn array_pat_empty_start() {
         assert_eq_ignore_span!(
             array_pat("[, a, [b], [c]]"),
-            Pat::Array(ArrayPat {
+            Pat::Array(Box::new(ArrayPat {
                 span,
                 optional: false,
                 elems: vec![
                     None,
                     Some(Pat::Ident(ident("a").into())),
-                    Some(Pat::Array(ArrayPat {
+                    Some(Pat::Array(Box::new(ArrayPat {
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("b").into()))],
                         type_ann: None
-                    })),
-                    Some(Pat::Array(ArrayPat {
+                    }))),
+                    Some(Pat::Array(Box::new(ArrayPat {
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("c").into()))],
                         type_ann: None
-                    }))
+                    })))
                 ],
                 type_ann: None
-            })
+            }))
         );
     }
 
@@ -1021,27 +1021,27 @@ mod tests {
     fn array_pat_empty() {
         assert_eq_ignore_span!(
             array_pat("[a, , [b], [c]]"),
-            Pat::Array(ArrayPat {
+            Pat::Array(Box::new(ArrayPat {
                 span,
                 optional: false,
                 elems: vec![
                     Some(Pat::Ident(ident("a").into())),
                     None,
-                    Some(Pat::Array(ArrayPat {
+                    Some(Pat::Array(Box::new(ArrayPat {
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("b").into()))],
                         type_ann: None
-                    })),
-                    Some(Pat::Array(ArrayPat {
+                    }))),
+                    Some(Pat::Array(Box::new(ArrayPat {
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("c").into()))],
                         type_ann: None
-                    }))
+                    })))
                 ],
                 type_ann: None
-            })
+            }))
         );
     }
 
@@ -1049,12 +1049,12 @@ mod tests {
     fn array_pat_empty_end() {
         assert_eq_ignore_span!(
             array_pat("[a, ,]"),
-            Pat::Array(ArrayPat {
+            Pat::Array(Box::new(ArrayPat {
                 span,
                 optional: false,
                 elems: vec![Some(Pat::Ident(ident("a").into())), None,],
                 type_ann: None
-            })
+            }))
         );
     }
 
@@ -1062,12 +1062,12 @@ mod tests {
     fn array_binding_pattern_tail() {
         assert_eq_ignore_span!(
             array_pat("[...tail]"),
-            Pat::Array(ArrayPat {
+            Pat::Array(Box::new(ArrayPat {
                 span,
                 optional: false,
                 elems: vec![rest()],
                 type_ann: None
-            })
+            }))
         );
     }
 
@@ -1075,7 +1075,7 @@ mod tests {
     fn array_binding_pattern_assign() {
         assert_eq_ignore_span!(
             array_pat("[,a=1,]"),
-            Pat::Array(ArrayPat {
+            Pat::Array(Box::new(ArrayPat {
                 span,
                 optional: false,
                 elems: vec![
@@ -1091,7 +1091,7 @@ mod tests {
                     }))
                 ],
                 type_ann: None
-            })
+            }))
         );
     }
 
@@ -1099,12 +1099,12 @@ mod tests {
     fn array_binding_pattern_tail_with_elems() {
         assert_eq_ignore_span!(
             array_pat("[,,,...tail]"),
-            Pat::Array(ArrayPat {
+            Pat::Array(Box::new(ArrayPat {
                 span,
                 optional: false,
                 elems: vec![None, None, None, rest()],
                 type_ann: None
-            })
+            }))
         );
     }
 
@@ -1112,7 +1112,7 @@ mod tests {
     fn array_binding_pattern_tail_inside_tail() {
         assert_eq_ignore_span!(
             array_pat("[,,,...[...tail]]"),
-            Pat::Array(ArrayPat {
+            Pat::Array(Box::new(ArrayPat {
                 span,
                 optional: false,
                 elems: vec![
@@ -1123,16 +1123,16 @@ mod tests {
                         span,
                         dot3_token: span,
                         type_ann: None,
-                        arg: Box::new(Pat::Array(ArrayPat {
+                        arg: Box::new(Pat::Array(Box::new(ArrayPat {
                             span,
                             optional: false,
                             elems: vec![rest()],
                             type_ann: None
-                        }))
+                        })))
                     }))
                 ],
                 type_ann: None
-            })
+            }))
         );
     }
 
@@ -1140,7 +1140,7 @@ mod tests {
     fn object_binding_pattern_tail() {
         assert_eq_ignore_span!(
             object_pat("{...obj}"),
-            Pat::Object(ObjectPat {
+            Pat::Object(Box::new(ObjectPat {
                 span,
                 type_ann: None,
                 optional: false,
@@ -1150,7 +1150,7 @@ mod tests {
                     type_ann: None,
                     arg: Box::new(Pat::Ident(ident("obj").into()))
                 })]
-            })
+            }))
         );
     }
 
@@ -1158,7 +1158,7 @@ mod tests {
     fn object_binding_pattern_with_prop() {
         assert_eq_ignore_span!(
             object_pat("{prop = 10 }"),
-            Pat::Object(ObjectPat {
+            Pat::Object(Box::new(ObjectPat {
                 span,
                 type_ann: None,
                 optional: false,
@@ -1171,7 +1171,7 @@ mod tests {
                         raw: Some("10".into())
                     }))))
                 })]
-            })
+            }))
         );
     }
 
@@ -1194,7 +1194,7 @@ mod tests {
             object_pat(
                 "{obj = {$: num = 10, '': sym = '', \" \": quote = \" \", _: under = [...tail],}}"
             ),
-            Pat::Object(ObjectPat {
+            Pat::Object(Box::new(ObjectPat {
                 span,
                 type_ann: None,
                 optional: false,
@@ -1253,7 +1253,7 @@ mod tests {
                         ]
                     })))
                 })]
-            })
+            }))
         );
     }
 }

--- a/crates/swc_ecma_parser/src/parser/pat.rs
+++ b/crates/swc_ecma_parser/src/parser/pat.rs
@@ -195,13 +195,17 @@ impl<I: Tokens> Parser<I> {
                                 ref mut optional, ..
                             },
                         ..
-                    })
-                    | Pat::Array(ArrayPat {
-                        ref mut optional, ..
-                    })
-                    | Pat::Object(ObjectPat {
-                        ref mut optional, ..
                     }) => {
+                        *optional = true;
+                        opt = true;
+                    }
+                    Pat::Array(ref mut boxed) => {
+                        let ArrayPat { optional, .. } = &mut **boxed;
+                        *optional = true;
+                        opt = true;
+                    }
+                    Pat::Object(ref mut boxed) => {
+                        let ObjectPat { optional, .. } = &mut **boxed;
                         *optional = true;
                         opt = true;
                     }

--- a/crates/swc_ecma_parser/src/parser/pat.rs
+++ b/crates/swc_ecma_parser/src/parser/pat.rs
@@ -217,21 +217,9 @@ impl<I: Tokens> Parser<I> {
             }
 
             match pat {
-                Pat::Array(ArrayPat {
-                    ref mut type_ann,
-                    ref mut span,
-                    ..
-                })
-                | Pat::Object(ObjectPat {
-                    ref mut type_ann,
-                    ref mut span,
-                    ..
-                })
-                | Pat::Rest(RestPat {
-                    ref mut type_ann,
-                    ref mut span,
-                    ..
-                }) => {
+                Pat::Array(..) | Pat::Object(..) | Pat::Rest(..) => {
+                    let (type_ann, span) = self.get_type_ann_and_span_of_pat(&mut pat).unwrap();
+
                     let new_type_ann = self.try_parse_ts_type_ann()?;
                     if new_type_ann.is_some() {
                         *span = Span::new(pat_start, self.input.prev_span().hi);

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -757,10 +757,9 @@ impl<'a, I: Tokens> Parser<I> {
                 // self.emit_err(ty.span(), SyntaxError::TS1196);
 
                 match &mut pat {
-                    Pat::Ident(BindingIdent { type_ann, .. })
-                    | Pat::Array(ArrayPat { type_ann, .. })
-                    | Pat::Rest(RestPat { type_ann, .. })
-                    | Pat::Object(ObjectPat { type_ann, .. }) => {
+                    Pat::Ident(..) | Pat::Array(..) | Pat::Rest(..) | Pat::Object(..) => {
+                        let (type_ann, _span) =
+                            self.get_type_ann_and_span_of_pat(&mut pat).unwrap();
                         *type_ann = Some(Box::new(TsTypeAnn {
                             span: span!(self, type_ann_start),
                             type_ann: ty,
@@ -976,9 +975,7 @@ impl<'a, I: Tokens> Parser<I> {
         if self.input.syntax().typescript() && is!(self, ':') {
             let type_annotation = self.try_parse_ts_type_ann()?;
             match name {
-                Pat::Array(ArrayPat {
-                    ref mut type_ann, ..
-                })
+                Pat::Array(..)
                 | Pat::Ident(BindingIdent {
                     ref mut type_ann, ..
                 })

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1525,7 +1525,7 @@ mod tests {
                 },
                 handler: Some(CatchClause {
                     span,
-                    param: Pat::Object(ObjectPat {
+                    param: Some(Pat::Object(Box::new(ObjectPat {
                         span,
                         optional: false,
                         props: vec![ObjectPatProp::Rest(RestPat {
@@ -1537,8 +1537,7 @@ mod tests {
                             type_ann: None
                         })],
                         type_ann: None,
-                    })
-                    .into(),
+                    }))),
                     body: BlockStmt {
                         span,
                         ..Default::default()
@@ -2058,7 +2057,7 @@ export default function waitUntil(callback, options = {}) {
                     kind: VarDeclKind::Let,
                     decls: vec![VarDeclarator {
                         span,
-                        name: Pat::Array(ArrayPat {
+                        name: Pat::Array(Box::new(ArrayPat {
                             span,
                             type_ann: None,
                             optional: false,
@@ -2067,7 +2066,7 @@ export default function waitUntil(callback, options = {}) {
                                 None,
                                 Some(Pat::Ident(Ident::new_no_ctxt("t".into(), span).into()))
                             ]
-                        }),
+                        })),
                         init: Some(Box::new(Expr::Ident(Ident::new_no_ctxt(
                             "simple_array".into(),
                             span
@@ -2090,7 +2089,7 @@ export default function waitUntil(callback, options = {}) {
                     kind: VarDeclKind::Let,
                     decls: vec![VarDeclarator {
                         span,
-                        name: Pat::Object(ObjectPat {
+                        name: Pat::Object(Box::new(ObjectPat {
                             optional: false,
                             type_ann: None,
                             span,
@@ -2099,7 +2098,7 @@ export default function waitUntil(callback, options = {}) {
                                 key: Ident::new_no_ctxt("num".into(), span).into(),
                                 value: None
                             })]
-                        }),
+                        })),
                         init: Some(Box::new(Expr::Ident(Ident::new_no_ctxt(
                             "obj".into(),
                             span

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -975,16 +975,8 @@ impl<'a, I: Tokens> Parser<I> {
         if self.input.syntax().typescript() && is!(self, ':') {
             let type_annotation = self.try_parse_ts_type_ann()?;
             match name {
-                Pat::Array(..)
-                | Pat::Ident(BindingIdent {
-                    ref mut type_ann, ..
-                })
-                | Pat::Object(ObjectPat {
-                    ref mut type_ann, ..
-                })
-                | Pat::Rest(RestPat {
-                    ref mut type_ann, ..
-                }) => {
+                Pat::Array(..) | Pat::Ident(..) | Pat::Object(..) | Pat::Rest(..) => {
+                    let (type_ann, _span) = self.get_type_ann_and_span_of_pat(&mut name).unwrap();
                     *type_ann = type_annotation;
                 }
                 _ => unreachable!("invalid syntax: Pat: {:?}", name),

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -1188,7 +1188,7 @@ fn add_require(imports: Vec<(Ident, IdentName)>, src: &str, unresolved_mark: Mar
         declare: false,
         decls: vec![VarDeclarator {
             span: DUMMY_SP,
-            name: Pat::Object(ObjectPat {
+            name: Pat::Object(Box::new(ObjectPat {
                 span: DUMMY_SP,
                 props: imports
                     .into_iter()
@@ -1209,7 +1209,7 @@ fn add_require(imports: Vec<(Ident, IdentName)>, src: &str, unresolved_mark: Mar
                     .collect(),
                 optional: false,
                 type_ann: None,
-            }),
+            })),
             // require('react')
             init: Some(Box::new(Expr::Call(CallExpr {
                 span: DUMMY_SP,

--- a/crates/swc_ecma_visit_std/src/generated.rs
+++ b/crates/swc_ecma_visit_std/src/generated.rs
@@ -6947,10 +6947,10 @@ impl<V: ?Sized + Visit> VisitWith<V> for AssignTargetPat {
     fn visit_children_with(&self, visitor: &mut V) {
         match self {
             AssignTargetPat::Array { 0: _field_0 } => {
-                <ArrayPat as VisitWith<V>>::visit_with(_field_0, visitor);
+                <Box<ArrayPat> as VisitWith<V>>::visit_with(_field_0, visitor);
             }
             AssignTargetPat::Object { 0: _field_0 } => {
-                <ObjectPat as VisitWith<V>>::visit_with(_field_0, visitor);
+                <Box<ObjectPat> as VisitWith<V>>::visit_with(_field_0, visitor);
             }
             AssignTargetPat::Invalid { 0: _field_0 } => {
                 <Invalid as VisitWith<V>>::visit_with(_field_0, visitor);
@@ -9527,13 +9527,13 @@ impl<V: ?Sized + Visit> VisitWith<V> for Pat {
                 <BindingIdent as VisitWith<V>>::visit_with(_field_0, visitor);
             }
             Pat::Array { 0: _field_0 } => {
-                <ArrayPat as VisitWith<V>>::visit_with(_field_0, visitor);
+                <Box<ArrayPat> as VisitWith<V>>::visit_with(_field_0, visitor);
             }
             Pat::Rest { 0: _field_0 } => {
                 <RestPat as VisitWith<V>>::visit_with(_field_0, visitor);
             }
             Pat::Object { 0: _field_0 } => {
-                <ObjectPat as VisitWith<V>>::visit_with(_field_0, visitor);
+                <Box<ObjectPat> as VisitWith<V>>::visit_with(_field_0, visitor);
             }
             Pat::Assign { 0: _field_0 } => {
                 <AssignPat as VisitWith<V>>::visit_with(_field_0, visitor);
@@ -23006,7 +23006,7 @@ impl<V: ?Sized + VisitAstPath> VisitWithAstPath<V> for AssignTargetPat {
                     self,
                     self::fields::AssignTargetPatField::Array,
                 ));
-                <ArrayPat as VisitWithAstPath<V>>::visit_with_ast_path(
+                <Box<ArrayPat> as VisitWithAstPath<V>>::visit_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -23017,7 +23017,7 @@ impl<V: ?Sized + VisitAstPath> VisitWithAstPath<V> for AssignTargetPat {
                     self,
                     self::fields::AssignTargetPatField::Object,
                 ));
-                <ObjectPat as VisitWithAstPath<V>>::visit_with_ast_path(
+                <Box<ObjectPat> as VisitWithAstPath<V>>::visit_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -29303,7 +29303,7 @@ impl<V: ?Sized + VisitAstPath> VisitWithAstPath<V> for Pat {
             Pat::Array { 0: _field_0 } => {
                 let mut __ast_path = __ast_path
                     .with_guard(AstParentNodeRef::Pat(self, self::fields::PatField::Array));
-                <ArrayPat as VisitWithAstPath<V>>::visit_with_ast_path(
+                <Box<ArrayPat> as VisitWithAstPath<V>>::visit_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -29321,7 +29321,7 @@ impl<V: ?Sized + VisitAstPath> VisitWithAstPath<V> for Pat {
             Pat::Object { 0: _field_0 } => {
                 let mut __ast_path = __ast_path
                     .with_guard(AstParentNodeRef::Pat(self, self::fields::PatField::Object));
-                <ObjectPat as VisitWithAstPath<V>>::visit_with_ast_path(
+                <Box<ObjectPat> as VisitWithAstPath<V>>::visit_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -40098,10 +40098,10 @@ impl<V: ?Sized + VisitMut> VisitMutWith<V> for AssignTargetPat {
     fn visit_mut_children_with(&mut self, visitor: &mut V) {
         match self {
             AssignTargetPat::Array { 0: _field_0 } => {
-                <ArrayPat as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
+                <Box<ArrayPat> as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
             }
             AssignTargetPat::Object { 0: _field_0 } => {
-                <ObjectPat as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
+                <Box<ObjectPat> as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
             }
             AssignTargetPat::Invalid { 0: _field_0 } => {
                 <Invalid as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
@@ -42678,13 +42678,13 @@ impl<V: ?Sized + VisitMut> VisitMutWith<V> for Pat {
                 <BindingIdent as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
             }
             Pat::Array { 0: _field_0 } => {
-                <ArrayPat as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
+                <Box<ArrayPat> as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
             }
             Pat::Rest { 0: _field_0 } => {
                 <RestPat as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
             }
             Pat::Object { 0: _field_0 } => {
-                <ObjectPat as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
+                <Box<ObjectPat> as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
             }
             Pat::Assign { 0: _field_0 } => {
                 <AssignPat as VisitMutWith<V>>::visit_mut_with(_field_0, visitor);
@@ -53947,7 +53947,7 @@ impl<V: ?Sized + VisitMutAstPath> VisitMutWithAstPath<V> for AssignTargetPat {
                 let mut __ast_path = __ast_path.with_guard(AstParentKind::AssignTargetPat(
                     self::fields::AssignTargetPatField::Array,
                 ));
-                <ArrayPat as VisitMutWithAstPath<V>>::visit_mut_with_ast_path(
+                <Box<ArrayPat> as VisitMutWithAstPath<V>>::visit_mut_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -53957,7 +53957,7 @@ impl<V: ?Sized + VisitMutAstPath> VisitMutWithAstPath<V> for AssignTargetPat {
                 let mut __ast_path = __ast_path.with_guard(AstParentKind::AssignTargetPat(
                     self::fields::AssignTargetPatField::Object,
                 ));
-                <ObjectPat as VisitMutWithAstPath<V>>::visit_mut_with_ast_path(
+                <Box<ObjectPat> as VisitMutWithAstPath<V>>::visit_mut_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -58940,7 +58940,7 @@ impl<V: ?Sized + VisitMutAstPath> VisitMutWithAstPath<V> for Pat {
             Pat::Array { 0: _field_0 } => {
                 let mut __ast_path =
                     __ast_path.with_guard(AstParentKind::Pat(self::fields::PatField::Array));
-                <ArrayPat as VisitMutWithAstPath<V>>::visit_mut_with_ast_path(
+                <Box<ArrayPat> as VisitMutWithAstPath<V>>::visit_mut_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -58958,7 +58958,7 @@ impl<V: ?Sized + VisitMutAstPath> VisitMutWithAstPath<V> for Pat {
             Pat::Object { 0: _field_0 } => {
                 let mut __ast_path =
                     __ast_path.with_guard(AstParentKind::Pat(self::fields::PatField::Object));
-                <ObjectPat as VisitMutWithAstPath<V>>::visit_mut_with_ast_path(
+                <Box<ObjectPat> as VisitMutWithAstPath<V>>::visit_mut_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -69035,11 +69035,11 @@ impl<V: ?Sized + Fold> FoldWith<V> for AssignTargetPat {
     fn fold_children_with(self, visitor: &mut V) -> Self {
         match self {
             AssignTargetPat::Array { 0: _field_0 } => {
-                let _field_0 = <ArrayPat as FoldWith<V>>::fold_with(_field_0, visitor);
+                let _field_0 = <Box<ArrayPat> as FoldWith<V>>::fold_with(_field_0, visitor);
                 AssignTargetPat::Array { 0: _field_0 }
             }
             AssignTargetPat::Object { 0: _field_0 } => {
-                let _field_0 = <ObjectPat as FoldWith<V>>::fold_with(_field_0, visitor);
+                let _field_0 = <Box<ObjectPat> as FoldWith<V>>::fold_with(_field_0, visitor);
                 AssignTargetPat::Object { 0: _field_0 }
             }
             AssignTargetPat::Invalid { 0: _field_0 } => {
@@ -71608,7 +71608,7 @@ impl<V: ?Sized + Fold> FoldWith<V> for Pat {
                 Pat::Ident { 0: _field_0 }
             }
             Pat::Array { 0: _field_0 } => {
-                let _field_0 = <ArrayPat as FoldWith<V>>::fold_with(_field_0, visitor);
+                let _field_0 = <Box<ArrayPat> as FoldWith<V>>::fold_with(_field_0, visitor);
                 Pat::Array { 0: _field_0 }
             }
             Pat::Rest { 0: _field_0 } => {
@@ -71616,7 +71616,7 @@ impl<V: ?Sized + Fold> FoldWith<V> for Pat {
                 Pat::Rest { 0: _field_0 }
             }
             Pat::Object { 0: _field_0 } => {
-                let _field_0 = <ObjectPat as FoldWith<V>>::fold_with(_field_0, visitor);
+                let _field_0 = <Box<ObjectPat> as FoldWith<V>>::fold_with(_field_0, visitor);
                 Pat::Object { 0: _field_0 }
             }
             Pat::Assign { 0: _field_0 } => {
@@ -83458,7 +83458,7 @@ impl<V: ?Sized + FoldAstPath> FoldWithAstPath<V> for AssignTargetPat {
                 let mut __ast_path = __ast_path.with_guard(AstParentKind::AssignTargetPat(
                     self::fields::AssignTargetPatField::Array,
                 ));
-                let _field_0 = <ArrayPat as FoldWithAstPath<V>>::fold_with_ast_path(
+                let _field_0 = <Box<ArrayPat> as FoldWithAstPath<V>>::fold_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -83469,7 +83469,7 @@ impl<V: ?Sized + FoldAstPath> FoldWithAstPath<V> for AssignTargetPat {
                 let mut __ast_path = __ast_path.with_guard(AstParentKind::AssignTargetPat(
                     self::fields::AssignTargetPatField::Object,
                 ));
-                let _field_0 = <ObjectPat as FoldWithAstPath<V>>::fold_with_ast_path(
+                let _field_0 = <Box<ObjectPat> as FoldWithAstPath<V>>::fold_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -88839,7 +88839,7 @@ impl<V: ?Sized + FoldAstPath> FoldWithAstPath<V> for Pat {
             Pat::Array { 0: _field_0 } => {
                 let mut __ast_path =
                     __ast_path.with_guard(AstParentKind::Pat(self::fields::PatField::Array));
-                let _field_0 = <ArrayPat as FoldWithAstPath<V>>::fold_with_ast_path(
+                let _field_0 = <Box<ArrayPat> as FoldWithAstPath<V>>::fold_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,
@@ -88859,7 +88859,7 @@ impl<V: ?Sized + FoldAstPath> FoldWithAstPath<V> for Pat {
             Pat::Object { 0: _field_0 } => {
                 let mut __ast_path =
                     __ast_path.with_guard(AstParentKind::Pat(self::fields::PatField::Object));
-                let _field_0 = <ObjectPat as FoldWithAstPath<V>>::fold_with_ast_path(
+                let _field_0 = <Box<ObjectPat> as FoldWithAstPath<V>>::fold_with_ast_path(
                     _field_0,
                     visitor,
                     &mut *__ast_path,


### PR DESCRIPTION
**Description:**

These are relatively rare compared to identifier patterns, and more importantly, these types increase the size of the `Expr` type. So this PR moves them to the `Box`.