### PR TITLE
fix(es/decorators): Support negative numbers

### DIFF
--- a/.changeset/three-coins-eat.md
+++ b/.changeset/three-coins-eat.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_proposal: patch
+---
+
+fix(es/decorators): Support negative numbers

--- a/crates/swc/tests/fixture/issues-10xxx/10094/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-10xxx/10094/input/.swcrc
@@ -1,0 +1,23 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true,
+            "tsx": false
+        },
+        "target": "es2022",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        },
+        "transform": {
+            "decoratorMetadata": true
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": false,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10094/input/1.ts
+++ b/crates/swc/tests/fixture/issues-10xxx/10094/input/1.ts
@@ -1,0 +1,19 @@
+enum NegativeStatus {
+    open = -1,
+    close = 3,
+}
+
+enum Status {
+    open = 1,
+    close = 2,
+}
+
+function prop() { }
+
+class A {
+    @prop()
+    negativeStatus: NegativeStatus;
+
+    @prop()
+    status: Status;
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10094/output/1.ts
+++ b/crates/swc/tests/fixture/issues-10xxx/10094/output/1.ts
@@ -1,0 +1,25 @@
+var _ts_decorate = require("@swc/helpers/_/_ts_decorate");
+var _ts_metadata = require("@swc/helpers/_/_ts_metadata");
+var NegativeStatus = /*#__PURE__*/ function(NegativeStatus) {
+    NegativeStatus[NegativeStatus["open"] = -1] = "open";
+    NegativeStatus[NegativeStatus["close"] = 3] = "close";
+    return NegativeStatus;
+}(NegativeStatus || {});
+var Status = /*#__PURE__*/ function(Status) {
+    Status[Status["open"] = 1] = "open";
+    Status[Status["close"] = 2] = "close";
+    return Status;
+}(Status || {});
+function prop() {}
+class A {
+    negativeStatus;
+    status;
+}
+_ts_decorate._([
+    prop(),
+    _ts_metadata._("design:type", Number)
+], A.prototype, "negativeStatus", void 0);
+_ts_decorate._([
+    prop(),
+    _ts_metadata._("design:type", Number)
+], A.prototype, "status", void 0);

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
@@ -224,6 +224,10 @@ impl Visit for TscDecorator {
             .map(|member| member.init.as_ref())
             .map(|init| match init {
                 Some(e) => match &**e {
+                    Expr::Unary(UnaryExpr {
+                        op: op!(unary, "-"),
+                        ..
+                    }) => EnumKind::Num,
                     Expr::Lit(lit) => match lit {
                         Lit::Str(_) => EnumKind::Str,
                         Lit::Num(_) => EnumKind::Num,


### PR DESCRIPTION
**Description:**

A negative number is not a numeric literal so we need to handle unary expressions with `op = "-"`.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/10094