### PR TITLE
perf(swc_error_reporters): avoid creating miette handler when no diagnostics

### DIFF
--- a/crates/swc_error_reporters/src/handler.rs
+++ b/crates/swc_error_reporters/src/handler.rs
@@ -87,10 +87,18 @@ impl ThreadSafetyDiagnostics {
         skip_filename: bool,
         color: ColorConfig,
     ) -> Vec<String> {
-        let handler = to_pretty_handler(color);
-        self.0
+        let diagnostics = self
+            .0
             .lock()
-            .expect("Failed to access the diagnostics lock")
+            .expect("Failed to access the diagnostics lock");
+
+        // If there are no diagnostics, return empty vector without initializing handler
+        if diagnostics.is_empty() {
+            return Vec::new();
+        }
+
+        let handler = to_pretty_handler(color);
+        diagnostics
             .iter()
             .map(|d| d.to_pretty_string(cm, skip_filename, &handler))
             .collect::<Vec<String>>()


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Automatically prevent the creation of `miette::GraphicalReportHandler` when no diagnostics are present.

**BREAKING CHANGE:** No

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

See performance regression in https://github.com/web-infra-dev/rspack/pull/11006
