### PR TITLE
perf(es/parser): move `found_module_item` to `Parser`

### DIFF
--- a/.changeset/selfish-pears-shake.md
+++ b/.changeset/selfish-pears-shake.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+perf(es/parser): move `found_module_item` to `Parser`

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -1397,12 +1397,8 @@ impl<I: Tokens> Parser<I> {
             },
         );
 
-        let state = State {
-            labels: Vec::new(),
-            ..Default::default()
-        };
         self.with_ctx(ctx)
-            .with_state(state)
+            .with_state(State::default())
             .parse_fn_body_inner(is_simple_parameter_list)
     }
 }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2069,7 +2069,7 @@ impl<I: Tokens> Parser<I> {
         no_call: bool,
     ) -> PResult<Box<Expr>> {
         if eat!(self, '.') {
-            self.state.found_module_item = true;
+            self.found_module_item = true;
 
             let ident = self.parse_ident_name()?;
 

--- a/crates/swc_ecma_parser/src/parser/expr/ops.rs
+++ b/crates/swc_ecma_parser/src/parser/expr/ops.rs
@@ -399,7 +399,7 @@ impl<I: Tokens> Parser<I> {
 
         // This has been checked if start_of_await_token == true,
         if start_of_await_token.is_none() && ctx.contains(Context::TopLevel) {
-            self.state.found_module_item = true;
+            self.found_module_item = true;
             if !ctx.contains(Context::CanBeModule) {
                 self.emit_err(await_token, SyntaxError::TopLevelAwaitInScript);
             }

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -124,7 +124,7 @@ impl<'a, I: Tokens> Parser<I> {
         match cur!(self, true) {
             tok!("await") if include_decl || top_level => {
                 if top_level {
-                    self.state.found_module_item = true;
+                    self.found_module_item = true;
                     if !self.ctx().contains(Context::CanBeModule) {
                         self.emit_err(self.input.cur_span(), SyntaxError::TopLevelAwaitInScript);
                     }


### PR DESCRIPTION
I'm not sure whether this is correct. I just think `found_module_item` is a property of the whole Program rather than one function scope. This may reduce the cost of creating `State`(72 bytes -> 64 bytes) in `parse_fn_body`.