### PR TITLE
feat(ts/fast-strip): Emit json errors

### DIFF
--- a/.changeset/wild-roses-taste.md
+++ b/.changeset/wild-roses-taste.md
@@ -1,0 +1,7 @@
+---
+swc_core: minor
+swc_fast_ts_strip: minor
+swc_error_reporters: minor
+---
+
+feat(ts/fast-strip): Emit json errors

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5855,6 +5855,9 @@ dependencies = [
  "miette",
  "once_cell",
  "parking_lot",
+ "serde",
+ "serde_derive",
+ "serde_json",
  "swc_common",
 ]
 

--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`transform in strip-only mode should not emit 'Caused by: failed to parse' 1`] = `
-"{"code":"InvalidSyntax","message":"await isn't allowed in non-async function","snippet":".resolve(1); }","line":1,"column":23}
+"{"code":"InvalidSyntax","message":"await isn't allowed in non-async function","snippet":".resolve(1); }","filename":"test.ts","line":1,"column":23}
 "
 `;
 
@@ -32,12 +32,12 @@ exports[`transform in strip-only mode should remove declare enum 3`] = `
 `;
 
 exports[`transform in strip-only mode should report correct error for syntax error 1`] = `
-"{"code":"InvalidSyntax","message":"Expected ';', '}' or <eof>","snippet":" }","line":1,"column":25}
+"{"code":"InvalidSyntax","message":"Expected ';', '}' or <eof>","snippet":" }","filename":"test.ts","line":1,"column":25}
 "
 `;
 
 exports[`transform in strip-only mode should report correct error for unsupported syntax 1`] = `
-"{"code":"UnsupportedSyntax","message":"TypeScript enum is not supported in strip-only mode","snippet":"","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"TypeScript enum is not supported in strip-only mode","snippet":"","filename":"test.ts","line":1,"column":0}
 "
 `;
 
@@ -95,32 +95,32 @@ exports[`transform in strip-only mode should strip type declarations 1`] = `
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a module 1`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","filename":"test.ts","line":1,"column":0}
 "
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a module 2`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","line":1,"column":8}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","filename":"test.ts","line":1,"column":8}
 "
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a namespace 1`] = `
-"{"code":"UnsupportedSyntax","message":"TypeScript namespace declaration is not supported in strip-only mode","snippet":"","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"TypeScript namespace declaration is not supported in strip-only mode","snippet":"","filename":"test.ts","line":1,"column":0}
 "
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters an enum 1`] = `
-"{"code":"UnsupportedSyntax","message":"TypeScript enum is not supported in strip-only mode","snippet":"","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"TypeScript enum is not supported in strip-only mode","snippet":"","filename":"test.ts","line":1,"column":0}
 "
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a declared module 1`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","line":1,"column":8}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","filename":"test.ts","line":1,"column":8}
 "
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a module 1`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","filename":"test.ts","line":1,"column":0}
 "
 `;
 

--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -1,15 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`transform in strip-only mode should not emit 'Caused by: failed to parse' 1`] = `
-{
-  "code": "InvalidSyntax",
-  "message": "  x await isn't allowed in non-async function
-   ,----
- 1 | function foo() { await Promise.resolve(1); }
-   :                        ^^^^^^^
-   \`----
-",
-}
+"{"code":"InvalidSyntax","message":"await isn't allowed in non-async function","snippet":".resolve(1); }","line":1,"column":23}
+"
 `;
 
 exports[`transform in strip-only mode should remove declare enum 1`] = `
@@ -39,29 +32,13 @@ exports[`transform in strip-only mode should remove declare enum 3`] = `
 `;
 
 exports[`transform in strip-only mode should report correct error for syntax error 1`] = `
