### PR TITLE
fix(es/parser): Emit syntax errors for strict mode in non-module or scripts

### DIFF
--- a/crates/swc_ecma_lexer/src/common/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/mod.rs
@@ -167,6 +167,10 @@ pub trait Parser<'a>: Sized + Clone {
             return;
         }
         let error = crate::error::Error::new(span, error);
+        if self.ctx().contains(Context::Strict) {
+            self.input().iter().add_error(error);
+            return;
+        }
         self.input().iter().add_module_mode_error(error);
     }
 

--- a/crates/swc_ecma_parser/tests/errors/issue-10529/input.cjs
+++ b/crates/swc_ecma_parser/tests/errors/issue-10529/input.cjs
@@ -1,0 +1,3 @@
+class A {
+    constructor(static) { }
+}

--- a/crates/swc_ecma_parser/tests/errors/issue-10529/input.cjs.swc-stderr
+++ b/crates/swc_ecma_parser/tests/errors/issue-10529/input.cjs.swc-stderr
@@ -1,0 +1,7 @@
+  x `static` cannot be used as an identifier in strict mode
+   ,-[$DIR/tests/errors/issue-10529/input.cjs:2:1]
+ 1 | class A {
+ 2 |     constructor(static) { }
+   :                 ^^^^^^
+ 3 | }
+   `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/37cb7557997d4fd6.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/37cb7557997d4fd6.js.swc-stderr
@@ -3,3 +3,8 @@
  1 | "use strict"; for (let [a = let];;) {}
    :                        ^^^^^^^^^
    `----
+  x `let` cannot be used as an identifier in strict mode
+   ,-[$DIR/tests/test262-parser/fail/37cb7557997d4fd6.js:1:1]
+ 1 | "use strict"; for (let [a = let];;) {}
+   :                             ^^^
+   `----

--- a/crates/swc_ecma_parser/tests/test262-error-references/fail/d17d3aebb6a3cf43.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/test262-error-references/fail/d17d3aebb6a3cf43.js.swc-stderr
@@ -3,3 +3,8 @@
  1 | "use strict"; for (let {a: b = let};;) {}
    :                        ^^^^^^^^^^^^
    `----
+  x `let` cannot be used as an identifier in strict mode
+   ,-[$DIR/tests/test262-parser/fail/d17d3aebb6a3cf43.js:1:1]
+ 1 | "use strict"; for (let {a: b = let};;) {}
+   :                                ^^^
+   `----


### PR DESCRIPTION
**Related issue (if exists):**
- Closes: #10529 
