### PR TITLE
fix(es/typescript): Handle `export declare var` in namespace

### DIFF
--- a/.changeset/smart-wombats-share.md
+++ b/.changeset/smart-wombats-share.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_typescript: patch
+---
+
+fix(es/typescript): Handle `export declare var` in namespace

--- a/crates/swc/tests/fixture/issues-9xxx/9821/case-default/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-9xxx/9821/case-default/input/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+        "target": "es2022",
+        "parser": {
+            "syntax": "typescript"
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9821/case-default/input/index.ts
+++ b/crates/swc/tests/fixture/issues-9xxx/9821/case-default/input/index.ts
@@ -1,0 +1,22 @@
+export namespace ns {
+    export declare let a: number;
+    a = 1;
+}
+
+export namespace ns2 {
+    a = 1;
+    export declare let a: number;
+}
+
+export namespace ns3 {
+    export let b = a;
+    export declare const a: number;
+}
+
+export namespace ns4 {
+    export namespace ns5 {
+        export let b = a;
+    }
+
+    export declare const a: number;
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9821/case-default/output/index.ts
+++ b/crates/swc/tests/fixture/issues-9xxx/9821/case-default/output/index.ts
@@ -1,0 +1,15 @@
+(function(ns) {
+    ns.a = 1;
+})(ns || (ns = {}));
+(function(ns2) {
+    ns2.a = 1;
+})(ns2 || (ns2 = {}));
+(function(ns3) {
+    ns3.b = ns3.a;
+})(ns3 || (ns3 = {}));
+(function(ns4) {
+    (function(ns5) {
+        ns5.b = ns4.a;
+    })(ns4.ns5 || (ns4.ns5 = {}));
+})(ns4 || (ns4 = {}));
+export var ns, ns2, ns3, ns4;

--- a/crates/swc/tests/fixture/issues-9xxx/9821/case-verbatimModuleSyntax/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-9xxx/9821/case-verbatimModuleSyntax/input/.swcrc
@@ -1,0 +1,11 @@
+{
+    "jsc": {
+        "target": "es2022",
+        "parser": {
+            "syntax": "typescript"
+        },
+        "transform": {
+            "verbatimModuleSyntax": true
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9821/case-verbatimModuleSyntax/input/index.ts
+++ b/crates/swc/tests/fixture/issues-9xxx/9821/case-verbatimModuleSyntax/input/index.ts
@@ -1,0 +1,22 @@
+export namespace ns {
+    export declare let a: number;
+    a = 1;
+}
+
+export namespace ns2 {
+    a = 1;
+    export declare let a: number;
+}
+
+export namespace ns3 {
+    export let b = a;
+    export declare const a: number;
+}
+
+export namespace ns4 {
+    export namespace ns5 {
+        export let b = a;
+    }
+
+    export declare const a: number;
+}

--- a/crates/swc/tests/fixture/issues-9xxx/9821/case-verbatimModuleSyntax/output/index.ts
+++ b/crates/swc/tests/fixture/issues-9xxx/9821/case-verbatimModuleSyntax/output/index.ts
@@ -1,0 +1,15 @@
+(function(ns) {
+    ns.a = 1;
+})(ns || (ns = {}));
+(function(ns2) {
+    ns2.a = 1;
+})(ns2 || (ns2 = {}));
+(function(ns3) {
+    ns3.b = ns3.a;
+})(ns3 || (ns3 = {}));
+(function(ns4) {
+    (function(ns5) {
+        ns5.b = ns4.a;
+    })(ns4.ns5 || (ns4.ns5 = {}));
+})(ns4 || (ns4 = {}));
+export var ns, ns2, ns3, ns4;


### PR DESCRIPTION
**Related issue:**

- Closes: #9821 
