### PR TITLE
fix(ts/fast-strip): Increase Wasm stack size

### DIFF
--- a/bindings/binding_typescript_wasm/.cargo/config.toml
+++ b/bindings/binding_typescript_wasm/.cargo/config.toml
@@ -1,0 +1,3 @@
+[target.wasm32-unknown-unknown]
+# support more stack size due to issue: https://github.com/swc-project/swc/issues/10207
+rustflags = ["-C", "link-args=-z stack-size=2097152"]

--- a/bindings/binding_typescript_wasm/__tests__/transform.js
+++ b/bindings/binding_typescript_wasm/__tests__/transform.js
@@ -1,6 +1,6 @@
 const swc = require("../pkg");
 
-it("properly reports error", function () {
+it("properly reports error", () => {
     expect(() => {
         swc.transformSync("Foo {}", {});
     }).toThrow();
@@ -176,6 +176,15 @@ describe("transform", () => {
                 ),
             ).rejects.toMatchSnapshot();
         });
+
+        it("should not panic memory access out of bounds", async () => {
+            expect(() => swc.transformSync(`
+                var data = ""
+if(!(((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((data === "AED") || (data === "AFN")) || (data === "ALL")) || (data === "AMD")) || (data === "ANG")) || (data === "AOA")) || (data === "ARS")) || (data === "AUD")) || (data === "AWG")) || (data === "AZN")) || (data === "BAM")) || (data === "BBD")) || (data === "BDT")) || (data === "BGN")) || (data === "BHD")) || (data === "BIF")) || (data === "BMD")) || (data === "BND")) || (data === "BOB")) || (data === "BOV")) || (data === "BRL")) || (data === "BSD")) || (data === "BTN")) || (data === "BWP")) || (data === "BYN")) || (data === "BZD")) || (data === "CAD")) || (data === "CDF")) || (data === "CHE")) || (data === "CHF")) || (data === "CHW")) || (data === "CLF")) || (data === "CLP")) || (data === "CNY")) || (data === "COP")) || (data === "COU")) || (data === "CRC")) || (data === "CUC")) || (data === "CUP")) || (data === "CVE")) || (data === "CZK")) || (data === "DJF")) || (data === "DKK")) || (data === "DOP")) || (data === "DZD")) || (data === "EGP")) || (data === "ERN")) || (data === "ETB")) || (data === "EUR")) || (data === "FJD")) || (data === "FKP")) || (data === "GBP")) || (data === "GEL")) || (data === "GHS")) || (data === "GIP")) || (data === "GMD")) || (data === "GNF")) || (data === "GTQ")) || (data === "GYD")) || (data === "HKD")) || (data === "HNL")) || (data === "HRK")) || (data === "HTG")) || (data === "HUF")) || (data === "IDR")) || (data === "ILS")) || (data === "INR")) || (data === "IQD")) || (data === "IRR")) || (data === "ISK")) || (data === "JMD")) || (data === "JOD")) || (data === "JPY")) || (data === "KES")) || (data === "KGS")) || (data === "KHR")) || (data === "KMF")) || (data === "KPW")) || (data === "KRW")) || (data === "KWD")) || (data === "KYD")) || (data === "KZT")) || (data === "LAK")) || (data === "LBP")) || (data === "LKR")) || (data === "LRD")) || (data === "LSL")) || (data === "LYD")) || (data === "MAD")) || (data === "MDL")) || (data === "MGA")) || (data === "MKD")) || (data === "MMK")) || (data === "MNT")) || (data === "MOP")) || (data === "MRU")) || (data === "MUR")) || (data === "MVR")) || (data === "MWK")) || (data === "MXN")) || (data === "MXV")) || (data === "MYR")) || (data === "MZN")) || (data === "NAD")) || (data === "NGN")) || (data === "NIO")) || (data === "NOK")) || (data === "NPR")) || (data === "NZD")) || (data === "OMR")) || (data === "PAB")) || (data === "PEN")) || (data === "PGK")) || (data === "PHP")) || (data === "PKR")) || (data === "PLN")) || (data === "PYG")) || (data === "QAR")) || (data === "RON")) || (data === "RSD")) || (data === "RUB")) || (data === "RWF")) || (data === "SAR")) || (data === "SBD")) || (data === "SCR")) || (data === "SDG")) || (data === "SEK")) || (data === "SGD")) || (data === "SHP")) || (data === "SLL")) || (data === "SOS")) || (data === "SRD")) || (data === "SSP")) || (data === "STN")) || (data === "SVC")) || (data === "SYP")) || (data === "SZL")) || (data === "THB")) || (data === "TJS")) || (data === "TMT")) || (data === "TND")) || (data === "TOP")) || (data === "TRY")) || (data === "TTD")) || (data === "TWD")) || (data === "TZS")) || (data === "UAH")) || (data === "UGX")) || (data === "USD")) || (data === "USN")) || (data === "UYI")) || (data === "UYU")) || (data === "UYW")) || (data === "UZS")) || (data === "VES")) || (data === "VND")) || (data === "VUV")) || (data === "WST")) || (data === "XAF")) || (data === "XAG")) || (data === "XAU")) || (data === "XBA")) || (data === "XBB")) || (data === "XBC")) || (data === "XBD")) || (data === "XCD")) || (data === "XDR")) || (data === "XOF")) || (data === "XPD")) || (data === "XPF")) || (data === "XPT")) || (data === "XSU")) || (data === "XTS")) || (data === "XUA")) || (data === "XXX")) || (data === "YER")) || (data === "ZAR")) || (data === "ZMW")) || (data === "ZWL"))) {
+  console.log("Hello");
+}    
+            `)).not.toThrow();
+        })
     });
 
     describe("in transform mode", () => {

--- a/bindings/binding_typescript_wasm/scripts/build.sh
+++ b/bindings/binding_typescript_wasm/scripts/build.sh
@@ -3,7 +3,7 @@ set -eux
 
 export CARGO_PROFILE_RELEASE_LTO="fat"
 export CARGO_PROFILE_RELEASE_OPT_LEVEL="z"
-wasm-pack build --out-name wasm  --scope=swc --target nodejs
+wasm-pack build --out-name wasm --release --scope=swc --target nodejs
 ls -al ./pkg
 
 node ./scripts/patch.mjs

--- a/bindings/binding_typescript_wasm/scripts/build.sh
+++ b/bindings/binding_typescript_wasm/scripts/build.sh
@@ -3,7 +3,7 @@ set -eux
 
 export CARGO_PROFILE_RELEASE_LTO="fat"
 export CARGO_PROFILE_RELEASE_OPT_LEVEL="z"
-wasm-pack build --out-name wasm --release --scope=swc --target nodejs
+wasm-pack build --out-name wasm  --scope=swc --target nodejs
 ls -al ./pkg
 
 node ./scripts/patch.mjs


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Currently the stack-size for local variables of the generated wasm code is preconfigured to be 1048576 bytes. In some extreme case, it's easy to reach this limit. So we increased stack size by hand. 

More detail reference to: https://github.com/rustwasm/wasm-pack/issues/479

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->
None

**Related issue (if exists):**
Closes https://github.com/swc-project/swc/issues/10207