-{
-  "code": "InvalidSyntax",
-  "message": "  x Expected ';', '}' or <eof>
-   ,----
- 1 | function foo() { invalid syntax }
-   :                  ^^^|^^^ ^^^^^^
-   :                     \`-- This is the expression part of an expression statement
-   \`----
-",
-}
+"{"code":"InvalidSyntax","message":"Expected ';', '}' or <eof>","snippet":" }","line":1,"column":25}
+"
 `;
 
 exports[`transform in strip-only mode should report correct error for unsupported syntax 1`] = `
-{
-  "code": "UnsupportedSyntax",
-  "message": "  x TypeScript enum is not supported in strip-only mode
-   ,-[1:1]
- 1 | ,-> enum Foo {
- 2 | |                       a, b    
- 3 | \`->                     }
-   \`----
-",
-}
+"{"code":"UnsupportedSyntax","message":"TypeScript enum is not supported in strip-only mode","snippet":"","line":1,"column":0}
+"
 `;
 
 exports[`transform in strip-only mode should strip complex expressions 1`] = `
@@ -118,75 +95,33 @@ exports[`transform in strip-only mode should strip type declarations 1`] = `
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a module 1`] = `
-{
-  "code": "UnsupportedSyntax",
-  "message": "  x \`module\` keyword is not supported. Use \`namespace\` instead.
-   ,----
- 1 | module foo { }
-   : ^^^^^^
-   \`----
-",
-}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","line":1,"column":0}
+"
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a module 2`] = `
-{
-  "code": "UnsupportedSyntax",
-  "message": "  x \`module\` keyword is not supported. Use \`namespace\` instead.
-   ,----
- 1 | declare module foo { }
-   :         ^^^^^^
-   \`----
-",
-}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","line":1,"column":8}
+"
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a namespace 1`] = `
-{
-  "code": "UnsupportedSyntax",
-  "message": "  x TypeScript namespace declaration is not supported in strip-only mode
-   ,----
- 1 | namespace Foo { export const m = 1; }
-   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   \`----
-",
-}
+"{"code":"UnsupportedSyntax","message":"TypeScript namespace declaration is not supported in strip-only mode","snippet":"","line":1,"column":0}
+"
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters an enum 1`] = `
-{
-  "code": "UnsupportedSyntax",
-  "message": "  x TypeScript enum is not supported in strip-only mode
-   ,----
- 1 | enum Foo {}
-   : ^^^^^^^^^^^
-   \`----
-",
-}
+"{"code":"UnsupportedSyntax","message":"TypeScript enum is not supported in strip-only mode","snippet":"","line":1,"column":0}
+"
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a declared module 1`] = `
-{
-  "code": "UnsupportedSyntax",
-  "message": "  x \`module\` keyword is not supported. Use \`namespace\` instead.
-   ,----
- 1 | declare module foo { }
-   :         ^^^^^^
-   \`----
-",
-}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","line":1,"column":8}
+"
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a module 1`] = `
-{
-  "code": "UnsupportedSyntax",
-  "message": "  x \`module\` keyword is not supported. Use \`namespace\` instead.
-   ,----
- 1 | module foo { }
-   : ^^^^^^
-   \`----
-",
-}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","line":1,"column":0}
+"
 `;
 
 exports[`transform should strip types 1`] = `

--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -114,6 +114,11 @@ exports[`transform in strip-only mode should throw an error when it encounters a
 "
 `;
 
+exports[`transform in transform mode shoud throw an object even with deprecatedTsModuleAsError = true 1`] = `
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"<anon>","line":1,"column":0}
+"
+`;
+
 exports[`transform in transform mode should throw an error when it encounters a declared module 1`] = `
 "{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"test.ts","line":1,"column":8}
 "

--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`transform in strip-only mode should not emit 'Caused by: failed to parse' 1`] = `
-"{"code":"InvalidSyntax","message":"await isn't allowed in non-async function","snippet":".resolve(1); }","filename":"test.ts","line":1,"column":23}
+"{"code":"InvalidSyntax","message":"await isn't allowed in non-async function","snippet":"Promise","filename":"test.ts","line":1,"column":23}
 "
 `;
 
@@ -32,12 +32,12 @@ exports[`transform in strip-only mode should remove declare enum 3`] = `
 `;
 
 exports[`transform in strip-only mode should report correct error for syntax error 1`] = `
-"{"code":"InvalidSyntax","message":"Expected ';', '}' or <eof>","snippet":" }","filename":"test.ts","line":1,"column":25}
+"{"code":"InvalidSyntax","message":"Expected ';', '}' or <eof>","snippet":"syntax","filename":"test.ts","line":1,"column":25}
 "
 `;
 
 exports[`transform in strip-only mode should report correct error for unsupported syntax 1`] = `
-"{"code":"UnsupportedSyntax","message":"TypeScript enum is not supported in strip-only mode","snippet":"","filename":"test.ts","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"TypeScript enum is not supported in strip-only mode","snippet":"enum Foo {\\n                    a, b    \\n                    }","filename":"test.ts","line":1,"column":0}
 "
 `;
 
@@ -95,32 +95,32 @@ exports[`transform in strip-only mode should strip type declarations 1`] = `
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a module 1`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","filename":"test.ts","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"test.ts","line":1,"column":0}
 "
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a module 2`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","filename":"test.ts","line":1,"column":8}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"test.ts","line":1,"column":8}
 "
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a namespace 1`] = `
-"{"code":"UnsupportedSyntax","message":"TypeScript namespace declaration is not supported in strip-only mode","snippet":"","filename":"test.ts","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"TypeScript namespace declaration is not supported in strip-only mode","snippet":"namespace Foo { export const m = 1; }","filename":"test.ts","line":1,"column":0}
 "
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters an enum 1`] = `
-"{"code":"UnsupportedSyntax","message":"TypeScript enum is not supported in strip-only mode","snippet":"","filename":"test.ts","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"TypeScript enum is not supported in strip-only mode","snippet":"enum Foo {}","filename":"test.ts","line":1,"column":0}
 "
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a declared module 1`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","filename":"test.ts","line":1,"column":8}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"test.ts","line":1,"column":8}
 "
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a module 1`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":" foo { }","filename":"test.ts","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"test.ts","line":1,"column":0}
 "
 `;
 

