### PR TITLE
fix(swc_common): Fix skip condition for sourcemap

### DIFF
--- a/.changeset/moody-cows-sleep.md
+++ b/.changeset/moody-cows-sleep.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_common: patch
+---
+
+fix(swc_common): Fix skip condition for sourcemap

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1293,7 +1293,7 @@ pub fn build_source_map(
 
         let lc = *lc;
 
-        // If pos is same as a DUMMY_SP (eg BytePos(0)) and if line and col are 0;
+        // If pos is same as a DUMMY_SP (eg BytePos(0)) or if line and col are 0,
         // ignore the mapping.
         if lc.line == 0 && lc.col == 0 && pos.is_dummy() {
             continue;

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1284,8 +1284,8 @@ pub fn build_source_map(
     let mut ch_state = ByteToCharPosState::default();
     let mut line_state = ByteToCharPosState::default();
 
-    for (orig_pos, lc) in mappings.iter() {
-        let pos = files.map_raw_pos(*orig_pos);
+    for (raw_pos, lc) in mappings.iter() {
+        let pos = files.map_raw_pos(*raw_pos);
 
         if pos.is_reserved_for_comments() {
             continue;
@@ -1308,7 +1308,7 @@ pub fn build_source_map(
         let f = match cur_file {
             Some(ref f) if f.start_pos <= pos && pos < f.end_pos => f,
             _ => {
-                f = files.try_lookup_source_file(*orig_pos).unwrap();
+                f = files.try_lookup_source_file(*raw_pos).unwrap();
                 if config.skip(&f.name) {
                     continue;
                 }


### PR DESCRIPTION
**Description:**

We don't generate `BytePos(0)` so it was not a big deal for us, but now it matters because external crates are now allowed to generate `BytePos`