### PR TITLE
fix(es/react-compiler): Use tsx syntax for parser

### DIFF
--- a/.changeset/sweet-up-time.md
+++ b/.changeset/sweet-up-time.md
@@ -1,0 +1,5 @@
+---
+binding_react_compiler_node: patch
+---
+
+fix(binding_react_compiler_node): Should parse tsx or ts file correctly, otherwise it always return false.

--- a/bindings/binding_react_compiler_node/src/support.rs
+++ b/bindings/binding_react_compiler_node/src/support.rs
@@ -1,7 +1,7 @@
 use napi::bindgen_prelude::*;
 use swc_core::{
     common::{sync::Lrc, FileName, SourceMap},
-    ecma::ast::EsVersion,
+    ecma::{ast::EsVersion, parser::Syntax},
 };
 
 struct IsReactCompilerRequiredTask {
@@ -28,7 +28,11 @@ fn is_react_compiler_required_inner(code: &str) -> bool {
 
     let program = swc_core::ecma::parser::parse_file_as_program(
         &fm,
-        Default::default(),
+        Syntax::Typescript(swc_core::ecma::parser::TsSyntax {
+            decorators: true,
+            tsx: true,
+            ..Default::default()
+        }),
         EsVersion::latest(),
         None,
         &mut vec![],


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
We using `is_react_compiler_required` in ts or tsx file. But it's not support parse tsx syntax, so it's always return false.

https://github.com/swc-project/swc/blob/main/bindings/binding_react_compiler_node/src/support.rs#L37-L39

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
