### PR TITLE
fix(es/minifier): preserve scoping functions when executed multiple times

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -538,7 +538,7 @@ impl Optimizer<'_> {
                             // Similar to `_loop` generation of the
                             // block_scoping pass.
                             // If the function captures the environment, we
-                            // can't inline it.
+                            // can't inline it, as it would break scoping.
                             let params: Vec<Id> = find_pat_ids(&f.function.params);
 
                             if !params.is_empty() {
@@ -548,6 +548,14 @@ impl Optimizer<'_> {
                                     if captured.contains(&param) {
                                         return;
                                     }
+                                }
+                            } else {
+                                // Even if the function has no parameters, it might still capture
+                                // variables from the outer scope. If it does, we should not inline it
+                                // when it's executed multiple times.
+                                let captured = idents_captured_by(&f.function.body);
+                                if !captured.is_empty() {
+                                    return;
                                 }
                             }
                         }


### PR DESCRIPTION
Previously, the minifier would incorrectly inline functions that had no parameters but captured variables from the outer scope when executed multiple times. This broke the scoping behavior that TypeScript generates for block-scoped variables in loops.

The fix adds an additional check to prevent inlining functions that capture outer scope variables when executed multiple times, even if they have no parameters.

This resolves the issue where TypeScript-generated `_loop_*` functions were being inlined, causing variable hoisting problems.

Fixes #10807

🤖 Generated with [Claude Code](https://claude.ai/code)
