### PR TITLE
fix(es/minifier): Properly handle object shorthand syntax during compression

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -2279,28 +2279,6 @@ impl VisitMut for Optimizer<'_> {
     }
 
     #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
-    fn visit_mut_prop(&mut self, n: &mut Prop) {
-        n.visit_mut_children_with(self);
-
-        if let Prop::Shorthand(i) = n {
-            if self.vars.has_pending_inline_for(&i.to_id()) {
-                let mut e: Expr = i.clone().into();
-                e.visit_mut_with(self);
-
-                *n = Prop::KeyValue(KeyValueProp {
-                    key: PropName::Ident(i.clone().into()),
-                    value: Box::new(e),
-                });
-            }
-        }
-
-        #[cfg(debug_assertions)]
-        {
-            n.visit_with(&mut AssertValid);
-        }
-    }
-
-    #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
     fn visit_mut_return_stmt(&mut self, n: &mut ReturnStmt) {
         n.visit_mut_children_with(self);
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -453,6 +453,20 @@ impl VisitMut for Finalizer<'_> {
 
         n.retain(|v| !v.name.is_invalid());
     }
+
+    fn visit_mut_prop(&mut self, n: &mut Prop) {
+        n.visit_mut_children_with(self);
+
+        if let Prop::Shorthand(i) = n {
+            if let Some(expr) = self.lits.get(&i.to_id()) {
+                *n = Prop::KeyValue(KeyValueProp {
+                    key: i.take().into(),
+                    value: expr.clone(),
+                });
+                self.changed = true;
+            }
+        }
+    }
 }
 
 pub(crate) struct NormalMultiReplacer<'a> {

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10466/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10466/input.js
@@ -1,0 +1,10 @@
+const G = {
+    setPackageName({ packageName }) {
+        if ("string" == typeof packageName) this.packageName = packageName;
+        return this;
+    }
+};
+var packageName;
+packageName = "@clerk/clerk-react", G.setPackageName({
+    packageName
+}), console.log(G.packageName);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10466/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10466/output.js
@@ -1,0 +1,8 @@
+const G = {
+    setPackageName ({ packageName }) {
+        return "string" == typeof packageName && (this.packageName = packageName), this;
+    }
+};
+G.setPackageName({
+    packageName: "@clerk/clerk-react"
+}), console.log(G.packageName);


### PR DESCRIPTION
**Related issue:**

- Closes: #10466

