### PR TITLE
pref(es/common): use next rather than nth

### DIFF
--- a/.changeset/flat-humans-sneeze.md
+++ b/.changeset/flat-humans-sneeze.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_common: patch
+---
+
+pref(es/common): use next rather than nth

--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -80,12 +80,19 @@ impl Input for StringInput<'_> {
 
     #[inline]
     fn peek(&mut self) -> Option<char> {
-        self.iter.clone().nth(1)
+        let mut iter = self.iter.clone();
+        // https://github.com/rust-lang/rust/blob/1.86.0/compiler/rustc_lexer/src/cursor.rs#L56 say `next` is faster.
+        iter.next();
+        iter.next()
     }
 
     #[inline]
     fn peek_ahead(&mut self) -> Option<char> {
-        self.iter.clone().nth(2)
+        let mut iter = self.iter.clone();
+        // https://github.com/rust-lang/rust/blob/1.86.0/compiler/rustc_lexer/src/cursor.rs#L56 say `next` is faster
+        iter.next();
+        iter.next();
+        iter.next()
     }
 
     #[inline]


### PR DESCRIPTION
https://github.com/rust-lang/rust/blob/1.86.0/compiler/rustc_lexer/src/cursor.rs#L56 mentions that using `next` is more optimized than `nth`, let's give this optimization a try.