### PR TITLE
fix(es/minifier): don't elimiate class expr if some side effects contain `this`

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -8,7 +8,7 @@ use swc_atoms::Atom;
 use swc_common::{util::take::Take, Mark, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::perf::{Parallel, ParallelExt};
-use swc_ecma_utils::{collect_decls, ExprCtx, ExprExt, Remapper};
+use swc_ecma_utils::{collect_decls, contains_this_expr, ExprCtx, ExprExt, Remapper};
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 use tracing::debug;
 
@@ -161,34 +161,40 @@ impl Drop for WithCtx<'_, '_> {
     }
 }
 
-pub(crate) fn extract_class_side_effect(expr_ctx: ExprCtx, c: Class) -> Vec<Box<Expr>> {
+pub(crate) fn extract_class_side_effect(
+    expr_ctx: ExprCtx,
+    c: &mut Class,
+) -> Option<Vec<&mut Box<Expr>>> {
     let mut res = Vec::new();
-    if let Some(e) = c.super_class {
+    if let Some(e) = &mut c.super_class {
         if e.may_have_side_effects(expr_ctx) {
             res.push(e);
         }
     }
 
-    for m in c.body {
+    for m in &mut c.body {
         match m {
             ClassMember::Method(ClassMethod {
                 key: PropName::Computed(key),
                 ..
             }) => {
                 if key.expr.may_have_side_effects(expr_ctx) {
-                    res.push(key.expr);
+                    res.push(&mut key.expr);
                 }
             }
 
             ClassMember::ClassProp(p) => {
-                if let PropName::Computed(key) = p.key {
+                if let PropName::Computed(key) = &mut p.key {
                     if key.expr.may_have_side_effects(expr_ctx) {
-                        res.push(key.expr);
+                        res.push(&mut key.expr);
                     }
                 }
 
-                if let Some(v) = p.value {
+                if let Some(v) = &mut p.value {
                     if p.is_static && v.may_have_side_effects(expr_ctx) {
+                        if contains_this_expr(v) {
+                            return None;
+                        }
                         res.push(v);
                     }
                 }
@@ -199,6 +205,9 @@ pub(crate) fn extract_class_side_effect(expr_ctx: ExprCtx, c: Class) -> Vec<Box<
                 ..
             }) => {
                 if v.may_have_side_effects(expr_ctx) {
+                    if contains_this_expr(v) {
+                        return None;
+                    }
                     res.push(v);
                 }
             }
@@ -207,7 +216,7 @@ pub(crate) fn extract_class_side_effect(expr_ctx: ExprCtx, c: Class) -> Vec<Box<
         }
     }
 
-    res
+    Some(res)
 }
 
 pub(crate) fn is_valid_for_lhs(e: &Expr) -> bool {

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10981/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10981/input.js
@@ -1,0 +1,15 @@
+class C {
+    static foo = bar;
+}
+
+(class C {
+    static foo = bar;
+});
+
+class D {
+    static #_ = (this.FOO = {});
+}
+
+(class D {
+    static #_ = (this.FOO = {});
+});

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10981/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10981/output.js
@@ -1,0 +1,10 @@
+class C {
+    static foo = bar;
+}
+bar;
+class D {
+    static #_ = this.FOO = {};
+}
+(class {
+    static #_ = this.FOO = {};
+});


### PR DESCRIPTION
**Description:**

Um...There are some options to handle this problem:
1. Prefer size. Check if there's any `this` in the statement with side effect. This could be inefficient and I'm not sure whether there's any other corner case.
2. Prefer performance. Just like what oxc does, keep entire class declarations if some static property contains side effect initializer.

Since it's anti-pattern code, I'm not sure above options are worthy just for this case...Maybe a better one is emitting warnings for all those anti-pattern code. However, swc minifier doesn't diagnostic system for minifier, and I don't know how many code in swc minifier is used for handling such cases (so it could be redundant to introduce it now).

🫡 **After some consideration I finally decide to directly add `contains_this_expr` check for it.** 

**Related issue (if exists):**
fixes https://github.com/swc-project/swc/issues/10981