### PR TITLE
fix(es/lexer): Parse uppercase hex numbers correctly

### DIFF
--- a/.changeset/red-zoos-hang.md
+++ b/.changeset/red-zoos-hang.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_lexer: patch
+---
+
+fix(es/lexer): Parse uppercase hex numbers correctly

--- a/crates/swc/tests/fixture/issues-10xxx/10724/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-10xxx/10724/input/.swcrc
@@ -1,0 +1,7 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript"
+        }
+    }
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10724/input/index.ts
+++ b/crates/swc/tests/fixture/issues-10xxx/10724/input/index.ts
@@ -1,0 +1,4 @@
+export enum Mask {
+    /* prettier-ignore */
+    UseAll = 0x1F_FFFF_FFFF_FFFF
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10724/output/index.ts
+++ b/crates/swc/tests/fixture/issues-10xxx/10724/output/index.ts
@@ -1,0 +1,4 @@
+export var Mask = /*#__PURE__*/ function(Mask) {
+    /* prettier-ignore */ Mask[Mask["UseAll"] = 9007199254740991] = "UseAll";
+    return Mask;
+}({});

--- a/crates/swc_ecma_parser/tests/js/issue-10724/input.js
+++ b/crates/swc_ecma_parser/tests/js/issue-10724/input.js
@@ -1,0 +1,2 @@
+/* prettier-ignore */
+0x1F_FFFF_FFFF_FFFF;

--- a/crates/swc_ecma_parser/tests/js/issue-10724/input.js.json
+++ b/crates/swc_ecma_parser/tests/js/issue-10724/input.js.json
@@ -1,0 +1,26 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 23,
+    "end": 43
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 23,
+        "end": 43
+      },
+      "expression": {
+        "type": "NumericLiteral",
+        "span": {
+          "start": 23,
+          "end": 42
+        },
+        "value": 9007199254740991.0,
+        "raw": "0x1F_FFFF_FFFF_FFFF"
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Related issue:**

- Closes: #10724 