--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -95,12 +95,12 @@ exports[`transform in strip-only mode should strip type declarations 1`] = `
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a module 1`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"test.ts","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module foo","filename":"test.ts","line":1,"column":0}
 "
 `;
 
 exports[`transform in strip-only mode should throw an error when it encounters a module 2`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"test.ts","line":1,"column":8}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module foo","filename":"test.ts","line":1,"column":8}
 "
 `;
 
@@ -115,17 +115,17 @@ exports[`transform in strip-only mode should throw an error when it encounters a
 `;
 
 exports[`transform in transform mode shoud throw an object even with deprecatedTsModuleAsError = true 1`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"<anon>","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module F","filename":"<anon>","line":1,"column":0}
 "
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a declared module 1`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"test.ts","line":1,"column":8}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module foo","filename":"test.ts","line":1,"column":8}
 "
 `;
 
 exports[`transform in transform mode should throw an error when it encounters a module 1`] = `
-"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module","filename":"test.ts","line":1,"column":0}
+"{"code":"UnsupportedSyntax","message":"\`module\` keyword is not supported. Use \`namespace\` instead.","snippet":"module foo","filename":"test.ts","line":1,"column":0}
 "
 `;
 

--- a/bindings/binding_typescript_wasm/__tests__/transform.js
+++ b/bindings/binding_typescript_wasm/__tests__/transform.js
@@ -205,9 +205,7 @@ describe("transform", () => {
                     mode: "transform",
                     deprecatedTsModuleAsError: true,
                 }),
-            ).rejects.toMatchObject({
-                code: "UnsupportedSyntax",
-            });
+            ).rejects.toMatchSnapshot();
         })
     });
 });

--- a/bindings/binding_typescript_wasm/__tests__/transform.js
+++ b/bindings/binding_typescript_wasm/__tests__/transform.js
@@ -111,6 +111,7 @@ describe("transform", () => {
             await expect(
                 swc.transform("enum Foo {}", {
                     mode: "strip-only",
+                    filename: "test.ts",
                 }),
             ).rejects.toMatchSnapshot();
         });
@@ -119,6 +120,7 @@ describe("transform", () => {
             await expect(
                 swc.transform("namespace Foo { export const m = 1; }", {
                     mode: "strip-only",
+                    filename: "test.ts",
                 }),
             ).rejects.toMatchSnapshot();
         });
@@ -128,6 +130,7 @@ describe("transform", () => {
                 swc.transform("module foo { }", {
                     mode: "strip-only",
                     deprecatedTsModuleAsError: true,
+                    filename: "test.ts",
                 }),
             ).rejects.toMatchSnapshot();
         });
@@ -137,6 +140,7 @@ describe("transform", () => {
                 swc.transform("declare module foo { }", {
                     mode: "strip-only",
                     deprecatedTsModuleAsError: true,
+                    filename: "test.ts",
                 }),
             ).rejects.toMatchSnapshot();
         });
