### PR TITLE
fix(ts/isolated-dts): Skip parameters without accessibility modifiers in private constructors

### DIFF
--- a/.changeset/tidy-meals-share.md
+++ b/.changeset/tidy-meals-share.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_typescript: patch
+---
+
+fix(ts/isolated-dts): Skip parameters without accessibility modifiers in private constructors

--- a/crates/swc_typescript/tests/fixture/class-private-constructor.snap
+++ b/crates/swc_typescript/tests/fixture/class-private-constructor.snap
@@ -1,0 +1,11 @@
+```==================== .D.TS ====================
+
+export declare class Foo {
+    private constructor();
+}
+export declare class Bar {
+    readonly x: number;
+    private constructor();
+}
+
+

--- a/crates/swc_typescript/tests/fixture/class-private-constructor.ts
+++ b/crates/swc_typescript/tests/fixture/class-private-constructor.ts
@@ -1,0 +1,7 @@
+export class Foo {
+    private constructor(foo = new Set<string>()) {}
+}
+
+export class Bar {
+    private constructor(readonly x: number, foo = new Set<string>()) {}
+}


### PR DESCRIPTION
**Related issue:**

- Closes: #10674 
