### PR TITLE
chore: make swc_ecma_lint optional for swc crate

### DIFF
--- a/.changeset/fast-ladybugs-jog.md
+++ b/.changeset/fast-ladybugs-jog.md
@@ -1,0 +1,6 @@
+---
+swc: minor
+swc_core: minor
+---
+
+chore: make swc_ecma_lint optional

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -25,7 +25,7 @@ concurrent = [
 ]
 
 debug = ["swc_ecma_visit/debug", "swc_ecma_minifier/debug"]
-default = ["es3"]
+default = ["es3", "lint"]
 es3 = []
 node = ["napi", "napi-derive", "swc_compiler_base/node"]
 plugin = [
@@ -49,6 +49,8 @@ plugin_transform_host_native = [
 ]
 # Do not inject tokio runtime while running plugin transforms
 manual-tokio-runtime = []
+
+lint = ["swc_ecma_lints"]
 
 [dependencies]
 anyhow        = { workspace = true }
@@ -83,7 +85,7 @@ swc_config = { version = "3.1.1", path = "../swc_config" }
 swc_ecma_ast = { version = "13.0.0", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "15.0.1", path = "../swc_ecma_codegen" }
 swc_ecma_ext_transforms = { version = "18.0.0", path = "../swc_ecma_ext_transforms" }
-swc_ecma_lints = { version = "19.0.0", path = "../swc_ecma_lints" }
+swc_ecma_lints = { version = "19.0.0", path = "../swc_ecma_lints", optional = true }
 swc_ecma_loader = { version = "13.0.0", path = "../swc_ecma_loader", features = [
   "cache",
   "node",

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -19,7 +19,7 @@ use swc_common::plugin::metadata::TransformPluginMetadataContext;
 use swc_common::{
     comments::{Comments, SingleThreadedComments},
     errors::Handler,
-    FileName, Mark, SourceMap, SyntaxContext,
+    FileName, Mark, SourceMap,
 };
 pub use swc_compiler_base::SourceMapsConfig;
 pub use swc_config::is_module::IsModule;
@@ -30,6 +30,7 @@ use swc_config::{
 };
 use swc_ecma_ast::{noop_pass, EsVersion, Expr, Pass, Program};
 use swc_ecma_ext_transforms::jest;
+#[cfg(feature = "lint")]
 use swc_ecma_lints::{
     config::LintConfig,
     rules::{lint_pass, LintParams},
@@ -263,6 +264,7 @@ impl Options {
             paths,
             minify: mut js_minify,
             experimental,
+            #[cfg(feature = "lint")]
             lints,
             preserve_all_comments,
             ..
@@ -504,9 +506,6 @@ impl Options {
                 .map(|opts| opts.build(cm, handler, unresolved_mark))
         };
 
-        let unresolved_ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
-        let top_level_ctxt = SyntaxContext::empty().apply_mark(top_level_mark);
-
         let pass = (
             const_modules,
             optimization,
@@ -653,7 +652,6 @@ impl Options {
         );
 
         let keep_import_attributes = experimental.keep_import_attributes.into_bool();
-        let disable_all_lints = experimental.disable_all_lints.into_bool();
 
         #[cfg(feature = "plugin")]
         let plugin_transforms: Box<dyn Pass> = {
@@ -737,7 +735,24 @@ impl Options {
                     ),
                     DecoratorVersion::V202311 => todo!("2023-11 decorator"),
                 };
-
+            #[cfg(feature = "lint")]
+            let lint = {
+                use swc_common::SyntaxContext;
+                let disable_all_lints = experimental.disable_all_lints.into_bool();
+                let unresolved_ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
+                let top_level_ctxt = SyntaxContext::empty().apply_mark(top_level_mark);
+                Optional::new(
+                    lint_pass(swc_ecma_lints::rules::all(LintParams {
+                        program: &program,
+                        lint_config: &lints,
+                        top_level_ctxt,
+                        unresolved_ctxt,
+                        es_version,
+                        source_map: cm.clone(),
+                    })),
+                    !disable_all_lints,
+                )
+            };
             Box::new((
                 (
                     if experimental.run_plugin_first.into_bool() {
@@ -745,17 +760,8 @@ impl Options {
                     } else {
                         None
                     },
-                    Optional::new(
-                        lint_pass(swc_ecma_lints::rules::all(LintParams {
-                            program: &program,
-                            lint_config: &lints,
-                            top_level_ctxt,
-                            unresolved_ctxt,
-                            es_version,
-                            source_map: cm.clone(),
-                        })),
-                        !disable_all_lints,
-                    ),
+                    #[cfg(feature = "lint")]
+                    lint,
                     // Decorators may use type information
                     Optional::new(decorator_pass, syntax.decorators()),
                     Optional::new(
@@ -1265,6 +1271,7 @@ pub struct JscConfig {
     pub experimental: JscExperimental,
 
     #[serde(default)]
+    #[cfg(feature = "lint")]
     pub lints: LintConfig,
 
     #[serde(default)]


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
swc_ecma_lint is not necessary for parser & transform, so make it optional for Rust API users
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
