### PR TITLE
fix(swc_core): Fix downstream doc builds

### DIFF
--- a/crates/swc_core/src/lib.rs
+++ b/crates/swc_core/src/lib.rs
@@ -19,7 +19,13 @@ pub extern crate swc_ecma_quote_macros;
 
 // Plugins
 #[cfg(any(
-    docsrs,
+    all(
+        docsrs,
+        any(
+            feature = "__common_plugin_transform",
+            feature = "__plugin_transform_host"
+        )
+    ),
     feature = "__common_plugin_transform",
     feature = "__plugin_transform_host"
 ))]

--- a/crates/swc_core/src/plugin.rs
+++ b/crates/swc_core/src/plugin.rs
@@ -1,6 +1,12 @@
 // #[plugin_transform] macro
 #[cfg(any(
-    docsrs,
+    all(
+        docsrs,
+        any(
+            feature = "__common_plugin_transform",
+            feature = "__css_plugin_transform"
+        )
+    ),
     feature = "__common_plugin_transform",
     feature = "__css_plugin_transform",
 ))]
@@ -13,7 +19,14 @@
 )]
 pub use swc_plugin_macro::css_plugin_transform;
 #[cfg(any(
-    docsrs,
+    all(
+        docsrs,
+        any(
+            feature = "__common_plugin_transform",
+            feature = "__css_plugin_transform",
+            feature = "__ecma_plugin_transform"
+        )
+    ),
     feature = "__common_plugin_transform",
     feature = "__css_plugin_transform",
     feature = "__ecma_plugin_transform"
@@ -39,7 +52,14 @@ pub mod memory {
 /// Global HANDLER implementation for the plugin
 /// for error reporting.
 #[cfg(any(
-    docsrs,
+    all(
+        docsrs,
+        any(
+            feature = "__common_plugin_transform",
+            feature = "__css_plugin_transform",
+            feature = "__ecma_plugin_transform"
+        )
+    ),
     feature = "__common_plugin_transform",
     feature = "__css_plugin_transform",
     feature = "__ecma_plugin_transform"
@@ -58,7 +78,14 @@ pub mod errors {
 
 /// Plugin's environment metadata context.
 #[cfg(any(
-    docsrs,
+    all(
+        docsrs,
+        any(
+            feature = "__common_plugin_transform",
+            feature = "__css_plugin_transform",
+            feature = "__ecma_plugin_transform"
+        )
+    ),
     feature = "__common_plugin_transform",
     feature = "__css_plugin_transform",
     feature = "__ecma_plugin_transform"
@@ -79,7 +106,13 @@ pub mod metadata {
 /// Proxy to the host's data not attached to the AST, like sourcemap / comments.
 /// Or interfaces to setup the plugin's environment from the host.
 #[cfg(any(
-    docsrs,
+    all(
+        docsrs,
+        any(
+            feature = "__common_plugin_transform",
+            feature = "__plugin_transform_host"
+        )
+    ),
     feature = "__common_plugin_transform",
     feature = "__plugin_transform_host"
 ))]


### PR DESCRIPTION
**Description:**
This PR fixes an issue where downstream projects using swc_core as a dependency encounter build errors when generating documentation with --cfg docsrs. The problem occurs because certain conditional compilation flags include docsrs directly, causing rustdoc to include code that depends on modules not available in downstream projects.
The fix modifies conditional compilation flags in lib.rs and plugin.rs to require both docsrs and the relevant feature to be enabled, rather than including code with only docsrs set. This ensures that when a downstream project builds docs with --cfg docsrs, code is only included if the specific feature is also enabled

**BREAKING CHANGE:**
None. This change only affects documentation generation and has no impact on runtime behavior.

Closes #10384 
