### PR TITLE
refactor(hstr): Make the deallocation of `Atom`s explicit

### DIFF
--- a/.changeset/cyan-geese-attend.md
+++ b/.changeset/cyan-geese-attend.md
@@ -1,0 +1,5 @@
+---
+ hstr: major
+---
+
+refactor(hstr): dropless and resize vector

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -98,6 +98,7 @@ thread_local! {
     static GLOBAL_DATA: RefCell<AtomStore> = Default::default();
 }
 
+/// Cleans up atoms in the global store that are no longer referenced.
 pub fn global_atom_store_gc() {
     GLOBAL_DATA.with(|global| {
         let mut store = global.borrow_mut();

--- a/crates/hstr/src/lib.rs
+++ b/crates/hstr/src/lib.rs
@@ -14,7 +14,7 @@ use std::{
 use debug_unreachable::debug_unreachable;
 use once_cell::sync::Lazy;
 
-pub use crate::dynamic::AtomStore;
+pub use crate::dynamic::{global_atom_store_gc, AtomStore};
 use crate::tagged_value::TaggedValue;
 
 mod dynamic;

--- a/crates/hstr/src/lib.rs
+++ b/crates/hstr/src/lib.rs
@@ -83,11 +83,19 @@ mod tests;
 /// Small strings are stored in the [Atom] itself without any allocation.
 ///
 ///
-/// # Creating atoms
+/// ## Creating atoms
 ///
 /// If you are working on a module which creates lots of [Atom]s, you are
 /// recommended to use [AtomStore] API because it's faster. But if you are not,
 /// you can use global APIs for convenience.
+///
+/// ## Dealloc
+///
+/// - Atoms stored in the local `AtomStore` have the same lifetime as the store
+///   itself, and will be deallocated when the store is dropped.
+/// - Atoms created via the `atom!` macro or `String::into` are stored in the
+///   global atom store. By default, these atoms are never deallocated. To clean
+///   up unused atoms, call [global_atom_store_gc].
 pub struct Atom {
     // If this Atom is a dynamic one, this is *const Entry
     unsafe_data: TaggedValue,


### PR DESCRIPTION
**Description:**

Make the deallocation of `Atom`s explicit.

**BREAKING CHANGES:**

If you are developing a long-running process, you need to call `AtomStore::gc()`  for `Atom`s created by `AtomStore` API, and you need to call `global_atom_store_gc()` for strings created by other APIs, like `"".into()`.