@@ -144,6 +148,7 @@ describe("transform", () => {
         it("should not emit 'Caused by: failed to parse'", async () => {
             await expect(
                 swc.transform("function foo() { await Promise.resolve(1); }", {
+                    filename: "test.ts",
                     mode: "strip-only",
                 }),
             ).rejects.toMatchSnapshot();
@@ -153,6 +158,7 @@ describe("transform", () => {
             await expect(
                 swc.transform("function foo() { invalid syntax }", {
                     mode: "strip-only",
+                    filename: "test.ts"
                 }),
             ).rejects.toMatchSnapshot();
         });
@@ -165,6 +171,7 @@ describe("transform", () => {
                     }`,
                     {
                         mode: "strip-only",
+                        filename: "test.ts"
                     },
                 ),
             ).rejects.toMatchSnapshot();
@@ -177,6 +184,7 @@ describe("transform", () => {
                 swc.transform("module foo { }", {
                     mode: "transform",
                     deprecatedTsModuleAsError: true,
+                    filename: "test.ts"
                 }),
             ).rejects.toMatchSnapshot();
         });
@@ -186,6 +194,7 @@ describe("transform", () => {
                 swc.transform("declare module foo { }", {
                     mode: "transform",
                     deprecatedTsModuleAsError: true,
+                    filename: "test.ts",
                 }),
             ).rejects.toMatchSnapshot();
         });

--- a/bindings/binding_typescript_wasm/src/lib.rs
+++ b/bindings/binding_typescript_wasm/src/lib.rs
@@ -1,9 +1,8 @@
 use anyhow::Error;
 use js_sys::Uint8Array;
-use serde::Serialize;
 use swc_common::{errors::ColorConfig, sync::Lrc, SourceMap, GLOBALS};
 use swc_error_reporters::handler::{try_with_json_handler, HandlerOpts};
-use swc_fast_ts_strip::{ErrorCode, Options, TransformOutput, TsError};
+use swc_fast_ts_strip::{Options, TransformOutput};
 use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::{future_to_promise, js_sys::Promise};
 
@@ -67,5 +66,5 @@ fn operate(input: String, options: Options) -> Result<TransformOutput, Error> {
 }
 
 pub fn convert_err(err: Error) -> wasm_bindgen::prelude::JsValue {
-    format!("{}", err).into()
+    err.to_string().into()
 }

--- a/bindings/binding_typescript_wasm/src/lib.rs
+++ b/bindings/binding_typescript_wasm/src/lib.rs
@@ -57,7 +57,7 @@ fn operate(input: String, options: Options) -> Result<TransformOutput, Error> {
         cm.clone(),
         HandlerOpts {
             color: ColorConfig::Never,
-            skip_filename: true,
+            skip_filename: false,
         },
         |handler| {
             swc_fast_ts_strip::operate(&cm, handler, input, options).map_err(anyhow::Error::new)

--- a/crates/swc_error_reporters/Cargo.toml
+++ b/crates/swc_error_reporters/Cargo.toml
@@ -12,10 +12,13 @@ version       = "9.0.0"
 bench = false
 
 [dependencies]
-anyhow      = { workspace = true }
-miette      = { workspace = true, features = ["fancy-no-syscall"] }
-once_cell   = { workspace = true }
-parking_lot = { workspace = true }
+anyhow       = { workspace = true }
+miette       = { workspace = true, features = ["fancy-no-syscall"] }
+once_cell    = { workspace = true }
+parking_lot  = { workspace = true }
+serde        = { workspace = true }
+serde_derive = { workspace = true }
+serde_json   = { workspace = true }
 
 swc_common = { version = "8.0.0", path = "../swc_common", features = [
   "concurrent",

--- a/crates/swc_error_reporters/src/handler.rs
+++ b/crates/swc_error_reporters/src/handler.rs
@@ -119,19 +119,19 @@ where
     let wr = Box::<LockedWriter>::default();
 
     let emitter: Box<dyn Emitter> = if json {
+        Box::new(JsonEmitter::new(
+            cm,
+            wr.clone(),
+            JsonEmitterConfig {
+                skip_filename: config.skip_filename,
+            },
+        ))
+    } else {
         Box::new(PrettyEmitter::new(
             cm,
             wr.clone(),
             to_miette_reporter(config.color),
             PrettyEmitterConfig {
-                skip_filename: config.skip_filename,
-            },
-        ))
-    } else {
-        Box::new(JsonEmitter::new(
-            cm,
-            wr.clone(),
-            JsonEmitterConfig {
                 skip_filename: config.skip_filename,
             },
         ))

--- a/crates/swc_error_reporters/src/json_emitter.rs
+++ b/crates/swc_error_reporters/src/json_emitter.rs
@@ -1,14 +1,18 @@
-use miette::GraphicalReportHandler;
-use swc_common::{sync::Lrc, SourceMap};
+use std::{f128::consts::E, fmt::Write};
 
-use crate::WriterWrapper;
+use serde_derive::Serialize;
+use swc_common::{
+    errors::{DiagnosticBuilder, Emitter, Level},
+    sync::Lrc,
+    SourceMap,
+};
+
+use crate::{MietteDiagnostic, MietteSourceCode, MietteSubdiagnostic, WriterWrapper};
 
 pub struct JsonEmitter {
     cm: Lrc<SourceMap>,
 
     wr: WriterWrapper,
-
-    reporter: GraphicalReportHandler,
 
     config: JsonEmitterConfig,
 
@@ -18,4 +22,71 @@ pub struct JsonEmitter {
 #[derive(Debug, Clone, Default)]
 pub struct JsonEmitterConfig {
     pub skip_filename: bool,
+}
+
+impl Emitter for JsonEmitter {
+    fn emit(&mut self, db: &DiagnosticBuilder) {
+        let d = &**db;
+
+        let children = d
+            .children
+            .iter()
+            .map(|d| JsonSubdiagnostic {
+                code: &d.code,
+                message: &d.message,
+                snippet: d.snippet,
+                filename: d.filename(),
+                line: d.line(),
+            })
+            .collect::<Vec<_>>();
+
+        let error = JsonDiagnostic {
+            code: &d.code,
+            message: &d.message,
+            filename: d.filename(),
+            line: d.line(),
+            column: d.column(),
+            children,
+        };
+
+        let result = serde_json::to_string(&mut error).unwrap();
+
+        self.wr.write_str(&result).unwrap();
+
+        self.diagnostics.push(result);
+    }
+
+    fn take_diagnostics(&mut self) -> Vec<String> {
+        std::mem::take(&mut self.diagnostics)
+    }
+}
+
+#[derive(Serialize)]
+struct JsonDiagnostic<'a> {
+    /// Error code
+    code: &'a str,
+    message: &'a str,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    snippet: Option<&'a str>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    filename: Option<&'a str>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    line: Option<usize>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    column: Option<usize>,
+
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    children: Vec<JsonSubdiagnostic<'a>>,
+}
+
+#[derive(Serialize)]
+struct JsonSubdiagnostic<'a> {
+    code: &'a str,
+    message: &'a str,
+    snippet: &'a str,
+    filename: &'a str,
+    line: usize,
 }

--- a/crates/swc_error_reporters/src/json_emitter.rs
+++ b/crates/swc_error_reporters/src/json_emitter.rs
@@ -1,5 +1,18 @@
+use miette::GraphicalReportHandler;
+use swc_common::{sync::Lrc, SourceMap};
+
+use crate::WriterWrapper;
+
 pub struct JsonEmitter {
-    pub config: JsonEmitterConfig,
+    cm: Lrc<SourceMap>,
+
+    wr: WriterWrapper,
+
+    reporter: GraphicalReportHandler,
+
+    config: JsonEmitterConfig,
+
+    diagnostics: Vec<String>,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/crates/swc_error_reporters/src/json_emitter.rs
+++ b/crates/swc_error_reporters/src/json_emitter.rs
@@ -31,12 +31,7 @@ impl Emitter for JsonEmitter {
         let children = d
             .children
             .iter()
-            .map(|d| JsonSubdiagnostic {
-                message: &d.message,
-                snippet: d.snippet,
-                filename: d.filename(),
-                line: d.line(),
-            })
+            .map(|d| todo!("json subdiagnostic: {d:?}"))
             .collect::<Vec<_>>();
 
         let error_code = match &d.code {
@@ -50,12 +45,14 @@ impl Emitter for JsonEmitter {
             .primary_span()
             .and_then(|span| self.cm.try_lookup_char_pos(span.lo()).ok());
 
+        let filename = loc.map(|loc| loc.file.name.to_string());
+
         let error = JsonDiagnostic {
             code: error_code,
             message: &d.message,
-            filename: d.filename(),
-            line: d.span,
-            column: d.column(),
+            filename: filename.as_deref(),
+            line: loc.map(|loc| loc.line),
+            column: loc.map(|loc| loc.col_display),
             children,
         };
 

--- a/crates/swc_error_reporters/src/json_emitter.rs
+++ b/crates/swc_error_reporters/src/json_emitter.rs
@@ -84,7 +84,7 @@ impl Emitter for JsonEmitter {
         let result = serde_json::to_string(&error).unwrap();
 
         self.wr.write_str(&result).unwrap();
-        write!(self.wr, "\n").unwrap();
+        writeln!(self.wr).unwrap();
 
         self.diagnostics.push(result);
     }

--- a/crates/swc_error_reporters/src/json_emitter.rs
+++ b/crates/swc_error_reporters/src/json_emitter.rs
@@ -4,7 +4,7 @@ use serde_derive::Serialize;
 use swc_common::{
     errors::{DiagnosticBuilder, DiagnosticId, Emitter},
     sync::Lrc,
-    SourceMap,
+    SourceMap, SourceMapper,
 };
 
 use crate::WriterWrapper;
@@ -63,7 +63,7 @@ impl Emitter for JsonEmitter {
         let snippet = d
             .span
             .primary_span()
-            .and_then(|span| self.cm.span_to_next_source(span).ok());
+            .and_then(|span| self.cm.span_to_snippet(span).ok());
 
         let filename = if self.config.skip_filename {
             None

--- a/crates/swc_error_reporters/src/json_emitter.rs
+++ b/crates/swc_error_reporters/src/json_emitter.rs
@@ -1,0 +1,8 @@
+pub struct JsonEmitter {
+    pub config: JsonEmitterConfig,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct JsonEmitterConfig {
+    pub skip_filename: bool,
+}

--- a/crates/swc_error_reporters/src/json_emitter.rs
+++ b/crates/swc_error_reporters/src/json_emitter.rs
@@ -84,6 +84,7 @@ impl Emitter for JsonEmitter {
         let result = serde_json::to_string(&error).unwrap();
 
         self.wr.write_str(&result).unwrap();
+        write!(self.wr, "\n").unwrap();
 
         self.diagnostics.push(result);
     }

--- a/crates/swc_error_reporters/src/json_emitter.rs
+++ b/crates/swc_error_reporters/src/json_emitter.rs
@@ -19,6 +19,21 @@ pub struct JsonEmitter {
     diagnostics: Vec<String>,
 }
 
+impl JsonEmitter {
+    pub fn new(
+        cm: Lrc<SourceMap>,
+        wr: Box<dyn Write + Send + Sync>,
+        config: JsonEmitterConfig,
+    ) -> Self {
+        Self {
+            cm,
+            wr: WriterWrapper(wr),
+            config,
+            diagnostics: vec![],
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct JsonEmitterConfig {
     pub skip_filename: bool,

--- a/crates/swc_error_reporters/src/lib.rs
+++ b/crates/swc_error_reporters/src/lib.rs
@@ -193,9 +193,9 @@ impl Emitter for PrettyEmitter {
             .render_report(&mut format_result, &diagnostic)
             .unwrap();
 
-        self.diagnostics.push(format_result.clone());
+        self.wr.write_str(&format_result).unwrap();
 
-        self.wr.write_str(&format_result).unwrap()
+        self.diagnostics.push(format_result);
     }
 
     fn take_diagnostics(&mut self) -> Vec<String> {

--- a/crates/swc_error_reporters/src/lib.rs
+++ b/crates/swc_error_reporters/src/lib.rs
@@ -13,10 +13,8 @@ use swc_common::{
     BytePos, FileName, SourceMap, Span,
 };
 
-pub use crate::json_emitter::*;
-
 pub mod handler;
-mod json_emitter;
+pub mod json_emitter;
 
 pub struct PrettyEmitter {
     cm: Lrc<SourceMap>,

--- a/crates/swc_error_reporters/src/lib.rs
+++ b/crates/swc_error_reporters/src/lib.rs
@@ -13,7 +13,10 @@ use swc_common::{
     BytePos, FileName, SourceMap, Span,
 };
 
+pub use crate::json_emitter::*;
+
 pub mod handler;
+mod json_emitter;
 
 pub struct PrettyEmitter {
     cm: Lrc<SourceMap>,

--- a/crates/swc_fast_ts_strip/src/lib.rs
+++ b/crates/swc_fast_ts_strip/src/lib.rs
@@ -510,7 +510,7 @@ impl Visit for ErrorOnTsModule<'_> {
         HANDLER.with(|handler| {
             handler
                 .struct_span_err(
-                    span(pos, pos + BytePos(6)),
+                    span(pos, n.id.span().hi),
                     "`module` keyword is not supported. Use `namespace` instead.",
                 )
                 .code(DiagnosticId::Error("UnsupportedSyntax".into()))

--- a/crates/swc_fast_ts_strip/src/lib.rs
+++ b/crates/swc_fast_ts_strip/src/lib.rs
@@ -4,7 +4,7 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use swc_common::{
     comments::SingleThreadedComments,
-    errors::{Handler, HANDLER},
+    errors::{DiagnosticId, Handler, HANDLER},
     source_map::DefaultSourceMapGenConfig,
     sync::Lrc,
     BytePos, FileName, Mark, SourceMap, Span, Spanned,
@@ -216,10 +216,14 @@ pub fn operate(
     let mut program = match program {
         Ok(program) => program,
         Err(err) => {
-            err.into_diagnostic(handler).emit();
+            err.into_diagnostic(handler)
+                .code(DiagnosticId::Error("InvalidSyntax".into()))
+                .emit();
 
             for e in errors {
-                e.into_diagnostic(handler).emit();
+                e.into_diagnostic(handler)
+                    .code(DiagnosticId::Error("InvalidSyntax".into()))
+                    .emit();
             }
 
             return Err(TsError {
@@ -231,7 +235,9 @@ pub fn operate(
 
     if !errors.is_empty() {
         for e in errors {
-            e.into_diagnostic(handler).emit();
+            e.into_diagnostic(handler)
+                .code(DiagnosticId::Error("InvalidSyntax".into()))
+                .emit();
         }
 
         return Err(TsError {
@@ -507,6 +513,7 @@ impl Visit for ErrorOnTsModule<'_> {
                     span(pos, pos + BytePos(6)),
                     "`module` keyword is not supported. Use `namespace` instead.",
                 )
+                .code(DiagnosticId::Error("UnsupportedSyntax".into()))
                 .emit();
         });
     }
@@ -1275,6 +1282,7 @@ impl Visit for TsStrip {
                     n.span,
                     "TypeScript export assignment is not supported in strip-only mode",
                 )
+                .code(DiagnosticId::Error("UnsupportedSyntax".into()))
                 .emit();
         });
     }
@@ -1292,6 +1300,7 @@ impl Visit for TsStrip {
                     n.span,
                     "TypeScript import equals declaration is not supported in strip-only mode",
                 )
+                .code(DiagnosticId::Error("UnsupportedSyntax".into()))
                 .emit();
         });
     }
@@ -1313,6 +1322,7 @@ impl Visit for TsStrip {
                     e.span,
                     "TypeScript enum is not supported in strip-only mode",
                 )
+                .code(DiagnosticId::Error("UnsupportedSyntax".into()))
                 .emit();
         });
     }
@@ -1324,6 +1334,7 @@ impl Visit for TsStrip {
                     n.span(),
                     "TypeScript namespace declaration is not supported in strip-only mode",
                 )
+                .code(DiagnosticId::Error("UnsupportedSyntax".into()))
                 .emit();
         });
     }
@@ -1341,6 +1352,7 @@ impl Visit for TsStrip {
                     n.span(),
                     "TypeScript parameter property is not supported in strip-only mode",
                 )
+                .code(DiagnosticId::Error("UnsupportedSyntax".into()))
                 .emit();
         });
     }
@@ -1382,6 +1394,7 @@ impl Visit for TsStrip {
                     "The angle-bracket syntax for type assertions, `<T>expr`, is not supported in \
                      type strip mode. Instead, use the 'as' syntax: `expr as T`.",
                 )
+                .code(DiagnosticId::Error("UnsupportedSyntax".into()))
                 .emit();
         });
 

--- a/crates/swc_fast_ts_strip/tests/errors/enums.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/enums.swc-stderr
@@ -1,8 +1,12 @@
+UnsupportedSyntax
+
   x TypeScript enum is not supported in strip-only mode
    ,----
  1 | enum Foo { }
    : ^^^^^^^^^^^^
    `----
+UnsupportedSyntax
+
   x TypeScript enum is not supported in strip-only mode
    ,-[3:1]
  2 | 

--- a/crates/swc_fast_ts_strip/tests/errors/export-equals.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/export-equals.swc-stderr
@@ -1,3 +1,5 @@
+UnsupportedSyntax
+
   x TypeScript export assignment is not supported in strip-only mode
    ,-[2:1]
  1 | 

--- a/crates/swc_fast_ts_strip/tests/errors/import-equals.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/import-equals.swc-stderr
@@ -1,3 +1,5 @@
+UnsupportedSyntax
+
   x TypeScript import equals declaration is not supported in strip-only mode
    ,----
  1 | import foo = require("foo");

--- a/crates/swc_fast_ts_strip/tests/errors/invalid-syntax-1.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/invalid-syntax-1.swc-stderr
@@ -1,3 +1,5 @@
+InvalidSyntax
+
   x 'const' declarations must be initialized
    ,----
  1 | interface Foo { }; const foo;

--- a/crates/swc_fast_ts_strip/tests/errors/issue-9977.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/issue-9977.swc-stderr
@@ -1,3 +1,5 @@
+UnsupportedSyntax
+
   x TypeScript parameter property is not supported in strip-only mode
    ,-[6:1]
  5 |     // No parameter properties
@@ -5,6 +7,8 @@
    :                        ^^^^^^^^^^^
  7 | }
    `----
+UnsupportedSyntax
+
   x TypeScript namespace declaration is not supported in strip-only mode
     ,-[9:1]
   8 |     
@@ -12,6 +16,8 @@
  10 | |       export const m = 1;
  11 | `-> }
     `----
+UnsupportedSyntax
+
   x TypeScript namespace declaration is not supported in strip-only mode
     ,-[13:1]
  12 |     
@@ -21,6 +27,8 @@
  16 | |       }
  17 | `-> }
     `----
+UnsupportedSyntax
+
   x TypeScript namespace declaration is not supported in strip-only mode
     ,-[19:1]
  18 |     
@@ -30,6 +38,8 @@
  22 | |       }
  23 | `-> }
     `----
+UnsupportedSyntax
+
   x TypeScript enum is not supported in strip-only mode
     ,-[25:1]
  24 |     
@@ -37,12 +47,16 @@
  26 | |       B = 1
  27 | `-> }
     `----
+UnsupportedSyntax
+
   x TypeScript import equals declaration is not supported in strip-only mode
     ,-[29:1]
  28 | 
  29 | import NoGoodAlias = NotLegalEnum.B;
     : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
     `----
