### PR TITLE
perf(es/parser): remove useless `Rc<RefCell<T>>`

### DIFF
--- a/crates/swc_ecma_lexer/src/common/input.rs
+++ b/crates/swc_ecma_lexer/src/common/input.rs
@@ -33,7 +33,7 @@ pub trait Tokens<TokenAndSpan>: Clone + Iterator<Item = TokenAndSpan> {
     ///
     /// It is required because parser should backtrack while parsing typescript
     /// code.
-    fn add_error(&self, error: Error);
+    fn add_error(&mut self, error: Error);
 
     /// Add an error which is valid syntax in script mode.
     ///
@@ -42,7 +42,7 @@ pub trait Tokens<TokenAndSpan>: Clone + Iterator<Item = TokenAndSpan> {
     /// Implementor should check for if [Context].module, and buffer errors if
     /// module is false. Also, implementors should move errors to the error
     /// buffer on set_ctx if the parser mode become module mode.
-    fn add_module_mode_error(&self, error: Error);
+    fn add_module_mode_error(&mut self, error: Error);
 
     fn end_pos(&self) -> BytePos;
 

--- a/crates/swc_ecma_lexer/src/common/lexer/mod.rs
+++ b/crates/swc_ecma_lexer/src/common/lexer/mod.rs
@@ -92,7 +92,7 @@ pub trait Lexer<'a, TokenAndSpan>: Tokens<TokenAndSpan> + Sized {
     unsafe fn input_slice(&mut self, start: BytePos, end: BytePos) -> &'a str;
     fn input_uncons_while(&mut self, f: impl FnMut(char) -> bool) -> &'a str;
     fn atom<'b>(&self, s: impl Into<Cow<'b, str>>) -> swc_atoms::Atom;
-    fn push_error(&self, error: crate::error::Error);
+    fn push_error(&mut self, error: crate::error::Error);
 
     #[inline(always)]
     #[allow(clippy::misnamed_getters)]

--- a/crates/swc_ecma_lexer/src/common/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/mod.rs
@@ -159,21 +159,21 @@ pub trait Parser<'a>: Sized + Clone {
         let cur = self.input().cur();
         if cur.is_error() {
             let err = self.input_mut().expect_error_token_and_bump();
-            self.input().iter().add_error(err);
+            self.input_mut().iter_mut().add_error(err);
         }
-        self.input().iter().add_error(error);
+        self.input_mut().iter_mut().add_error(error);
     }
 
     #[cold]
