### PR TITLE
chore(ide): Enable `--workspace` for rust-analyzer check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,9 @@
         "crates/swc_ecma_transforms_proposal/tests/decorator-tests"
     ],
     "eslint.enable": false,
+    // Rust analyzer has a weird bug related to features of cargo, but if we enable workspace check, it will be fixed.
+    "rust-analyzer.check.workspace": true,
     "rust-analyzer.check.command": "clippy",
     // SWC project is too complex to use rust-analyzer
-    "rust-analyzer.diagnostics.enable": false
+    "rust-analyzer.diagnostics.enable": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,6 +25,7 @@
     "eslint.enable": false,
     // Rust analyzer has a weird bug related to features of cargo, but if we enable workspace check, it will be fixed.
     "rust-analyzer.check.workspace": true,
+    "rust-analyzer.check.features": ["plugin"],
     "rust-analyzer.check.command": "clippy",
     // SWC project is too complex to use rust-analyzer
     "rust-analyzer.diagnostics.enable": false,


### PR DESCRIPTION
**Description:**

We need to enable this feature to do `"rust-analyzer.check.features": ["plugin"],`, which is necessary for development.