### PR TITLE
fix(es/minifier): Allow TypeScript nodes to fix `styled-jsx`

### DIFF
--- a/.changeset/smart-flies-sort.md
+++ b/.changeset/smart-flies-sort.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): Allow TypeScript nodes to fix `styled-jsx`

--- a/crates/swc_ecma_minifier/src/compress/pure/vars.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/vars.rs
@@ -300,7 +300,7 @@ pub(super) struct VarWithOutInitCounter {
 }
 
 impl Visit for VarWithOutInitCounter {
-    noop_visit_type!(fail);
+    noop_visit_type!();
 
     fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 
@@ -368,7 +368,7 @@ pub(super) struct VarMover {
 }
 
 impl VisitMut for VarMover {
-    noop_visit_mut_type!(fail);
+    noop_visit_mut_type!();
 
     /// Noop
     fn visit_mut_arrow_expr(&mut self, _: &mut ArrowExpr) {}
@@ -492,7 +492,7 @@ pub(super) struct VarPrepender {
 }
 
 impl VisitMut for VarPrepender {
-    noop_visit_mut_type!(fail);
+    noop_visit_mut_type!();
 
     /// Noop
     fn visit_mut_arrow_expr(&mut self, _: &mut ArrowExpr) {}


### PR DESCRIPTION
**Description:**

`styled-jsx` passes typescript input to the `Evaluator`.