### PR TITLE
refactor(swc_common):  replace `Option<Vec<Comment>>` with `Vec<Comment>` 

### DIFF
--- a/crates/jsdoc/tests/fixture.rs
+++ b/crates/jsdoc/tests/fixture.rs
@@ -89,19 +89,17 @@ impl Comments for SwcComments {
     }
 
     fn move_leading(&self, from: BytePos, to: BytePos) {
-        let cmt = self.take_leading(from);
+        let mut cmt = self.take_leading(from);
 
-        if let Some(mut cmt) = cmt {
             if from < to && self.has_leading(to) {
-                cmt.extend(self.take_leading(to).unwrap());
+                cmt.extend(self.take_leading(to));
             }
 
             self.add_leading_comments(to, cmt);
-        }
     }
 
-    fn take_leading(&self, pos: BytePos) -> Option<Vec<Comment>> {
-        self.leading.remove(&pos).map(|v| v.1)
+    fn take_leading(&self, pos: BytePos) -> Vec<Comment> {
+        self.leading.remove(&pos).map(|v| v.1).expect("Comment should exist")
     }
 
     fn get_leading(&self, pos: BytePos) -> Option<Vec<Comment>> {

--- a/crates/swc_ecma_codegen/src/comments.rs
+++ b/crates/swc_ecma_codegen/src/comments.rs
@@ -5,10 +5,11 @@ use super::*;
 
 macro_rules! write_comments {
     ($e:expr, $prefix_space:expr, $cmts:expr) => {{
-        let cmts = match $cmts {
-            Some(v) => v,
-            None => return Ok(()),
-        };
+        let cmts = $cmts;
+        
+        if cmts.is_empty() {
+            return Ok(());
+        }
 
         for cmt in cmts.iter() {
             match cmt.kind {
@@ -68,7 +69,7 @@ where
     ) -> Result {
         let cmts = self.take_trailing_comments_of_pos(pos);
 
-        write_comments!(self, prefix_space, &cmts)
+        write_comments!(self, prefix_space, cmts)
     }
 
     pub(super) fn emit_trailing_comments_of_pos_with(
@@ -81,20 +82,20 @@ where
 
         callback(self)?;
 
-        write_comments!(self, prefix_space, &cmts)
+        write_comments!(self, prefix_space, cmts)
     }
 
-    fn take_trailing_comments_of_pos(&mut self, pos: BytePos) -> Option<Vec<Comment>> {
+    fn take_trailing_comments_of_pos(&mut self, pos: BytePos) -> Vec<Comment> {
         if pos.is_dummy() {
-            return None;
+            return Vec::new();
         }
 
         let comments = match self.comments {
             Some(ref comments) => comments,
-            None => return None,
+            None => return Vec::new(),
         };
 
-        comments.take_trailing(pos)
+        comments.take_trailing(pos).unwrap_or_default()
     }
 
     pub(super) fn emit_leading_comments(&mut self, mut pos: BytePos, is_hi: bool) -> Result {
@@ -106,11 +107,11 @@ where
             write_comments!(
                 self,
                 false,
-                Some(vec![Comment {
+                vec![Comment {
                     kind: CommentKind::Block,
                     span: DUMMY_SP,
                     text: atom!("#__PURE__"),
-                }])
+                }]
             );
         }
 

--- a/crates/swc_estree_compat/src/babelify/mod.rs
+++ b/crates/swc_estree_compat/src/babelify/mod.rs
@@ -95,11 +95,9 @@ impl Context {
     /// Note that we removes comment from the comment map because `.babelify`
     /// takes `self`. (not reference)
     fn base(&self, span: Span) -> BaseNode {
-        let leading_comments = self
-            .comments
-            .take_leading(span.lo)
-            .map(|v| self.convert_comments(v))
-            .unwrap_or_default();
+        let leading_comments = self.convert_comments(
+            self.comments.take_leading(span.lo)
+        );
         let trailing_comments = self
             .comments
             .take_trailing(span.hi)

--- a/crates/swc_node_comments/src/lib.rs
+++ b/crates/swc_node_comments/src/lib.rs
@@ -37,19 +37,17 @@ impl Comments for SwcComments {
     }
 
     fn move_leading(&self, from: BytePos, to: BytePos) {
-        let cmt = self.take_leading(from);
+        let mut cmt = self.take_leading(from);
 
-        if let Some(mut cmt) = cmt {
             if from < to && self.has_leading(to) {
-                cmt.extend(self.take_leading(to).unwrap());
+                cmt.extend(self.take_leading(to));
             }
 
             self.add_leading_comments(to, cmt);
-        }
     }
 
-    fn take_leading(&self, pos: BytePos) -> Option<Vec<Comment>> {
-        self.leading.remove(&pos).map(|v| v.1)
+    fn take_leading(&self, pos: BytePos) -> Vec<Comment> {
+        self.leading.remove(&pos).map(|v| v.1).expect("Comment should exist")
     }
 
     fn get_leading(&self, pos: BytePos) -> Option<Vec<Comment>> {


### PR DESCRIPTION
**Description:**
replace `Option<Vec<Comment>>` with `Vec<Comment>` 

**BREAKING CHANGE:**
N/A

**Related issue (if exists):**
closes #10531 