### PR TITLE
fix(cli/plugin): cli plugin target wasm32-wasip1

### DIFF
--- a/.changeset/stale-plants-hammer.md
+++ b/.changeset/stale-plants-hammer.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_cli_impl: patch
+swc_plugin_runner: patch
+---
+
+fix(cli/plugin): cli plugin target wasm32-wasip1

--- a/.github/swc-ecosystem-ci/tests/plugin-css-variable.ts
+++ b/.github/swc-ecosystem-ci/tests/plugin-css-variable.ts
@@ -7,7 +7,7 @@ export async function test(options: RunOptions) {
     repo: "jantimon/css-variable",
     branch: "main",
     build: "build",
-    beforeBuild: "rustup target add wasm32-wasi",
+    beforeBuild: "rustup target add wasm32-wasip1",
     test: ["test:swc"],
     isWasm: true,
   });

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -219,7 +219,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          target: wasm32-wasi
+          target: wasm32-wasip1
           # MSRV is current stable for ES crates and nightly for other languages
           # toolchain: stable
           # override: true
@@ -381,7 +381,7 @@ jobs:
 
       - name: Prepare
         run: |
-          rustup target add wasm32-wasi
+          rustup target add wasm32-wasip1
           corepack enable
           yarn
 
@@ -429,7 +429,7 @@ jobs:
 
       - name: Prepare
         run: |
