### PR TITLE
fix(es/parser): Fix span of wrong `await` tokens

### DIFF
--- a/.changeset/silver-fishes-fry.md
+++ b/.changeset/silver-fishes-fry.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+fix(es/parser): Fix span of wrong `await` tokens

--- a/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
+++ b/bindings/binding_typescript_wasm/__tests__/__snapshots__/transform.js.snap
@@ -3,12 +3,12 @@
 exports[`transform in strip-only mode should not emit 'Caused by: failed to parse' 1`] = `
 {
   "code": "InvalidSyntax",
-  "endColumn": 30,
+  "endColumn": 22,
   "endLine": 1,
   "filename": "test.ts",
   "message": "await isn't allowed in non-async function",
-  "snippet": "Promise",
-  "startColumn": 23,
+  "snippet": "await",
+  "startColumn": 17,
   "startLine": 1,
 }
 `;

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -379,6 +379,8 @@ impl<I: Tokens> Parser<I> {
             assert_and_bump!(self, "await");
         }
 
+        let await_token = span!(self, start);
+
         if is!(self, '*') {
             syntax_error!(self, SyntaxError::AwaitStar);
         }
@@ -396,7 +398,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         if ctx.in_function && !ctx.in_async {
-            self.emit_err(self.input.cur_span(), SyntaxError::AwaitInFunction);
+            self.emit_err(await_token, SyntaxError::AwaitInFunction);
         }
 
         if ctx.in_parameters && !ctx.in_function {


### PR DESCRIPTION
**Description:**

