### PR TITLE
fix(es/minifier): inline object of member if prop is an ident

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -351,6 +351,7 @@ impl VisitMut for Finalizer<'_> {
                     let sym = match &e.prop {
                         MemberProp::Ident(i) => &i.sym,
                         MemberProp::Computed(e) => match &*e.expr {
+                            Expr::Ident(ident) => &ident.sym,
                             Expr::Lit(Lit::Str(s)) => &s.value,
                             _ => return,
                         },

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10532/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10532/input.js
@@ -1,0 +1,14 @@
+(function () {
+    function WL(t) {
+        var n = (console.log(), t);
+        Object.keys(n).forEach(function (t) {
+            console.log(n);
+            console.log(t);
+            console.log(n[t]);
+        });
+    }
+    try {
+        t = { a: 1 };
+        WL(t);
+    } catch {}
+})();

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10532/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10532/output.js
@@ -1,0 +1,8 @@
+try {
+    var t1;
+    t1 = t = {
+        a: 1
+    }, console.log(), Object.keys(t1).forEach(function(t2) {
+        console.log(t1), console.log(t2), console.log(t1[t2]);
+    });
+} catch  {}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Currently if there's object ident in the member with an computed ident prop, it won't be inlined. So add this case.

**Related issue (if exists):**

fixes: https://github.com/swc-project/swc/issues/10532