### PR TITLE
feat(bindings): Enhance existing parse function to accept both string and buffer types #9876

### DIFF
--- a/bindings/binding_core_node/src/parse.rs
+++ b/bindings/binding_core_node/src/parse.rs
@@ -138,7 +138,7 @@ impl Task for ParseFileTask {
 
 fn stringify(src: Either<Buffer, String>) -> String {
     match src {
-        Either::A(src) => String::from_utf8_lossy(src.as_ref()).to_string(),
+        Either::A(src) => String::from_utf8_lossy(src.as_ref()).into_owned(),
         Either::B(src) => src,
     }
 }

--- a/packages/core/__tests__/parse/api_test.js
+++ b/packages/core/__tests__/parse/api_test.js
@@ -29,3 +29,17 @@ it("can be emit code back synchronously", async () => {
 
     expect(out.code.trim().replace("\n", "")).toBe(`class Foo {}`);
 });
+
+it("can be emit code back asynchronously for buffer input", async () => {
+    const m = await swc.parse(Buffer.from(`class Foo {}`));
+    const out = await swc.print(m);
+
+    expect(out.code.trim().replace("\n", "")).toBe(`class Foo {}`);
+});
+
+it("can be emit code back synchronously for buffer input", async () => {
+    const m = swc.parseSync(Buffer.from(`class Foo {}`));
+    const out = swc.printSync(m);
+
+    expect(out.code.trim().replace("\n", "")).toBe(`class Foo {}`);
+});

--- a/packages/core/binding.d.ts
+++ b/packages/core/binding.d.ts
@@ -24,13 +24,13 @@ export interface NapiMinifyExtra {
 
 export declare function newMangleNameCache(): object
 
-export declare function parse(src: string, options: Buffer, filename?: string | undefined | null, signal?: AbortSignal | undefined | null): Promise<string>
+export declare function parse(src: Buffer | string, options: Buffer, filename?: string | undefined | null, signal?: AbortSignal | undefined | null): Promise<string>
 
 export declare function parseFile(path: string, options: Buffer, signal?: AbortSignal | undefined | null): Promise<string>
 
 export declare function parseFileSync(path: string, opts: Buffer): string
 
-export declare function parseSync(src: string, opts: Buffer, filename?: string | undefined | null): string
+export declare function parseSync(src: Buffer | string, opts: Buffer, filename?: string | undefined | null): string
 
 export declare function print(programJson: string, options: Buffer, signal?: AbortSignal | undefined | null): Promise<TransformOutput>
 


### PR DESCRIPTION
- Enhanced existing `parse` and `parseSync` functions to accept both string and Buffer inputs.
- Updated TypeScript definitions and JavaScript bindings to reflect the new input types.
- Improved tests to cover the new capabilities for parsing from both string and Buffer inputs.

Fixes: #9876

<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->