+UnsupportedSyntax
+
   x TypeScript enum is not supported in strip-only mode
     ,-[31:1]
  30 |     

--- a/crates/swc_fast_ts_strip/tests/errors/modules.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/modules.swc-stderr
@@ -3,7 +3,7 @@ UnsupportedSyntax
   x `module` keyword is not supported. Use `namespace` instead.
    ,----
  1 | module aModuleKeywordNamespace { }
-   : ^^^^^^
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 UnsupportedSyntax
 
@@ -11,7 +11,7 @@ UnsupportedSyntax
    ,-[3:1]
  2 | 
  3 | declare module aModuleKeywordDeclareNamespace { }
-   :         ^^^^^^
+   :         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 UnsupportedSyntax
 
@@ -19,7 +19,7 @@ UnsupportedSyntax
    ,-[5:1]
  4 | 
  5 | export module aModuleKeywordExportedNamespace { }
-   :        ^^^^^^
+   :        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 UnsupportedSyntax
 
@@ -27,7 +27,7 @@ UnsupportedSyntax
    ,-[7:1]
  6 | 
  7 | export declare module aModuleKeywordExportedDeclareNamespace { }
-   :                ^^^^^^
+   :                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
 UnsupportedSyntax
 
@@ -35,6 +35,6 @@ UnsupportedSyntax
     ,-[10:1]
   9 | namespace foo {
  10 |     export module aModuleKeywordExportedNamespaceInNamespace { }
-    :            ^^^^^^
+    :            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  11 | }
     `----

--- a/crates/swc_fast_ts_strip/tests/errors/modules.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/modules.swc-stderr
@@ -1,26 +1,36 @@
+UnsupportedSyntax
+
   x `module` keyword is not supported. Use `namespace` instead.
    ,----
  1 | module aModuleKeywordNamespace { }
    : ^^^^^^
    `----
