### PR TITLE
perf(es/minifier): Use bigflags to reduce context size of analyzer

### DIFF
--- a/.changeset/five-jobs-teach.md
+++ b/.changeset/five-jobs-teach.md
@@ -1,0 +1,7 @@
+---
+swc_ecma_minifier: minor
+swc_ecma_usage_analyzer: minor
+swc_core: minor
+---
+
+perf(es/usage_analyzer): Use bigflags to reduce context size

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5869,6 +5869,7 @@ dependencies = [
 name = "swc_ecma_usage_analyzer"
 version = "13.0.0"
 dependencies = [
+ "bitflags 2.6.0",
  "indexmap 2.7.1",
  "rustc-hash 2.1.0",
  "swc_atoms",

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -345,7 +345,7 @@ impl Storage for ProgramData {
             })
         });
 
-        e.used_as_ref |= ctx.is_id_ref;
+        e.used_as_ref |= ctx.is_id_ref();
         e.ref_count += 1;
         e.usage_count += 1;
         // If it is inited in some child scope, but referenced in current scope
@@ -354,9 +354,9 @@ impl Storage for ProgramData {
             e.var_initialized = false;
         }
 
-        e.inline_prevented |= ctx.inline_prevented;
-        e.executed_multiple_time |= ctx.executed_multiple_time;
-        e.used_in_cond |= ctx.in_cond;
+        e.inline_prevented |= ctx.inline_prevented();
+        e.executed_multiple_time |= ctx.executed_multiple_time();
+        e.used_in_cond |= ctx.in_cond();
     }
 
     fn report_assign(&mut self, ctx: Ctx, i: Id, is_op: bool, ty: Value<Type>) {
@@ -395,9 +395,9 @@ impl Storage for ProgramData {
             let curr = &to_visit[idx];
 
             if let Some(usage) = self.vars.get_mut(curr) {
-                usage.inline_prevented |= ctx.inline_prevented;
-                usage.executed_multiple_time |= ctx.executed_multiple_time;
-                usage.used_in_cond |= ctx.in_cond;
+                usage.inline_prevented |= ctx.inline_prevented();
+                usage.executed_multiple_time |= ctx.executed_multiple_time();
+                usage.used_in_cond |= ctx.in_cond();
 
                 if is_op {
                     usage.usage_count += 1;
@@ -422,7 +422,7 @@ impl Storage for ProgramData {
         // }
 
         let v = self.vars.entry(i.to_id()).or_default();
-        v.is_top_level |= ctx.is_top_level;
+        v.is_top_level |= ctx.is_top_level();
 
         // assigned or declared before this declaration
         if init_type.is_some() {
@@ -441,7 +441,8 @@ impl Storage for ProgramData {
         // This is not delcared yet, so this is the first declaration.
         if !v.declared {
             v.var_kind = kind;
-            v.no_side_effect_for_member_access = ctx.in_decl_with_no_side_effect_for_member_access;
+            v.no_side_effect_for_member_access =
+                ctx.in_decl_with_no_side_effect_for_member_access();
         }
 
         if v.used_in_non_child_fn {
@@ -450,7 +451,7 @@ impl Storage for ProgramData {
 
         v.var_initialized |= init_type.is_some();
 
-        if ctx.in_pat_of_param {
+        if ctx.in_pat_of_param() {
             v.merged_var_type = Some(Value::Unknown);
         } else {
             v.merged_var_type.merge(init_type);
@@ -462,7 +463,7 @@ impl Storage for ProgramData {
         if init_type.is_some() || kind.is_none() {
             self.initialized_vars.insert(i.to_id());
         }
-        v.declared_as_catch_param |= ctx.in_catch_param;
+        v.declared_as_catch_param |= ctx.in_catch_param();
 
         v
     }

--- a/crates/swc_ecma_usage_analyzer/Cargo.toml
+++ b/crates/swc_ecma_usage_analyzer/Cargo.toml
@@ -23,6 +23,7 @@ trace-ast     = []
 tracing-spans = []
 
 [dependencies]
+bitflags   = { workspace = true }
 indexmap   = { workspace = true }
 rustc-hash = { workspace = true }
 tracing    = { workspace = true }

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/ctx.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/ctx.rs
@@ -27,20 +27,61 @@ where
 pub struct Ctx {
     pub var_decl_kind_of_pat: Option<VarDeclKind>,
     pub in_pat_of_var_decl_with_init: Option<Value<Type>>,
-    pub bit_ctx: BitContext,
+    pub(crate) bit_ctx: BitContext,
 }
 
 impl Ctx {
     #[inline]
-    pub fn with(mut self, flag: BitContext, value: bool) -> Self {
+    pub(crate) fn with(mut self, flag: BitContext, value: bool) -> Self {
         self.bit_ctx = self.bit_ctx.with(flag, value);
         self
+    }
+
+    #[inline]
+    pub fn in_decl_with_no_side_effect_for_member_access(&self) -> bool {
+        self.bit_ctx
+            .contains(BitContext::InDeclWithNoSideEffectForMemberAccess)
+    }
+
+    #[inline]
+    pub fn in_pat_of_param(&self) -> bool {
+        self.bit_ctx.contains(BitContext::InPatOfParam)
+    }
+
+    #[inline]
+    pub fn in_catch_param(&self) -> bool {
+        self.bit_ctx.contains(BitContext::InCatchParam)
+    }
+
+    #[inline]
+    pub fn is_id_ref(&self) -> bool {
+        self.bit_ctx.contains(BitContext::IsIdRef)
+    }
+
+    #[inline]
+    pub fn inline_prevented(&self) -> bool {
+        self.bit_ctx.contains(BitContext::InlinePrevented)
+    }
+
+    #[inline]
+    pub fn in_cond(&self) -> bool {
+        self.bit_ctx.contains(BitContext::InCond)
+    }
+
+    #[inline]
+    pub fn executed_multiple_time(&self) -> bool {
+        self.bit_ctx.contains(BitContext::ExecutedMultipleTime)
+    }
+
+    #[inline]
+    pub fn is_top_level(&self) -> bool {
+        self.bit_ctx.contains(BitContext::IsTopLevel)
     }
 }
 
 bitflags! {
     #[derive(Debug, Clone, Copy, Default)]
-    pub struct BitContext: u16 {
+    pub(crate) struct BitContext: u16 {
         const InDeclWithNoSideEffectForMemberAccess = 1 << 0;
         const InPatOfVarDecl = 1 << 1;
         const InPatOfParam = 1 << 2;

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/ctx.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/ctx.rs
@@ -2,6 +2,7 @@
 
 use std::ops::{Deref, DerefMut};
 
+use bitflags::bitflags;
 use swc_ecma_ast::VarDeclKind;
 use swc_ecma_utils::{Type, Value};
 
@@ -25,26 +26,41 @@ where
 #[non_exhaustive]
 pub struct Ctx {
     pub var_decl_kind_of_pat: Option<VarDeclKind>,
-
-    pub in_decl_with_no_side_effect_for_member_access: bool,
-
-    pub in_pat_of_var_decl: bool,
     pub in_pat_of_var_decl_with_init: Option<Value<Type>>,
-    pub in_pat_of_param: bool,
-    pub in_catch_param: bool,
+    pub bit_ctx: BitContext,
+}
 
-    pub is_id_ref: bool,
+impl Ctx {
+    #[inline]
+    pub fn with(mut self, flag: BitContext, value: bool) -> Self {
+        self.bit_ctx = self.bit_ctx.with(flag, value);
+        self
+    }
+}
 
-    pub in_await_arg: bool,
+bitflags! {
+    #[derive(Debug, Clone, Copy, Default)]
+    pub struct BitContext: u16 {
+        const InDeclWithNoSideEffectForMemberAccess = 1 << 0;
+        const InPatOfVarDecl = 1 << 1;
+        const InPatOfParam = 1 << 2;
+        const InCatchParam = 1 << 3;
+        const IsIdRef = 1 << 4;
+        const InAwaitArg = 1 << 5;
+        const InLeftOfForLoop = 1 << 6;
+        const ExecutedMultipleTime = 1 << 7;
+        const InCond = 1 << 8;
+        const InlinePrevented = 1 << 9;
+        const IsTopLevel = 1 << 10;
+    }
+}
 
-    pub in_left_of_for_loop: bool,
-
-    pub executed_multiple_time: bool,
-    pub in_cond: bool,
-
-    pub inline_prevented: bool,
-
-    pub is_top_level: bool,
+impl BitContext {
+    #[inline]
+    pub fn with(mut self, flag: Self, value: bool) -> Self {
+        self.set(flag, value);
+        self
+    }
 }
 
 pub(super) struct WithCtx<'a, S>


### PR DESCRIPTION
Related https://github.com/swc-project/swc/issues/10379

context 16 bytes -> 8 bytes

Let's wait for the benchmark results