### PR TITLE
chore(ide): Disable RA diagnostics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -26,5 +26,7 @@
     "rust-analyzer.check.command": "clippy",
     "rust-analyzer.cargo.features": [
         "plugin"
-    ]
+    ],
+    // SWC project is too complex to use rust-analyzer
+    "rust-analyzer.diagnostics.enable": false
 }


### PR DESCRIPTION
**Description:**

I found that `rust-analyzer` is not detecting macro-expanded code correctly while working on https://github.com/swc-project/swc/pull/10261