### PR TITLE
fix(isolated_declarations): add edges `SymbolFlags::Value` and `SymbolFlags::Type` in exports

### DIFF
--- a/.changeset/weak-shirts-count.md
+++ b/.changeset/weak-shirts-count.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_typescript: patch
+---
+
+fix(isolated_declarations): add edges `SymbolFlags::Value` and `SymbolFlags::Type` in exports

--- a/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
+++ b/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
@@ -326,7 +326,13 @@ impl Visit for TypeUsageAnalyzer<'_> {
             for specifier in &node.specifiers {
                 if let Some(name) = specifier.as_named() {
                     if let ModuleExportName::Ident(ident) = &name.orig {
-                        this.add_edge(Symbol::new(ident.to_id(), SymbolFlags::all()), true);
+                        // We should add egdes for all three possible namespaces because there's no
+                        // mechanism to merge SymbolFlags with same Ids
+                        this.add_edge(Symbol::new(ident.to_id(), SymbolFlags::Type), true);
+                        if !node.type_only {
+                            this.add_edge(Symbol::new(ident.to_id(), SymbolFlags::Value), true);
+                            this.add_edge(Symbol::new(ident.to_id(), SymbolFlags::all()), true);
+                        }
                     }
                 }
             }
@@ -342,6 +348,10 @@ impl Visit for TypeUsageAnalyzer<'_> {
     fn visit_export_default_expr(&mut self, node: &ExportDefaultExpr) {
         self.with_source(self.source, |this| {
             if let Some(ident) = node.expr.as_ident() {
+                // We should add egdes for all three possible namespaces because there's no
+                // mechanism to merge SymbolFlags with same Ids
+                this.add_edge(Symbol::new(ident.to_id(), SymbolFlags::Type), true);
+                this.add_edge(Symbol::new(ident.to_id(), SymbolFlags::Value), true);
                 this.add_edge(Symbol::new(ident.to_id(), SymbolFlags::all()), true);
             }
             node.visit_children_with(this);

--- a/crates/swc_typescript/tests/fixture/issues/10576.snap
+++ b/crates/swc_typescript/tests/fixture/issues/10576.snap
@@ -1,0 +1,9 @@
+```==================== .D.TS ====================
+
+import type Animal from "the/jungle/book";
+interface King extends Animal {
+    isLouie(): boolean;
+}
+export type { King as default };
+
+

--- a/crates/swc_typescript/tests/fixture/issues/10576.ts
+++ b/crates/swc_typescript/tests/fixture/issues/10576.ts
@@ -1,0 +1,7 @@
+import type Animal from "the/jungle/book";
+
+interface King extends Animal {
+    isLouie(): boolean;
+}
+
+export type { King as default };


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

We should add egdes for all three possible namespaces because there's no mechanism to merge SymbolFlags with same Ids.

For example: 
```ts
const a = 1 // SymbolFlags::Value
type a = number // SymbolFlags::Type
class A {} // SymbolFlags::all()

export { a, A }
```

Ideally we should merge two `a`s with `SymbolFlags::all`. But it's not efficient to merge nodes in the real time. So when exporting symbols, we add edges for all possible cases.

**Related issue (if exists):**

fixes: https://github.com/swc-project/swc/issues/10576