### PR TITLE
feat(es/codegen): Support `sourceMap.url` option of `terser`

### DIFF
--- a/.changeset/forty-tables-obey.md
+++ b/.changeset/forty-tables-obey.md
@@ -1,0 +1,5 @@
+---
+swc_compiler_base: major
+---
+
+feat(es/codegen): Support `sourceMap.url` option of `terser`

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -767,7 +767,7 @@ impl Options {
             output: JscOutputConfig {
                 charset,
                 preamble,
-                preserve_annotations: cfg.jsc.output.preserve_annotations,
+                ..cfg.jsc.output
             },
             emit_assert_for_import_attributes: experimental
                 .emit_assert_for_import_attributes
@@ -1184,6 +1184,9 @@ pub struct JscOutputConfig {
 
     #[serde(default)]
     pub preserve_annotations: BoolConfig<false>,
+
+    #[serde(default)]
+    pub source_map_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -760,18 +760,18 @@ impl Compiler {
 
             let target = opts.ecma.clone().into();
 
-            let (source_map, orig) = opts
+            let (source_map, orig, source_map_url) = opts
                 .source_map
                 .as_ref()
                 .map(|obj| -> Result<_, Error> {
                     let orig = obj.content.as_ref().map(|s| s.to_sourcemap()).transpose()?;
 
-                    Ok((SourceMapsConfig::Bool(true), orig))
+                    Ok((SourceMapsConfig::Bool(true), orig, obj.url.as_deref()))
                 })
                 .unwrap_as_option(|v| {
                     Some(Ok(match v {
-                        Some(true) => (SourceMapsConfig::Bool(true), None),
-                        _ => (SourceMapsConfig::Bool(false), None),
+                        Some(true) => (SourceMapsConfig::Bool(true), None, None),
+                        _ => (SourceMapsConfig::Bool(false), None, None),
                     }))
                 })
                 .unwrap()?;
@@ -924,6 +924,7 @@ impl Compiler {
                                 .reduce_escaped_newline,
                         ),
                     output: None,
+                    source_map_url,
                 },
             );
 
@@ -1073,6 +1074,7 @@ impl Compiler {
                     } else {
                         Some(output)
                     },
+                    source_map_url: config.output.source_map_url.as_deref(),
                 },
             )
         })

--- a/crates/swc/tests/fixture/issues-10xxx/10346/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-10xxx/10346/input/.swcrc
@@ -1,0 +1,6 @@
+{
+    "sourceMaps": true,
+    "jsc": {
+        "sourceMapUrl": "input.js.map"
+    }
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10346/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-10xxx/10346/input/.swcrc
@@ -1,6 +1,8 @@
 {
     "sourceMaps": true,
     "jsc": {
-        "sourceMapUrl": "input.js.map"
+        "output": {
+            "sourceMapUrl": "input.js.map"
+        }
     }
 }

--- a/crates/swc/tests/fixture/issues-10xxx/10346/input/input.js
+++ b/crates/swc/tests/fixture/issues-10xxx/10346/input/input.js
@@ -1,0 +1,2 @@
+
+export const foo = 1;

--- a/crates/swc/tests/fixture/issues-10xxx/10346/output/input.js
+++ b/crates/swc/tests/fixture/issues-10xxx/10346/output/input.js
@@ -1,0 +1,3 @@
+export var foo = 1;
+
+//# sourceMappingURL=input.js.map

--- a/crates/swc/tests/fixture/issues-10xxx/10346/output/input.map
+++ b/crates/swc/tests/fixture/issues-10xxx/10346/output/input.map
@@ -1,0 +1,13 @@
+{
+  "mappings": "AACA,OAAO,IAAMA,MAAM,EAAE",
+  "names": [
+    "foo"
+  ],
+  "sources": [
+    "../../input/input.js"
+  ],
+  "sourcesContent": [
+    "\nexport const foo = 1;"
+  ],
+  "version": 3
+}

--- a/crates/swc/tests/minify/issue-7475/issue-8372/1/output.js
+++ b/crates/swc/tests/minify/issue-7475/issue-8372/1/output.js
@@ -1,1 +1,2 @@
 let a={aób:"\xf3"};console.log(a);
+//# sourceMappingURL=input.map

--- a/crates/swc_compiler_base/src/lib.rs
+++ b/crates/swc_compiler_base/src/lib.rs
@@ -180,7 +180,7 @@ where
 
     let mut src_map_buf = Vec::new();
 
-    let src = {
+    let mut src = {
         let mut buf = std::vec::Vec::new();
         {
             let mut w = swc_ecma_codegen::text_writer::JsWriter::new(
@@ -266,7 +266,6 @@ where
             }
         }
         SourceMapsConfig::Str(_) => {
-            let mut src = src;
             let mut buf = std::vec::Vec::new();
 
             map.unwrap()

--- a/crates/swc_compiler_base/src/lib.rs
+++ b/crates/swc_compiler_base/src/lib.rs
@@ -250,7 +250,13 @@ where
                 map.unwrap()
                     .to_writer(&mut buf)
                     .context("failed to write source map")?;
-                let map = String::from_utf8(buf).context("source map is not utf-8")?;
+                let mut map = String::from_utf8(buf).context("source map is not utf-8")?;
+
+                if let Some(source_map_url) = source_map_url {
+                    map.push_str("\n//# sourceMappingURL=");
+                    map.push_str(source_map_url);
+                }
+
                 (src, Some(map))
             } else {
                 (src, None)

--- a/crates/swc_compiler_base/src/lib.rs
+++ b/crates/swc_compiler_base/src/lib.rs
@@ -119,6 +119,7 @@ pub struct PrintArgs<'a> {
     pub preamble: &'a str,
     pub codegen_config: swc_ecma_codegen::Config,
     pub output: Option<FxHashMap<String, String>>,
+    pub source_map_url: Option<&'a str>,
 }
 
 impl Default for PrintArgs<'_> {
@@ -138,6 +139,7 @@ impl Default for PrintArgs<'_> {
             preamble: "",
             codegen_config: Default::default(),
             output: None,
+            source_map_url: None,
         }
     }
 }
@@ -168,6 +170,7 @@ pub fn print<T>(
         preamble,
         codegen_config,
         output,
+        source_map_url,
     }: PrintArgs,
 ) -> Result<TransformOutput, Error>
 where

--- a/crates/swc_compiler_base/src/lib.rs
+++ b/crates/swc_compiler_base/src/lib.rs
@@ -253,11 +253,11 @@ where
                 map.unwrap()
                     .to_writer(&mut buf)
                     .context("failed to write source map")?;
-                let mut map = String::from_utf8(buf).context("source map is not utf-8")?;
+                let map = String::from_utf8(buf).context("source map is not utf-8")?;
 
                 if let Some(source_map_url) = source_map_url {
-                    map.push_str("\n//# sourceMappingURL=");
-                    map.push_str(source_map_url);
+                    src.push_str("\n//# sourceMappingURL=");
+                    src.push_str(source_map_url);
                 }
 
                 (src, Some(map))


### PR DESCRIPTION
**Description:**

**Related issue:**

 - https://github.com/vercel/ncc/pull/1258