### PR TITLE
refactor(es/ast): Replace `Literal` with `StringLiteral` in JSXAttrValue type

### DIFF
--- a/bindings/binding_core_wasm/src/types.rs
+++ b/bindings/binding_core_wasm/src/types.rs
@@ -1727,7 +1727,7 @@ export interface JSXAttribute extends Node, HasSpan {
 export type JSXAttributeName = Identifier | JSXNamespacedName;
 
 export type JSXAttrValue =
-  | Literal
+  | StringLiteral
   | JSXExpressionContainer
   | JSXElement
   | JSXFragment;

--- a/bindings/binding_minifier_wasm/src/types.rs
+++ b/bindings/binding_minifier_wasm/src/types.rs
@@ -1726,7 +1726,7 @@ export interface JSXAttribute extends Node, HasSpan {
 export type JSXAttributeName = Identifier | JSXNamespacedName;
 
 export type JSXAttrValue =
-  | Literal
+  | StringLiteral
   | JSXExpressionContainer
   | JSXElement
   | JSXFragment;

--- a/crates/swc_ecma_ast/src/jsx.rs
+++ b/crates/swc_ecma_ast/src/jsx.rs
@@ -5,9 +5,8 @@ use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 use crate::{
     expr::{Expr, SpreadElement},
     ident::Ident,
-    lit::Lit,
     typescript::TsTypeParamInstantiation,
-    IdentName,
+    IdentName, Str,
 };
 
 /// Used for `obj` property of `JSXMemberExpr`.
@@ -190,12 +189,7 @@ pub enum JSXAttrName {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXAttrValue {
     #[tag("StringLiteral")]
-    #[tag("BooleanLiteral")]
-    #[tag("NullLiteral")]
-    #[tag("NumericLiteral")]
-    #[tag("RegExpLiteral")]
-    #[tag("JSXText")]
-    Lit(Lit),
+    Str(Str),
 
     #[tag("JSXExpressionContainer")]
     JSXExprContainer(JSXExprContainer),

--- a/crates/swc_ecma_codegen/src/jsx.rs
+++ b/crates/swc_ecma_codegen/src/jsx.rs
@@ -85,7 +85,7 @@ impl MacroNode for JSXAttr {
 impl MacroNode for JSXAttrValue {
     fn emit(&mut self, emitter: &mut Macro) -> Result {
         match *self {
-            JSXAttrValue::Lit(ref n) => emit!(n),
+            JSXAttrValue::Str(ref n) => emit!(n),
             JSXAttrValue::JSXExprContainer(ref n) => emit!(n),
             JSXAttrValue::JSXElement(ref n) => emit!(n),
             JSXAttrValue::JSXFragment(ref n) => emit!(n),

--- a/crates/swc_ecma_lexer/src/common/parser/jsx.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/jsx.rs
@@ -169,7 +169,7 @@ fn parse_jsx_attr_value<'a, P: Parser<'a>>(p: &mut P) -> PResult<JSXAttrValue> {
         let node = parse_jsx_expr_container(p)?;
         jsx_expr_container_to_jsx_attr_value(p, start, node)
     } else if cur.is_str() {
-        Ok(JSXAttrValue::Lit(Lit::Str(parse_str_lit(p))))
+        Ok(JSXAttrValue::Str(parse_str_lit(p)))
     } else if cur.is_jsx_tag_start() {
         let expr = parse_jsx_element(p)?;
         match expr {

--- a/crates/swc_ecma_parser/src/parser/jsx/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/jsx/mod.rs
@@ -241,7 +241,7 @@ impl<I: Tokens> Parser<I> {
             match cur.token {
                 Token::Str => {
                     let value = parse_str_lit(self);
-                    Ok(Some(JSXAttrValue::Lit(Lit::Str(value))))
+                    Ok(Some(JSXAttrValue::Str(value)))
                 }
                 Token::LBrace => {
                     let start = self.cur_pos();
@@ -498,11 +498,11 @@ mod tests {
                     attrs: vec![JSXAttrOrSpread::JSXAttr(JSXAttr {
                         span,
                         name: JSXAttrName::Ident(IdentName::new(atom!("id"), span)),
-                        value: Some(JSXAttrValue::Lit(Lit::Str(Str {
+                        value: Some(JSXAttrValue::Str(Str {
                             span,
                             value: atom!("w < w"),
                             raw: Some(atom!("\"w &lt; w\"")),
-                        }))),
+                        })),
                     })],
                     name: JSXElementName::Ident(Ident::new_no_ctxt(atom!("div"), span)),
                     self_closing: true,

--- a/crates/swc_ecma_quote_macros/src/ast/expr.rs
+++ b/crates/swc_ecma_quote_macros/src/ast/expr.rs
@@ -145,7 +145,7 @@ impl_struct!(JSXAttr, [span, name, value]);
 
 impl_enum!(
     JSXAttrValue,
-    [Lit, JSXExprContainer, JSXElement, JSXFragment]
+    [Str, JSXExprContainer, JSXElement, JSXFragment]
 );
 
 impl_enum!(JSXAttrName, [Ident, JSXNamespacedName]);

--- a/crates/swc_ecma_transforms_react/src/jsx/automatic.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/automatic.rs
@@ -639,7 +639,7 @@ fn add_require(imports: Vec<(Ident, IdentName)>, src: &str, unresolved_mark: Mar
 
 fn jsx_attr_value_to_expr(v: JSXAttrValue) -> Option<Box<Expr>> {
     Some(match v {
-        JSXAttrValue::Lit(Lit::Str(s)) => {
+        JSXAttrValue::Str(s) => {
             let value = transform_jsx_attr_str(&s.value);
 
             Lit::Str(Str {
@@ -649,7 +649,6 @@ fn jsx_attr_value_to_expr(v: JSXAttrValue) -> Option<Box<Expr>> {
             })
             .into()
         }
-        JSXAttrValue::Lit(lit) => Box::new(lit.into()),
         JSXAttrValue::JSXExprContainer(e) => match e.expr {
             JSXExpr::JSXEmptyExpr(_) => None?,
             JSXExpr::Expr(e) => e,

--- a/crates/swc_ecma_transforms_react/src/jsx/classic.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/classic.rs
@@ -274,7 +274,7 @@ impl Classic {
         let value = a
             .value
             .map(|v| match v {
-                JSXAttrValue::Lit(Lit::Str(s)) => {
+                JSXAttrValue::Str(s) => {
                     let value = transform_jsx_attr_str(&s.value);
 
                     Lit::Str(Str {
@@ -290,7 +290,6 @@ impl Classic {
                 }) => e,
                 JSXAttrValue::JSXElement(element) => Box::new(self.jsx_elem_to_expr(*element)),
                 JSXAttrValue::JSXFragment(fragment) => Box::new(self.jsx_frag_to_expr(fragment)),
-                JSXAttrValue::Lit(lit) => Box::new(lit.into()),
                 JSXAttrValue::JSXExprContainer(JSXExprContainer {
                     span: _,
                     expr: JSXExpr::JSXEmptyExpr(_),

--- a/crates/swc_estree_compat/src/babelify/jsx.rs
+++ b/crates/swc_estree_compat/src/babelify/jsx.rs
@@ -4,7 +4,7 @@ use swc_ecma_ast::{
     JSXAttr, JSXAttrName, JSXAttrOrSpread, JSXAttrValue, JSXClosingElement, JSXClosingFragment,
     JSXElement, JSXElementChild, JSXElementName, JSXEmptyExpr, JSXExpr, JSXExprContainer,
     JSXFragment, JSXMemberExpr, JSXNamespacedName, JSXObject, JSXOpeningElement,
-    JSXOpeningFragment, JSXSpreadChild, JSXText, Lit,
+    JSXOpeningFragment, JSXSpreadChild, JSXText,
 };
 use swc_estree_ast::{
     flavor::Flavor, JSXAttrName as BabelJSXAttrName, JSXAttrVal, JSXAttribute,
@@ -212,17 +212,7 @@ impl Babelify for JSXAttrValue {
 
     fn babelify(self, ctx: &Context) -> Self::Output {
         match self {
-            JSXAttrValue::Lit(lit) => {
-                // TODO(dwoznicki): Babel only seems to accept string literals here. Is that
-                // right?
-                match lit {
-                    Lit::Str(s) => JSXAttrVal::String(s.babelify(ctx)),
-                    _ => panic!(
-                        "illegal conversion: Cannot convert {:?} to JsxAttrVal::Lit",
-                        &lit
-                    ),
-                }
-            }
+            JSXAttrValue::Str(s) => JSXAttrVal::String(s.babelify(ctx)),
             JSXAttrValue::JSXExprContainer(e) => JSXAttrVal::Expr(e.babelify(ctx)),
             JSXAttrValue::JSXElement(e) => JSXAttrVal::Element(e.babelify(ctx)),
             JSXAttrValue::JSXFragment(f) => JSXAttrVal::Fragment(f.babelify(ctx)),

--- a/crates/swc_estree_compat/src/swcify/expr.rs
+++ b/crates/swc_estree_compat/src/swcify/expr.rs
@@ -941,7 +941,7 @@ impl Swcify for JSXAttrVal {
         match self {
             JSXAttrVal::Element(v) => JSXAttrValue::JSXElement(Box::new(v.swcify(ctx))),
             JSXAttrVal::Fragment(v) => JSXAttrValue::JSXFragment(v.swcify(ctx)),
-            JSXAttrVal::String(v) => JSXAttrValue::Lit(Lit::Str(v.swcify(ctx))),
+            JSXAttrVal::String(v) => JSXAttrValue::Str(v.swcify(ctx)),
             JSXAttrVal::Expr(v) => JSXAttrValue::JSXExprContainer(v.swcify(ctx)),
         }
     }

--- a/packages/core/src/Visitor.ts
+++ b/packages/core/src/Visitor.ts
@@ -1628,14 +1628,6 @@ export class Visitor {
         if (!n) return n;
 
         switch (n.type) {
-            case "BooleanLiteral":
-                return this.visitBooleanLiteral(n);
-            case "NullLiteral":
-                return this.visitNullLiteral(n);
-            case "NumericLiteral":
-                return this.visitNumericLiteral(n);
-            case "JSXText":
-                return this.visitJSXText(n);
             case "StringLiteral":
                 return this.visitStringLiteral(n);
 

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1799,7 +1799,7 @@ export interface JSXAttribute extends Node, HasSpan {
 export type JSXAttributeName = Identifier | JSXNamespacedName;
 
 export type JSXAttrValue =
-    | Literal
+    | StringLiteral
     | JSXExpressionContainer
     | JSXElement
     | JSXFragment;


### PR DESCRIPTION
**Related issue:**
- Closes: #10584