### PR TITLE
perf(es/minifier): Adjust parallelism threshold

### DIFF
--- a/.changeset/swift-days-accept.md
+++ b/.changeset/swift-days-accept.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_minifier: minor
+swc_core: minor
+---
+
+perf(es/minifier): Adjust parallelism threshold


### PR DESCRIPTION
**Description:**

I'll post the benchmark result soon.

```

es/minifier/real/es/minifier/real/sequential
                        time:   [10.736 s 10.755 s 10.776 s]
                        change: [+0.8409% +1.4726% +1.9502%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 10 measurements (10.00%)
  1 (10.00%) high mild
Benchmarking es/minifier/real/es/minifier/real/parallel: Warming up for 3.0000 s
Warning: Unable to complete 10 samples in 5.0s. You may wish to increase target time to 27.6s.
es/minifier/real/es/minifier/real/parallel
                        time:   [2.3177 s 2.3962 s 2.4913 s]
                        change: [-18.366% -10.442% -1.8769%] (p = 0.04 < 0.05)
                        Performance has improved.
Found 4 outliers among 10 measurements (40.00%)
  2 (20.00%) low mild
  1 (10.00%) high mild
  1 (10.00%) high severe
```

I'll try more adjustments over time