### PR TITLE
 update stale workflow for 'Need more info' issues from 30 to 14 days

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,9 +16,9 @@ jobs:
         with:
           repo-token: ${{ secrets.GH_TOKEN }}
           only-labels: "Need more info"
-          close-issue-message: "This issue has been automatically closed because it received no activity for a month and had no reproduction to investigate. If you think this was closed by accident, please leave a comment. If you are running into a similar issue, please open a new issue with a reproduction. Thank you."
+          close-issue-message: "This issue has been automatically closed because it received no activity for 2 weeks and had no reproduction to investigate. If you think this was closed by accident, please leave a comment. If you are running into a similar issue, please open a new issue with a reproduction. Thank you."
           days-before-issue-close: 1
-          days-before-issue-stale: 30
+          days-before-issue-stale: 14
           days-before-pr-close: -1
           days-before-pr-stale: -1
           exempt-issue-labels: "blocked,must,should,keep"


### PR DESCRIPTION
**Description:**

Updates the stale workflow configuration to automatically close issues labeled as 'Need more info' after 2 weeks of inactivity, reduced from the previous 30-day period. This change helps maintain a cleaner issue tracker by ensuring that issues requiring additional information from contributors don't remain open indefinitely when no response is received, while still providing a reasonable timeframe for responses.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/10271