### PR TITLE
fix(es/module): Support optional chaining in `import.meta`

### DIFF
--- a/.changeset/ninety-cobras-stare.md
+++ b/.changeset/ninety-cobras-stare.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_transforms_module: patch
+---
+
+fix(es/module): Support optional chaining in `import.meta`

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -286,6 +286,8 @@ where
             }
             Expr::OptChain(OptChainExpr { base, .. }) if !self.config.preserve_import_meta => {
                 let OptChainBase::Member(MemberExpr { obj, prop, span }) = &mut **base else {
+                    println!("OptChainBase::Member {:?}", base.span());
+                    n.visit_mut_children_with(self);
                     return;
                 };
                 if obj
@@ -301,6 +303,7 @@ where
                         },
                         MemberProp::PrivateName(..) => return,
                     };
+                    self.found_import_meta = true;
 
                     match p {
                         "url" => {
@@ -347,6 +350,8 @@ where
                         }
                         _ => {}
                     }
+                } else {
+                    n.visit_mut_children_with(self);
                 }
             }
             Expr::Member(MemberExpr { span, obj, prop })

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -284,76 +284,6 @@ where
                     self.support_arrow,
                 );
             }
-            Expr::OptChain(OptChainExpr { base, .. }) if !self.config.preserve_import_meta => {
-                let OptChainBase::Member(MemberExpr { obj, prop, span }) = &mut **base else {
-                    println!("OptChainBase::Member {:?}", base.span());
-                    n.visit_mut_children_with(self);
-                    return;
-                };
-                if obj
-                    .as_meta_prop()
-                    .map(|p| p.kind == MetaPropKind::ImportMeta)
-                    .unwrap_or_default()
-                {
-                    let p = match prop {
-                        MemberProp::Ident(IdentName { sym, .. }) => &**sym,
-                        MemberProp::Computed(ComputedPropName { expr, .. }) => match &**expr {
-                            Expr::Lit(Lit::Str(s)) => &s.value,
-                            _ => return,
-                        },
-                        MemberProp::PrivateName(..) => return,
-                    };
-                    self.found_import_meta = true;
-
-                    match p {
-                        "url" => {
-                            *n = amd_import_meta_url(*span, self.module());
-                        }
-                        "resolve" => {
-                            let require = quote_ident!(
-                                SyntaxContext::empty().apply_mark(self.unresolved_mark),
-                                obj.span(),
-                                "require"
-                            );
-
-                            *obj = Box::new(require.into());
-                        }
-                        "filename" => {
-                            *n = quote_ident!(
-                                SyntaxContext::empty().apply_mark(self.unresolved_mark),
-                                *span,
-                                "__filename"
-                            )
-                            .into();
-                        }
-                        "dirname" => {
-                            *n = quote_ident!(
-                                SyntaxContext::empty().apply_mark(self.unresolved_mark),
-                                *span,
-                                "__dirname"
-                            )
-                            .into();
-                        }
-                        "main" => {
-                            let ctxt = SyntaxContext::empty().apply_mark(self.unresolved_mark);
-                            let require = quote_ident!(ctxt, "require");
-                            let require_main = require.make_member(quote_ident!("main"));
-                            let module = quote_ident!(ctxt, "module");
-
-                            *n = BinExpr {
-                                span: *span,
-                                op: op!("=="),
-                                left: require_main.into(),
-                                right: module.into(),
-                            }
-                            .into();
-                        }
-                        _ => {}
-                    }
-                } else {
-                    n.visit_mut_children_with(self);
-                }
-            }
             Expr::Member(MemberExpr { span, obj, prop })
                 if !self.config.preserve_import_meta
                     && obj
@@ -433,6 +363,21 @@ where
                     }
                     _ => {}
                 }
