### PR TITLE
perf(es/minifier): Use `bitflags` for var info

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/hoist_decls.rs
+++ b/crates/swc_ecma_minifier/src/compress/hoist_decls.rs
@@ -8,7 +8,7 @@ use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith, VisitWith};
 
 use super::util::drop_invalid_stmts;
 use crate::{
-    program_data::ProgramData,
+    program_data::{ProgramData, VarUsageInfoFlags},
     util::{is_hoisted_var_decl_without_init, sort::is_sorted_by, IsModuleItem, ModuleItemExt},
 };
 
@@ -61,7 +61,7 @@ impl Hoister<'_> {
                             self.data
                                 .vars
                                 .get(id)
-                                .map(|v| !v.used_above_decl)
+                                .map(|v| !v.flags.contains(VarUsageInfoFlags::USED_ABOVE_DECL))
                                 .unwrap_or(false)
                         }) {
                             2
@@ -130,7 +130,11 @@ impl Hoister<'_> {
                                                 .data
                                                 .vars
                                                 .get(&id.to_id())
-                                                .map(|v| v.declared_as_fn_param)
+                                                .map(|v| {
+                                                    v.flags.contains(
+                                                        VarUsageInfoFlags::DECLARED_AS_FN_PARAM,
+                                                    )
+                                                })
                                                 .unwrap_or(false)
                                         {
                                             continue;
@@ -212,7 +216,11 @@ impl Hoister<'_> {
                                                 .data
                                                 .vars
                                                 .get(&name.to_id())
-                                                .map(|v| v.declared_as_fn_param)
+                                                .map(|v| {
+                                                    v.flags.contains(
+                                                        VarUsageInfoFlags::DECLARED_AS_FN_PARAM,
+                                                    )
+                                                })
                                                 .unwrap_or(false)
                                         {
                                             return false;

--- a/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/bools.rs
@@ -3,6 +3,7 @@ use swc_ecma_ast::*;
 use swc_ecma_utils::{ExprExt, Type, Value};
 
 use super::Optimizer;
+use crate::program_data::VarUsageInfoFlags;
 
 /// Methods related to the options `bools` and `bool_as_ints`.
 impl Optimizer<'_> {
@@ -22,7 +23,7 @@ impl Optimizer<'_> {
                     // TODO?
                     if let Expr::Ident(arg) = &**arg {
                         if let Some(usage) = o.data.vars.get(&arg.to_id()) {
-                            if !usage.declared {
+                            if !usage.flags.contains(VarUsageInfoFlags::DECLARED) {
                                 return false;
                             }
                         }

--- a/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
@@ -12,6 +12,7 @@ use crate::{
         optimize::BitCtx,
         util::{negate, negate_cost},
     },
+    program_data::VarUsageInfoFlags,
     DISABLE_BUGGY_PASSES,
 };
 
@@ -398,7 +399,11 @@ impl Optimizer<'_> {
                     .data
                     .vars
                     .get(&cons_callee.to_id())
-                    .map(|v| v.is_fn_local && v.declared)
+                    .map(|v| {
+                        v.flags.contains(
+                            VarUsageInfoFlags::IS_FN_LOCAL.union(VarUsageInfoFlags::DECLARED),
+                        )
+                    })
                     .unwrap_or(false);
 
                 if side_effect_free

--- a/crates/swc_ecma_minifier/src/compress/optimize/dead_code.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/dead_code.rs
@@ -2,6 +2,7 @@ use swc_common::util::take::Take;
 use swc_ecma_ast::*;
 
 use super::{BitCtx, Optimizer};
+use crate::program_data::VarUsageInfoFlags;
 
 /// Methods related to option `dead_code`.
 impl Optimizer<'_> {
@@ -51,7 +52,11 @@ impl Optimizer<'_> {
                     .data
                     .vars
                     .get(&lhs.to_id())
-                    .map(|var| var.declared && var.is_fn_local && !var.declared_as_fn_param)
+                    .map(|var| {
+                        var.flags.contains(
+                            VarUsageInfoFlags::DECLARED.union(VarUsageInfoFlags::IS_FN_LOCAL),
+                        ) && !var.flags.contains(VarUsageInfoFlags::DECLARED_AS_FN_PARAM)
+                    })
                     .unwrap_or(false)
                 {
                     report_change!(
@@ -78,7 +83,11 @@ impl Optimizer<'_> {
                         .data
                         .vars
                         .get(&lhs.to_id())
-                        .map(|var| var.declared && var.is_fn_local)
+                        .map(|var| {
+                            var.flags.contains(
+                                VarUsageInfoFlags::DECLARED.union(VarUsageInfoFlags::IS_FN_LOCAL),
+                            )
+                        })
                         .unwrap_or(false)
                     {
                         report_change!(

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -156,7 +156,7 @@ impl Optimizer<'_> {
         };
 
         if let Some(scope) = find_scope(self.data, callee) {
-            if scope.used_arguments {
+            if scope.contains(ScopeData::USED_ARGUMENTS) {
                 log_abort!("iife: [x] Found usage of arguments");
                 return;
             }
@@ -792,7 +792,7 @@ impl Optimizer<'_> {
         // We completely abort on eval, because we cannot know whether a variable in
         // upper scope will be afftected by eval.
         // https://github.com/swc-project/swc/issues/6628
-        if self.data.top.has_eval_call {
+        if self.data.top.contains(ScopeData::HAS_EVAL_CALL) {
             log_abort!("iife: [x] Aborting because of eval");
             return false;
         }

--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -8,7 +8,7 @@ use swc_ecma_visit::VisitMutWith;
 use super::Optimizer;
 use crate::{
     compress::optimize::{util::is_valid_for_lhs, BitCtx},
-    program_data::{VarUsageInfo, VarUsageInfoFlags},
+    program_data::{ScopeData, VarUsageInfo, VarUsageInfoFlags},
     util::{
         idents_captured_by, idents_used_by, idents_used_by_ignoring_nested, size::SizeWithCtxt,
     },
@@ -34,7 +34,7 @@ impl Optimizer<'_> {
             may_remove
         );
 
-        if self.data.top.has_eval_call {
+        if self.data.top.contains(ScopeData::HAS_EVAL_CALL) {
             return;
         }
 
@@ -49,7 +49,7 @@ impl Optimizer<'_> {
                 return;
             }
 
-            if self.data.top.used_arguments
+            if self.data.top.contains(ScopeData::USED_ARGUMENTS)
                 && usage
                     .flags
                     .contains(VarUsageInfoFlags::DECLARED_AS_FN_PARAM)
@@ -667,7 +667,11 @@ impl Optimizer<'_> {
             return;
         }
 
-        if self.data.top.has_eval_call || self.data.top.has_with_stmt {
+        if self
+            .data
+            .top
+            .intersects(ScopeData::HAS_EVAL_CALL.union(ScopeData::HAS_WITH_STMT))
+        {
             return;
         }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -30,7 +30,7 @@ use crate::{
     maybe_par,
     mode::Mode,
     option::{CompressOptions, MangleOptions},
-    program_data::{ProgramData, VarUsageInfo},
+    program_data::{ProgramData, VarUsageInfoFlags},
     util::{
         contains_eval, contains_leaping_continue_with_label, make_number, ExprOptExt, ModuleItemExt,
     },
@@ -333,8 +333,11 @@ impl From<&Function> for FnMetadata {
 
 impl Optimizer<'_> {
     fn may_remove_ident(&self, id: &Ident) -> bool {
-        if let Some(VarUsageInfo { exported: true, .. }) =
-            self.data.vars.get(&id.clone().to_id()).map(|v| &**v)
+        if self
+            .data
+            .vars
+            .get(&id.to_id())
+            .is_some_and(|v| v.flags.contains(VarUsageInfoFlags::EXPORTED))
         {
             return false;
         }
@@ -787,7 +790,9 @@ impl Optimizer<'_> {
                 if let Expr::Ident(callee) = &**callee {
                     if self.options.reduce_vars && self.options.side_effects {
                         if let Some(usage) = self.data.vars.get(&callee.to_id()) {
-                            if !usage.reassigned && usage.pure_fn {
+                            if !usage.flags.contains(VarUsageInfoFlags::REASSIGNED)
+                                && usage.flags.contains(VarUsageInfoFlags::PURE_FN)
+                            {
                                 self.changed = true;
                                 report_change!("Reducing function call to a variable");
 
@@ -2933,7 +2938,10 @@ impl VisitMut for Optimizer<'_> {
                 if let Some(Expr::Invalid(..)) = var.init.as_deref() {
                     if let Pat::Ident(i) = &var.name {
                         if let Some(usage) = self.data.vars.get(&i.id.to_id()) {
-                            if usage.declared_as_catch_param {
+                            if usage
+                                .flags
+                                .contains(VarUsageInfoFlags::DECLARED_AS_CATCH_PARAM)
+                            {
                                 var.init = None;
                                 debug_assert_valid(var);
                                 return true;

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -23,6 +23,7 @@ use crate::{
         util::{is_directive, is_ident_used_by, replace_expr},
     },
     option::CompressOptions,
+    program_data::VarUsageInfoFlags,
     util::{
         idents_used_by, idents_used_by_ignoring_nested, ExprOptExt, IdentUsageCollector,
         ModuleItemExt,
@@ -391,7 +392,8 @@ impl Optimizer<'_> {
                 })) => {
                     if let Some(id) = obj.as_ident() {
                         if let Some(usage) = self.data.vars.get(&id.to_id()) {
-                            id.ctxt != self.ctx.expr_ctx.unresolved_ctxt && !usage.reassigned
+                            id.ctxt != self.ctx.expr_ctx.unresolved_ctxt
+                                && !usage.flags.contains(VarUsageInfoFlags::REASSIGNED)
                         } else {
                             false
                         }
@@ -795,30 +797,33 @@ impl Optimizer<'_> {
                     // Merge sequentially
 
                     match b {
-                        Mergable::Var(b) => match b.init.as_deref_mut() {
-                            Some(b) => {
-                                if !merge_seq_cache.is_top_retain(self, a, a_idx)
-                                    && self.merge_sequential_expr(a, b)?
-                                {
-                                    changed = true;
-                                    merge_seq_cache.invalidate(a_idx);
-                                    merge_seq_cache.invalidate(b_idx);
-                                    break;
-                                }
-                            }
-                            None => {
-                                if let Mergable::Expr(Expr::Assign(a_exp)) = a {
-                                    if let (Some(a_id), Some(b_id)) =
-                                        (a_exp.left.as_ident(), b.name.as_ident())
+                        Mergable::Var(b) => {
+                            match b.init.as_deref_mut() {
+                                Some(b) => {
+                                    if !merge_seq_cache.is_top_retain(self, a, a_idx)
+                                        && self.merge_sequential_expr(a, b)?
                                     {
-                                        if a_id.id.eq_ignore_span(&b_id.id)
+                                        changed = true;
+                                        merge_seq_cache.invalidate(a_idx);
+                                        merge_seq_cache.invalidate(b_idx);
+                                        break;
+                                    }
+                                }
+                                None => {
+                                    if let Mergable::Expr(Expr::Assign(a_exp)) = a {
+                                        if let (Some(a_id), Some(b_id)) =
+                                            (a_exp.left.as_ident(), b.name.as_ident())
+                                        {
+                                            if a_id.id.eq_ignore_span(&b_id.id)
                                             && a_exp.op == op!("=")
                                             && self
                                                 .data
                                                 .vars
                                                 .get(&a_id.id.to_id())
                                                 .map(|u| {
-                                                    !u.inline_prevented && !u.declared_as_fn_expr
+                                                    !u.flags.intersects(
+                                                        VarUsageInfoFlags::INLINE_PREVENTED.union(VarUsageInfoFlags::DECLARED_AS_FN_EXPR)
+                                                    )
                                                 })
                                                 .unwrap_or(false)
                                         {
@@ -834,12 +839,13 @@ impl Optimizer<'_> {
 
                                             break;
                                         }
+                                        }
                                     }
-                                }
 
-                                continue;
+                                    continue;
+                                }
                             }
-                        },
+                        }
                         Mergable::Expr(b) => {
                             if !merge_seq_cache.is_top_retain(self, a, a_idx)
                                 && self.merge_sequential_expr(a, b)?
@@ -1433,7 +1439,12 @@ impl Optimizer<'_> {
                     }
                     _ => a.may_have_side_effects(self.ctx.expr_ctx),
                 };
-                if has_side_effect && !usgae.is_fn_local && (usgae.exported || usgae.reassigned) {
+                if has_side_effect
+                    && !usgae.flags.contains(VarUsageInfoFlags::IS_FN_LOCAL)
+                    && (usgae.flags.intersects(
+                        VarUsageInfoFlags::EXPORTED.union(VarUsageInfoFlags::REASSIGNED),
+                    ))
+                {
                     log_abort!("a (expr) has side effect");
                     return false;
                 }
@@ -1441,8 +1452,10 @@ impl Optimizer<'_> {
             Mergable::Var(a) => {
                 if let Some(init) = &a.init {
                     if init.may_have_side_effects(self.ctx.expr_ctx)
-                        && !usgae.is_fn_local
-                        && (usgae.exported || usgae.reassigned)
+                        && !usgae.flags.contains(VarUsageInfoFlags::IS_FN_LOCAL)
+                        && (usgae.flags.intersects(
+                            VarUsageInfoFlags::EXPORTED.union(VarUsageInfoFlags::REASSIGNED),
+                        ))
                     {
                         log_abort!("a (var) init has side effect");
                         return false;
@@ -1698,8 +1711,10 @@ impl Optimizer<'_> {
                             if let Some(left_obj) = b_left.obj.as_ident() {
                                 if let Some(usage) = self.data.vars.get(&left_obj.to_id()) {
                                     if left_obj.ctxt != self.ctx.expr_ctx.unresolved_ctxt
-                                        && !usage.inline_prevented
-                                        && !usage.reassigned
+                                        && !usage
+                                            .flags
+                                            .contains(VarUsageInfoFlags::INLINE_PREVENTED)
+                                        && !usage.flags.contains(VarUsageInfoFlags::REASSIGNED)
                                         && !b_left.prop.is_computed()
                                     {
                                         match &*a {
@@ -2229,7 +2244,7 @@ impl Optimizer<'_> {
                         };
 
                         if let Some(usage) = self.data.vars.get(&left_id.to_id()) {
-                            if usage.inline_prevented {
+                            if usage.flags.contains(VarUsageInfoFlags::INLINE_PREVENTED) {
                                 return Ok(false);
                             }
 
@@ -2238,7 +2253,7 @@ impl Optimizer<'_> {
                                 return Ok(false);
                             }
 
-                            if usage.declared_as_fn_expr {
+                            if usage.flags.contains(VarUsageInfoFlags::DECLARED_AS_FN_EXPR) {
                                 log_abort!(
                                     "sequences: Declared as fn expr ({}, {:?})",
                                     left_id.sym,
@@ -2248,10 +2263,12 @@ impl Optimizer<'_> {
                             }
 
                             // We can remove this variable same as unused pass
-                            if !usage.reassigned
-                                && usage.usage_count == 1
-                                && usage.declared
-                                && !usage.used_recursively
+                            if usage.usage_count == 1
+                                && usage.flags.contains(VarUsageInfoFlags::DECLARED)
+                                && !usage.flags.intersects(
+                                    VarUsageInfoFlags::USED_RECURSIVELY
+                                        .union(VarUsageInfoFlags::REASSIGNED),
+                                )
                             {
                                 can_remove = true;
                             }
@@ -2277,7 +2294,10 @@ impl Optimizer<'_> {
                         _ => false,
                     };
 
-                    if usage.ref_count != 1 || usage.reassigned || !usage.is_fn_local {
+                    if usage.ref_count != 1
+                        || usage.flags.contains(VarUsageInfoFlags::REASSIGNED)
+                        || !usage.flags.contains(VarUsageInfoFlags::IS_FN_LOCAL)
+                    {
                         if is_lit {
                             can_take_init = false
                         } else {
@@ -2287,7 +2307,10 @@ impl Optimizer<'_> {
                         can_take_init = true;
                     }
 
-                    if usage.inline_prevented || usage.used_recursively {
+                    if usage.flags.intersects(
+                        VarUsageInfoFlags::INLINE_PREVENTED
+                            .union(VarUsageInfoFlags::USED_RECURSIVELY),
+                    ) {
                         return Ok(false);
                     }
 
@@ -2309,11 +2332,14 @@ impl Optimizer<'_> {
 
             Mergable::FnDecl(a) => {
                 if let Some(usage) = self.data.vars.get(&a.ident.to_id()) {
-                    if usage.ref_count != 1 || usage.reassigned || !usage.is_fn_local {
+                    if usage.ref_count != 1
+                        || usage.flags.contains(VarUsageInfoFlags::REASSIGNED)
+                        || !usage.flags.contains(VarUsageInfoFlags::IS_FN_LOCAL)
+                    {
                         return Ok(false);
                     }
 
-                    if usage.inline_prevented {
+                    if usage.flags.contains(VarUsageInfoFlags::INLINE_PREVENTED) {
                         return Ok(false);
                     }
 
@@ -2348,7 +2374,10 @@ impl Optimizer<'_> {
                         if let Some(usage) = self.data.vars.get(&left_id.to_id()) {
                             // We are eliminating one usage, so we use 1 instead of
                             // 0
-                            if !force_drop && usage.usage_count == 1 && !usage.reassigned {
+                            if !force_drop
+                                && usage.usage_count == 1
+                                && !usage.flags.contains(VarUsageInfoFlags::REASSIGNED)
+                            {
                                 report_change!("sequences: Dropping inlined variable");
                                 a.name.take();
                             }

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -23,7 +23,7 @@ use crate::{
         util::{is_directive, is_ident_used_by, replace_expr},
     },
     option::CompressOptions,
-    program_data::VarUsageInfoFlags,
+    program_data::{ScopeData, VarUsageInfoFlags},
     util::{
         idents_used_by, idents_used_by_ignoring_nested, ExprOptExt, IdentUsageCollector,
         ModuleItemExt,
@@ -531,7 +531,13 @@ impl Optimizer<'_> {
             return;
         }
 
-        if self.data.scopes.get(&self.ctx.scope).unwrap().has_eval_call {
+        if self
+            .data
+            .scopes
+            .get(&self.ctx.scope)
+            .unwrap()
+            .contains(ScopeData::HAS_EVAL_CALL)
+        {
             log_abort!("sequences: Eval call");
             return;
         }
@@ -659,7 +665,13 @@ impl Optimizer<'_> {
     pub(super) fn merge_sequences_in_seq_expr(&mut self, e: &mut SeqExpr) {
         self.normalize_sequences(e);
 
-        if self.data.scopes.get(&self.ctx.scope).unwrap().has_eval_call {
+        if self
+            .data
+            .scopes
+            .get(&self.ctx.scope)
+            .unwrap()
+            .contains(ScopeData::HAS_EVAL_CALL)
+        {
             log_abort!("sequences: Eval call");
             return;
         }

--- a/crates/swc_ecma_minifier/src/pass/mangle_props.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_props.rs
@@ -11,7 +11,7 @@ use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 use crate::{
     option::ManglePropertiesOptions,
-    program_data::{analyze, ProgramData},
+    program_data::{analyze, ProgramData, VarUsageInfoFlags},
     util::base54::Base54Chars,
 };
 
@@ -175,7 +175,7 @@ fn is_root_of_member_expr_declared(member_expr: &MemberExpr, data: &ProgramData)
         Expr::Ident(expr) => data
             .vars
             .get(&expr.to_id())
-            .map(|var| var.declared)
+            .map(|var| var.flags.contains(VarUsageInfoFlags::DECLARED))
             .unwrap_or(false),
 
         _ => false,


### PR DESCRIPTION
**Description**:

Convert lots of boolean flags into a single field with `bitflags`. This reduces the memory consumption a bit, and makes it a bit faster.