### PR TITLE
fix(es/codegen): Handle unicode escapes correctly

### DIFF
--- a/.changeset/beige-walls-type.md
+++ b/.changeset/beige-walls-type.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_codegen: patch
+---
+
+fix(es/codegen): Handle unicode escapes correctly

--- a/crates/swc_ecma_codegen/src/lit.rs
+++ b/crates/swc_ecma_codegen/src/lit.rs
@@ -452,24 +452,32 @@ pub fn get_quoted_utf16(v: &str, ascii_only: bool, target: EsVersion) -> (AsciiC
                             let range = if is_curly {
                                 3..(inner_buf.len() - 1)
                             } else {
-                                2..6
+                                3..7
                             };
 
                             if is_valid {
                                 let val_str = &inner_buf[range];
+                                dbg!(&val_str);
                                 if let Ok(v) = u32::from_str_radix(val_str, 16) {
+                                    dbg!(&v);
+
                                     if v > 0xffff {
+                                        dbg!("push");
                                         buf.push_str(&inner_buf);
                                         let end = if is_curly { 7 } else { 5 };
                                         for _ in 0..end {
                                             iter.next();
                                         }
                                     } else if (0xd800..=0xdfff).contains(&v) {
+                                        dbg!("push: \\");
                                         buf.push('\\');
                                     } else {
+                                        dbg!("push: \\\\");
                                         buf.push_str("\\\\");
                                     }
                                 } else {
+                                    dbg!("push: \\\\ (invalid)");
+
                                     buf.push_str("\\\\");
                                 }
                             } else {

--- a/crates/swc_ecma_codegen/src/lit.rs
+++ b/crates/swc_ecma_codegen/src/lit.rs
@@ -419,7 +419,8 @@ pub fn get_quoted_utf16(v: &str, ascii_only: bool, target: EsVersion) -> (AsciiC
                         }
 
                         if let Some(c @ 'D' | c @ 'd') = next {
-                            let mut inner_buf = String::with_capacity(8);
+                            let mut inner_buf = String::with_capacity(9);
+                            inner_buf.push('\\');
                             inner_buf.push('\\');
                             inner_buf.push('u');
 

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -9796,7 +9796,8 @@ fn issue_4120() {
         r#"
         const a = "\u0591-\u06ef\u06fa-\u08ff\u200f\ud802-\ud803\ud83a-\ud83b\ufb1d-\ufdff\ufe70-\ufefc";
         const b = "A-Za-z\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02b8\u0300-\u0590\u0900-\u1fff\u200e\u2c00-\ud801\ud804-\ud839\ud83c-\udbff\uf900-\ufb1c\ufe00-\ufe6f\ufefd-\uffff";
-        export default { a, b };
+        console.log(a);
+        console.log(b);
         "#,
     );
 }

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -9791,18 +9791,21 @@ fn try_catch_5() {
 }
 
 #[test]
-fn issue_4120() {
+fn issue_4120_1() {
     run_default_exec_test(
         r#"
         const a = "\u0591-\u06ef\u06fa-\u08ff\u200f\ud802-\ud803\ud83a-\ud83b\ufb1d-\ufdff\ufe70-\ufefc";
+        console.log(a);
+        "#,
+    );
+}
+
+#[test]
+fn issue_4120_2() {
+    run_default_exec_test(
+        r#"
         const b = "A-Za-z\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02b8\u0300-\u0590\u0900-\u1fff\u200e\u2c00-\ud801\ud804-\ud839\ud83c-\udbff\uf900-\ufb1c\ufe00-\ufe6f\ufefd-\uffff";
-        function toHex(str) {
-            return str.split("")
-                .map(c => c.charCodeAt(0).toString(16).padStart(2, "0"))
-                .join(" ");
-        }
-        console.log(toHex(a));
-        console.log(toHex(b));
+        console.log(b);
         "#,
     );
 }

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -10958,6 +10958,22 @@ fn issue_7274() {
 }
 
 #[test]
+fn issue_7678() {
+    run_default_exec_test(
+        r#"
+        let str = "\\uD83D\\uDC68\\u200D\\uD83D\\uDE80";
+
+        let obj = {
+            "\\uD83D\\uDC68\\u200D\\uD83D\\uDE80": "wrong"
+        };
+
+        console.log(str);
+        console.log(obj);
+        "#,
+    );
+}
+
+#[test]
 fn issue_8119_1() {
     run_exec_test(
         r#"

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -11477,3 +11477,12 @@ fn issue_10133() {
     ",
     );
 }
+
+#[test]
+fn issue_10353() {
+    run_default_exec_test(
+        r#"
+        console.log("\\"\\\\uD83D\\\\uDE42\\"");
+        "#,
+    );
+}

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -9796,8 +9796,13 @@ fn issue_4120() {
         r#"
         const a = "\u0591-\u06ef\u06fa-\u08ff\u200f\ud802-\ud803\ud83a-\ud83b\ufb1d-\ufdff\ufe70-\ufefc";
         const b = "A-Za-z\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02b8\u0300-\u0590\u0900-\u1fff\u200e\u2c00-\ud801\ud804-\ud839\ud83c-\udbff\uf900-\ufb1c\ufe00-\ufe6f\ufefd-\uffff";
-        console.log(a);
-        console.log(b);
+        function toHex(str) {
+            return str.split("")
+                .map(c => c.charCodeAt(0).toString(16).padStart(2, "0"))
+                .join(" ");
+        }
+        console.log(toHex(a));
+        console.log(toHex(b));
         "#,
     );
 }

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -9791,6 +9791,17 @@ fn try_catch_5() {
 }
 
 #[test]
+fn issue_4120() {
+    run_default_exec_test(
+        r#"
+        const a = "\u0591-\u06ef\u06fa-\u08ff\u200f\ud802-\ud803\ud83a-\ud83b\ufb1d-\ufdff\ufe70-\ufefc";
+        const b = "A-Za-z\u00c0-\u00d6\u00d8-\u00f6\u00f8-\u02b8\u0300-\u0590\u0900-\u1fff\u200e\u2c00-\ud801\ud804-\ud839\ud83c-\udbff\uf900-\ufb1c\ufe00-\ufe6f\ufefd-\uffff";
+        export default { a, b };
+        "#,
+    );
+}
+
+#[test]
 fn issue_4444_1() {
     let src = r#"
     const test = () => {

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -11482,7 +11482,7 @@ fn issue_10133() {
 fn issue_10353() {
     run_default_exec_test(
         r#"
-        console.log("\\"\\\\uD83D\\\\uDE42\\"");
+        console.log("\\uD83D\\uDE42");
         "#,
     );
 }

--- a/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
+++ b/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
@@ -1,10 +1,10 @@
 | File | Original Size | Compressed Size | Gzipped Size |
 | --- | --- | --- | --- |
-| antd.js | 6.38 MiB | 2.06 MiB | 445.44 KiB |
+| antd.js | 6.38 MiB | 2.06 MiB | 445.45 KiB |
 | d3.js | 542.74 KiB | 261.63 KiB | 85.57 KiB |
 | echarts.js | 3.41 MiB | 977.96 KiB | 314.33 KiB |
 | jquery.js | 280.89 KiB | 87.80 KiB | 30.21 KiB |
-| lodash.js | 531.35 KiB | 68.91 KiB | 24.60 KiB |
+| lodash.js | 531.35 KiB | 68.92 KiB | 24.60 KiB |
 | moment.js | 169.83 KiB | 57.40 KiB | 18.26 KiB |
 | react.js | 70.45 KiB | 22.44 KiB | 8.04 KiB |
 | terser.js | 1.08 MiB | 446.78 KiB | 120.52 KiB |


### PR DESCRIPTION
**Description:**


**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/10353