### PR TITLE
feat(isolated_declarations): distinguish js value and ts type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6330,6 +6330,7 @@ dependencies = [
 name = "swc_typescript"
 version = "10.0.1"
 dependencies = [
+ "bitflags 2.6.0",
  "petgraph 0.7.1",
  "rustc-hash 2.1.0",
  "swc_atoms",

--- a/crates/swc_typescript/Cargo.toml
+++ b/crates/swc_typescript/Cargo.toml
@@ -9,6 +9,7 @@ repository    = { workspace = true }
 version       = "10.0.1"
 
 [dependencies]
+bitflags = {workspace = true }
 petgraph   = { workspace = true }
 rustc-hash = { workspace = true }
 thiserror  = { workspace = true }

--- a/crates/swc_typescript/src/fast_dts/decl.rs
+++ b/crates/swc_typescript/src/fast_dts/decl.rs
@@ -20,7 +20,7 @@ impl FastDts {
                     return;
                 }
 
-                if check_binding && !self.used_refs.contains(&class_decl.ident.to_id()) {
+                if check_binding && !self.used_refs.used(&class_decl.ident.to_id()) {
                     return;
                 }
 
@@ -32,7 +32,7 @@ impl FastDts {
                     return;
                 }
 
-                if check_binding && !self.used_refs.contains(&fn_decl.ident.to_id()) {
+                if check_binding && !self.used_refs.used_as_value(&fn_decl.ident.to_id()) {
                     return;
                 }
 
@@ -50,7 +50,7 @@ impl FastDts {
                         && decl
                             .name
                             .as_ident()
-                            .map_or(false, |ident| !self.used_refs.contains(&ident.to_id()))
+                            .map_or(false, |ident| !self.used_refs.used_as_value(&ident.to_id()))
                     {
                         return;
                     }
@@ -63,7 +63,7 @@ impl FastDts {
                         && decl
                             .name
                             .as_ident()
-                            .map_or(false, |ident| !self.used_refs.contains(&ident.to_id()))
+                            .map_or(false, |ident| !self.used_refs.used_as_value(&ident.to_id()))
                     {
                         return;
                     }
@@ -72,7 +72,7 @@ impl FastDts {
             }
             Decl::TsEnum(ts_enum) => {
                 ts_enum.declare = is_declare;
-                if check_binding && !self.used_refs.contains(&ts_enum.id.to_id()) {
+                if check_binding && !self.used_refs.used(&ts_enum.id.to_id()) {
                     return;
                 }
                 self.transform_enum(ts_enum.as_mut());
@@ -88,7 +88,7 @@ impl FastDts {
                     && ts_module
                         .id
                         .as_ident()
-                        .map_or(false, |ident| !self.used_refs.contains(&ident.to_id()))
+                        .map_or(false, |ident| !self.used_refs.used_as_type(&ident.to_id()))
                 {
                     return;
                 }
@@ -139,7 +139,7 @@ impl FastDts {
 
         if matches!(pat, Pat::Array(_) | Pat::Object(_)) {
             pat.bound_names(&mut |ident| {
-                if !check_binding || self.used_refs.contains(&ident.to_id()) {
+                if !check_binding || self.used_refs.used_as_value(&ident.to_id()) {
                     self.binding_element_export(ident.span);
                 }
             });

--- a/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
+++ b/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
@@ -180,7 +180,7 @@ impl TypeUsageAnalyzer<'_> {
 impl Visit for TypeUsageAnalyzer<'_> {
     fn visit_ts_property_signature(&mut self, node: &TsPropertySignature) {
         if let Some(ident) = node.key.get_root_ident() {
-            self.add_edge(Symbol::new(ident.to_id(), SymbolFlags::Type), true);
+            self.add_edge(Symbol::new(ident.to_id(), SymbolFlags::Value), true);
         }
         node.visit_children_with(self);
     }

--- a/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
+++ b/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
@@ -1,3 +1,6 @@
+use std::collections::hash_map::Entry;
+
+use bitflags::bitflags;
 use petgraph::{
     graph::{DiGraph, NodeIndex},
     visit::Bfs,
@@ -7,16 +10,39 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use swc_common::{BytePos, Spanned, SyntaxContext};
 use swc_ecma_ast::{
     Accessibility, ArrowExpr, Class, ClassMember, Decl, ExportDecl, ExportDefaultDecl,
-    ExportDefaultExpr, Function, Id, Ident, ModuleExportName, ModuleItem, NamedExport,
-    TsEntityName, TsExportAssignment, TsExprWithTypeArgs, TsPropertySignature, TsTypeElement,
+    ExportDefaultExpr, Function, Id, ModuleExportName, ModuleItem, NamedExport, TsEntityName,
+    TsExportAssignment, TsExprWithTypeArgs, TsPropertySignature, TsTypeElement,
 };
 use swc_ecma_visit::{Visit, VisitWith};
 
 use crate::fast_dts::util::ast_ext::ExprExit;
 
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct SymbolFlags: u8 {
+        const Value = 1 << 0;
+        const Type = 1 << 1;
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct Symbol {
+    id: Id,
+    kind: SymbolFlags,
+}
+
+impl Symbol {
+    fn new(id: Id, kind: SymbolFlags) -> Self {
+        Symbol { id, kind }
+    }
+}
+
 pub struct TypeUsageAnalyzer<'a> {
-    graph: DiGraph<Id, ()>,
-    nodes: FxHashMap<Id, NodeIndex>,
+    /// The graph may contain multiple symbol nodes with the same `Id` and
+    /// different `SymbolFlags`. This is ok because they will be merged into the
+    /// final result `UsedRefs`
+    graph: DiGraph<Symbol, ()>,
+    nodes: FxHashMap<Symbol, NodeIndex>,
     /// Global scope + nested ts module block scope
     scope_entries: Vec<NodeIndex>,
     /// Dts will only consider referred nodes and ignore binding nodes
@@ -27,14 +53,58 @@ pub struct TypeUsageAnalyzer<'a> {
     internal_annotations: Option<&'a FxHashSet<BytePos>>,
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct UsedRefs(FxHashMap<Id, SymbolFlags>);
+
+impl UsedRefs {
+    pub fn add_usage(&mut self, id: Id, kind: SymbolFlags) {
+        match self.0.entry(id) {
+            Entry::Occupied(mut occupied_entry) => {
+                let value = occupied_entry.get_mut();
+                *value = value.union(kind);
+            }
+            Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(kind);
+            }
+        }
+    }
+
+    pub fn used_as_type(&self, id: &Id) -> bool {
+        self.0
+            .get(id)
+            .map_or(false, |ref_type| ref_type.contains(SymbolFlags::Type))
+    }
+
+    pub fn used_as_value(&self, id: &Id) -> bool {
+        self.0
+            .get(id)
+            .map_or(false, |ref_type| ref_type.contains(SymbolFlags::Value))
+    }
+
+    pub fn used(&self, id: &Id) -> bool {
+        self.0
+            .get(id)
+            .map_or(false, |ref_type| !ref_type.is_empty())
+    }
+
+    pub fn extend(&mut self, other: Self) {
+        for (id, kind) in other.0 {
+            self.add_usage(id, kind);
+        }
+    }
+}
+
 impl TypeUsageAnalyzer<'_> {
     pub fn analyze(
         module_items: &Vec<ModuleItem>,
         internal_annotations: Option<&FxHashSet<BytePos>>,
-    ) -> FxHashSet<Id> {
+    ) -> UsedRefs {
         // Create a fake entry reprensting global scope
         let mut graph = Graph::default();
-        let entry = graph.add_node(("".into(), SyntaxContext::empty()));
+        let entry = graph.add_node(Symbol::new(
+            ("".into(), SyntaxContext::empty()),
+            SymbolFlags::empty(),
+        ));
 
         let mut analyzer = TypeUsageAnalyzer {
             graph,
@@ -46,13 +116,17 @@ impl TypeUsageAnalyzer<'_> {
         };
         module_items.visit_with(&mut analyzer);
 
-        // Reachability
-        let mut used_refs = FxHashSet::default();
+        // Reachability: used_refs = all references - unreachable references
+        let mut used_refs = UsedRefs::default();
         let mut bfs = Bfs::new(&analyzer.graph, entry);
         bfs.next(&analyzer.graph);
         while let Some(node_id) = bfs.next(&analyzer.graph) {
             if analyzer.references.contains(&node_id) {
-                used_refs.insert(analyzer.graph[node_id].clone());
+                let symbol = analyzer
+                    .graph
+                    .node_weight(node_id)
+                    .expect("unexpected invalid node id");
+                used_refs.add_usage(symbol.id.clone(), symbol.kind);
             }
         }
         used_refs
@@ -70,19 +144,19 @@ impl TypeUsageAnalyzer<'_> {
 
     /// All the nested idents will depend on the usage of the passed ident
     /// This is usually called when meeting a binding ident
-    fn with_source_ident<F: FnMut(&mut TypeUsageAnalyzer)>(&mut self, ident: &Ident, f: F) {
-        self.add_edge(ident.to_id(), false);
+    fn with_source_ident<F: FnMut(&mut TypeUsageAnalyzer)>(&mut self, symbol: Symbol, f: F) {
+        self.add_edge(symbol.clone(), false);
         let id = *self
             .nodes
-            .entry(ident.to_id())
-            .or_insert_with(|| self.graph.add_node(ident.to_id()));
+            .entry(symbol.clone())
+            .or_insert_with(|| self.graph.add_node(symbol));
         self.with_source(Some(id), f);
     }
 
     /// Add a dependency edge from current source to the reference
     /// If `is_ref` is false, the reference is a binding ident such as a
     /// variable declaration, which means it is not a usage.
-    fn add_edge(&mut self, reference: Id, is_ref: bool) {
+    fn add_edge(&mut self, reference: Symbol, is_ref: bool) {
         if let Some(source) = self.source {
             let target_id = *self
                 .nodes
@@ -106,14 +180,14 @@ impl TypeUsageAnalyzer<'_> {
 impl Visit for TypeUsageAnalyzer<'_> {
     fn visit_ts_property_signature(&mut self, node: &TsPropertySignature) {
         if let Some(ident) = node.key.get_root_ident() {
-            self.add_edge(ident.to_id(), true);
+            self.add_edge(Symbol::new(ident.to_id(), SymbolFlags::Type), true);
         }
         node.visit_children_with(self);
     }
 
     fn visit_ts_expr_with_type_args(&mut self, node: &TsExprWithTypeArgs) {
         if let Some(ident) = node.expr.get_root_ident() {
-            self.add_edge(ident.to_id(), true);
+            self.add_edge(Symbol::new(ident.to_id(), SymbolFlags::Type), true);
         }
         node.visit_children_with(self);
     }
@@ -124,7 +198,7 @@ impl Visit for TypeUsageAnalyzer<'_> {
                 ts_qualified_name.left.visit_with(self);
             }
             TsEntityName::Ident(ident) => {
-                self.add_edge(ident.to_id(), true);
+                self.add_edge(Symbol::new(ident.to_id(), SymbolFlags::Value), true);
             }
         };
     }
@@ -132,16 +206,25 @@ impl Visit for TypeUsageAnalyzer<'_> {
     fn visit_decl(&mut self, node: &Decl) {
         match node {
             Decl::Class(class_decl) => {
-                self.with_source_ident(&class_decl.ident, |this| class_decl.class.visit_with(this));
+                self.with_source_ident(
+                    Symbol::new(class_decl.ident.to_id(), SymbolFlags::all()),
+                    |this| class_decl.class.visit_with(this),
+                );
             }
             Decl::Fn(fn_decl) => {
-                self.with_source_ident(&fn_decl.ident, |this| fn_decl.function.visit_with(this));
+                self.with_source_ident(
+                    Symbol::new(fn_decl.ident.to_id(), SymbolFlags::Value),
+                    |this| fn_decl.function.visit_with(this),
+                );
             }
             Decl::Var(var_decl) => {
                 for decl in &var_decl.decls {
                     decl.name.visit_with(self);
                     if let Some(name) = decl.name.as_ident() {
-                        self.with_source_ident(&name.id, |this| decl.init.visit_with(this));
+                        self.with_source_ident(
+                            Symbol::new(name.id.to_id(), SymbolFlags::Value),
+                            |this| decl.init.visit_with(this),
+                        );
                     }
                 }
             }
@@ -149,27 +232,39 @@ impl Visit for TypeUsageAnalyzer<'_> {
                 for decl in &using_decl.decls {
                     decl.name.visit_with(self);
                     if let Some(name) = decl.name.as_ident() {
-                        self.with_source_ident(&name.id, |this| decl.init.visit_with(this));
+                        self.with_source_ident(
+                            Symbol::new(name.to_id(), SymbolFlags::Value),
+                            |this| decl.init.visit_with(this),
+                        );
                     }
                 }
             }
             Decl::TsInterface(ts_interface_decl) => {
-                self.with_source_ident(&ts_interface_decl.id, |this| {
-                    ts_interface_decl.body.visit_with(this);
-                    ts_interface_decl.extends.visit_with(this);
-                    ts_interface_decl.type_params.visit_with(this);
-                });
+                self.with_source_ident(
+                    Symbol::new(ts_interface_decl.id.to_id(), SymbolFlags::Type),
+                    |this| {
+                        ts_interface_decl.body.visit_with(this);
+                        ts_interface_decl.extends.visit_with(this);
+                        ts_interface_decl.type_params.visit_with(this);
+                    },
+                );
             }
             Decl::TsTypeAlias(ts_type_alias_decl) => {
-                self.with_source_ident(&ts_type_alias_decl.id, |this| {
-                    ts_type_alias_decl.type_ann.visit_with(this);
-                    ts_type_alias_decl.type_params.visit_with(this);
-                });
+                self.with_source_ident(
+                    Symbol::new(ts_type_alias_decl.id.to_id(), SymbolFlags::Type),
+                    |this| {
+                        ts_type_alias_decl.type_ann.visit_with(this);
+                        ts_type_alias_decl.type_params.visit_with(this);
+                    },
+                );
             }
             Decl::TsEnum(ts_enum_decl) => {
-                self.with_source_ident(&ts_enum_decl.id, |this| {
-                    ts_enum_decl.members.visit_with(this);
-                });
+                self.with_source_ident(
+                    Symbol::new(ts_enum_decl.id.to_id(), SymbolFlags::all()),
+                    |this| {
+                        ts_enum_decl.members.visit_with(this);
+                    },
+                );
             }
             Decl::TsModule(ts_module_decl) => {
                 if ts_module_decl.global || ts_module_decl.id.is_str() {
@@ -180,11 +275,12 @@ impl Visit for TypeUsageAnalyzer<'_> {
                 } else if let Some(ident) = ts_module_decl.id.as_ident() {
                     // Push a new scope and set current scope to None, which indicates that
                     // non-exported elements in ts module block are unreachable
-                    self.add_edge(ident.to_id(), false);
+                    let symbol = Symbol::new(ident.to_id(), SymbolFlags::Type);
+                    self.add_edge(symbol.clone(), false);
                     let id = *self
                         .nodes
-                        .entry(ident.to_id())
-                        .or_insert_with(|| self.graph.add_node(ident.to_id()));
+                        .entry(symbol.clone())
+                        .or_insert_with(|| self.graph.add_node(symbol));
                     self.scope_entries.push(id);
                     let old_source = self.source.take();
                     ts_module_decl.body.visit_with(self);
@@ -206,7 +302,7 @@ impl Visit for TypeUsageAnalyzer<'_> {
             for specifier in &node.specifiers {
                 if let Some(name) = specifier.as_named() {
                     if let ModuleExportName::Ident(ident) = &name.orig {
-                        this.add_edge(ident.to_id(), true);
+                        this.add_edge(Symbol::new(ident.to_id(), SymbolFlags::all()), true);
                     }
                 }
             }
@@ -222,7 +318,7 @@ impl Visit for TypeUsageAnalyzer<'_> {
     fn visit_export_default_expr(&mut self, node: &ExportDefaultExpr) {
         self.with_source(self.source, |this| {
             if let Some(ident) = node.expr.as_ident() {
-                this.add_edge(ident.to_id(), true);
+                this.add_edge(Symbol::new(ident.to_id(), SymbolFlags::all()), true);
             }
             node.visit_children_with(this);
         });
@@ -252,7 +348,7 @@ impl Visit for TypeUsageAnalyzer<'_> {
     fn visit_class(&mut self, node: &Class) {
         if let Some(super_class) = &node.super_class {
             if let Some(ident) = super_class.get_root_ident() {
-                self.add_edge(ident.to_id(), true);
+                self.add_edge(Symbol::new(ident.to_id(), SymbolFlags::Value), true);
             }
         }
         node.visit_children_with(self);

--- a/crates/swc_typescript/tests/fixture/issues/10276.snap
+++ b/crates/swc_typescript/tests/fixture/issues/10276.snap
@@ -1,0 +1,11 @@
+```==================== .D.TS ====================
+
+export declare const Tabs: {
+    readonly Name: "name";
+};
+export interface BandMember {
+    name: string;
+}
+export declare const MemberTab: () => BandMember;
+
+

--- a/crates/swc_typescript/tests/fixture/issues/10276.ts
+++ b/crates/swc_typescript/tests/fixture/issues/10276.ts
@@ -1,0 +1,17 @@
+export const Tabs = {
+    Name: "name",
+} as const;
+
+export interface BandMember {
+    name: string;
+}
+
+const MemberTabs = {
+    Name: Tabs.Name,
+};
+
+type MemberTab = keyof typeof MemberTabs;
+
+export const MemberTab: () => BandMember = () => {
+    return { name: "Mark" };
+};


### PR DESCRIPTION
**Description:**

1. I mixed up the types and values with the same identifier in the usage graph before. Now I define a flag to distinguish them.
2. Also add many docs to `TypeUsageAnalyzer`

**Related issue (if exists):**

fixes https://github.com/swc-project/swc/issues/10276
