### PR TITLE
fix(es/minifier): Handle nested switch in break detection

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/pure/switches.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/switches.rs
@@ -799,7 +799,15 @@ impl Visit for BreakFinder {
     /// We don't care about breaks in a loop
     fn visit_while_stmt(&mut self, _: &WhileStmt) {}
 
-    fn visit_switch_stmt(&mut self, _: &SwitchStmt) {}
+    fn visit_switch_stmt(&mut self, s: &SwitchStmt) {
+        if self.top_level {
+            self.top_level = false;
+            s.visit_children_with(self);
+            self.top_level = true;
+        } else {
+            s.visit_children_with(self);
+        }
+    }
 
     fn visit_function(&mut self, _: &Function) {}
 

--- a/crates/swc_ecma_minifier/tests/terser/compress/switch/nested_switch_break/config.json
+++ b/crates/swc_ecma_minifier/tests/terser/compress/switch/nested_switch_break/config.json
@@ -1,0 +1,3 @@
+{
+    "switches": true
+}

--- a/crates/swc_ecma_minifier/tests/terser/compress/switch/nested_switch_break/input.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/switch/nested_switch_break/input.js
@@ -1,0 +1,26 @@
+function useMeow() {
+    const state = 'init';
+    const onMeow = () => {
+        switch (state) {
+            case 'init': {
+                const innerCondition = getCondition();
+                switch (innerCondition) {
+                    case 'a':
+                        break;
+                    case 'b':
+                        break;
+                    default:
+                        doSomething();
+                }
+                break;
+            }
+            default: {
+                doSomething();
+                break;
+            }
+        }
+    };
+    return {
+        onMeow,
+    };
+}

--- a/crates/swc_ecma_minifier/tests/terser/compress/switch/nested_switch_break/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/switch/nested_switch_break/output.js
@@ -1,0 +1,26 @@
+function useMeow() {
+    const state = 'init';
+    const onMeow = () => {
+        switch (state) {
+            case 'init': {
+                const innerCondition = getCondition();
+                switch (innerCondition) {
+                    case 'a':
+                        break;
+                    case 'b':
+                        break;
+                    default:
+                        doSomething();
+                }
+                break;
+            }
+            default: {
+                doSomething();
+                break;
+            }
+        }
+    };
+    return {
+        onMeow,
+    };
+}


### PR DESCRIPTION
**Description:**

The BreakFinder visitor was not properly traversing nested switch statements, causing incorrect optimization of switches with nested breaks. This fix implements proper nested switch traversal similar to how if statements are handled.



**Related issue:**

 - Closes #10885

---

🤖 Generated with [Claude Code](https://claude.ai/code)
