### PR TITLE
refactor: Use debug level tracing for ast related tracing

### DIFF
--- a/.changeset/smooth-parrots-happen.md
+++ b/.changeset/smooth-parrots-happen.md
@@ -1,0 +1,16 @@
+---
+swc_core: patch
+swc_ecma_codegen: patch
+swc_ecma_compat_es2015: patch
+swc_ecma_compat_es2016: patch
+swc_ecma_compat_es2017: patch
+swc_ecma_compat_es2018: patch
+swc_ecma_compat_es2020: patch
+swc_ecma_minifier: patch
+swc_ecma_parser: patch
+swc_ecma_transforms_optimization: patch
+swc_ecma_usage_analyzer: patch
+swc_trace_macro: patch
+---
+
+fix: use debug level tracing for ast related tracing

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1415,7 +1415,7 @@ impl MacroNode for Program {
 
 #[node_impl]
 impl MacroNode for Module {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         emitter.emit_leading_comments_of_span(self.span(), false)?;
 
@@ -1443,7 +1443,7 @@ impl MacroNode for Module {
 
 #[node_impl]
 impl MacroNode for Script {
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         emitter.emit_leading_comments_of_span(self.span(), false)?;
 

--- a/crates/swc_ecma_compat_es2015/src/classes/mod.rs
+++ b/crates/swc_ecma_compat_es2015/src/classes/mod.rs
@@ -935,7 +935,7 @@ impl Classes {
     }
 }
 
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn inject_class_call_check(c: &mut Vec<Stmt>, name: Ident) {
     let mut class_name_sym = name.clone();
     class_name_sym.span = DUMMY_SP;
@@ -956,7 +956,7 @@ fn inject_class_call_check(c: &mut Vec<Stmt>, name: Ident) {
 }
 
 /// Returns true if no `super` is used before `super()` call.
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn is_always_initialized(body: &[Stmt]) -> bool {
     struct SuperFinder {
         found: bool,

--- a/crates/swc_ecma_compat_es2015/src/destructuring.rs
+++ b/crates/swc_ecma_compat_es2015/src/destructuring.rs
@@ -1137,7 +1137,7 @@ fn make_ref_ident(c: Config, decls: &mut Vec<VarDeclarator>, init: Option<Box<Ex
     make_ref_ident_for_array(c, decls, init, None)
 }
 
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn make_ref_ident_for_array(
     c: Config,
     decls: &mut Vec<VarDeclarator>,

--- a/crates/swc_ecma_compat_es2015/src/for_of.rs
+++ b/crates/swc_ecma_compat_es2015/src/for_of.rs
@@ -560,7 +560,7 @@ impl ForOf {
 ///     }
 ///   }
 /// ```
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn make_finally_block(
     iterator_return: Box<Expr>,
     normal_completion_ident: &Ident,

--- a/crates/swc_ecma_compat_es2015/src/generator.rs
+++ b/crates/swc_ecma_compat_es2015/src/generator.rs
@@ -974,7 +974,7 @@ impl VisitMut for Generator {
         }
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "debug", skip_all)]
     fn visit_mut_stmt(&mut self, node: &mut Stmt) {
         match node {
             Stmt::Break(b) => {
@@ -3089,7 +3089,7 @@ impl Generator {
         });
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     fn try_enter_label(&mut self, op_index: usize) {
         if self.label_offsets.is_none() {
             return;
@@ -3143,7 +3143,7 @@ impl Generator {
     }
 
     /// Tries to enter or leave a code block.
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     fn try_enter_or_leave_block(&mut self, op_index: usize) {
         if let Some(blocks) = &self.blocks {
             while self.block_index < self.block_actions.as_ref().unwrap().len()
@@ -3210,7 +3210,7 @@ impl Generator {
 
     /// Writes an operation as a statement to the current label's statement
     /// list.
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(level = "debug", skip(self))]
     fn write_operation(&mut self, op_index: usize) {
         if cfg!(debug_assertions) {
             debug!("Writing operation {}", op_index);

--- a/crates/swc_ecma_compat_es2015/src/spread.rs
+++ b/crates/swc_ecma_compat_es2015/src/spread.rs
@@ -462,7 +462,7 @@ impl Spread {
     }
 }
 
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn expand_literal_args(
     args: impl ExactSizeIterator<Item = Option<ExprOrSpread>>,
 ) -> Vec<Option<ExprOrSpread>> {

--- a/crates/swc_ecma_compat_es2015/src/typeof_symbol.rs
+++ b/crates/swc_ecma_compat_es2015/src/typeof_symbol.rs
@@ -138,7 +138,7 @@ impl VisitMut for TypeOfSymbol {
     }
 }
 
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn is_non_symbol_literal(e: &Expr) -> bool {
     match e {
         Expr::Lit(Lit::Str(Str { value, .. })) => matches!(

--- a/crates/swc_ecma_compat_es2016/src/exponentiation.rs
+++ b/crates/swc_ecma_compat_es2016/src/exponentiation.rs
@@ -136,7 +136,7 @@ impl VisitMut for Exponentiation {
     }
 }
 
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn mk_call(span: Span, left: Box<Expr>, right: Box<Expr>) -> Expr {
     // Math.pow()
     CallExpr {

--- a/crates/swc_ecma_compat_es2017/src/async_to_generator.rs
+++ b/crates/swc_ecma_compat_es2017/src/async_to_generator.rs
@@ -399,7 +399,7 @@ impl VisitMut for AsyncToGenerator {
 /// Creates
 ///
 /// `_async_to_generator(function*() {})()` from `async function() {}`;
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn make_fn_ref(fn_state: &FnState, params: Vec<Param>, body: BlockStmt) -> Expr {
     let helper = if fn_state.is_generator {
         helper_expr!(PURE_SP, wrap_async_generator)
@@ -439,7 +439,7 @@ fn make_fn_ref(fn_state: &FnState, params: Vec<Param>, body: BlockStmt) -> Expr 
     }
 }
 
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn could_potentially_throw(param: &[Param], unresolved_ctxt: SyntaxContext) -> bool {
     for param in param {
         debug_assert!(param.decorators.is_empty());
@@ -500,7 +500,7 @@ impl Check for ShouldWork {
     }
 }
 
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
     let s = match stmt {
         Stmt::ForOf(s @ ForOfStmt { is_await: true, .. }) => s.take(),

--- a/crates/swc_ecma_compat_es2018/src/object_rest.rs
+++ b/crates/swc_ecma_compat_es2018/src/object_rest.rs
@@ -889,7 +889,7 @@ impl ObjectRest {
     }
 }
 
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn object_without_properties(
     obj: Box<Expr>,
     excluded_props: Vec<Option<ExprOrSpread>>,
@@ -967,7 +967,7 @@ fn object_without_properties(
     .into()
 }
 
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn excluded_props(props: &[ObjectPatProp]) -> Vec<Option<ExprOrSpread>> {
     props
         .iter()

--- a/crates/swc_ecma_compat_es2020/src/nullish_coalescing.rs
+++ b/crates/swc_ecma_compat_es2020/src/nullish_coalescing.rs
@@ -224,7 +224,7 @@ impl VisitMut for NullishCoalescing {
     }
 }
 
-#[tracing::instrument(level = "info", skip_all)]
+#[tracing::instrument(level = "debug", skip_all)]
 fn make_cond(c: Config, span: Span, alias: &Ident, var_expr: Expr, init: Box<Expr>) -> Expr {
     if c.no_document_all {
         CondExpr {

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -139,7 +139,7 @@ impl Optimizer<'_> {
     ///     })(x);
     /// })(7);
     /// ```
-    #[cfg_attr(feature = "debug", tracing::instrument(skip(self, e)))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip(self, e)))]
     pub(super) fn inline_args_of_iife(&mut self, e: &mut CallExpr) {
         if self.options.inline == 0 && !self.options.reduce_vars && !self.options.reduce_fns {
             return;
@@ -409,7 +409,7 @@ impl Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn inline_vars_in_node<N>(&mut self, n: &mut N, mut vars: FxHashMap<Id, Box<Expr>>)
     where
         N: for<'aa> VisitMutWith<NormalMultiReplacer<'aa>>,

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -414,7 +414,7 @@ impl Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn handle_stmt_likes<T>(&mut self, stmts: &mut Vec<T>, will_terminate: bool)
     where
         T: StmtLike + ModuleItemLike + ModuleItemExt + VisitMutWith<Self> + VisitWith<AssertValid>,
@@ -587,7 +587,7 @@ impl Optimizer<'_> {
 
     /// Returns [None] if expression is side-effect-free.
     /// If an expression has a side effect, only side effects are returned.
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn ignore_return_value(&mut self, e: &mut Expr) -> Option<Expr> {
         self.compress_cond_to_logical_ignoring_return_value(e);
 
@@ -1410,7 +1410,7 @@ impl Optimizer<'_> {
 impl VisitMut for Optimizer<'_> {
     noop_visit_mut_type!();
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_arrow_expr(&mut self, n: &mut ArrowExpr) {
         self.drop_unused_arrow_params(&mut n.params);
 
@@ -1456,7 +1456,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_assign_expr(&mut self, e: &mut AssignExpr) {
         {
             let ctx = self
@@ -1469,7 +1469,7 @@ impl VisitMut for Optimizer<'_> {
         e.right.visit_mut_with(self);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_assign_pat_prop(&mut self, n: &mut AssignPatProp) {
         n.visit_mut_children_with(self);
 
@@ -1480,7 +1480,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_bin_expr(&mut self, n: &mut BinExpr) {
         {
             let ctx = self.ctx.clone().with(
@@ -1511,7 +1511,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_block_stmt(&mut self, n: &mut BlockStmt) {
         let ctx = Ctx {
             bit_ctx: self
@@ -1538,7 +1538,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_call_expr(&mut self, e: &mut CallExpr) {
         let is_this_undefined = match &e.callee {
             Callee::Super(_) | Callee::Import(_) => false,
@@ -1600,7 +1600,7 @@ impl VisitMut for Optimizer<'_> {
         self.inline_args_of_iife(e);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_class(&mut self, n: &mut Class) {
         n.decorators.visit_mut_with(self);
 
@@ -1626,7 +1626,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_class_expr(&mut self, e: &mut ClassExpr) {
         if !self.options.keep_classnames {
             if e.ident.is_some() && !contains_eval(&e.class, true) {
@@ -1637,7 +1637,7 @@ impl VisitMut for Optimizer<'_> {
         e.visit_mut_children_with(self);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_decl(&mut self, decl: &mut Decl) {
         match decl {
             Decl::Class(class_decl) => self.visit_mut_class(&mut class_decl.class),
@@ -1651,7 +1651,7 @@ impl VisitMut for Optimizer<'_> {
         self.store_decl_for_inlining(decl);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_default_decl(&mut self, n: &mut DefaultDecl) {
         match n {
             DefaultDecl::Class(_) => {}
@@ -1671,7 +1671,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_export_decl(&mut self, n: &mut ExportDecl) {
         if let Decl::Fn(f) = &mut n.decl {
             self.drop_unused_params(&mut f.function.params);
@@ -1862,7 +1862,7 @@ impl VisitMut for Optimizer<'_> {
         tracing::debug!("Output: {}", dump(e, true));
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_expr_stmt(&mut self, n: &mut ExprStmt) {
         let was_directive = matches!(&*n.expr, Expr::Lit(Lit::Str(..)));
 
@@ -1976,7 +1976,7 @@ impl VisitMut for Optimizer<'_> {
         f.visit_mut_children_with(&mut *self.with_ctx(ctx));
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_fn_expr(&mut self, e: &mut FnExpr) {
         if let Some(ident) = &e.ident {
             self.functions
@@ -2000,7 +2000,7 @@ impl VisitMut for Optimizer<'_> {
         e.visit_mut_children_with(&mut *self.with_ctx(ctx));
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_for_in_stmt(&mut self, n: &mut ForInStmt) {
         n.right.visit_mut_with(self);
 
@@ -2019,7 +2019,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_for_of_stmt(&mut self, n: &mut ForOfStmt) {
         n.right.visit_mut_with(self);
 
@@ -2038,7 +2038,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_for_stmt(&mut self, s: &mut ForStmt) {
         self.visit_with_prepend(&mut s.init);
 
@@ -2051,7 +2051,7 @@ impl VisitMut for Optimizer<'_> {
         s.body.visit_mut_with(&mut *self.with_ctx(ctx.clone()));
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_function(&mut self, n: &mut Function) {
         n.decorators.visit_mut_with(self);
 
@@ -2117,7 +2117,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_if_stmt(&mut self, n: &mut IfStmt) {
         n.test.visit_mut_with(self);
 
@@ -2130,7 +2130,7 @@ impl VisitMut for Optimizer<'_> {
         self.negate_if_stmt(n);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_labeled_stmt(&mut self, n: &mut LabeledStmt) {
         let ctx = self.ctx.clone().with(
             BitCtx::DontUsePrependNorAppend,
@@ -2142,7 +2142,7 @@ impl VisitMut for Optimizer<'_> {
         self.try_remove_label(n);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_member_expr(&mut self, n: &mut MemberExpr) {
         {
             let ctx = self
@@ -2165,7 +2165,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_module_item(&mut self, s: &mut ModuleItem) {
         s.visit_mut_children_with(self);
 
@@ -2180,7 +2180,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_module_items(&mut self, stmts: &mut Vec<ModuleItem>) {
         let ctx = self.ctx.clone().with(BitCtx::TopLevel, true);
         self.with_ctx(ctx).handle_stmt_likes(stmts, true);
@@ -2192,7 +2192,7 @@ impl VisitMut for Optimizer<'_> {
         drop_invalid_stmts(stmts);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_new_expr(&mut self, n: &mut NewExpr) {
         {
             let ctx = self
@@ -2214,7 +2214,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_opt_stmt(&mut self, s: &mut Option<Box<Stmt>>) {
         s.visit_mut_children_with(self);
 
@@ -2225,7 +2225,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_opt_var_decl_or_expr(&mut self, n: &mut Option<VarDeclOrExpr>) {
         n.visit_mut_children_with(self);
 
@@ -2248,7 +2248,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_param(&mut self, n: &mut Param) {
         let ctx = Ctx {
             bit_ctx: self.ctx.bit_ctx.with(BitCtx::InParam, true),
@@ -2267,7 +2267,7 @@ impl VisitMut for Optimizer<'_> {
         n.retain(|p| !p.pat.is_invalid());
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_prop(&mut self, n: &mut Prop) {
         n.visit_mut_children_with(self);
 
@@ -2289,7 +2289,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_return_stmt(&mut self, n: &mut ReturnStmt) {
         n.visit_mut_children_with(self);
 
@@ -2298,7 +2298,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_script(&mut self, s: &mut Script) {
         let ctx = self.ctx.clone().with(BitCtx::TopLevel, true);
         s.visit_mut_children_with(&mut *self.with_ctx(ctx));
@@ -2310,14 +2310,14 @@ impl VisitMut for Optimizer<'_> {
         drop_invalid_stmts(&mut s.body);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_seq_expr(&mut self, n: &mut SeqExpr) {
         n.visit_mut_children_with(self);
 
         self.merge_sequences_in_seq_expr(n);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_stmt(&mut self, s: &mut Stmt) {
         let old_prepend = self.prepend_stmts.take();
         let old_append = self.append_stmts.take();
@@ -2547,7 +2547,7 @@ impl VisitMut for Optimizer<'_> {
         debug_assert_valid(s);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_stmts(&mut self, stmts: &mut Vec<Stmt>) {
         // Skip if `use asm` exists.
         if maybe_par!(
@@ -2586,7 +2586,7 @@ impl VisitMut for Optimizer<'_> {
         s.visit_mut_children_with(self);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_super_prop_expr(&mut self, n: &mut SuperPropExpr) {
         if let SuperProp::Computed(c) = &mut n.prop {
             let ctx = self
@@ -2598,7 +2598,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_switch_stmt(&mut self, n: &mut SwitchStmt) {
         n.discriminant.visit_mut_with(self);
 
@@ -2606,7 +2606,7 @@ impl VisitMut for Optimizer<'_> {
     }
 
     /// We don't optimize [Tpl] contained in [TaggedTpl].
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_tagged_tpl(&mut self, n: &mut TaggedTpl) {
         n.tag.visit_mut_with(
             &mut *self.with_ctx(self.ctx.clone().with(BitCtx::IsThisAwareCallee, true)),
@@ -2615,14 +2615,14 @@ impl VisitMut for Optimizer<'_> {
         n.tpl.exprs.visit_mut_with(self);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_throw_stmt(&mut self, n: &mut ThrowStmt) {
         n.visit_mut_children_with(self);
 
         self.optimize_last_expr_before_termination(&mut n.arg);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_tpl(&mut self, n: &mut Tpl) {
         debug_assert_eq!(n.exprs.len() + 1, n.quasis.len());
 
@@ -2637,7 +2637,7 @@ impl VisitMut for Optimizer<'_> {
             .for_each(|expr| self.optimize_expr_in_str_ctx(expr));
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_try_stmt(&mut self, n: &mut TryStmt) {
         let ctx = self.ctx.clone().with(BitCtx::InTryBlock, true);
         n.block.visit_mut_with(&mut *self.with_ctx(ctx));
@@ -2662,7 +2662,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_unary_expr(&mut self, n: &mut UnaryExpr) {
         let ctx = self
             .ctx
@@ -2690,14 +2690,14 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_update_expr(&mut self, n: &mut UpdateExpr) {
         let ctx = self.ctx.clone().with(BitCtx::IsUpdateArg, true);
 
         n.visit_mut_children_with(&mut *self.with_ctx(ctx));
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_using_decl(&mut self, n: &mut UsingDecl) {
         let ctx = Ctx {
             bit_ctx: self
@@ -2714,7 +2714,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_var_decl(&mut self, n: &mut VarDecl) {
         {
             let ctx = Ctx {
@@ -2746,7 +2746,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_var_declarator(&mut self, var: &mut VarDeclarator) {
         var.name.visit_mut_with(self);
 
@@ -2782,7 +2782,7 @@ impl VisitMut for Optimizer<'_> {
         debug_assert_valid(&var.init);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_var_declarators(&mut self, vars: &mut Vec<VarDeclarator>) {
         vars.retain_mut(|var| {
             if var.name.is_invalid() {
@@ -2951,7 +2951,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_while_stmt(&mut self, n: &mut WhileStmt) {
         {
             let ctx = self.ctx.clone().with(BitCtx::ExecutedMultipleTime, true);
@@ -2959,7 +2959,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_with_stmt(&mut self, n: &mut WithStmt) {
         n.obj.visit_mut_with(self);
 
@@ -2969,7 +2969,7 @@ impl VisitMut for Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_yield_expr(&mut self, n: &mut YieldExpr) {
         n.visit_mut_children_with(self);
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -514,7 +514,7 @@ impl Optimizer<'_> {
         })
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn merge_sequences_in_stmts<T>(&mut self, stmts: &mut Vec<T>, will_terminate: bool)
     where
         T: ModuleItemExt,
@@ -1148,7 +1148,7 @@ impl Optimizer<'_> {
         false
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn is_skippable_for_seq(&self, a: Option<&Mergable>, e: &Expr) -> bool {
         if self.ctx.bit_ctx.contains(BitCtx::InTryBlock) {
             log_abort!("try block");

--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -23,7 +23,7 @@ pub(crate) struct PropertyAccessOpts {
 
 /// Methods related to the option `unused`.
 impl Optimizer<'_> {
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn drop_unused_var_declarator(
         &mut self,
         var: &mut VarDeclarator,
@@ -78,7 +78,7 @@ impl Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn drop_unused_param(&mut self, pat: &mut Pat, ignore_fn_length: bool) {
         if !self.options.unused && !self.options.reduce_fns {
             return;
@@ -100,7 +100,7 @@ impl Optimizer<'_> {
         self.take_pat_if_unused(pat, None, false)
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn drop_unused_vars(&mut self, name: &mut Pat, init: Option<&mut Expr>) {
         if self
             .ctx
@@ -137,7 +137,7 @@ impl Optimizer<'_> {
         self.take_pat_if_unused(name, init, true);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn drop_unused_params(&mut self, params: &mut Vec<Param>) {
         if self.options.keep_fargs || !self.options.unused {
             return;
@@ -154,7 +154,7 @@ impl Optimizer<'_> {
         params.retain(|p| !p.pat.is_invalid());
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn drop_unused_arrow_params(&mut self, params: &mut Vec<Pat>) {
         if self.options.keep_fargs || !self.options.unused {
             return;
@@ -171,7 +171,7 @@ impl Optimizer<'_> {
         params.retain(|p| !p.is_invalid());
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn take_ident_of_pat_if_unused(&mut self, i: &mut Ident, init: Option<&mut Expr>) {
         trace_op!("unused: Checking identifier `{}`", i);
 
@@ -308,7 +308,7 @@ impl Optimizer<'_> {
 
     /// `parent_span` should be [Span] of [VarDeclarator] or [AssignExpr]
     #[allow(clippy::only_used_in_recursion)]
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn take_pat_if_unused(
         &mut self,
         name: &mut Pat,
@@ -446,7 +446,7 @@ impl Optimizer<'_> {
     }
 
     /// Creates an empty [VarDecl] if `decl` should be removed.
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn drop_unused_decl(&mut self, decl: &mut Decl) {
         if self.ctx.bit_ctx.contains(BitCtx::IsExported) {
             return;
@@ -580,7 +580,7 @@ impl Optimizer<'_> {
     }
 
     /// This should be only called from ignore_return_value
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn drop_unused_update(&mut self, e: &mut Expr) {
         if !self.options.unused {
             return;
@@ -609,7 +609,7 @@ impl Optimizer<'_> {
     }
 
     /// This should be only called from ignore_return_value
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn drop_unused_op_assign(&mut self, e: &mut Expr) {
         if !self.options.unused {
             return;
@@ -648,7 +648,7 @@ impl Optimizer<'_> {
         }
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn drop_unused_assignments(&mut self, e: &mut Expr) {
         if self.ctx.bit_ctx.contains(BitCtx::IsDeleteArg) {
             return;
@@ -724,7 +724,7 @@ impl Optimizer<'_> {
     }
 
     /// Make `name` [None] if the name is not used.
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     pub(super) fn remove_name_if_not_used(&mut self, name: &mut Option<Ident>) {
         if !self.options.unused {
             return;

--- a/crates/swc_ecma_minifier/src/compress/util/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/util/mod.rs
@@ -231,7 +231,10 @@ pub(crate) fn is_ok_to_negate_rhs(expr_ctx: ExprCtx, rhs: &Expr) -> bool {
 }
 
 /// A negative value means that it's efficient to negate the expression.
-#[cfg_attr(feature = "debug", tracing::instrument(skip(e, expr_ctx)))]
+#[cfg_attr(
+    feature = "debug",
+    tracing::instrument(level = "debug", skip(e, expr_ctx))
+)]
 #[allow(clippy::let_and_return)]
 pub(crate) fn negate_cost(
     expr_ctx: ExprCtx,
@@ -240,7 +243,7 @@ pub(crate) fn negate_cost(
     is_ret_val_ignored: bool,
 ) -> isize {
     #[allow(clippy::only_used_in_recursion)]
-    #[cfg_attr(test, tracing::instrument(skip(e)))]
+    #[cfg_attr(test, tracing::instrument(level = "debug", skip(e)))]
     fn cost(
         expr_ctx: ExprCtx,
         e: &Expr,

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -36,7 +36,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     ///`parseMaybeAssign` (overridden)
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     pub(super) fn parse_assignment_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_assignment_expr);
 
@@ -76,7 +79,10 @@ impl<I: Tokens> Parser<I> {
     /// operators like `+=`.
     ///
     /// `parseMaybeAssign`
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn parse_assignment_expr_base(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_assignment_expr_base);
         let start = self.input.cur_span();
@@ -207,7 +213,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     /// Spec: 'ConditionalExpression'
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn parse_cond_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_cond_expr);
 
@@ -239,7 +248,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     /// Parse a primary expression or arrow function
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     pub(super) fn parse_primary_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_primary_expr);
 
@@ -484,7 +496,10 @@ impl<I: Tokens> Parser<I> {
         syntax_error!(self, self.input.cur_span(), SyntaxError::TS1109)
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn parse_array_lit(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_array_lit);
 
@@ -526,7 +541,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     /// `is_new_expr`: true iff we are parsing production 'NewExpression'.
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn parse_member_expr_or_new_expr(&mut self, is_new_expr: bool) -> PResult<Box<Expr>> {
         let ctx = self.ctx() | Context::ShouldNotLexLtOrGtAsType;
         self.with_ctx(ctx)
@@ -673,7 +691,10 @@ impl<I: Tokens> Parser<I> {
 
     /// Parse `NewExpression`.
     /// This includes `MemberExpression`.
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     pub(super) fn parse_new_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_new_expr);
 
@@ -681,7 +702,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     /// Parse `Arguments[Yield, Await]`
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     pub(super) fn parse_args(&mut self, is_dynamic_import: bool) -> PResult<Vec<ExprOrSpread>> {
         trace_cur!(self, parse_args);
 
@@ -751,7 +775,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     /// Parse paren expression or arrow function expression.
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn parse_paren_expr_or_arrow_fn(
         &mut self,
         can_be_arrow: bool,
@@ -1087,7 +1114,10 @@ impl<I: Tokens> Parser<I> {
         })
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     pub(super) fn parse_subscripts(
         &mut self,
         mut obj: Callee,
@@ -1104,7 +1134,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     /// returned bool is true if this method should be called again.
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn parse_subscript(
         &mut self,
         start: BytePos,
@@ -1552,7 +1585,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     /// Parse call, dot, and `[]`-subscript expressions.
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     pub(super) fn parse_lhs_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_lhs_expr);
 
@@ -1691,7 +1727,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     // Returns (args_or_pats, trailing_comma)
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     pub(super) fn parse_args_or_pats(
         &mut self,
     ) -> PResult<(Vec<AssignTargetOrSpread>, Option<Span>)> {

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -592,7 +592,10 @@ impl<I: Tokens> Parser<I> {
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     pub(super) fn try_parse_ts_type_args(&mut self) -> Option<Box<TsTypeParamInstantiation>> {
         trace_cur!(self, try_parse_ts_type_args);
         debug_assert!(self.input.syntax().typescript());
@@ -658,7 +661,10 @@ impl<I: Tokens> Parser<I> {
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     pub(super) fn parse_ts_type_ann(
         &mut self,
         eat_colon: bool,
@@ -1984,7 +1990,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     /// `tsTryParseTypeAnnotation`
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     pub(super) fn try_parse_ts_type_ann(&mut self) -> PResult<Option<Box<TsTypeAnn>>> {
         if !cfg!(feature = "typescript") {
             return Ok(None);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1055,7 +1055,7 @@ impl VisitMut for TreeShaker {
         n.visit_mut_children_with(self);
     }
 
-    #[cfg_attr(feature = "debug", tracing::instrument(skip_all))]
+    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_using_decl(&mut self, n: &mut UsingDecl) {
         for decl in n.decls.iter_mut() {
             decl.init.visit_mut_with(self);

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
@@ -228,7 +228,10 @@ where
         n.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_arrow_expr(&mut self, n: &ArrowExpr) {
         self.with_child(n.ctxt, ScopeKind::Fn, |child| {
             {
@@ -250,7 +253,10 @@ where
         })
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_assign_expr(&mut self, n: &AssignExpr) {
         let is_op_assign = n.op != op!("=");
         n.left.visit_with(self);
@@ -326,7 +332,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_await_expr(&mut self, n: &AwaitExpr) {
         let ctx = self.ctx.with(BitContext::InAwaitArg, true);
         n.visit_children_with(&mut *self.with_ctx(ctx));
@@ -365,19 +374,28 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_binding_ident(&mut self, n: &BindingIdent) {
         self.visit_pat_id(&Ident::from(n));
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_block_stmt(&mut self, n: &BlockStmt) {
         self.with_child(n.ctxt, ScopeKind::Block, |child| {
             n.visit_children_with(child);
         });
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_call_expr(&mut self, n: &CallExpr) {
         let inline_prevented = self.ctx.bit_ctx.contains(BitContext::InlinePrevented)
             || self
@@ -478,7 +496,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_catch_clause(&mut self, n: &CatchClause) {
         {
             let ctx = self
@@ -494,7 +515,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_class(&mut self, n: &Class) {
         n.decorators.visit_with(self);
 
@@ -506,14 +530,20 @@ where
         self.with_child(n.ctxt, ScopeKind::Fn, |child| n.body.visit_with(child))
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_class_decl(&mut self, n: &ClassDecl) {
         self.declare_decl(&n.ident, Some(Value::Unknown), None, false);
 
         n.visit_children_with(self);
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_class_expr(&mut self, n: &ClassExpr) {
         n.visit_children_with(self);
 
@@ -522,7 +552,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_class_method(&mut self, n: &ClassMethod) {
         n.function.decorators.visit_with(self);
 
@@ -537,21 +570,30 @@ where
         });
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_class_prop(&mut self, n: &ClassProp) {
         let ctx = self.ctx.with(BitContext::IsIdRef, true);
 
         n.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_computed_prop_name(&mut self, n: &ComputedPropName) {
         let ctx = self.ctx.with(BitContext::IsIdRef, true);
 
         n.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_cond_expr(&mut self, n: &CondExpr) {
         n.test.visit_with(self);
 
@@ -562,7 +604,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_constructor(&mut self, n: &Constructor) {
         self.with_child(n.ctxt, ScopeKind::Fn, |child| {
             {
@@ -595,7 +640,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_do_while_stmt(&mut self, n: &DoWhileStmt) {
         n.body
             .visit_with(&mut *self.with_ctx(self.ctx.with(BitContext::ExecutedMultipleTime, true)));
@@ -603,7 +651,10 @@ where
             .visit_with(&mut *self.with_ctx(self.ctx.with(BitContext::ExecutedMultipleTime, true)));
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_export_decl(&mut self, n: &ExportDecl) {
         n.visit_children_with(self);
 
@@ -625,7 +676,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_export_default_expr(&mut self, n: &ExportDefaultExpr) {
         let ctx = self.ctx.with(BitContext::IsIdRef, true);
 
@@ -644,7 +698,10 @@ where
         };
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip(self, e)))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip(self, e))
+    )]
     fn visit_expr(&mut self, e: &Expr) {
         let ctx = Ctx {
             bit_ctx: self
@@ -675,7 +732,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_expr_or_spread(&mut self, e: &ExprOrSpread) {
         e.visit_children_with(self);
 
@@ -688,7 +748,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_fn_decl(&mut self, n: &FnDecl) {
         let ctx = self
             .ctx
@@ -725,7 +788,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_fn_expr(&mut self, n: &FnExpr) {
         if let Some(n_id) = &n.ident {
             self.data
@@ -760,7 +826,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_for_in_stmt(&mut self, n: &ForInStmt) {
         n.right.visit_with(self);
 
@@ -788,7 +857,10 @@ where
         });
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_for_of_stmt(&mut self, n: &ForOfStmt) {
         n.right.visit_with(self);
 
@@ -813,7 +885,10 @@ where
         });
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_for_stmt(&mut self, n: &ForStmt) {
         n.init.visit_with(self);
 
@@ -827,7 +902,10 @@ where
         self.with_ctx(ctx).visit_in_cond(&n.body);
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_function(&mut self, n: &Function) {
         n.decorators.visit_with(self);
 
@@ -845,7 +923,10 @@ where
             })
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_getter_prop(&mut self, n: &GetterProp) {
         self.with_child(SyntaxContext::empty(), ScopeKind::Fn, |a| {
             n.key.visit_with(a);
@@ -854,7 +935,10 @@ where
         });
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_if_stmt(&mut self, n: &IfStmt) {
         let ctx = self.ctx.with(BitContext::InCond, true);
         n.test.visit_with(self);
@@ -875,7 +959,10 @@ where
         self.declare_decl(&n.local, Some(Value::Unknown), None, false);
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_jsx_element_name(&mut self, n: &JSXElementName) {
         let ctx = Ctx {
             bit_ctx: self
@@ -896,7 +983,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip(self, e)))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip(self, e))
+    )]
     fn visit_member_expr(&mut self, e: &MemberExpr) {
         {
             let ctx = self.ctx.with(BitContext::IsIdRef, false);
@@ -930,7 +1020,10 @@ where
         })
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_method_prop(&mut self, n: &MethodProp) {
         n.function.decorators.visit_with(self);
 
@@ -957,7 +1050,10 @@ where
         n.visit_children_with(self);
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_new_expr(&mut self, n: &NewExpr) {
         {
             n.callee.visit_with(self);
@@ -976,7 +1072,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_param(&mut self, n: &Param) {
         let ctx = self.ctx.with(BitContext::InPatOfParam, false);
         n.decorators.visit_with(&mut *self.with_ctx(ctx));
@@ -993,7 +1092,10 @@ where
         n.pat.visit_with(&mut *self.with_ctx(ctx));
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_pat(&mut self, n: &Pat) {
         match n {
             Pat::Ident(i) => {
@@ -1008,7 +1110,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_private_method(&mut self, n: &PrivateMethod) {
         n.function.decorators.visit_with(self);
 
@@ -1023,13 +1128,19 @@ where
         });
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_private_prop(&mut self, n: &PrivateProp) {
         let ctx = self.ctx.with(BitContext::IsIdRef, true);
         n.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_prop(&mut self, n: &Prop) {
         let ctx = self.ctx.with(BitContext::IsIdRef, true);
         n.visit_children_with(&mut *self.with_ctx(ctx));
@@ -1044,7 +1155,10 @@ where
         n.visit_children_with(&mut *self.with_ctx(ctx))
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_setter_prop(&mut self, n: &SetterProp) {
         self.with_child(SyntaxContext::empty(), ScopeKind::Fn, |a| {
             n.key.visit_with(a);
@@ -1057,7 +1171,10 @@ where
         });
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_spread_element(&mut self, e: &SpreadElement) {
         e.visit_children_with(self);
 
@@ -1068,7 +1185,10 @@ where
         });
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_stmt(&mut self, n: &Stmt) {
         let ctx = self
             .ctx
@@ -1095,7 +1215,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip(self, e)))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip(self, e))
+    )]
     fn visit_super_prop_expr(&mut self, e: &SuperPropExpr) {
         if let SuperProp::Computed(c) = &e.prop {
             let ctx = self.ctx.with(BitContext::IsIdRef, false);
@@ -1108,7 +1231,10 @@ where
         n.visit_children_with(&mut *self.with_ctx(ctx))
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_switch_stmt(&mut self, n: &SwitchStmt) {
         n.discriminant.visit_with(self);
 
@@ -1126,7 +1252,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_tagged_tpl(&mut self, n: &TaggedTpl) {
         {
             let ctx = self.ctx.with(BitContext::IsIdRef, false);
@@ -1140,19 +1269,28 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_tpl(&mut self, n: &Tpl) {
         let ctx = self.ctx.with(BitContext::IsIdRef, false);
         n.visit_children_with(&mut *self.with_ctx(ctx))
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_try_stmt(&mut self, n: &TryStmt) {
         let ctx = self.ctx.with(BitContext::InCond, true);
         self.with_ctx(ctx).visit_children_in_cond(n);
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_unary_expr(&mut self, n: &UnaryExpr) {
         if n.op == op!("delete") {
             self.mark_mutation_if_member(n.arg.as_member());
@@ -1160,7 +1298,10 @@ where
         n.visit_children_with(self);
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_update_expr(&mut self, n: &UpdateExpr) {
         n.visit_children_with(self);
 
@@ -1168,7 +1309,10 @@ where
         self.mark_mutation_if_member(n.arg.as_member());
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_var_decl(&mut self, n: &VarDecl) {
         let ctx = Ctx {
             var_decl_kind_of_pat: Some(n.kind),
@@ -1198,7 +1342,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip(self, e)))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip(self, e))
+    )]
     fn visit_var_declarator(&mut self, e: &VarDeclarator) {
         let prevent_inline = matches!(&e.name, Pat::Ident(BindingIdent {
                 id: Ident { sym: arguments, .. },
@@ -1264,7 +1411,10 @@ where
         }
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_while_stmt(&mut self, n: &WhileStmt) {
         n.test
             .visit_with(&mut *self.with_ctx(self.ctx.with(BitContext::ExecutedMultipleTime, true)));
@@ -1275,7 +1425,10 @@ where
         self.with_ctx(ctx).visit_in_cond(&n.body);
     }
 
-    #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
+    #[cfg_attr(
+        feature = "tracing-spans",
+        tracing::instrument(level = "debug", skip_all)
+    )]
     fn visit_with_stmt(&mut self, n: &WithStmt) {
         self.scope.mark_with_stmt();
         n.visit_children_with(self);

--- a/crates/swc_trace_macro/src/lib.rs
+++ b/crates/swc_trace_macro/src/lib.rs
@@ -24,7 +24,7 @@ pub fn swc_trace(
                 pound_token: Default::default(),
                 style: AttrStyle::Outer,
                 bracket_token: Default::default(),
-                meta: parse_quote!(tracing::instrument(level = "info", skip_all)),
+                meta: parse_quote!(tracing::instrument(level = "debug", skip_all)),
             };
             m.attrs.push(attr);
         }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
ast related tracing contains too much trace data and seems not suitable for info level tracing, so change it to debug level which is same as rustc https://github.com/rust-lang/rust/blob/2ea33b591050c4ca1a3752830b29112638faecf6/compiler/rustc_ast_lowering/src/index.rs#L74
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**
No
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
