### PR TITLE
ci: add swc_plugins test to ecosystem CI

### DIFF
--- a/.github/swc-ecosystem-ci/tests/swc-plugins.ts
+++ b/.github/swc-ecosystem-ci/tests/swc-plugins.ts
@@ -1,0 +1,13 @@
+import { runInRepo } from "../utils.js";
+import type { RunOptions } from "../types.js";
+
+export async function test(options: RunOptions) {
+  await runInRepo({
+    ...options,
+    repo: "swc-project/plugins",
+    branch: "main",
+    build: "prepack",
+    test: "test",
+    isWasm: true,
+  });
+}


### PR DESCRIPTION
**Description:**

Add swc_plugins wasm plugin test to ecosystem ci to avoid the latest `@swc/core` load wams plugin failed.

Reference PR: https://github.com/swc-project/plugins/pull/424

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/10127