### PR TITLE
refactor(es/parser): rm `WithState`

### DIFF
--- a/crates/swc_ecma_lexer/src/common/parser/class_and_fn.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/class_and_fn.rs
@@ -642,10 +642,7 @@ fn parse_fn_body<'a, P: Parser<'a>, T>(
 
     let f_with_generator_context = |p: &mut P| {
         let f_with_inside_non_arrow_fn_scope = |p: &mut P| {
-            let f_with_new_state = |p: &mut P| {
-                let mut p = p.with_state(crate::common::parser::state::State::default());
-                f(&mut p, is_simple_parameter_list)
-            };
+            let f_with_new_state = |p: &mut P| f(p, is_simple_parameter_list);
 
             if is_arrow_function && !p.ctx().contains(Context::InsideNonArrowFunctionScope) {
                 p.do_outside_of_context(Context::InsideNonArrowFunctionScope, f_with_new_state)

--- a/crates/swc_ecma_lexer/src/common/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/mod.rs
@@ -7,7 +7,7 @@ use swc_ecma_ast::*;
 
 use self::{
     buffer::{Buffer, NextTokenAndSpan},
-    state::{State, WithState},
+    state::State,
     token_and_span::TokenAndSpan,
 };
 use super::{context::Context, input::Tokens, lexer::token::TokenFactory};
@@ -68,16 +68,6 @@ pub trait Parser<'a>: Sized + Clone {
     fn input_mut(&mut self) -> &mut Self::Buffer;
     fn state(&self) -> &State;
     fn state_mut(&mut self) -> &mut State;
-
-    #[inline(always)]
-    fn with_state<'w>(&'w mut self, state: State) -> WithState<'a, 'w, Self> {
-        let orig_state = std::mem::replace(self.state_mut(), state);
-        WithState {
-            orig_state,
-            inner: self,
-            marker: std::marker::PhantomData,
-        }
-    }
 
     #[inline(always)]
     fn ctx(&self) -> Context {

--- a/crates/swc_ecma_lexer/src/common/parser/state.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/state.rs
@@ -1,5 +1,3 @@
-use std::ops::{Deref, DerefMut};
-
 use rustc_hash::FxHashMap;
 use swc_atoms::Atom;
 use swc_common::{BytePos, Span};
@@ -11,29 +9,4 @@ pub struct State {
     pub potential_arrow_start: Option<BytePos>,
     /// Start position of an AST node and the span of its trailing comma.
     pub trailing_commas: FxHashMap<BytePos, Span>,
-}
-
-pub struct WithState<'a, 'w, Parser: super::Parser<'a>> {
-    pub(super) inner: &'w mut Parser,
-    pub(super) orig_state: crate::common::parser::state::State,
-    pub(super) marker: std::marker::PhantomData<&'a ()>,
-}
-
-impl<'a, Parser: super::Parser<'a>> Deref for WithState<'a, '_, Parser> {
-    type Target = Parser;
-
-    fn deref(&self) -> &Parser {
-        self.inner
-    }
-}
-impl<'a, Parser: super::Parser<'a>> DerefMut for WithState<'a, '_, Parser> {
-    fn deref_mut(&mut self) -> &mut Parser {
-        self.inner
-    }
-}
-
-impl<'a, Parser: super::Parser<'a>> Drop for WithState<'a, '_, Parser> {
-    fn drop(&mut self) {
-        std::mem::swap(self.inner.state_mut(), &mut self.orig_state);
-    }
 }

--- a/crates/swc_ecma_lexer/src/common/parser/stmt.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/stmt.rs
@@ -835,15 +835,6 @@ fn parse_labelled_stmt<'a, P: Parser<'a>>(p: &mut P, l: Ident) -> PResult<Stmt> 
         p.do_outside_of_context(Context::AllowUsingDecl, |p| {
             let start = l.span.lo();
 
-            let mut errors = Vec::new();
-            for lb in &p.state().labels {
-                if l.sym == *lb {
-                    errors.push(Error::new(
-                        l.span,
-                        SyntaxError::DuplicateLabel(l.sym.clone()),
-                    ));
-                }
-            }
             p.state_mut().labels.push(l.sym.clone());
 
             let body = Box::new(if p.input_mut().is(&P::Token::FUNCTION) {
@@ -861,10 +852,6 @@ fn parse_labelled_stmt<'a, P: Parser<'a>>(p: &mut P, l: Ident) -> PResult<Stmt> 
             } else {
                 p.do_outside_of_context(Context::TopLevel, parse_stmt)?
             });
-
-            for err in errors {
-                p.emit_error(err);
-            }
 
             {
                 let pos = p.state().labels.iter().position(|v| v == &l.sym);


### PR DESCRIPTION
`SyntaxError::DuplicateLabel` appears to serve no practical purpose.