### PR TITLE
Fix wrong shell in workflow action

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -276,6 +276,7 @@ jobs:
         with:
           image: ${{ matrix.settings.docker }}
           options: -v ${{ env.HOME }}/.cargo/git:/root/.cargo/git -v ${{ env.HOME }}/.cargo/registry:/root/.cargo/registry -v ${{ github.workspace }}:/build -w /build
+          shell: bash
           run: >-
             cd ./packages/${{ inputs.package }} &&
             npm install -f -g yarn@1.22 &&
@@ -454,6 +455,7 @@ jobs:
   #       with:
   #         image: node:lts-alpine
   #         options: "--platform linux/arm64 -v ${{ github.workspace }}:/build -w /build"
+  #         shell: bash
   #         run: >-
   #           set -e &&
   #           npm install -f -g yarn@1.22 &&
@@ -501,6 +503,7 @@ jobs:
   #       with:
   #         image: node:${{ matrix.node }}-slim
   #         options: "--platform linux/arm/v7 -v ${{ github.workspace }}:/build -w /build"
+  #         shell: bash
   #         run: >-
   #           set -e &&
   #           npm install -f -g yarn@1.22 &&


### PR DESCRIPTION
The Bash shell is needed in order to execute the build properly. 

**Related issue (if exists):**

Fixes #9769.