### PR TITLE
fix(es/react-compiler): Mark function components declared as a var interesting

### DIFF
--- a/crates/swc_ecma_react_compiler/src/fast_check.rs
+++ b/crates/swc_ecma_react_compiler/src/fast_check.rs
@@ -77,6 +77,8 @@ impl Visit for Finder {
         if let Pat::Ident(ident) = &node.name {
             self.is_interested = ident.sym.starts_with("use")
                 || ident.sym.starts_with(|c: char| c.is_ascii_uppercase());
+        } else {
+            self.is_interested = false;
         }
 
         node.visit_children_with(self);

--- a/crates/swc_ecma_react_compiler/src/fast_check.rs
+++ b/crates/swc_ecma_react_compiler/src/fast_check.rs
@@ -1,4 +1,4 @@
-use swc_ecma_ast::{Callee, Expr, FnDecl, FnExpr, Program, ReturnStmt};
+use swc_ecma_ast::{Callee, Expr, FnDecl, FnExpr, Pat, Program, ReturnStmt, VarDeclarator};
 use swc_ecma_visit::{Visit, VisitWith};
 
 /// Returns true if the `program` is a good target for the react compiler.
@@ -69,5 +69,18 @@ impl Visit for Finder {
         }
 
         node.visit_children_with(self);
+    }
+
+    fn visit_var_declarator(&mut self, node: &VarDeclarator) {
+        let old = self.is_interested;
+
+        if let Pat::Ident(ident) = &node.name {
+            self.is_interested = ident.sym.starts_with("use")
+                || ident.sym.starts_with(|c: char| c.is_ascii_uppercase());
+        }
+
+        node.visit_children_with(self);
+
+        self.is_interested = old;
     }
 }


### PR DESCRIPTION
**Description:**


**Related issue:**

 - https://github.com/vercel/next.js/issues/78867