### PR TITLE
fix(es/minifier): Prevent array.join optimization with nullable values

### DIFF
--- a/crates/swc_ecma_minifier/tests/fixture/issues/10936/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10936/config.json
@@ -1,0 +1,5 @@
+{
+  "defaults": true,
+  "passes": 1,
+  "unsafe_passes": true
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10936/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10936/input.js
@@ -1,0 +1,20 @@
+const variable = {};
+
+const params = [
+    'OrderNumber=',
+    variable.data?.orderNumber,
+    '|AuditNo=',
+    variable.data?.auditNo,
+    '|JournalType=',
+    transactionTypeCode[variable.data.transactionType],
+    '|IsPreview=0',
+].join('');
+
+console.log(params);
+
+// Additional test cases
+const test1 = [1, null, 2].join('');
+const test2 = [1, undefined, 2].join('');
+const test3 = [1, variable?.notExist, 2].join('');
+const test4 = [1, variable.data?.value, 2].join('');
+const test5 = [1, obj?.a?.b?.c, 2].join('');

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10936/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10936/output.js
@@ -1,0 +1,28 @@
+const variable = {};
+const params = [
+    'OrderNumber=',
+    variable.data?.orderNumber,
+    '|AuditNo=',
+    variable.data?.auditNo,
+    '|JournalType=',
+    transactionTypeCode[variable.data.transactionType],
+    '|IsPreview=0'
+].join('');
+console.log(params);
+const test1 = "12";
+const test2 = "12";
+const test3 = [
+    1,
+    variable?.notExist,
+    2
+].join('');
+const test4 = [
+    1,
+    variable.data?.value,
+    2
+].join('');
+const test5 = [
+    1,
+    obj?.a?.b?.c,
+    2
+].join('');


### PR DESCRIPTION

**Description:**

The minifier was incorrectly optimizing array.join('''') to string concatenation when the array contained optional chaining or member expressions that could produce undefined values. This caused undefined to be converted to the string undefined instead of an empty string.

Fixed by preventing the optimization when array contains:
- OptChain expressions (e.g., obj?.prop)
- Member expressions that might be undefined


**Related issue:**

 - Closes #10936
