### PR TITLE
fix(ts/fast-strip): Throw object consistently

### DIFF
--- a/.changeset/brave-fishes-mate.md
+++ b/.changeset/brave-fishes-mate.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_fast_ts_strip: patch
+---
+
+fix(ts/fast-strip): Throw object consistently

--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -166,21 +166,27 @@ exports[`transform in strip-only mode should throw an error when it encounters a
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a declared module 1`] = `
-"  x \`module\` keyword is not supported. Use \`namespace\` instead.
+{
+  "code": "UnsupportedSyntax",
+  "message": "  x \`module\` keyword is not supported. Use \`namespace\` instead.
    ,----
  1 | declare module foo { }
    :         ^^^^^^
    \`----
-"
+",
+}
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a module 1`] = `
-"  x \`module\` keyword is not supported. Use \`namespace\` instead.
+{
+  "code": "UnsupportedSyntax",
+  "message": "  x \`module\` keyword is not supported. Use \`namespace\` instead.
    ,----
  1 | module foo { }
    : ^^^^^^
    \`----
-"
+",
+}
 `;
 
 exports[`transform should strip types 1`] = `

--- a/bindings/binding_typescript_wasm/__tests__/transform.js
+++ b/bindings/binding_typescript_wasm/__tests__/transform.js
@@ -189,5 +189,14 @@ describe("transform", () => {
                 }),
             ).rejects.toMatchSnapshot();
         });
+
+        it('shoud throw an object even with deprecatedTsModuleAsError = true', async () => {
+            await expect(
+                swc.transform("module F { export type x = number }", {
+                    mode: "transform",
+                    deprecatedTsModuleAsError: true,
+                }),
+            ).rejects.toMatchSnapshot();
+        })
     });
 });

--- a/bindings/binding_typescript_wasm/__tests__/transform.js
+++ b/bindings/binding_typescript_wasm/__tests__/transform.js
@@ -196,7 +196,9 @@ describe("transform", () => {
                     mode: "transform",
                     deprecatedTsModuleAsError: true,
                 }),
-            ).rejects.toMatchSnapshot();
+            ).rejects.toMatchObject({
+                code: "UnsupportedSyntax",
+            });
         })
     });
 });

--- a/crates/swc_fast_ts_strip/src/lib.rs
+++ b/crates/swc_fast_ts_strip/src/lib.rs
@@ -255,6 +255,12 @@ pub fn operate(
                     src: &fm.src,
                     tokens: &tokens,
                 });
+                if handler.has_errors() {
+                    return Err(TsError {
+                        message: "Unsupported syntax".to_string(),
+                        code: ErrorCode::UnsupportedSyntax,
+                    });
+                }
             }
 
             // Strip typescript types
@@ -365,6 +371,12 @@ pub fn operate(
                         src: &fm.src,
                         tokens: &tokens,
                     });
+                    if handler.has_errors() {
+                        return Err(TsError {
+                            message: "Unsupported syntax".to_string(),
+                            code: ErrorCode::UnsupportedSyntax,
+                        });
+                    }
                 }
 
                 program.mutate(&mut typescript::typescript(
@@ -378,7 +390,9 @@ pub fn operate(
                 program.mutate(&mut hygiene());
 
                 program.mutate(&mut fixer(Some(&comments)));
-            });
+
+                Ok(())
+            })?;
 
             let mut src = std::vec::Vec::new();
             let mut src_map_buf = if options.source_map {

--- a/crates/swc_fast_ts_strip/tests/errors/ts-module.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/ts-module.swc-stderr
@@ -18,10 +18,3 @@
  8 | declare module Bar { }
    :         ^^^^^^
    `----
-  x TypeScript namespace declaration is not supported in strip-only mode
-   ,-[3:1]
- 2 |     
- 3 | ,-> module Foo {
- 4 | |       export const foo = 1;
- 5 | `-> }
-   `----


### PR DESCRIPTION
**Description:**

This PR adds an early return to code paths to make them throw an object on error.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/10087