### PR TITLE
chore(es/minifier): Make `test.sh` faster

### DIFF
--- a/crates/swc_ecma_minifier/scripts/test.sh
+++ b/crates/swc_ecma_minifier/scripts/test.sh
@@ -8,7 +8,9 @@ export SWC_RUN=0
 
 touch tests/compress.rs
 
-UPDATE=1 cargo test -p swc_ecma_minifier --release --test size
+UPDATE=1 cargo test -p swc_ecma_minifier --release --test size &
 cargo test -p swc_ecma_minifier -p swc --no-fail-fast --test projects --test tsc --test compress --test mangle --features concurrent $@
 
 # find ../swc/tests/ -type f -empty -delete
+
+wait


### PR DESCRIPTION
**Description:**

We can run `size.rs` tests concurrently with compress tests, so do it. Without this patch, the script is too slow.