### PR TITLE
fix(es/minifier): add side effect check for test expr when compressing IfStmt

### DIFF
--- a/crates/swc_ecma_minifier/tests/fixture/issues/10473/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10473/input.js
@@ -1,0 +1,92 @@
+"use strict";
+
+function _typeof(e) {
+    return (_typeof =
+        "function" == typeof Symbol && "symbol" == typeof Symbol.iterator
+            ? function (e) {
+                  return typeof e;
+              }
+            : function (e) {
+                  return e &&
+                      "function" == typeof Symbol &&
+                      e.constructor === Symbol &&
+                      e !== Symbol.prototype
+                      ? "symbol"
+                      : typeof e;
+              })(e);
+}
+
+function ownKeys(t, e) {
+    var o,
+        r = Object.keys(t);
+    return (
+        Object.getOwnPropertySymbols &&
+            ((o = Object.getOwnPropertySymbols(t)),
+            e &&
+                (o = o.filter(function (e) {
+                    return Object.getOwnPropertyDescriptor(t, e).enumerable;
+                })),
+            r.push.apply(r, o)),
+        r
+    );
+}
+
+function _objectSpread(t) {
+    for (var e = 1; e < arguments.length; e++) {
+        var o = null != arguments[e] ? arguments[e] : {};
+        e % 2
+            ? ownKeys(Object(o), !0).forEach(function (e) {
+                  _defineProperty(t, e, o[e]);
+              })
+            : Object.getOwnPropertyDescriptors
+            ? Object.defineProperties(t, Object.getOwnPropertyDescriptors(o))
+            : ownKeys(Object(o)).forEach(function (e) {
+                  Object.defineProperty(
+                      t,
+                      e,
+                      Object.getOwnPropertyDescriptor(o, e)
+                  );
+              });
+    }
+    return t;
+}
+
+function _defineProperty(e, t, o) {
+    return (
+        (t = _toPropertyKey(t)) in e
+            ? Object.defineProperty(e, t, {
+                  value: o,
+                  enumerable: !0,
+                  configurable: !0,
+                  writable: !0,
+              })
+            : (e[t] = o),
+        e
+    );
+}
+
+function _toPropertyKey(e) {
+    e = _toPrimitive(e, "string");
+    return "symbol" == _typeof(e) ? e : e + "";
+}
+
+function _toPrimitive(e, t) {
+    if ("object" != _typeof(e) || !e) return e;
+    var o = e[Symbol.toPrimitive];
+    if (void 0 === o) return ("string" === t ? String : Number)(e);
+    o = o.call(e, t || "default");
+    if ("object" != _typeof(o)) return o;
+    throw new TypeError("@@toPrimitive must return a primitive value.");
+}
+
+var cmConfig = (cmConfig = {
+        isToutiao: "Toutiao" === Math.random(),
+        appid: "xxx",
+        version: "5.8.20",
+    }).isToutiao
+        ? _objectSpread(_objectSpread({}, cmConfig), { name: "toutiao" })
+        : _objectSpread(_objectSpread({}, cmConfig), { name: "douyin" }),
+    // config should equal { ...cmConfig, ...douyin }
+    config = (exports.config = cmConfig);
+
+console.log(config);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10473/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10473/output.js
@@ -1,0 +1,49 @@
+"use strict";
+function _typeof(e) {
+    return (_typeof = "function" == typeof Symbol && "symbol" == typeof Symbol.iterator ? function(e) {
+        return typeof e;
+    } : function(e) {
+        return e && "function" == typeof Symbol && e.constructor === Symbol && e !== Symbol.prototype ? "symbol" : typeof e;
+    })(e);
+}
+function ownKeys(t, e) {
+    var o, r = Object.keys(t);
+    return Object.getOwnPropertySymbols && (o = Object.getOwnPropertySymbols(t), e && (o = o.filter(function(e) {
+        return Object.getOwnPropertyDescriptor(t, e).enumerable;
+    })), r.push.apply(r, o)), r;
+}
+function _objectSpread(t) {
+    for(var e = 1; e < arguments.length; e++){
+        var o = null != arguments[e] ? arguments[e] : {};
+        e % 2 ? ownKeys(Object(o), !0).forEach(function(e) {
+            !function(e, t, o) {
+                var e1;
+                (e1 = function(e, t) {
+                    if ("object" != _typeof(e) || !e) return e;
+                    var o = e[Symbol.toPrimitive];
+                    if (void 0 === o) return ("string" === t ? String : Number)(e);
+                    if (o = o.call(e, t || "default"), "object" != _typeof(o)) return o;
+                    throw TypeError("@@toPrimitive must return a primitive value.");
+                }(e1 = t, "string"), (t = "symbol" == _typeof(e1) ? e1 : e1 + "") in e) ? Object.defineProperty(e, t, {
+                    value: o,
+                    enumerable: !0,
+                    configurable: !0,
+                    writable: !0
+                }) : e[t] = o;
+            }(t, e, o[e]);
+        }) : Object.getOwnPropertyDescriptors ? Object.defineProperties(t, Object.getOwnPropertyDescriptors(o)) : ownKeys(Object(o)).forEach(function(e) {
+            Object.defineProperty(t, e, Object.getOwnPropertyDescriptor(o, e));
+        });
+    }
+    return t;
+}
+var cmConfig = (cmConfig = {
+    isToutiao: "Toutiao" === Math.random(),
+    appid: "xxx",
+    version: "5.8.20"
+}).isToutiao ? _objectSpread(_objectSpread({}, cmConfig), {
+    name: "toutiao"
+}) : _objectSpread(_objectSpread({}, cmConfig), {
+    name: "douyin"
+});
+console.log(exports.config = cmConfig);

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -721,6 +721,11 @@ pub trait ExprExt {
         is_one_of_global_ref_to(self.as_expr(), ctx, ids)
     }
 
+    #[inline(always)]
+    fn is_pure(&self, ctx: ExprCtx) -> bool {
+        self.as_pure_bool(ctx).is_known()
+    }
+
     /// Get bool value of `self` if it does not have any side effects.
     #[inline(always)]
     fn as_pure_bool(&self, ctx: ExprCtx) -> BoolValue {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

The minimization result of IfStmt compressing is wrong if test exprs modifies some variables that are used in the common args of cons and alt. For example: 
```
(a = 1) ? f(a, true) : f(a, false)

f(a, a = 1 ? true : false)
```

**Related issue (if exists):**

fixes: https://github.com/swc-project/swc/issues/10473