### PR TITLE
perf(ts/fast-strip): Use `swc_ecma_parser::Lexer`

### DIFF
--- a/.changeset/swift-socks-reflect.md
+++ b/.changeset/swift-socks-reflect.md
@@ -1,0 +1,7 @@
+---
+swc_ecma_parser: minor
+swc_ts_fast_strip: minor
+swc_core: minor
+---
+
+refactor(ts/fast-strip): use `swc_ecma_parser::Lexer`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6563,7 +6563,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
- "swc_ecma_lexer",
+ "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_react",
  "swc_ecma_transforms_typescript",

--- a/crates/swc_ecma_parser/src/lexer/capturing.rs
+++ b/crates/swc_ecma_parser/src/lexer/capturing.rs
@@ -1,0 +1,190 @@
+use std::{cell::RefCell, mem, rc::Rc};
+
+use crate::{input::Tokens, lexer::token::TokenAndSpan};
+
+#[derive(Debug)]
+pub struct Capturing<I> {
+    inner: I,
+    captured: Rc<RefCell<Vec<TokenAndSpan>>>,
+}
+
+impl<I: Clone> Clone for Capturing<I> {
+    fn clone(&self) -> Self {
+        Capturing {
+            inner: self.inner.clone(),
+            captured: self.captured.clone(),
+        }
+    }
+}
+
+impl<I> Capturing<I> {
+    pub fn new(input: I) -> Self {
+        Capturing {
+            inner: input,
+            captured: Default::default(),
+        }
+    }
+
+    pub fn tokens(&self) -> Rc<RefCell<Vec<TokenAndSpan>>> {
+        self.captured.clone()
+    }
+
+    /// Take captured tokens
+    pub fn take(&mut self) -> Vec<TokenAndSpan> {
+        mem::take(&mut *self.captured.borrow_mut())
+    }
+}
+
+impl<I: Iterator<Item = TokenAndSpan>> Iterator for Capturing<I> {
+    type Item = TokenAndSpan;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.inner.next();
+
+        match next {
+            Some(ts) => {
+                let mut v = self.captured.borrow_mut();
+
+                // remove tokens that could change due to backtracing
+                while let Some(last) = v.last() {
+                    if last.span.lo >= ts.span.lo {
+                        v.pop();
+                    } else {
+                        break;
+                    }
+                }
+
+                v.push(ts);
+
+                Some(ts)
+            }
+            None => None,
+        }
+    }
+}
+
+impl<I: swc_ecma_lexer::common::input::Tokens<TokenAndSpan>>
+    swc_ecma_lexer::common::input::Tokens<TokenAndSpan> for Capturing<I>
+{
+    fn set_ctx(&mut self, ctx: swc_ecma_lexer::common::context::Context) {
+        self.inner.set_ctx(ctx);
+    }
+
+    fn ctx(&self) -> swc_ecma_lexer::common::context::Context {
+        self.inner.ctx()
+    }
+
+    fn syntax(&self) -> swc_ecma_lexer::Syntax {
+        self.inner.syntax()
+    }
+
+    fn target(&self) -> swc_ecma_ast::EsVersion {
+        self.inner.target()
+    }
+
+    fn set_expr_allowed(&mut self, allow: bool) {
+        self.inner.set_expr_allowed(allow);
+    }
+
+    fn set_next_regexp(&mut self, start: Option<swc_common::BytePos>) {
+        self.inner.set_next_regexp(start);
+    }
+
+    fn token_context(&self) -> &swc_ecma_lexer::lexer::TokenContexts {
+        self.inner.token_context()
+    }
+
+    fn token_context_mut(&mut self) -> &mut swc_ecma_lexer::lexer::TokenContexts {
+        self.inner.token_context_mut()
+    }
+
+    fn set_token_context(&mut self, c: swc_ecma_lexer::lexer::TokenContexts) {
+        self.inner.set_token_context(c);
+    }
+
+    fn add_error(&self, error: swc_ecma_lexer::error::Error) {
+        self.inner.add_error(error);
+    }
+
+    fn add_module_mode_error(&self, error: swc_ecma_lexer::error::Error) {
+        self.inner.add_module_mode_error(error);
+    }
+
+    fn end_pos(&self) -> swc_common::BytePos {
+        self.inner.end_pos()
+    }
+
+    fn take_errors(&mut self) -> Vec<swc_ecma_lexer::error::Error> {
+        self.inner.take_errors()
+    }
+
+    fn take_script_module_errors(&mut self) -> Vec<swc_ecma_lexer::error::Error> {
+        self.inner.take_script_module_errors()
+    }
+
+    fn update_token_flags(&mut self, f: impl FnOnce(&mut swc_ecma_lexer::lexer::TokenFlags)) {
+        self.inner.update_token_flags(f);
+    }
+
+    fn token_flags(&self) -> swc_ecma_lexer::lexer::TokenFlags {
+        self.inner.token_flags()
+    }
+}
+
+impl<I: Tokens> Tokens for Capturing<I> {
+    fn clone_token_value(&self) -> Option<super::TokenValue> {
+        self.inner.clone_token_value()
+    }
+
+    fn take_token_value(&mut self) -> Option<super::TokenValue> {
+        self.inner.take_token_value()
+    }
+
+    fn get_token_value(&self) -> Option<&super::TokenValue> {
+        self.inner.get_token_value()
+    }
+
+    fn set_token_value(&mut self, token_value: Option<super::TokenValue>) {
+        self.inner.set_token_value(token_value);
+    }
+
+    fn scan_jsx_token(&mut self, allow_multiline_jsx_text: bool) -> Option<TokenAndSpan> {
+        self.inner.scan_jsx_token(allow_multiline_jsx_text)
+    }
+
+    fn scan_jsx_open_el_terminal_token(&mut self) -> Option<TokenAndSpan> {
+        self.inner.scan_jsx_open_el_terminal_token()
+    }
+
+    fn rescan_jsx_open_el_terminal_token(
+        &mut self,
+        reset: swc_common::BytePos,
+    ) -> Option<TokenAndSpan> {
+        self.inner.rescan_jsx_open_el_terminal_token(reset)
+    }
+
+    fn rescan_jsx_token(
+        &mut self,
+        allow_multiline_jsx_text: bool,
+        reset: swc_common::BytePos,
+    ) -> Option<TokenAndSpan> {
+        self.inner.rescan_jsx_token(allow_multiline_jsx_text, reset)
+    }
+
+    fn scan_jsx_identifier(&mut self, start: swc_common::BytePos) -> TokenAndSpan {
+        self.inner.scan_jsx_identifier(start)
+    }
+
+    fn scan_jsx_attribute_value(&mut self) -> Option<TokenAndSpan> {
+        self.inner.scan_jsx_attribute_value()
+    }
+
+    fn rescan_template_token(
+        &mut self,
+        start: swc_common::BytePos,
+        start_with_back_tick: bool,
+    ) -> Option<TokenAndSpan> {
+        self.inner
+            .rescan_template_token(start, start_with_back_tick)
+    }
+}

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -24,6 +24,8 @@ use crate::{
     Context, Syntax,
 };
 
