### PR TITLE
perf(ts/fast-strip): prealloc buf for codegen

### DIFF
--- a/.changeset/stupid-llamas-remain.md
+++ b/.changeset/stupid-llamas-remain.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_fast_ts_strip: patch
+---
+
+perf(ts/fast-strip): prealloc buf for codegen

--- a/crates/swc_fast_ts_strip/src/lib.rs
+++ b/crates/swc_fast_ts_strip/src/lib.rs
@@ -237,6 +237,7 @@ pub fn operate(
         .filename
         .map_or(FileName::Anon, |f| FileName::Real(f.into()));
 
+    let source_len = input.len();
     let fm = cm.new_source_file(filename.into(), input);
 
     let syntax = Syntax::Typescript(options.parser);
@@ -475,7 +476,7 @@ pub fn operate(
                 Ok(())
             })?;
 
-            let mut src = std::vec::Vec::new();
+            let mut src = std::vec::Vec::with_capacity(source_len);
             let mut src_map_buf = if options.source_map {
                 Some(Vec::new())
             } else {


### PR DESCRIPTION
**Description:**

Learnt from oxc's codegen. However, swc doesn't provide a universal codegen api, so the users should do this by themselves.