### PR TITLE
fix(es/compat): Hoist `arguments` in object method while lowering async functions

### DIFF
--- a/.changeset/foo-bar.md
+++ b/.changeset/foo-bar.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_compat_es2017: patch
+swc_core: patch
+---
+
+fix(es/compat): Hoist arguments in object method while lowering async functions

--- a/crates/swc/tests/fixture/issues-10xxx/10149/1/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-10xxx/10149/1/input/.swcrc
@@ -1,0 +1,11 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": false
+        },
+        "target": "es5"
+    },
+    "minify": false,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10149/1/input/index.ts
+++ b/crates/swc/tests/fixture/issues-10xxx/10149/1/input/index.ts
@@ -1,0 +1,15 @@
+var foo = {
+    async bar({ name }) {
+        console.log("arguments.length", arguments.length);
+    },
+};
+
+class Foo {
+    async bar({ name }) {
+        console.log("arguments.length", arguments.length);
+    }
+}
+
+async function bar({ name }) {
+    console.log("arguments.length", arguments.length);
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10149/1/output/index.ts
+++ b/crates/swc/tests/fixture/issues-10xxx/10149/1/output/index.ts
@@ -1,0 +1,59 @@
+var _async_to_generator = require("@swc/helpers/_/_async_to_generator");
+var _class_call_check = require("@swc/helpers/_/_class_call_check");
+var _create_class = require("@swc/helpers/_/_create_class");
+var _ts_generator = require("@swc/helpers/_/_ts_generator");
+var foo = {
+    bar: function bar(param) {
+        var name = param.name;
+        var _arguments = arguments;
+        return _async_to_generator._(function() {
+            return _ts_generator._(this, function(_state) {
+                console.log("arguments.length", _arguments.length);
+                return [
+                    2
+                ];
+            });
+        })();
+    }
+};
+var Foo = /*#__PURE__*/ function() {
+    "use strict";
+    function Foo() {
+        _class_call_check._(this, Foo);
+    }
+    _create_class._(Foo, [
+        {
+            key: "bar",
+            value: function bar(param) {
+                var name = param.name;
+                var _arguments = arguments;
+                return _async_to_generator._(function() {
+                    return _ts_generator._(this, function(_state) {
+                        console.log("arguments.length", _arguments.length);
+                        return [
+                            2
+                        ];
+                    });
+                })();
+            }
+        }
+    ]);
+    return Foo;
+}();
+function bar(_) {
+    return _bar.apply(this, arguments);
+}
+function _bar() {
+    _bar = _async_to_generator._(function(param) {
+        var name;
+        var _arguments = arguments;
+        return _ts_generator._(this, function(_state) {
+            name = param.name;
+            console.log("arguments.length", _arguments.length);
+            return [
+                2
+            ];
+        });
+    });
+    return _bar.apply(this, arguments);
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10149/2/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-10xxx/10149/2/input/.swcrc
@@ -1,0 +1,11 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": false
+        },
+        "target": "es2016"
+    },
+    "minify": false,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10149/2/input/index.ts
+++ b/crates/swc/tests/fixture/issues-10xxx/10149/2/input/index.ts
@@ -1,0 +1,15 @@
+var foo = {
+    async bar({ name }) {
+        console.log("arguments.length", arguments.length);
+    },
+};
+
+class Foo {
+    async bar({ name }) {
+        console.log("arguments.length", arguments.length);
+    }
+}
+
+async function bar({ name }) {
+    console.log("arguments.length", arguments.length);
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10149/2/output/index.ts
+++ b/crates/swc/tests/fixture/issues-10xxx/10149/2/output/index.ts
@@ -1,0 +1,26 @@
+var _async_to_generator = require("@swc/helpers/_/_async_to_generator");
+var foo = {
+    bar ({ name }) {
+        var _arguments = arguments;
+        return _async_to_generator._(function*() {
+            console.log("arguments.length", _arguments.length);
+        })();
+    }
+};
+class Foo {
+    bar({ name }) {
+        var _arguments = arguments;
+        return _async_to_generator._(function*() {
+            console.log("arguments.length", _arguments.length);
+        })();
+    }
+}
+function bar(_) {
+    return _bar.apply(this, arguments);
+}
+function _bar() {
+    _bar = _async_to_generator._(function*({ name }) {
+        console.log("arguments.length", arguments.length);
+    });
+    return _bar.apply(this, arguments);
+}

--- a/crates/swc/tests/fixture/issues-1xxx/1575/case1/output/index.js
+++ b/crates/swc/tests/fixture/issues-1xxx/1575/case1/output/index.js
@@ -3,14 +3,15 @@ var _ts_generator = require("@swc/helpers/_/_ts_generator");
 Vue.component("test", {
     methods: {
         onSend: function onSend() {
+            var _this = this;
             return _async_to_generator._(function() {
                 return _ts_generator._(this, function(_state) {
-                    if (this.msg === "") {}
+                    if (_this.msg === "") {}
                     return [
                         2
                     ];
                 });
-            }).apply(this);
+            })();
         }
     }
 });

--- a/crates/swc/tests/fixture/issues-1xxx/1575/case2/output/index.js
+++ b/crates/swc/tests/fixture/issues-1xxx/1575/case2/output/index.js
@@ -3,14 +3,15 @@ var _ts_generator = require("@swc/helpers/_/_ts_generator");
 var obj = {
     foo: 5,
     method: function method() {
+        var _this = this;
         return _async_to_generator._(function() {
             return _ts_generator._(this, function(_state) {
                 return [
                     2,
-                    this.foo
+                    _this.foo
                 ];
             });
-        }).apply(this);
+        })();
     }
 };
 obj.method().then(function(v) {


### PR DESCRIPTION
**Related issue:**

- Closes #10149

