### PR TITLE
perf(es/fast-lexer): replace PHF with static keyword lookup table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5313,7 +5313,6 @@ dependencies = [
  "criterion",
  "memchr",
  "num-bigint",
- "phf",
  "pretty_assertions",
  "serde_json",
  "swc_atoms",

--- a/crates/swc_ecma_fast_parser/Cargo.toml
+++ b/crates/swc_ecma_fast_parser/Cargo.toml
@@ -21,7 +21,6 @@ swc_ecma_ast = { version = "8.0.0", path = "../swc_ecma_ast" }
 assume     = { workspace = true }
 memchr     = { workspace = true }
 num-bigint = { workspace = true }
-phf        = { workspace = true, features = ["macros"] }
 wide       = { workspace = true }
 
 [dev-dependencies]

--- a/crates/swc_ecma_fast_parser/src/lexer/cursor.rs
+++ b/crates/swc_ecma_fast_parser/src/lexer/cursor.rs
@@ -108,30 +108,31 @@ impl<'a> Cursor<'a> {
     where
         F: FnMut(u8) -> bool,
     {
-        const BATCH_SIZE: u32 = 32;
+        // Warning: Do not scalarize if we do not use SIMD
+        // const BATCH_SIZE: u32 = 32;
 
-        // Process in batches if we have more than BATCH_SIZE bytes
-        while self.pos + BATCH_SIZE <= self.len {
-            let mut should_stop = false;
+        // // Process in batches if we have more than BATCH_SIZE bytes
+        // while self.pos + BATCH_SIZE <= self.len {
+        //     let mut should_stop = false;
 
-            // Check all bytes in the batch
-            for i in 0..BATCH_SIZE {
-                // SAFETY: We've verified bounds above
-                let byte = unsafe { *self.input.get_unchecked((self.pos + i) as usize) };
-                if !predicate(byte) {
-                    should_stop = true;
-                    break;
-                }
-            }
+        //     // Check all bytes in the batch
+        //     for i in 0..BATCH_SIZE {
+        //         // SAFETY: We've verified bounds above
+        //         let byte = unsafe { *self.input.get_unchecked((self.pos + i) as
+        // usize) };         if !predicate(byte) {
+        //             should_stop = true;
+        //             break;
+        //         }
+        //     }
 
-            if should_stop {
-                // Found stopping byte, switch to byte-by-byte
-                break;
-            }
+        //     if should_stop {
+        //         // Found stopping byte, switch to byte-by-byte
+        //         break;
+        //     }
 
-            // Skip the entire batch
-            self.pos += BATCH_SIZE;
-        }
+        //     // Skip the entire batch
+        //     self.pos += BATCH_SIZE;
+        // }
 
         // Byte-by-byte for the remainder
         while let Some(byte) = self.peek() {

--- a/crates/swc_ecma_fast_parser/src/lexer/identifier.rs
+++ b/crates/swc_ecma_fast_parser/src/lexer/identifier.rs
@@ -101,6 +101,7 @@ impl Lexer<'_> {
         let ident_start = start_pos.0;
         let ident_end = self.cursor.position();
         let ident_bytes = unsafe { self.cursor.slice_unchecked(ident_start, ident_end) };
+        // SAFETY: We've verified the bytes are valid UTF-8
         let ident_str = unsafe { std::str::from_utf8_unchecked(ident_bytes) };
         let had_line_break_bool: bool = self.had_line_break.into();
 
@@ -110,7 +111,6 @@ impl Lexer<'_> {
         // Only process if first byte is an ASCII lowercase letter (all keywords start
         // with a-z)
         if len > 0 && ident_bytes[0] >= b'a' && ident_bytes[0] <= b'z' {
-            // Fallback path: Check in the PHF map if this is a keyword
             // Only runs for potential keywords not in our direct lookup tables
             if let Some(token_type) = keyword_to_token_type(ident_str) {
                 return Ok(Token::new(


### PR DESCRIPTION


<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Replaces the perfect hash function (PHF) keyword lookup with a more performant static keyword lookup table. The new implementation:

- Removes dependency on `phf` crate
- Adds a custom static keyword lookup mechanism
- Introduces a more cache-friendly keyword search algorithm
- Adds support for the `module` keyword

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
