### PR TITLE
fix(@swc/types): Add `resolveFully` to `BaseModuleConfig`

### DIFF
--- a/bindings/binding_core_wasm/src/types.rs
+++ b/bindings/binding_core_wasm/src/types.rs
@@ -1088,7 +1088,7 @@ export interface BaseModuleConfig {
   importInterop?: "swc" | "babel" | "node" | "none";
   /**
    * Output extension for generated files.
-   * 
+   *
    * Defaults to `js`.
   */
   outFileExtension?: "js" | "mjs" | "cjs";
@@ -1096,7 +1096,7 @@ export interface BaseModuleConfig {
    * Emits `cjs-module-lexer` annotation
    * `cjs-module-lexer` is used in Node.js core for detecting the named exports available when importing a CJS module into ESM.
    * swc will emit `cjs-module-lexer` detectable annotation with this option enabled.
-   * 
+   *
    * Defaults to `true` if import_interop is Node, else `false`
    */
   exportInteropAnnotation?: boolean;
@@ -1106,6 +1106,10 @@ export interface BaseModuleConfig {
   ignoreDynamic?: boolean;
   allowTopLevelThis?: boolean;
   preserveImportMeta?: boolean;
+  /**
+   * If set to true, This will resolve top .mjs
+   */
+  resolveFully?: boolean;
 }
 
 export interface Es6Config extends BaseModuleConfig {

--- a/bindings/binding_minifier_wasm/src/types.rs
+++ b/bindings/binding_minifier_wasm/src/types.rs
@@ -1089,7 +1089,7 @@ export interface BaseModuleConfig {
   importInterop?: "swc" | "babel" | "node" | "none";
   /**
    * Output extension for generated files.
-   * 
+   *
    * Defaults to `js`.
   */
   outFileExtension?: "js" | "mjs" | "cjs";
@@ -1097,7 +1097,7 @@ export interface BaseModuleConfig {
    * Emits `cjs-module-lexer` annotation
    * `cjs-module-lexer` is used in Node.js core for detecting the named exports available when importing a CJS module into ESM.
    * swc will emit `cjs-module-lexer` detectable annotation with this option enabled.
-   * 
+   *
    * Defaults to `true` if import_interop is Node, else `false`
    */
   exportInteropAnnotation?: boolean;
@@ -1107,6 +1107,10 @@ export interface BaseModuleConfig {
   ignoreDynamic?: boolean;
   allowTopLevelThis?: boolean;
   preserveImportMeta?: boolean;
+  /**
+   * If set to true, This will resolve top .mjs
+   */
+  resolveFully?: boolean;
 }
 
 export interface Es6Config extends BaseModuleConfig {

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -351,7 +351,7 @@ export interface TerserMangleOptions {
     reserved?: string[];
 }
 
-export interface TerserManglePropertiesOptions { }
+export interface TerserManglePropertiesOptions {}
 
 /**
  * Programmatic options.
@@ -915,27 +915,27 @@ export interface ReactConfig {
      * Enable fast refresh feature for React app
      */
     refresh?:
-    | boolean
-    | {
-        /**
-         * Identifier for the `react-refresh` register function.
-         *
-         * Defaults to `$RefreshReg$`
-         */
-        refreshReg?: string;
-        /**
-         * Identifier for the `react-refresh` signature function.
-         *
-         * Defaults to `$RefreshSig$`
-         */
-        refreshSig?: string;
-        /**
-         * Flag to emit full signatures.
-         *
-         * Defaults to `false`
-         */
-        emitFullSignatures?: boolean;
-    };
+        | boolean
+        | {
+              /**
+               * Identifier for the `react-refresh` register function.
+               *
+               * Defaults to `$RefreshReg$`
+               */
+              refreshReg?: string;
+              /**
+               * Identifier for the `react-refresh` signature function.
+               *
+               * Defaults to `$RefreshSig$`
+               */
+              refreshSig?: string;
+              /**
+               * Flag to emit full signatures.
+               *
+               * Defaults to `false`
+               */
+              emitFullSignatures?: boolean;
+          };
 
     /**
      * jsx runtime
@@ -1162,7 +1162,7 @@ export interface BaseModuleConfig {
     importInterop?: "swc" | "babel" | "node" | "none";
     /**
      * Output extension for generated files.
-     * 
+     *
      * Defaults to `js`.
      */
     outFileExtension?: "js" | "mjs" | "cjs";
@@ -1180,6 +1180,10 @@ export interface BaseModuleConfig {
     ignoreDynamic?: boolean;
     allowTopLevelThis?: boolean;
     preserveImportMeta?: boolean;
+    /**
+     * If set to true, This will resolve top .mjs
+     */
+    resolveFully?: boolean;
 }
 
 export interface Es6Config extends BaseModuleConfig {
@@ -1218,7 +1222,7 @@ export interface Output {
     map?: string;
 }
 
-export interface MatchPattern { }
+export interface MatchPattern {}
 
 // -------------------------------
 // ---------- Ast nodes ----------
@@ -1450,7 +1454,7 @@ export type Expression =
     | OptionalChainingExpression
     | Invalid;
 
-interface ExpressionBase extends Node, HasSpan { }
+interface ExpressionBase extends Node, HasSpan {}
 
 export interface Identifier extends ExpressionBase {
     type: "Identifier";
@@ -2918,19 +2922,18 @@ export interface Invalid extends Node, HasSpan {
     type: "Invalid";
 }
 
-
 export type WasmAnalysisOptions = {
-    parser?: ParserConfig,
+    parser?: ParserConfig;
 
-    module?: true | false | 'unknown'
+    module?: true | false | "unknown";
 
     filename?: string;
 
-    errorFormat?: 'json' | 'normal'
+    errorFormat?: "json" | "normal";
 
     cacheRoot?: string;
 
-    plugins: WasmPlugin[]
-}
+    plugins: WasmPlugin[];
+};
 
-export type WasmPlugin = [wasmPackage: string, config: Record<string, any>]
+export type WasmPlugin = [wasmPackage: string, config: Record<string, any>];


### PR DESCRIPTION
**Description:**
This PR adds `resolveFully` to `BaseModuleConfig`  because `resolveFully` is missing.


**Related issue:**

 - Closes #9672 