+UnsupportedSyntax
+
   x `module` keyword is not supported. Use `namespace` instead.
    ,-[3:1]
  2 | 
  3 | declare module aModuleKeywordDeclareNamespace { }
    :         ^^^^^^
    `----
+UnsupportedSyntax
+
   x `module` keyword is not supported. Use `namespace` instead.
    ,-[5:1]
  4 | 
  5 | export module aModuleKeywordExportedNamespace { }
    :        ^^^^^^
    `----
+UnsupportedSyntax
+
   x `module` keyword is not supported. Use `namespace` instead.
    ,-[7:1]
  6 | 
  7 | export declare module aModuleKeywordExportedDeclareNamespace { }
    :                ^^^^^^
    `----
+UnsupportedSyntax
+
   x `module` keyword is not supported. Use `namespace` instead.
     ,-[10:1]
   9 | namespace foo {

--- a/crates/swc_fast_ts_strip/tests/errors/namespaces.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/namespaces.swc-stderr
@@ -1,8 +1,12 @@
+UnsupportedSyntax
+
   x TypeScript namespace declaration is not supported in strip-only mode
    ,----
  1 | namespace Foo { export const m = 1; }
    : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    `----
+UnsupportedSyntax
+
   x TypeScript namespace declaration is not supported in strip-only mode
    ,-[3:1]
  2 | 

