### PR TITLE
feat: add support for preserving macro comments containing @common

### DIFF
--- a/crates/swc_compiler_base/src/lib.rs
+++ b/crates/swc_compiler_base/src/lib.rs
@@ -403,6 +403,17 @@ pub fn minify_file_comments(
             t.retain(preserve_excl);
         }
 
+        BoolOr::Data(JsMinifyCommentOption::PreserveMacroComments) => {
+            let preserve_excl = |_: &BytePos, vc: &mut std::vec::Vec<Comment>| -> bool {
+                vc.retain(|c: &Comment| c.text.contains("@common"));
+                !vc.is_empty()
+            };
+            let (mut l, mut t) = comments.borrow_all_mut();
+
+            l.retain(preserve_excl);
+            t.retain(preserve_excl);
+        }
+
         BoolOr::Data(JsMinifyCommentOption::PreserveRegexComments { regex }) => {
             let preserve_excl = |_: &BytePos, vc: &mut std::vec::Vec<Comment>| -> bool {
                 // Preserve comments that match the regex

--- a/crates/swc_ecma_minifier/src/js.rs
+++ b/crates/swc_ecma_minifier/src/js.rs
@@ -215,6 +215,8 @@ pub enum JsMinifyCommentOption {
     PreserveSomeComments,
     #[serde(rename = "all")]
     PreserveAllComments,
+    #[serde(rename = "macro")]
+    PreserveMacroComments,
     #[serde(untagged)]
     PreserveRegexComments { regex: CachedJsRegex },
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Support preservation of proposed macro `common` namespace. Prevents SWC from removing annotations intended for 'last-mile' optimization. 

**BREAKING CHANGE:**

No breaking changes introduced 

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
N/A