### PR TITLE
fix(es/minifier): Do not drop self-referential class expressions

### DIFF
--- a/.changeset/khaki-years-divide.md
+++ b/.changeset/khaki-years-divide.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_minifier: patch
+swc_core: patch
+---
+
+fix(es/minifier): Do not drop self-referential class expressions

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10539/1/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10539/1/input.js
@@ -1,0 +1,4 @@
+
+(class ClassExpr {
+    static prop = new ClassExpr();
+});

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10539/1/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10539/1/input.js
@@ -2,3 +2,5 @@
 (class ClassExpr {
     static prop = new ClassExpr();
 });
+
+console.log('foo')

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10539/1/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10539/1/output.js
@@ -1,0 +1,3 @@
+(class ClassExpr {
+    static prop = new ClassExpr();
+}), console.log('foo');

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10539/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10539/input.js
@@ -6,13 +6,6 @@ var DoesntWork = class DoesntWorkClass {
     static prop = new DoesntWorkClass();
 };
 
-// Extra test case
-
-(class ClassExpr {
-    static prop = new ClassExpr();
-});
-
-
 // works fine
 class WorksClass {
     static prop = new WorksClass();

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10539/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10539/input.js
@@ -4,7 +4,14 @@ var DisappearsCompletely = class DisappearsCompletelyClass { };
 // class def disappears, leaving only `new DoesntWorkClass()` as output
 var DoesntWork = class DoesntWorkClass {
     static prop = new DoesntWorkClass();
-}
+};
+
+// Extra test case
+
+(class ClassExpr {
+    static prop = new ClassExpr();
+});
+
 
 // works fine
 class WorksClass {

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10539/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10539/input.js
@@ -1,0 +1,12 @@
+// class def completely disappears
+var DisappearsCompletely = class DisappearsCompletelyClass { };
+
+// class def disappears, leaving only `new DoesntWorkClass()` as output
+var DoesntWork = class DoesntWorkClass {
+    static prop = new DoesntWorkClass();
+}
+
+// works fine
+class WorksClass {
+    static prop = new WorksClass();
+};

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10539/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10539/output.js
@@ -1,0 +1,9 @@
+// class def completely disappears
+// class def disappears, leaving only `new DoesntWorkClass()` as output
+(class DoesntWorkClass {
+    static prop = new DoesntWorkClass();
+});
+// works fine
+class WorksClass {
+    static prop = new WorksClass();
+}

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -484,21 +484,13 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_class_expr(&mut self, n: &ClassExpr) {
-        self.with_ast_path(
-            n.ident.as_ref().map(|i| i.to_id()).into_iter().collect(),
-            |v| {
-                let old = v.cur_class_id.take();
-                v.cur_class_id = n.ident.as_ref().map(|i| i.to_id());
-                n.visit_children_with(v);
-                v.cur_class_id = old;
+        n.visit_children_with(self);
 
-                if !n.class.decorators.is_empty() {
-                    if let Some(i) = &n.ident {
-                        v.add(i.to_id(), false);
-                    }
-                }
-            },
-        )
+        if !n.class.decorators.is_empty() {
+            if let Some(i) = &n.ident {
+                self.add(i.to_id(), false);
+            }
+        }
     }
 
     fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -484,13 +484,21 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_class_expr(&mut self, n: &ClassExpr) {
-        n.visit_children_with(self);
+        self.with_ast_path(
+            n.ident.as_ref().map(|i| i.to_id()).into_iter().collect(),
+            |v| {
+                let old = v.cur_class_id.take();
+                v.cur_class_id = n.ident.as_ref().map(|i| i.to_id());
+                n.visit_children_with(v);
+                v.cur_class_id = old;
 
-        if !n.class.decorators.is_empty() {
-            if let Some(i) = &n.ident {
-                self.add(i.to_id(), false);
-            }
-        }
+                if !n.class.decorators.is_empty() {
+                    if let Some(i) = &n.ident {
+                        v.add(i.to_id(), false);
+                    }
+                }
+            },
+        )
     }
 
     fn visit_export_named_specifier(&mut self, n: &ExportNamedSpecifier) {


### PR DESCRIPTION
**Description:**

I'll implement proper removal logic with follow-up PRs.

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/10539