### PR TITLE
fix(es/parser): Make `export` in NS to not affect file type

### DIFF
--- a/.changeset/olive-carrots-work.md
+++ b/.changeset/olive-carrots-work.md
@@ -1,0 +1,7 @@
+---
+swc_ecma_lexer: patch
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): export in ns not affect file type

--- a/crates/swc_ecma_lexer/src/common/context.rs
+++ b/crates/swc_ecma_lexer/src/common/context.rs
@@ -65,5 +65,7 @@ bitflags::bitflags! {
       const AllowUsingDecl = 1 << 28;
 
       const TopLevel = 1 << 29;
+
+      const TsModuleBlock = 1 << 30;
   }
 }

--- a/crates/swc_ecma_lexer/src/common/parser/module_item.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/module_item.rs
@@ -33,7 +33,10 @@ fn handle_import_export<'a, P: Parser<'a>>(
     p: &mut P,
     decorators: Vec<Decorator>,
 ) -> PResult<ModuleItem> {
-    if !p.ctx().contains(Context::TopLevel) {
+    if !p
+        .ctx()
+        .intersects(Context::TopLevel.union(Context::TsModuleBlock))
+    {
         syntax_error!(p, SyntaxError::NonTopLevelImportExport);
     }
 
@@ -343,7 +346,7 @@ fn parse_export<'a, P: Parser<'a>>(
     p: &mut P,
     mut decorators: Vec<Decorator>,
 ) -> PResult<ModuleDecl> {
-    if !p.ctx().contains(Context::Module) {
+    if !p.ctx().contains(Context::Module) && p.ctx().contains(Context::TopLevel) {
         // Switch to module mode
         let ctx = p.ctx() | Context::Module | Context::Strict;
         p.set_ctx(ctx);

--- a/crates/swc_ecma_lexer/src/common/parser/typescript.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/typescript.rs
@@ -2345,10 +2345,10 @@ fn parse_ts_module_block<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsModuleBlock>
 
     let start = p.cur_pos();
     expect!(p, &P::Token::LBRACE);
-    // Inside of a module block is considered "top-level", meaning it can have
-    // imports and exports.
-    let body = p.do_inside_of_context(Context::TopLevel, |p| {
-        parse_module_item_block_body(p, false, Some(&P::Token::RBRACE))
+    let body = p.do_inside_of_context(Context::TsModuleBlock, |p| {
+        p.do_outside_of_context(Context::TopLevel, |p| {
+            parse_module_item_block_body(p, false, Some(&P::Token::RBRACE))
+        })
     })?;
 
     Ok(TsModuleBlock {

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -28,7 +28,7 @@ impl<I: Tokens> Parser<I> {
 mod tests {
     use swc_atoms::atom;
     use swc_common::{comments::SingleThreadedComments, DUMMY_SP as span};
-    use swc_ecma_lexer::common::parser::stmt::TempForHead;
+    use swc_ecma_lexer::{common::parser::stmt::TempForHead, TsSyntax};
     use swc_ecma_visit::assert_eq_ignore_span;
 
     use super::*;
@@ -1180,5 +1180,31 @@ const foo;"#;
         let src = "let x = 0 < { } / 0 ;";
 
         test_parser(src, Default::default(), |p| p.parse_script());
+    }
+
+    #[test]
+    fn issue_10797_0() {
+        let src = "
+var b = delete ANY1;
+
+module A {
+    export const a = 1
+}";
+        test_parser(src, Syntax::Typescript(TsSyntax::default()), |p| {
+            p.parse_script()
+        });
+    }
+
+    #[test]
+    fn issue_10797_1() {
+        let src = "
+module A {
+    export const a = 1
+}
+
+var b = delete ANY1;";
+        test_parser(src, Syntax::Typescript(TsSyntax::default()), |p| {
+            p.parse_script()
+        });
     }
 }


### PR DESCRIPTION
Fixes #10797