### PR TITLE
fix(es/parser): parse program as module with TLA in non-expression statement

### DIFF
--- a/.changeset/honest-sloths-flash.md
+++ b/.changeset/honest-sloths-flash.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_parser: major
+---
+
+fix(parser): parse program as module with TLA in non-expression statement

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -432,6 +432,8 @@ pub struct Context {
     disallow_conditional_types: bool,
 
     allow_using_decl: bool,
+
+    top_level: bool,
 }
 
 #[derive(Debug, Clone, Copy, Default)]

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -1417,6 +1417,7 @@ impl<I: Tokens> Parser<I> {
             in_static_block: false,
             is_break_allowed: false,
             is_continue_allowed: false,
+            top_level: false,
             ..self.ctx()
         };
         let state = State {

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -337,12 +337,6 @@ impl<I: Tokens> Parser<I> {
         }
 
         if is!(self, "await") {
-            if self.ctx().top_level {
-                self.state.found_module_item = true;
-                if !self.ctx().can_be_module {
-                    self.emit_err(self.input.cur_span(), SyntaxError::TopLevelAwaitInScript);
-                }
-            }
             return self.parse_await_expr(None);
         }
 
@@ -401,6 +395,13 @@ impl<I: Tokens> Parser<I> {
             }
 
             return Ok(Ident::new_no_ctxt("await".into(), span).into());
+        }
+
+        if ctx.top_level {
+            self.state.found_module_item = true;
+            if !self.ctx().can_be_module {
+                self.emit_err(await_token, SyntaxError::TopLevelAwaitInScript);
+            }
         }
 
         if ctx.in_function && !ctx.in_async {

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -337,6 +337,12 @@ impl<I: Tokens> Parser<I> {
         }
 
         if is!(self, "await") {
+            if self.ctx().top_level {
+                self.state.found_module_item = true;
+                if !self.ctx().can_be_module {
+                    self.emit_err(self.input.cur_span(), SyntaxError::TopLevelAwaitInScript);
+                }
+            }
             return self.parse_await_expr(None);
         }
 

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -397,9 +397,10 @@ impl<I: Tokens> Parser<I> {
             return Ok(Ident::new_no_ctxt("await".into(), span).into());
         }
 
-        if ctx.top_level {
+        // This has been checked if start_of_await_token == true,
+        if start_of_await_token.is_none() && ctx.top_level {
             self.state.found_module_item = true;
-            if !self.ctx().can_be_module {
+            if !ctx.can_be_module {
                 self.emit_err(await_token, SyntaxError::TopLevelAwaitInScript);
             }
         }

--- a/crates/swc_ecma_parser/src/parser/expr/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/tests.rs
@@ -27,7 +27,7 @@ fn member_expr(s: &'static str) -> Box<Expr> {
 
 fn expr(s: &'static str) -> Box<Expr> {
     test_parser(s, syntax(), |p| {
-        p.parse_stmt(true).map(|stmt| match stmt {
+        p.parse_stmt().map(|stmt| match stmt {
             Stmt::Expr(expr) => expr.expr,
             _ => unreachable!(),
         })
@@ -368,7 +368,7 @@ fn issue_319_1() {
 fn issue_328() {
     assert_eq_ignore_span!(
         test_parser("import('test')", Syntax::Es(Default::default()), |p| {
-            p.parse_stmt(true)
+            p.parse_stmt()
         }),
         Stmt::Expr(ExprStmt {
             span,

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -77,6 +77,7 @@ impl<I: Tokens> Parser<I> {
         let in_declare = false;
         let ctx = Context {
             in_declare,
+            top_level: true,
             ..input.ctx()
         };
         input.set_ctx(ctx);
@@ -100,6 +101,7 @@ impl<I: Tokens> Parser<I> {
 
         let ctx = Context {
             module: false,
+            top_level: true,
             ..self.ctx()
         };
         self.set_ctx(ctx);
@@ -108,7 +110,7 @@ impl<I: Tokens> Parser<I> {
 
         let shebang = self.parse_shebang()?;
 
-        self.parse_block_body(true, true, None).map(|body| Script {
+        self.parse_block_body(true, None).map(|body| Script {
             span: span!(self, start),
             body,
             shebang,
@@ -124,6 +126,7 @@ impl<I: Tokens> Parser<I> {
         let ctx = Context {
             module: true,
             strict: false,
+            top_level: true,
             ..self.ctx()
         };
         // Module code is always in strict mode
@@ -132,7 +135,7 @@ impl<I: Tokens> Parser<I> {
         let start = cur_pos!(self);
         let shebang = self.parse_shebang()?;
 
-        self.parse_block_body(true, true, None).map(|body| Module {
+        self.parse_block_body(true, None).map(|body| Module {
             span: span!(self, start),
             body,
             shebang,
@@ -149,10 +152,11 @@ impl<I: Tokens> Parser<I> {
         let shebang = self.parse_shebang()?;
         let ctx = Context {
             can_be_module: true,
+            top_level: true,
             ..self.ctx()
         };
 
-        let body: Vec<ModuleItem> = self.with_ctx(ctx).parse_block_body(true, true, None)?;
+        let body: Vec<ModuleItem> = self.with_ctx(ctx).parse_block_body(true, None)?;
         let has_module_item = self.state.found_module_item
             || body
                 .iter()
@@ -162,6 +166,7 @@ impl<I: Tokens> Parser<I> {
                 module: true,
                 can_be_module: true,
                 strict: true,
+                top_level: true,
                 ..self.ctx()
             };
             // Emit buffered strict mode / module code violations
@@ -195,6 +200,7 @@ impl<I: Tokens> Parser<I> {
             module: true,
             can_be_module: true,
             strict: true,
+            top_level: true,
             ..self.ctx()
         };
         // Module code is always in strict mode
@@ -203,7 +209,7 @@ impl<I: Tokens> Parser<I> {
         let start = cur_pos!(self);
         let shebang = self.parse_shebang()?;
 
-        self.parse_block_body(true, true, None).map(|body| Module {
+        self.parse_block_body(true, None).map(|body| Module {
             span: span!(self, start),
             body,
             shebang,

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -133,8 +133,16 @@ impl<'a, I: Tokens> Parser<I> {
                 .map(Stmt::from);
         }
 
+        let top_level = self.ctx().top_level;
         match cur!(self, true) {
-            tok!("await") if include_decl => {
+            tok!("await") if include_decl || top_level => {
+                if top_level {
+                    self.state.found_module_item = true;
+                    if !self.ctx().can_be_module {
+                        self.emit_err(self.input.cur_span(), SyntaxError::TopLevelAwaitInScript);
+                    }
+                }
+
                 if peeked_is!(self, "using") {
                     let eaten_await = Some(self.input.cur_pos());
                     assert_and_bump!(self, "await");

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -133,16 +133,8 @@ impl<'a, I: Tokens> Parser<I> {
                 .map(Stmt::from);
         }
 
-        let top_level = self.ctx().top_level;
         match cur!(self, true) {
-            tok!("await") if include_decl || top_level => {
-                if top_level {
-                    self.state.found_module_item = true;
-                    if !self.ctx().can_be_module {
-                        self.emit_err(self.input.cur_span(), SyntaxError::TopLevelAwaitInScript);
-                    }
-                }
-
+            tok!("await") if include_decl => {
                 if peeked_is!(self, "using") {
                     let eaten_await = Some(self.input.cur_pos());
                     assert_and_bump!(self, "await");

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -2257,6 +2257,15 @@ export default function waitUntil(callback, options = {}) {
     }
 
     #[test]
+    fn top_level_await_in_decl() {
+        test_parser(r#"const t = await test();"#, Default::default(), |p| {
+            let program = p.parse_program()?;
+            assert!(program.is_module());
+            Ok(program)
+        });
+    }
+
+    #[test]
     fn class_static_blocks() {
         let src = "class Foo { static { 1 + 1; } }";
         assert_eq_ignore_span!(

--- a/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
@@ -880,12 +880,8 @@ impl IsDirective for ModuleItem {
 }
 
 impl<I: Tokens> StmtLikeParser<'_, ModuleItem> for Parser<I> {
-    fn handle_import_export(
-        &mut self,
-        top_level: bool,
-        decorators: Vec<Decorator>,
-    ) -> PResult<ModuleItem> {
-        if !top_level {
+    fn handle_import_export(&mut self, decorators: Vec<Decorator>) -> PResult<ModuleItem> {
+        if !self.ctx().top_level {
             syntax_error!(self, SyntaxError::NonTopLevelImportExport);
         }
 

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -369,3 +369,12 @@ fn parse_program_take_script_module_errors() {
         Ok(program)
     });
 }
+
+#[test]
+fn parse_tla_in_non_expression_statement() {
+    test_parser(r#"const t = await test();"#, Default::default(), |p| {
+        let program = p.parse_program()?;
+        assert!(program.is_module());
+        Ok(program)
+    });
+}

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -369,12 +369,3 @@ fn parse_program_take_script_module_errors() {
         Ok(program)
     });
 }
-
-#[test]
-fn parse_tla_in_non_expression_statement() {
-    test_parser(r#"const t = await test();"#, Default::default(), |p| {
-        let program = p.parse_program()?;
-        assert!(program.is_module());
-        Ok(program)
-    });
-}

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -861,11 +861,14 @@ impl<I: Tokens> Parser<I> {
         expect!(self, '{');
         // Inside of a module block is considered "top-level", meaning it can have
         // imports and exports.
-        let body = self.parse_block_body(
-            /* directives */ false,
-            /* topLevel */ true,
-            /* end */ Some(&tok!('}')),
-        )?;
+        let body = self
+            .with_ctx(Context {
+                top_level: true,
+                ..self.ctx()
+            })
+            .parse_with(|p| {
+                p.parse_block_body(/* directives */ false, /* end */ Some(&tok!('}')))
+            })?;
 
         Ok(TsModuleBlock {
             span: span!(self, start),

--- a/crates/swc_ecma_quote_macros/src/ret_type.rs
+++ b/crates/swc_ecma_quote_macros/src/ret_type.rs
@@ -38,7 +38,7 @@ pub(crate) fn parse_input_type(input_str: &str, ty: &Type) -> Result<BoxWrapper,
             match &*ident.to_string() {
                 "Expr" => return parse(input_str, &mut |p| p.parse_expr().map(|v| *v)),
                 "Pat" => return parse(input_str, &mut |p| p.parse_pat()),
-                "Stmt" => return parse(input_str, &mut |p| p.parse_stmt_list_item(true)),
+                "Stmt" => return parse(input_str, &mut |p| p.parse_stmt_list_item()),
                 "AssignTarget" => {
                     return parse(input_str, &mut |p| {
                         Ok(AssignTarget::try_from(p.parse_pat()?)


### PR DESCRIPTION
fixes: https://github.com/swc-project/swc/issues/10109

1. Lift `top_level` flag to parser context
2. Add checks before parsing `await` in unary expr.

Let's wait for CI to pass all the tests