### PR TITLE
fix(es/parser): Support keywords as JSX member expression properties

### DIFF
--- a/.changeset/long-parrots-love.md
+++ b/.changeset/long-parrots-love.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): Support keywords as JSX member expression properties

--- a/crates/swc/tests/fixture/issues-10xxx/10698/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-10xxx/10698/input/.swcrc
@@ -1,0 +1,14 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": true
+        },
+        "transform": {
+            "react": {
+                "runtime": "automatic",
+                "throwIfNamespace": false
+            }
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10698/input/index.jsx
+++ b/crates/swc/tests/fixture/issues-10xxx/10698/input/index.jsx
@@ -1,0 +1,15 @@
+const render = () => {
+    return <widget.component.type />;
+};
+
+const foo = () => {
+    return (
+        <widget.string>
+            <Foo.interface />
+        </widget.string>
+    );
+};
+
+const bar = () => {
+    return <widget:number></widget:number>;
+};

--- a/crates/swc/tests/fixture/issues-10xxx/10698/output/index.jsx
+++ b/crates/swc/tests/fixture/issues-10xxx/10698/output/index.jsx
@@ -1,0 +1,12 @@
+var _require = require("react/jsx-runtime"), _jsx = _require.jsx;
+var render = function() {
+    return /*#__PURE__*/ _jsx(widget.component.type, {});
+};
+var foo = function() {
+    return /*#__PURE__*/ _jsx(widget.string, {
+        children: /*#__PURE__*/ _jsx(Foo.interface, {})
+    });
+};
+var bar = function() {
+    return /*#__PURE__*/ _jsx("widget:number", {});
+};

--- a/crates/swc_ecma_parser/src/parser/jsx/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/jsx/mod.rs
@@ -8,6 +8,7 @@ use swc_ecma_lexer::{
             buffer::Buffer,
             expr::{parse_assignment_expr, parse_str_lit},
             get_qualified_jsx_name,
+            ident::parse_ident_name,
             jsx::{
                 jsx_expr_container_to_jsx_attr_value, parse_jsx_expr_container,
                 parse_jsx_spread_child,
@@ -84,7 +85,7 @@ impl<I: Tokens> Parser<I> {
         };
         while self.input_mut().eat(&Token::Dot) {
             let _ = self.input_mut().cur();
-            let prop: IdentName = self.parse_jsx_ident()?.into();
+            let prop: IdentName = parse_ident_name(self)?;
             let new_node = JSXElementName::JSXMemberExpr(JSXMemberExpr {
                 span: self.span(start),
                 obj: match node {

--- a/crates/swc_ecma_parser/tests/jsx/basic/issue-10698/input.js
+++ b/crates/swc_ecma_parser/tests/jsx/basic/issue-10698/input.js
@@ -1,0 +1,7 @@
+<widget.component.type />;
+
+<widget.string>
+    <Foo.interface />
+</widget.string>;
+
+<widget:number></widget:number>;

--- a/crates/swc_ecma_parser/tests/jsx/basic/issue-10698/input.js
+++ b/crates/swc_ecma_parser/tests/jsx/basic/issue-10698/input.js
@@ -5,3 +5,10 @@
 </widget.string>;
 
 <widget:number></widget:number>;
+
+<a-b.type />;
+<a-type.c />;
+<a-type.type />;
+<type-type.type />;
+<type-b.type />;
+<type-type.c />;

--- a/crates/swc_ecma_parser/tests/jsx/basic/issue-10698/input.js.json
+++ b/crates/swc_ecma_parser/tests/jsx/basic/issue-10698/input.js.json
@@ -2,7 +2,7 @@
   "type": "Module",
   "span": {
     "start": 1,
-    "end": 118
+    "end": 218
   },
   "body": [
     {
@@ -292,6 +292,312 @@
             }
           }
         }
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 120,
+        "end": 133
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 120,
+          "end": 132
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXMemberExpression",
+            "span": {
+              "start": 121,
+              "end": 129
+            },
+            "object": {
+              "type": "Identifier",
+              "span": {
+                "start": 121,
+                "end": 124
+              },
+              "ctxt": 0,
+              "value": "a-b",
+              "optional": false
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 125,
+                "end": 129
+              },
+              "value": "type"
+            }
+          },
+          "span": {
+            "start": 120,
+            "end": 132
+          },
+          "attributes": [],
+          "selfClosing": true,
+          "typeArguments": null
+        },
+        "children": [],
+        "closing": null
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 134,
+        "end": 147
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 134,
+          "end": 146
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXMemberExpression",
+            "span": {
+              "start": 135,
+              "end": 143
+            },
+            "object": {
+              "type": "Identifier",
+              "span": {
+                "start": 135,
+                "end": 141
+              },
+              "ctxt": 0,
+              "value": "a-type",
+              "optional": false
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 142,
+                "end": 143
+              },
+              "value": "c"
+            }
+          },
+          "span": {
+            "start": 134,
+            "end": 146
+          },
+          "attributes": [],
+          "selfClosing": true,
+          "typeArguments": null
+        },
+        "children": [],
+        "closing": null
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 148,
+        "end": 164
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 148,
+          "end": 163
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXMemberExpression",
+            "span": {
+              "start": 149,
+              "end": 160
+            },
+            "object": {
+              "type": "Identifier",
+              "span": {
+                "start": 149,
+                "end": 155
+              },
+              "ctxt": 0,
+              "value": "a-type",
+              "optional": false
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 156,
+                "end": 160
+              },
+              "value": "type"
+            }
+          },
+          "span": {
+            "start": 148,
+            "end": 163
+          },
+          "attributes": [],
+          "selfClosing": true,
+          "typeArguments": null
+        },
+        "children": [],
+        "closing": null
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 165,
+        "end": 184
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 165,
+          "end": 183
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXMemberExpression",
+            "span": {
+              "start": 166,
+              "end": 180
+            },
+            "object": {
+              "type": "Identifier",
+              "span": {
+                "start": 166,
+                "end": 175
+              },
+              "ctxt": 0,
+              "value": "type-type",
+              "optional": false
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 176,
+                "end": 180
+              },
+              "value": "type"
+            }
+          },
+          "span": {
+            "start": 165,
+            "end": 183
+          },
+          "attributes": [],
+          "selfClosing": true,
+          "typeArguments": null
+        },
+        "children": [],
+        "closing": null
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 185,
+        "end": 201
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 185,
+          "end": 200
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXMemberExpression",
+            "span": {
+              "start": 186,
+              "end": 197
+            },
+            "object": {
+              "type": "Identifier",
+              "span": {
+                "start": 186,
+                "end": 192
+              },
+              "ctxt": 0,
+              "value": "type-b",
+              "optional": false
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 193,
+                "end": 197
+              },
+              "value": "type"
+            }
+          },
+          "span": {
+            "start": 185,
+            "end": 200
+          },
+          "attributes": [],
+          "selfClosing": true,
+          "typeArguments": null
+        },
+        "children": [],
+        "closing": null
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 202,
+        "end": 218
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 202,
+          "end": 217
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXMemberExpression",
+            "span": {
+              "start": 203,
+              "end": 214
+            },
+            "object": {
+              "type": "Identifier",
+              "span": {
+                "start": 203,
+                "end": 212
+              },
+              "ctxt": 0,
+              "value": "type-type",
+              "optional": false
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 213,
+                "end": 214
+              },
+              "value": "c"
+            }
+          },
+          "span": {
+            "start": 202,
+            "end": 217
+          },
+          "attributes": [],
+          "selfClosing": true,
+          "typeArguments": null
+        },
+        "children": [],
+        "closing": null
       }
     }
   ],

