### PR TITLE
perf(es/optimization): Rely on `resolver` from `inline_globals`

### DIFF
--- a/.changeset/silver-shirts-end.md
+++ b/.changeset/silver-shirts-end.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_transforms_optimization: major
+---
+
+perf(es/optimization): Rely on `resolver` from `inline_globals`

--- a/crates/swc/src/builder.rs
+++ b/crates/swc/src/builder.rs
@@ -131,7 +131,7 @@ impl<'a, 'b, P: Pass> PassBuilder<'a, 'b, P> {
     }
 
     pub fn inline_globals(self, c: GlobalPassOption) -> PassBuilder<'a, 'b, (P, impl Pass)> {
-        let pass = c.build(self.cm, self.handler);
+        let pass = c.build(self.cm, self.handler, self.unresolved_mark);
         self.then(pass)
     }
 

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -60,7 +60,7 @@ use swc_ecma_transforms::{
 };
 use swc_ecma_transforms_compat::es2015::regenerator;
 use swc_ecma_transforms_optimization::{
-    inline_globals2,
+    inline_globals,
     simplify::{dce::Config as DceConfig, Config as SimplifyConfig},
     GlobalExprMap,
 };
@@ -1708,7 +1708,7 @@ impl GlobalPassOption {
             }
         };
 
-        inline_globals2(env_map, global_map, global_exprs, Arc::new(self.typeofs))
+        inline_globals(env_map, global_map, global_exprs, Arc::new(self.typeofs))
     }
 }
 

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -498,7 +498,7 @@ impl Options {
         let optimization = {
             optimizer
                 .and_then(|o| o.globals)
-                .map(|opts| opts.build(cm, handler))
+                .map(|opts| opts.build(cm, handler, unresolved_mark))
         };
 
         let unresolved_ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
@@ -1554,7 +1554,12 @@ impl Default for GlobalInliningPassEnvs {
 }
 
 impl GlobalPassOption {
-    pub fn build(self, cm: &SourceMap, handler: &Handler) -> impl 'static + Pass {
+    pub(crate) fn build(
+        self,
+        cm: &SourceMap,
+        handler: &Handler,
+        unresolved_mark: Mark,
+    ) -> impl 'static + Pass {
         type ValuesMap = Arc<FxHashMap<Atom, Expr>>;
 
         fn expr(cm: &SourceMap, handler: &Handler, src: String) -> Box<Expr> {
@@ -1708,7 +1713,13 @@ impl GlobalPassOption {
             }
         };
 
-        inline_globals(env_map, global_map, global_exprs, Arc::new(self.typeofs))
+        inline_globals(
+            unresolved_mark,
+            env_map,
+            global_map,
+            global_exprs,
+            Arc::new(self.typeofs),
+        )
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/lib.rs
+++ b/crates/swc_ecma_transforms_optimization/src/lib.rs
@@ -5,7 +5,7 @@
 pub use self::{
     const_modules::const_modules,
     debug::{debug_assert_valid, AssertValid},
-    inline_globals::{inline_globals, inline_globals2, GlobalExprMap},
+    inline_globals::{inline_globals, GlobalExprMap},
     json_parse::json_parse,
     simplify::simplifier,
 };

--- a/crates/swc_node_bundler/src/loaders/swc.rs
+++ b/crates/swc_node_bundler/src/loaders/swc.rs
@@ -185,7 +185,9 @@ impl SwcLoader {
                     ));
 
                     program.mutate(&mut inline_globals(
+                        unresolved_mark,
                         self.env_map(),
+                        Default::default(),
                         Default::default(),
                         Default::default(),
                     ));
@@ -280,7 +282,9 @@ impl SwcLoader {
                         ));
 
                         program.mutate(&mut inline_globals(
+                            unresolved_mark,
                             self.env_map(),
+                            Default::default(),
                             Default::default(),
                             Default::default(),
                         ));


### PR DESCRIPTION
**Description:**

We don't need to collect bindings