### PR TITLE
perf(es/parser): less array access

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -803,10 +803,12 @@ impl Lexer<'_> {
                         can_be_keyword = false;
                     }
 
-                    if Ident::is_valid_ascii_continue(c) {
-                        l.bump();
-                        continue;
-                    } else if first && Ident::is_valid_ascii_start(c) {
+                    if !first {
+                        if Ident::is_valid_ascii_continue(c) {
+                            l.bump();
+                            continue;
+                        }
+                    } else if Ident::is_valid_ascii_start(c) {
                         l.bump();
                         first = false;
                         continue;
@@ -863,10 +865,12 @@ impl Lexer<'_> {
 
                     break;
                 } else if let Some(c) = l.input.cur() {
-                    if Ident::is_valid_non_ascii_continue(c) {
-                        l.bump();
-                        continue;
-                    } else if first && Ident::is_valid_non_ascii_start(c) {
+                    if !first {
+                        if Ident::is_valid_non_ascii_continue(c) {
+                            l.bump();
+                            continue;
+                        }
+                    } else if Ident::is_valid_non_ascii_start(c) {
                         l.bump();
                         first = false;
                         continue;


### PR DESCRIPTION
Just checking if this actually leads to any measurable improvements. If not, I'll go ahead and close this.