### PR TITLE
fix(es/parser): Parse `export default from;` with `exportDefaultFrom: true` option

### DIFF
--- a/.changeset/weak-coins-cheat.md
+++ b/.changeset/weak-coins-cheat.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): Parse `export default from;` with `exportDefaultFrom: true` option

--- a/crates/swc_ecma_parser/src/parser/macros.rs
+++ b/crates/swc_ecma_parser/src/parser/macros.rs
@@ -111,6 +111,13 @@ macro_rules! peeked_is {
         }
     }};
 
+    ($p:expr, Str) => {{
+        match peek!($p) {
+            Some(&Token::Str { .. }) => true,
+            _ => false,
+        }
+    }};
+
     ($p:expr, ';') => {{
         compile_error!("peeked_is!(self, ';') is invalid");
     }};

--- a/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt/module_item.rs
@@ -491,7 +491,7 @@ impl<I: Tokens> Parser<I> {
                 let decl = self.parse_default_fn(start, decorators)?;
                 return Ok(decl.into());
             } else if self.input.syntax().export_default_from()
-                && (is!(self, "from")
+                && ((is!(self, "from") && peeked_is!(self, Str))
                     || (is!(self, ',') && (peeked_is!(self, '{') || peeked_is!(self, '*'))))
             {
                 export_default = Some(Ident::new_no_ctxt("default".into(), self.input.prev_span()))

--- a/crates/swc_ecma_parser/tests/js.rs
+++ b/crates/swc_ecma_parser/tests/js.rs
@@ -6,7 +6,6 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use serde_json;
 use swc_common::{comments::SingleThreadedComments, FileName};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, EsSyntax, PResult, Parser, Syntax};

--- a/crates/swc_ecma_parser/tests/js.rs
+++ b/crates/swc_ecma_parser/tests/js.rs
@@ -6,6 +6,7 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use serde_json;
 use swc_common::{comments::SingleThreadedComments, FileName};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, EsSyntax, PResult, Parser, Syntax};
@@ -23,10 +24,11 @@ fn spec(file: PathBuf) {
         "{}.json",
         file.file_name().unwrap().to_string_lossy()
     ));
-    run_spec(&file, &output);
+    let config_path = file.parent().unwrap().join("config.json");
+    run_spec(&file, &output, &config_path);
 }
 
-fn run_spec(file: &Path, output_json: &Path) {
+fn run_spec(file: &Path, output_json: &Path, config_path: &Path) {
     let file_name = file
         .display()
         .to_string()
@@ -50,7 +52,7 @@ fn run_spec(file: &Path, output_json: &Path) {
         );
     }
 
-    with_parser(false, file, false, |p, _| {
+    with_parser(false, file, false, config_path, |p, _| {
         let program = p.parse_program()?.fold_with(&mut Normalizer {
             drop_span: false,
             is_test262: false,
@@ -73,6 +75,7 @@ fn with_parser<F, Ret>(
     treat_error_as_bug: bool,
     file_name: &Path,
     shift: bool,
+    config_path: &Path,
     f: F,
 ) -> Result<Ret, StdErr>
 where
@@ -89,17 +92,30 @@ where
             .load_file(file_name)
             .unwrap_or_else(|e| panic!("failed to load {}: {}", file_name.display(), e));
 
-        let lexer = Lexer::new(
+        // Try to load EsSyntax configuration from config.json in the same directory as
+        // the test file
+        let syntax = {
+            let mut config_str = String::new();
+            File::open(config_path)
+                .ok()
+                .and_then(|mut file| file.read_to_string(&mut config_str).ok())
+                .and_then(|_| serde_json::from_str::<EsSyntax>(&config_str).ok())
+        }
+        .map(Syntax::Es)
+        .unwrap_or_else(|| {
+            eprintln!(
+                "Failed to load or parse {}, using default configuration",
+                config_path.display()
+            );
             Syntax::Es(EsSyntax {
                 explicit_resource_management: true,
                 import_attributes: true,
                 decorators: true,
                 ..Default::default()
-            }),
-            EsVersion::Es2015,
-            (&*fm).into(),
-            Some(&comments),
-        );
+            })
+        });
+
+        let lexer = Lexer::new(syntax, EsVersion::Es2015, (&*fm).into(), Some(&comments));
 
         let mut p = Parser::new_from(lexer);
 

--- a/crates/swc_ecma_parser/tests/js/issue-10372/config.json
+++ b/crates/swc_ecma_parser/tests/js/issue-10372/config.json
@@ -1,0 +1,5 @@
+{
+    "syntax": "ecmascript",
+    "exportDefaultFrom": true,
+    "jsx": false
+}

--- a/crates/swc_ecma_parser/tests/js/issue-10372/input.js
+++ b/crates/swc_ecma_parser/tests/js/issue-10372/input.js
@@ -1,0 +1,2 @@
+const from = {};
+export default from;

--- a/crates/swc_ecma_parser/tests/js/issue-10372/input.js.json
+++ b/crates/swc_ecma_parser/tests/js/issue-10372/input.js.json
@@ -1,0 +1,66 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 38
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 1,
+        "end": 17
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 7,
+            "end": 16
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 7,
+              "end": 11
+            },
+            "ctxt": 0,
+            "value": "from",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ObjectExpression",
+            "span": {
+              "start": 14,
+              "end": 16
+            },
+            "properties": []
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "ExportDefaultExpression",
+      "span": {
+        "start": 18,
+        "end": 38
+      },
+      "expression": {
+        "type": "Identifier",
+        "span": {
+          "start": 33,
+          "end": 37
+        },
+        "ctxt": 0,
+        "value": "from",
+        "optional": false
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Related issue:**

- Closes https://github.com/swc-project/swc/issues/10372