### PR TITLE
fix: Skip all transpilation and adding any polyfills when unknown browser version used

### DIFF
--- a/crates/swc_ecma_preset_env/src/lib.rs
+++ b/crates/swc_ecma_preset_env/src/lib.rs
@@ -58,7 +58,7 @@ where
             let f = transform_data::Feature::$feature;
             !exclude.contains(&f)
                 && (c.force_all_transforms
-                    || (is_any_target
+                    || (!is_any_target
                         || include.contains(&f)
                         || f.should_enable(&targets, c.bugfixes, $default)))
         }};
@@ -369,6 +369,9 @@ impl Polyfills {
             + VisitMutWith<corejs2::Entry>
             + VisitMutWith<corejs3::Entry>,
     {
+        if self.targets.is_any_target() {
+            return Default::default();
+        }
         let required = match self.mode {
             None => Default::default(),
             Some(Mode::Usage) => {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Skip all transpilation and adding any polyfills when unknown browser version used
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
I need some help. Right now, my approach is: 
when an unsupported browser version is set in browserslist-rs — for example:
```
"env": {
  "targets": ["Chrome > 130"]
}
```
Because the [`targets_to_versions`](https://github.com/swc-project/swc/blob/main/crates/swc_ecma_preset_env/src/lib.rs#L48C19-L48C38) has the  [`ignore_unkonwn_versions`](https://github.com/swc-project/swc/blob/main/crates/preset_env_base/src/query.rs#L57) option enabled in  [`browserslist_opts`](https://github.com/swc-project/swc/blob/main/crates/preset_env_base/src/query.rs#L106), it ends up returning an empty result, and [`is_any_target`](https://github.com/swc-project/swc/blob/main/crates/swc_ecma_preset_env/src/lib.rs#L49) becomes true.

So, I added a check to skip processing when the `targets` list is empty. But when I run `cargo test`, not all the tests pass. I'm not sure if there's a problem with my approach, or if I’m missing some edge cases.


<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
#9778 