### PR TITLE
fix(es/minifier): Remove unused patterns from destructuring 

### DIFF
--- a/crates/swc_ecma_minifier/tests/fixture/issues/10962-simple/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10962-simple/config.json
@@ -1,0 +1,5 @@
+{
+  "defaults": {
+    "passes": 1
+  }
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10962-simple/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10962-simple/input.js
@@ -1,0 +1,6 @@
+function test(obj) {
+    var unused1 = obj.prop1;
+    var unused2 = obj.prop2;
+    var used = obj.prop3;
+    console.log(used);
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10962-simple/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10962-simple/output.js
@@ -1,0 +1,4 @@
+function test(obj) {
+    var used = obj.prop3;
+    console.log(used);
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10962/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10962/config.json
@@ -1,0 +1,6 @@
+{
+  "defaults": {
+    "passes": 3,
+    "toplevel": false
+  }
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10962/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10962/input.js
@@ -1,0 +1,13 @@
+// This is the ES5-transformed version of:
+// export default function render(factory) {
+//   return factory(({aaa, bbb, ccc}) => {
+//     ccc(1)
+//   }, [0, 19])
+// }
+
+export default function render(factory) {
+  return factory(function(param) {
+    var aaa = param.aaa, bbb = param.bbb, ccc = param.ccc;
+    ccc(1)
+  }, [0, 19])
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10962/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10962/output.js
@@ -1,0 +1,8 @@
+export default function render(c) {
+    return c(function(c) {
+        (0, c.ccc)(1);
+    }, [
+        0,
+        19
+    ]);
+}


### PR DESCRIPTION
When destructuring patterns are transformed to member expressions (e.g., for ES5 targets),
the unused member expressions were not being removed during minification.

This fix improves the ignore_return_value method to properly handle member expressions:
- Check if computed property expressions have side effects
- Use the pure_getters option to determine if property access is safe to drop
- If the object has side effects, evaluate it but drop the member access
- Otherwise, drop the entire member expression when safe

Fixes #10962

Generated with [Claude Code](https://claude.ai/code)