+            }
+            Expr::OptChain(OptChainExpr { base, .. }) if !self.config.preserve_import_meta => {
+                if let OptChainBase::Member(member) = &mut **base {
+                    if member
+                        .obj
+                        .as_meta_prop()
+                        .is_some_and(|meta_prop| meta_prop.kind == MetaPropKind::ImportMeta)
+                    {
+                        *n = member.take().into();
+                        n.visit_mut_with(self);
+                        return;
+                    }
+                };
+
+                n.visit_mut_children_with(self);
             }
             _ => n.visit_mut_children_with(self),
         }

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -283,10 +283,13 @@ impl VisitMut for Cjs {
             }
             Expr::OptChain(OptChainExpr { base, .. }) if !self.config.preserve_import_meta => {
                 let OptChainBase::Member(MemberExpr { obj, prop, span }) = &mut **base else {
+                    n.visit_mut_children_with(self);
                     return;
                 };
                 if let Some(expr) = get_meta_expr(obj, prop, self.unresolved_mark, span) {
                     *n = expr;
+                } else {
+                    n.visit_mut_children_with(self);
                 }
             }
             Expr::Member(MemberExpr { span, obj, prop }) if !self.config.preserve_import_meta => {

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -168,82 +168,6 @@ impl VisitMut for Cjs {
     }
 
     fn visit_mut_expr(&mut self, n: &mut Expr) {
-        fn get_meta_expr(
-            obj: &mut Box<Expr>,
-            prop: &MemberProp,
-            unresolved_mark: Mark,
-            span: &Span,
-        ) -> Option<Expr> {
-            if obj
-                .as_meta_prop()
-                .map(|p| p.kind == MetaPropKind::ImportMeta)
-                .unwrap_or_default()
-            {
-                let p = match prop {
-                    MemberProp::Ident(IdentName { sym, .. }) => &**sym,
-                    MemberProp::Computed(ComputedPropName { expr, .. }) => match &**expr {
-                        Expr::Lit(Lit::Str(s)) => &s.value,
-                        _ => return None,
-                    },
-                    MemberProp::PrivateName(..) => return None,
-                };
-
-                match p {
-                    "url" => {
-                        let require = quote_ident!(
-                            SyntaxContext::empty().apply_mark(unresolved_mark),
-                            "require"
-                        );
-                        Some(cjs_import_meta_url(*span, require, unresolved_mark))
-                    }
-                    "resolve" => {
-                        let require = quote_ident!(
-                            SyntaxContext::empty().apply_mark(unresolved_mark),
-                            obj.span(),
-                            "require"
-                        );
-
-                        *obj = Box::new(require.into());
-                        None
-                    }
-                    "filename" => Some(
-                        quote_ident!(
-                            SyntaxContext::empty().apply_mark(unresolved_mark),
-                            *span,
-                            "__filename"
-                        )
-                        .into(),
-                    ),
-                    "dirname" => Some(
-                        quote_ident!(
-                            SyntaxContext::empty().apply_mark(unresolved_mark),
-                            *span,
-                            "__dirname"
-                        )
-                        .into(),
-                    ),
-                    "main" => {
-                        let ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
-                        let require = quote_ident!(ctxt, "require");
-                        let require_main = require.make_member(quote_ident!("main"));
-                        let module = quote_ident!(ctxt, "module");
-
-                        Some(
-                            BinExpr {
-                                span: *span,
-                                op: op!("=="),
-                                left: require_main.into(),
-                                right: module.into(),
-                            }
-                            .into(),
-                        )
-                    }
-                    _ => None,
-                }
-            } else {
-                None
-            }
-        }
         match n {
             Expr::Call(CallExpr {
                 span,
@@ -281,21 +205,86 @@ impl VisitMut for Cjs {
                     is_lit_path,
                 );
             }
-            Expr::OptChain(OptChainExpr { base, .. }) if !self.config.preserve_import_meta => {
-                let OptChainBase::Member(MemberExpr { obj, prop, span }) = &mut **base else {
-                    n.visit_mut_children_with(self);
-                    return;
+            Expr::Member(MemberExpr { span, obj, prop })
+                if !self.config.preserve_import_meta
+                    && obj
+                        .as_meta_prop()
+                        .map(|p| p.kind == MetaPropKind::ImportMeta)
+                        .unwrap_or_default() =>
+            {
+                let p = match prop {
+                    MemberProp::Ident(IdentName { sym, .. }) => &**sym,
+                    MemberProp::Computed(ComputedPropName { expr, .. }) => match &**expr {
+                        Expr::Lit(Lit::Str(s)) => &s.value,
+                        _ => return,
+                    },
+                    MemberProp::PrivateName(..) => return,
                 };
-                if let Some(expr) = get_meta_expr(obj, prop, self.unresolved_mark, span) {
-                    *n = expr;
-                } else {
-                    n.visit_mut_children_with(self);
+
+                match p {
+                    "url" => {
+                        let require = quote_ident!(
+                            SyntaxContext::empty().apply_mark(self.unresolved_mark),
+                            "require"
+                        );
+                        *n = cjs_import_meta_url(*span, require, self.unresolved_mark);
+                    }
+                    "resolve" => {
+                        let require = quote_ident!(
+                            SyntaxContext::empty().apply_mark(self.unresolved_mark),
+                            obj.span(),
+                            "require"
+                        );
+
+                        *obj = Box::new(require.into());
+                    }
+                    "filename" => {
+                        *n = quote_ident!(
+                            SyntaxContext::empty().apply_mark(self.unresolved_mark),
+                            *span,
+                            "__filename"
+                        )
+                        .into();
+                    }
+                    "dirname" => {
+                        *n = quote_ident!(
+                            SyntaxContext::empty().apply_mark(self.unresolved_mark),
+                            *span,
+                            "__dirname"
+                        )
+                        .into();
+                    }
+                    "main" => {
+                        let ctxt = SyntaxContext::empty().apply_mark(self.unresolved_mark);
+                        let require = quote_ident!(ctxt, "require");
+                        let require_main = require.make_member(quote_ident!("main"));
+                        let module = quote_ident!(ctxt, "module");
+
+                        *n = BinExpr {
+                            span: *span,
+                            op: op!("=="),
+                            left: require_main.into(),
+                            right: module.into(),
+                        }
+                        .into();
+                    }
+                    _ => {}
                 }
             }
-            Expr::Member(MemberExpr { span, obj, prop }) if !self.config.preserve_import_meta => {
-                if let Some(expr) = get_meta_expr(obj, prop, self.unresolved_mark, span) {
-                    *n = expr;
-                }
+            Expr::OptChain(OptChainExpr { base, .. }) if !self.config.preserve_import_meta => {
+                if let OptChainBase::Member(member) = &mut **base {
+                    if member
+                        .obj
+                        .as_meta_prop()
+                        .is_some_and(|meta_prop| meta_prop.kind == MetaPropKind::ImportMeta)
+                    {
+                        *n = member.take().into();
+                        n.visit_mut_with(self);
+                        return;
+                    }
+                };
+
+                n.visit_mut_children_with(self);
             }
             _ => n.visit_mut_children_with(self),
         }

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/input.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/input.js
@@ -5,6 +5,7 @@ const filename = import.meta.filename;
 const dirname = import.meta.dirname;
 const main = import.meta.main;
 
+foo?.bar(import.meta.url);
 console.log(react);
 console.log(url);
 console.log(filename);

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/input.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/input.js
@@ -1,5 +1,6 @@
 const react = import.meta.resolve("react");
 const url = import.meta.url;
+const urlMaybe = import.meta?.url;
 const filename = import.meta.filename;
 const dirname = import.meta.dirname;
 const main = import.meta.main;

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.amd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.amd.js
@@ -5,6 +5,7 @@ define([
     "use strict";
     const react = require.toUrl("react");
     const url = new URL(module.uri, document.baseURI).href;
+    const urlMaybe = new URL(module.uri, document.baseURI).href;
     const filename = module.uri.split("/").pop();
     const dirname = require.toUrl(".");
     const main = module.id == "main";

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.amd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.amd.js
@@ -9,6 +9,7 @@ define([
     const filename = module.uri.split("/").pop();
     const dirname = require.toUrl(".");
     const main = module.id == "main";
+    foo?.bar(new URL(module.uri, document.baseURI).href);
     console.log(react);
     console.log(url);
     console.log(filename);

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.cjs
@@ -5,6 +5,7 @@ const urlMaybe = require("url").pathToFileURL(__filename).toString();
 const filename = __filename;
 const dirname = __dirname;
 const main = require.main == module;
+foo?.bar(require("url").pathToFileURL(__filename).toString());
 console.log(react);
 console.log(url);
 console.log(filename);

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.cjs
@@ -1,6 +1,7 @@
 "use strict";
 const react = require.resolve("react");
 const url = require("url").pathToFileURL(__filename).toString();
+const urlMaybe = require("url").pathToFileURL(__filename).toString();
 const filename = __filename;
 const dirname = __dirname;
 const main = require.main == module;

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.umd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.umd.js
@@ -6,6 +6,7 @@
     "use strict";
     const react = import.meta.resolve("react");
     const url = import.meta.url;
+    const urlMaybe = import.meta?.url;
     const filename = import.meta.filename;
     const dirname = import.meta.dirname;
     const main = import.meta.main;

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.umd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/import-meta/output.umd.js
@@ -10,6 +10,7 @@
     const filename = import.meta.filename;
     const dirname = import.meta.dirname;
     const main = import.meta.main;
+    foo?.bar(import.meta.url);
     console.log(react);
     console.log(url);
     console.log(filename);


### PR DESCRIPTION
**Description:**

`import.meta?.url` is not currently supported so it will not get transpiled. my thought is that it should get transpiled, so we are treating it the same as if the optional chain did not exist.

Example of this in `@cesium/engine` here: https://github.com/CesiumGS/cesium/blob/52f55d0e7063115b47b12fee20bfc1c291edcddb/packages/engine/Source/Core/buildModuleUrl.js#L44

**Related issue (if exists):**

closes #10988