### PR TITLE
fix(swc): Fix wrong caching of resolvers regarding file exts

### DIFF
--- a/.changeset/yellow-pugs-relax.md
+++ b/.changeset/yellow-pugs-relax.md
@@ -1,0 +1,6 @@
+---
+swc: patch
+swc_core: patch
+---
+
+fix(swc): build_resolver with error cache (without file_extension)

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1839,8 +1839,9 @@ fn build_resolver(
     resolve_fully: bool,
     file_extension: &str,
 ) -> SwcImportResolver {
-    static CACHE: Lazy<DashMap<(PathBuf, CompiledPaths, bool), SwcImportResolver, FxBuildHasher>> =
-        Lazy::new(Default::default);
+    static CACHE: Lazy<
+        DashMap<(PathBuf, CompiledPaths, bool, String), SwcImportResolver, FxBuildHasher>,
+    > = Lazy::new(Default::default);
 
     // On Windows, we need to normalize path as UNC path.
     if cfg!(target_os = "windows") {
@@ -1856,7 +1857,12 @@ fn build_resolver(
             .unwrap();
     }
 
-    if let Some(cached) = CACHE.get(&(base_url.clone(), paths.clone(), resolve_fully)) {
+    if let Some(cached) = CACHE.get(&(
+        base_url.clone(),
+        paths.clone(),
+        resolve_fully,
+        file_extension.to_owned(),
+    )) {
         return cached.clone();
     }
 
@@ -1883,7 +1889,10 @@ fn build_resolver(
         Arc::new(r)
     };
 
-    CACHE.insert((base_url, paths, resolve_fully), r.clone());
+    CACHE.insert(
+        (base_url, paths, resolve_fully, file_extension.to_owned()),
+        r.clone(),
+    );
 
     r
 }


### PR DESCRIPTION
**Description:**

fn `build_resolver` should not return cache when pass different `file_extension` value


https://github.com/swc-project/swc/blob/20551778ff9ce4cbde59b36a1582993f656b2eef/crates/swc/src/config/mod.rs#L1859-L1861
