### PR TITLE
fix(es/minifier): Mark `cons` and `alt` of `CondExpr` as `ref`

### DIFF
--- a/.changeset/rotten-rules-jump.md
+++ b/.changeset/rotten-rules-jump.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_usage_analyzer: patch
+---
+
+fix(es/minifier): Mark `cons` and `alt` of `CondExpr` as `ref`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5654,7 +5654,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "17.2.0"
+version = "17.2.1"
 dependencies = [
  "arrayvec",
  "bitflags 2.6.0",

--- a/crates/swc/tests/tsc-references/destructuringObjectBindingPatternAndAssignment1ES5.2.minified.js
+++ b/crates/swc/tests/tsc-references/destructuringObjectBindingPatternAndAssignment1ES5.2.minified.js
@@ -1,9 +1,13 @@
 //// [destructuringObjectBindingPatternAndAssignment1ES5.ts]
+(void 0).a1;
+var tmp = {
+    b21: "world"
+};
 function foo1() {
     return {
         prop1: 2
     };
 }
-(void 0).a1, (void 0 === tmp ? {
+(void 0 === tmp ? {
     b21: "string"
 } : tmp).b21, foo1().prop1, foo1().prop2;

--- a/crates/swc/tests/tsc-references/destructuringVariableDeclaration1ES5.2.minified.js
+++ b/crates/swc/tests/tsc-references/destructuringVariableDeclaration1ES5.2.minified.js
@@ -1,6 +1,9 @@
 //// [destructuringVariableDeclaration1ES5.ts]
 import { _ as _sliced_to_array } from "@swc/helpers/_/_sliced_to_array";
 import { _ as _to_consumable_array } from "@swc/helpers/_/_to_consumable_array";
+var tmp = {
+    b11: "world"
+};
 (void 0 === tmp ? {
     b11: "string"
 } : tmp).b11;

--- a/crates/swc/tests/tsc-references/destructuringVariableDeclaration1ES5iterable.2.minified.js
+++ b/crates/swc/tests/tsc-references/destructuringVariableDeclaration1ES5iterable.2.minified.js
@@ -1,6 +1,9 @@
 //// [destructuringVariableDeclaration1ES5iterable.ts]
 import { _ as _sliced_to_array } from "@swc/helpers/_/_sliced_to_array";
 import { _ as _to_consumable_array } from "@swc/helpers/_/_to_consumable_array";
+var tmp = {
+    b11: "world"
+};
 (void 0 === tmp ? {
     b11: "string"
 } : tmp).b11;

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10721/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10721/input.js
@@ -1,0 +1,13 @@
+var _ref1 = {
+    b1: {
+        b11: "world"
+    }
+}, tmp = _ref1.b1, b11 = (tmp === void 0 ? {
+    b11: "string"
+} : tmp).b11;
+var temp = {
+    t1: true,
+    t2: "false"
+};
+
+export { b11 };

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10721/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10721/output.js
@@ -1,0 +1,6 @@
+var tmp = {
+    b11: "world"
+}, b11 = (void 0 === tmp ? {
+    b11: "string"
+} : tmp).b11;
+export { b11 };

--- a/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
+++ b/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
@@ -1,14 +1,14 @@
 | File | Original Size | Compressed Size | Gzipped Size |
 | --- | --- | --- | --- |
 | antd.js | 6.38 MiB | 2.06 MiB | 445.41 KiB |
-| d3.js | 542.74 KiB | 261.63 KiB | 85.57 KiB |
-| echarts.js | 3.41 MiB | 977.52 KiB | 314.19 KiB |
+| d3.js | 542.74 KiB | 261.44 KiB | 85.33 KiB |
+| echarts.js | 3.41 MiB | 977.51 KiB | 314.17 KiB |
 | jquery.js | 280.89 KiB | 87.80 KiB | 30.21 KiB |
 | lodash.js | 531.35 KiB | 68.91 KiB | 24.60 KiB |
 | moment.js | 169.83 KiB | 57.39 KiB | 18.26 KiB |
 | react.js | 70.45 KiB | 22.44 KiB | 8.04 KiB |
 | terser.js | 1.08 MiB | 446.68 KiB | 120.49 KiB |
 | three.js | 1.19 MiB | 630.83 KiB | 154.80 KiB |
-| typescript.js | 10.45 MiB | 3.17 MiB | 840.68 KiB |
+| typescript.js | 10.45 MiB | 3.17 MiB | 840.67 KiB |
 | victory.js | 2.30 MiB | 694.16 KiB | 154.24 KiB |
 | vue.js | 334.13 KiB | 113.72 KiB | 41.82 KiB |

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
@@ -607,10 +607,17 @@ where
         tracing::instrument(level = "debug", skip_all)
     )]
     fn visit_cond_expr(&mut self, n: &CondExpr) {
-        n.test.visit_with(self);
+        {
+            let ctx = self.ctx.with(BitContext::IsIdRef, false);
+
+            n.test.visit_with(&mut *self.with_ctx(ctx));
+        }
 
         {
-            let ctx = self.ctx.with(BitContext::InCond, true);
+            let ctx = self
+                .ctx
+                .with(BitContext::InCond, true)
+                .with(BitContext::IsIdRef, true);
             self.with_ctx(ctx).visit_in_cond(&n.cons);
             self.with_ctx(ctx).visit_in_cond(&n.alt);
         }

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/mod.rs
@@ -1488,6 +1488,9 @@ where
 fn for_each_id_ref_in_expr(e: &Expr, op: &mut impl FnMut(&Ident)) {
     match e {
         Expr::Ident(i) => op(i),
+        Expr::Paren(p) => {
+            for_each_id_ref_in_expr(&p.expr, op);
+        }
         Expr::Cond(c) => {
             for_each_id_ref_in_expr(&c.cons, op);
             for_each_id_ref_in_expr(&c.alt, op);


### PR DESCRIPTION
**Description:**

These are acutall references

**Related issue:**

 - Closes https://github.com/swc-project/swc/issues/10721