--- a/crates/swc_ecma_parser/tests/jsx/basic/issue-10698/input.js.json
+++ b/crates/swc_ecma_parser/tests/jsx/basic/issue-10698/input.js.json
@@ -1,0 +1,299 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 118
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 1,
+        "end": 27
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 1,
+          "end": 26
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXMemberExpression",
+            "span": {
+              "start": 2,
+              "end": 23
+            },
+            "object": {
+              "type": "JSXMemberExpression",
+              "span": {
+                "start": 2,
+                "end": 18
+              },
+              "object": {
+                "type": "Identifier",
+                "span": {
+                  "start": 2,
+                  "end": 8
+                },
+                "ctxt": 0,
+                "value": "widget",
+                "optional": false
+              },
+              "property": {
+                "type": "Identifier",
+                "span": {
+                  "start": 9,
+                  "end": 18
+                },
+                "value": "component"
+              }
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 19,
+                "end": 23
+              },
+              "value": "type"
+            }
+          },
+          "span": {
+            "start": 1,
+            "end": 26
+          },
+          "attributes": [],
+          "selfClosing": true,
+          "typeArguments": null
+        },
+        "children": [],
+        "closing": null
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 29,
+        "end": 84
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 29,
+          "end": 83
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXMemberExpression",
+            "span": {
+              "start": 30,
+              "end": 43
+            },
+            "object": {
+              "type": "Identifier",
+              "span": {
+                "start": 30,
+                "end": 36
+              },
+              "ctxt": 0,
+              "value": "widget",
+              "optional": false
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 37,
+                "end": 43
+              },
+              "value": "string"
+            }
+          },
+          "span": {
+            "start": 29,
+            "end": 44
+          },
+          "attributes": [],
+          "selfClosing": false,
+          "typeArguments": null
+        },
+        "children": [
+          {
+            "type": "JSXText",
+            "span": {
+              "start": 44,
+              "end": 49
+            },
+            "value": "\n    ",
+            "raw": "\n    "
+          },
+          {
+            "type": "JSXElement",
+            "span": {
+              "start": 49,
+              "end": 66
+            },
+            "opening": {
+              "type": "JSXOpeningElement",
+              "name": {
+                "type": "JSXMemberExpression",
+                "span": {
+                  "start": 50,
+                  "end": 63
+                },
+                "object": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 50,
+                    "end": 53
+                  },
+                  "ctxt": 0,
+                  "value": "Foo",
+                  "optional": false
+                },
+                "property": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 54,
+                    "end": 63
+                  },
+                  "value": "interface"
+                }
+              },
+              "span": {
+                "start": 49,
+                "end": 66
+              },
+              "attributes": [],
+              "selfClosing": true,
+              "typeArguments": null
+            },
+            "children": [],
+            "closing": null
+          },
+          {
+            "type": "JSXText",
+            "span": {
+              "start": 66,
+              "end": 67
+            },
+            "value": "\n",
+            "raw": "\n"
+          }
+        ],
+        "closing": {
+          "type": "JSXClosingElement",
+          "span": {
+            "start": 67,
+            "end": 83
+          },
+          "name": {
+            "type": "JSXMemberExpression",
+            "span": {
+              "start": 69,
+              "end": 82
+            },
+            "object": {
+              "type": "Identifier",
+              "span": {
+                "start": 69,
+                "end": 75
+              },
+              "ctxt": 0,
+              "value": "widget",
+              "optional": false
+            },
+            "property": {
+              "type": "Identifier",
+              "span": {
+                "start": 76,
+                "end": 82
+              },
+              "value": "string"
+            }
+          }
+        }
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 86,
+        "end": 118
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 86,
+          "end": 117
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "JSXNamespacedName",
+            "span": {
+              "start": 87,
+              "end": 100
+            },
+            "namespace": {
+              "type": "Identifier",
+              "span": {
+                "start": 87,
+                "end": 93
+              },
+              "value": "widget"
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 94,
+                "end": 100
+              },
+              "value": "number"
+            }
+          },
+          "span": {
+            "start": 86,
+            "end": 101
+          },
+          "attributes": [],
+          "selfClosing": false,
+          "typeArguments": null
+        },
+        "children": [],
+        "closing": {
+          "type": "JSXClosingElement",
+          "span": {
+            "start": 101,
+            "end": 117
+          },
+          "name": {
+            "type": "JSXNamespacedName",
+            "span": {
+              "start": 103,
+              "end": 116
+            },
+            "namespace": {
+              "type": "Identifier",
+              "span": {
+                "start": 103,
+                "end": 109
+              },
+              "value": "widget"
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 110,
+                "end": 116
+              },
+              "value": "number"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Related issue:**

- Closes: #10698

