### PR TITLE
perf(es/jsx): Cache FileName for JSX pass (#9951)

### DIFF
--- a/.changeset/real-seas-fix.md
+++ b/.changeset/real-seas-fix.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_react: patch
+---
+
+perf(es/jsx): Cache FileName for JSX pass (#9951)

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -394,7 +394,7 @@ impl JsxDirectives {
 
 #[cfg(feature = "concurrent")]
 fn cache_filename(name: &str) -> Arc<FileName> {
-    static FILENAME_CACHE: Lazy<RwLock<FxHashMap<String, Arc<FileName>>>> =
+    static FILENAME_CACHE: Lazy<RwLock<FxHashMap<String, Lrc<FileName>>>> =
         Lazy::new(|| RwLock::new(FxHashMap::default()));
 
     {

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -3,7 +3,7 @@
 use std::{
     borrow::Cow,
     iter::{self, once},
-    sync::{Arc, RwLock},
+    sync::RwLock,
 };
 
 use once_cell::sync::Lazy;
@@ -402,8 +402,7 @@ fn cache_filename(name: &str) -> Lrc<FileName> {
             .read()
             .expect("Failed to read FILENAME_CACHE");
         if let Some(f) = cache.get(name) {
-            return f.clone(); // Cloning the Arc — cheap, just increases ref
-                              // count
+            return f.clone();
         }
     }
 
@@ -421,7 +420,7 @@ fn cache_filename(name: &str) -> Lrc<FileName> {
 
 #[cfg(not(feature = "concurrent"))]
 fn cache_filename(name: &str) -> Lrc<FileName> {
-    Arc::new(FileName::Internal(format!("jsx-config-{}.js", name)))
+    Lrc::new(FileName::Internal(format!("jsx-config-{}.js", name)))
 }
 
 #[cfg(feature = "concurrent")]

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -137,7 +137,6 @@ pub fn parse_expr_for_jsx(
     src: Lrc<String>,
     top_level_mark: Mark,
 ) -> Box<Expr> {
-
     let fm = cm.new_source_file_from(cache_filename(name).into(), src);
 
     parse_file_as_expr(
@@ -395,7 +394,7 @@ impl JsxDirectives {
 
 #[cfg(feature = "concurrent")]
 fn cache_filename(name: &str) -> FileName {
-       static FILENAME_CACHE: Lazy<RwLock<FxHashMap<String, FileName>>> =
+    static FILENAME_CACHE: Lazy<RwLock<FxHashMap<String, FileName>>> =
         Lazy::new(|| RwLock::new(FxHashMap::default()));
 
     {

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -394,7 +394,7 @@ impl JsxDirectives {
 
 #[cfg(feature = "concurrent")]
 fn cache_filename(name: &str) -> FileName {
-    static FILENAME_CACHE: Lazy<RwLock<FxHashMap<String, FileName>>> =
+    static FILENAME_CACHE: Lazy<RwLock<FxHashMap<String, Arc<FileName>>>> =
         Lazy::new(|| RwLock::new(FxHashMap::default()));
 
     {

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -393,7 +393,7 @@ impl JsxDirectives {
 }
 
 #[cfg(feature = "concurrent")]
-fn cache_filename(name: &str) -> Arc<FileName> {
+fn cache_filename(name: &str) -> Lrc<FileName> {
     static FILENAME_CACHE: Lazy<RwLock<FxHashMap<String, Lrc<FileName>>>> =
         Lazy::new(|| RwLock::new(FxHashMap::default()));
 

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -420,7 +420,7 @@ fn cache_filename(name: &str) -> Arc<FileName> {
 }
 
 #[cfg(not(feature = "concurrent"))]
-fn cache_filename(name: &str) -> Arc<FileName> {
+fn cache_filename(name: &str) -> Lrc<FileName> {
     Arc::new(FileName::Internal(format!("jsx-config-{}.js", name)))
 }
 

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -407,7 +407,7 @@ fn cache_filename(name: &str) -> Arc<FileName> {
         }
     }
 
-    let file = Arc::new(FileName::Internal(format!("jsx-config-{}.js", name)));
+    let file = Lrc::new(FileName::Internal(format!("jsx-config-{}.js", name)));
 
     {
         let mut cache = FILENAME_CACHE


### PR DESCRIPTION
### Summary

This PR improves performance by caching the `FileName` used when creating new source files during the JSX transform pass. This avoids repeated `format!` calls and reduces allocations by reusing existing `FileName` values.

### Changes

- Added `cache_filename` function with `FxHashMap` behind a `RwLock`.
- Used `cache_filename(name).into()` instead of formatting a new string each time.

### Motivation

Related to issue #9951.  
Reduces redundant string formatting and allocations in the JSX parser.

### Linked Issue

Closes #9951
