### PR TITLE
fix(es/codegen): Don't call `cmt.get_leading` for dummy span

### DIFF
--- a/.changeset/sixty-pans-help.md
+++ b/.changeset/sixty-pans-help.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_codegen: patch
+swc_core: patch
+---
+
+Don't call `cmt.get_leading` for dummy span

--- a/crates/swc_ecma_codegen/src/lib.rs
+++ b/crates/swc_ecma_codegen/src/lib.rs
@@ -1382,6 +1382,10 @@ fn is_empty_comments(span: &Span, comments: &Option<&dyn Comments>) -> bool {
 fn span_has_leading_comment(cmt: &dyn Comments, span: Span) -> bool {
     let lo = span.lo;
 
+    if lo.is_dummy() {
+        return false;
+    }
+
     // see #415
     if let Some(cmt) = cmt.get_leading(lo) {
         if cmt.iter().any(|cmt| {


### PR DESCRIPTION
This was the only place where `Comments` were queried for dummy spans (`BytePos(0)`)