--- a/crates/swc_fast_ts_strip/tests/errors/parameter-property.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/parameter-property.swc-stderr
@@ -1,3 +1,5 @@
+UnsupportedSyntax
+
   x TypeScript parameter property is not supported in strip-only mode
    ,-[5:1]
  4 | class Foo {
@@ -5,6 +7,8 @@
    :                        ^^^^^^^^^^
  6 | }
    `----
+UnsupportedSyntax
+
   x TypeScript parameter property is not supported in strip-only mode
     ,-[10:1]
   9 | class Bar {

--- a/crates/swc_fast_ts_strip/tests/errors/ts-module.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/ts-module.swc-stderr
@@ -4,7 +4,7 @@ UnsupportedSyntax
    ,-[3:1]
  2 | 
  3 | module Foo {
-   : ^^^^^^
+   : ^^^^^^^^^^
  4 |     export const foo = 1;
    `----
 UnsupportedSyntax
@@ -13,7 +13,7 @@ UnsupportedSyntax
    ,-[7:1]
  6 | 
  7 | module Foo { }
-   : ^^^^^^
+   : ^^^^^^^^^^
  8 | declare module Bar { }
    `----
 UnsupportedSyntax
@@ -22,5 +22,5 @@ UnsupportedSyntax
    ,-[8:1]
  7 | module Foo { }
  8 | declare module Bar { }
-   :         ^^^^^^
+   :         ^^^^^^^^^^
    `----

