### PR TITLE
fix(isolated_declaration): the usage of its type annotation should also depend on the usage of the ident name

### DIFF
--- a/.changeset/brave-drinks-remain.md
+++ b/.changeset/brave-drinks-remain.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_typescript: patch
+---
+
+fix(isolated_declaration): the usage of its type annotation should also depend on the usage of the ident name

--- a/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
+++ b/crates/swc_typescript/src/fast_dts/visitors/type_usage.rs
@@ -137,9 +137,6 @@ impl TypeUsageAnalyzer<'_> {
                 used_refs.add_usage(symbol.id.clone(), symbol.kind);
             }
         }
-        dbg!(&analyzer.references);
-        dbg!(&analyzer.graph);
-        dbg!(&used_refs);
         used_refs
     }
 

--- a/crates/swc_typescript/tests/fixture/issues/10620.snap
+++ b/crates/swc_typescript/tests/fixture/issues/10620.snap
@@ -1,0 +1,15 @@
+```==================== .D.TS ====================
+
+declare class Person {
+    name: string;
+    location: string;
+    constructor(name: string, location: string);
+}
+type PersonConstructor = new(name: string, location: string) => Person;
+declare const PersonsInJail: () => PersonConstructor;
+declare const NemesisLocation: ReturnType<typeof PersonsInJail>;
+export declare class KrustyShow extends NemesisLocation {
+}
+export { };
+
+

--- a/crates/swc_typescript/tests/fixture/issues/10620.ts
+++ b/crates/swc_typescript/tests/fixture/issues/10620.ts
@@ -1,0 +1,17 @@
+class Person {
+    constructor(public name: string, public location: string) {}
+}
+
+type PersonConstructor = new (name: string, location: string) => Person;
+
+const PersonsInJail: () => PersonConstructor = () => {
+    return class extends Person {
+        isInJail(): boolean {
+            return this.name === "Sideshow Bob";
+        }
+    };
+};
+
+const NemesisLocation: ReturnType<typeof PersonsInJail> = PersonsInJail();
+
+export class KrustyShow extends NemesisLocation {}


### PR DESCRIPTION
**Description:**
When the name of the decl is a binding ident, the usage of its type annotation should also depend on the usage of the ident name

**Related issue (if exists):**

fixes https://github.com/swc-project/swc/issues/10620