### PR TITLE
fix(es/jest): Hoisting vars with names starting with mock

### DIFF
--- a/.changeset/olive-feet-flow.md
+++ b/.changeset/olive-feet-flow.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_ext_transforms: patch
+---
+
+fix: Hoisting issue for variables with names starting with mock

--- a/crates/swc_ecma_ext_transforms/src/jest.rs
+++ b/crates/swc_ecma_ext_transforms/src/jest.rs
@@ -153,39 +153,11 @@ impl VisitMut for Jest {
             }
         }
 
-        // After collecting imports, scan and find mock variables
-        for item in items.iter() {
-            if let ModuleItem::Stmt(Stmt::Decl(Decl::Var(var_decl))) = item {
-                for decl in &var_decl.decls {
-                    if let Pat::Ident(ident) = &decl.name {
-                        let name = &*ident.id.sym;
-                        if name.starts_with("mock") {
-                            self.mock_vars.push(ident.id.to_id());
-                        }
-                    }
-                }
-            }
-        }
-
         // Now process and hoist as needed
         self.visit_mut_stmt_like(items)
     }
 
     fn visit_mut_stmts(&mut self, stmts: &mut Vec<Stmt>) {
-        // Check for mock variables in statements as well
-        for stmt in stmts.iter() {
-            if let Stmt::Decl(Decl::Var(var_decl)) = stmt {
-                for decl in &var_decl.decls {
-                    if let Pat::Ident(ident) = &decl.name {
-                        let name = &*ident.id.sym;
-                        if name.starts_with("mock") {
-                            self.mock_vars.push(ident.id.to_id());
-                        }
-                    }
-                }
-            }
-        }
-
         self.visit_mut_stmt_like(stmts)
     }
 }


### PR DESCRIPTION
**Description:**
When using jest.mock() in conjunction with variables whose names start with "mock", these variables are not correctly hoisted. This results in unexpected behavior during testing, as the mock variables are not available as expected.So this PR tries to fixes that 

**BREAKING CHANGE:**
N/A

Fixes #9552 
