### PR TITLE
fix(swc_core): Add `default-features = false` to drop `stacker`

### DIFF
--- a/.changeset/gentle-hounds-buy.md
+++ b/.changeset/gentle-hounds-buy.md
@@ -1,0 +1,19 @@
+---
+swc: patch
+swc_bundler: patch
+swc_compiler_base: patch
+swc_core: patch
+swc_ecma_minifier: patch
+swc_ecma_quote_macros: patch
+swc_ecma_transforms_base: patch
+swc_ecma_transforms_base: patch
+swc_ecma_transforms_module: patch
+swc_ecma_transforms_optimization: patch
+swc_ecma_transforms_react: patch
+swc_estree_compat: patch
+swc_html_minifier: patch
+swc_node_bundler: patch
+swc_ts_fast_strip: patch
+---
+
+fix(swc_core): Add `default-features = false` to drop `stacker`

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -91,7 +91,7 @@ swc_ecma_loader = { version = "14.0.0", path = "../swc_ecma_loader", features = 
   "tsc",
 ] }
 swc_ecma_minifier = { version = "27.0.3", path = "../swc_ecma_minifier" }
-swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_preset_env = { version = "27.0.0", path = "../swc_ecma_preset_env" }
 swc_ecma_transforms = { version = "26.0.0", path = "../swc_ecma_transforms", features = [
   "compat",

--- a/crates/swc_bundler/Cargo.toml
+++ b/crates/swc_bundler/Cargo.toml
@@ -42,7 +42,7 @@ swc_common                       = { version = "14.0.1", path = "../swc_common" 
 swc_ecma_ast                     = { version = "14.0.0", path = "../swc_ecma_ast" }
 swc_ecma_codegen                 = { version = "16.0.0", path = "../swc_ecma_codegen" }
 swc_ecma_loader                  = { version = "14.0.0", path = "../swc_ecma_loader" }
-swc_ecma_parser                  = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser                  = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_transforms_base         = { version = "22.0.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_optimization = { version = "23.0.0", path = "../swc_ecma_transforms_optimization" }
 swc_ecma_utils                   = { version = "19.0.0", path = "../swc_ecma_utils" }

--- a/crates/swc_compiler_base/Cargo.toml
+++ b/crates/swc_compiler_base/Cargo.toml
@@ -31,7 +31,7 @@ swc_config = { version = "3.1.1", path = "../swc_config" }
 swc_ecma_ast = { version = "14.0.0", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "16.0.0", path = "../swc_ecma_codegen" }
 swc_ecma_minifier = { version = "27.0.3", path = "../swc_ecma_minifier" }
-swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_visit = { version = "14.0.0", path = "../swc_ecma_visit" }
 swc_timer = { version = "1.0.0", path = "../swc_timer" }
 

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -369,7 +369,7 @@ swc_ecma_codegen                 = { optional = true, version = "16.0.0", path =
 swc_ecma_lints                   = { optional = true, version = "20.0.0", path = "../swc_ecma_lints" }
 swc_ecma_loader                  = { optional = true, version = "14.0.0", path = "../swc_ecma_loader" }
 swc_ecma_minifier                = { optional = true, version = "27.0.3", path = "../swc_ecma_minifier" }
-swc_ecma_parser                  = { optional = true, version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser                  = { optional = true, version = "21.0.1", path = "../swc_ecma_parser", default-features = false }
 swc_ecma_preset_env              = { optional = true, version = "27.0.0", path = "../swc_ecma_preset_env" }
 swc_ecma_quote_macros            = { optional = true, version = "21.0.0", path = "../swc_ecma_quote_macros" }
 swc_ecma_react_compiler          = { optional = true, version = "7.0.0", path = "../swc_ecma_react_compiler" }

--- a/crates/swc_ecma_minifier/Cargo.toml
+++ b/crates/swc_ecma_minifier/Cargo.toml
@@ -59,7 +59,7 @@ swc_ecma_ast = { version = "14.0.0", path = "../swc_ecma_ast", features = [
   "serde",
 ] }
 swc_ecma_codegen = { version = "16.0.0", path = "../swc_ecma_codegen" }
-swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_transforms_base = { version = "22.0.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_optimization = { version = "23.0.0", path = "../swc_ecma_transforms_optimization" }
 swc_ecma_usage_analyzer = { version = "20.0.0", path = "../swc_ecma_usage_analyzer" }

--- a/crates/swc_ecma_quote_macros/Cargo.toml
+++ b/crates/swc_ecma_quote_macros/Cargo.toml
@@ -22,5 +22,5 @@ syn         = { workspace = true }
 swc_atoms         = { version = "7.0.0", path = "../swc_atoms" }
 swc_common        = { version = "14.0.1", path = "../swc_common" }
 swc_ecma_ast      = { version = "14.0.0", path = "../swc_ecma_ast" }
-swc_ecma_parser   = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser   = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_macros_common = { version = "1.0.1", path = "../swc_macros_common" }

--- a/crates/swc_ecma_transforms_base/Cargo.toml
+++ b/crates/swc_ecma_transforms_base/Cargo.toml
@@ -32,7 +32,7 @@ tracing           = { workspace = true }
 swc_atoms       = { version = "7.0.0", path = "../swc_atoms" }
 swc_common      = { version = "14.0.1", path = "../swc_common" }
 swc_ecma_ast    = { version = "14.0.0", path = "../swc_ecma_ast" }
-swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_utils  = { version = "19.0.0", path = "../swc_ecma_utils" }
 swc_ecma_visit  = { version = "14.0.0", path = "../swc_ecma_visit" }
 

--- a/crates/swc_ecma_transforms_module/Cargo.toml
+++ b/crates/swc_ecma_transforms_module/Cargo.toml
@@ -33,7 +33,7 @@ swc_config = { version = "3.1.1", path = "../swc_config", features = [
 swc_ecma_ast = { version = "14.0.0", path = "../swc_ecma_ast" }
 swc_ecma_loader = { version = "14.0.0", path = "../swc_ecma_loader", features = [
 ] }
-swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_transforms_base = { version = "22.0.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_utils = { version = "19.0.0", path = "../swc_ecma_utils" }
 swc_ecma_visit = { version = "14.0.0", path = "../swc_ecma_visit" }

--- a/crates/swc_ecma_transforms_optimization/Cargo.toml
+++ b/crates/swc_ecma_transforms_optimization/Cargo.toml
@@ -31,7 +31,7 @@ tracing    = { workspace = true }
 swc_atoms                = { version = "7.0.0", path = "../swc_atoms" }
 swc_common               = { version = "14.0.1", path = "../swc_common" }
 swc_ecma_ast             = { version = "14.0.0", path = "../swc_ecma_ast" }
-swc_ecma_parser          = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser          = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_transforms_base = { version = "22.0.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_utils           = { version = "19.0.0", path = "../swc_ecma_utils" }
 swc_ecma_visit           = { version = "14.0.0", path = "../swc_ecma_visit" }

--- a/crates/swc_ecma_transforms_react/Cargo.toml
+++ b/crates/swc_ecma_transforms_react/Cargo.toml
@@ -31,7 +31,7 @@ swc_atoms                  = { version = "7.0.0", path = "../swc_atoms" }
 swc_common                 = { version = "14.0.1", path = "../swc_common" }
 swc_config                 = { version = "3.1.1", path = "../swc_config" }
 swc_ecma_ast               = { version = "14.0.0", path = "../swc_ecma_ast" }
-swc_ecma_parser            = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser            = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_transforms_base   = { version = "22.0.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_utils             = { version = "19.0.0", path = "../swc_ecma_utils" }
 swc_ecma_visit             = { version = "14.0.0", path = "../swc_ecma_visit" }

--- a/crates/swc_estree_compat/Cargo.toml
+++ b/crates/swc_estree_compat/Cargo.toml
@@ -29,7 +29,7 @@ swc_common = { version = "14.0.1", path = "../swc_common", features = [
   "tty-emitter",
 ] }
 swc_ecma_ast = { version = "14.0.0", path = "../swc_ecma_ast" }
-swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_utils = { version = "19.0.0", path = "../swc_ecma_utils" }
 swc_ecma_visit = { version = "14.0.0", path = "../swc_ecma_visit" }
 swc_estree_ast = { version = "14.0.0", path = "../swc_estree_ast" }

--- a/crates/swc_html_minifier/Cargo.toml
+++ b/crates/swc_html_minifier/Cargo.toml
@@ -45,7 +45,7 @@ swc_ecma_codegen = { version = "16.0.0", path = "../swc_ecma_codegen", features 
 swc_ecma_minifier = { version = "27.0.3", path = "../swc_ecma_minifier", features = [
   "extra-serde",
 ] }
-swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_transforms_base = { version = "22.0.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_visit = { version = "14.0.0", path = "../swc_ecma_visit" }
 swc_html_ast = { version = "14.0.0", path = "../swc_html_ast" }

--- a/crates/swc_node_bundler/Cargo.toml
+++ b/crates/swc_node_bundler/Cargo.toml
@@ -36,7 +36,7 @@ swc_common = { version = "14.0.1", path = "../swc_common", features = [
 swc_ecma_ast = { version = "14.0.0", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "16.0.0", path = "../swc_ecma_codegen" }
 swc_ecma_loader = { version = "14.0.0", path = "../swc_ecma_loader" }
-swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser" }
+swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = ["typescript"] }
 swc_ecma_transforms = { version = "26.0.0", path = "../swc_ecma_transforms" }
 swc_ecma_utils = { version = "19.0.0", path = "../swc_ecma_utils" }
 swc_malloc = { version = "1.2.3", path = "../swc_malloc" }

--- a/crates/swc_ts_fast_strip/Cargo.toml
+++ b/crates/swc_ts_fast_strip/Cargo.toml
@@ -25,7 +25,8 @@ swc_common = { version = "14.0.1", path = "../swc_common", features = [
 ] }
 swc_ecma_ast = { version = "14.0.0", path = "../swc_ecma_ast" }
 swc_ecma_codegen = { version = "16.0.0", path = "../swc_ecma_codegen" }
-swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser", features = [
+swc_ecma_parser = { version = "21.0.1", path = "../swc_ecma_parser", default-features = false, features = [
+  "typescript",
   "unstable",
 ] }
 swc_ecma_transforms_base = { version = "22.0.0", path = "../swc_ecma_transforms_base" }


### PR DESCRIPTION
**Description:**

This prevents the transitive dependency on stacker when using crates like swc_core and swc_ecma_transforms_base. All crates now explicitly opt-in to only the features they need (TypeScript in most cases).


**Related issue:**

 - Closes #8422