### PR TITLE
perf(es/parser): Use `bitflags` to reduce parser context size

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5489,6 +5489,7 @@ dependencies = [
 name = "swc_ecma_parser"
 version = "11.0.1"
 dependencies = [
+ "bitflags 2.6.0",
  "codspeed-criterion-compat",
  "criterion",
  "either",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,13 +146,6 @@ lto = true
 debug = true
 lto   = true
 
-[profile.profiling]
-debug           = "limited"
-inherits        = "release"
-lto             = "thin"
-split-debuginfo = "off"
-strip           = false
-
 # Optimize for iteration
 [profile.dev.build-override]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,6 +146,13 @@ lto = true
 debug = true
 lto   = true
 
+[profile.profiling]
+debug           = "limited"
+inherits        = "release"
+lto             = "thin"
+split-debuginfo = "off"
+strip           = false
+
 # Optimize for iteration
 [profile.dev.build-override]
 opt-level = 3

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -25,6 +25,7 @@ typescript    = []
 verify        = ["swc_ecma_visit"]
 
 [dependencies]
+bitflags    = { workspace = true }
 either      = { workspace = true }
 num-bigint  = { workspace = true }
 num-traits  = { workspace = true }

--- a/crates/swc_ecma_parser/examples/perf.rs
+++ b/crates/swc_ecma_parser/examples/perf.rs
@@ -22,30 +22,28 @@ fn main() {
 
         let fm = cm.load_file(entry.path()).unwrap();
 
-        for _ in 0..1000 {
-            let lexer = Lexer::new(
-                Syntax::Typescript(TsSyntax {
-                    no_early_errors: true,
-                    tsx: entry.path().to_string_lossy().ends_with(".tsx"),
-                    ..Default::default()
-                }),
-                Default::default(),
-                StringInput::from(&*fm),
-                None,
-            );
+        let lexer = Lexer::new(
+            Syntax::Typescript(TsSyntax {
+                no_early_errors: true,
+                tsx: entry.path().to_string_lossy().ends_with(".tsx"),
+                ..Default::default()
+            }),
+            Default::default(),
+            StringInput::from(&*fm),
+            None,
+        );
 
-            let mut parser = Parser::new_from(lexer);
+        let mut parser = Parser::new_from(lexer);
 
-            let module = parser.parse_typescript_module();
+        let module = parser.parse_typescript_module();
 
-            if let Ok(module) = &module {
-                module.hash(&mut hasher);
-            }
-
-            let _ = black_box(module);
-
-            cnt += 1;
+        if let Ok(module) = &module {
+            module.hash(&mut hasher);
         }
+
+        let _ = black_box(module);
+
+        cnt += 1;
     }
 
     eprintln!("Parsed {} files", cnt);

--- a/crates/swc_ecma_parser/examples/perf.rs
+++ b/crates/swc_ecma_parser/examples/perf.rs
@@ -22,28 +22,30 @@ fn main() {
 
         let fm = cm.load_file(entry.path()).unwrap();
 
-        let lexer = Lexer::new(
-            Syntax::Typescript(TsSyntax {
-                no_early_errors: true,
-                tsx: entry.path().to_string_lossy().ends_with(".tsx"),
-                ..Default::default()
-            }),
-            Default::default(),
-            StringInput::from(&*fm),
-            None,
-        );
+        for _ in 0..1000 {
+            let lexer = Lexer::new(
+                Syntax::Typescript(TsSyntax {
+                    no_early_errors: true,
+                    tsx: entry.path().to_string_lossy().ends_with(".tsx"),
+                    ..Default::default()
+                }),
+                Default::default(),
+                StringInput::from(&*fm),
+                None,
+            );
 
-        let mut parser = Parser::new_from(lexer);
+            let mut parser = Parser::new_from(lexer);
 
-        let module = parser.parse_typescript_module();
+            let module = parser.parse_typescript_module();
 
-        if let Ok(module) = &module {
-            module.hash(&mut hasher);
+            if let Ok(module) = &module {
+                module.hash(&mut hasher);
+            }
+
+            let _ = black_box(module);
+
+            cnt += 1;
         }
-
-        let _ = black_box(module);
-
-        cnt += 1;
     }
 
     eprintln!("Parsed {} files", cnt);

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -663,7 +663,9 @@ impl Lexer<'_> {
         let c = self.cur().unwrap();
         self.bump();
 
-        if self.syntax.typescript() && self.ctx.in_type && !self.ctx.should_not_lex_lt_or_gt_as_type
+        if self.syntax.typescript()
+            && self.ctx.contains(Context::InDeclare)
+            && !self.ctx.contains(Context::ShouldNotLexLtOrGtAsType)
         {
             if c == '<' {
                 return Ok(Some(tok!('<')));

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -664,7 +664,7 @@ impl Lexer<'_> {
         self.bump();
 
         if self.syntax.typescript()
-            && self.ctx.contains(Context::InDeclare)
+            && self.ctx.contains(Context::InType)
             && !self.ctx.contains(Context::ShouldNotLexLtOrGtAsType)
         {
             if c == '<' {

--- a/crates/swc_ecma_parser/src/lexer/number.rs
+++ b/crates/swc_ecma_parser/src/lexer/number.rs
@@ -782,7 +782,7 @@ mod tests {
             let vec = panic::catch_unwind(|| {
                 crate::with_test_sess(case, |_, input| {
                     let mut l = Lexer::new(Syntax::default(), Default::default(), input, None);
-                    l.ctx.strict = strict;
+                    l.ctx.set(Context::Strict, strict);
                     Ok(l.map(|ts| ts.token).collect::<Vec<_>>())
                 })
                 .unwrap()

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -124,7 +124,7 @@ impl From<TokenKind> for TokenType {
 impl Tokens for Lexer<'_> {
     #[inline]
     fn set_ctx(&mut self, ctx: Context) {
-        if ctx.module && !self.module_errors.borrow().is_empty() {
+        if ctx.contains(Context::Module) && !self.module_errors.borrow().is_empty() {
             let mut module_errors = self.module_errors.borrow_mut();
             self.errors.borrow_mut().append(&mut *module_errors);
         }
@@ -181,7 +181,7 @@ impl Tokens for Lexer<'_> {
     }
 
     fn add_module_mode_error(&self, error: Error) {
-        if self.ctx.module {
+        if self.ctx.contains(Context::Module) {
             self.add_error(error);
             return;
         }
@@ -284,7 +284,7 @@ impl Lexer<'_> {
 
         self.state.start = *start;
 
-        if self.syntax.jsx() && !self.ctx.in_property_name && !self.ctx.in_type {
+        if self.syntax.jsx() && !self.ctx.contains(Context::InPropertyName | Context::InType) {
             //jsx
             if self.state.context.current() == Some(TokenContext::JSXExpr) {
                 return self.read_jsx_token();
@@ -852,8 +852,8 @@ pub(crate) fn lex(syntax: Syntax, s: &'static str) -> Vec<TokenAndSpan> {
 #[cfg(test)]
 pub(crate) fn lex_module_errors(syntax: Syntax, s: &'static str) -> Vec<Error> {
     with_lexer(syntax, Default::default(), s, |l| {
-        l.ctx.strict = true;
-        l.ctx.module = true;
+        l.ctx.insert(Context::Module);
+        l.ctx.insert(Context::Strict);
 
         let _: Vec<_> = l.collect();
 

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -284,7 +284,10 @@ impl Lexer<'_> {
 
         self.state.start = *start;
 
-        if self.syntax.jsx() && !self.ctx.contains(Context::InPropertyName | Context::InType) {
+        if self.syntax.jsx()
+            && !self.ctx.contains(Context::InPropertyName)
+            && !self.ctx.contains(Context::InType)
+        {
             //jsx
             if self.state.context.current() == Some(TokenContext::JSXExpr) {
                 return self.read_jsx_token();

--- a/crates/swc_ecma_parser/src/lexer/util.rs
+++ b/crates/swc_ecma_parser/src/lexer/util.rs
@@ -16,7 +16,7 @@ use super::{comments_buffer::BufferedComment, whitespace::SkipWhitespace, Char, 
 use crate::{
     error::{Error, SyntaxError},
     lexer::comments_buffer::BufferedCommentKind,
-    Tokens,
+    Context, Tokens,
 };
 
 impl Lexer<'_> {
@@ -104,7 +104,7 @@ impl Lexer<'_> {
     #[cold]
     #[inline(never)]
     pub(super) fn emit_error_span(&mut self, span: Span, kind: SyntaxError) {
-        if self.ctx.ignore_error {
+        if self.ctx.contains(Context::IgnoreError) {
             return;
         }
 
@@ -123,7 +123,7 @@ impl Lexer<'_> {
     #[cold]
     #[inline(never)]
     pub(super) fn emit_strict_mode_error_span(&mut self, span: Span, kind: SyntaxError) {
-        if self.ctx.strict {
+        if self.ctx.contains(Context::Strict) {
             self.emit_error_span(span, kind);
             return;
         }

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -369,79 +369,76 @@ pub struct EsSyntax {
     pub explicit_resource_management: bool,
 }
 
-/// Syntactic context.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct Context {
+use bitflags::bitflags;
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, Default)]
+    pub struct Context: u32 {
+
     /// `true` while backtracking
-    ignore_error: bool,
+    const IgnoreError = 1 << 0;
 
     /// Is in module code?
-    module: bool,
-    can_be_module: bool,
-    strict: bool,
+    const Module = 1<< 1;
+    const CanBeModule = 1 << 2;
+    const Strict = 1<<3;
 
-    expr_ctx: ExpressionContext,
+    const ForLoopInit = 1 << 4;
+    const ForAwaitLoopInit = 1 << 5;
 
-    include_in_expr: bool,
+    const IncludeInExpr = 1 << 6;
     /// If true, await expression is parsed, and "await" is treated as a
     /// keyword.
-    in_async: bool,
+    const InAsync = 1 << 7;
     /// If true, yield expression is parsed, and "yield" is treated as a
     /// keyword.
-    in_generator: bool,
+    const InGenerator = 1 << 8;
 
     /// If true, await is treated as a keyword.
-    in_static_block: bool,
+    const InStaticBlock = 1 << 9;
 
-    is_continue_allowed: bool,
-    is_break_allowed: bool,
+    const IsContinueAllowed = 1 << 10;
+    const IsBreakAllowed = 1 << 11;
 
-    in_type: bool,
+    const InType = 1 << 12;
     /// Typescript extension.
-    should_not_lex_lt_or_gt_as_type: bool,
+    const ShouldNotLexLtOrGtAsType = 1 << 13;
     /// Typescript extension.
-    in_declare: bool,
+    const InDeclare = 1 << 14;
 
     /// If true, `:` should not be treated as a type annotation.
-    in_cond_expr: bool,
-    will_expect_colon_for_cond: bool,
+    const InCondExpr = 1 << 15;
+    const WillExpectColonForCond = 1 << 16;
 
-    in_class: bool,
+    const InClass = 1 << 17;
 
-    in_class_field: bool,
+    const InClassField = 1 << 18;
 
-    in_function: bool,
+    const InFunction = 1 << 19;
 
     /// This indicates current scope or the scope out of arrow function is
     /// function declaration or function expression or not.
-    inside_non_arrow_function_scope: bool,
+    const InsideNonArrowFunctionScope = 1 << 20;
 
-    in_parameters: bool,
+    const InParameters = 1 << 21;
 
-    has_super_class: bool,
+    const HasSuperClass = 1 << 22;
 
-    in_property_name: bool,
+    const InPropertyName = 1 << 23;
 
-    in_forced_jsx_context: bool,
+    const InForcedJsxContext = 1 << 24;
 
     // If true, allow super.x and super[x]
-    allow_direct_super: bool,
+    const AllowDirectSuper = 1 << 25;
 
-    ignore_else_clause: bool,
+    const IgnoreElseClause = 1 << 26;
 
-    disallow_conditional_types: bool,
+    const DisallowConditionalTypes = 1 << 27;
 
-    allow_using_decl: bool,
+    const AllowUsingDecl = 1 << 28;
 
-    top_level: bool,
-}
-
-#[derive(Debug, Clone, Copy, Default)]
-struct ExpressionContext {
-    // TODO:
-    // - include_in
-    for_loop_init: bool,
-    for_await_loop_init: bool,
+    const TopLevel = 1 << 29;
+    }
 }
 
 #[cfg(test)]
@@ -499,7 +496,7 @@ macro_rules! expose {
 
 expose!(parse_file_as_expr, Box<Expr>, |p| {
     // This allow to parse `import.meta`
-    p.input().ctx.can_be_module = true;
+    p.input().ctx.insert(Context::CanBeModule);
     p.parse_expr()
 });
 expose!(parse_file_as_module, Module, |p| { p.parse_module() });

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -375,69 +375,69 @@ bitflags! {
     #[derive(Debug, Clone, Copy, Default)]
     pub struct Context: u32 {
 
-    /// `true` while backtracking
-    const IgnoreError = 1 << 0;
+        /// `true` while backtracking
+        const IgnoreError = 1 << 0;
 
-    /// Is in module code?
-    const Module = 1<< 1;
-    const CanBeModule = 1 << 2;
-    const Strict = 1<<3;
+        /// Is in module code?
+        const Module = 1 << 1;
+        const CanBeModule = 1 << 2;
+        const Strict = 1 << 3;
 
-    const ForLoopInit = 1 << 4;
-    const ForAwaitLoopInit = 1 << 5;
+        const ForLoopInit = 1 << 4;
+        const ForAwaitLoopInit = 1 << 5;
 
-    const IncludeInExpr = 1 << 6;
-    /// If true, await expression is parsed, and "await" is treated as a
-    /// keyword.
-    const InAsync = 1 << 7;
-    /// If true, yield expression is parsed, and "yield" is treated as a
-    /// keyword.
-    const InGenerator = 1 << 8;
+        const IncludeInExpr = 1 << 6;
+        /// If true, await expression is parsed, and "await" is treated as a
+        /// keyword.
+        const InAsync = 1 << 7;
+        /// If true, yield expression is parsed, and "yield" is treated as a
+        /// keyword.
+        const InGenerator = 1 << 8;
 
-    /// If true, await is treated as a keyword.
-    const InStaticBlock = 1 << 9;
+        /// If true, await is treated as a keyword.
+        const InStaticBlock = 1 << 9;
 
-    const IsContinueAllowed = 1 << 10;
-    const IsBreakAllowed = 1 << 11;
+        const IsContinueAllowed = 1 << 10;
+        const IsBreakAllowed = 1 << 11;
 
-    const InType = 1 << 12;
-    /// Typescript extension.
-    const ShouldNotLexLtOrGtAsType = 1 << 13;
-    /// Typescript extension.
-    const InDeclare = 1 << 14;
+        const InType = 1 << 12;
+        /// Typescript extension.
+        const ShouldNotLexLtOrGtAsType = 1 << 13;
+        /// Typescript extension.
+        const InDeclare = 1 << 14;
 
-    /// If true, `:` should not be treated as a type annotation.
-    const InCondExpr = 1 << 15;
-    const WillExpectColonForCond = 1 << 16;
+        /// If true, `:` should not be treated as a type annotation.
+        const InCondExpr = 1 << 15;
+        const WillExpectColonForCond = 1 << 16;
 
-    const InClass = 1 << 17;
+        const InClass = 1 << 17;
 
-    const InClassField = 1 << 18;
+        const InClassField = 1 << 18;
 
-    const InFunction = 1 << 19;
+        const InFunction = 1 << 19;
 
-    /// This indicates current scope or the scope out of arrow function is
-    /// function declaration or function expression or not.
-    const InsideNonArrowFunctionScope = 1 << 20;
+        /// This indicates current scope or the scope out of arrow function is
+        /// function declaration or function expression or not.
+        const InsideNonArrowFunctionScope = 1 << 20;
 
-    const InParameters = 1 << 21;
+        const InParameters = 1 << 21;
 
-    const HasSuperClass = 1 << 22;
+        const HasSuperClass = 1 << 22;
 
-    const InPropertyName = 1 << 23;
+        const InPropertyName = 1 << 23;
 
-    const InForcedJsxContext = 1 << 24;
+        const InForcedJsxContext = 1 << 24;
 
-    // If true, allow super.x and super[x]
-    const AllowDirectSuper = 1 << 25;
+        // If true, allow super.x and super[x]
+        const AllowDirectSuper = 1 << 25;
 
-    const IgnoreElseClause = 1 << 26;
+        const IgnoreElseClause = 1 << 26;
 
-    const DisallowConditionalTypes = 1 << 27;
+        const DisallowConditionalTypes = 1 << 27;
 
-    const AllowUsingDecl = 1 << 28;
+        const AllowUsingDecl = 1 << 28;
 
-    const TopLevel = 1 << 29;
+        const TopLevel = 1 << 29;
     }
 }
 

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -151,12 +151,9 @@ impl<I: Tokens> Parser<I> {
             }
 
             expect!(p, '{');
-            let body = p
-                .with_ctx(Context {
-                    has_super_class: super_class.is_some(),
-                    ..p.ctx()
-                })
-                .parse_class_body()?;
+            let mut ctx = p.ctx();
+            ctx.set(Context::HasSuperClass, super_class.is_some());
+            let body = p.with_ctx(ctx).parse_class_body()?;
 
             if p.input.cur().is_none() {
                 let eof_text = p.input.dump_cur();
@@ -197,10 +194,7 @@ impl<I: Tokens> Parser<I> {
         T: OutputType,
     {
         let (ident, mut class) = self
-            .with_ctx(Context {
-                in_class: true,
-                ..self.ctx()
-            })
+            .with_ctx(self.ctx() | Context::InClass)
             .parse_class_inner(start, class_start, decorators, T::IS_IDENT_REQUIRED)?;
 
         if is_abstract {
@@ -266,12 +260,15 @@ impl<I: Tokens> Parser<I> {
         }
 
         if is!(self, "export") {
-            if !self.ctx().in_class && !self.ctx().in_function && !allow_export {
+            if !self.ctx().contains(Context::InClass)
+                && !self.ctx().contains(Context::InFunction)
+                && !allow_export
+            {
                 syntax_error!(self, self.input.cur_span(), SyntaxError::ExportNotAllowed);
             }
 
-            if !self.ctx().in_class
-                && !self.ctx().in_function
+            if !self.ctx().contains(Context::InClass)
+                && !self.ctx().contains(Context::InFunction)
                 && !self.syntax().decorators_before_export()
             {
                 syntax_error!(self, span!(self, start), SyntaxError::DecoratorOnExport);
@@ -343,13 +340,10 @@ impl<I: Tokens> Parser<I> {
                 }));
                 continue;
             }
-            let mut p = self.with_ctx(Context {
-                allow_direct_super: true,
-                ..self.ctx()
-            });
+            let mut p = self.with_ctx(self.ctx() | Context::AllowDirectSuper);
             let elem = p.parse_class_member()?;
 
-            if !p.ctx().in_declare {
+            if !p.ctx().contains(Context::InDeclare) {
                 if let ClassMember::Constructor(Constructor {
                     body: Some(..),
                     span,
@@ -590,12 +584,12 @@ impl<I: Tokens> Parser<I> {
 
     fn parse_static_block(&mut self, start: BytePos) -> PResult<ClassMember> {
         let body = self
-            .with_ctx(Context {
-                in_static_block: true,
-                in_class_field: true,
-                allow_using_decl: true,
-                ..self.ctx()
-            })
+            .with_ctx(
+                self.ctx()
+                    | Context::InStaticBlock
+                    | Context::InClassField
+                    | Context::AllowUsingDecl,
+            )
             .parse_block(false)?;
 
         let span = span!(self, start);
@@ -653,7 +647,7 @@ impl<I: Tokens> Parser<I> {
                             self.input.prev_span(),
                             SyntaxError::TS1243("override".into(), "declare".into()),
                         );
-                    } else if !self.ctx().has_super_class {
+                    } else if !self.ctx().contains(Context::HasSuperClass) {
                         self.emit_err(self.input.prev_span(), SyntaxError::TS4112);
                     }
                     is_override = true;
@@ -1074,11 +1068,7 @@ impl<I: Tokens> Parser<I> {
 
         let type_ann = self.try_parse_ts_type_ann()?;
 
-        let ctx = Context {
-            include_in_expr: true,
-            in_class_field: true,
-            ..self.ctx()
-        };
+        let ctx = self.ctx() | Context::IncludeInExpr | Context::InClassField;
         self.with_ctx(ctx).parse_with(|p| {
             let value = if is!(p, '=') {
                 assert_and_bump!(p, '=');
@@ -1186,32 +1176,24 @@ impl<I: Tokens> Parser<I> {
         let is_generator = eat!(self, '*');
 
         let ident = if is_fn_expr {
-            //
-            self.with_ctx(Context {
-                in_async: is_async,
-                in_generator: is_generator,
-                allow_direct_super: false,
-                in_class_field: false,
-                ..self.ctx()
-            })
-            .parse_maybe_opt_binding_ident(is_ident_required, false)?
+            let mut ctx = self.ctx() & !Context::AllowDirectSuper & !Context::InClassField;
+            ctx.set(Context::InAsync, is_async);
+            ctx.set(Context::InGenerator, is_generator);
+            self.with_ctx(ctx)
+                .parse_maybe_opt_binding_ident(is_ident_required, false)?
         } else {
             // function declaration does not change context for `BindingIdentifier`.
-            self.with_ctx(Context {
-                allow_direct_super: false,
-                in_class_field: false,
-                ..self.ctx()
-            })
-            .parse_maybe_opt_binding_ident(is_ident_required, false)?
+            self.with_ctx(self.ctx() & !Context::AllowDirectSuper & !Context::InClassField)
+                .parse_maybe_opt_binding_ident(is_ident_required, false)?
         }
         .map(Ident::from);
 
-        self.with_ctx(Context {
-            allow_direct_super: false,
-            in_class_field: false,
-            will_expect_colon_for_cond: false,
-            ..self.ctx()
-        })
+        self.with_ctx(
+            self.ctx()
+                & !Context::AllowDirectSuper
+                & !Context::InClassField
+                & !Context::WillExpectColonForCond,
+        )
         .parse_with(|p| {
             let f = p.parse_fn_args_body(
                 decorators,
@@ -1283,11 +1265,9 @@ impl<I: Tokens> Parser<I> {
     {
         trace_cur!(self, parse_fn_args_body);
         // let prev_in_generator = self.ctx().in_generator;
-        let ctx = Context {
-            in_async: is_async,
-            in_generator: is_generator,
-            ..self.ctx()
-        };
+        let mut ctx = self.ctx();
+        ctx.set(Context::InAsync, is_async);
+        ctx.set(Context::InGenerator, is_generator);
 
         self.with_ctx(ctx).parse_with(|p| {
             let type_params = if p.syntax().typescript() {
@@ -1319,13 +1299,9 @@ impl<I: Tokens> Parser<I> {
 
             expect!(p, '(');
 
-            let arg_ctx = Context {
-                in_parameters: true,
-                in_function: false,
-                in_async: is_async,
-                in_generator: is_generator,
-                ..p.ctx()
-            };
+            let mut arg_ctx = p.ctx() | Context::InParameters & !Context::InFunction;
+            arg_ctx.set(Context::InAsync, is_async);
+            arg_ctx.set(Context::InGenerator, is_generator);
             let params = p.with_ctx(arg_ctx).parse_with(|p| parse_args(p))?;
 
             expect!(p, ')');
@@ -1397,7 +1373,7 @@ impl<I: Tokens> Parser<I> {
     where
         Self: FnBodyParser<T>,
     {
-        if self.ctx().in_declare && self.syntax().typescript() && is!(self, '{') {
+        if self.ctx().contains(Context::InDeclare) && self.syntax().typescript() && is!(self, '{') {
             //            self.emit_err(
             //                self.ctx().span_of_fn_name.expect("we are not in function"),
             //                SyntaxError::TS1183,
@@ -1405,21 +1381,23 @@ impl<I: Tokens> Parser<I> {
             self.emit_err(self.input.cur_span(), SyntaxError::TS1183);
         }
 
-        let ctx = Context {
-            in_async: is_async,
-            in_generator: is_generator,
-            inside_non_arrow_function_scope: if is_arrow_function {
-                self.ctx().inside_non_arrow_function_scope
+        let mut ctx = self.ctx()
+            | Context::InFunction
+                & !Context::InStaticBlock
+                & !Context::IsBreakAllowed
+                & !Context::IsContinueAllowed
+                & !Context::TopLevel;
+        ctx.set(Context::InAsync, is_async);
+        ctx.set(Context::InGenerator, is_generator);
+        ctx.set(
+            Context::InsideNonArrowFunctionScope,
+            if is_arrow_function {
+                self.ctx().contains(Context::InsideNonArrowFunctionScope)
             } else {
                 true
             },
-            in_function: true,
-            in_static_block: false,
-            is_break_allowed: false,
-            is_continue_allowed: false,
-            top_level: false,
-            ..self.ctx()
-        };
+        );
+
         let state = State {
             labels: Vec::new(),
             ..Default::default()
@@ -1455,11 +1433,7 @@ impl<I: Tokens> Parser<I> {
 
         let is_static = static_token.is_some();
         let function = self
-            .with_ctx(Context {
-                allow_direct_super: true,
-                in_class_field: false,
-                ..self.ctx()
-            })
+            .with_ctx(self.ctx() | Context::AllowDirectSuper & !Context::InClassField)
             .parse_with(|p| {
                 p.parse_fn_args_body(decorators, start, parse_args, is_async, is_generator)
             })?;

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -1299,7 +1299,7 @@ impl<I: Tokens> Parser<I> {
 
             expect!(p, '(');
 
-            let mut arg_ctx = p.ctx() | Context::InParameters & !Context::InFunction;
+            let mut arg_ctx = (p.ctx() | Context::InParameters) & !Context::InFunction;
             arg_ctx.set(Context::InAsync, is_async);
             arg_ctx.set(Context::InGenerator, is_generator);
             let params = p.with_ctx(arg_ctx).parse_with(|p| parse_args(p))?;
@@ -1381,12 +1381,11 @@ impl<I: Tokens> Parser<I> {
             self.emit_err(self.input.cur_span(), SyntaxError::TS1183);
         }
 
-        let mut ctx = self.ctx()
-            | Context::InFunction
-                & !Context::InStaticBlock
-                & !Context::IsBreakAllowed
-                & !Context::IsContinueAllowed
-                & !Context::TopLevel;
+        let mut ctx = (self.ctx() | Context::InFunction)
+            & !Context::InStaticBlock
+            & !Context::IsBreakAllowed
+            & !Context::IsContinueAllowed
+            & !Context::TopLevel;
         ctx.set(Context::InAsync, is_async);
         ctx.set(Context::InGenerator, is_generator);
         ctx.set(
@@ -1433,7 +1432,7 @@ impl<I: Tokens> Parser<I> {
 
         let is_static = static_token.is_some();
         let function = self
-            .with_ctx(self.ctx() | Context::AllowDirectSuper & !Context::InClassField)
+            .with_ctx((self.ctx() | Context::AllowDirectSuper) & !Context::InClassField)
             .parse_with(|p| {
                 p.parse_fn_args_body(decorators, start, parse_args, is_async, is_generator)
             })?;

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -223,7 +223,7 @@ impl<I: Tokens> Parser<I> {
                 | Context::IncludeInExpr;
             let cons = self.with_ctx(ctx).parse_assignment_expr()?;
             expect!(self, ':');
-            let ctx = self.ctx() | Context::InCondExpr & !Context::WillExpectColonForCond;
+            let ctx = (self.ctx() | Context::InCondExpr) & !Context::WillExpectColonForCond;
             let alt = self.with_ctx(ctx).parse_assignment_expr()?;
             let span = Span::new(start, alt.span_hi());
             Ok(CondExpr {
@@ -548,11 +548,10 @@ impl<I: Tokens> Parser<I> {
                     .into();
 
                     let ctx = self.ctx();
-                    if !ctx.contains(
-                        Context::InsideNonArrowFunctionScope
-                            | Context::InParameters
-                            | Context::InClass,
-                    ) {
+                    if !ctx.contains(Context::InsideNonArrowFunctionScope)
+                        && !ctx.contains(Context::InParameters)
+                        && !ctx.contains(Context::InClass)
+                    {
                         self.emit_err(span, SyntaxError::InvalidNewTarget);
                     }
 
@@ -1788,7 +1787,7 @@ impl<I: Tokens> Parser<I> {
                         let cons = self.with_ctx(ctx).parse_assignment_expr()?;
                         expect!(self, ':');
                         let ctx =
-                            self.ctx() | Context::InCondExpr & !Context::WillExpectColonForCond;
+                            (self.ctx() | Context::InCondExpr) & !Context::WillExpectColonForCond;
                         let alt = self.with_ctx(ctx).parse_assignment_expr()?;
 
                         arg = ExprOrSpread {

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -390,7 +390,7 @@ impl<I: Tokens> Parser<I> {
         let span = span!(self, start);
 
         if is_one_of!(self, ')', ']', ';', ',') && !ctx.contains(Context::InAsync) {
-            if ctx.contains(Context::InAsync) {
+            if ctx.contains(Context::Module) {
                 self.emit_err(span, SyntaxError::InvalidIdentInAsync);
             }
 

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -16,7 +16,7 @@ impl<I: Tokens> Parser<I> {
                 trace_cur!(self, parse_bin_expr__recovery_unary_err);
 
                 match cur!(self, true) {
-                    &tok!("in") if ctx.include_in_expr => {
+                    &tok!("in") if ctx.contains(Context::IncludeInExpr) => {
                         self.emit_err(self.input.cur_span(), SyntaxError::TS1109);
 
                         Invalid { span: err.span() }.into()
@@ -141,7 +141,7 @@ impl<I: Tokens> Parser<I> {
             Err(..) => return Ok((left, None)),
         };
         let op = match *word {
-            tok!("in") if ctx.include_in_expr => op!("in"),
+            tok!("in") if ctx.contains(Context::IncludeInExpr) => op!("in"),
             tok!("instanceof") => op!("instanceof"),
             Token::BinOp(op) => op.into(),
             _ => {
@@ -389,8 +389,8 @@ impl<I: Tokens> Parser<I> {
 
         let span = span!(self, start);
 
-        if is_one_of!(self, ')', ']', ';', ',') && !ctx.in_async {
-            if ctx.module {
+        if is_one_of!(self, ')', ']', ';', ',') && !ctx.contains(Context::InAsync) {
+            if ctx.contains(Context::InAsync) {
                 self.emit_err(span, SyntaxError::InvalidIdentInAsync);
             }
 
@@ -398,18 +398,18 @@ impl<I: Tokens> Parser<I> {
         }
 
         // This has been checked if start_of_await_token == true,
-        if start_of_await_token.is_none() && ctx.top_level {
+        if start_of_await_token.is_none() && ctx.contains(Context::TopLevel) {
             self.state.found_module_item = true;
-            if !ctx.can_be_module {
+            if !ctx.contains(Context::CanBeModule) {
                 self.emit_err(await_token, SyntaxError::TopLevelAwaitInScript);
             }
         }
 
-        if ctx.in_function && !ctx.in_async {
+        if ctx.contains(Context::InFunction) && !ctx.contains(Context::InAsync) {
             self.emit_err(await_token, SyntaxError::AwaitInFunction);
         }
 
-        if ctx.in_parameters && !ctx.in_function {
+        if ctx.contains(Context::InParameters) && !ctx.contains(Context::InFunction) {
             self.emit_err(span, SyntaxError::AwaitParamInAsync);
         }
 

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -94,7 +94,7 @@ impl Iterator for TokensInput {
 
 impl Tokens for TokensInput {
     fn set_ctx(&mut self, ctx: Context) {
-        if ctx.module && !self.module_errors.borrow().is_empty() {
+        if ctx.contains(Context::Module) && !self.module_errors.borrow().is_empty() {
             let mut module_errors = self.module_errors.borrow_mut();
             self.errors.borrow_mut().append(&mut *module_errors);
         }
@@ -138,7 +138,7 @@ impl Tokens for TokensInput {
     }
 
     fn add_module_mode_error(&self, error: Error) {
-        if self.ctx.module {
+        if self.ctx.contains(Context::Module) {
             self.add_error(error);
             return;
         }

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -96,7 +96,7 @@ impl<I: Tokens> Parser<I> {
     pub fn parse_script(&mut self) -> PResult<Script> {
         trace_cur!(self, parse_script);
 
-        let ctx = self.ctx() & !Context::Module | Context::TopLevel;
+        let ctx = (self.ctx() & !Context::Module) | Context::TopLevel;
         self.set_ctx(ctx);
 
         let start = cur_pos!(self);
@@ -116,7 +116,7 @@ impl<I: Tokens> Parser<I> {
         debug_assert!(self.syntax().typescript());
 
         //TODO: parse() -> PResult<Program>
-        let ctx = self.ctx() | Context::Module | Context::TopLevel & !Context::Strict;
+        let ctx = (self.ctx() | Context::Module | Context::TopLevel) & !Context::Strict;
         // Module code is always in strict mode
         self.set_ctx(ctx);
 

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -146,7 +146,11 @@ impl<I: Tokens> Parser<I> {
                 .iter()
                 .any(|item| matches!(item, ModuleItem::ModuleDecl(..)));
         if has_module_item && !self.ctx().contains(Context::Module) {
-            let ctx = self.ctx() | Context::Module | Context::CanBeModule | Context::TopLevel;
+            let ctx = self.ctx()
+                | Context::Module
+                | Context::CanBeModule
+                | Context::TopLevel
+                | Context::Strict;
             // Emit buffered strict mode / module code violations
             self.input.set_ctx(ctx);
         }

--- a/crates/swc_ecma_parser/src/parser/object.rs
+++ b/crates/swc_ecma_parser/src/parser/object.rs
@@ -11,114 +11,107 @@ impl<I: Tokens> Parser<I> {
     where
         Self: ParseObject<T>,
     {
-        let ctx = Context {
-            will_expect_colon_for_cond: false,
-            ..self.ctx()
-        };
-        self.with_ctx(ctx).parse_with(|p| {
-            trace_cur!(p, parse_object);
+        self.with_ctx(self.ctx() & !Context::WillExpectColonForCond)
+            .parse_with(|p| {
+                trace_cur!(p, parse_object);
 
-            let start = cur_pos!(p);
-            let mut trailing_comma = None;
-            assert_and_bump!(p, '{');
+                let start = cur_pos!(p);
+                let mut trailing_comma = None;
+                assert_and_bump!(p, '{');
 
-            let mut props = Vec::with_capacity(8);
+                let mut props = Vec::with_capacity(8);
 
-            while !eat!(p, '}') {
-                props.push(p.parse_object_prop()?);
+                while !eat!(p, '}') {
+                    props.push(p.parse_object_prop()?);
 
-                if !is!(p, '}') {
-                    expect!(p, ',');
-                    if is!(p, '}') {
-                        trailing_comma = Some(p.input.prev_span());
+                    if !is!(p, '}') {
+                        expect!(p, ',');
+                        if is!(p, '}') {
+                            trailing_comma = Some(p.input.prev_span());
+                        }
                     }
                 }
-            }
 
-            p.make_object(span!(p, start), props, trailing_comma)
-        })
+                p.make_object(span!(p, start), props, trailing_comma)
+            })
     }
 
     /// spec: 'PropertyName'
     pub(super) fn parse_prop_name(&mut self) -> PResult<PropName> {
         trace_cur!(self, parse_prop_name);
 
-        let ctx = self.ctx();
-        self.with_ctx(Context {
-            in_property_name: true,
-            ..ctx
-        })
-        .parse_with(|p| {
-            let start = cur_pos!(p);
+        self.with_ctx(self.ctx() | Context::InPropertyName)
+            .parse_with(|p| {
+                let start = cur_pos!(p);
 
-            let v = match *cur!(p, true) {
-                Token::Str { .. } => match bump!(p) {
-                    Token::Str { value, raw } => PropName::Str(Str {
-                        span: span!(p, start),
-                        value,
-                        raw: Some(raw),
-                    }),
-                    _ => unreachable!(),
-                },
-                Token::Num { .. } => match bump!(p) {
-                    Token::Num { value, raw } => PropName::Num(Number {
-                        span: span!(p, start),
-                        value,
-                        raw: Some(raw),
-                    }),
-                    _ => unreachable!(),
-                },
-                Token::BigInt { .. } => match bump!(p) {
-                    Token::BigInt { value, raw } => PropName::BigInt(BigInt {
-                        span: span!(p, start),
-                        value,
-                        raw: Some(raw),
-                    }),
-                    _ => unreachable!(),
-                },
-                Word(..) => match bump!(p) {
-                    Word(w) => PropName::Ident(IdentName::new(w.into(), span!(p, start))),
-                    _ => unreachable!(),
-                },
-                tok!('[') => {
-                    bump!(p);
-                    let inner_start = cur_pos!(p);
+                let v = match *cur!(p, true) {
+                    Token::Str { .. } => match bump!(p) {
+                        Token::Str { value, raw } => PropName::Str(Str {
+                            span: span!(p, start),
+                            value,
+                            raw: Some(raw),
+                        }),
+                        _ => unreachable!(),
+                    },
+                    Token::Num { .. } => match bump!(p) {
+                        Token::Num { value, raw } => PropName::Num(Number {
+                            span: span!(p, start),
+                            value,
+                            raw: Some(raw),
+                        }),
+                        _ => unreachable!(),
+                    },
+                    Token::BigInt { .. } => match bump!(p) {
+                        Token::BigInt { value, raw } => PropName::BigInt(BigInt {
+                            span: span!(p, start),
+                            value,
+                            raw: Some(raw),
+                        }),
+                        _ => unreachable!(),
+                    },
+                    Word(..) => match bump!(p) {
+                        Word(w) => PropName::Ident(IdentName::new(w.into(), span!(p, start))),
+                        _ => unreachable!(),
+                    },
+                    tok!('[') => {
+                        bump!(p);
+                        let inner_start = cur_pos!(p);
 
-                    let mut expr = p.include_in_expr(true).parse_assignment_expr()?;
+                        let mut expr = p.include_in_expr(true).parse_assignment_expr()?;
 
-                    if p.syntax().typescript() && is!(p, ',') {
-                        let mut exprs = vec![expr];
+                        if p.syntax().typescript() && is!(p, ',') {
+                            let mut exprs = vec![expr];
 
-                        while eat!(p, ',') {
-                            exprs.push(p.include_in_expr(true).parse_assignment_expr()?);
+                            while eat!(p, ',') {
+                                exprs.push(p.include_in_expr(true).parse_assignment_expr()?);
+                            }
+
+                            p.emit_err(span!(p, inner_start), SyntaxError::TS1171);
+
+                            expr = Box::new(
+                                SeqExpr {
+                                    span: span!(p, inner_start),
+                                    exprs,
+                                }
+                                .into(),
+                            );
                         }
 
-                        p.emit_err(span!(p, inner_start), SyntaxError::TS1171);
+                        expect!(p, ']');
 
-                        expr = Box::new(
-                            SeqExpr {
-                                span: span!(p, inner_start),
-                                exprs,
-                            }
-                            .into(),
-                        );
+                        PropName::Computed(ComputedPropName {
+                            span: span!(p, start),
+                            expr,
+                        })
                     }
+                    _ => unexpected!(
+                        p,
+                        "identifier, string literal, numeric literal or [ for the computed key"
+                    ),
+                };
 
-                    expect!(p, ']');
-
-                    PropName::Computed(ComputedPropName {
-                        span: span!(p, start),
-                        expr,
-                    })
-                }
-                _ => unexpected!(
-                    p,
-                    "identifier, string literal, numeric literal or [ for the computed key"
-                ),
-            };
-
-            Ok(v)
-        })
+                Ok(v)
+            })
     }
 }
 
@@ -156,11 +149,7 @@ impl<I: Tokens> ParseObject<Expr> for Parser<I> {
         if eat!(self, '*') {
             let name = self.parse_prop_name()?;
             return self
-                .with_ctx(Context {
-                    allow_direct_super: true,
-                    in_class_field: false,
-                    ..self.ctx()
-                })
+                .with_ctx(self.ctx() | Context::AllowDirectSuper & !Context::InClassField)
                 .parse_fn_args_body(
                     // no decorator in an object literal
                     Vec::new(),
@@ -214,11 +203,7 @@ impl<I: Tokens> ParseObject<Expr> for Parser<I> {
         // Handle `a(){}` (and async(){} / get(){} / set(){})
         if (self.input.syntax().typescript() && is!(self, '<')) || is!(self, '(') {
             return self
-                .with_ctx(Context {
-                    allow_direct_super: true,
-                    in_class_field: false,
-                    ..self.ctx()
-                })
+                .with_ctx(self.ctx() | Context::AllowDirectSuper & !Context::InClassField)
                 .parse_fn_args_body(
                     // no decorator in an object literal
                     Vec::new(),
@@ -277,51 +262,10 @@ impl<I: Tokens> ParseObject<Expr> for Parser<I> {
                 let is_generator = ident.sym == "async" && eat!(self, '*');
                 let key = self.parse_prop_name()?;
                 let key_span = key.span();
-                self.with_ctx(Context {
-                    allow_direct_super: true,
-                    in_class_field: false,
-                    ..self.ctx()
-                })
-                .parse_with(|parser| {
-                    match &*ident.sym {
-                        "get" => parser
-                            .parse_fn_args_body(
-                                // no decorator in an object literal
-                                Vec::new(),
-                                start,
-                                |p| {
-                                    let params = p.parse_formal_params()?;
-
-                                    if params.iter().filter(|p| is_not_this(p)).count() != 0 {
-                                        p.emit_err(key_span, SyntaxError::GetterParam);
-                                    }
-
-                                    Ok(params)
-                                },
-                                false,
-                                false,
-                            )
-                            .map(|v| *v)
-                            .map(
-                                |Function {
-                                     body, return_type, ..
-                                 }| {
-                                    if parser.input.syntax().typescript()
-                                        && parser.input.target() == EsVersion::Es3
-                                    {
-                                        parser.emit_err(key_span, SyntaxError::TS1056);
-                                    }
-
-                                    PropOrSpread::Prop(Box::new(Prop::Getter(GetterProp {
-                                        span: span!(parser, start),
-                                        key,
-                                        type_ann: return_type,
-                                        body,
-                                    })))
-                                },
-                            ),
-                        "set" => {
-                            parser
+                self.with_ctx(self.ctx() | Context::AllowDirectSuper & !Context::InClassField)
+                    .parse_with(|parser| {
+                        match &*ident.sym {
+                            "get" => parser
                                 .parse_fn_args_body(
                                     // no decorator in an object literal
                                     Vec::new(),
@@ -329,23 +273,8 @@ impl<I: Tokens> ParseObject<Expr> for Parser<I> {
                                     |p| {
                                         let params = p.parse_formal_params()?;
 
-                                        if params.iter().filter(|p| is_not_this(p)).count() != 1 {
-                                            p.emit_err(key_span, SyntaxError::SetterParam);
-                                        }
-
-                                        if !params.is_empty() {
-                                            if let Pat::Rest(..) = params[0].pat {
-                                                p.emit_err(
-                                                    params[0].span(),
-                                                    SyntaxError::RestPatInSetter,
-                                                );
-                                            }
-                                        }
-
-                                        if p.input.syntax().typescript()
-                                            && p.input.target() == EsVersion::Es3
-                                        {
-                                            p.emit_err(key_span, SyntaxError::TS1056);
+                                        if params.iter().filter(|p| is_not_this(p)).count() != 0 {
+                                            p.emit_err(key_span, SyntaxError::GetterParam);
                                         }
 
                                         Ok(params)
@@ -356,57 +285,110 @@ impl<I: Tokens> ParseObject<Expr> for Parser<I> {
                                 .map(|v| *v)
                                 .map(
                                     |Function {
-                                         mut params, body, ..
+                                         body, return_type, ..
                                      }| {
-                                        let mut this = None;
-                                        if params.len() >= 2 {
-                                            this = Some(params.remove(0).pat);
+                                        if parser.input.syntax().typescript()
+                                            && parser.input.target() == EsVersion::Es3
+                                        {
+                                            parser.emit_err(key_span, SyntaxError::TS1056);
                                         }
 
-                                        let param = Box::new(
-                                            params
-                                                .into_iter()
-                                                .next()
-                                                .map(|v| v.pat)
-                                                .unwrap_or_else(|| {
-                                                    parser.emit_err(
-                                                        key_span,
-                                                        SyntaxError::SetterParam,
-                                                    );
-
-                                                    Invalid { span: DUMMY_SP }.into()
-                                                }),
-                                        );
-
-                                        // debug_assert_eq!(params.len(), 1);
-                                        PropOrSpread::Prop(Box::new(Prop::Setter(SetterProp {
+                                        PropOrSpread::Prop(Box::new(Prop::Getter(GetterProp {
                                             span: span!(parser, start),
                                             key,
+                                            type_ann: return_type,
                                             body,
-                                            param,
-                                            this_param: this,
                                         })))
                                     },
+                                ),
+                            "set" => {
+                                parser
+                                    .parse_fn_args_body(
+                                        // no decorator in an object literal
+                                        Vec::new(),
+                                        start,
+                                        |p| {
+                                            let params = p.parse_formal_params()?;
+
+                                            if params.iter().filter(|p| is_not_this(p)).count() != 1
+                                            {
+                                                p.emit_err(key_span, SyntaxError::SetterParam);
+                                            }
+
+                                            if !params.is_empty() {
+                                                if let Pat::Rest(..) = params[0].pat {
+                                                    p.emit_err(
+                                                        params[0].span(),
+                                                        SyntaxError::RestPatInSetter,
+                                                    );
+                                                }
+                                            }
+
+                                            if p.input.syntax().typescript()
+                                                && p.input.target() == EsVersion::Es3
+                                            {
+                                                p.emit_err(key_span, SyntaxError::TS1056);
+                                            }
+
+                                            Ok(params)
+                                        },
+                                        false,
+                                        false,
+                                    )
+                                    .map(|v| *v)
+                                    .map(
+                                        |Function {
+                                             mut params, body, ..
+                                         }| {
+                                            let mut this = None;
+                                            if params.len() >= 2 {
+                                                this = Some(params.remove(0).pat);
+                                            }
+
+                                            let param = Box::new(
+                                                params
+                                                    .into_iter()
+                                                    .next()
+                                                    .map(|v| v.pat)
+                                                    .unwrap_or_else(|| {
+                                                        parser.emit_err(
+                                                            key_span,
+                                                            SyntaxError::SetterParam,
+                                                        );
+
+                                                        Invalid { span: DUMMY_SP }.into()
+                                                    }),
+                                            );
+
+                                            // debug_assert_eq!(params.len(), 1);
+                                            PropOrSpread::Prop(Box::new(Prop::Setter(SetterProp {
+                                                span: span!(parser, start),
+                                                key,
+                                                body,
+                                                param,
+                                                this_param: this,
+                                            })))
+                                        },
+                                    )
+                            }
+                            "async" => parser
+                                .parse_fn_args_body(
+                                    // no decorator in an object literal
+                                    Vec::new(),
+                                    start,
+                                    |p| p.parse_unique_formal_params(),
+                                    true,
+                                    is_generator,
                                 )
+                                .map(|function| {
+                                    PropOrSpread::Prop(Box::new(Prop::Method(MethodProp {
+                                        key,
+                                        function,
+                                    })))
+                                }),
+                            _ => unreachable!(),
                         }
-                        "async" => parser
-                            .parse_fn_args_body(
-                                // no decorator in an object literal
-                                Vec::new(),
-                                start,
-                                |p| p.parse_unique_formal_params(),
-                                true,
-                                is_generator,
-                            )
-                            .map(|function| {
-                                PropOrSpread::Prop(Box::new(Prop::Method(MethodProp {
-                                    key,
-                                    function,
-                                })))
-                            }),
-                        _ => unreachable!(),
-                    }
-                })
+                    })
             }
             _ => {
                 if self.input.syntax().typescript() {
@@ -453,7 +435,8 @@ impl<I: Tokens> ParseObject<Pat> for Parser<I> {
             }
         }
 
-        let optional = (self.input.syntax().dts() || self.ctx().in_declare) && eat!(self, '?');
+        let optional = (self.input.syntax().dts() || self.ctx().contains(Context::InDeclare))
+            && eat!(self, '?');
 
         Ok(ObjectPat {
             span,

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -95,7 +95,7 @@ impl<'a, I: Tokens> Parser<I> {
             return self.handle_import_export(decorators);
         }
 
-        self.with_ctx(self.ctx() & !Context::WillExpectColonForCond | Context::AllowUsingDecl)
+        self.with_ctx((self.ctx() & !Context::WillExpectColonForCond) | Context::AllowUsingDecl)
             .parse_stmt_internal(start, include_decl, decorators)
             .map(From::from)
     }
@@ -1014,8 +1014,8 @@ impl<'a, I: Tokens> Parser<I> {
 
         assert_and_bump!(self, "do");
 
-        let ctx =
-            self.ctx() | Context::IsBreakAllowed | Context::IsContinueAllowed & !Context::TopLevel;
+        let ctx = (self.ctx() | Context::IsBreakAllowed | Context::IsContinueAllowed)
+            & !Context::TopLevel;
         let body = self.with_ctx(ctx).parse_stmt().map(Box::new)?;
         expect!(self, "while");
         expect!(self, '(');
@@ -1038,8 +1038,8 @@ impl<'a, I: Tokens> Parser<I> {
         let test = self.include_in_expr(true).parse_expr()?;
         expect!(self, ')');
 
-        let ctx =
-            self.ctx() | Context::IsBreakAllowed | Context::IsContinueAllowed & !Context::TopLevel;
+        let ctx = (self.ctx() | Context::IsBreakAllowed | Context::IsContinueAllowed)
+            & !Context::TopLevel;
         let body = self.with_ctx(ctx).parse_stmt().map(Box::new)?;
 
         let span = span!(self, start);
@@ -1065,7 +1065,7 @@ impl<'a, I: Tokens> Parser<I> {
         let obj = self.include_in_expr(true).parse_expr()?;
         expect!(self, ')');
 
-        let ctx = self.ctx() | Context::InFunction & !Context::TopLevel;
+        let ctx = (self.ctx() | Context::InFunction) & !Context::TopLevel;
         let body = self.with_ctx(ctx).parse_stmt().map(Box::new)?;
 
         let span = span!(self, start);
@@ -1090,7 +1090,7 @@ impl<'a, I: Tokens> Parser<I> {
     }
 
     fn parse_labelled_stmt(&mut self, l: Ident) -> PResult<Stmt> {
-        let ctx = self.ctx() | Context::IsBreakAllowed & !Context::AllowUsingDecl;
+        let ctx = (self.ctx() | Context::IsBreakAllowed) & !Context::AllowUsingDecl;
         self.with_ctx(ctx).parse_with(|p| {
             let start = l.span.lo();
 
@@ -1158,8 +1158,8 @@ impl<'a, I: Tokens> Parser<I> {
 
         let head = self.with_ctx(ctx).parse_for_head()?;
         expect!(self, ')');
-        let ctx =
-            self.ctx() | Context::IsBreakAllowed | Context::IsContinueAllowed & !Context::TopLevel;
+        let ctx = (self.ctx() | Context::IsBreakAllowed | Context::IsContinueAllowed)
+            & !Context::TopLevel;
         let body = self.with_ctx(ctx).parse_stmt().map(Box::new)?;
 
         let span = span!(self, start);

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -8,11 +8,8 @@ mod module_item;
 
 impl<'a, I: Tokens> Parser<I> {
     pub fn parse_module_item(&mut self) -> PResult<ModuleItem> {
-        self.with_ctx(Context {
-            top_level: true,
-            ..self.ctx()
-        })
-        .parse_stmt_like(true)
+        self.with_ctx(self.ctx() | Context::TopLevel)
+            .parse_stmt_like(true)
     }
 
     pub(super) fn parse_block_body<Type>(
@@ -46,12 +43,7 @@ impl<'a, I: Tokens> Parser<I> {
             if allow_directives {
                 allow_directives = false;
                 if stmt.is_use_strict() {
-                    let ctx = Context {
-                        strict: true,
-                        ..old_ctx
-                    };
-                    self.set_ctx(ctx);
-
+                    self.set_ctx(old_ctx | Context::Strict);
                     if self.input.knows_cur() && !is!(self, ';') {
                         unreachable!(
                             "'use strict'; directive requires parser.input.cur to be empty or \
@@ -103,12 +95,7 @@ impl<'a, I: Tokens> Parser<I> {
             return self.handle_import_export(decorators);
         }
 
-        let ctx = Context {
-            will_expect_colon_for_cond: false,
-            allow_using_decl: true,
-            ..self.ctx()
-        };
-        self.with_ctx(ctx)
+        self.with_ctx(self.ctx() & !Context::WillExpectColonForCond | Context::AllowUsingDecl)
             .parse_stmt_internal(start, include_decl, decorators)
             .map(From::from)
     }
@@ -133,12 +120,12 @@ impl<'a, I: Tokens> Parser<I> {
                 .map(Stmt::from);
         }
 
-        let top_level = self.ctx().top_level;
+        let top_level = self.ctx().contains(Context::TopLevel);
         match cur!(self, true) {
             tok!("await") if include_decl || top_level => {
                 if top_level {
                     self.state.found_module_item = true;
-                    if !self.ctx().can_be_module {
+                    if !self.ctx().contains(Context::CanBeModule) {
                         self.emit_err(self.input.cur_span(), SyntaxError::TopLevelAwaitInScript);
                     }
                 }
@@ -179,10 +166,10 @@ impl<'a, I: Tokens> Parser<I> {
                     if label.is_some() && !self.state.labels.contains(&label.as_ref().unwrap().sym)
                     {
                         self.emit_err(span, SyntaxError::TS1116);
-                    } else if !self.ctx().is_break_allowed {
+                    } else if !self.ctx().contains(Context::IsBreakAllowed) {
                         self.emit_err(span, SyntaxError::TS1105);
                     }
-                } else if !self.ctx().is_continue_allowed {
+                } else if !self.ctx().contains(Context::IsContinueAllowed) {
                     self.emit_err(span, SyntaxError::TS1115);
                 } else if label.is_some()
                     && !self.state.labels.contains(&label.as_ref().unwrap().sym)
@@ -300,7 +287,7 @@ impl<'a, I: Tokens> Parser<I> {
 
             // 'let' can start an identifier reference.
             tok!("let") if include_decl => {
-                let strict = self.ctx().strict;
+                let strict = self.ctx().contains(Context::Strict);
                 let is_keyword = match peek!(self) {
                     Some(t) => t.kind().follows_keyword_let(strict),
                     _ => false,
@@ -353,11 +340,10 @@ impl<'a, I: Tokens> Parser<I> {
             }
 
             tok!('{') => {
-                let ctx = Context {
-                    allow_using_decl: true,
-                    ..self.ctx()
-                };
-                return self.with_ctx(ctx).parse_block(false).map(Stmt::Block);
+                return self
+                    .with_ctx(self.ctx() | Context::AllowUsingDecl)
+                    .parse_block(false)
+                    .map(Stmt::Block);
             }
 
             _ => {}
@@ -489,12 +475,8 @@ impl<'a, I: Tokens> Parser<I> {
         let if_token = self.input.prev_span();
 
         expect!(self, '(');
-        let ctx = Context {
-            ignore_else_clause: false,
-            ..self.ctx()
-        };
         let test = self
-            .with_ctx(ctx)
+            .with_ctx(self.ctx() & !Context::IgnoreElseClause)
             .include_in_expr(true)
             .parse_expr()
             .map_err(|err| {
@@ -514,30 +496,24 @@ impl<'a, I: Tokens> Parser<I> {
             // Prevent stack overflow
             crate::maybe_grow(256 * 1024, 1024 * 1024, || {
                 // Annex B
-                if !self.ctx().strict && is!(self, "function") {
+                if !self.ctx().contains(Context::Strict) && is!(self, "function") {
                     // TODO: report error?
                 }
-                let ctx = Context {
-                    ignore_else_clause: false,
-                    top_level: false,
-                    ..self.ctx()
-                };
-                self.with_ctx(ctx).parse_stmt().map(Box::new)
+                self.with_ctx(self.ctx() & !Context::IgnoreElseClause & !Context::TopLevel)
+                    .parse_stmt()
+                    .map(Box::new)
             })?
         };
 
         // We parse `else` branch iteratively, to avoid stack overflow
         // See https://github.com/swc-project/swc/pull/3961
 
-        let alt = if self.ctx().ignore_else_clause {
+        let alt = if self.ctx().contains(Context::IgnoreElseClause) {
             None
         } else {
             let mut cur = None;
 
-            let ctx = Context {
-                ignore_else_clause: true,
-                ..self.ctx()
-            };
+            let ctx = self.ctx() | Context::IgnoreElseClause;
 
             let last = loop {
                 if !eat!(self, "else") {
@@ -545,11 +521,7 @@ impl<'a, I: Tokens> Parser<I> {
                 }
 
                 if !is!(self, "if") {
-                    let ctx = Context {
-                        ignore_else_clause: false,
-                        top_level: false,
-                        ..self.ctx()
-                    };
+                    let ctx = self.ctx() & !Context::IgnoreElseClause & !Context::TopLevel;
 
                     // As we eat `else` above, we need to parse statement once.
                     let last = self.with_ctx(ctx).parse_stmt()?;
@@ -610,7 +582,9 @@ impl<'a, I: Tokens> Parser<I> {
             .into())
         });
 
-        if !self.ctx().in_function && !self.input.syntax().allow_return_outside_function() {
+        if !self.ctx().contains(Context::InFunction)
+            && !self.input.syntax().allow_return_outside_function()
+        {
             self.emit_err(span!(self, start), SyntaxError::ReturnNotAllowed);
         }
 
@@ -630,11 +604,8 @@ impl<'a, I: Tokens> Parser<I> {
         let mut span_of_previous_default = None;
 
         expect!(self, '{');
-        let ctx = Context {
-            is_break_allowed: true,
-            ..self.ctx()
-        };
 
+        let ctx = self.ctx() | Context::IsBreakAllowed;
         self.with_ctx(ctx).parse_with(|p| {
             while is_one_of!(p, "case", "default") {
                 let mut cons = Vec::new();
@@ -655,11 +626,8 @@ impl<'a, I: Tokens> Parser<I> {
 
                 while !eof!(p) && !is_one_of!(p, "case", "default", '}') {
                     cons.push(
-                        p.with_ctx(Context {
-                            top_level: false,
-                            ..p.ctx()
-                        })
-                        .parse_stmt_list_item()?,
+                        p.with_ctx(p.ctx() & !Context::TopLevel)
+                            .parse_stmt_list_item()?,
                     );
                 }
 
@@ -759,10 +727,7 @@ impl<'a, I: Tokens> Parser<I> {
             let type_ann_start = cur_pos!(self);
 
             if self.syntax().typescript() && eat!(self, ':') {
-                let ctx = Context {
-                    in_type: true,
-                    ..self.ctx()
-                };
+                let ctx = self.ctx() | Context::InType;
 
                 let ty = self.with_ctx(ctx).parse_with(|p| p.parse_ts_type())?;
                 // self.emit_err(ty.span(), SyntaxError::TS1196);
@@ -831,7 +796,7 @@ impl<'a, I: Tokens> Parser<I> {
             self.emit_err(span!(self, start), SyntaxError::UsingDeclNotEnabled);
         }
 
-        if !self.ctx().allow_using_decl {
+        if !self.ctx().contains(Context::AllowUsingDecl) {
             self.emit_err(span!(self, start), SyntaxError::UsingDeclNotAllowed);
         }
 
@@ -912,10 +877,7 @@ impl<'a, I: Tokens> Parser<I> {
             }
 
             let ctx = if should_include_in {
-                Context {
-                    include_in_expr: true,
-                    ..self.ctx()
-                }
+                self.ctx() | Context::IncludeInExpr
             } else {
                 self.ctx()
             };
@@ -1013,9 +975,12 @@ impl<'a, I: Tokens> Parser<I> {
             } else {
                 // Destructuring bindings require initializers, but
                 // typescript allows `declare` vars not to have initializers.
-                if self.ctx().in_declare {
+                if self.ctx().contains(Context::InDeclare) {
                     None
-                } else if kind == VarDeclKind::Const && !for_loop && !self.ctx().in_declare {
+                } else if kind == VarDeclKind::Const
+                    && !for_loop
+                    && !self.ctx().contains(Context::InDeclare)
+                {
                     self.emit_err(
                         span!(self, start),
                         SyntaxError::ConstDeclarationsRequireInitialization,
@@ -1049,12 +1014,8 @@ impl<'a, I: Tokens> Parser<I> {
 
         assert_and_bump!(self, "do");
 
-        let ctx = Context {
-            is_break_allowed: true,
-            is_continue_allowed: true,
-            top_level: false,
-            ..self.ctx()
-        };
+        let ctx =
+            self.ctx() | Context::IsBreakAllowed | Context::IsContinueAllowed & !Context::TopLevel;
         let body = self.with_ctx(ctx).parse_stmt().map(Box::new)?;
         expect!(self, "while");
         expect!(self, '(');
@@ -1077,12 +1038,8 @@ impl<'a, I: Tokens> Parser<I> {
         let test = self.include_in_expr(true).parse_expr()?;
         expect!(self, ')');
 
-        let ctx = Context {
-            is_break_allowed: true,
-            is_continue_allowed: true,
-            top_level: false,
-            ..self.ctx()
-        };
+        let ctx =
+            self.ctx() | Context::IsBreakAllowed | Context::IsContinueAllowed & !Context::TopLevel;
         let body = self.with_ctx(ctx).parse_stmt().map(Box::new)?;
 
         let span = span!(self, start);
@@ -1108,11 +1065,7 @@ impl<'a, I: Tokens> Parser<I> {
         let obj = self.include_in_expr(true).parse_expr()?;
         expect!(self, ')');
 
-        let ctx = Context {
-            in_function: true,
-            top_level: false,
-            ..self.ctx()
-        };
+        let ctx = self.ctx() | Context::InFunction & !Context::TopLevel;
         let body = self.with_ctx(ctx).parse_stmt().map(Box::new)?;
 
         let span = span!(self, start);
@@ -1125,10 +1078,7 @@ impl<'a, I: Tokens> Parser<I> {
         expect!(self, '{');
 
         let stmts = self
-            .with_ctx(Context {
-                top_level: false,
-                ..self.ctx()
-            })
+            .with_ctx(self.ctx() & !Context::TopLevel)
             .parse_block_body(allow_directives, Some(&tok!('}')))?;
 
         let span = span!(self, start);
@@ -1140,11 +1090,7 @@ impl<'a, I: Tokens> Parser<I> {
     }
 
     fn parse_labelled_stmt(&mut self, l: Ident) -> PResult<Stmt> {
-        let ctx = Context {
-            is_break_allowed: true,
-            allow_using_decl: false,
-            ..self.ctx()
-        };
+        let ctx = self.ctx() | Context::IsBreakAllowed & !Context::AllowUsingDecl;
         self.with_ctx(ctx).parse_with(|p| {
             let start = l.span.lo();
 
@@ -1162,7 +1108,7 @@ impl<'a, I: Tokens> Parser<I> {
             let body = Box::new(if is!(p, "function") {
                 let f = p.parse_fn_decl(Vec::new())?;
                 if let Decl::Fn(FnDecl { function, .. }) = &f {
-                    if p.ctx().strict {
+                    if p.ctx().contains(Context::Strict) {
                         p.emit_err(function.span, SyntaxError::LabelledFunctionInStrict)
                     }
                     if function.is_generator || function.is_async {
@@ -1172,11 +1118,7 @@ impl<'a, I: Tokens> Parser<I> {
 
                 f.into()
             } else {
-                p.with_ctx(Context {
-                    top_level: false,
-                    ..p.ctx()
-                })
-                .parse_stmt()?
+                p.with_ctx(p.ctx() & !Context::TopLevel).parse_stmt()?
             });
 
             for err in errors {
@@ -1211,18 +1153,13 @@ impl<'a, I: Tokens> Parser<I> {
         };
         expect!(self, '(');
 
-        let mut ctx = self.ctx();
-        ctx.expr_ctx.for_loop_init = true;
-        ctx.expr_ctx.for_await_loop_init = await_token.is_some();
+        let mut ctx = self.ctx() | Context::ForLoopInit;
+        ctx.set(Context::ForAwaitLoopInit, await_token.is_some());
 
         let head = self.with_ctx(ctx).parse_for_head()?;
         expect!(self, ')');
-        let ctx = Context {
-            is_break_allowed: true,
-            is_continue_allowed: true,
-            top_level: false,
-            ..self.ctx()
-        };
+        let ctx =
+            self.ctx() | Context::IsBreakAllowed | Context::IsContinueAllowed & !Context::TopLevel;
         let body = self.with_ctx(ctx).parse_stmt().map(Box::new)?;
 
         let span = span!(self, start);
@@ -1266,7 +1203,7 @@ impl<'a, I: Tokens> Parser<I> {
     }
 
     fn parse_for_head(&mut self) -> PResult<TempForHead> {
-        let strict = self.ctx().strict;
+        let strict = self.ctx().contains(Context::Strict);
 
         if is_one_of!(self, "const", "var")
             || (is!(self, "let")
@@ -1280,7 +1217,9 @@ impl<'a, I: Tokens> Parser<I> {
                         self.emit_err(d.name.span(), SyntaxError::TooManyVarInForInHead);
                     }
                 } else {
-                    if (self.ctx().strict || is!(self, "of")) && decl.decls[0].init.is_some() {
+                    if (self.ctx().contains(Context::Strict) || is!(self, "of"))
+                        && decl.decls[0].init.is_some()
+                    {
                         self.emit_err(
                             decl.decls[0].name.span(),
                             SyntaxError::VarInitializerInForInHead,

--- a/crates/swc_ecma_parser/src/parser/util.rs
+++ b/crates/swc_ecma_parser/src/parser/util.rs
@@ -6,9 +6,13 @@ impl Context {
         match *word {
             Word::Keyword(Keyword::Let) => self.contains(Context::Strict),
             Word::Keyword(Keyword::Await) => {
-                self.contains(Context::InAsync | Context::InStaticBlock | Context::Strict)
+                self.contains(Context::InAsync)
+                    || self.contains(Context::InStaticBlock)
+                    || self.contains(Context::Strict)
             }
-            Word::Keyword(Keyword::Yield) => self.contains(Context::InGenerator | Context::Strict),
+            Word::Keyword(Keyword::Yield) => {
+                self.contains(Context::InGenerator) || self.contains(Context::Strict)
+            }
 
             Word::Null
             | Word::True
@@ -77,8 +81,12 @@ impl Context {
             //     let await = 1;
             // }
             // ```
-            "await" => self.contains(Context::InAsync | Context::InStaticBlock | Context::Module),
-            "yield" => self.contains(Context::InGenerator | Context::Strict),
+            "await" => {
+                self.contains(Context::InAsync)
+                    || self.contains(Context::InStaticBlock)
+                    || self.contains(Context::Module)
+            }
+            "yield" => self.contains(Context::InGenerator) || self.contains(Context::Strict),
 
             "null" | "true" | "false" | "break" | "case" | "catch" | "continue" | "debugger"
             | "default" | "do" | "export" | "else" | "finally" | "for" | "function" | "if"


### PR DESCRIPTION
`Context` size: 30 bytes -> 4 bytes
