### PR TITLE
fix(es/proposal): Preserve class id for hoisted classes when transforming `using` declarations

### DIFF
--- a/.changeset/stupid-pens-talk.md
+++ b/.changeset/stupid-pens-talk.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_transforms_proposal: patch
+swc_core: patch
+---
+
+fix(es/proposal): Preserve class id when transforming using declarations with exported class

--- a/crates/swc/tests/fixture/issues-8xxx/8629/output/1.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8629/output/1.js
@@ -8,7 +8,7 @@ const env = {
 try {
     var _computedKey;
     _computedKey = Symbol.dispose;
-    var Disposable = class {
+    var Disposable = class Disposable {
         [_computedKey]() {
             console.log('dispose');
         }

--- a/crates/swc/tests/tsc-references/awaitUsingDeclarations.1(target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/awaitUsingDeclarations.1(target=es2015).1.normal.js
@@ -35,7 +35,7 @@ try {
                 if (result) yield result;
             }
         })();
-    var C1 = class {
+    var C1 = class C1 {
         am() {
             return /*#__PURE__*/ _async_to_generator(function*() {
                 const env = {

--- a/crates/swc/tests/tsc-references/awaitUsingDeclarations.1(target=es2017).1.normal.js
+++ b/crates/swc/tests/tsc-references/awaitUsingDeclarations.1(target=es2017).1.normal.js
@@ -28,7 +28,7 @@ try {
             if (result) await result;
         }
     };
-    var C1 = class {
+    var C1 = class C1 {
         async am() {
             const env = {
                 stack: [],

--- a/crates/swc/tests/tsc-references/awaitUsingDeclarations.1(target=es2022).1.normal.js
+++ b/crates/swc/tests/tsc-references/awaitUsingDeclarations.1(target=es2022).1.normal.js
@@ -28,7 +28,7 @@ try {
             if (result) await result;
         }
     };
-    var C1 = class {
+    var C1 = class C1 {
         async am() {
             const env = {
                 stack: [],

--- a/crates/swc/tests/tsc-references/awaitUsingDeclarations.1(target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/awaitUsingDeclarations.1(target=esnext).1.normal.js
@@ -28,7 +28,7 @@ try {
             if (result) await result;
         }
     };
-    var C1 = class {
+    var C1 = class C1 {
         async am() {
             const env = {
                 stack: [],

--- a/crates/swc/tests/tsc-references/usingDeclarations.1(target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarations.1(target=es2015).1.normal.js
@@ -10,7 +10,7 @@ const env = {
     hasError: false
 };
 try {
-    var _class;
+    var _C1;
     var d1 = _ts_add_disposable_resource(env, {
         [Symbol.dispose] () {}
     }, false);
@@ -31,7 +31,7 @@ try {
             _ts_dispose_resources(env);
         }
     };
-    var C1 = (_class = class {
+    var C1 = (_C1 = class C1 {
         m() {
             const env = {
                 stack: [],
@@ -193,8 +193,8 @@ try {
         } finally{
             _ts_dispose_resources(env);
         }
-    })(), _class);
-    var C2 = class extends C1 {
+    })(), _C1);
+    var C2 = class C2 extends C1 {
         constructor(){
             const env = {
                 stack: [],
@@ -214,7 +214,7 @@ try {
             }
         }
     };
-    var C3 = class extends C1 {
+    var C3 = class C3 extends C1 {
         constructor(){
             const env = {
                 stack: [],

--- a/crates/swc/tests/tsc-references/usingDeclarations.1(target=es2017).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarations.1(target=es2017).1.normal.js
@@ -7,7 +7,7 @@ const env = {
     hasError: false
 };
 try {
-    var _class;
+    var _C1;
     var d1 = _ts_add_disposable_resource(env, {
         [Symbol.dispose] () {}
     }, false);
@@ -28,7 +28,7 @@ try {
             _ts_dispose_resources(env);
         }
     };
-    var C1 = (_class = class {
+    var C1 = (_C1 = class C1 {
         m() {
             const env = {
                 stack: [],
@@ -186,8 +186,8 @@ try {
         } finally{
             _ts_dispose_resources(env);
         }
-    })(), _class);
-    var C2 = class extends C1 {
+    })(), _C1);
+    var C2 = class C2 extends C1 {
         constructor(){
             const env = {
                 stack: [],
@@ -207,7 +207,7 @@ try {
             }
         }
     };
-    var C3 = class extends C1 {
+    var C3 = class C3 extends C1 {
         constructor(){
             const env = {
                 stack: [],

--- a/crates/swc/tests/tsc-references/usingDeclarations.1(target=es2022).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarations.1(target=es2022).1.normal.js
@@ -27,7 +27,7 @@ try {
             _ts_dispose_resources(env);
         }
     };
-    var C1 = class {
+    var C1 = class C1 {
         constructor(){
             this.a = ()=>{
                 const env = {
@@ -187,7 +187,7 @@ try {
             }
         }
     };
-    var C2 = class extends C1 {
+    var C2 = class C2 extends C1 {
         constructor(){
             const env = {
                 stack: [],
@@ -207,7 +207,7 @@ try {
             }
         }
     };
-    var C3 = class extends C1 {
+    var C3 = class C3 extends C1 {
         constructor(){
             const env = {
                 stack: [],

--- a/crates/swc/tests/tsc-references/usingDeclarations.1(target=es5).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarations.1(target=es5).1.normal.js
@@ -17,7 +17,7 @@ var env = {
     hasError: false
 };
 try {
-    var _class;
+    var _C1;
     var d1 = _ts_add_disposable_resource(env, _define_property({}, Symbol.dispose, function() {}), false);
     var a = function() {
         var env = {
@@ -34,10 +34,10 @@ try {
             _ts_dispose_resources(env);
         }
     };
-    var C1 = (_class = /*#__PURE__*/ function() {
+    var C1 = (_C1 = /*#__PURE__*/ function() {
         "use strict";
-        function _class() {
-            _class_call_check(this, _class);
+        function C1() {
+            _class_call_check(this, C1);
             this.a = function() {
                 var env = {
                     stack: [],
@@ -67,7 +67,7 @@ try {
                 _ts_dispose_resources(env);
             }
         }
-        var _proto = _class.prototype;
+        var _proto = C1.prototype;
         _proto.m = function m() {
             var env = {
                 stack: [],
@@ -238,7 +238,7 @@ try {
                 });
             })();
         };
-        _create_class(_class, [
+        _create_class(C1, [
             {
                 key: "x",
                 get: function get() {
@@ -274,7 +274,7 @@ try {
                 }
             }
         ]);
-        return _class;
+        return C1;
     }(), function() {
         var env = {
             stack: [],
@@ -289,7 +289,7 @@ try {
         } finally{
             _ts_dispose_resources(env);
         }
-    }(), _class);
+    }(), _C1);
     var C2 = /*#__PURE__*/ function(C1) {
         "use strict";
         _inherits(C2, C1);

--- a/crates/swc/tests/tsc-references/usingDeclarations.1(target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarations.1(target=esnext).1.normal.js
@@ -27,7 +27,7 @@ try {
             _ts_dispose_resources(env);
         }
     };
-    var C1 = class {
+    var C1 = class C1 {
         constructor(){
             this.a = ()=>{
                 const env = {
@@ -187,7 +187,7 @@ try {
             }
         }
     };
-    var C2 = class extends C1 {
+    var C2 = class C2 extends C1 {
         constructor(){
             const env = {
                 stack: [],
@@ -207,7 +207,7 @@ try {
             }
         }
     };
-    var C3 = class extends C1 {
+    var C3 = class C3 extends C1 {
         constructor(){
             const env = {
                 stack: [],

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=commonjs,target=es2015).1.normal.js
@@ -13,7 +13,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=commonjs,target=esnext).1.normal.js
@@ -13,7 +13,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=es6,target=es2015).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=es6,target=esnext).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=system,target=es2015).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var C = class {
+                var C = class C {
                 };
                 C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.1(module=system,target=esnext).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var C = class {
+                var C = class C {
                 };
                 C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=commonjs,target=es2015).1.normal.js
@@ -18,7 +18,7 @@ const env = {
     hasError: false
 };
 try {
-    var _class = class {
+    var _class = class _class {
     };
     _class = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=commonjs,target=esnext).1.normal.js
@@ -18,7 +18,7 @@ const env = {
     hasError: false
 };
 try {
-    var _class = class {
+    var _class = class _class {
     };
     _class = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=es6,target=es2015).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var _class = class {
+    var _class = class _class {
     };
     _class = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=es6,target=esnext).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var _class = class {
+    var _class = class _class {
     };
     _class = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=system,target=es2015).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var _class = class {
+                var _class = class _class {
                 };
                 _export("default", _class = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.10(module=system,target=esnext).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var _class = class {
+                var _class = class _class {
                 };
                 _export("default", _class = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=commonjs,target=es2015).1.normal.js
@@ -18,7 +18,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=commonjs,target=esnext).1.normal.js
@@ -18,7 +18,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=es6,target=es2015).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=es6,target=esnext).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=system,target=es2015).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var C = class {
+                var C = class C {
                 };
                 _export("C", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.11(module=system,target=esnext).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var C = class {
+                var C = class C {
                 };
                 _export("C", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=commonjs,target=es2015).1.normal.js
@@ -18,7 +18,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=commonjs,target=esnext).1.normal.js
@@ -18,7 +18,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=es6,target=es2015).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=es6,target=esnext).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=system,target=es2015).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var C = class {
+                var C = class C {
                 };
                 _export("D", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.12(module=system,target=esnext).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var C = class {
+                var C = class C {
                 };
                 _export("D", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=commonjs,target=es2015).1.normal.js
@@ -19,7 +19,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=commonjs,target=esnext).1.normal.js
@@ -19,7 +19,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=es6,target=es2015).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=es6,target=esnext).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=system,target=es2015).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var C = class {
+                var C = class C {
                 };
                 _export("C", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.2(module=system,target=esnext).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var C = class {
+                var C = class C {
                 };
                 _export("C", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=commonjs,target=es2015).1.normal.js
@@ -19,7 +19,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=commonjs,target=esnext).1.normal.js
@@ -19,7 +19,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=es6,target=es2015).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=es6,target=esnext).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=system,target=es2015).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var C = class {
+                var C = class C {
                 };
                 _export("default", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.3(module=system,target=esnext).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var C = class {
+                var C = class C {
                 };
                 _export("default", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=commonjs,target=es2015).1.normal.js
@@ -19,7 +19,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var _class = class {
+    var _class = class _class {
     };
     _class = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=commonjs,target=esnext).1.normal.js
@@ -19,7 +19,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var _class = class {
+    var _class = class _class {
     };
     _class = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=es6,target=es2015).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var _class = class {
+    var _class = class _class {
     };
     _class = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=es6,target=esnext).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var _class = class {
+    var _class = class _class {
     };
     _class = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=system,target=es2015).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var _class = class {
+                var _class = class _class {
                 };
                 _export("default", _class = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.4(module=system,target=esnext).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var _class = class {
+                var _class = class _class {
                 };
                 _export("default", _class = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=commonjs,target=es2015).1.normal.js
@@ -19,7 +19,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=commonjs,target=esnext).1.normal.js
@@ -19,7 +19,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=es6,target=es2015).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=es6,target=esnext).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=system,target=es2015).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var C = class {
+                var C = class C {
                 };
                 _export("C", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.5(module=system,target=esnext).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var C = class {
+                var C = class C {
                 };
                 _export("C", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=commonjs,target=es2015).1.normal.js
@@ -19,7 +19,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=commonjs,target=esnext).1.normal.js
@@ -19,7 +19,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource._(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=es6,target=es2015).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=es6,target=esnext).1.normal.js
@@ -9,7 +9,7 @@ const env = {
 };
 try {
     var before = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=system,target=es2015).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var C = class {
+                var C = class C {
                 };
                 _export("D", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.6(module=system,target=esnext).1.normal.js
@@ -26,7 +26,7 @@ System.register([
             };
             try {
                 var before = _ts_add_disposable_resource(env, null, false);
-                var C = class {
+                var C = class C {
                 };
                 _export("D", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=commonjs,target=es2015).1.normal.js
@@ -12,7 +12,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=commonjs,target=esnext).1.normal.js
@@ -12,7 +12,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=es6,target=es2015).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=es6,target=esnext).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=system,target=es2015).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var C = class {
+                var C = class C {
                 };
                 C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.7(module=system,target=esnext).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var C = class {
+                var C = class C {
                 };
                 C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=commonjs,target=es2015).1.normal.js
@@ -18,7 +18,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=commonjs,target=esnext).1.normal.js
@@ -18,7 +18,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=es6,target=es2015).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=es6,target=esnext).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=system,target=es2015).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var C = class {
+                var C = class C {
                 };
                 _export("C", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.8(module=system,target=esnext).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var C = class {
+                var C = class C {
                 };
                 _export("C", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=commonjs,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=commonjs,target=es2015).1.normal.js
@@ -18,7 +18,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=commonjs,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=commonjs,target=esnext).1.normal.js
@@ -18,7 +18,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate._([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=es6,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=es6,target=es2015).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=es6,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=es6,target=esnext).1.normal.js
@@ -8,7 +8,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
     };
     C = _ts_decorate([
         dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=system,target=es2015).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=system,target=es2015).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var C = class {
+                var C = class C {
                 };
                 _export("default", C = _ts_decorate([
                     dec

--- a/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=system,target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsWithLegacyClassDecorators.9(module=system,target=esnext).1.normal.js
@@ -25,7 +25,7 @@ System.register([
                 hasError: false
             };
             try {
-                var C = class {
+                var C = class C {
                 };
                 _export("default", C = _ts_decorate([
                     dec

--- a/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/issue-10392/1/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/issue-10392/1/output.js
@@ -4,7 +4,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
         [Symbol.dispose]() {
             console.log("dispose");
         }

--- a/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/issue-10392/2/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/issue-10392/2/output.js
@@ -4,7 +4,7 @@ const env = {
     hasError: false
 };
 try {
-    var C = class {
+    var C = class C {
         [Symbol.dispose]() {
             console.log("dispose");
         }

--- a/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/issue-10392/3/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/issue-10392/3/output.js
@@ -10,7 +10,7 @@ try {
             console.log(2);
         }
     };
-    var C = class {
+    var C = class C {
         [Symbol.dispose]() {
             console.log("dispose");
         }

--- a/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/transform-top-level/hoisting-default-class/output.mjs
+++ b/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/transform-top-level/hoisting-default-class/output.mjs
@@ -5,7 +5,7 @@ const env = {
 };
 try {
     var x = _ts_add_disposable_resource(env, null, false);
-    var C = class {
+    var C = class C {
     };
 } catch (e) {
     env.error = e;

--- a/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/transform-top-level/hoisting-mutate-outer-class-binding/input.mjs
+++ b/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/transform-top-level/hoisting-mutate-outer-class-binding/input.mjs
@@ -1,0 +1,7 @@
+export class A { static get self() { return A } }
+
+using x = null;
+
+export class B { static get self() { return B } }
+
+A = B = null;

--- a/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/transform-top-level/hoisting-mutate-outer-class-binding/output.mjs
+++ b/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/transform-top-level/hoisting-mutate-outer-class-binding/output.mjs
@@ -1,0 +1,26 @@
+const env = {
+    stack: [],
+    error: void 0,
+    hasError: false
+};
+try {
+    var A = class A {
+        static get self() {
+            return A;
+        }
+    };
+    var x = _ts_add_disposable_resource(env, null, false);
+    var B = class B {
+        static get self() {
+            return B;
+        }
+    };
+    A = B = null;
+} catch (e) {
+    env.error = e;
+    env.hasError = true;
+} finally{
+    _ts_dispose_resources(env);
+}
+export { A };
+export { B };

--- a/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/transform-top-level/hoisting/output.mjs
+++ b/crates/swc_ecma_transforms_proposal/tests/explicit-resource-management/transform-top-level/hoisting/output.mjs
@@ -6,9 +6,9 @@ const env = {
 try {
     doSomething();
     var c = 2;
-    var A = class {
+    var A = class A {
     };
-    var B = class {
+    var B = class B {
     };
     var x = _ts_add_disposable_resource(env, null, false);
 } catch (e) {


### PR DESCRIPTION
**Related issue:**

- https://github.com/babel/babel/issues/17172