### PR TITLE
fix(es/compat): Properly handle rest assignment in for-in/of RHS

### DIFF
--- a/.changeset/olive-owls-type.md
+++ b/.changeset/olive-owls-type.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_compat_es2018: patch
+---
+
+fix(es/compat): Properly handle rest assignment in for-in/of RHS

--- a/crates/swc/tests/fixture/issues-10xxx/10877/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-10xxx/10877/input/.swcrc
@@ -1,0 +1,8 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript"
+        },
+        "target": "es3"
+    }
+}

--- a/crates/swc/tests/fixture/issues-10xxx/10877/input/index.js
+++ b/crates/swc/tests/fixture/issues-10xxx/10877/input/index.js
@@ -1,0 +1,7 @@
+for (var value in (() => {
+  let { property, ...rest } = foo;
+  return rest;
+})()) {
+  console.log(value);
+}
+

--- a/crates/swc/tests/fixture/issues-10xxx/10877/output/index.js
+++ b/crates/swc/tests/fixture/issues-10xxx/10877/output/index.js
@@ -1,0 +1,10 @@
+var _object_without_properties = require("@swc/helpers/_/_object_without_properties");
+for(var _ref in function() {
+    var property = foo.property, rest = _object_without_properties._(foo, [
+        "property"
+    ]);
+    return rest;
+}()){
+    var value = _ref;
+    console.log(value);
+}

--- a/crates/swc_ecma_compat_es2018/src/object_rest.rs
+++ b/crates/swc_ecma_compat_es2018/src/object_rest.rs
@@ -125,6 +125,7 @@ macro_rules! impl_for_for_stmt {
                 },
             }));
 
+            for_stmt.right.visit_mut_with(self);
             for_stmt.body.visit_mut_with(self);
         }
     };


### PR DESCRIPTION
**Description:**

Fix a panic
```
thread 'main' panicked at /Users/niklas/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/swc_ecma_compat_es2015-22.0.0/src/destructuring.rs:419:52:
internal error: entered unreachable code: Object rest pattern should be removed by es2018::object_rest_spread pass
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

**Related issue:**

Closes #10877
