### PR TITLE
perf(es/parser): introduce checkpoint to reduce clone

### DIFF
--- a/crates/swc_ecma_lexer/src/common/input.rs
+++ b/crates/swc_ecma_lexer/src/common/input.rs
@@ -7,11 +7,16 @@ use crate::{common::syntax::SyntaxFlags, error::Error, lexer};
 /// Clone should be cheap if you are parsing typescript because typescript
 /// syntax requires backtracking.
 pub trait Tokens<TokenAndSpan>: Clone + Iterator<Item = TokenAndSpan> {
+    type Checkpoint;
+
     fn set_ctx(&mut self, ctx: Context);
     fn ctx(&self) -> Context;
     fn ctx_mut(&mut self) -> &mut Context;
     fn syntax(&self) -> SyntaxFlags;
     fn target(&self) -> EsVersion;
+
+    fn checkpoint_save(&self) -> Self::Checkpoint;
+    fn checkpoint_load(&mut self, checkpoint: Self::Checkpoint);
 
     fn start_pos(&self) -> BytePos {
         BytePos(0)

--- a/crates/swc_ecma_lexer/src/common/lexer/token.rs
+++ b/crates/swc_ecma_lexer/src/common/lexer/token.rs
@@ -11,7 +11,6 @@ pub trait TokenFactory<'a, TokenAndSpan, I: Tokens<TokenAndSpan>>: Sized + Parti
         'a,
         I = I,
         Token = Self,
-        Lexer = Self::Lexer,
         TokenAndSpan = TokenAndSpan,
     >;
 

--- a/crates/swc_ecma_lexer/src/common/parser/buffer.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/buffer.rs
@@ -19,7 +19,6 @@ pub trait NextTokenAndSpan {
 
 pub trait Buffer<'a> {
     type Token: std::fmt::Debug + PartialEq + Clone + TokenFactory<'a, Self::TokenAndSpan, Self::I>;
-    type Lexer: super::super::lexer::Lexer<'a, Self::TokenAndSpan>;
     type Next: NextTokenAndSpan<Token = Self::Token>;
     type TokenAndSpan: TokenAndSpanTrait<Token = Self::Token>;
     type I: Tokens<Self::TokenAndSpan>;

--- a/crates/swc_ecma_lexer/src/common/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/mod.rs
@@ -61,11 +61,14 @@ pub trait Parser<'a>: Sized + Clone {
         TokenAndSpan = Self::TokenAndSpan,
         I = Self::I,
     >;
+    type Checkpoint;
 
     fn input(&self) -> &Self::Buffer;
     fn input_mut(&mut self) -> &mut Self::Buffer;
     fn state(&self) -> &State;
     fn state_mut(&mut self) -> &mut State;
+    fn checkpoint_save(&self) -> Self::Checkpoint;
+    fn checkpoint_load(&mut self, checkpoint: Self::Checkpoint);
 
     #[inline(always)]
     fn with_state<'w>(&'w mut self, state: State) -> WithState<'a, 'w, Self> {

--- a/crates/swc_ecma_lexer/src/common/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/mod.rs
@@ -52,13 +52,11 @@ pub trait Parser<'a>: Sized + Clone {
     type Token: std::fmt::Debug
         + Clone
         + TokenFactory<'a, Self::TokenAndSpan, Self::I, Buffer = Self::Buffer>;
-    type Lexer: super::lexer::Lexer<'a, Self::TokenAndSpan>;
     type Next: NextTokenAndSpan<Token = Self::Token>;
     type TokenAndSpan: TokenAndSpan<Token = Self::Token>;
     type I: Tokens<Self::TokenAndSpan>;
     type Buffer: self::buffer::Buffer<
         'a,
-        Lexer = Self::Lexer,
         Token = Self::Token,
         TokenAndSpan = Self::TokenAndSpan,
         I = Self::I,

--- a/crates/swc_ecma_lexer/src/input.rs
+++ b/crates/swc_ecma_lexer/src/input.rs
@@ -55,6 +55,16 @@ impl Iterator for TokensInput {
 }
 
 impl Tokens<TokenAndSpan> for TokensInput {
+    type Checkpoint = Self;
+
+    fn checkpoint_save(&self) -> Self::Checkpoint {
+        self.clone()
+    }
+
+    fn checkpoint_load(&mut self, checkpoint: Self::Checkpoint) {
+        *self = checkpoint;
+    }
+
     fn set_ctx(&mut self, ctx: Context) {
         if ctx.contains(Context::Module) && !self.module_errors.borrow().is_empty() {
             let mut module_errors = self.module_errors.borrow_mut();
@@ -213,6 +223,16 @@ impl<I: Tokens<TokenAndSpan>> Iterator for Capturing<I> {
 }
 
 impl<I: Tokens<TokenAndSpan>> Tokens<TokenAndSpan> for Capturing<I> {
+    type Checkpoint = I::Checkpoint;
+
+    fn checkpoint_save(&self) -> Self::Checkpoint {
+        self.inner.checkpoint_save()
+    }
+
+    fn checkpoint_load(&mut self, checkpoint: Self::Checkpoint) {
+        self.inner.checkpoint_load(checkpoint);
+    }
+
     #[inline(always)]
     fn set_ctx(&mut self, ctx: Context) {
         self.inner.set_ctx(ctx)

--- a/crates/swc_ecma_lexer/src/input.rs
+++ b/crates/swc_ecma_lexer/src/input.rs
@@ -328,7 +328,6 @@ impl<I: Tokens<TokenAndSpan>> Buffer<I> {
 
 impl<'a, I: Tokens<TokenAndSpan>> crate::common::parser::buffer::Buffer<'a> for Buffer<I> {
     type I = I;
-    type Lexer = super::lexer::Lexer<'a>;
     type Next = TokenAndSpan;
     type Token = Token;
     type TokenAndSpan = TokenAndSpan;

--- a/crates/swc_ecma_lexer/src/lexer/state.rs
+++ b/crates/swc_ecma_lexer/src/lexer/state.rs
@@ -641,6 +641,8 @@ impl crate::common::lexer::state::TokenType for TokenType {
 }
 
 impl Tokens<TokenAndSpan> for Lexer<'_> {
+    type Checkpoint = Self;
+
     #[inline]
     fn set_ctx(&mut self, ctx: Context) {
         if ctx.contains(Context::Module) && !self.module_errors.borrow().is_empty() {
@@ -658,6 +660,14 @@ impl Tokens<TokenAndSpan> for Lexer<'_> {
     #[inline]
     fn ctx_mut(&mut self) -> &mut Context {
         &mut self.ctx
+    }
+
+    fn checkpoint_save(&self) -> Self::Checkpoint {
+        self.clone()
+    }
+
+    fn checkpoint_load(&mut self, checkpoint: Self::Checkpoint) {
+        *self = checkpoint;
     }
 
     #[inline]

--- a/crates/swc_ecma_lexer/src/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/parser/mod.rs
@@ -39,7 +39,6 @@ pub struct Parser<I: Tokens<TokenAndSpan>> {
 impl<'a, I: Tokens<TokenAndSpan>> crate::common::parser::Parser<'a> for Parser<I> {
     type Buffer = Buffer<I>;
     type I = I;
-    type Lexer = crate::lexer::Lexer<'a>;
     type Next = TokenAndSpan;
     type Token = Token;
     type TokenAndSpan = TokenAndSpan;

--- a/crates/swc_ecma_lexer/src/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/parser/mod.rs
@@ -38,6 +38,7 @@ pub struct Parser<I: Tokens<TokenAndSpan>> {
 
 impl<'a, I: Tokens<TokenAndSpan>> crate::common::parser::Parser<'a> for Parser<I> {
     type Buffer = Buffer<I>;
+    type Checkpoint = Self;
     type I = I;
     type Next = TokenAndSpan;
     type Token = Token;
@@ -61,6 +62,14 @@ impl<'a, I: Tokens<TokenAndSpan>> crate::common::parser::Parser<'a> for Parser<I
     #[inline(always)]
     fn state_mut(&mut self) -> &mut common::parser::state::State {
         &mut self.state
+    }
+
+    fn checkpoint_save(&self) -> Self::Checkpoint {
+        self.clone()
+    }
+
+    fn checkpoint_load(&mut self, checkpoint: Self::Checkpoint) {
+        *self = checkpoint;
     }
 
     #[inline(always)]

--- a/crates/swc_ecma_parser/src/lexer/capturing.rs
+++ b/crates/swc_ecma_parser/src/lexer/capturing.rs
@@ -68,6 +68,16 @@ impl<I: Iterator<Item = TokenAndSpan>> Iterator for Capturing<I> {
 impl<I: swc_ecma_lexer::common::input::Tokens<TokenAndSpan>>
     swc_ecma_lexer::common::input::Tokens<TokenAndSpan> for Capturing<I>
 {
+    type Checkpoint = I::Checkpoint;
+
+    fn checkpoint_save(&self) -> Self::Checkpoint {
+        self.inner.checkpoint_save()
+    }
+
+    fn checkpoint_load(&mut self, checkpoint: Self::Checkpoint) {
+        self.inner.checkpoint_load(checkpoint);
+    }
+
     fn set_ctx(&mut self, ctx: swc_ecma_lexer::common::context::Context) {
         self.inner.set_ctx(ctx);
     }

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -1,12 +1,12 @@
 use std::mem::take;
 
-use swc_common::BytePos;
+use swc_common::{comments::Comments, BytePos};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_lexer::{
     common::{
         lexer::{
             char::CharExt,
-            comments_buffer::{BufferedComment, BufferedCommentKind},
+            comments_buffer::{BufferedComment, BufferedCommentKind, CommentsBuffer},
             state::State as StateTrait,
             LexResult,
         },
@@ -42,15 +42,33 @@ pub struct State {
     token_type: Option<Token>,
 }
 
-impl swc_ecma_lexer::common::input::Tokens<TokenAndSpan> for Lexer<'_> {
-    type Checkpoint = Self;
+pub struct LexerCheckpoint<'a> {
+    comments: Option<&'a dyn Comments>,
+    comments_buffer: Option<CommentsBuffer>,
+    state: State,
+    ctx: Context,
+    input_last_pos: BytePos,
+}
+
+impl<'a> swc_ecma_lexer::common::input::Tokens<TokenAndSpan> for Lexer<'a> {
+    type Checkpoint = LexerCheckpoint<'a>;
 
     fn checkpoint_save(&self) -> Self::Checkpoint {
-        self.clone()
+        Self::Checkpoint {
+            comments: self.comments,
+            comments_buffer: self.comments_buffer.clone(),
+            state: self.state.clone(),
+            ctx: self.ctx,
+            input_last_pos: self.input.last_pos(),
+        }
     }
 
     fn checkpoint_load(&mut self, checkpoint: Self::Checkpoint) {
-        *self = checkpoint;
+        self.comments = checkpoint.comments;
+        self.comments_buffer = checkpoint.comments_buffer;
+        self.state = checkpoint.state;
+        self.ctx = checkpoint.ctx;
+        unsafe { self.input.reset_to(checkpoint.input_last_pos) };
     }
 
     #[inline]

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -43,6 +43,16 @@ pub struct State {
 }
 
 impl swc_ecma_lexer::common::input::Tokens<TokenAndSpan> for Lexer<'_> {
+    type Checkpoint = Self;
+
+    fn checkpoint_save(&self) -> Self::Checkpoint {
+        self.clone()
+    }
+
+    fn checkpoint_load(&mut self, checkpoint: Self::Checkpoint) {
+        *self = checkpoint;
+    }
+
     #[inline]
     fn set_ctx(&mut self, ctx: Context) {
         if ctx.contains(Context::Module) && !self.module_errors.borrow().is_empty() {

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -155,7 +155,6 @@ impl<I: Tokens> Buffer<I> {
 
 impl<'a, I: Tokens> swc_ecma_lexer::common::parser::buffer::Buffer<'a> for Buffer<I> {
     type I = I;
-    type Lexer = super::super::lexer::Lexer<'a>;
     type Next = NextTokenAndSpan;
     type Token = super::super::lexer::Token;
     type TokenAndSpan = TokenAndSpan;

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -47,7 +47,6 @@ pub struct Parser<I: self::input::Tokens> {
 impl<'a, I: Tokens> swc_ecma_lexer::common::parser::Parser<'a> for Parser<I> {
     type Buffer = self::input::Buffer<I>;
     type I = I;
-    type Lexer = crate::lexer::Lexer<'a>;
     type Next = crate::lexer::NextTokenAndSpan;
     type Token = Token;
     type TokenAndSpan = TokenAndSpan;

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -46,6 +46,7 @@ pub struct Parser<I: self::input::Tokens> {
 
 impl<'a, I: Tokens> swc_ecma_lexer::common::parser::Parser<'a> for Parser<I> {
     type Buffer = self::input::Buffer<I>;
+    type Checkpoint = Self;
     type I = I;
     type Next = crate::lexer::NextTokenAndSpan;
     type Token = Token;
@@ -69,6 +70,14 @@ impl<'a, I: Tokens> swc_ecma_lexer::common::parser::Parser<'a> for Parser<I> {
     #[inline(always)]
     fn state_mut(&mut self) -> &mut swc_ecma_lexer::common::parser::state::State {
         &mut self.state
+    }
+
+    fn checkpoint_save(&self) -> Self::Checkpoint {
+        self.clone()
+    }
+
+    fn checkpoint_load(&mut self, checkpoint: Self::Checkpoint) {
+        *self = checkpoint;
     }
 
     #[inline(always)]


### PR DESCRIPTION
**Description:**

There could be no need to clone entire lexer and parser when calling `try_parse_xxx` in typescript. Here introduces checkpoints which only contains necessary data to recover from failed trials. This is also the prerequisite for https://github.com/swc-project/swc/pull/11000. And we can also remove the `Rc<RefCell<T>>` in the lexer later 

I'm not sure the data is completed for correctness. Let's see the test results.