### PR TITLE
fix(es/ast): Fix Typo in API

### DIFF
--- a/.changeset/new-dancers-remember.md
+++ b/.changeset/new-dancers-remember.md
@@ -1,5 +1,7 @@
 ---
 swc_ecma_ast: patch
+swc_ecma_minifier: patch
+swc_ecma_transforms_optimization: patch
 swc_core: patch
 ---
 

--- a/.changeset/new-dancers-remember.md
+++ b/.changeset/new-dancers-remember.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_ast: patch
+swc_core: patch
+---
+
+AST API

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -315,8 +315,13 @@ impl Expr {
         }
     }
 
-    /// Returns true for `eval` and member expressions.
+    #[deprecated(note = "Use `directness_matters` instead")]
     pub fn directness_maters(&self) -> bool {
+        self.directness_matters()
+    }
+
+    /// Returns true for `eval` and member expressions.
+    pub fn directness_matters(&self) -> bool {
         self.is_ident_ref_to("eval") || matches!(self, Expr::Member(..))
     }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -2491,7 +2491,7 @@ impl VisitMut for Optimizer<'_> {
             .exprs
             .last()
             .map(|v| &**v)
-            .map_or(false, Expr::directness_maters);
+            .map_or(false, Expr::directness_matters);
 
         let ctx = Ctx {
             dont_use_negated_iife: true,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -354,7 +354,7 @@ impl VisitMut for Remover {
 
         let last = e.exprs.pop().unwrap();
 
-        let should_preserved_this = last.directness_maters();
+        let should_preserved_this = last.directness_matters();
 
         let mut exprs = if should_preserved_this {
             e.exprs

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -545,7 +545,7 @@ impl SimplifyExpr {
                     if !left.may_have_side_effects(self.expr_ctx) {
                         self.changed = true;
 
-                        if node.directness_maters() {
+                        if node.directness_matters() {
                             *expr = SeqExpr {
                                 span: node.span(),
                                 exprs: vec![0.into(), node.take()],
@@ -1250,7 +1250,7 @@ impl VisitMut for SimplifyExpr {
                             .exprs
                             .last()
                             .map(|v| &**v)
-                            .map_or(false, Expr::directness_maters)
+                            .map_or(false, Expr::directness_matters)
                         {
                             match seq.exprs.first().map(|v| &**v) {
                                 Some(Expr::Lit(..) | Expr::Ident(..)) => {}
@@ -1371,7 +1371,7 @@ impl VisitMut for SimplifyExpr {
 
                     let expr_value = if val { cons } else { alt };
                     *expr = if p.is_pure() {
-                        if expr_value.directness_maters() {
+                        if expr_value.directness_matters() {
                             SeqExpr {
                                 span: *span,
                                 exprs: vec![0.into(), expr_value.take()],
@@ -1730,7 +1730,7 @@ fn nth_char(s: &str, mut idx: usize) -> Option<Cow<str>> {
 }
 
 fn need_zero_for_this(e: &Expr) -> bool {
-    e.directness_maters() || e.is_seq()
+    e.directness_matters() || e.is_seq()
 }
 
 /// Gets the value of the given key from the given object properties, if the key


### PR DESCRIPTION
**Description:**

This is a breaking change, so I deprecated it instead of removing it.