### PR TITLE
perf(es/fast-lexer): Make whitespace skipper use SIMD properly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3828,15 +3828,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]

--- a/crates/swc_ecma_fast_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_fast_parser/src/lexer/mod.rs
@@ -516,12 +516,6 @@ impl<'a> Lexer<'a> {
             u8x16::new(bytes)
         };
 
-        // Create SIMD vectors for common whitespace characters
-        let space_vec = u8x16::splat(b' ');
-        let tab_vec = u8x16::splat(b'\t');
-        let form_feed_vec = u8x16::splat(0x0c); // Form feed
-        let vert_tab_vec = u8x16::splat(0x0b); // Vertical tab
-
         // Handle special characters separately for better branch prediction
         let first_byte = unsafe { *input.get_unchecked(0) };
 
@@ -563,6 +557,12 @@ impl<'a> Lexer<'a> {
             }
             _ => {}
         }
+
+        // Create SIMD vectors for common whitespace characters
+        let space_vec = u8x16::splat(b' ');
+        let tab_vec = u8x16::splat(b'\t');
+        let form_feed_vec = u8x16::splat(0x0c); // Form feed
+        let vert_tab_vec = u8x16::splat(0x0b); // Vertical tab
 
         // Fast path for regular whitespace (space, tab, form feed, vertical tab)
         // Compare with our whitespace vectors

--- a/crates/swc_ecma_fast_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_fast_parser/src/lexer/mod.rs
@@ -509,11 +509,12 @@ impl<'a> Lexer<'a> {
 
         // Get current 16 bytes
         let input = self.cursor.rest();
-        let data = unsafe {
+        let data = [0u8; 16];
+        unsafe {
             // SAFETY: We've checked that we have at least 16 bytes
-            let ptr = input.as_ptr();
-            u8x16::from_ptr_aligned_unaligned(ptr)
-        };
+            std::ptr::copy_nonoverlapping(input.as_ptr(), data.as_mut_ptr(), 16);
+        }
+        let data = u8x16::new(data);
 
         // Create SIMD vectors for common whitespace characters
         let space_vec = u8x16::splat(b' ');


### PR DESCRIPTION
**Description:**

Previously the SIMD function processed one byte at a time.