### PR TITLE
feat(plugin): Remove `bytecheck` to make Wasm plugins backward compatible

### DIFF
--- a/.changeset/nice-planes-hide.md
+++ b/.changeset/nice-planes-hide.md
@@ -1,0 +1,5 @@
+---
+swc_common: major
+---
+
+feat(plugin): Remove `bytecheck` to make Wasm plugins backward compatible


### PR DESCRIPTION
**Description:**

By default, and for obvious reasons, AST plugins are not compatible only if the memory layout changes. But with bytecheck, any field modification is an ABI-breaking change because `bytecheck` exists to do that.


**Related issues:**

 - Closes https://github.com/swc-project/swc/issues/5060