### PR TITLE
Fix 10662: make the inline optimization compatible with earlier rust versions

### DIFF
--- a/.changeset/tidy-tigers-lick.md
+++ b/.changeset/tidy-tigers-lick.md
@@ -1,0 +1,6 @@
+---
+hstr: patch
+swc_core: patch
+---
+
+Fix 10662: make the inline optimization compatible with earlier rust versions

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -155,14 +155,16 @@ pub(crate) const fn inline_atom(text: &str) -> Option<Atom> {
         // INLINE_TAG ensures this is never zero
         let tag = INLINE_TAG | ((len as u8) << LEN_OFFSET);
         let mut unsafe_data = TaggedValue::new_tag(NonZeroU8::new(tag).unwrap());
-        // This odd pattern is needed because we cannot create slices from ranges in
-        // constant context.
+        // This odd pattern is needed because we cannot create slices from ranges or
+        // ranges at all in constant context.  So we write our own copying loop.
         unsafe {
-            unsafe_data
-                .data_mut()
-                .split_at_mut(len)
-                .0
-                .copy_from_slice(text.as_bytes());
+            let data = unsafe_data.data_mut();
+            let bytes = text.as_bytes();
+            let mut i = 0;
+            while i < len {
+                data[i] = bytes[i];
+                i += 1;
+            }
         }
         return Some(Atom { unsafe_data });
     }
@@ -257,9 +259,11 @@ mod tests {
 
     #[test]
     fn global_ref_count_dynamic() {
-        let atom1 = Atom::new("Hello, world!");
+        // The strings should be long enough so that the are not inline even under
+        // feature `atom_size_128`
+        let atom1 = Atom::new("Hello, beautiful world!");
 
-        let atom2 = Atom::new("Hello, world!");
+        let atom2 = Atom::new("Hello, beautiful world!");
 
         // 2 for the two atoms, 1 for the global store
         assert_eq!(atom1.ref_count(), 3);

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -259,7 +259,7 @@ mod tests {
 
     #[test]
     fn global_ref_count_dynamic() {
-        // The strings should be long enough so that the are not inline even under
+        // The strings should be long enough so that they are not inline even under
         // feature `atom_size_128`
         let atom1 = Atom::new("Hello, beautiful world!");
 


### PR DESCRIPTION
The `copy_from_slice` method was not stabilized as `const` until 1.90. This replaces that method with a simple while loop which should be much more 'const compatible'

Tested with `rustup run 1.86 cargo test   -p hstr`  (note that also required removing the `-Zshare-generics=y` compiler flag).

Fixes #10662