### PR TITLE
perf(minifier): use `u8` for `remaining_depth`

### DIFF
--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -705,7 +705,7 @@ pub struct ExprCtx {
     /// function should not operate and return the safe value.
     ///
     /// Default value is `4`
-    pub remaining_depth: u32,
+    pub remaining_depth: u8,
 }
 
 /// Extension methods for [Expr].


### PR DESCRIPTION
**Description:**

`u8` is enough for this field. Actually there are two more optimization we probably can do:
1. `unresolved_ctxt` is rarely changed so we can avoid copying it when copying `ExprCtx`.
2. On the top of point 1, the remaining fields can be compacted into a `u8` 

But I don't want to do them, since they will make code messier and less extendable.
This pr makes `ExprCtx` from 12 bytes to 8 bytes. 8 bits = 64 bits is good enough for now.