### PR TITLE
refactor(es/parser): Remove `cur!(false)` macro

### DIFF
--- a/crates/swc_ecma_lexer/src/common/parser/ident.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/ident.rs
@@ -11,7 +11,7 @@ use crate::{
 
 // https://tc39.es/ecma262/#prod-ModuleExportName
 pub fn parse_module_export_name<'a, P: Parser<'a>>(p: &mut P) -> PResult<ModuleExportName> {
-    let Ok(cur) = cur!(p, false) else {
+    let Some(cur) = p.input_mut().cur() else {
         unexpected!(p, "identifier or string");
     };
     let module_export_name = if cur.is_str() {

--- a/crates/swc_ecma_lexer/src/common/parser/jsx.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/jsx.rs
@@ -132,7 +132,7 @@ fn parse_jsx_empty_expr<'a>(p: &mut impl Parser<'a>) -> JSXEmptyExpr {
 
 pub fn parse_jsx_text<'a>(p: &mut impl Parser<'a>) -> JSXText {
     debug_assert!(p.input().syntax().jsx());
-    debug_assert!(cur!(p, false).is_ok_and(|t| t.is_jsx_text()));
+    debug_assert!(p.input_mut().cur().is_some_and(|t| t.is_jsx_text()));
     let token = p.bump();
     let span = p.input().prev_span();
     let (value, raw) = token.take_jsx_text(p.input_mut());
@@ -246,7 +246,7 @@ fn parse_jsx_opening_element_at<'a, P: Parser<'a>>(
 pub fn parse_jsx_attrs<'a, P: Parser<'a>>(p: &mut P) -> PResult<Vec<JSXAttrOrSpread>> {
     let mut attrs = Vec::with_capacity(8);
 
-    while cur!(p, false).is_ok() {
+    while p.input_mut().cur().is_some() {
         trace_cur!(p, parse_jsx_opening__attrs_loop);
 
         if p.input_mut()

--- a/crates/swc_ecma_lexer/src/common/parser/macros.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/macros.rs
@@ -1,18 +1,5 @@
 /// cur!($parser, required:bool)
 macro_rules! cur {
-    ($p:expr, false) => {{
-        match $p.input_mut().cur() {
-            Some(c) => Ok(c),
-            None => {
-                let pos = $p.input().end_pos();
-                let last = Span::new(pos, pos);
-                Err(crate::error::Error::new(
-                    last,
-                    crate::error::SyntaxError::Eof,
-                ))
-            }
-        }
-    }};
     ($p:expr, true) => {{
         match $p.input_mut().cur() {
             Some(c) => {
@@ -90,7 +77,7 @@ macro_rules! peek {
             $p.input().knows_cur(),
             "parser should not call peek() without knowing current token.
 Current token is {:?}",
-            cur!($p, false),
+            $p.input_mut().cur(),
         );
         $p.input_mut().peek()
     }};
@@ -121,7 +108,7 @@ macro_rules! debug_tracing {
 /// Returns true on eof.
 macro_rules! eof {
     ($p:expr) => {
-        cur!($p, false).is_err()
+        $p.input_mut().cur().is_none()
     };
 }
 

--- a/crates/swc_ecma_lexer/src/common/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/mod.rs
@@ -207,7 +207,7 @@ pub trait Parser<'a>: Sized + Clone {
 
     fn eat_general_semi(&mut self) -> bool {
         if cfg!(feature = "debug") {
-            tracing::trace!("eat(';'): cur={:?}", cur!(self, false));
+            tracing::trace!("eat(';'): cur={:?}", self.input_mut().cur());
         }
         let Some(cur) = self.input_mut().cur() else {
             return true;
@@ -472,11 +472,20 @@ pub trait Parser<'a>: Sized + Clone {
 }
 
 pub fn parse_shebang<'a>(p: &mut impl Parser<'a>) -> PResult<Option<Atom>> {
-    let cur = cur!(p, false);
-    Ok(if cur.is_ok_and(|t| t.is_shebang()) {
+    Ok(if p.input_mut().cur().is_some_and(|t| t.is_shebang()) {
         let t = p.bump();
         Some(t.take_shebang(p.input_mut()))
     } else {
         None
     })
+}
+
+pub fn eof_error<'a, P: Parser<'a>>(p: &mut P) -> crate::error::Error {
+    debug_assert!(
+        p.input_mut().cur().is_none(),
+        "Parser should not call throw_eof_error() without knowing current token"
+    );
+    let pos = p.input().end_pos();
+    let last = Span::new(pos, pos);
+    crate::error::Error::new(last, crate::error::SyntaxError::Eof)
 }

--- a/crates/swc_ecma_lexer/src/common/parser/module_item.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/module_item.rs
@@ -70,7 +70,7 @@ fn parse_from_clause_and_semi<'a, P: Parser<'a>>(
     } else {
         unexpected!(p, "a string literal")
     };
-    let _ = cur!(p, false);
+    p.input_mut().cur();
     let with = if p.input().syntax().import_attributes()
         && !p.input_mut().had_line_break_before_cur()
         && (p.input_mut().eat(&P::Token::ASSERT) || p.input_mut().eat(&P::Token::WITH))
@@ -758,9 +758,10 @@ fn parse_import<'a, P: Parser<'a>>(p: &mut P) -> PResult<ModuleItem> {
     expect!(p, &P::Token::IMPORT);
 
     // Handle import 'mod.js'
-    if cur!(p, false).is_ok_and(|cur| cur.is_str()) {
+    if p.input_mut().cur().is_some_and(|cur| cur.is_str()) {
         let src = Box::new(parse_str_lit(p));
-        let _ = cur!(p, false);
+        debug_assert!(p.input_mut().get_cur().is_none());
+        p.input_mut().cur();
         let with = if p.input().syntax().import_attributes()
             && !p.input_mut().had_line_break_before_cur()
             && (p.input_mut().eat(&P::Token::ASSERT) || p.input_mut().eat(&P::Token::WITH))
@@ -886,7 +887,7 @@ fn parse_import<'a, P: Parser<'a>>(p: &mut P) -> PResult<ModuleItem> {
         }
     };
 
-    let _ = cur!(p, false);
+    p.input_mut().cur();
     let with = if p.input().syntax().import_attributes()
         && !p.input_mut().had_line_break_before_cur()
         && (p.input_mut().eat(&P::Token::ASSERT) || p.input_mut().eat(&P::Token::WITH))


### PR DESCRIPTION
try removing `cur!($parser, false)` since in most cases it's unnecessary to generate the error structure at this point.