-          rustup target add wasm32-wasi
+          rustup target add wasm32-wasip1
           corepack enable
           yarn
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,9 +104,9 @@ For running all tests, take the following steps:
 
     See [official install guide of deno](https://docs.deno.com/runtime/manual/getting_started/installation/) to install it.
 
-5. Add wasm32-wasi target
+5. Add wasm32-wasip1 target
 
-    `rustup target add wasm32-wasi`
+    `rustup target add wasm32-wasip1`
 
 6. Ensure you're using Node.JS >= 16
 

--- a/crates/swc_cli_impl/src/commands/plugin.rs
+++ b/crates/swc_cli_impl/src/commands/plugin.rs
@@ -12,8 +12,8 @@ use swc_core::diagnostics::get_core_engine_diagnostics;
 pub enum PluginTargetType {
     /// wasm32-unknown-unknown target.
     Wasm32UnknownUnknown,
-    /// wasm32-wasi target.
-    Wasm32Wasi,
+    /// wasm32-wasip1 target.
+    Wasm32WasiP1,
 }
 
 #[derive(Parser, Debug)]
@@ -24,7 +24,7 @@ pub struct PluginScaffoldOptions {
 
     /// Sets default build target type of the plugin.
     ///
-    /// "wasm32-wasi" enables wasi (https://github.com/WebAssembly/WASI) support for the generated
+    /// "wasm32-wasip1" enables wasi (https://github.com/WebAssembly/WASI) support for the generated
     /// binary which allows to use macros like 'println!' or 'dbg!' and other
     /// system-related calls.
     ///
@@ -166,7 +166,7 @@ serde = "1"
 swc_core = {{ version = "{}", features = ["ecma_plugin_transform"] }}
 
 # .cargo/config.toml defines few alias to build plugin.
-# cargo build-wasi generates wasm-wasi32 binary
+# cargo build-wasip1 generates wasm32-wasip1 binary
 # cargo build-wasm32 generates wasm32-unknown-unknown binary.
 "#,
                 name, swc_core_version
@@ -177,12 +177,12 @@ swc_core = {{ version = "{}", features = ["ecma_plugin_transform"] }}
 
         let build_target = match self.target_type {
             PluginTargetType::Wasm32UnknownUnknown => "wasm32-unknown-unknown",
-            PluginTargetType::Wasm32Wasi => "wasm32-wasi",
+            PluginTargetType::Wasm32WasiP1 => "wasm32-wasip1",
         };
 
         let build_alias = match self.target_type {
             PluginTargetType::Wasm32UnknownUnknown => "build-wasm32",
-            PluginTargetType::Wasm32Wasi => "build-wasi",
+            PluginTargetType::Wasm32WasiP1 => "build-wasip1",
         };
 
         // Create `.cargo/config.toml` file for build target
@@ -193,7 +193,7 @@ swc_core = {{ version = "{}", features = ["ecma_plugin_transform"] }}
             r#"# These command aliases are not final, may change
 [alias]
 # Alias to build actual plugin binary for the specified target.
-build-wasi = "build --target wasm32-wasi"
+build-wasip1 = "build --target wasm32-wasip1"
 build-wasm32 = "build --target wasm32-unknown-unknown"
 "#
             .as_bytes(),

--- a/crates/swc_cli_impl/src/commands/plugin.rs
+++ b/crates/swc_cli_impl/src/commands/plugin.rs
@@ -13,7 +13,7 @@ pub enum PluginTargetType {
     /// wasm32-unknown-unknown target.
     Wasm32UnknownUnknown,
     /// wasm32-wasip1 target.
-    Wasm32WasiP1,
+    Wasm32Wasip1,
 }
 
 #[derive(Parser, Debug)]
@@ -177,12 +177,12 @@ swc_core = {{ version = "{}", features = ["ecma_plugin_transform"] }}
 
         let build_target = match self.target_type {
             PluginTargetType::Wasm32UnknownUnknown => "wasm32-unknown-unknown",
-            PluginTargetType::Wasm32WasiP1 => "wasm32-wasip1",
+            PluginTargetType::Wasm32Wasip1 => "wasm32-wasip1",
         };
 
         let build_alias = match self.target_type {
             PluginTargetType::Wasm32UnknownUnknown => "build-wasm32",
-            PluginTargetType::Wasm32WasiP1 => "build-wasip1",
+            PluginTargetType::Wasm32Wasip1 => "build-wasip1",
         };
 
         // Create `.cargo/config.toml` file for build target

--- a/crates/swc_plugin_runner/benches/ecma_invoke.rs
+++ b/crates/swc_plugin_runner/benches/ecma_invoke.rs
@@ -33,7 +33,7 @@ fn plugin_group(c: &mut Criterion) {
         cmd.current_dir(&plugin_dir);
         cmd.arg("build")
             .arg("--release")
-            .arg("--target=wasm32-wasi");
+            .arg("--target=wasm32-wasip1");
 
         let status = cmd.status().unwrap();
         assert!(status.success());
@@ -45,7 +45,7 @@ fn plugin_group(c: &mut Criterion) {
 fn bench_transform(b: &mut Bencher, plugin_dir: &Path) {
     let path = &plugin_dir
         .join("target")
-        .join("wasm32-wasi")
+        .join("wasm32-wasip1")
         .join("release")
         .join("swc_noop_plugin.wasm");
     let raw_module_bytes = std::fs::read(path).expect("Should able to read plugin bytes");

--- a/crates/swc_plugin_runner/src/transform_executor.rs
+++ b/crates/swc_plugin_runner/src/transform_executor.rs
@@ -269,9 +269,9 @@ impl TransformExecutor {
         );
 
         // Plugin binary can be either wasm32-wasip1 or wasm32-unknown-unknown.
-        // Wasi specific env need to be initialized if given module targets wasm32-wasip1.
-        // TODO: wasm host native runtime throws 'Memory should be set on `WasiEnv`
-        // first'
+        // Wasi specific env need to be initialized if given module targets
+        // wasm32-wasip1. TODO: wasm host native runtime throws 'Memory should
+        // be set on `WasiEnv` first'
         let (instance, wasi_env) = if is_wasi_module(&module) {
             let builder = WasiEnv::builder(self.module_bytes.get_module_name());
             let builder = if let Some(runtime) = &self.runtime {

--- a/crates/swc_plugin_runner/src/transform_executor.rs
+++ b/crates/swc_plugin_runner/src/transform_executor.rs
@@ -268,8 +268,8 @@ impl TransformExecutor {
             &diagnostics_env,
         );
 
-        // Plugin binary can be either wasm32-wasi or wasm32-unknown-unknown.
-        // Wasi specific env need to be initialized if given module targets wasm32-wasi.
+        // Plugin binary can be either wasm32-wasip1 or wasm32-unknown-unknown.
+        // Wasi specific env need to be initialized if given module targets wasm32-wasip1.
         // TODO: wasm host native runtime throws 'Memory should be set on `WasiEnv`
         // first'
         let (instance, wasi_env) = if is_wasi_module(&module) {
@@ -397,19 +397,19 @@ impl TransformExecutor {
                      used by the plugin is compatible with the host runtime. See the \
                      documentation for compatibility information. If you are an author of the \
                      plugin, please update `swc_core` to the compatible version.
-                 
+
                 Note that if you want to use the os features like filesystem, you need to use \
                      `wasi`. Wasm itself does not have concept of filesystem.
-                 
+
                 https://swc.rs/docs/plugin/selecting-swc-core
 
                 See https://plugins.swc.rs/versions/from-plugin-runner/{PKG_VERSION} for the list of the compatible versions.
-                 
-                Build info: 
+
+                Build info:
                     Date: {BUILD_DATE}
                     Timestamp: {BUILD_TIMESTAMP}
-                    
-                Version info: 
+
+                Version info:
                     swc_plugin_runner: {PKG_VERSION}
                     Dependencies: {PKG_DEPS}
                 "

--- a/crates/swc_plugin_runner/tests/css_rkyv.rs
+++ b/crates/swc_plugin_runner/tests/css_rkyv.rs
@@ -22,7 +22,7 @@ fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
         cmd.env("CARGO_TARGET_DIR", &*CARGO_TARGET_DIR);
 
         cmd.current_dir(dir);
-        cmd.args(["build", "--target=wasm32-wasi", "--release"])
+        cmd.args(["build", "--target=wasm32-wasip1", "--release"])
             .stderr(Stdio::inherit());
         cmd.output()?;
 
@@ -35,7 +35,7 @@ fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
         }
     }
 
-    for entry in fs::read_dir(CARGO_TARGET_DIR.join("wasm32-wasi").join("release"))? {
+    for entry in fs::read_dir(CARGO_TARGET_DIR.join("wasm32-wasip1").join("release"))? {
         let entry = entry?;
 
         let s = entry.file_name().to_string_lossy().into_owned();

--- a/crates/swc_plugin_runner/tests/ecma_integration.rs
+++ b/crates/swc_plugin_runner/tests/ecma_integration.rs
@@ -26,7 +26,7 @@ fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
         let mut cmd = Command::new("cargo");
         cmd.env("CARGO_TARGET_DIR", &*CARGO_TARGET_DIR);
         cmd.current_dir(dir);
-        cmd.args(["build", "--target=wasm32-wasi"])
+        cmd.args(["build", "--target=wasm32-wasip1"])
             .stderr(Stdio::inherit());
         cmd.output()?;
 
@@ -39,7 +39,7 @@ fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
         }
     }
 
-    for entry in fs::read_dir(CARGO_TARGET_DIR.join("wasm32-wasi").join("debug"))? {
+    for entry in fs::read_dir(CARGO_TARGET_DIR.join("wasm32-wasip1").join("debug"))? {
         let entry = entry?;
 
         let s = entry.file_name().to_string_lossy().into_owned();

--- a/crates/swc_plugin_runner/tests/ecma_rkyv.rs
+++ b/crates/swc_plugin_runner/tests/ecma_rkyv.rs
@@ -23,7 +23,7 @@ fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
         let mut cmd = Command::new("cargo");
         cmd.env("CARGO_TARGET_DIR", &*CARGO_TARGET_DIR);
         cmd.current_dir(dir);
-        cmd.args(["build", "--target=wasm32-wasi", "--release"])
+        cmd.args(["build", "--target=wasm32-wasip1", "--release"])
             .stderr(Stdio::inherit());
         cmd.output()?;
 
@@ -36,7 +36,7 @@ fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
         }
     }
 
-    for entry in fs::read_dir(CARGO_TARGET_DIR.join("wasm32-wasi").join("release"))? {
+    for entry in fs::read_dir(CARGO_TARGET_DIR.join("wasm32-wasip1").join("release"))? {
         let entry = entry?;
 
         let s = entry.file_name().to_string_lossy().into_owned();

--- a/crates/swc_plugin_runner/tests/issues.rs
+++ b/crates/swc_plugin_runner/tests/issues.rs
@@ -23,7 +23,7 @@ fn build_plugin(dir: &Path, crate_name: &str) -> Result<PathBuf, Error> {
         let mut cmd = Command::new("cargo");
         cmd.env("CARGO_TARGET_DIR", &*CARGO_TARGET_DIR);
         cmd.current_dir(dir);
-        cmd.args(["build", "--release", "--target=wasm32-wasi"])
+        cmd.args(["build", "--release", "--target=wasm32-wasip1"])
             .stderr(Stdio::inherit());
         cmd.output()?;
 
@@ -36,7 +36,7 @@ fn build_plugin(dir: &Path, crate_name: &str) -> Result<PathBuf, Error> {
         }
     }
 
-    for entry in fs::read_dir(CARGO_TARGET_DIR.join("wasm32-wasi").join("release"))? {
+    for entry in fs::read_dir(CARGO_TARGET_DIR.join("wasm32-wasip1").join("release"))? {
         let entry = entry?;
 
         let s = entry.file_name().to_string_lossy().into_owned();

--- a/packages/core/e2e/plugins/plugins.schema.test.js
+++ b/packages/core/e2e/plugins/plugins.schema.test.js
@@ -17,7 +17,7 @@ const waitProcessAsync = async (proc) =>
 const getPluginAbsolutePath = (feature) =>
     path.join(
         getPkgRoot(),
-        `node-swc/e2e/fixtures/${feature}/target/wasm32-wasi/debug/${feature}.wasm`
+        `node-swc/e2e/fixtures/${feature}/target/wasm32-wasip1/debug/${feature}.wasm`
     );
 
 /**
@@ -50,7 +50,7 @@ const buildPlugin = async (feature) => {
         "--manifest-path",
         `./node-swc/e2e/fixtures/${feature}/Cargo.toml`,
         "--target",
-        "wasm32-wasi",
+        "wasm32-wasip1",
     ];
 
     const options = { cwd: getPkgRoot(), stdio: "inherit" };


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fixed the error where the target type behavior was inconsistent with the [documentation](https://swc.rs/docs/plugin/ecmascript/getting-started#create-a-project) when creating a plugin using CLI. Now `wasm32-wasip1` can be used normally as a target.

```shell
❯ cargo run -p swc_cli_impl -- plugin new --target-type wasm32-wasip1 my-first-plugin
     Running `target\debug\swc.exe plugin new --target-type wasm32-wasip1 my-first-plugin`
✅ Successfully created my-first-plugin.
If you haven't, please ensure to add target via "rustup target add wasm32-wasip1"
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

- https://github.com/swc-project/swc/issues/10284