+#[cfg(feature = "unstable")]
+pub(crate) mod capturing;
 mod state;
 mod table;
 pub(crate) mod token;

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -135,13 +135,16 @@ pub mod unstable {
     //!
     //! Although it's marked as unstable, we can ensure that we will not
     //! introduce too many breaking changes. And we also encourage the
-    //! applications to migrate to the lexer and tokens in the respect to
+    //! applications to migrate to the lexer and tokens in terms of
     //! the performance.
     //!
     //! Also see the dicussion https://github.com/swc-project/swc/discussions/10683
     pub use swc_ecma_lexer::common::lexer::token::TokenFactory;
 
-    pub use crate::lexer::token::{NextTokenAndSpan, Token, TokenAndSpan, TokenValue};
+    pub use crate::lexer::{
+        capturing::Capturing,
+        token::{NextTokenAndSpan, Token, TokenAndSpan, TokenValue},
+    };
 }
 
 pub mod lexer;

--- a/crates/swc_ts_fast_strip/Cargo.toml
+++ b/crates/swc_ts_fast_strip/Cargo.toml
@@ -28,7 +28,9 @@ swc_common = { version = "13.0.1", path = "../swc_common", features = [
 ] }
 swc_ecma_ast = { version = "13.0.0", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "15.0.1", path = "../swc_ecma_codegen" }
