### PR TITLE
fix(typescript): Skip the body of ArrowExpr in type usage analysis 

### DIFF
--- a/.changeset/unlucky-olives-whisper.md
+++ b/.changeset/unlucky-olives-whisper.md
@@ -1,0 +1,6 @@
+---
+swc_typescript: patch
+swc_core: patch
+---
+
+fix(typescript): Skip the body of ArrowExpr in type usage analysis 

--- a/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
+++ b/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
@@ -53,7 +53,6 @@ impl TypeUsageAnalyzer<'_> {
                 used_refs.insert(analyzer.graph[node_id].clone());
             }
         }
-        dbg!(&used_refs);
         used_refs
     }
 

--- a/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
+++ b/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
@@ -6,9 +6,9 @@ use petgraph::{
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_common::{BytePos, Spanned, SyntaxContext};
 use swc_ecma_ast::{
-    Accessibility, Class, ClassMember, Decl, ExportDecl, ExportDefaultDecl, ExportDefaultExpr,
-    Function, Id, Ident, ModuleExportName, ModuleItem, NamedExport, TsEntityName,
-    TsExportAssignment, TsExprWithTypeArgs, TsPropertySignature, TsTypeElement,
+    Accessibility, ArrowExpr, Class, ClassMember, Decl, ExportDecl, ExportDefaultDecl,
+    ExportDefaultExpr, Function, Id, Ident, ModuleExportName, ModuleItem, NamedExport,
+    TsEntityName, TsExportAssignment, TsExprWithTypeArgs, TsPropertySignature, TsTypeElement,
 };
 use swc_ecma_visit::{Visit, VisitWith};
 
@@ -53,6 +53,7 @@ impl TypeUsageAnalyzer<'_> {
                 used_refs.insert(analyzer.graph[node_id].clone());
             }
         }
+        dbg!(&used_refs);
         used_refs
     }
 
@@ -228,6 +229,13 @@ impl Visit for TypeUsageAnalyzer<'_> {
         self.with_source(self.source, |this| {
             node.visit_children_with(this);
         });
+    }
+
+    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
+        // Skip body
+        node.params.visit_with(self);
+        node.type_params.visit_with(self);
+        node.return_type.visit_with(self);
     }
 
     fn visit_function(&mut self, node: &Function) {

--- a/crates/swc_typescript/tests/fixture/issues/10171.snap
+++ b/crates/swc_typescript/tests/fixture/issues/10171.snap
@@ -1,0 +1,8 @@
+```==================== .D.TS ====================
+
+export declare const Externals: {
+    Pinkie: string;
+};
+export declare const magical: () => string;
+
+

--- a/crates/swc_typescript/tests/fixture/issues/10171.ts
+++ b/crates/swc_typescript/tests/fixture/issues/10171.ts
@@ -1,0 +1,16 @@
+export const Externals = {
+    Pinkie: "Pinkie Pie",
+};
+
+const Ponies = {
+    name: Externals.Pinkie,
+};
+
+type Pony = keyof typeof Ponies;
+
+export const magical = (): string => {
+    const pinkie = (): Pony => "name";
+
+    console.log(Ponies.name);
+    return pinkie();
+};


### PR DESCRIPTION
Fixes https://github.com/swc-project/swc/issues/10171