### PR TITLE
 fix: change visibility of lexer::token exports from crate to public

### DIFF
--- a/.changeset/cyan-humans-kick-cat.md
+++ b/.changeset/cyan-humans-kick-cat.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_parser: patch
+---
+
+fix: change parser::lexer::token as public

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -26,7 +26,7 @@ mod table;
 mod token;
 pub mod util;
 
-pub(crate) use token::{NextTokenAndSpan, Token, TokenAndSpan, TokenValue};
+pub use token::{NextTokenAndSpan, Token, TokenAndSpan, TokenValue};
 
 #[derive(Clone)]
 pub struct Lexer<'a> {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Current, swc have two lexer and tokenize parser.
One suit locate in `swc_ecma_lexer`, other locate in `swc_ecma_parser`.
Exports `swc_ecma_parser::lexer::token` as public so that layer user can got token's type.

The Layer bundler maybe need this types in parser process. 
For Examples: https://github.com/web-infra-dev/rspack/blob/main/crates/rspack_plugin_javascript/src/visitors/semicolon.rs#L2-L16


**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
