### PR TITLE
chore(es/minifier): Fix lints & `size.sh`

### DIFF
--- a/crates/swc_ecma_minifier/scripts/size.sh
+++ b/crates/swc_ecma_minifier/scripts/size.sh
@@ -4,5 +4,6 @@ set -eu
 export UPDATE=1
 export DIFF=0
 export RUST_LOG=off
+export MIMALLOC_SHOW_STATS=0
 
 for f in ./benches/full/*.js; do cargo run --release --features concurrent --example minifier -- $f && gzip -9 -c output.js | wc -c; done

--- a/crates/swc_ecma_minifier/src/compress/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/mod.rs
@@ -12,15 +12,19 @@ use swc_ecma_transforms_optimization::simplify::{
     dead_branch_remover, expr_simplifier, ExprSimplifierConfig,
 };
 use swc_ecma_usage_analyzer::marks::Marks;
-use swc_ecma_visit::{visit_mut_pass, VisitMutWith, VisitWith};
+#[cfg(debug_assertions)]
+use swc_ecma_visit::VisitWith;
+use swc_ecma_visit::{visit_mut_pass, VisitMutWith};
 use swc_timer::timer;
 use tracing::{debug, error};
 
 pub(crate) use self::pure::{pure_optimizer, PureOptimizerConfig};
 use self::{hoist_decls::DeclHoisterConfig, optimize::optimizer};
+#[cfg(debug_assertions)]
+use crate::debug::AssertValid;
 use crate::{
     compress::hoist_decls::decl_hoister,
-    debug::{dump, AssertValid},
+    debug::dump,
     mode::Mode,
     option::{CompressOptions, MangleOptions},
     program_data::analyze,


### PR DESCRIPTION
**Description:**

```
    Finished `release` profile [optimized + debuginfo] target(s) in 48.34s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/antd.js`
File: ./benches/full/antd.js
  456855
    Finished `release` profile [optimized + debuginfo] target(s) in 0.15s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/d3.js`
File: ./benches/full/d3.js
   86899
    Finished `release` profile [optimized + debuginfo] target(s) in 0.14s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/echarts.js`
File: ./benches/full/echarts.js
  320588
    Finished `release` profile [optimized + debuginfo] target(s) in 0.18s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/jquery.js`
File: ./benches/full/jquery.js
   30878
    Finished `release` profile [optimized + debuginfo] target(s) in 0.17s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/lodash.js`
File: ./benches/full/lodash.js
   25094
    Finished `release` profile [optimized + debuginfo] target(s) in 0.20s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/moment.js`
File: ./benches/full/moment.js
   18589
    Finished `release` profile [optimized + debuginfo] target(s) in 0.15s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/react.js`
File: ./benches/full/react.js
    8194
    Finished `release` profile [optimized + debuginfo] target(s) in 0.14s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/terser.js`
File: ./benches/full/terser.js
  116704
    Finished `release` profile [optimized + debuginfo] target(s) in 0.15s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/three.js`
File: ./benches/full/three.js
  158097
    Finished `release` profile [optimized + debuginfo] target(s) in 0.15s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/typescript.js`
File: ./benches/full/typescript.js
  812096
    Finished `release` profile [optimized + debuginfo] target(s) in 0.15s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/victory.js`
File: ./benches/full/victory.js
  157199
    Finished `release` profile [optimized + debuginfo] target(s) in 0.15s
     Running `/Users/kdy1/projects/s/minifier/target/release/examples/minifier ./benches/full/vue.js`
File: ./benches/full/vue.js
   42651
```