--- a/crates/swc_fast_ts_strip/tests/errors/ts-module.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/ts-module.swc-stderr
@@ -1,3 +1,5 @@
+UnsupportedSyntax
+
   x `module` keyword is not supported. Use `namespace` instead.
    ,-[3:1]
  2 | 
@@ -5,6 +7,8 @@
    : ^^^^^^
  4 |     export const foo = 1;
    `----
+UnsupportedSyntax
+
   x `module` keyword is not supported. Use `namespace` instead.
    ,-[7:1]
  6 | 
@@ -12,6 +16,8 @@
    : ^^^^^^
  8 | declare module Bar { }
    `----
+UnsupportedSyntax
+
   x `module` keyword is not supported. Use `namespace` instead.
    ,-[8:1]
  7 | module Foo { }

--- a/crates/swc_fast_ts_strip/tests/errors/ts-namespace.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/ts-namespace.swc-stderr
@@ -1,3 +1,5 @@
+UnsupportedSyntax
+
   x TypeScript namespace declaration is not supported in strip-only mode
    ,-[3:1]
  2 |     

--- a/crates/swc_fast_ts_strip/tests/errors/type-assertions.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/errors/type-assertions.swc-stderr
@@ -1,3 +1,5 @@
+UnsupportedSyntax
+
   x The angle-bracket syntax for type assertions, `<T>expr`, is not supported in type strip mode. Instead, use the 'as' syntax: `expr as T`.
    ,-[3:1]
  2 | 

--- a/crates/swc_fast_ts_strip/tests/fixture/class-properties.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/fixture/class-properties.swc-stderr
@@ -1,3 +1,5 @@
+UnsupportedSyntax
+
   x TypeScript parameter property is not supported in strip-only mode
    ,-[3:1]
  2 |     x = console.log(1)

--- a/crates/swc_fast_ts_strip/tests/fixture/unicode.swc-stderr
+++ b/crates/swc_fast_ts_strip/tests/fixture/unicode.swc-stderr
@@ -1,3 +1,5 @@
+UnsupportedSyntax
+
   x The angle-bracket syntax for type assertions, `<T>expr`, is not supported in type strip mode. Instead, use the 'as' syntax: `expr as T`.
    ,-[4:1]
  3 | function foo() {


### PR DESCRIPTION
**Description:**

 - Improves span for `swc_fast_ts_strip`.
 - Add `try_with_json_handler` to `swc_error_reporters`.
 - `@swc/wasm-typescript` now throws a string separated by `\n`.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/9884