### PR TITLE
perf(es/minifier): avoid calling some costly function when optimizing deep nested binary expr

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/pure/drop_console.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/drop_console.rs
@@ -4,9 +4,9 @@ use swc_ecma_ast::*;
 use super::Pure;
 
 impl Pure<'_> {
-    pub(super) fn drop_console(&mut self, e: &mut Expr) {
+    pub(super) fn drop_console(&mut self, e: &mut Expr) -> bool {
         if !self.options.drop_console {
-            return;
+            return false;
         }
 
         let Some(callee) = (match e {
@@ -14,7 +14,7 @@ impl Pure<'_> {
             Expr::OptChain(opt_chain) => opt_chain.base.as_call().map(|call| &call.callee),
             _ => None,
         }) else {
-            return;
+            return false;
         };
 
         let Some(mut loop_co) = (match callee.as_ref() {
@@ -22,14 +22,14 @@ impl Pure<'_> {
             Expr::OptChain(opt_chain) => opt_chain.base.as_member().map(|member| &member.obj),
             _ => None,
         }) else {
-            return;
+            return false;
         };
 
         loop {
             match loop_co.as_ref() {
                 Expr::Ident(obj) => {
                     if obj.sym != *"console" {
-                        return;
+                        return false;
                     }
                     break;
                 }
@@ -42,14 +42,15 @@ impl Pure<'_> {
                 }
                 Expr::OptChain(opt_chain) => match opt_chain.base.as_member() {
                     Some(member) => loop_co = &member.obj,
-                    None => return,
+                    None => return false,
                 },
-                _ => return,
+                _ => return false,
             }
         }
 
         report_change!("drop_console: Removing console call");
         self.changed = true;
         *e = *Expr::undefined(DUMMY_SP);
+        true
     }
 }

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -411,6 +411,8 @@ impl Pure<'_> {
         *args = new_args;
     }
 
