### PR TITLE
chore: Enable fat LTO by default

### DIFF
--- a/bindings/Cargo.toml
+++ b/bindings/Cargo.toml
@@ -63,7 +63,7 @@ resolver = "2"
 # lto = true
 
 # We use CARGO_PROFILE_RELEASE_LTO for production builds
-# lto = "fat"
+lto = "fat"
 
 # debug = true
 # opt-level = 'z'
@@ -72,9 +72,6 @@ resolver = "2"
 strip = "symbols"
 
   [profile.release.package]
-
-    [profile.release.package.std]
-    opt-level = 3
 
     [profile.release.package.wasmer-wasix]
     opt-level = "s"


### PR DESCRIPTION
**Description:**

### The binary size of `swc_cli`

#### With fat LTO: `24.3MiB`

#### Without LTO

