### PR TITLE
fix(es/react-compiler): Fix usefulness detection

### DIFF
--- a/.changeset/ten-tables-design.md
+++ b/.changeset/ten-tables-design.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_react_compiler: patch
+---
+
+fix(react-compiler/support): Fix usefulness detection


### PR DESCRIPTION
**Description:**

JSX is also a target of the React Compiler

**Related issue:**

 - https://github.com/vercel/next.js/pull/79479