### PR TITLE
fix(ts/fast-dts): Correctly emit Symbol-keyed accessors in declarations

### DIFF
--- a/.changeset/silent-cameras-invent.md
+++ b/.changeset/silent-cameras-invent.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_typescript: patch
+---
+
+fix(ts/fast-dts): Correctly emit Symbol-keyed accessors in declarations

--- a/crates/swc_typescript/src/fast_dts/util/ast_ext.rs
+++ b/crates/swc_typescript/src/fast_dts/util/ast_ext.rs
@@ -1,12 +1,15 @@
 use std::borrow::Cow;
 
 use swc_atoms::Atom;
+use swc_common::Mark;
 use swc_ecma_ast::{
-    BindingIdent, Expr, Ident, Lit, MemberProp, ObjectPatProp, Pat, Prop, PropName, TsTypeAnn,
+    BindingIdent, ComputedPropName, Expr, Ident, Lit, MemberProp, ObjectPatProp, Pat, Prop,
+    PropName, TsTypeAnn,
 };
 
 pub trait ExprExit {
     fn get_root_ident(&self) -> Option<&Ident>;
+    fn get_global_symbol_prop(&self, unresolved_mark: Mark) -> Option<&MemberProp>;
 }
 
 impl ExprExit for Expr {
@@ -20,6 +23,43 @@ impl ExprExit for Expr {
                 .and_then(|member_expr| member_expr.obj.get_root_ident()),
             _ => None,
         }
+    }
+
+    fn get_global_symbol_prop(&self, unresolved_mark: Mark) -> Option<&MemberProp> {
+        let (obj, prop) = (match self {
+            Expr::Member(member) => Some((&member.obj, &member.prop)),
+            Expr::OptChain(opt_chain) => opt_chain
+                .base
+                .as_member()
+                .map(|member| (&member.obj, &member.prop)),
+            _ => None,
+        })?;
+
+        // https://github.com/microsoft/TypeScript/blob/cbac1ddfc73ca3b9d8741c1b51b74663a0f24695/src/compiler/transformers/declarations.ts#L1011
+        if let Some(ident) = obj.as_ident() {
+            // Exactly `Symbol.something` and `Symbol` either does not resolve
+            // or definitely resolves to the global Symbol
+            return if ident.sym.as_str() == "Symbol" && ident.ctxt.has_mark(unresolved_mark) {
+                Some(prop)
+            } else {
+                None
+            };
+        }
+
+        if let Some(member_expr) = obj.as_member() {
+            // Exactly `globalThis.Symbol.something` and `globalThis` resolves
+            // to the global `globalThis`
+            if let Some(ident) = member_expr.obj.as_ident() {
+                if ident.sym.as_str() == "globalThis"
+                    && ident.ctxt.has_mark(unresolved_mark)
+                    && member_expr.prop.is_ident_with("Symbol")
+                {
+                    return Some(prop);
+                }
+            }
+        }
+
+        None
     }
 }
 