-swc_ecma_lexer = { version = "17.0.5", path = "../swc_ecma_lexer" }
+swc_ecma_parser = { version = "17.1.0", path = "../swc_ecma_parser", features = [
+  "unstable",
+] }
 swc_ecma_transforms_base = { version = "18.0.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_react = { version = "20.0.0", path = "../swc_ecma_transforms_react" }
 swc_ecma_transforms_typescript = { version = "20.0.0", path = "../swc_ecma_transforms_typescript" }

--- a/crates/swc_ts_fast_strip/src/lib.rs
+++ b/crates/swc_ts_fast_strip/src/lib.rs
@@ -709,7 +709,7 @@ impl TsStrip {
 
         if let TokenAndSpan {
             // Only `(`, `[` and backtick affect ASI.
-            token: Token::LParen | Token::LBracket | Token::BackQuote,
+            token: Token::LParen | Token::LBracket | Token::NoSubstitutionTemplateLiteral,
             had_line_break: true,
             ..
         } = &self.tokens[index + 1]

--- a/crates/swc_ts_fast_strip/src/lib.rs
+++ b/crates/swc_ts_fast_strip/src/lib.rs
@@ -734,7 +734,7 @@ impl TsStrip {
 
             // see ts_next_token_can_follow_modifier
             // class { public public() {} }
-            if <Token as TokenFactory<'_, TokenAndSpan, Capturing<Lexer>>>::is_word(&next.token)
+            if !<Token as TokenFactory<'_, TokenAndSpan, Capturing<Lexer>>>::is_word(&next.token)
                 && !matches!(
                     next.token,
                     Token::LBracket

--- a/crates/swc_ts_fast_strip/src/lib.rs
+++ b/crates/swc_ts_fast_strip/src/lib.rs
@@ -21,10 +21,10 @@ use swc_ecma_ast::{
     TsSatisfiesExpr, TsTypeAliasDecl, TsTypeAnn, TsTypeAssertion, TsTypeParamDecl,
     TsTypeParamInstantiation, VarDeclarator, WhileStmt, YieldExpr,
 };
-use swc_ecma_lexer::{
+use swc_ecma_parser::{
     lexer::Lexer,
-    token::{BinOpToken, IdentLike, KnownIdent, Token, TokenAndSpan, Word},
-    Capturing, Parser, StringInput, Syntax, TsSyntax,
+    unstable::{Capturing, Token, TokenAndSpan, TokenFactory},
+    Parser, StringInput, Syntax, TsSyntax,
 };
 use swc_ecma_transforms_base::{
     fixer::fixer,
@@ -564,16 +564,13 @@ impl Visit for ErrorOnTsModule<'_> {
                 .binary_search_by_key(&pos, |t| t.span.lo)
                 .unwrap();
 
-            debug_assert_eq!(
-                self.tokens[declare_index].token,
-                Token::Word(Word::Ident(IdentLike::Known(KnownIdent::Declare)))
-            );
+            debug_assert_eq!(self.tokens[declare_index].token, Token::Declare);
 
             let TokenAndSpan { token, span, .. } = &self.tokens[declare_index + 1];
             // declare global
             // declare module
             // declare namespace
-            if let Token::Word(Word::Ident(IdentLike::Known(KnownIdent::Namespace))) = token {
+            if matches!(token, Token::Namespace) {
                 return;
             }
 
@@ -688,8 +685,10 @@ impl TsStrip {
         match token {
             Token::LParen
             | Token::LBracket
-            | Token::BackQuote
-            | Token::BinOp(BinOpToken::Add | BinOpToken::Sub | BinOpToken::Div) => {
+            | Token::NoSubstitutionTemplateLiteral
+            | Token::Plus
+            | Token::Minus
+            | Token::Slash => {
                 if prev_token == &Token::Semi {
                     self.add_overwrite(prev_span.lo, b';');
                     return;
@@ -735,34 +734,30 @@ impl TsStrip {
 
             // see ts_next_token_can_follow_modifier
             // class { public public() {} }
-            if !matches!(
-                next.token,
-                Token::LBracket
-                    | Token::LBrace
-                    | Token::BinOp(BinOpToken::Mul)
-                    | Token::DotDotDot
-                    | Token::Hash
-                    | Token::Word(_)
-                    | Token::Str { .. }
-                    | Token::Num { .. }
-                    | Token::BigInt { .. }
-            ) {
+            if <Token as TokenFactory<'_, TokenAndSpan, Capturing<Lexer>>>::is_word(&next.token)
+                && !matches!(
+                    next.token,
+                    Token::LBracket
+                        | Token::LBrace
+                        | Token::Asterisk
+                        | Token::DotDotDot
+                        | Token::Hash
+                        | Token::Str
+                        | Token::Num
+                        | Token::BigInt
+                )
+            {
                 return;
             }
 
             match token {
-                Token::Word(Word::Ident(IdentLike::Known(KnownIdent::Static))) => {
+                Token::Static => {
                     continue;
                 }
-                Token::Word(Word::Ident(IdentLike::Known(
-                    KnownIdent::Readonly
-                    | KnownIdent::Public
-                    | KnownIdent::Protected
-                    | KnownIdent::Private,
-                ))) => {
+                Token::Readonly | Token::Public | Token::Protected | Token::Private => {
                     self.add_replacement(*span);
                 }
-                Token::Word(Word::Ident(IdentLike::Other(o))) if *o == "override" => {
+                Token::Override => {
                     self.add_replacement(*span);
                 }
                 _ => {
@@ -980,19 +975,13 @@ impl Visit for TsStrip {
             let mark_pos = n.decorators.last().map_or(n.span.lo, |d| d.span.hi);
             let r#abstract = self.get_next_token_index(mark_pos);
 
-            self.strip_token(
-                r#abstract,
-                Token::Word(Word::Ident(IdentLike::Known(KnownIdent::Abstract))),
-            )
+            self.strip_token(r#abstract, Token::Abstract)
         }
 
         if !n.implements.is_empty() {
             let implements =
                 self.get_prev_token(n.implements.first().unwrap().span.lo - BytePos(1));
-            debug_assert_eq!(
-                implements.token,
-                Token::Word(Word::Ident(IdentLike::Known(KnownIdent::Implements)))
-            );
+            debug_assert_eq!(implements.token, Token::Implements);
 
             let last = n.implements.last().unwrap();
             let span = span(implements.span.lo, last.span.hi);
@@ -1335,10 +1324,7 @@ impl Visit for TsStrip {
             span: as_span,
             ..
         } = self.get_next_token(n.expr.span_hi());
-        debug_assert_eq!(
-            token,
-            &Token::Word(Word::Ident(IdentLike::Known(KnownIdent::As)))
-        );
+        debug_assert_eq!(token, &Token::As);
         self.fix_asi_in_expr(span(as_span.lo, n.span.hi));
 
         n.expr.visit_children_with(self);
@@ -1440,10 +1426,7 @@ impl Visit for TsStrip {
             span: as_span,
             ..
         } = self.get_next_token(n.expr.span_hi());
-        debug_assert_eq!(
-            token,
-            &Token::Word(Word::Ident(IdentLike::Known(KnownIdent::Satisfies)))
-        );
+        debug_assert_eq!(token, &Token::Satisfies);
         self.fix_asi_in_expr(span(as_span.lo, n.span.hi));
 
         n.expr.visit_children_with(self);

--- a/crates/swc_ts_fast_strip/tests/fixture.rs
+++ b/crates/swc_ts_fast_strip/tests/fixture.rs
@@ -4,7 +4,9 @@ use swc_common::{
     comments::SingleThreadedComments, errors::Handler, sync::Lrc, FileName, SourceMap,
 };
 use swc_ecma_ast::EsVersion;
-use swc_ecma_lexer::{lexer::Lexer, Capturing, EsSyntax, Parser, StringInput, Syntax, TsSyntax};
+use swc_ecma_parser::{
+    lexer::Lexer, unstable::Capturing, EsSyntax, Parser, StringInput, Syntax, TsSyntax,
+};
 use swc_ts_fast_strip::{operate, Mode, Options, TransformConfig};
 use testing::NormalizedOutput;
 


### PR DESCRIPTION
**Description:**

`ts_fast_strip` can benefit from the new lexer, see: https://github.com/swc-project/swc/discussions/10683