### PR TITLE
feat(es/codegen): Introduce `SpanWriter` and `adjust_span`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5125,6 +5125,7 @@ name = "swc_ecma_codegen"
 version = "10.0.0"
 dependencies = [
  "ascii",
+ "auto_impl",
  "base64 0.22.1",
  "codspeed-criterion-compat",
  "compact_str",

--- a/crates/swc_ecma_codegen/Cargo.toml
+++ b/crates/swc_ecma_codegen/Cargo.toml
@@ -18,6 +18,7 @@ bench = false
 
 [dependencies]
 ascii       = { workspace = true }
+auto_impl   = { workspace = true }
 compact_str = { workspace = true }
 memchr      = { workspace = true }
 num-bigint  = { workspace = true, features = ["serde"] }

--- a/crates/swc_ecma_codegen/src/class.rs
+++ b/crates/swc_ecma_codegen/src/class.rs
@@ -63,10 +63,7 @@ impl MacroNode for ClassExpr {
 
         srcmap!(emitter, self, true);
 
-        for dec in dispatch!(
-            self.class.decorators.iter(),
-            self.class.decorators.iter_mut()
-        ) {
+        for dec in ref_maybe_mut!(self.class.decorators) {
             emit!(dec);
         }
 
@@ -80,7 +77,7 @@ impl MacroNode for ClassExpr {
         if let Some(i) = ref_maybe_mut!(self.ident) {
             space!(emitter);
             emit!(i);
-            emit!(self.class.type_params);
+            emit_ref!(emitter, self.class.type_params);
         }
 
         emitter.emit_class_trailing(&self.class)?;
@@ -106,8 +103,8 @@ impl MacroNode for Class {
                     formatting_space!(emitter)
                 }
             }
-            emit!(self.super_class);
-            emit!(self.super_type_params);
+            emit_ref!(emitter, self.super_class);
+            emit_ref!(emitter, self.super_type_params);
         }
 
         if !self.implements.is_empty() {
@@ -180,9 +177,9 @@ impl MacroNode for AutoAccessor {
         keyword!(emitter, "accessor");
         space!(emitter);
 
-        emit!(self.key);
+        emit_ref!(emitter, self.key);
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             if self.definite {
                 punct!(emitter, "!");
             }
@@ -191,7 +188,7 @@ impl MacroNode for AutoAccessor {
             emit!(type_ann);
         }
 
-        if let Some(init) = &self.value {
+        if let Some(init) = ref_maybe_mut!(self.value) {
             formatting_space!(emitter);
             punct!(emitter, "=");
             formatting_space!(emitter);
@@ -237,19 +234,19 @@ impl MacroNode for PrivateMethod {
                     punct!(emitter, "*");
                 }
 
-                emit!(self.key);
+                emit_ref!(emitter, self.key);
             }
             MethodKind::Getter => {
                 keyword!(emitter, "get");
                 space!(emitter);
 
-                emit!(self.key);
+                emit_ref!(emitter, self.key);
             }
             MethodKind::Setter => {
                 keyword!(emitter, "set");
                 space!(emitter);
 
-                emit!(self.key);
+                emit_ref!(emitter, self.key);
             }
         }
 

--- a/crates/swc_ecma_codegen/src/class.rs
+++ b/crates/swc_ecma_codegen/src/class.rs
@@ -77,7 +77,7 @@ impl MacroNode for ClassExpr {
         if let Some(i) = ref_maybe_mut!(self.ident) {
             space!(emitter);
             emit!(i);
-            emit_ref!(emitter, self.class.type_params);
+            emit!(self.class.type_params);
         }
 
         emitter.emit_class_trailing(&self.class)?;
@@ -103,8 +103,8 @@ impl MacroNode for Class {
                     formatting_space!(emitter)
                 }
             }
-            emit_ref!(emitter, self.super_class);
-            emit_ref!(emitter, self.super_type_params);
+            emit!(self.super_class);
+            emit!(self.super_type_params);
         }
 
         if !self.implements.is_empty() {
@@ -177,7 +177,7 @@ impl MacroNode for AutoAccessor {
         keyword!(emitter, "accessor");
         space!(emitter);
 
-        emit_ref!(emitter, self.key);
+        emit!(self.key);
 
         if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             if self.definite {
@@ -234,19 +234,19 @@ impl MacroNode for PrivateMethod {
                     punct!(emitter, "*");
                 }
 
-                emit_ref!(emitter, self.key);
+                emit!(self.key);
             }
             MethodKind::Getter => {
                 keyword!(emitter, "get");
                 space!(emitter);
 
-                emit_ref!(emitter, self.key);
+                emit!(self.key);
             }
             MethodKind::Setter => {
                 keyword!(emitter, "set");
                 space!(emitter);
 
-                emit_ref!(emitter, self.key);
+                emit!(self.key);
             }
         }
 
@@ -315,7 +315,7 @@ impl MacroNode for ClassMethod {
                     punct!(emitter, "*");
                 }
 
-                emit_ref!(emitter, self.key);
+                emit!(self.key);
             }
             MethodKind::Getter => {
                 keyword!(emitter, "get");
@@ -326,7 +326,7 @@ impl MacroNode for ClassMethod {
                     formatting_space!(emitter)
                 }
 
-                emit_ref!(emitter, self.key);
+                emit!(self.key);
             }
             MethodKind::Setter => {
                 keyword!(emitter, "set");
@@ -337,7 +337,7 @@ impl MacroNode for ClassMethod {
                     formatting_space!(emitter)
                 }
 
-                emit_ref!(emitter, self.key);
+                emit!(self.key);
             }
         }
 
@@ -401,7 +401,7 @@ impl MacroNode for PrivateProp {
             space!(emitter);
         }
 
-        emit_ref!(emitter, self.key);
+        emit!(self.key);
 
         if self.is_optional {
             punct!(emitter, "?");
@@ -475,7 +475,7 @@ impl MacroNode for ClassProp {
             space!(emitter)
         }
 
-        emit_ref!(emitter, self.key);
+        emit!(self.key);
 
         if self.is_optional {
             punct!(emitter, "?");
@@ -544,7 +544,7 @@ impl MacroNode for StaticBlock {
         srcmap!(emitter, self, true);
 
         keyword!(emitter, "static");
-        emit_ref!(emitter, self.body);
+        emit!(self.body);
 
         srcmap!(emitter, self, false);
 

--- a/crates/swc_ecma_codegen/src/class.rs
+++ b/crates/swc_ecma_codegen/src/class.rs
@@ -140,15 +140,15 @@ impl MacroNode for Class {
 impl MacroNode for ClassMember {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         match self {
-            ClassMember::Constructor(ref n) => emit!(n),
-            ClassMember::ClassProp(ref n) => emit!(n),
-            ClassMember::Method(ref n) => emit!(n),
-            ClassMember::PrivateMethod(ref n) => emit!(n),
-            ClassMember::PrivateProp(ref n) => emit!(n),
-            ClassMember::TsIndexSignature(ref n) => emit!(n),
-            ClassMember::Empty(ref n) => emit!(n),
-            ClassMember::StaticBlock(ref n) => emit!(n),
-            ClassMember::AutoAccessor(ref n) => emit!(n),
+            ClassMember::Constructor(n) => emit!(n),
+            ClassMember::ClassProp(n) => emit!(n),
+            ClassMember::Method(n) => emit!(n),
+            ClassMember::PrivateMethod(n) => emit!(n),
+            ClassMember::PrivateProp(n) => emit!(n),
+            ClassMember::TsIndexSignature(n) => emit!(n),
+            ClassMember::Empty(n) => emit!(n),
+            ClassMember::StaticBlock(n) => emit!(n),
+            ClassMember::AutoAccessor(n) => emit!(n),
         }
 
         Ok(())

--- a/crates/swc_ecma_codegen/src/class.rs
+++ b/crates/swc_ecma_codegen/src/class.rs
@@ -63,7 +63,10 @@ impl MacroNode for ClassExpr {
 
         srcmap!(emitter, self, true);
 
-        for dec in &self.class.decorators {
+        for dec in dispatch!(
+            self.class.decorators.iter(),
+            self.class.decorators.iter_mut()
+        ) {
             emit!(dec);
         }
 
@@ -74,7 +77,7 @@ impl MacroNode for ClassExpr {
 
         keyword!(emitter, "class");
 
-        if let Some(ref i) = self.ident {
+        if let Some(i) = ref_maybe_mut!(self.ident) {
             space!(emitter);
             emit!(i);
             emit!(self.class.type_params);

--- a/crates/swc_ecma_codegen/src/class.rs
+++ b/crates/swc_ecma_codegen/src/class.rs
@@ -265,7 +265,7 @@ impl MacroNode for ClassMethod {
 
         srcmap!(emitter, self, true);
 
-        for d in &self.function.decorators {
+        for d in ref_maybe_mut!(self.function.decorators) {
             emit!(d);
         }
 
@@ -315,7 +315,7 @@ impl MacroNode for ClassMethod {
                     punct!(emitter, "*");
                 }
 
-                emit!(self.key);
+                emit_ref!(emitter, self.key);
             }
             MethodKind::Getter => {
                 keyword!(emitter, "get");
@@ -326,7 +326,7 @@ impl MacroNode for ClassMethod {
                     formatting_space!(emitter)
                 }
 
-                emit!(self.key);
+                emit_ref!(emitter, self.key);
             }
             MethodKind::Setter => {
                 keyword!(emitter, "set");
@@ -337,7 +337,7 @@ impl MacroNode for ClassMethod {
                     formatting_space!(emitter)
                 }
 
-                emit!(self.key);
+                emit_ref!(emitter, self.key);
             }
         }
 
@@ -345,7 +345,7 @@ impl MacroNode for ClassMethod {
             punct!(emitter, "?");
         }
 
-        if let Some(type_params) = &self.function.type_params {
+        if let Some(type_params) = ref_maybe_mut!(self.function.type_params) {
             emit!(type_params);
         }
 
@@ -358,13 +358,13 @@ impl MacroNode for ClassMethod {
 
         punct!(emitter, ")");
 
-        if let Some(ty) = &self.function.return_type {
+        if let Some(ty) = ref_maybe_mut!(self.function.return_type) {
             punct!(emitter, ":");
             formatting_space!(emitter);
             emit!(ty);
         }
 
-        if let Some(body) = &self.function.body {
+        if let Some(body) = ref_maybe_mut!(self.function.body) {
             formatting_space!(emitter);
             emit!(body);
         } else {
@@ -401,13 +401,13 @@ impl MacroNode for PrivateProp {
             space!(emitter);
         }
 
-        emit!(self.key);
+        emit_ref!(emitter, self.key);
 
         if self.is_optional {
             punct!(emitter, "?");
         }
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             if self.definite {
                 punct!(emitter, "!");
             }
@@ -416,7 +416,7 @@ impl MacroNode for PrivateProp {
             emit!(type_ann);
         }
 
-        if let Some(value) = &self.value {
+        if let Some(value) = ref_maybe_mut!(self.value) {
             formatting_space!(emitter);
             punct!(emitter, "=");
             formatting_space!(emitter);
@@ -444,7 +444,7 @@ impl MacroNode for ClassProp {
         emitter.emit_leading_comments_of_span(self.span(), false)?;
         srcmap!(emitter, self, true);
 
-        for dec in &self.decorators {
+        for dec in ref_maybe_mut!(self.decorators) {
             emit!(dec)
         }
 
@@ -475,13 +475,13 @@ impl MacroNode for ClassProp {
             space!(emitter)
         }
 
-        emit!(self.key);
+        emit_ref!(emitter, self.key);
 
         if self.is_optional {
             punct!(emitter, "?");
         }
 
-        if let Some(ty) = &self.type_ann {
+        if let Some(ty) = ref_maybe_mut!(self.type_ann) {
             if self.definite {
                 punct!(emitter, "!");
             }
@@ -490,7 +490,7 @@ impl MacroNode for ClassProp {
             emit!(ty);
         }
 
-        if let Some(v) = &self.value {
+        if let Some(v) = ref_maybe_mut!(self.value) {
             formatting_space!(emitter);
             punct!(emitter, "=");
             formatting_space!(emitter);
@@ -526,7 +526,7 @@ impl MacroNode for Constructor {
         emitter.emit_list(self.span(), Some(&self.params), ListFormat::Parameters)?;
         punct!(emitter, ")");
 
-        if let Some(body) = &self.body {
+        if let Some(body) = ref_maybe_mut!(self.body) {
             emit!(body);
         } else {
             formatting_semi!(emitter);
@@ -544,7 +544,7 @@ impl MacroNode for StaticBlock {
         srcmap!(emitter, self, true);
 
         keyword!(emitter, "static");
-        emit!(self.body);
+        emit_ref!(emitter, self.body);
 
         srcmap!(emitter, self, false);
 

--- a/crates/swc_ecma_codegen/src/decl.rs
+++ b/crates/swc_ecma_codegen/src/decl.rs
@@ -162,7 +162,7 @@ impl MacroNode for FnDecl {
             space!(emitter);
         }
 
-        emit_ref!(emitter, self.ident);
+        emit!(self.ident);
 
         emitter.emit_fn_trailing(&self.function)?;
 
@@ -185,7 +185,7 @@ impl MacroNode for VarDeclarator {
 
         srcmap!(emitter, self, true);
 
-        emit_ref!(emitter, self.name);
+        emit!(self.name);
 
         if let Some(init) = ref_maybe_mut!(self.init) {
             formatting_space!(emitter);

--- a/crates/swc_ecma_codegen/src/decl.rs
+++ b/crates/swc_ecma_codegen/src/decl.rs
@@ -162,7 +162,7 @@ impl MacroNode for FnDecl {
             space!(emitter);
         }
 
-        emit!(self.ident);
+        emit_ref!(emitter, self.ident);
 
         emitter.emit_fn_trailing(&self.function)?;
 
@@ -185,9 +185,9 @@ impl MacroNode for VarDeclarator {
 
         srcmap!(emitter, self, true);
 
-        emit!(self.name);
+        emit_ref!(emitter, self.name);
 
-        if let Some(ref init) = self.init {
+        if let Some(init) = ref_maybe_mut!(self.init) {
             formatting_space!(emitter);
             punct!(emitter, "=");
             formatting_space!(emitter);

--- a/crates/swc_ecma_codegen/src/jsx.rs
+++ b/crates/swc_ecma_codegen/src/jsx.rs
@@ -15,7 +15,7 @@ where
 #[node_impl]
 impl MacroNode for JSXElement {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        emit_ref!(emitter, self.opening);
+        emit!(self.opening);
         emitter.emit_list(
             self.span(),
             Some(&self.children),
@@ -32,7 +32,7 @@ impl MacroNode for JSXElement {
 impl MacroNode for JSXOpeningElement {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         punct!(emitter, "<");
-        emit_ref!(emitter, self.name);
+        emit!(self.name);
 
         if let Some(type_args) = ref_maybe_mut!(self.type_args) {
             emit!(type_args);
@@ -71,7 +71,7 @@ impl MacroNode for JSXElementName {
 #[node_impl]
 impl MacroNode for JSXAttr {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        emit_ref!(emitter, self.name);
+        emit!(self.name);
 
         if let Some(value) = ref_maybe_mut!(self.value) {
             punct!(emitter, "=");
@@ -139,7 +139,7 @@ impl MacroNode for JSXSpreadChild {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         punct!(emitter, "{");
         punct!(emitter, "...");
-        emit_ref!(emitter, self.expr);
+        emit!(self.expr);
         punct!(emitter, "}");
         Ok(())
     }
@@ -149,7 +149,7 @@ impl MacroNode for JSXSpreadChild {
 impl MacroNode for JSXExprContainer {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         punct!(emitter, "{");
-        emit_ref!(emitter, self.expr);
+        emit!(self.expr);
         punct!(emitter, "}");
         Ok(())
     }
@@ -170,7 +170,7 @@ impl MacroNode for JSXExpr {
 impl MacroNode for JSXClosingElement {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         punct!(emitter, "</");
-        emit_ref!(emitter, self.name);
+        emit!(self.name);
         punct!(emitter, ">");
         Ok(())
     }
@@ -179,7 +179,7 @@ impl MacroNode for JSXClosingElement {
 #[node_impl]
 impl MacroNode for JSXFragment {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        emit_ref!(emitter, self.opening);
+        emit!(self.opening);
 
         emitter.emit_list(
             self.span(),
@@ -187,7 +187,7 @@ impl MacroNode for JSXFragment {
             ListFormat::JsxElementOrFragmentChildren,
         )?;
 
-        emit_ref!(emitter, self.closing);
+        emit!(self.closing);
         Ok(())
     }
 }
@@ -211,9 +211,9 @@ impl MacroNode for JSXClosingFragment {
 #[node_impl]
 impl MacroNode for JSXNamespacedName {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        emit_ref!(emitter, self.ns);
+        emit!(self.ns);
         punct!(emitter, ":");
-        emit_ref!(emitter, self.name);
+        emit!(self.name);
         Ok(())
     }
 }
@@ -236,9 +236,9 @@ impl MacroNode for JSXText {
 #[node_impl]
 impl MacroNode for JSXMemberExpr {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        emit_ref!(emitter, self.obj);
+        emit!(self.obj);
         punct!(emitter, ".");
-        emit_ref!(emitter, self.prop);
+        emit!(self.prop);
         Ok(())
     }
 }

--- a/crates/swc_ecma_codegen/src/jsx.rs
+++ b/crates/swc_ecma_codegen/src/jsx.rs
@@ -15,13 +15,13 @@ where
 #[node_impl]
 impl MacroNode for JSXElement {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        emit!(self.opening);
+        emit_ref!(emitter, self.opening);
         emitter.emit_list(
             self.span(),
             Some(&self.children),
             ListFormat::JsxElementOrFragmentChildren,
         )?;
-        if let Some(ref closing) = self.closing {
+        if let Some(closing) = ref_maybe_mut!(self.closing) {
             emit!(closing)
         }
         Ok(())
@@ -32,9 +32,9 @@ impl MacroNode for JSXElement {
 impl MacroNode for JSXOpeningElement {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         punct!(emitter, "<");
-        emit!(self.name);
+        emit_ref!(emitter, self.name);
 
-        if let Some(type_args) = &self.type_args {
+        if let Some(type_args) = ref_maybe_mut!(self.type_args) {
             emit!(type_args);
         }
 
@@ -59,10 +59,10 @@ impl MacroNode for JSXOpeningElement {
 #[node_impl]
 impl MacroNode for JSXElementName {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        match *self {
-            JSXElementName::Ident(ref n) => emit!(n),
-            JSXElementName::JSXMemberExpr(ref n) => emit!(n),
-            JSXElementName::JSXNamespacedName(ref n) => emit!(n),
+        match self {
+            JSXElementName::Ident(n) => emit!(n),
+            JSXElementName::JSXMemberExpr(n) => emit!(n),
+            JSXElementName::JSXNamespacedName(n) => emit!(n),
         }
         Ok(())
     }
@@ -71,9 +71,9 @@ impl MacroNode for JSXElementName {
 #[node_impl]
 impl MacroNode for JSXAttr {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        emit!(self.name);
+        emit_ref!(emitter, self.name);
 
-        if let Some(ref value) = self.value {
+        if let Some(value) = ref_maybe_mut!(self.value) {
             punct!(emitter, "=");
             emit!(value);
         }
@@ -84,11 +84,11 @@ impl MacroNode for JSXAttr {
 #[node_impl]
 impl MacroNode for JSXAttrValue {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        match *self {
-            JSXAttrValue::Lit(ref n) => emit!(n),
-            JSXAttrValue::JSXExprContainer(ref n) => emit!(n),
-            JSXAttrValue::JSXElement(ref n) => emit!(n),
-            JSXAttrValue::JSXFragment(ref n) => emit!(n),
+        match self {
+            JSXAttrValue::Lit(n) => emit!(n),
+            JSXAttrValue::JSXExprContainer(n) => emit!(n),
+            JSXAttrValue::JSXElement(n) => emit!(n),
+            JSXAttrValue::JSXFragment(n) => emit!(n),
         }
         Ok(())
     }
@@ -97,9 +97,9 @@ impl MacroNode for JSXAttrValue {
 #[node_impl]
 impl MacroNode for JSXAttrName {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        match *self {
-            JSXAttrName::Ident(ref n) => emit!(n),
-            JSXAttrName::JSXNamespacedName(ref n) => emit!(n),
+        match self {
+            JSXAttrName::Ident(n) => emit!(n),
+            JSXAttrName::JSXNamespacedName(n) => emit!(n),
         }
         Ok(())
     }
@@ -108,9 +108,9 @@ impl MacroNode for JSXAttrName {
 #[node_impl]
 impl MacroNode for JSXAttrOrSpread {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        match *self {
-            JSXAttrOrSpread::JSXAttr(ref n) => emit!(n),
-            JSXAttrOrSpread::SpreadElement(ref n) => {
+        match self {
+            JSXAttrOrSpread::JSXAttr(n) => emit!(n),
+            JSXAttrOrSpread::SpreadElement(n) => {
                 punct!(emitter, "{");
                 emit!(n);
                 punct!(emitter, "}");
@@ -123,12 +123,12 @@ impl MacroNode for JSXAttrOrSpread {
 #[node_impl]
 impl MacroNode for JSXElementChild {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        match *self {
-            JSXElementChild::JSXElement(ref n) => emit!(n),
-            JSXElementChild::JSXExprContainer(ref n) => emit!(n),
-            JSXElementChild::JSXFragment(ref n) => emit!(n),
-            JSXElementChild::JSXSpreadChild(ref n) => emit!(n),
-            JSXElementChild::JSXText(ref n) => emit!(n),
+        match self {
+            JSXElementChild::JSXElement(n) => emit!(n),
+            JSXElementChild::JSXExprContainer(n) => emit!(n),
+            JSXElementChild::JSXFragment(n) => emit!(n),
+            JSXElementChild::JSXSpreadChild(n) => emit!(n),
+            JSXElementChild::JSXText(n) => emit!(n),
         }
         Ok(())
     }
@@ -139,7 +139,7 @@ impl MacroNode for JSXSpreadChild {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         punct!(emitter, "{");
         punct!(emitter, "...");
-        emit!(self.expr);
+        emit_ref!(emitter, self.expr);
         punct!(emitter, "}");
         Ok(())
     }
@@ -149,7 +149,7 @@ impl MacroNode for JSXSpreadChild {
 impl MacroNode for JSXExprContainer {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         punct!(emitter, "{");
-        emit!(self.expr);
+        emit_ref!(emitter, self.expr);
         punct!(emitter, "}");
         Ok(())
     }
@@ -158,9 +158,9 @@ impl MacroNode for JSXExprContainer {
 #[node_impl]
 impl MacroNode for JSXExpr {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        match *self {
-            JSXExpr::Expr(ref n) => emit!(n),
-            JSXExpr::JSXEmptyExpr(ref n) => emit!(n),
+        match self {
+            JSXExpr::Expr(n) => emit!(n),
+            JSXExpr::JSXEmptyExpr(n) => emit!(n),
         }
         Ok(())
     }
@@ -170,7 +170,7 @@ impl MacroNode for JSXExpr {
 impl MacroNode for JSXClosingElement {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         punct!(emitter, "</");
-        emit!(self.name);
+        emit_ref!(emitter, self.name);
         punct!(emitter, ">");
         Ok(())
     }
@@ -179,7 +179,7 @@ impl MacroNode for JSXClosingElement {
 #[node_impl]
 impl MacroNode for JSXFragment {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        emit!(self.opening);
+        emit_ref!(emitter, self.opening);
 
         emitter.emit_list(
             self.span(),
@@ -187,7 +187,7 @@ impl MacroNode for JSXFragment {
             ListFormat::JsxElementOrFragmentChildren,
         )?;
 
-        emit!(self.closing);
+        emit_ref!(emitter, self.closing);
         Ok(())
     }
 }
@@ -211,9 +211,9 @@ impl MacroNode for JSXClosingFragment {
 #[node_impl]
 impl MacroNode for JSXNamespacedName {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        emit!(self.ns);
+        emit_ref!(emitter, self.ns);
         punct!(emitter, ":");
-        emit!(self.name);
+        emit_ref!(emitter, self.name);
         Ok(())
     }
 }
@@ -236,9 +236,9 @@ impl MacroNode for JSXText {
 #[node_impl]
 impl MacroNode for JSXMemberExpr {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        emit!(self.obj);
+        emit_ref!(emitter, self.obj);
         punct!(emitter, ".");
-        emit!(self.prop);
+        emit_ref!(emitter, self.prop);
         Ok(())
     }
 }
@@ -246,9 +246,9 @@ impl MacroNode for JSXMemberExpr {
 #[node_impl]
 impl MacroNode for JSXObject {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
-        match *self {
-            JSXObject::Ident(ref n) => emit!(n),
-            JSXObject::JSXMemberExpr(ref n) => emit!(n),
+        match self {
+            JSXObject::Ident(n) => emit!(n),
+            JSXObject::JSXMemberExpr(n) => emit!(n),
         }
         Ok(())
     }

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -90,7 +90,7 @@ pub trait Node: Spanned {
 }
 
 pub trait NodeMut: Node {
-    fn rewrite_span<W, S>(&self, e: &mut SpanRewriter<'_, W, S>) -> Result
+    fn rewrite_span<W, S>(&mut self, e: &mut SpanRewriter<'_, W, S>) -> Result
     where
         W: WriteJs + SpannedWriteJs,
         S: SourceMapper + SourceMapperExt;

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -13,6 +13,7 @@ use std::{
     str,
 };
 
+use auto_impl::auto_impl;
 use compact_str::{format_compact, CompactString};
 use memchr::memmem::Finder;
 use once_cell::sync::Lazy;
@@ -89,6 +90,7 @@ pub trait Node: Spanned {
         S: SourceMapper + SourceMapperExt;
 }
 
+#[auto_impl(&mut, Box)]
 pub trait NodeMut: Node {
     fn rewrite_span<W, S>(&mut self, e: &mut SpanRewriter<'_, W, S>) -> Result
     where
@@ -2020,7 +2022,7 @@ impl MacroNode for FnExpr {
         if self.function.is_generator {
             punct!(emitter, "*");
         }
-        if let Some(ref i) = self.ident {
+        if let Some(i) = self.ident {
             space!(emitter);
             emit!(i);
         }

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1937,7 +1937,7 @@ impl MacroNode for BinExpr {
             while let Some(l) = left {
                 lefts.push(l);
 
-                match &*l.left {
+                match ref_maybe_mut!(*l.left) {
                     Expr::Bin(b) => {
                         left = Some(b);
                     }
@@ -2022,7 +2022,7 @@ impl MacroNode for FnExpr {
         if self.function.is_generator {
             punct!(emitter, "*");
         }
-        if let Some(i) = self.ident {
+        if let Some(i) = ref_maybe_mut!(self.ident) {
             space!(emitter);
             emit!(i);
         }

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1475,7 +1475,7 @@ impl MacroNode for Module {
             emitter.wr.write_str_lit(DUMMY_SP, shebang)?;
             emitter.wr.write_line()?;
         }
-        for stmt in &self.body {
+        for stmt in ref_maybe_mut!(self.body) {
             emit!(stmt);
         }
 
@@ -1894,7 +1894,7 @@ impl MacroNode for SeqExpr {
 
         let mut first = true;
         //TODO: Indention
-        for e in &self.exprs {
+        for e in ref_maybe_mut!(self.exprs) {
             if first {
                 first = false
             } else {

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1639,6 +1639,8 @@ impl MacroNode for OptChainExpr {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         emitter.emit_leading_comments_of_span(self.span(), false)?;
 
+        let span = self.span();
+
         match ref_maybe_mut!(*self.base) {
             OptChainBase::Member(e) => {
                 if let Expr::New(new) = &*e.obj {
@@ -1667,11 +1669,7 @@ impl MacroNode for OptChainExpr {
                 }
 
                 punct!(emitter, "(");
-                emitter.emit_expr_or_spreads(
-                    self.span(),
-                    &e.args,
-                    ListFormat::CallExpressionArguments,
-                )?;
+                emitter.emit_expr_or_spreads(span, &e.args, ListFormat::CallExpressionArguments)?;
                 punct!(emitter, ")");
             }
         }
@@ -1754,26 +1752,26 @@ impl MacroNode for MemberExpr {
             MemberProp::Computed(computed) => emit!(computed),
             MemberProp::Ident(ident) => {
                 if needs_2dots_for_property_access {
-                    if self.prop.span().lo() >= BytePos(2) {
-                        emitter.emit_leading_comments(self.prop.span().lo() - BytePos(2), false)?;
+                    if ident.span.lo() >= BytePos(2) {
+                        emitter.emit_leading_comments(ident.span.lo() - BytePos(2), false)?;
                     }
                     punct!(emitter, ".");
                 }
-                if self.prop.span().lo() >= BytePos(1) {
-                    emitter.emit_leading_comments(self.prop.span().lo() - BytePos(1), false)?;
+                if ident.span.lo() >= BytePos(1) {
+                    emitter.emit_leading_comments(ident.span.lo() - BytePos(1), false)?;
                 }
                 punct!(emitter, ".");
                 emit!(ident);
             }
             MemberProp::PrivateName(private) => {
                 if needs_2dots_for_property_access {
-                    if self.prop.span().lo() >= BytePos(2) {
-                        emitter.emit_leading_comments(self.prop.span().lo() - BytePos(2), false)?;
+                    if private.span().lo() >= BytePos(2) {
+                        emitter.emit_leading_comments(private.span().lo() - BytePos(2), false)?;
                     }
                     punct!(emitter, ".");
                 }
-                if self.prop.span().lo() >= BytePos(1) {
-                    emitter.emit_leading_comments(self.prop.span().lo() - BytePos(1), false)?;
+                if private.span.lo() >= BytePos(1) {
+                    emitter.emit_leading_comments(private.span.lo() - BytePos(1), false)?;
                 }
                 punct!(emitter, ".");
                 emit!(private);
@@ -1798,8 +1796,8 @@ impl MacroNode for SuperPropExpr {
         match ref_maybe_mut!(self.prop) {
             SuperProp::Computed(computed) => emit!(computed),
             SuperProp::Ident(i) => {
-                if self.prop.span().lo() >= BytePos(1) {
-                    emitter.emit_leading_comments(self.prop.span().lo() - BytePos(1), false)?;
+                if i.span.lo() >= BytePos(1) {
+                    emitter.emit_leading_comments(i.span.lo() - BytePos(1), false)?;
                 }
                 punct!(emitter, ".");
                 emit!(i);

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1644,7 +1644,7 @@ impl MacroNode for OptChainExpr {
                 if let Expr::New(new) = &*e.obj {
                     emitter.emit_new(new, false)?;
                 } else {
-                    emit_ref!(emitter, e.obj);
+                    emit!(e.obj);
                 }
                 if self.optional {
                     punct!(emitter, "?.");
@@ -1660,7 +1660,7 @@ impl MacroNode for OptChainExpr {
             }
             OptChainBase::Call(e) => {
                 debug_assert!(!e.callee.is_new());
-                emit_ref!(emitter, e.callee);
+                emit!(e.callee);
 
                 if self.optional {
                     punct!(emitter, "?.");
@@ -1700,7 +1700,7 @@ impl MacroNode for CallExpr {
 
         srcmap!(emitter, self, true);
 
-        emit_ref!(emitter, self.callee);
+        emit!(self.callee);
 
         if let Some(type_args) = ref_maybe_mut!(self.type_args) {
             emit!(type_args);
@@ -1793,7 +1793,7 @@ impl MacroNode for SuperPropExpr {
 
         srcmap!(emitter, self, true);
 
-        emit_ref!(emitter, self.obj);
+        emit!(self.obj);
 
         match ref_maybe_mut!(self.prop) {
             SuperProp::Computed(computed) => emit!(computed),
@@ -1841,7 +1841,7 @@ impl MacroNode for ArrowExpr {
                 _ => true,
             };
 
-        emit_ref!(emitter, self.type_params);
+        emit!(self.type_params);
 
         if parens {
             punct!(emitter, "(");
@@ -1860,7 +1860,7 @@ impl MacroNode for ArrowExpr {
         }
 
         punct!(emitter, "=>");
-        emit_ref!(emitter, self.body);
+        emit!(self.body);
 
         Ok(())
     }
@@ -1914,11 +1914,11 @@ impl MacroNode for AssignExpr {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         emitter.emit_leading_comments_of_span(self.span(), false)?;
 
-        emit_ref!(emitter, self.left);
+        emit!(self.left);
         formatting_space!(emitter);
         operator!(emitter, self.op.as_str());
         formatting_space!(emitter);
-        emit_ref!(emitter, self.right);
+        emit!(self.right);
 
         Ok(())
     }
@@ -1949,7 +1949,7 @@ impl MacroNode for BinExpr {
 
             for (i, left) in lefts.into_iter().rev().enumerate() {
                 if i == 0 {
-                    emit_ref!(emitter, left.left);
+                    emit!(left.left);
                 }
                 // Check if it's last
                 if i + 1 != len {
@@ -1972,7 +1972,7 @@ impl MacroNode for Decorator {
         srcmap!(emitter, self, true);
 
         punct!(emitter, "@");
-        emit_ref!(emitter, self.expr);
+        emit!(self.expr);
         emitter.wr.write_line()?;
 
         srcmap!(emitter, self, false);
@@ -1988,15 +1988,15 @@ impl MacroNode for CondExpr {
 
         srcmap!(emitter, self, true);
 
-        emit_ref!(emitter, self.test);
+        emit!(self.test);
         formatting_space!(emitter);
         punct!(emitter, "?");
         formatting_space!(emitter);
-        emit_ref!(emitter, self.cons);
+        emit!(self.cons);
         formatting_space!(emitter);
         punct!(emitter, ":");
         formatting_space!(emitter);
-        emit_ref!(emitter, self.alt);
+        emit!(self.alt);
 
         Ok(())
     }
@@ -2075,10 +2075,10 @@ impl MacroNode for Tpl {
 
         for i in 0..(self.quasis.len() + self.exprs.len()) {
             if i % 2 == 0 {
-                emit_ref!(emitter, self.quasis[i / 2]);
+                emit!(self.quasis[i / 2]);
             } else {
                 punct!(emitter, "${");
-                emit_ref!(emitter, self.exprs[i / 2]);
+                emit!(self.exprs[i / 2]);
                 punct!(emitter, "}");
             }
         }
@@ -2146,10 +2146,10 @@ impl MacroNode for TaggedTpl {
         if let Expr::New(new) = &*self.tag {
             emitter.emit_new(new, false)?;
         } else {
-            emit_ref!(emitter, self.tag);
+            emit!(self.tag);
         }
 
-        emit_ref!(emitter, self.type_params);
+        emit!(self.type_params);
         emitter.emit_template_for_tagged_template(&self.tpl)?;
 
         srcmap!(emitter, self, false);
@@ -2183,7 +2183,7 @@ impl MacroNode for UnaryExpr {
             formatting_space!(emitter);
         }
 
-        emit_ref!(emitter, self.arg);
+        emit!(self.arg);
 
         Ok(())
     }
@@ -2199,9 +2199,9 @@ impl MacroNode for UpdateExpr {
         if self.prefix {
             operator!(emitter, self.op.as_str());
             //TODO: Check if we should use should_emit_whitespace_before_operand
-            emit_ref!(emitter, self.arg);
+            emit!(self.arg);
         } else {
-            emit_ref!(emitter, self.arg);
+            emit!(self.arg);
             operator!(emitter, self.op.as_str());
         }
 
@@ -2235,7 +2235,7 @@ impl MacroNode for YieldExpr {
                 formatting_space!(emitter)
             }
 
-            emit_ref!(emitter, self.arg);
+            emit!(self.arg);
             if need_paren {
                 punct!(emitter, ")")
             }
@@ -2254,7 +2254,7 @@ impl MacroNode for ExprOrSpread {
             punct!(emitter, "...");
         }
 
-        emit_ref!(emitter, self.expr);
+        emit!(self.expr);
 
         Ok(())
     }
@@ -2270,7 +2270,7 @@ impl MacroNode for AwaitExpr {
         keyword!(emitter, "await");
         space!(emitter);
 
-        emit_ref!(emitter, self.arg);
+        emit!(self.arg);
 
         Ok(())
     }
@@ -2308,7 +2308,7 @@ impl MacroNode for ParenExpr {
         srcmap!(emitter, self, true);
 
         punct!(emitter, "(");
-        emit_ref!(emitter, self.expr);
+        emit!(self.expr);
 
         srcmap!(emitter, self, false, true);
         punct!(emitter, ")");

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1020,6 +1020,22 @@ where
     }
 }
 
+impl<N> NodeMut for Option<N>
+where
+    N: NodeMut,
+{
+    fn rewrite_span<W, S>(&mut self, e: &mut SpanRewriter<'_, W, S>) -> Result
+    where
+        W: WriteJs + SpannedWriteJs,
+        S: SourceMapper + SourceMapperExt,
+    {
+        match self {
+            Some(ref mut n) => n.rewrite_span(e),
+            None => Ok(()),
+        }
+    }
+}
+
 fn get_template_element_from_raw(
     s: &str,
     ascii_only: bool,

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -5,7 +5,13 @@
 #![allow(clippy::nonminimal_bool)]
 #![allow(non_local_definitions)]
 
-use std::{borrow::Cow, fmt::Write, io, ops::Deref, str};
+use std::{
+    borrow::Cow,
+    fmt::Write,
+    io,
+    ops::{Deref, DerefMut},
+    str,
+};
 
 use compact_str::{format_compact, CompactString};
 use memchr::memmem::Finder;
@@ -127,12 +133,30 @@ where
     W: WriteJs + SpannedWriteJs,
     S: SourceMapperExt,
 {
-    pub cfg: config::Config,
-    pub cm: Lrc<S>,
-    pub comments: Option<&'a dyn Comments>,
-    pub wr: W,
+    inner: Emitter<'a, W, S>,
 }
 
+impl<'a, W, S: SourceMapper> Deref for SpanRewriter<'a, W, S>
+where
+    W: WriteJs + SpannedWriteJs,
+    S: SourceMapperExt,
+{
+    type Target = Emitter<'a, W, S>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<'a, W, S: SourceMapper> DerefMut for SpanRewriter<'a, W, S>
+where
+    W: WriteJs + SpannedWriteJs,
+    S: SourceMapperExt,
+{
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
 enum CowStr<'a> {
     Borrowed(&'a str),
     Owned(CompactString),

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1639,7 +1639,7 @@ impl MacroNode for OptChainExpr {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         emitter.emit_leading_comments_of_span(self.span(), false)?;
 
-        match &*self.base {
+        match ref_maybe_mut!(*self.base) {
             OptChainBase::Member(e) => {
                 if let Expr::New(new) = &*e.obj {
                     emitter.emit_new(new, false)?;

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1750,7 +1750,7 @@ impl MacroNode for MemberExpr {
             }
         }
 
-        match &self.prop {
+        match ref_maybe_mut!(self.prop) {
             MemberProp::Computed(computed) => emit!(computed),
             MemberProp::Ident(ident) => {
                 if needs_2dots_for_property_access {

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1914,11 +1914,11 @@ impl MacroNode for AssignExpr {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         emitter.emit_leading_comments_of_span(self.span(), false)?;
 
-        emit!(self.left);
+        emit_ref!(emitter, self.left);
         formatting_space!(emitter);
         operator!(emitter, self.op.as_str());
         formatting_space!(emitter);
-        emit!(self.right);
+        emit_ref!(emitter, self.right);
 
         Ok(())
     }
@@ -1949,7 +1949,7 @@ impl MacroNode for BinExpr {
 
             for (i, left) in lefts.into_iter().rev().enumerate() {
                 if i == 0 {
-                    emit!(left.left);
+                    emit_ref!(emitter, left.left);
                 }
                 // Check if it's last
                 if i + 1 != len {
@@ -1972,7 +1972,7 @@ impl MacroNode for Decorator {
         srcmap!(emitter, self, true);
 
         punct!(emitter, "@");
-        emit!(self.expr);
+        emit_ref!(emitter, self.expr);
         emitter.wr.write_line()?;
 
         srcmap!(emitter, self, false);

--- a/crates/swc_ecma_codegen/src/lit.rs
+++ b/crates/swc_ecma_codegen/src/lit.rs
@@ -24,16 +24,16 @@ impl MacroNode for Lit {
                 }
             }
             Lit::Null(Null { .. }) => keyword!(emitter, "null"),
-            Lit::Str(ref s) => emit!(s),
-            Lit::BigInt(ref s) => emit!(s),
-            Lit::Num(ref n) => emit!(n),
-            Lit::Regex(ref n) => {
+            Lit::Str(s) => emit!(s),
+            Lit::BigInt(s) => emit!(s),
+            Lit::Num(n) => emit!(n),
+            Lit::Regex(n) => {
                 punct!(emitter, "/");
                 emitter.wr.write_str(&n.exp)?;
                 punct!(emitter, "/");
                 emitter.wr.write_str(&n.flags)?;
             }
-            Lit::JSXText(ref n) => emit!(n),
+            Lit::JSXText(n) => emit!(n),
         }
 
         Ok(())

--- a/crates/swc_ecma_codegen/src/macros.rs
+++ b/crates/swc_ecma_codegen/src/macros.rs
@@ -133,4 +133,7 @@ macro_rules! emit_node_inner {
     ($emitter:expr, true, $n:expr) => {
         crate::Node::emit_with(&$n, $emitter)?
     };
+    ($emitter:expr, false, $n:expr) => {
+        crate::NodeMut::rewrite_span(&mut $n, $emitter)?
+    };
 }

--- a/crates/swc_ecma_codegen/src/macros.rs
+++ b/crates/swc_ecma_codegen/src/macros.rs
@@ -148,3 +148,13 @@ macro_rules! dispatch {
         $b
     };
 }
+
+macro_rules! ref_maybe_mut {
+    (true, $e:expr) => {
+        &$e
+    };
+
+    (false, $e:expr) => {
+        &mut $e
+    };
+}

--- a/crates/swc_ecma_codegen/src/macros.rs
+++ b/crates/swc_ecma_codegen/src/macros.rs
@@ -131,10 +131,10 @@ macro_rules! srcmap {
 
 macro_rules! emit_node_inner {
     ($emitter:expr, true, $n:expr) => {
-        crate::Node::emit_with(&$n, $emitter)?
+        crate::Node::emit_with($n, $emitter)?
     };
     ($emitter:expr, false, $n:expr) => {
-        crate::NodeMut::rewrite_span(&mut $n, $emitter)?
+        crate::NodeMut::rewrite_span($n, $emitter)?
     };
 }
 
@@ -156,5 +156,14 @@ macro_rules! ref_maybe_mut {
 
     (false, $e:expr) => {
         &mut $e
+    };
+}
+
+macro_rules! emit_ref {
+    (true, $emitter:expr, $n:expr) => {
+        crate::Node::emit_with(&$n, $emitter)?
+    };
+    (false, $emitter:expr, $n:expr) => {
+        crate::NodeMut::rewrite_span(&mut $n, $emitter)?
     };
 }

--- a/crates/swc_ecma_codegen/src/macros.rs
+++ b/crates/swc_ecma_codegen/src/macros.rs
@@ -137,3 +137,14 @@ macro_rules! emit_node_inner {
         crate::NodeMut::rewrite_span(&mut $n, $emitter)?
     };
 }
+
+/// If `is_emit` is true, emit `a`.
+/// Otherwise, rewrite `b`
+macro_rules! dispatch {
+    (true, $a:expr, $b:expr) => {
+        $a
+    };
+    (false, $a:expr, $b:expr) => {
+        $b
+    };
+}

--- a/crates/swc_ecma_codegen/src/macros.rs
+++ b/crates/swc_ecma_codegen/src/macros.rs
@@ -131,10 +131,10 @@ macro_rules! srcmap {
 
 macro_rules! emit_node_inner {
     ($emitter:expr, true, $n:ident) => {
-        crate::Node::emit_with(&$n, $emitter)?
+        crate::Node::emit_with($n, $emitter)?
     };
     ($emitter:expr, true, $n:expr) => {
-        crate::Node::emit_with($n, $emitter)?
+        crate::Node::emit_with(&$n, $emitter)?
     };
     ($emitter:expr, false, $n:ident) => {
         crate::NodeMut::rewrite_span($n, $emitter)?

--- a/crates/swc_ecma_codegen/src/macros.rs
+++ b/crates/swc_ecma_codegen/src/macros.rs
@@ -130,11 +130,17 @@ macro_rules! srcmap {
 }
 
 macro_rules! emit_node_inner {
+    ($emitter:expr, true, $n:ident) => {
+        crate::Node::emit_with(&$n, $emitter)?
+    };
     ($emitter:expr, true, $n:expr) => {
         crate::Node::emit_with($n, $emitter)?
     };
-    ($emitter:expr, false, $n:expr) => {
+    ($emitter:expr, false, $n:ident) => {
         crate::NodeMut::rewrite_span($n, $emitter)?
+    };
+    ($emitter:expr, false, $n:expr) => {
+        crate::NodeMut::rewrite_span(&mut $n, $emitter)?
     };
 }
 
@@ -156,14 +162,5 @@ macro_rules! ref_maybe_mut {
 
     (false, $e:expr) => {
         &mut $e
-    };
-}
-
-macro_rules! emit_ref {
-    (true, $emitter:expr, $n:expr) => {
-        crate::Node::emit_with(&$n, $emitter)?
-    };
-    (false, $emitter:expr, $n:expr) => {
-        crate::NodeMut::rewrite_span(&mut $n, $emitter)?
     };
 }

--- a/crates/swc_ecma_codegen/src/module_decls.rs
+++ b/crates/swc_ecma_codegen/src/module_decls.rs
@@ -10,15 +10,15 @@ impl MacroNode for ModuleDecl {
         emitter.emit_leading_comments_of_span(self.span(), false)?;
 
         match self {
-            ModuleDecl::Import(ref d) => emit!(d),
-            ModuleDecl::ExportDecl(ref d) => emit!(d),
-            ModuleDecl::ExportNamed(ref d) => emit!(d),
-            ModuleDecl::ExportDefaultDecl(ref d) => emit!(d),
-            ModuleDecl::ExportDefaultExpr(ref n) => emit!(n),
-            ModuleDecl::ExportAll(ref d) => emit!(d),
-            ModuleDecl::TsExportAssignment(ref n) => emit!(n),
-            ModuleDecl::TsImportEquals(ref n) => emit!(n),
-            ModuleDecl::TsNamespaceExport(ref n) => emit!(n),
+            ModuleDecl::Import(d) => emit!(d),
+            ModuleDecl::ExportDecl(d) => emit!(d),
+            ModuleDecl::ExportNamed(d) => emit!(d),
+            ModuleDecl::ExportDefaultDecl(d) => emit!(d),
+            ModuleDecl::ExportDefaultExpr(n) => emit!(n),
+            ModuleDecl::ExportAll(d) => emit!(d),
+            ModuleDecl::TsExportAssignment(n) => emit!(n),
+            ModuleDecl::TsImportEquals(n) => emit!(n),
+            ModuleDecl::TsNamespaceExport(n) => emit!(n),
         }
 
         emitter.emit_trailing_comments_of_pos(self.span().hi, true, true)?;
@@ -38,7 +38,7 @@ impl MacroNode for ExportDecl {
 
         match &self.decl {
             Decl::Class(decl) => {
-                for dec in &decl.class.decorators {
+                for dec in ref_maybe_mut!(decl.class.decorators) {
                     emit!(dec);
                 }
 
@@ -51,7 +51,7 @@ impl MacroNode for ExportDecl {
                 keyword!(emitter, "export");
 
                 space!(emitter);
-                emit!(self.decl);
+                emit_ref!(emitter, self.decl);
             }
         }
 
@@ -75,7 +75,7 @@ impl MacroNode for ExportDefaultExpr {
             } else {
                 formatting_space!(emitter);
             }
-            emit!(self.expr);
+            emit_ref!(emitter, self.expr);
         }
         semi!(emitter);
 
@@ -97,10 +97,10 @@ impl MacroNode for ExportDefaultDecl {
         space!(emitter);
         keyword!(emitter, "default");
         space!(emitter);
-        match self.decl {
-            DefaultDecl::Class(ref n) => emit!(n),
-            DefaultDecl::Fn(ref n) => emit!(n),
-            DefaultDecl::TsInterfaceDecl(ref n) => emit!(n),
+        match ref_maybe_mut!(self.decl) {
+            DefaultDecl::Class(n) => emit!(n),
+            DefaultDecl::Fn(n) => emit!(n),
+            DefaultDecl::TsInterfaceDecl(n) => emit!(n),
         }
 
         Ok(())
@@ -152,8 +152,8 @@ impl MacroNode for ImportDecl {
                 ImportSpecifier::Named(ref s) => {
                     specifiers.push(s);
                 }
-                ImportSpecifier::Default(ref s) => {
-                    emit!(s.local);
+                ImportSpecifier::Default(s) => {
+                    emit_ref!(emitter, s.local);
                     emitted_default = true;
                 }
                 ImportSpecifier::Namespace(ref ns) => {
@@ -169,7 +169,7 @@ impl MacroNode for ImportDecl {
                     formatting_space!(emitter);
                     keyword!(emitter, "as");
                     space!(emitter);
-                    emit!(ns.local);
+                    emit_ref!(emitter, ns.local);
                 }
             }
         }
@@ -199,9 +199,9 @@ impl MacroNode for ImportDecl {
             formatting_space!(emitter);
         }
 
-        emit!(self.src);
+        emit_ref!(emitter, self.src);
 
-        if let Some(with) = &self.with {
+        if let Some(with) = ref_maybe_mut!(self.with) {
             formatting_space!(emitter);
             if emitter.cfg.emit_assert_for_import_attributes {
                 keyword!(emitter, "assert");
@@ -230,14 +230,14 @@ impl MacroNode for ImportNamedSpecifier {
             space!(emitter);
         }
 
-        if let Some(ref imported) = self.imported {
+        if let Some(imported) = ref_maybe_mut!(self.imported) {
             emit!(imported);
             space!(emitter);
             keyword!(emitter, "as");
             space!(emitter);
         }
 
-        emit!(self.local);
+        emit_ref!(emitter, self.local);
 
         srcmap!(emitter, self, false);
 
@@ -252,8 +252,8 @@ impl MacroNode for ExportSpecifier {
             ExportSpecifier::Default(..) => {
                 unimplemented!("codegen of `export default from 'foo';`")
             }
-            ExportSpecifier::Namespace(ref node) => emit!(node),
-            ExportSpecifier::Named(ref node) => emit!(node),
+            ExportSpecifier::Namespace(node) => emit!(node),
+            ExportSpecifier::Named(node) => emit!(node),
         }
 
         Ok(())
@@ -271,7 +271,7 @@ impl MacroNode for ExportNamespaceSpecifier {
         formatting_space!(emitter);
         keyword!(emitter, "as");
         space!(emitter);
-        emit!(self.name);
+        emit_ref!(emitter, self.name);
 
         srcmap!(emitter, self, false);
 
@@ -291,14 +291,14 @@ impl MacroNode for ExportNamedSpecifier {
             space!(emitter);
         }
 
-        if let Some(exported) = &self.exported {
-            emit!(self.orig);
+        if let Some(exported) = ref_maybe_mut!(self.exported) {
+            emit_ref!(emitter, self.orig);
             space!(emitter);
             keyword!(emitter, "as");
             space!(emitter);
             emit!(exported);
         } else {
-            emit!(self.orig);
+            emit_ref!(emitter, self.orig);
         }
         srcmap!(emitter, self, false);
 

--- a/crates/swc_ecma_codegen/src/module_decls.rs
+++ b/crates/swc_ecma_codegen/src/module_decls.rs
@@ -36,7 +36,7 @@ impl MacroNode for ExportDecl {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         srcmap!(emitter, self, true);
 
-        match &self.decl {
+        match ref_maybe_mut!(self.decl) {
             Decl::Class(decl) => {
                 for dec in ref_maybe_mut!(decl.class.decorators) {
                     emit!(dec);
@@ -383,7 +383,7 @@ impl MacroNode for NamedExport {
             formatting_space!(emitter);
             emit!(src);
 
-            if let Some(with) = &self.with {
+            if let Some(with) = ref_maybe_mut!(self.with) {
                 formatting_space!(emitter);
                 if emitter.cfg.emit_assert_for_import_attributes {
                     keyword!(emitter, "assert");

--- a/crates/swc_ecma_codegen/src/module_decls.rs
+++ b/crates/swc_ecma_codegen/src/module_decls.rs
@@ -425,7 +425,7 @@ impl MacroNode for ExportAll {
         formatting_space!(emitter);
         emit!(self.src);
 
-        if let Some(with) = &self.with {
+        if let Some(with) = ref_maybe_mut!(self.with) {
             formatting_space!(emitter);
             if emitter.cfg.emit_assert_for_import_attributes {
                 keyword!(emitter, "assert");

--- a/crates/swc_ecma_codegen/src/module_decls.rs
+++ b/crates/swc_ecma_codegen/src/module_decls.rs
@@ -147,16 +147,16 @@ impl MacroNode for ImportDecl {
         let mut specifiers = Vec::new();
         let mut emitted_default = false;
         let mut emitted_ns = false;
-        for specifier in &self.specifiers {
+        for specifier in ref_maybe_mut!(self.specifiers) {
             match specifier {
-                ImportSpecifier::Named(ref s) => {
+                ImportSpecifier::Named(s) => {
                     specifiers.push(s);
                 }
                 ImportSpecifier::Default(s) => {
                     emit!(s.local);
                     emitted_default = true;
                 }
-                ImportSpecifier::Namespace(ref ns) => {
+                ImportSpecifier::Namespace(ns) => {
                     if emitted_default {
                         punct!(emitter, ",");
                         formatting_space!(emitter);
@@ -373,7 +373,7 @@ impl MacroNode for NamedExport {
             punct!(emitter, "}");
         }
 
-        if let Some(ref src) = self.src {
+        if let Some(src) = ref_maybe_mut!(self.src) {
             if has_named_specs || !has_namespace_spec {
                 formatting_space!(emitter);
             } else if has_namespace_spec {

--- a/crates/swc_ecma_codegen/src/module_decls.rs
+++ b/crates/swc_ecma_codegen/src/module_decls.rs
@@ -51,7 +51,7 @@ impl MacroNode for ExportDecl {
                 keyword!(emitter, "export");
 
                 space!(emitter);
-                emit_ref!(emitter, self.decl);
+                emit!(self.decl);
             }
         }
 
@@ -75,7 +75,7 @@ impl MacroNode for ExportDefaultExpr {
             } else {
                 formatting_space!(emitter);
             }
-            emit_ref!(emitter, self.expr);
+            emit!(self.expr);
         }
         semi!(emitter);
 
@@ -153,7 +153,7 @@ impl MacroNode for ImportDecl {
                     specifiers.push(s);
                 }
                 ImportSpecifier::Default(s) => {
-                    emit_ref!(emitter, s.local);
+                    emit!(s.local);
                     emitted_default = true;
                 }
                 ImportSpecifier::Namespace(ref ns) => {
@@ -169,7 +169,7 @@ impl MacroNode for ImportDecl {
                     formatting_space!(emitter);
                     keyword!(emitter, "as");
                     space!(emitter);
-                    emit_ref!(emitter, ns.local);
+                    emit!(ns.local);
                 }
             }
         }
@@ -199,7 +199,7 @@ impl MacroNode for ImportDecl {
             formatting_space!(emitter);
         }
 
-        emit_ref!(emitter, self.src);
+        emit!(self.src);
 
         if let Some(with) = ref_maybe_mut!(self.with) {
             formatting_space!(emitter);
@@ -237,7 +237,7 @@ impl MacroNode for ImportNamedSpecifier {
             space!(emitter);
         }
 
-        emit_ref!(emitter, self.local);
+        emit!(self.local);
 
         srcmap!(emitter, self, false);
 
@@ -271,7 +271,7 @@ impl MacroNode for ExportNamespaceSpecifier {
         formatting_space!(emitter);
         keyword!(emitter, "as");
         space!(emitter);
-        emit_ref!(emitter, self.name);
+        emit!(self.name);
 
         srcmap!(emitter, self, false);
 
@@ -292,13 +292,13 @@ impl MacroNode for ExportNamedSpecifier {
         }
 
         if let Some(exported) = ref_maybe_mut!(self.exported) {
-            emit_ref!(emitter, self.orig);
+            emit!(self.orig);
             space!(emitter);
             keyword!(emitter, "as");
             space!(emitter);
             emit!(exported);
         } else {
-            emit_ref!(emitter, self.orig);
+            emit!(self.orig);
         }
         srcmap!(emitter, self, false);
 

--- a/crates/swc_ecma_codegen/src/object.rs
+++ b/crates/swc_ecma_codegen/src/object.rs
@@ -193,6 +193,8 @@ impl MacroNode for MethodProp {
 #[node_impl]
 impl MacroNode for PropName {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
+        let target = emitter.cfg.target;
+
         match self {
             PropName::Ident(ident) => {
                 // TODO: Use write_symbol when ident is a symbol.
@@ -207,7 +209,7 @@ impl MacroNode for PropName {
                     if emitter.wr.can_ignore_invalid_unicodes() {
                         emitter.wr.write_symbol(
                             DUMMY_SP,
-                            &crate::get_ascii_only_ident(&ident.sym, true, emitter.cfg.target),
+                            &crate::get_ascii_only_ident(&ident.sym, true, target),
                         )?;
                     } else {
                         emitter.wr.write_symbol(
@@ -215,7 +217,7 @@ impl MacroNode for PropName {
                             &crate::get_ascii_only_ident(
                                 &crate::handle_invalid_unicodes(&ident.sym),
                                 true,
-                                emitter.cfg.target,
+                                target,
                             ),
                         )?;
                     }

--- a/crates/swc_ecma_codegen/src/object.rs
+++ b/crates/swc_ecma_codegen/src/object.rs
@@ -44,12 +44,12 @@ impl MacroNode for ObjectLit {
 impl MacroNode for Prop {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         match self {
-            Prop::Shorthand(ref n) => emit!(n),
-            Prop::KeyValue(ref n) => emit!(n),
-            Prop::Assign(ref n) => emit!(n),
-            Prop::Getter(ref n) => emit!(n),
-            Prop::Setter(ref n) => emit!(n),
-            Prop::Method(ref n) => emit!(n),
+            Prop::Shorthand(n) => emit!(n),
+            Prop::KeyValue(n) => emit!(n),
+            Prop::Assign(n) => emit!(n),
+            Prop::Getter(n) => emit!(n),
+            Prop::Setter(n) => emit!(n),
+            Prop::Method(n) => emit!(n),
         }
 
         Ok(())
@@ -223,10 +223,10 @@ impl MacroNode for PropName {
                     emit!(ident);
                 }
             }
-            PropName::Str(ref n) => emit!(n),
-            PropName::Num(ref n) => emit!(n),
-            PropName::BigInt(ref n) => emit!(n),
-            PropName::Computed(ref n) => emit!(n),
+            PropName::Str(n) => emit!(n),
+            PropName::Num(n) => emit!(n),
+            PropName::BigInt(n) => emit!(n),
+            PropName::Computed(n) => emit!(n),
         }
 
         Ok(())

--- a/crates/swc_ecma_codegen/src/object.rs
+++ b/crates/swc_ecma_codegen/src/object.rs
@@ -148,7 +148,7 @@ impl MacroNode for SetterProp {
         formatting_space!(emitter);
 
         punct!(emitter, "(");
-        if let Some(this) = &self.this_param {
+        if let Some(this) = ref_maybe_mut!(self.this_param) {
             emit!(this);
             punct!(emitter, ",");
 

--- a/crates/swc_ecma_codegen/src/pat.rs
+++ b/crates/swc_ecma_codegen/src/pat.rs
@@ -48,7 +48,7 @@ impl MacroNode for RestPat {
         punct!(emitter, self.dot3_token, "...");
         emit!(self.arg);
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             punct!(emitter, ":");
             formatting_space!(emitter);
             emit!(type_ann);
@@ -155,7 +155,7 @@ impl MacroNode for ArrayPat {
             punct!(emitter, "?");
         }
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             punct!(emitter, ":");
             space!(emitter);
             emit!(type_ann);
@@ -257,7 +257,7 @@ impl MacroNode for AssignPatProp {
         srcmap!(emitter, self, true);
 
         emit!(self.key);
-        if let Some(value) = &self.value {
+        if let Some(value) = ref_maybe_mut!(self.value) {
             formatting_space!(emitter);
             punct!(emitter, "=");
             formatting_space!(emitter);

--- a/crates/swc_ecma_codegen/src/pat.rs
+++ b/crates/swc_ecma_codegen/src/pat.rs
@@ -206,7 +206,7 @@ impl MacroNode for ObjectPat {
             punct!(emitter, "?");
         }
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             punct!(emitter, ":");
             space!(emitter);
             emit!(type_ann);

--- a/crates/swc_ecma_codegen/src/pat.rs
+++ b/crates/swc_ecma_codegen/src/pat.rs
@@ -23,12 +23,12 @@ impl MacroNode for Param {
 impl MacroNode for Pat {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         match self {
-            Pat::Array(ref n) => emit!(n),
-            Pat::Assign(ref n) => emit!(n),
-            Pat::Expr(ref n) => emit!(n),
-            Pat::Ident(ref n) => emit!(n),
-            Pat::Object(ref n) => emit!(n),
-            Pat::Rest(ref n) => emit!(n),
+            Pat::Array(n) => emit!(n),
+            Pat::Assign(n) => emit!(n),
+            Pat::Expr(n) => emit!(n),
+            Pat::Ident(n) => emit!(n),
+            Pat::Object(n) => emit!(n),
+            Pat::Rest(n) => emit!(n),
             Pat::Invalid(n) => emit!(n),
         }
 
@@ -62,8 +62,8 @@ impl MacroNode for RestPat {
 impl MacroNode for PropOrSpread {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         match self {
-            PropOrSpread::Prop(ref n) => emit!(n),
-            PropOrSpread::Spread(ref n) => emit!(n),
+            PropOrSpread::Prop(n) => emit!(n),
+            PropOrSpread::Spread(n) => emit!(n),
         }
 
         Ok(())
@@ -92,8 +92,8 @@ impl MacroNode for SpreadElement {
 impl MacroNode for AssignTarget {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         match self {
-            AssignTarget::Simple(ref n) => emit!(n),
-            AssignTarget::Pat(ref n) => emit!(n),
+            AssignTarget::Simple(n) => emit!(n),
+            AssignTarget::Pat(n) => emit!(n),
         }
 
         Ok(())
@@ -222,9 +222,9 @@ impl MacroNode for ObjectPat {
 impl MacroNode for ObjectPatProp {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         match self {
-            ObjectPatProp::KeyValue(ref node) => emit!(node),
-            ObjectPatProp::Assign(ref node) => emit!(node),
-            ObjectPatProp::Rest(ref node) => emit!(node),
+            ObjectPatProp::KeyValue(node) => emit!(node),
+            ObjectPatProp::Assign(node) => emit!(node),
+            ObjectPatProp::Rest(node) => emit!(node),
         }
 
         Ok(())

--- a/crates/swc_ecma_codegen/src/stmt.rs
+++ b/crates/swc_ecma_codegen/src/stmt.rs
@@ -229,7 +229,7 @@ impl MacroNode for SwitchCase {
 
         srcmap!(emitter, self, true);
 
-        if let Some(test) = self.test {
+        if let Some(test) = ref_maybe_mut!(self.test) {
             keyword!(emitter, "case");
 
             let starts_with_alpha_num = test.starts_with_alpha_num();
@@ -312,12 +312,12 @@ impl MacroNode for TryStmt {
         formatting_space!(emitter);
         emit!(self.block);
 
-        if let Some(catch) = self.handler {
+        if let Some(catch) = ref_maybe_mut!(self.handler) {
             formatting_space!(emitter);
             emit!(catch);
         }
 
-        if let Some(finally) = self.finalizer {
+        if let Some(finally) = ref_maybe_mut!(self.finalizer) {
             formatting_space!(emitter);
             keyword!(emitter, "finally");
             // space!(emitter);

--- a/crates/swc_ecma_codegen/src/stmt.rs
+++ b/crates/swc_ecma_codegen/src/stmt.rs
@@ -555,7 +555,7 @@ impl MacroNode for IfStmt {
 
         emit!(self.cons);
 
-        if let Some(alt) = self.alt {
+        if let Some(alt) = ref_maybe_mut!(self.alt) {
             if is_cons_block {
                 formatting_space!(emitter);
             }

--- a/crates/swc_ecma_codegen/src/stmt.rs
+++ b/crates/swc_ecma_codegen/src/stmt.rs
@@ -204,7 +204,7 @@ impl MacroNode for CatchClause {
 
         formatting_space!(emitter);
 
-        if let Some(param) = &self.param {
+        if let Some(param) = ref_maybe_mut!(self.param) {
             punct!(emitter, "(");
             emit!(param);
             punct!(emitter, ")");

--- a/crates/swc_ecma_codegen/src/stmt.rs
+++ b/crates/swc_ecma_codegen/src/stmt.rs
@@ -8,27 +8,27 @@ use crate::util::{EndsWithAlphaNum, StartsWithAlphaNum};
 impl MacroNode for Stmt {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         match self {
-            Stmt::Expr(ref e) => emit!(e),
-            Stmt::Block(ref e) => {
+            Stmt::Expr(e) => emit!(e),
+            Stmt::Block(e) => {
                 emit!(e);
                 return Ok(());
             }
-            Stmt::Empty(ref e) => emit!(e),
-            Stmt::Debugger(ref e) => emit!(e),
-            Stmt::With(ref e) => emit!(e),
-            Stmt::Return(ref e) => emit!(e),
-            Stmt::Labeled(ref e) => emit!(e),
-            Stmt::Break(ref e) => emit!(e),
-            Stmt::Continue(ref e) => emit!(e),
-            Stmt::If(ref e) => emit!(e),
-            Stmt::Switch(ref e) => emit!(e),
-            Stmt::Throw(ref e) => emit!(e),
-            Stmt::Try(ref e) => emit!(e),
-            Stmt::While(ref e) => emit!(e),
-            Stmt::DoWhile(ref e) => emit!(e),
-            Stmt::For(ref e) => emit!(e),
-            Stmt::ForIn(ref e) => emit!(e),
-            Stmt::ForOf(ref e) => emit!(e),
+            Stmt::Empty(e) => emit!(e),
+            Stmt::Debugger(e) => emit!(e),
+            Stmt::With(e) => emit!(e),
+            Stmt::Return(e) => emit!(e),
+            Stmt::Labeled(e) => emit!(e),
+            Stmt::Break(e) => emit!(e),
+            Stmt::Continue(e) => emit!(e),
+            Stmt::If(e) => emit!(e),
+            Stmt::Switch(e) => emit!(e),
+            Stmt::Throw(e) => emit!(e),
+            Stmt::Try(e) => emit!(e),
+            Stmt::While(e) => emit!(e),
+            Stmt::DoWhile(e) => emit!(e),
+            Stmt::For(e) => emit!(e),
+            Stmt::ForIn(e) => emit!(e),
+            Stmt::ForOf(e) => emit!(e),
             Stmt::Decl(Decl::Var(e)) => {
                 emit!(e);
                 semi!(emitter);
@@ -37,7 +37,7 @@ impl MacroNode for Stmt {
                 emit!(e);
                 semi!(emitter);
             }
-            Stmt::Decl(ref e) => emit!(e),
+            Stmt::Decl(e) => emit!(e),
         }
         if emitter.comments.is_some() {
             emitter.emit_trailing_comments_of_pos(self.span().hi(), true, true)?;
@@ -229,7 +229,7 @@ impl MacroNode for SwitchCase {
 
         srcmap!(emitter, self, true);
 
-        if let Some(ref test) = self.test {
+        if let Some(test) = self.test {
             keyword!(emitter, "case");
 
             let starts_with_alpha_num = test.starts_with_alpha_num();
@@ -312,12 +312,12 @@ impl MacroNode for TryStmt {
         formatting_space!(emitter);
         emit!(self.block);
 
-        if let Some(ref catch) = self.handler {
+        if let Some(catch) = self.handler {
             formatting_space!(emitter);
             emit!(catch);
         }
 
-        if let Some(ref finally) = self.finalizer {
+        if let Some(finally) = self.finalizer {
             formatting_space!(emitter);
             keyword!(emitter, "finally");
             // space!(emitter);
@@ -500,7 +500,7 @@ impl MacroNode for BreakStmt {
 
         keyword!(emitter, "break");
 
-        if let Some(ref label) = self.label {
+        if let Some(label) = self.label {
             space!(emitter);
             emit!(label);
         }
@@ -520,7 +520,7 @@ impl MacroNode for ContinueStmt {
 
         keyword!(emitter, "continue");
 
-        if let Some(ref label) = self.label {
+        if let Some(label) = self.label {
             space!(emitter);
             emit!(label);
         }
@@ -555,7 +555,7 @@ impl MacroNode for IfStmt {
 
         emit!(self.cons);
 
-        if let Some(ref alt) = self.alt {
+        if let Some(alt) = self.alt {
             if is_cons_block {
                 formatting_space!(emitter);
             }

--- a/crates/swc_ecma_codegen/src/stmt.rs
+++ b/crates/swc_ecma_codegen/src/stmt.rs
@@ -520,7 +520,7 @@ impl MacroNode for ContinueStmt {
 
         keyword!(emitter, "continue");
 
-        if let Some(label) = self.label {
+        if let Some(label) = ref_maybe_mut!(self.label) {
             space!(emitter);
             emit!(label);
         }

--- a/crates/swc_ecma_codegen/src/stmt.rs
+++ b/crates/swc_ecma_codegen/src/stmt.rs
@@ -129,12 +129,8 @@ impl MacroNode for ReturnStmt {
 
         keyword!(emitter, "return");
 
-        if let Some(arg) = self.arg.as_deref() {
-            let need_paren = self
-                .arg
-                .as_deref()
-                .map(|expr| emitter.has_leading_comment(expr))
-                .unwrap_or(false);
+        if let Some(arg) = ref_maybe_mut!(self.arg) {
+            let need_paren = emitter.has_leading_comment(arg);
             if need_paren {
                 punct!(emitter, "(");
             } else if arg.starts_with_alpha_num() {

--- a/crates/swc_ecma_codegen/src/stmt.rs
+++ b/crates/swc_ecma_codegen/src/stmt.rs
@@ -500,7 +500,7 @@ impl MacroNode for BreakStmt {
 
         keyword!(emitter, "break");
 
-        if let Some(label) = self.label {
+        if let Some(label) = ref_maybe_mut!(self.label) {
             space!(emitter);
             emit!(label);
         }

--- a/crates/swc_ecma_codegen/src/text_writer.rs
+++ b/crates/swc_ecma_codegen/src/text_writer.rs
@@ -248,3 +248,7 @@ where
         (**self).can_ignore_invalid_unicodes()
     }
 }
+
+pub trait SpannedWriteJs: WriteJs {
+    fn get_pos(&self) -> BytePos;
+}

--- a/crates/swc_ecma_codegen/src/typescript.rs
+++ b/crates/swc_ecma_codegen/src/typescript.rs
@@ -569,21 +569,21 @@ impl MacroNode for TsMappedType {
 
         emit!(self.type_param.name);
 
-        if let Some(constraints) = &self.type_param.constraint {
+        if let Some(constraints) = ref_maybe_mut!(self.type_param.constraint) {
             space!(emitter);
             keyword!(emitter, "in");
             space!(emitter);
             emit!(constraints);
         }
 
-        if let Some(default) = &self.type_param.default {
+        if let Some(default) = ref_maybe_mut!(self.type_param.default) {
             formatting_space!(emitter);
             punct!(emitter, "=");
             formatting_space!(emitter);
             emit!(default);
         }
 
-        if let Some(name_type) = &self.name_type {
+        if let Some(name_type) = ref_maybe_mut!(self.name_type) {
             space!(emitter);
             keyword!(emitter, "as");
             space!(emitter);

--- a/crates/swc_ecma_codegen/src/typescript.rs
+++ b/crates/swc_ecma_codegen/src/typescript.rs
@@ -69,7 +69,7 @@ impl MacroNode for TsCallSignatureDecl {
         emitter.emit_list(self.span, Some(&self.params), ListFormat::Parameters)?;
         punct!(emitter, ")");
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             space!(emitter);
             punct!(emitter, ":");
             space!(emitter);
@@ -113,7 +113,7 @@ impl MacroNode for TsConstructSignatureDecl {
         emitter.emit_leading_comments_of_span(self.span(), false)?;
 
         keyword!(emitter, "new");
-        if let Some(type_params) = &self.type_params {
+        if let Some(type_params) = ref_maybe_mut!(self.type_params) {
             space!(emitter);
             emit!(type_params);
         }
@@ -122,7 +122,7 @@ impl MacroNode for TsConstructSignatureDecl {
         emitter.emit_list(self.span, Some(&self.params), ListFormat::Parameters)?;
         punct!(emitter, ")");
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             punct!(emitter, ":");
             space!(emitter);
             emit!(type_ann);
@@ -142,7 +142,7 @@ impl MacroNode for TsConstructorType {
         }
 
         keyword!(emitter, "new");
-        if let Some(type_params) = &self.type_params {
+        if let Some(type_params) = ref_maybe_mut!(self.type_params) {
             space!(emitter);
             emit!(type_params);
         }
@@ -212,7 +212,7 @@ impl MacroNode for TsEnumMember {
 
         emit!(self.id);
 
-        if let Some(init) = &self.init {
+        if let Some(init) = ref_maybe_mut!(self.init) {
             formatting_space!(emitter);
             punct!(emitter, "=");
             formatting_space!(emitter);
@@ -363,7 +363,7 @@ impl MacroNode for TsIndexSignature {
         emitter.emit_list(self.span, Some(&self.params), ListFormat::Parameters)?;
         punct!(emitter, "]");
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             punct!(emitter, ":");
             formatting_space!(emitter);
             emit!(type_ann);
@@ -427,7 +427,7 @@ impl MacroNode for TsInterfaceDecl {
 
         emit!(self.id);
 
-        if let Some(type_params) = &self.type_params {
+        if let Some(type_params) = ref_maybe_mut!(self.type_params) {
             emit!(type_params);
         }
 
@@ -609,7 +609,7 @@ impl MacroNode for TsMappedType {
             },
         }
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             punct!(emitter, ":");
             space!(emitter);
             emit!(type_ann);
@@ -641,7 +641,7 @@ impl MacroNode for TsMethodSignature {
             punct!(emitter, "?");
         }
 
-        if let Some(type_params) = &self.type_params {
+        if let Some(type_params) = ref_maybe_mut!(self.type_params) {
             emit!(type_params);
         }
 
@@ -649,7 +649,7 @@ impl MacroNode for TsMethodSignature {
         emitter.emit_list(self.span, Some(&self.params), ListFormat::Parameters)?;
         punct!(emitter, ")");
 
-        if let Some(ref type_ann) = self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             punct!(emitter, ":");
             formatting_space!(emitter);
             emit!(type_ann);
@@ -694,11 +694,11 @@ impl MacroNode for TsModuleDecl {
             emit!(self.id);
         }
 
-        if let Some(mut body) = self.body.as_ref() {
+        if let Some(mut body) = ref_maybe_mut!(self.body) {
             while let TsNamespaceBody::TsNamespaceDecl(decl) = body {
                 punct!(emitter, ".");
                 emit!(decl.id);
-                body = &*decl.body;
+                body = ref_maybe_mut!(*decl.body);
             }
             formatting_space!(emitter);
             emit!(body);
@@ -958,7 +958,7 @@ impl MacroNode for TsTupleElement {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         emitter.emit_leading_comments_of_span(self.span(), false)?;
 
-        if let Some(label) = &self.label {
+        if let Some(label) = ref_maybe_mut!(self.label) {
             emit!(label);
             punct!(emitter, ":");
             formatting_space!(emitter);
@@ -1061,7 +1061,7 @@ impl MacroNode for TsTypeAliasDecl {
         space!(emitter);
 
         emit!(self.id);
-        if let Some(type_params) = &self.type_params {
+        if let Some(type_params) = ref_maybe_mut!(self.type_params) {
             emit!(type_params);
         }
         formatting_space!(emitter);
@@ -1238,14 +1238,14 @@ impl MacroNode for TsTypeParam {
 
         emit!(self.name);
 
-        if let Some(constraints) = &self.constraint {
+        if let Some(constraints) = ref_maybe_mut!(self.constraint) {
             space!(emitter);
             keyword!(emitter, "extends");
             space!(emitter);
             emit!(constraints);
         }
 
-        if let Some(default) = &self.default {
+        if let Some(default) = ref_maybe_mut!(self.default) {
             formatting_space!(emitter);
             punct!(emitter, "=");
             formatting_space!(emitter);
@@ -1294,7 +1294,7 @@ impl MacroNode for TsTypePredicate {
 
         emit!(self.param_name);
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             space!(emitter);
             keyword!(emitter, "is");
             space!(emitter);
@@ -1335,7 +1335,7 @@ impl MacroNode for TsTypeRef {
 
         emit!(self.type_name);
 
-        if let Some(n) = &self.type_params {
+        if let Some(n) = ref_maybe_mut!(self.type_params) {
             punct!(emitter, "<");
             emitter.emit_list(n.span, Some(&n.params), ListFormat::TypeArguments)?;
             punct!(emitter, ">");

--- a/crates/swc_ecma_codegen/src/typescript.rs
+++ b/crates/swc_ecma_codegen/src/typescript.rs
@@ -1153,7 +1153,7 @@ impl MacroNode for TsGetterSignature {
         punct!(emitter, "(");
         punct!(emitter, ")");
 
-        if let Some(ty) = &self.type_ann {
+        if let Some(ty) = ref_maybe_mut!(self.type_ann) {
             punct!(emitter, ":");
             formatting_space!(emitter);
 

--- a/crates/swc_ecma_codegen/src/typescript.rs
+++ b/crates/swc_ecma_codegen/src/typescript.rs
@@ -882,7 +882,7 @@ impl MacroNode for TsPropertySignature {
             punct!(emitter, "?");
         }
 
-        if let Some(type_ann) = &self.type_ann {
+        if let Some(type_ann) = ref_maybe_mut!(self.type_ann) {
             punct!(emitter, ":");
             formatting_space!(emitter);
             emit!(type_ann);
@@ -1006,14 +1006,14 @@ impl MacroNode for TsImportType {
         keyword!(emitter, "import");
         punct!(emitter, "(");
         emit!(self.arg);
-        if let Some(attributes) = &self.attributes {
+        if let Some(attributes) = ref_maybe_mut!(self.attributes) {
             punct!(emitter, ",");
             formatting_space!(emitter);
             emit!(attributes);
         }
         punct!(emitter, ")");
 
-        if let Some(n) = &self.qualifier {
+        if let Some(n) = ref_maybe_mut!(self.qualifier) {
             punct!(emitter, ".");
             emit!(n);
         }

--- a/crates/swc_ecma_codegen_macros/src/lib.rs
+++ b/crates/swc_ecma_codegen_macros/src/lib.rs
@@ -61,6 +61,7 @@ pub fn node_impl(
 /// Returns `(emitter_method, adjuster_method)`
 fn expand_node_impl_method(node_type: &Type, src: ImplItemFn) -> (ItemImpl, ItemImpl) {
     let emit_block = ReplaceEmit { emit: true }.fold_block(src.block.clone());
+    let adjust_block = ReplaceEmit { emit: false }.fold_block(src.block.clone());
 
     (
         parse_quote!(
@@ -81,7 +82,7 @@ fn expand_node_impl_method(node_type: &Type, src: ImplItemFn) -> (ItemImpl, Item
                     W: crate::text_writer::SpannedWriteJs,
                     S: swc_common::SourceMapper + swc_ecma_ast::SourceMapperExt,
                 {
-                    #emit_block
+                    #adjust_block
                 }
             }
         ),

--- a/crates/swc_ecma_codegen_macros/src/lib.rs
+++ b/crates/swc_ecma_codegen_macros/src/lib.rs
@@ -98,7 +98,7 @@ impl Fold for ReplaceEmit {
         let name_path = &i.path;
         let name = i.path.clone().into_token_stream().to_string();
 
-        if matches!(&*name, "dispatch" | "ref_maybe_mut") {
+        if matches!(&*name, "dispatch" | "ref_maybe_mut" | "emit_ref") {
             let args: Punctuated<Expr, Token![,]> = parse_args(i.tokens);
             let args: TokenStream = args
                 .into_pairs()

--- a/crates/swc_ecma_codegen_macros/src/lib.rs
+++ b/crates/swc_ecma_codegen_macros/src/lib.rs
@@ -98,7 +98,7 @@ impl Fold for ReplaceEmit {
         let name_path = &i.path;
         let name = i.path.clone().into_token_stream().to_string();
 
-        if matches!(&*name, "dispatch") {
+        if matches!(&*name, "dispatch" | "ref_maybe_mut") {
             let args: Punctuated<Expr, Token![,]> = parse_args(i.tokens);
             let args: TokenStream = args
                 .into_pairs()

--- a/crates/swc_ecma_codegen_macros/src/lib.rs
+++ b/crates/swc_ecma_codegen_macros/src/lib.rs
@@ -77,7 +77,7 @@ fn expand_node_impl_method(node_type: &Type, src: ImplItemFn) -> (ItemImpl, Item
         ),
         parse_quote!(
             impl crate::NodeMut for #node_type {
-                fn rewrite_span<W, S>(&self, emitter: &mut crate::SpanRewriter<'_, W, S>) -> crate::Result
+                fn rewrite_span<W, S>(&mut self, emitter: &mut crate::SpanRewriter<'_, W, S>) -> crate::Result
                 where
                     W: crate::text_writer::SpannedWriteJs,
                     S: swc_common::SourceMapper + swc_ecma_ast::SourceMapperExt,


### PR DESCRIPTION
**Description:**

We don't have HKT in Rust, but we can mimic it using macro. This PR introduces `SpanWriter` and modifies `#[node_impl]` macro to expand to two impl blocks. The first one is for the normal `Emitter`, and the new second one is for the `SpanWriter`. `SpanWriter` dereferences to the `Emitter`, and accepts `&mut AstNode`. This PR is about making code for recursion identical for `SpanWriter` and `Emitter` to ensure that the rewritten span of the `SpanWriter` is identical to one generated by the `Emitter`.


We can expand

```rust
#[node_impl]
impl MacroNode for Program {
    fn emit(&mut self, emitter: &mut Macro) {
        match self {
            Program::Module(m) => emit!(m),
            Program::Script(s) => emit!(s),
        }
    }
}
```

to 

```rust
impl crate::Node for Macro {
    fn emit_with<W, S>(&self, e: &mut crate::Emitter<'_, W, S>) -> Result
    where
        W: crate::text_writer::WriteJs,
        S: swc_common::SourceMapper + swc_ecma_ast::SourceMapperExt,
    {
        {
            match self {
                Program::Module(m) => Node::emit_with(&m, emitter),
                Program::Script(s) => Node::emit_with(&s, emitter),
            }
        }
    }

    fn adjust_span<W, S>(&mut self, wr: &mut crate::SpanWriter<'_, W, S>) -> Result
    where
        W: crate::text_writer::SpannedWriteJs,
        S: swc_common::SourceMapper + swc_ecma_ast::SourceMapperExt,
    {
        {
            match self {
                Program::Module(m) => Node::adjust_span(&mut m, emitter),
                Program::Script(s) => Node::adjust_span(&mut s, emitter),
            }
        }
    }
}
```



But I'm stuck with minor issues. We can workaround them by manually splitting the implementation into two copies, but I'm not sure if that's the correct approach.

#### Workaround

For example, we may need to copy `impl MacroNode for BinExpr` in the screenshot below into two implementation blocks.

![image](https://github.com/user-attachments/assets/706f74cc-8639-4bba-bf59-39c34bae7f06)

The first one would be

```rust
impl Node for BinExpr {
    fn emit_with<W, S>(&self, e: &mut crate::Emitter<'_, W, S>) -> Result
    where
        W: crate::text_writer::WriteJs,
        S: swc_common::SourceMapper + swc_ecma_ast::SourceMapperExt,
    {
		// code 1
	}
}
```
and the second one would be 

```rust
impl NodeMut for BinExpr {
    fn adjust_span<W, S>(&mut self, wr: &mut crate::SpanWriter<'_, W, S>) -> Result
    where
        W: crate::text_writer::SpannedWriteJs,
        S: swc_common::SourceMapper + swc_ecma_ast::SourceMapperExt,
    {}
}
```

but we need a way to keep these implementations in sync.


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/9976