@@ -88,6 +128,7 @@ impl PatExt for Pat {
 
 pub trait PropNameExit {
     fn static_name(&self) -> Option<Cow<str>>;
+    fn static_prop(&self, unresolved_mark: Mark) -> Option<StaticProp>;
 }
 
 impl PropNameExit for PropName {
@@ -97,23 +138,54 @@ impl PropNameExit for PropName {
             PropName::Str(string) => Some(Cow::Borrowed(string.value.as_str())),
             PropName::Num(number) => Some(Cow::Owned(number.value.to_string())),
             PropName::BigInt(big_int) => Some(Cow::Owned(big_int.value.to_string())),
-            PropName::Computed(computed_prop_name) => match computed_prop_name.expr.as_ref() {
-                Expr::Lit(lit) => match lit {
-                    Lit::Str(string) => Some(Cow::Borrowed(string.value.as_str())),
-                    Lit::Bool(b) => Some(Cow::Owned(b.value.to_string())),
-                    Lit::Null(_) => Some(Cow::Borrowed("null")),
-                    Lit::Num(number) => Some(Cow::Owned(number.value.to_string())),
-                    Lit::BigInt(big_int) => Some(Cow::Owned(big_int.value.to_string())),
-                    Lit::Regex(regex) => Some(Cow::Owned(regex.exp.to_string())),
-                    Lit::JSXText(_) => None,
-                },
-                Expr::Tpl(tpl) if tpl.exprs.is_empty() => tpl
-                    .quasis
-                    .first()
-                    .and_then(|e| e.cooked.as_ref())
-                    .map(|atom| Cow::Borrowed(atom.as_str())),
-                _ => None,
+            PropName::Computed(computed_prop_name) => computed_prop_name.static_name(),
+        }
+    }
+
+    fn static_prop(&self, unresolved_mark: Mark) -> Option<StaticProp> {
+        match self {
+            PropName::Computed(c) => c.static_prop(unresolved_mark),
+            prop => prop.static_name().map(Into::into).map(StaticProp::Name),
+        }
+    }
+}
+
+impl PropNameExit for ComputedPropName {
+    fn static_name(&self) -> Option<Cow<str>> {
+        match self.expr.as_ref() {
+            Expr::Lit(lit) => match lit {
+                Lit::Str(string) => Some(Cow::Borrowed(string.value.as_str())),
+                Lit::Bool(b) => Some(Cow::Owned(b.value.to_string())),
+                Lit::Null(_) => Some(Cow::Borrowed("null")),
+                Lit::Num(number) => Some(Cow::Owned(number.value.to_string())),
+                Lit::BigInt(big_int) => Some(Cow::Owned(big_int.value.to_string())),
+                Lit::Regex(regex) => Some(Cow::Owned(regex.exp.to_string())),
+                Lit::JSXText(_) => None,
             },
+            Expr::Tpl(tpl) if tpl.exprs.is_empty() => tpl
+                .quasis
+                .first()
+                .and_then(|e| e.cooked.as_ref())
+                .map(|atom| Cow::Borrowed(atom.as_str())),
+            _ => None,
+        }
+    }
+
+    fn static_prop(&self, unresolved_mark: Mark) -> Option<StaticProp> {
+        match self.expr.as_ref() {
+            Expr::Member(..) | Expr::OptChain(..) => self
+                .expr
+                .get_global_symbol_prop(unresolved_mark)
+                .and_then(|prop| match prop {
+                    MemberProp::Ident(ident_name) => {
+                        Some(StaticProp::Symbol(ident_name.sym.clone()))
+                    }
+                    MemberProp::Computed(c) => {
+                        c.static_name().map(Into::into).map(StaticProp::Symbol)
+                    }
+                    MemberProp::PrivateName(..) => None,
+                }),
+            _ => self.static_name().map(Into::into).map(StaticProp::Name),
         }
     }
 }
@@ -127,6 +199,17 @@ impl PropNameExit for Prop {
             Self::Getter(getter_prop) => getter_prop.key.static_name(),
             Self::Setter(setter_prop) => setter_prop.key.static_name(),
             Self::Method(method_prop) => method_prop.key.static_name(),
+        }
+    }
+
+    fn static_prop(&self, unresolved_mark: Mark) -> Option<StaticProp> {
+        match self {
+            Self::Shorthand(ident_name) => Some(StaticProp::Name(ident_name.sym.clone())),
+            Self::KeyValue(key_value_prop) => key_value_prop.key.static_prop(unresolved_mark),
+            Self::Assign(..) => None,
+            Self::Getter(getter_prop) => getter_prop.key.static_prop(unresolved_mark),
+            Self::Setter(setter_prop) => setter_prop.key.static_prop(unresolved_mark),
+            Self::Method(method_prop) => method_prop.key.static_prop(unresolved_mark),
         }
     }
 }
@@ -149,4 +232,10 @@ impl MemberPropExt for MemberProp {
             MemberProp::PrivateName(_) => None,
         }
     }
+}
+
+#[derive(Eq, Hash, PartialEq, Clone)]
+pub(crate) enum StaticProp {
+    Name(Atom),
+    Symbol(Atom),
 }

--- a/crates/swc_typescript/tests/fixture/symbol-getter-setter.snap
+++ b/crates/swc_typescript/tests/fixture/symbol-getter-setter.snap
@@ -1,0 +1,14 @@
+```==================== .D.TS ====================
+
+// @isolatedDeclarations: true
+// @emitDeclarationOnly: true
+export declare const foo: {
+    [Symbol.toStringTag]: string;
+};
+export declare class Foo {
+    #private;
+    get [Symbol.toStringTag](): string;
+    set [Symbol.toStringTag](value: string);
+}
+
+

--- a/crates/swc_typescript/tests/fixture/symbol-getter-setter.ts
+++ b/crates/swc_typescript/tests/fixture/symbol-getter-setter.ts
@@ -1,0 +1,23 @@
+// @isolatedDeclarations: true
+// @emitDeclarationOnly: true
+
+let x = "";
+
+export const foo = {
+    get [Symbol.toStringTag]() {
+        return x;
+    },
+    set [Symbol.toStringTag](value: string) {
+        x = value;
+    },
+};
+
+export class Foo {
+    #x = "";
+    get [Symbol.toStringTag]() {
+        return this.#x;
+    }
+    set [Symbol.toStringTag](value: string) {
+        this.#x = value;
+    }
+}


### PR DESCRIPTION
**Related issue:**

- Closes: #10507 
