### PR TITLE
Remove unused vars of destructuring while 'init' is identifier

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -356,13 +356,15 @@ impl Optimizer<'_> {
 
             if !has_pure_ann {
                 if let Some(init) = init.as_mut() {
-                    if self.should_preserve_property_access(
-                        init,
-                        PropertyAccessOpts {
-                            allow_getter: false,
-                            only_ident: false,
-                        },
-                    ) {
+                    if !matches!(init, Expr::Ident(_))
+                        && self.should_preserve_property_access(
+                            init,
+                            PropertyAccessOpts {
+                                allow_getter: false,
+                                only_ident: false,
+                            },
+                        )
+                    {
                         return;
                     }
                 }

--- a/crates/swc_ecma_minifier/tests/terser/compress/pure_getters/destructuring/config.json
+++ b/crates/swc_ecma_minifier/tests/terser/compress/pure_getters/destructuring/config.json
@@ -1,0 +1,7 @@
+{
+    "pure_getters": true,
+    "side_effects": true,
+    "toplevel": true,
+    "unused": true,
+    "passes": 1
+}

--- a/crates/swc_ecma_minifier/tests/terser/compress/pure_getters/destructuring/input.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/pure_getters/destructuring/input.js
@@ -1,0 +1,15 @@
+import declare from "phantom";
+const declared = declare();
+const { a1, b1, c1 = "c" } = declared;
+const { a2, b2, c2 = "c" } = undeclared;
+const { a3, b3, c3 = "c" } = window;
+function fn({ a, b, c = "c", d }) {
+    console.log(d);
+}
+fn({
+    a: "a",
+    get b() {
+        console.log("side effect of b");
+        return "b";
+    },
+});

--- a/crates/swc_ecma_minifier/tests/terser/compress/pure_getters/destructuring/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/pure_getters/destructuring/output.js
@@ -1,0 +1,15 @@
+import declare from "phantom";
+const declared = declare();
+const { c1 = "c" } = declared;
+const { c2 = "c" } = undeclared;
+const { c3 = "c" } = window;
+function fn({ c = "c", d }) {
+    console.log(d);
+}
+fn({
+    a: "a",
+    get b () {
+        console.log("side effect of b");
+        return "b";
+    }
+});

--- a/crates/swc_ecma_minifier/tests/terser/compress/pure_getters/destructuring/output.mangleOnly.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/pure_getters/destructuring/output.mangleOnly.js
@@ -1,0 +1,15 @@
+import o from "phantom";
+const c = o();
+const { a1: n, b1: t, c1: e = "c" } = c;
+const { a2: s, b2: f, c2: l = "c" } = undeclared;
+const { a3: r, b3: a, c3: d = "c" } = window;
+function i({ a: o, b: c, c: n = "c", d: t }) {
+    console.log(t);
+}
+i({
+    a: "a",
+    get b () {
+        console.log("side effect of b");
+        return "b";
+    }
+});

--- a/crates/swc_ecma_minifier/tests/terser/compress/pure_getters/destructuring/output.terser.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/pure_getters/destructuring/output.terser.js
@@ -1,0 +1,15 @@
+import declare from "phantom";
+const declared = declare();
+const { c1 = "c" } = declared;
+const { c2 = "c" } = undeclared;
+const { c3 = "c" } = window;
+function fn({ c = "c", d }) {
+    console.log(d);
+}
+fn({
+    a: "a",
+    get b () {
+        console.log("side effect of b");
+        return "b";
+    }
+});


### PR DESCRIPTION

<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
If `pure_getters` is `true`, remove unused vars of destructuring **while 'init' is identifier**.
We should follow user's configuration at least in simple scenarios.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):** #10962 
