### PR TITLE
fix(es): Use `default-features = false` for `swc` crate usages

### DIFF
--- a/.changeset/blue-beers-raise.md
+++ b/.changeset/blue-beers-raise.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_estree_compat: patch
+---
+
+fix: make default_features empty by default

--- a/.changeset/quiet-dolphins-brush.md
+++ b/.changeset/quiet-dolphins-brush.md
@@ -1,0 +1,6 @@
+---
+swc_core: major
+swc_estree_compat: major
+---
+
+fix(es): Use `default-features = false` for `swc` crate usages

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -347,7 +347,7 @@ par-core = { workspace = true, optional = true }
 
 # swc_* dependencies
 binding_macros                   = { optional = true, version = "29.0.0", path = "../binding_macros" }
-swc                              = { optional = true, version = "29.1.1", path = "../swc" }
+swc                              = { optional = true, version = "29.1.1", path = "../swc", default-features = false }
 swc_allocator                    = { version = "4.0.1", path = "../swc_allocator", default-features = false }
 swc_atoms                        = { optional = true, version = "6.0.1", path = "../swc_atoms" }
 swc_bundler                      = { optional = true, version = "23.0.1", path = "../swc_bundler" }

--- a/crates/swc_estree_compat/Cargo.toml
+++ b/crates/swc_estree_compat/Cargo.toml
@@ -39,7 +39,7 @@ swc_node_comments = { version = "13.0.0", path = "../swc_node_comments/" }
 codspeed-criterion-compat = { workspace = true }
 pretty_assertions         = { workspace = true }
 
-swc                 = { version = "29.1.1", path = "../swc" }
+swc                 = { version = "29.1.1", path = "../swc", default-features = false }
 swc_ecma_ast        = { version = "13.0.1", path = "../swc_ecma_ast" }
 swc_ecma_parser     = { version = "18.0.2", path = "../swc_ecma_parser" }
 swc_ecma_transforms = { version = "23.0.1", path = "../swc_ecma_transforms/" }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
setting default-features=false for swc usage to avoid introduce unnecessary lint and es3 code for consumers
**BREAKING CHANGE:**
yes for swc and swc_core crate api 
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