-    fn emit_strict_mode_err(&self, span: Span, error: SyntaxError) {
+    fn emit_strict_mode_err(&mut self, span: Span, error: SyntaxError) {
         if self.ctx().contains(Context::IgnoreError) {
             return;
         }
         let error = crate::error::Error::new(span, error);
         if self.ctx().contains(Context::Strict) {
-            self.input().iter().add_error(error);
+            self.input_mut().iter_mut().add_error(error);
         } else {
-            self.input().iter().add_module_mode_error(error);
+            self.input_mut().iter_mut().add_module_mode_error(error);
         }
     }
 

--- a/crates/swc_ecma_lexer/src/common/parser/pat.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/pat.rs
@@ -25,7 +25,7 @@ use crate::{
 /// argument of arrow is pattern, although idents in pattern is already
 /// checked if is a keyword, it should also be checked if is arguments or
 /// eval
-fn pat_is_valid_argument_in_strict<'a>(p: &impl Parser<'a>, pat: &Pat) {
+fn pat_is_valid_argument_in_strict<'a>(p: &mut impl Parser<'a>, pat: &Pat) {
     debug_assert!(p.ctx().contains(Context::Strict));
     match pat {
         Pat::Ident(i) => {

--- a/crates/swc_ecma_lexer/src/input.rs
+++ b/crates/swc_ecma_lexer/src/input.rs
@@ -119,12 +119,12 @@ impl Tokens<TokenAndSpan> for TokensInput {
     }
 
     #[inline(always)]
-    fn add_error(&self, error: Error) {
+    fn add_error(&mut self, error: Error) {
         self.errors.borrow_mut().push(error);
     }
 
     #[inline(always)]
-    fn add_module_mode_error(&self, error: Error) {
+    fn add_module_mode_error(&mut self, error: Error) {
         if self.ctx.contains(Context::Module) {
             self.add_error(error);
             return;
@@ -288,12 +288,12 @@ impl<I: Tokens<TokenAndSpan>> Tokens<TokenAndSpan> for Capturing<I> {
     }
 
     #[inline(always)]
-    fn add_error(&self, error: Error) {
+    fn add_error(&mut self, error: Error) {
         self.inner.add_error(error);
     }
 
     #[inline(always)]
-    fn add_module_mode_error(&self, error: Error) {
+    fn add_module_mode_error(&mut self, error: Error) {
         self.inner.add_module_mode_error(error)
     }
 

--- a/crates/swc_ecma_lexer/src/lexer/mod.rs
+++ b/crates/swc_ecma_lexer/src/lexer/mod.rs
@@ -70,7 +70,7 @@ impl<'a> crate::common::lexer::Lexer<'a, TokenAndSpan> for Lexer<'a> {
     }
 
     #[inline(always)]
-    fn push_error(&self, error: crate::error::Error) {
+    fn push_error(&mut self, error: crate::error::Error) {
         self.errors.borrow_mut().push(error);
     }
 

--- a/crates/swc_ecma_lexer/src/lexer/state.rs
+++ b/crates/swc_ecma_lexer/src/lexer/state.rs
@@ -711,12 +711,12 @@ impl Tokens<TokenAndSpan> for Lexer<'_> {
     }
 
     #[inline]
-    fn add_error(&self, error: Error) {
+    fn add_error(&mut self, error: Error) {
         self.errors.borrow_mut().push(error);
     }
 
     #[inline]
-    fn add_module_mode_error(&self, error: Error) {
+    fn add_module_mode_error(&mut self, error: Error) {
         if self.ctx.contains(Context::Module) {
             self.add_error(error);
             return;

--- a/crates/swc_ecma_parser/src/lexer/capturing.rs
+++ b/crates/swc_ecma_parser/src/lexer/capturing.rs
@@ -118,11 +118,11 @@ impl<I: swc_ecma_lexer::common::input::Tokens<TokenAndSpan>>
         self.inner.set_token_context(c);
     }
 
-    fn add_error(&self, error: swc_ecma_lexer::error::Error) {
+    fn add_error(&mut self, error: swc_ecma_lexer::error::Error) {
         self.inner.add_error(error);
     }
 
-    fn add_module_mode_error(&self, error: swc_ecma_lexer::error::Error) {
+    fn add_module_mode_error(&mut self, error: swc_ecma_lexer::error::Error) {
         self.inner.add_module_mode_error(error);
     }
 

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -1,6 +1,6 @@
 //! ECMAScript lexer.
 
-use std::{cell::RefCell, char, iter::FusedIterator, rc::Rc};
+use std::{char, iter::FusedIterator, rc::Rc};
 
 use swc_atoms::AtomStoreCell;
 use swc_common::{
@@ -50,8 +50,8 @@ pub struct Lexer<'a> {
     pub(crate) syntax: SyntaxFlags,
     pub(crate) target: EsVersion,
 
-    errors: Rc<RefCell<Vec<Error>>>,
-    module_errors: Rc<RefCell<Vec<Error>>>,
+    errors: Vec<Error>,
+    module_errors: Vec<Error>,
 
     atoms: Rc<AtomStoreCell>,
 }
@@ -73,8 +73,8 @@ impl<'a> swc_ecma_lexer::common::lexer::Lexer<'a, TokenAndSpan> for Lexer<'a> {
     }
 
     #[inline(always)]
-    fn push_error(&self, error: Error) {
-        self.errors.borrow_mut().push(error);
+    fn push_error(&mut self, error: Error) {
+        self.errors.push(error);
     }
 
     #[inline(always)]


### PR DESCRIPTION
**Description:**

See https://github.com/swc-project/swc/pull/11001

I also remove `comments` since it's immutable. But we should be careful not to clone entire parser and lexer (we can ensure this by benchmark)