### PR TITLE
feat(es/typescript): expose native_class_properties in jsc.transform config

### DIFF
--- a/crates/swc/tests/fixture/issues-6xxx/6985/useDefineForClassFields/2022_TS/output/index.ts
+++ b/crates/swc/tests/fixture/issues-6xxx/6985/useDefineForClassFields/2022_TS/output/index.ts
@@ -1,12 +1,10 @@
 class Foo {
     foo;
-    a;
-    #b;
+    a = 1;
+    #b = 2;
     static c = 3;
     static #d = 4;
     constructor(foo){
         this.foo = foo;
-        this.a = 1;
-        this.#b = 2;
     }
 }

--- a/crates/swc/tests/tsc-references/assignParameterPropertyToPropertyDeclarationES2022.1.normal.js
+++ b/crates/swc/tests/tsc-references/assignParameterPropertyToPropertyDeclarationES2022.1.normal.js
@@ -1,38 +1,29 @@
 //// [assignParameterPropertyToPropertyDeclarationES2022.ts]
 class C {
     foo;
-    qux;
-    bar;
-    quiz;
-    quench;
-    quanch;
+    qux = this.bar // should error
+    ;
+    bar = this.foo // should error
+    ;
+    quiz = this.bar // ok
+    ;
+    quench = this.m1() // ok
+    ;
+    quanch = this.m3() // should error
+    ;
     m1() {
         this.foo // ok
         ;
     }
-    m3;
+    m3 = function() {};
     constructor(foo){
         this.foo = foo;
-        this.qux = this.bar // should error
-        ;
-        this.bar = this.foo // should error
-        ;
-        this.quiz = this.bar // ok
-        ;
-        this.quench = this.m1() // ok
-        ;
-        this.quanch = this.m3() // should error
-        ;
-        this.m3 = function() {};
-        this.quim = this.baz // should error
-        ;
-        this.baz = this.foo;
-        this.quid = this.baz // ok
-        ;
     }
-    quim;
-    baz;
-    quid;
+    quim = this.baz // should error
+    ;
+    baz = this.foo;
+    quid = this.baz // ok
+    ;
     m2() {
         this.foo // ok
         ;
@@ -44,12 +35,10 @@ class D extends C {
 }
 class E {
     foo2;
-    bar;
-    foo1;
+    bar = ()=>this.foo1 + this.foo2;
+    foo1 = '';
     constructor(foo2){
         this.foo2 = foo2;
-        this.bar = ()=>this.foo1 + this.foo2;
-        this.foo1 = '';
     }
 }
 class F {
@@ -60,23 +49,20 @@ class F {
 }
 class G {
     p1;
-    Inner;
+    Inner = class extends G {
+        p2 = this.p1;
+    };
     constructor(p1){
         this.p1 = p1;
-        this.Inner = class extends G {
-            p2 = this.p1;
-        };
     }
 }
 class H {
     p1;
     constructor(p1){
         this.p1 = p1;
-        this.p2 = ()=>{
-            return this.p1.foo;
-        };
-        this.p3 = ()=>this.p1.foo;
     }
-    p2;
-    p3;
+    p2 = ()=>{
+        return this.p1.foo;
+    };
+    p3 = ()=>this.p1.foo;
 }

--- a/crates/swc/tests/tsc-references/assignParameterPropertyToPropertyDeclarationES2022.2.minified.js
+++ b/crates/swc/tests/tsc-references/assignParameterPropertyToPropertyDeclarationES2022.2.minified.js
@@ -5,3 +5,12 @@ class F {
     };
     p1 = 0;
 }
+class G {
+    p1;
+    Inner = class extends G {
+        p2 = this.p1;
+    };
+    constructor(p1){
+        this.p1 = p1;
+    }
+}

--- a/crates/swc/tests/tsc-references/assignParameterPropertyToPropertyDeclarationESNext.1.normal.js
+++ b/crates/swc/tests/tsc-references/assignParameterPropertyToPropertyDeclarationESNext.1.normal.js
@@ -1,38 +1,29 @@
 //// [assignParameterPropertyToPropertyDeclarationESNext.ts]
 class C {
     foo;
-    qux;
-    bar;
-    quiz;
-    quench;
-    quanch;
+    qux = this.bar // should error
+    ;
+    bar = this.foo // should error
+    ;
+    quiz = this.bar // ok
+    ;
+    quench = this.m1() // ok
+    ;
+    quanch = this.m3() // should error
+    ;
     m1() {
         this.foo // ok
         ;
     }
-    m3;
+    m3 = function() {};
     constructor(foo){
         this.foo = foo;
-        this.qux = this.bar // should error
-        ;
-        this.bar = this.foo // should error
-        ;
-        this.quiz = this.bar // ok
-        ;
-        this.quench = this.m1() // ok
-        ;
-        this.quanch = this.m3() // should error
-        ;
-        this.m3 = function() {};
-        this.quim = this.baz // should error
-        ;
-        this.baz = this.foo;
-        this.quid = this.baz // ok
-        ;
     }
-    quim;
-    baz;
-    quid;
+    quim = this.baz // should error
+    ;
+    baz = this.foo;
+    quid = this.baz // ok
+    ;
     m2() {
         this.foo // ok
         ;
@@ -44,12 +35,10 @@ class D extends C {
 }
 class E {
     foo2;
-    bar;
-    foo1;
+    bar = ()=>this.foo1 + this.foo2;
+    foo1 = '';
     constructor(foo2){
         this.foo2 = foo2;
-        this.bar = ()=>this.foo1 + this.foo2;
-        this.foo1 = '';
     }
 }
 class F {
@@ -60,23 +49,20 @@ class F {
 }
 class G {
     p1;
-    Inner;
+    Inner = class extends G {
+        p2 = this.p1;
+    };
     constructor(p1){
         this.p1 = p1;
-        this.Inner = class extends G {
-            p2 = this.p1;
-        };
     }
 }
 class H {
     p1;
     constructor(p1){
         this.p1 = p1;
-        this.p2 = ()=>{
-            return this.p1.foo;
-        };
-        this.p3 = ()=>this.p1.foo;
     }
-    p2;
-    p3;
+    p2 = ()=>{
+        return this.p1.foo;
+    };
+    p3 = ()=>this.p1.foo;
 }

--- a/crates/swc/tests/tsc-references/assignParameterPropertyToPropertyDeclarationESNext.2.minified.js
+++ b/crates/swc/tests/tsc-references/assignParameterPropertyToPropertyDeclarationESNext.2.minified.js
@@ -5,3 +5,12 @@ class F {
     };
     p1 = 0;
 }
+class G {
+    p1;
+    Inner = class extends G {
+        p2 = this.p1;
+    };
+    constructor(p1){
+        this.p1 = p1;
+    }
+}

--- a/crates/swc/tests/tsc-references/defineProperty(target=esnext).1.normal.js
+++ b/crates/swc/tests/tsc-references/defineProperty(target=esnext).1.normal.js
@@ -2,30 +2,25 @@
 var x = "p";
 class A {
     y;
-    a;
+    a = this.y;
     b;
     c;
-    ["computed"];
-    [_x = x];
+    ["computed"] = 13;
+    [x] = 14;
     m() {}
     constructor(y){
         this.y = y;
-        this.a = this.y;
-        this["computed"] = 13;
-        this[_x] = 14;
-        this.z = this.y;
     }
-    z;
+    z = this.y;
 }
 class B {
     a;
 }
 class C extends B {
     ka;
-    z;
+    z = this.ka;
     constructor(ka){
-        super(), this.ka = ka, this.z = this.ka, this.ki = this.ka;
+        super(), this.ka = ka;
     }
-    ki;
+    ki = this.ka;
 }
-var _x;

--- a/crates/swc/tests/tsc-references/redefinedPararameterProperty.1.normal.js
+++ b/crates/swc/tests/tsc-references/redefinedPararameterProperty.1.normal.js
@@ -4,8 +4,8 @@ class Base {
 }
 class Derived extends Base {
     a;
-    b;
+    b = this.a /*undefined*/ ;
     constructor(a){
-        super(), this.a = a, this.b = this.a /*undefined*/ ;
+        super(), this.a = a;
     }
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

The `native_class_properties` option was added in https://github.com/swc-project/swc/commit/d2929d1ce61a00360cc0596441041571a958da23 to address https://github.com/swc-project/swc/issues/9418.

However, it was not actually exposed  for users to set.

Arguably it should be set automatically, in order to make the behavior match `tsc` and `esbuild`, but that may change behavior for users unexpectedly.

**Related issue (if exists):**

https://github.com/swc-project/swc/issues/9418
https://github.com/web-infra-dev/rspack/issues/10260
