### PR TITLE
fix: expose GlobalPassOption.build

### DIFF
--- a/.changeset/flat-turkeys-hammer.md
+++ b/.changeset/flat-turkeys-hammer.md
@@ -1,0 +1,6 @@
+---
+swc: patch
+swc_core: patch
+---
+
+fix: expose GlobalPassOption.build

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1665,7 +1665,7 @@ impl Default for GlobalInliningPassEnvs {
 }
 
 impl GlobalPassOption {
-    pub(crate) fn build(
+    pub fn build(
         self,
         cm: &SourceMap,
         handler: &Handler,


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

This PR #10449 changed `GlobalPassOption.build` to `pub(crate)`, but ReactLynx's WASM plugin depends on it (see https://github.com/lynx-family/lynx-stack/blob/main/packages/react/transform/src/lib.rs#L412). 

When upgrading `swc_core`, we encountered a crash due to this change. This PR aims to restore `GlobalPassOption.build` to `pub`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

