### PR TITLE
fix(es/parser): Mark `static` as reserved in strict mode

### DIFF
--- a/crates/swc/tests/fixture/issues-2xxx/2844/input/index.swc-stderr
+++ b/crates/swc/tests/fixture/issues-2xxx/2844/input/index.swc-stderr
@@ -1,0 +1,10 @@
+  x Unexpected escape sequence in reserved word: static
+   ,-[$DIR/tests/fixture/issues-2xxx/2844/input/index.js:1:1]
+ 1 | class X { st\u0061tic y() { } }
+   :           ^^^^^^^^^^^
+   `----
+  x Unexpected token `<lexing error: Error { error: (11..22, EscapeInReservedWord { word: "static" }) }>`. Expected identifier, string literal, numeric literal or [ for the computed key
+   ,-[$DIR/tests/fixture/issues-2xxx/2844/input/index.js:1:1]
+ 1 | class X { st\u0061tic y() { } }
+   :           ^^^^^^^^^^^
+   `----

--- a/crates/swc/tests/tsc-references/parserStrictMode1.1.normal.js
+++ b/crates/swc/tests/tsc-references/parserStrictMode1.1.normal.js
@@ -1,5 +1,5 @@
 //// [parserStrictMode1.ts]
-//!   x `static` cannot be used as an identifier in strict mode
+//!   x Expression expected
 //!    ,-[4:1]
 //!  1 | foo1();
 //!  2 | foo1();

--- a/crates/swc/tests/tsc-references/parserStrictMode1.2.minified.js
+++ b/crates/swc/tests/tsc-references/parserStrictMode1.2.minified.js
@@ -1,5 +1,5 @@
 //// [parserStrictMode1.ts]
-//!   x `static` cannot be used as an identifier in strict mode
+//!   x Expression expected
 //!    ,-[4:1]
 //!  1 | foo1();
 //!  2 | foo1();

--- a/crates/swc_ecma_lexer/src/common/parser/expr.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/expr.rs
@@ -2446,12 +2446,6 @@ pub fn parse_primary_expr_rest<'a, P: Parser<'a>>(
         .into())
     } else if p.is_ident_ref() {
         let cur = p.bump();
-        if cur.is_static() {
-            p.emit_strict_mode_err(
-                p.input().prev_span(),
-                SyntaxError::InvalidIdentInStrict(cur.clone().take_word(p.input()).unwrap()),
-            );
-        }
         let Some(word) = cur.take_word(p.input_mut()) else {
             unreachable!()
         };

--- a/crates/swc_ecma_lexer/src/utils.rs
+++ b/crates/swc_ecma_lexer/src/utils.rs
@@ -6,7 +6,9 @@ use crate::token::*;
 impl Context {
     pub fn is_reserved(self, word: &Word) -> bool {
         match *word {
-            Word::Keyword(Keyword::Let) => self.contains(Context::Strict),
+            Word::Keyword(Keyword::Let) | Word::Ident(IdentLike::Known(known_ident!("static"))) => {
+                self.contains(Context::Strict)
+            }
             Word::Keyword(Keyword::Await) => {
                 self.contains(Context::InAsync)
                     || self.contains(Context::InStaticBlock)

--- a/crates/swc_ecma_parser/src/lexer/token.rs
+++ b/crates/swc_ecma_parser/src/lexer/token.rs
@@ -904,7 +904,7 @@ impl std::fmt::Debug for Token {
 impl Token {
     pub(crate) fn is_reserved(&self, ctx: Context) -> bool {
         match self {
-            Token::Let => ctx.contains(Context::Strict),
+            Token::Let | Token::Static => ctx.contains(Context::Strict),
             Token::Await => {
                 ctx.contains(Context::InAsync)
                     || ctx.contains(Context::InStaticBlock)


### PR DESCRIPTION
Fixes #10851