### PR TITLE
fix(es/parser): Throw error if JSX does not end with `>`

### DIFF
--- a/.changeset/mean-pans-burn.md
+++ b/.changeset/mean-pans-burn.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): throw error if jsx not end with gt

--- a/crates/swc_ecma_parser/src/parser/jsx/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/jsx/mod.rs
@@ -369,12 +369,11 @@ impl<I: Tokens> Parser<I> {
                 } else {
                     // <xxxxx/>
                     p.expect(&Token::Slash)?;
-                    if p.expect_without_advance(&Token::Gt).is_ok() {
-                        if in_expr_context {
-                            p.bump();
-                        } else {
-                            p.input_mut().scan_jsx_token(true);
-                        }
+                    p.expect_without_advance(&Token::Gt)?;
+                    if in_expr_context {
+                        p.bump();
+                    } else {
+                        p.input_mut().scan_jsx_token(true);
                     }
                     let span = if in_expr_context {
                         Span::new(start, p.last_pos())

--- a/crates/swc_ecma_parser/tests/jsx/errors/issue-10681/index.js
+++ b/crates/swc_ecma_parser/tests/jsx/errors/issue-10681/index.js
@@ -1,0 +1,1 @@
+export default () => <div /

--- a/crates/swc_ecma_parser/tests/jsx/errors/issue-10681/index.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/jsx/errors/issue-10681/index.js.swc-stderr
@@ -1,0 +1,4 @@
+  x Unexpected eof
+   ,-[$DIR/tests/jsx/errors/issue-10681/index.js:1:1]
+ 1 | export default () => <div /
+   `----


### PR DESCRIPTION
Fixes #10681