### PR TITLE
feat(es/minifier): Default to the smallest size

### DIFF
--- a/.changeset/loud-humans-arrive.md
+++ b/.changeset/loud-humans-arrive.md
@@ -1,0 +1,6 @@
+---
+swc_core: minor
+swc_ecma_minifier: minor
+---
+
+feat(es/minifier): Default to smallest size

--- a/crates/swc/tests/fixture/issues-8xxx/8251/output/2.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8251/output/2.js
@@ -1,2 +1,1 @@
-y=(value// @license comment
-)=>foo();
+y=value=>foo();

--- a/crates/swc/tests/size.rs
+++ b/crates/swc/tests/size.rs
@@ -7,7 +7,7 @@ use flate2::{write::GzEncoder, Compression};
 use humansize::format_size;
 use indexmap::IndexMap;
 use rustc_hash::FxBuildHasher;
-use swc::{config::JsMinifyOptions, BoolOrDataConfig, Compiler};
+use swc::{config::JsMinifyOptions, Compiler};
 use swc_common::{FileName, GLOBALS};
 use swc_ecma_utils::parallel::{Parallel, ParallelExt};
 use testing::NormalizedOutput;
@@ -115,8 +115,7 @@ fn run(src: &str) -> FileSize {
         let c = Compiler::new(cm.clone());
         let fm = cm.new_source_file(FileName::Anon.into(), src.into());
 
-        let mut config = JsMinifyOptions::default();
-        config.format.comments = BoolOrDataConfig::from_bool(false);
+        let config = JsMinifyOptions::default();
 
         let output = c.minify(fm, &handler, &config, Default::default()).unwrap();
 

--- a/crates/swc/tests/vercel/full/firebase/dist/1/output/index.js
+++ b/crates/swc/tests/vercel/full/firebase/dist/1/output/index.js
@@ -67,38 +67,8 @@ var e, t = require("@firebase/util"), n = require("tslib"), r = require("@fireba
             options: this.options
         };
     }, e;
-}(), s = ((e = {})["no-app"] = "No Firebase App '{$appName}' has been created - call Firebase App.initializeApp()", e["invalid-app-argument"] = "firebase.{$appName}() takes either no argument or a Firebase App instance.", e), c = new t.ErrorFactory("app-compat", "Firebase", s), u = /**
- * @license
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */ function e() {
-    var r = /**
- * @license
- * Copyright 2019 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */ function(e) {
+}(), s = ((e = {})["no-app"] = "No Firebase App '{$appName}' has been created - call Firebase App.initializeApp()", e["invalid-app-argument"] = "firebase.{$appName}() takes either no argument or a Firebase App instance.", e), c = new t.ErrorFactory("app-compat", "Firebase", s), u = function e() {
+    var r = function(e) {
         var n = {}, r = {
             __esModule: !0,
             initializeApp: function(i, a) {
@@ -164,22 +134,7 @@ var e, t = require("@firebase/util"), n = require("tslib"), r = require("@fireba
         deepExtend: t.deepExtend
     }), r;
 }(), l = new a.Logger("@firebase/app-compat");
-/**
- * @license
- * Copyright 2020 Google LLC
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */ if (t.isBrowser() && void 0 !== self.firebase) {
+if (t.isBrowser() && void 0 !== self.firebase) {
     l.warn("\n    Warning: Firebase is already defined in the global scope. Please make sure\n    Firebase library is only loaded once.\n  ");
     var d = self.firebase.SDK_VERSION;
     d && d.indexOf("LITE") >= 0 && l.warn("\n    Warning: You are trying to load Firebase while using Firebase Performance standalone script.\n    You should load Firebase Performance with this instance of Firebase to avoid loading duplicate code.\n    ");

--- a/crates/swc_ecma_minifier/src/js.rs
+++ b/crates/swc_ecma_minifier/src/js.rs
@@ -199,7 +199,7 @@ impl Default for JsMinifyFormatOptions {
 }
 
 fn default_comments() -> BoolOrDataConfig<JsMinifyCommentOption> {
-    BoolOrDataConfig::from_obj(JsMinifyCommentOption::PreserveSomeComments)
+    BoolOrDataConfig::from_bool(false)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/packages/core/__tests__/minify_test.mjs
+++ b/packages/core/__tests__/minify_test.mjs
@@ -216,6 +216,9 @@ describe("should remove comments", () => {
                 mangle: {
                     topLevel: true,
                 },
+                format: {
+                    comments: 'some'
+                }
             }
         );
 
@@ -244,6 +247,9 @@ describe("should remove comments", () => {
                 mangle: {
                     topLevel: true,
                 },
+                format: {
+                    comments: 'some'
+                }
             }
         );
 


### PR DESCRIPTION
**Description:**

AFAIK all bundlers used in production support extracting license comments. We can default to the smallest size, I think.