+    /// This function will be costly if the expr is a very long binary expr.
+    /// Call it only when necessary.
     pub(super) fn remove_invalid(&mut self, e: &mut Expr) {
         match e {
             Expr::Seq(seq) => {

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -413,6 +413,7 @@ impl Pure<'_> {
 
     /// This function will be costly if the expr is a very long binary expr.
     /// Call it only when necessary.
+    /// See also compress::optimize::remove_invalid_bin
     pub(super) fn remove_invalid(&mut self, e: &mut Expr) {
         match e {
             Expr::Seq(seq) => {

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -452,9 +452,9 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        let changed = self.eval_str_addition(e);
+        self.eval_str_addition(e);
 
-        if changed {
+        if self.changed {
             self.remove_invalid(e);
         }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -452,13 +452,17 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.eval_str_addition(e);
+        let changed = self.eval_str_addition(e);
 
-        self.remove_invalid(e);
+        if changed {
+            self.remove_invalid(e);
+        }
 
-        self.drop_console(e);
+        let changed = self.drop_console(e);
 
-        self.remove_invalid(e);
+        if changed {
+            self.remove_invalid(e);
+        }
 
         if let Expr::Seq(seq) = e {
             if seq.exprs.is_empty() {

--- a/crates/swc_ecma_minifier/src/compress/pure/strings.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/strings.rs
@@ -11,7 +11,7 @@ use super::Pure;
 impl Pure<'_> {
     /// This only handles `'foo' + ('bar' + baz) because others are handled by
     /// expression simplifier.
-    pub(super) fn eval_str_addition(&mut self, e: &mut Expr) {
+    pub(super) fn eval_str_addition(&mut self, e: &mut Expr) -> bool {
         let (span, l_l, r_l, r_r) = match e {
             Expr::Bin(
                 e @ BinExpr {
@@ -23,18 +23,18 @@ impl Pure<'_> {
                         op: op!(bin, "+"), ..
                     },
                 ) => (e.span, &mut *e.left, &mut *r.left, &mut r.right),
-                _ => return,
+                _ => return false,
             },
-            _ => return,
+            _ => return false,
         };
 
         match l_l.get_type(self.expr_ctx) {
             Known(Type::Str) => {}
-            _ => return,
+            _ => return false,
         }
         match r_l.get_type(self.expr_ctx) {
             Known(Type::Str) => {}
-            _ => return,
+            _ => return false,
         }
 
         let lls = l_l.as_pure_string(self.expr_ctx);
@@ -52,7 +52,9 @@ impl Pure<'_> {
                 right: r_r.take(),
             }
             .into();
+            return true;
         }
+        false
     }
 
     pub(super) fn eval_tpl_as_str(&mut self, e: &mut Expr) {

--- a/crates/swc_ecma_minifier/src/compress/pure/strings.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/strings.rs
@@ -11,7 +11,7 @@ use super::Pure;
 impl Pure<'_> {
     /// This only handles `'foo' + ('bar' + baz) because others are handled by
     /// expression simplifier.
-    pub(super) fn eval_str_addition(&mut self, e: &mut Expr) -> bool {
+    pub(super) fn eval_str_addition(&mut self, e: &mut Expr) {
         let (span, l_l, r_l, r_r) = match e {
             Expr::Bin(
                 e @ BinExpr {
@@ -23,18 +23,18 @@ impl Pure<'_> {
                         op: op!(bin, "+"), ..
                     },
                 ) => (e.span, &mut *e.left, &mut *r.left, &mut r.right),
-                _ => return false,
+                _ => return,
             },
-            _ => return false,
+            _ => return,
         };
 
         match l_l.get_type(self.expr_ctx) {
             Known(Type::Str) => {}
-            _ => return false,
+            _ => return,
         }
         match r_l.get_type(self.expr_ctx) {
             Known(Type::Str) => {}
-            _ => return false,
+            _ => return,
         }
 
         let lls = l_l.as_pure_string(self.expr_ctx);
@@ -52,9 +52,7 @@ impl Pure<'_> {
                 right: r_r.take(),
             }
             .into();
-            return true;
         }
-        false
     }
 
     pub(super) fn eval_tpl_as_str(&mut self, e: &mut Expr) {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -1005,25 +1005,23 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
     match op {
         op!(bin, "+") => {
             // It's string concatenation if either left or right is string.
-            if left.is_str() || left.is_array_lit() || right.is_str() || right.is_array_lit() {
-                if let (Known(l), Known(r)) = (
-                    left.as_pure_string(expr_ctx),
-                    right.as_pure_string(expr_ctx),
-                ) {
-                    let mut l = l.into_owned();
+            if let (Known(l), Known(r)) = (
+                left.as_pure_string(expr_ctx),
+                right.as_pure_string(expr_ctx),
+            ) {
+                let mut l = l.into_owned();
 
-                    l.push_str(&r);
+                l.push_str(&r);
 
-                    *changed = true;
+                *changed = true;
 
-                    *expr = Lit::Str(Str {
-                        raw: None,
-                        value: l.into(),
-                        span: *span,
-                    })
-                    .into();
-                    return;
-                }
+                *expr = Lit::Str(Str {
+                    raw: None,
+                    value: l.into(),
+                    span: *span,
+                })
+                .into();
+                return;
             }
 
             match expr.get_type(expr_ctx) {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -1009,19 +1009,21 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
                 left.as_pure_string(expr_ctx),
                 right.as_pure_string(expr_ctx),
             ) {
-                let mut l = l.into_owned();
+                if left.is_str() || left.is_array_lit() || right.is_str() || right.is_array_lit() {
+                    let mut l = l.into_owned();
 
-                l.push_str(&r);
+                    l.push_str(&r);
 
-                *changed = true;
+                    *changed = true;
 
-                *expr = Lit::Str(Str {
-                    raw: None,
-                    value: l.into(),
-                    span: *span,
-                })
-                .into();
-                return;
+                    *expr = Lit::Str(Str {
+                        raw: None,
+                        value: l.into(),
+                        span: *span,
+                    })
+                    .into();
+                    return;
+                }
             }
 
             match expr.get_type(expr_ctx) {


### PR DESCRIPTION
**Description:**

From profiling, there are some time consuming function due to the deeply nested binary expr:
1. recursively visit expr
2. recursive function: `compress::pure::misc::remove_invalid`
3. recursive function: `compress::optimize::remove_invalid_bin`
4. recursive function: `swc_ecma_utils::is_str`

Sadly it's hard to eliminate all of them (especially reason 1). This pr only decreases the calling of function 2, 3, 4.

Before: 2.17s with samply https://share.firefox.dev/3TmuvkH
After: 0.77s with samply https://share.firefox.dev/3FYPMOk 

**Related issue (if exists):**

related: https://github.com/swc-project/swc/issues/10219