### PR TITLE
refactor(es/helpers): Make inline helpers optional at compile time

### DIFF
--- a/.changeset/many-roses-mate.md
+++ b/.changeset/many-roses-mate.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_transforms_base: major
+---
+
+refactor(es/helpers): Make inline helpers optional at compile time

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6253,6 +6253,7 @@ dependencies = [
  "swc_ecma_loader",
  "swc_ecma_parser",
  "swc_ecma_transforms",
+ "swc_ecma_transforms_base",
  "swc_ecma_utils",
  "swc_malloc",
  "testing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,8 +125,8 @@ resolver = "2"
   wasmer                    = { version = "6.0.0", default-features = false }
   wasmer-wasix              = { version = "0.600.0", default-features = false }
 
-  precomputed-map           = "0.2"
-  foldhash                  = "0.1"
+  foldhash        = "0.1"
+  precomputed-map = "0.2"
 
   [workspace.metadata.cargo-shear]
   # `serde` is used when #[ast_node] is expanded
@@ -140,6 +140,7 @@ resolver = "2"
     "tracing",
     "num-bigint",
     "swc_ecma_utils",
+    "swc_ecma_transforms_base",
   ]
 
 [profile.release]

--- a/bindings/binding_core_node/Cargo.toml
+++ b/bindings/binding_core_node/Cargo.toml
@@ -57,6 +57,7 @@ swc_core = { workspace = true, features = [
   "common_concurrent",
   "bundler",
   "ecma_loader",
+  "ecma_helpers_inline",
   "ecma_transforms",
   "ecma_visit",
   "base_node",

--- a/bindings/binding_core_wasm/Cargo.toml
+++ b/bindings/binding_core_wasm/Cargo.toml
@@ -41,9 +41,10 @@ swc_core = { workspace = true, features = [
   "binding_macro_wasm",
   "ecma_transforms",
   "ecma_visit",
+  "ecma_helpers_inline",
 ] }
 tracing = { workspace = true, features = ["max_level_off"] }
 wasm-bindgen = { workspace = true, features = ["enable-interning"] }
 
-[package.metadata.wasm-pack.profile.release]
-wasm-opt = false
+  [package.metadata.wasm-pack.profile.release]
+  wasm-opt = false

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -131,13 +131,11 @@ swc_visit = { version = "2.0.1", path = "../swc_visit" }
   workspace = true
 
 [dev-dependencies]
-ansi_term = { workspace = true }
-criterion = { workspace = true }
-walkdir   = { workspace = true }
-
-
+ansi_term                 = { workspace = true }
 codspeed-criterion-compat = { workspace = true }
+criterion                 = { workspace = true }
 par-core                  = { workspace = true, features = ["chili"] }
+walkdir                   = { workspace = true }
 
 swc_ecma_ast = { version = "13.0.1", path = "../swc_ecma_ast", features = [
   "serde-impl",
@@ -146,6 +144,9 @@ swc_ecma_lints = { version = "19.0.3", path = "../swc_ecma_lints", features = [
   "non_critical_lints",
 ] }
 swc_ecma_testing = { version = "14.0.0", path = "../swc_ecma_testing" }
+swc_ecma_transforms_base = { version = "20.0.0", path = "../swc_ecma_transforms_base", features = [
+  "inline-helpers",
+] }
 swc_malloc = { version = "1.2.3", path = "../swc_malloc" }
 testing = { version = "14.0.1", path = "../testing" }
 

--- a/crates/swc_bundler/Cargo.toml
+++ b/crates/swc_bundler/Cargo.toml
@@ -65,6 +65,9 @@ swc_ecma_loader = { version = "13.0.0", path = "../swc_ecma_loader", features = 
 swc_ecma_minifier = { version = "25.0.0", path = "../swc_ecma_minifier", features = [
   "concurrent",
 ] }
+swc_ecma_transforms_base = { version = "20.0.0", path = "../swc_ecma_transforms_base", features = [
+  "inline-helpers",
+] }
 swc_ecma_transforms_proposal = { version = "20.0.0", path = "../swc_ecma_transforms_proposal" }
 swc_ecma_transforms_react = { version = "22.1.0", path = "../swc_ecma_transforms_react" }
 swc_ecma_transforms_typescript = { version = "22.0.0", path = "../swc_ecma_transforms_typescript" }

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -156,6 +156,8 @@ ecma_preset_env = ["__ecma", "swc_ecma_preset_env"]
 # Enable swc_ecma_usage_analyzer
 ecma_usage_analyzer = ["__ecma", "swc_ecma_usage_analyzer"]
 
+ecma_helpers_inline = ["__ecma", "swc_ecma_transforms_base/inline-helpers"]
+
 # Enable swc_css
 css_ast        = ["__css", "swc_css_ast"]
 css_ast_serde  = ["css_ast", "swc_css_ast/serde-impl"]

--- a/crates/swc_ecma_transforms/Cargo.toml
+++ b/crates/swc_ecma_transforms/Cargo.toml
@@ -33,7 +33,7 @@ stacker = ["swc_ecma_utils/stacker"]
 typescript = ["swc_ecma_transforms_typescript"]
 
 [dependencies]
-par-core = { workspace = true }
+par-core                         = { workspace = true }
 swc_common                       = { version = "13.0.4", path = "../swc_common" }
 swc_ecma_ast                     = { version = "13.0.1", path = "../swc_ecma_ast" }
 swc_ecma_transforms_base         = { version = "20.0.0", path = "../swc_ecma_transforms_base" }
@@ -47,7 +47,10 @@ swc_ecma_utils                   = { version = "18.1.0", path = "../swc_ecma_uti
 
 
 [dev-dependencies]
-par-core                    = { workspace = true, features = ["chili"] }
-swc_ecma_parser             = { version = "19.0.1", path = "../swc_ecma_parser" }
+par-core = { workspace = true, features = ["chili"] }
+swc_ecma_parser = { version = "19.0.0", path = "../swc_ecma_parser" }
+swc_ecma_transforms_base = { version = "20.0.0", path = "../swc_ecma_transforms_base", features = [
+  "inline-helpers",
+] }
 swc_ecma_transforms_testing = { version = "23.0.0", path = "../swc_ecma_transforms_testing" }
-testing                     = { version = "14.0.1", path = "../testing" }
+testing = { version = "14.0.1", path = "../testing" }

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -15,6 +15,8 @@ bench = false
 [features]
 concurrent         = ["concurrent-renamer", "par-iter", "swc_ecma_utils/concurrent"]
 concurrent-renamer = ["par-iter"]
+# Allow helpers to be inlined. If this feature is disabled, the helpers will always be imported.
+inline-helpers = []
 
 [dependencies]
 better_scoped_tls = { version = "1.0.1", path = "../better_scoped_tls" }

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -208,7 +208,6 @@ macro_rules! define_helpers {
                 let mut buf = Vec::new();
 
                 HELPERS.with(|helpers|{
-                    debug_assert!(!helpers.external);
                     let inner = helpers.inner.borrow();
                     $(
                             add_to!(buf, $name, inner.$name, helpers.mark.0);
@@ -223,7 +222,6 @@ macro_rules! define_helpers {
 
                 HELPERS.with(|helpers|{
                     let inner = helpers.inner.borrow();
-                    debug_assert!(helpers.external);
                     $(
                             add_import_to!(buf, $name, inner.$name, helpers.mark.0);
                     )*
@@ -235,7 +233,6 @@ macro_rules! define_helpers {
             fn build_requires(&self) -> Vec<Stmt>{
                 let mut buf = Vec::new();
                 HELPERS.with(|helpers|{
-                    debug_assert!(helpers.external);
                     let inner = helpers.inner.borrow();
                     $(
                         let enable = inner.$name;

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -18,6 +18,7 @@ macro_rules! enable_helper {
     }};
 }
 
+#[cfg(feature = "inline-helpers")]
 fn parse(code: &str) -> Vec<Stmt> {
     let cm = SourceMap::new(FilePathMapping::empty());
 
@@ -42,6 +43,7 @@ fn parse(code: &str) -> Vec<Stmt> {
     .unwrap()
 }
 
+#[cfg(feature = "inline-helpers")]
 macro_rules! add_to {
     ($buf:expr, $name:ident, $b:expr, $mark:expr) => {{
         static STMTS: Lazy<Vec<Stmt>> = Lazy::new(|| {

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -686,6 +686,7 @@ _throw();",
     }
 
     #[test]
+    #[cfg(feature = "inline-helpers")]
     fn use_strict_before_helper() {
         crate::tests::test_transform(
             Default::default(),
@@ -705,6 +706,7 @@ function _throw(e) {
     }
 
     #[test]
+    #[cfg(feature = "inline-helpers")]
     fn name_conflict() {
         crate::tests::test_transform(
             Default::default(),
@@ -740,6 +742,7 @@ let x = 4;",
     }
 
     #[test]
+    #[cfg(feature = "inline-helpers")]
     fn issue_8871() {
         crate::tests::test_transform(
             Default::default(),

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -1,9 +1,8 @@
 use std::{cell::RefCell, mem::replace};
 
-use once_cell::sync::Lazy;
 use rustc_hash::FxHashMap;
 use swc_atoms::{atom, Atom};
-use swc_common::{FileName, FilePathMapping, Mark, SourceMap, SyntaxContext, DUMMY_SP};
+use swc_common::{Mark, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{prepend_stmts, quote_ident, DropSpan, ExprFactory};
 use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
@@ -20,10 +19,10 @@ macro_rules! enable_helper {
 
 #[cfg(feature = "inline-helpers")]
 fn parse(code: &str) -> Vec<Stmt> {
-    let cm = SourceMap::new(FilePathMapping::empty());
+    let cm = swc_common::SourceMap::default();
 
     let fm = cm.new_source_file(
-        FileName::Custom(stringify!($name).into()).into(),
+        swc_common::FileName::Custom(stringify!($name).into()).into(),
         code.to_string(),
     );
     swc_ecma_parser::parse_file_as_script(
@@ -46,7 +45,7 @@ fn parse(code: &str) -> Vec<Stmt> {
 #[cfg(feature = "inline-helpers")]
 macro_rules! add_to {
     ($buf:expr, $name:ident, $b:expr, $mark:expr) => {{
-        static STMTS: Lazy<Vec<Stmt>> = Lazy::new(|| {
+        static STMTS: once_cell::sync::Lazy<Vec<Stmt>> = once_cell::sync::Lazy::new(|| {
             let code = include_str!(concat!("./_", stringify!($name), ".js"));
             parse(&code)
         });

--- a/crates/swc_ecma_transforms_base/src/perf.rs
+++ b/crates/swc_ecma_transforms_base/src/perf.rs
@@ -5,6 +5,7 @@ use swc_ecma_ast::*;
 pub use swc_ecma_utils::parallel::*;
 use swc_ecma_visit::{Fold, FoldWith, Visit, VisitMut, VisitMutWith, VisitWith};
 
+#[cfg(feature = "concurrent")]
 use crate::helpers::Helpers;
 #[cfg(feature = "concurrent")]
 use crate::helpers::HELPERS;

--- a/crates/swc_ecma_transforms_compat/Cargo.toml
+++ b/crates/swc_ecma_transforms_compat/Cargo.toml
@@ -24,28 +24,31 @@ par-core = { workspace = true }
 serde    = { workspace = true, features = ["derive"] }
 tracing  = { workspace = true }
 
-swc_atoms                   = { version = "6.0.1", path = "../swc_atoms" }
-swc_common                  = { version = "13.0.4", path = "../swc_common" }
-swc_ecma_ast                = { version = "13.0.1", path = "../swc_ecma_ast" }
-swc_ecma_compat_bugfixes    = { version = "21.0.0", path = "../swc_ecma_compat_bugfixes" }
-swc_ecma_compat_common      = { version = "18.0.1", path = "../swc_ecma_compat_common" }
-swc_ecma_compat_es2015      = { version = "21.0.0", path = "../swc_ecma_compat_es2015" }
-swc_ecma_compat_es2016      = { version = "20.0.0", path = "../swc_ecma_compat_es2016" }
-swc_ecma_compat_es2017      = { version = "20.0.0", path = "../swc_ecma_compat_es2017" }
-swc_ecma_compat_es2018      = { version = "20.0.0", path = "../swc_ecma_compat_es2018" }
-swc_ecma_compat_es2019      = { version = "20.0.0", path = "../swc_ecma_compat_es2019" }
-swc_ecma_compat_es2020      = { version = "21.0.0", path = "../swc_ecma_compat_es2020" }
-swc_ecma_compat_es2021      = { version = "20.0.0", path = "../swc_ecma_compat_es2021" }
-swc_ecma_compat_es2022      = { version = "21.0.0", path = "../swc_ecma_compat_es2022" }
-swc_ecma_compat_es3         = { version = "19.0.1", path = "../swc_ecma_compat_es3" }
-swc_ecma_transforms_base    = { version = "20.0.0", path = "../swc_ecma_transforms_base" }
-swc_ecma_utils              = { version = "18.1.0", path = "../swc_ecma_utils" }
-swc_ecma_visit              = { version = "13.0.0", path = "../swc_ecma_visit" }
+swc_atoms                = { version = "6.0.1", path = "../swc_atoms" }
+swc_common               = { version = "13.0.4", path = "../swc_common" }
+swc_ecma_ast             = { version = "13.0.1", path = "../swc_ecma_ast" }
+swc_ecma_compat_bugfixes = { version = "21.0.0", path = "../swc_ecma_compat_bugfixes" }
+swc_ecma_compat_common   = { version = "18.0.1", path = "../swc_ecma_compat_common" }
+swc_ecma_compat_es2015   = { version = "21.0.0", path = "../swc_ecma_compat_es2015" }
+swc_ecma_compat_es2016   = { version = "20.0.0", path = "../swc_ecma_compat_es2016" }
+swc_ecma_compat_es2017   = { version = "20.0.0", path = "../swc_ecma_compat_es2017" }
+swc_ecma_compat_es2018   = { version = "20.0.0", path = "../swc_ecma_compat_es2018" }
+swc_ecma_compat_es2019   = { version = "20.0.0", path = "../swc_ecma_compat_es2019" }
+swc_ecma_compat_es2020   = { version = "21.0.0", path = "../swc_ecma_compat_es2020" }
+swc_ecma_compat_es2021   = { version = "20.0.0", path = "../swc_ecma_compat_es2021" }
+swc_ecma_compat_es2022   = { version = "21.0.0", path = "../swc_ecma_compat_es2022" }
+swc_ecma_compat_es3      = { version = "19.0.1", path = "../swc_ecma_compat_es3" }
+swc_ecma_transforms_base = { version = "20.0.0", path = "../swc_ecma_transforms_base" }
+swc_ecma_utils           = { version = "18.1.0", path = "../swc_ecma_utils" }
+swc_ecma_visit           = { version = "13.0.0", path = "../swc_ecma_visit" }
 
 [dev-dependencies]
 par-core   = { workspace = true, features = ["chili"] }
 serde_json = { workspace = true }
 
-swc_ecma_parser             = { version = "19.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser = { version = "19.0.1", path = "../swc_ecma_parser" }
+swc_ecma_transforms_base = { version = "20.0.0", path = "../swc_ecma_transforms_base", features = [
+  "inline-helpers",
+] }
 swc_ecma_transforms_testing = { version = "23.0.0", path = "../swc_ecma_transforms_testing" }
-testing                     = { version = "14.0.1", path = "../testing" }
+testing = { version = "14.0.1", path = "../testing" }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -28,22 +28,25 @@ rustc-hash = { workspace = true }
 serde_json = { workspace = true }
 tracing    = { workspace = true }
 
-swc_atoms                  = { version = "6.0.1", path = "../swc_atoms" }
-swc_common                 = { version = "13.0.4", path = "../swc_common" }
-swc_ecma_ast               = { version = "13.0.1", path = "../swc_ecma_ast" }
-swc_ecma_parser            = { version = "19.0.1", path = "../swc_ecma_parser" }
-swc_ecma_transforms_base   = { version = "20.0.0", path = "../swc_ecma_transforms_base" }
-swc_ecma_utils             = { version = "18.1.0", path = "../swc_ecma_utils" }
-swc_ecma_visit             = { version = "13.0.0", path = "../swc_ecma_visit" }
+swc_atoms                = { version = "6.0.1", path = "../swc_atoms" }
+swc_common               = { version = "13.0.4", path = "../swc_common" }
+swc_ecma_ast             = { version = "13.0.1", path = "../swc_ecma_ast" }
+swc_ecma_parser          = { version = "19.0.1", path = "../swc_ecma_parser" }
+swc_ecma_transforms_base = { version = "20.0.0", path = "../swc_ecma_transforms_base" }
+swc_ecma_utils           = { version = "18.1.0", path = "../swc_ecma_utils" }
+swc_ecma_visit           = { version = "13.0.0", path = "../swc_ecma_visit" }
 
 
 [dev-dependencies]
 par-core = { workspace = true, features = ["chili"] }
 
 
-swc_ecma_transforms_compat     = { version = "22.0.0", path = "../swc_ecma_transforms_compat" }
-swc_ecma_transforms_module     = { version = "22.0.0", path = "../swc_ecma_transforms_module" }
-swc_ecma_transforms_proposal   = { version = "20.0.0", path = "../swc_ecma_transforms_proposal" }
-swc_ecma_transforms_testing    = { version = "23.0.0", path = "../swc_ecma_transforms_testing" }
+swc_ecma_transforms_base = { version = "20.0.0", path = "../swc_ecma_transforms_base", features = [
+    "inline-helpers",
+] }
+swc_ecma_transforms_compat = { version = "22.0.0", path = "../swc_ecma_transforms_compat" }
+swc_ecma_transforms_module = { version = "22.0.0", path = "../swc_ecma_transforms_module" }
+swc_ecma_transforms_proposal = { version = "20.0.0", path = "../swc_ecma_transforms_proposal" }
+swc_ecma_transforms_testing = { version = "23.0.0", path = "../swc_ecma_transforms_testing" }
 swc_ecma_transforms_typescript = { version = "22.0.0", path = "../swc_ecma_transforms_typescript" }
-testing                        = { version = "14.0.1", path = "../testing" }
+testing = { version = "14.0.1", path = "../testing" }

--- a/crates/swc_node_bundler/Cargo.toml
+++ b/crates/swc_node_bundler/Cargo.toml
@@ -43,4 +43,7 @@ swc_malloc = { version = "1.2.3", path = "../swc_malloc" }
 
 [dev-dependencies]
 
+swc_ecma_transforms_base = { version = "20.0.0", path = "../swc_ecma_transforms_base", features = [
+  "inline-helpers",
+] }
 testing = { version = "14.0.1", path = "../testing" }


### PR DESCRIPTION
**Description:**

This feature would be helpful for rspack/Deno/next.js folks because they always use external helpers. I didn't list up other ones because I don't know their details.


**BREAKING CHANGE**:

This PR introduces a breaking change for Rust API because `external: false` will not have an impact anymore if the `inline-helpers` feature is disabled