### PR TITLE
fix(es/optimization): Revert `perf(es/optimization): Rely on resolver from inline_globals`

### DIFF
--- a/.changeset/ninety-parrots-flow.md
+++ b/.changeset/ninety-parrots-flow.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_transforms_optimization: major
+---
+
+fix(es/optimization): Revert `perf(es/optimization): Rely on resolver from inline_globals`

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -65,7 +65,7 @@ use swc_ecma_transforms::{
 };
 use swc_ecma_transforms_compat::es2015::regenerator;
 use swc_ecma_transforms_optimization::{
-    inline_globals,
+    inline_globals2,
     simplify::{dce::Config as DceConfig, Config as SimplifyConfig},
     GlobalExprMap,
 };
@@ -535,7 +535,7 @@ impl Options {
         let optimization = {
             optimizer
                 .and_then(|o| o.globals)
-                .map(|opts| opts.build(cm, handler, unresolved_mark))
+                .map(|opts| opts.build(cm, handler))
         };
 
         let pass = (
@@ -1708,12 +1708,7 @@ impl Default for GlobalInliningPassEnvs {
 }
 
 impl GlobalPassOption {
-    pub fn build(
-        self,
-        cm: &SourceMap,
-        handler: &Handler,
-        unresolved_mark: Mark,
-    ) -> impl 'static + Pass {
+    pub fn build(self, cm: &SourceMap, handler: &Handler) -> impl 'static + Pass {
         type ValuesMap = Arc<FxHashMap<Atom, Expr>>;
 
         fn expr(cm: &SourceMap, handler: &Handler, src: String) -> Box<Expr> {
@@ -1867,13 +1862,7 @@ impl GlobalPassOption {
             }
         };
 
-        inline_globals(
-            unresolved_mark,
-            env_map,
-            global_map,
-            global_exprs,
-            Arc::new(self.typeofs),
-        )
+        inline_globals2(env_map, global_map, global_exprs, Arc::new(self.typeofs))
     }
 }
 

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -65,7 +65,7 @@ use swc_ecma_transforms::{
 };
 use swc_ecma_transforms_compat::es2015::regenerator;
 use swc_ecma_transforms_optimization::{
-    inline_globals2,
+    inline_globals,
     simplify::{dce::Config as DceConfig, Config as SimplifyConfig},
     GlobalExprMap,
 };
@@ -1862,7 +1862,7 @@ impl GlobalPassOption {
             }
         };
 
-        inline_globals2(env_map, global_map, global_exprs, Arc::new(self.typeofs))
+        inline_globals(env_map, global_map, global_exprs, Arc::new(self.typeofs))
     }
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/inline_globals.rs
+++ b/crates/swc_ecma_transforms_optimization/src/inline_globals.rs
@@ -1,9 +1,9 @@
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::Atom;
-use swc_common::{sync::Lrc, Mark, SyntaxContext};
+use swc_common::sync::Lrc;
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::perf::{ParVisitMut, Parallel};
-use swc_ecma_utils::{parallel::cpu_count, NodeIgnoringSpan};
+use swc_ecma_utils::{collect_decls, parallel::cpu_count, NodeIgnoringSpan};
 use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
 
 /// The key will be compared using [EqIgnoreSpan::eq_ignore_span], and matched
@@ -17,20 +17,25 @@ pub type GlobalExprMap = Lrc<FxHashMap<NodeIgnoringSpan<'static, Expr>, Expr>>;
 ///
 /// Note: Values specified in `global_exprs` have higher precedence than
 pub fn inline_globals(
-    unresolved_mark: Mark,
+    envs: Lrc<FxHashMap<Atom, Expr>>,
+    globals: Lrc<FxHashMap<Atom, Expr>>,
+    typeofs: Lrc<FxHashMap<Atom, Atom>>,
+) -> impl Pass {
+    inline_globals2(envs, globals, Default::default(), typeofs)
+}
+
+pub fn inline_globals2(
     envs: Lrc<FxHashMap<Atom, Expr>>,
     globals: Lrc<FxHashMap<Atom, Expr>>,
     global_exprs: GlobalExprMap,
     typeofs: Lrc<FxHashMap<Atom, Atom>>,
 ) -> impl Pass {
-    let unresolved_ctxt = SyntaxContext::default().apply_mark(unresolved_mark);
-
     visit_mut_pass(InlineGlobals {
         envs,
         globals,
         global_exprs,
         typeofs,
-        unresolved_ctxt,
+        bindings: Default::default(),
     })
 }
 
@@ -42,7 +47,7 @@ struct InlineGlobals {
 
     typeofs: Lrc<FxHashMap<Atom, Atom>>,
 
-    unresolved_ctxt: SyntaxContext,
+    bindings: Lrc<FxHashSet<Id>>,
 }
 
 impl Parallel for InlineGlobals {
@@ -61,9 +66,8 @@ impl VisitMut for InlineGlobals {
     }
 
     fn visit_mut_expr(&mut self, expr: &mut Expr) {
-        if let Expr::Ident(Ident { ctxt, .. }) = expr {
-            // Ignore declared variables
-            if *ctxt != self.unresolved_ctxt {
+        if let Expr::Ident(id) = expr {
+            if self.bindings.contains(&id.to_id()) {
                 return;
             }
         }
@@ -94,14 +98,9 @@ impl VisitMut for InlineGlobals {
                 arg,
                 ..
             }) => {
-                if let Expr::Ident(Ident {
-                    ref sym,
-                    ctxt: arg_ctxt,
-                    ..
-                }) = &**arg
-                {
+                if let Expr::Ident(ident @ Ident { ref sym, .. }) = &**arg {
                     // It's a declared variable
-                    if *arg_ctxt != self.unresolved_ctxt {
+                    if self.bindings.contains(&ident.to_id()) {
                         return;
                     }
 
@@ -156,6 +155,12 @@ impl VisitMut for InlineGlobals {
         self.visit_mut_par(cpu_count(), n);
     }
 
+    fn visit_mut_module(&mut self, module: &mut Module) {
+        self.bindings = Lrc::new(collect_decls(&*module));
+
+        module.visit_mut_children_with(self);
+    }
+
     fn visit_mut_opt_vec_expr_or_spreads(&mut self, n: &mut Vec<Option<ExprOrSpread>>) {
         self.visit_mut_par(cpu_count(), n);
     }
@@ -165,7 +170,7 @@ impl VisitMut for InlineGlobals {
 
         if let Prop::Shorthand(i) = p {
             // Ignore declared variables
-            if i.ctxt != self.unresolved_ctxt {
+            if self.bindings.contains(&i.to_id()) {
                 return;
             }
 
@@ -183,12 +188,16 @@ impl VisitMut for InlineGlobals {
     fn visit_mut_prop_or_spreads(&mut self, n: &mut Vec<PropOrSpread>) {
         self.visit_mut_par(cpu_count(), n);
     }
+
+    fn visit_mut_script(&mut self, script: &mut Script) {
+        self.bindings = Lrc::new(collect_decls(&*script));
+
+        script.visit_mut_children_with(self);
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use swc_common::Mark;
-    use swc_ecma_transforms_base::resolver;
     use swc_ecma_transforms_testing::{test, Tester};
     use swc_ecma_utils::{DropSpan, StmtOrModuleItem};
 
@@ -245,19 +254,11 @@ mod tests {
     test!(
         ::swc_ecma_parser::Syntax::default(),
         |tester| {
-            let unresolved_mark = Mark::new();
-            let top_level_mark = Mark::new();
-
-            (
-                resolver(unresolved_mark, top_level_mark, false),
-                inline_globals(
-                    unresolved_mark,
-                    envs(tester, &[]),
-                    globals(tester, &[]),
-                    Default::default(),
-                    Default::default(),
-                ),
-            )
+            (inline_globals(
+                envs(tester, &[("NODE_ENV", "development")]),
+                globals(tester, &[]),
+                Default::default(),
+            ),)
         },
         issue_215,
         r#"if (process.env.x === 'development') {}"#
@@ -266,19 +267,11 @@ mod tests {
     test!(
         ::swc_ecma_parser::Syntax::default(),
         |tester| {
-            let unresolved_mark = Mark::new();
-            let top_level_mark = Mark::new();
-
-            (
-                resolver(unresolved_mark, top_level_mark, false),
-                inline_globals(
-                    unresolved_mark,
-                    envs(tester, &[("NODE_ENV", "development")]),
-                    globals(tester, &[]),
-                    Default::default(),
-                    Default::default(),
-                ),
-            )
+            (inline_globals(
+                envs(tester, &[("NODE_ENV", "development")]),
+                globals(tester, &[]),
+                Default::default(),
+            ),)
         },
         node_env,
         r#"if (process.env.NODE_ENV === 'development') {}"#
@@ -287,19 +280,11 @@ mod tests {
     test!(
         ::swc_ecma_parser::Syntax::default(),
         |tester| {
-            let unresolved_mark = Mark::new();
-            let top_level_mark = Mark::new();
-
-            (
-                resolver(unresolved_mark, top_level_mark, false),
-                inline_globals(
-                    unresolved_mark,
-                    envs(tester, &[]),
-                    globals(tester, &[("__DEBUG__", "true")]),
-                    Default::default(),
-                    Default::default(),
-                ),
-            )
+            (inline_globals(
+                envs(tester, &[]),
+                globals(tester, &[("__DEBUG__", "true")]),
+                Default::default(),
+            ),)
         },
         globals_simple,
         r#"if (__DEBUG__) {}"#
@@ -308,19 +293,11 @@ mod tests {
     test!(
         ::swc_ecma_parser::Syntax::default(),
         |tester| {
-            let unresolved_mark = Mark::new();
-            let top_level_mark = Mark::new();
-
-            (
-                resolver(unresolved_mark, top_level_mark, false),
-                inline_globals(
-                    unresolved_mark,
-                    envs(tester, &[]),
-                    globals(tester, &[("debug", "true")]),
-                    Default::default(),
-                    Default::default(),
-                ),
-            )
+            (inline_globals(
+                envs(tester, &[]),
+                globals(tester, &[("debug", "true")]),
+                Default::default(),
+            ),)
         },
         non_global,
         r#"if (foo.debug) {}"#
@@ -329,19 +306,11 @@ mod tests {
     test!(
         Default::default(),
         |tester| {
-            let unresolved_mark = Mark::new();
-            let top_level_mark = Mark::new();
-
-            (
-                resolver(unresolved_mark, top_level_mark, false),
-                inline_globals(
-                    unresolved_mark,
-                    envs(tester, &[]),
-                    globals(tester, &[]),
-                    Default::default(),
-                    Default::default(),
-                ),
-            )
+            (inline_globals(
+                envs(tester, &[]),
+                globals(tester, &[]),
+                Default::default(),
+            ),)
         },
         issue_417_1,
         "const test = process.env['x']"
@@ -350,19 +319,11 @@ mod tests {
     test!(
         Default::default(),
         |tester| {
-            let unresolved_mark = Mark::new();
-            let top_level_mark = Mark::new();
-
-            (
-                resolver(unresolved_mark, top_level_mark, false),
-                inline_globals(
-                    unresolved_mark,
-                    envs(tester, &[("x", "FOO")]),
-                    globals(tester, &[]),
-                    Default::default(),
-                    Default::default(),
-                ),
-            )
+            (inline_globals(
+                envs(tester, &[("x", "FOO")]),
+                globals(tester, &[]),
+                Default::default(),
+            ),)
         },
         issue_417_2,
         "const test = process.env['x']"
@@ -371,19 +332,11 @@ mod tests {
     test!(
         Default::default(),
         |tester| {
-            let unresolved_mark = Mark::new();
-            let top_level_mark = Mark::new();
-
-            (
-                resolver(unresolved_mark, top_level_mark, false),
-                inline_globals(
-                    unresolved_mark,
-                    envs(tester, &[("x", "BAR")]),
-                    globals(tester, &[]),
-                    Default::default(),
-                    Default::default(),
-                ),
-            )
+            (inline_globals(
+                envs(tester, &[("x", "BAR")]),
+                globals(tester, &[]),
+                Default::default(),
+            ),)
         },
         issue_2499_1,
         "process.env.x = 'foo'"

--- a/crates/swc_ecma_transforms_optimization/src/inline_globals.rs
+++ b/crates/swc_ecma_transforms_optimization/src/inline_globals.rs
@@ -19,14 +19,6 @@ pub type GlobalExprMap = Lrc<FxHashMap<NodeIgnoringSpan<'static, Expr>, Expr>>;
 pub fn inline_globals(
     envs: Lrc<FxHashMap<Atom, Expr>>,
     globals: Lrc<FxHashMap<Atom, Expr>>,
-    typeofs: Lrc<FxHashMap<Atom, Atom>>,
-) -> impl Pass {
-    inline_globals2(envs, globals, Default::default(), typeofs)
-}
-
-pub fn inline_globals2(
-    envs: Lrc<FxHashMap<Atom, Expr>>,
-    globals: Lrc<FxHashMap<Atom, Expr>>,
     global_exprs: GlobalExprMap,
     typeofs: Lrc<FxHashMap<Atom, Atom>>,
 ) -> impl Pass {
@@ -258,6 +250,7 @@ mod tests {
         |tester| inline_globals(
             envs(tester, &[("NODE_ENV", "development")]),
             globals(tester, &[]),
+            Default::default(),
             Default::default()
         ),
         issue_215,
@@ -270,6 +263,7 @@ mod tests {
             envs(tester, &[("NODE_ENV", "development")]),
             globals(tester, &[]),
             Default::default(),
+            Default::default(),
         ),
         node_env,
         r#"if (process.env.NODE_ENV === 'development') {}"#
@@ -280,6 +274,7 @@ mod tests {
         |tester| inline_globals(
             envs(tester, &[]),
             globals(tester, &[("__DEBUG__", "true")]),
+            Default::default(),
             Default::default()
         ),
         globals_simple,
@@ -292,6 +287,7 @@ mod tests {
             envs(tester, &[]),
             globals(tester, &[("debug", "true")]),
             Default::default(),
+            Default::default(),
         ),
         non_global,
         r#"if (foo.debug) {}"#
@@ -299,7 +295,12 @@ mod tests {
 
     test!(
         Default::default(),
-        |tester| inline_globals(envs(tester, &[]), globals(tester, &[]), Default::default()),
+        |tester| inline_globals(
+            envs(tester, &[]),
+            globals(tester, &[]),
+            Default::default(),
+            Default::default(),
+        ),
         issue_417_1,
         "const test = process.env['x']"
     );
@@ -309,6 +310,7 @@ mod tests {
         |tester| inline_globals(
             envs(tester, &[("x", "FOO")]),
             globals(tester, &[]),
+            Default::default(),
             Default::default(),
         ),
         issue_417_2,
@@ -320,6 +322,7 @@ mod tests {
         |tester| inline_globals(
             envs(tester, &[("x", "BAR")]),
             globals(tester, &[]),
+            Default::default(),
             Default::default(),
         ),
         issue_2499_1,
@@ -333,6 +336,7 @@ mod tests {
             inline_globals(
                 envs(tester, &[]),
                 globals(tester, &[("__MY_HOST__", "'https://swc.rs/'")]),
+                Default::default(),
                 Default::default(),
             )
         ),

--- a/crates/swc_ecma_transforms_optimization/src/lib.rs
+++ b/crates/swc_ecma_transforms_optimization/src/lib.rs
@@ -5,7 +5,7 @@
 pub use self::{
     const_modules::const_modules,
     debug::{debug_assert_valid, AssertValid},
-    inline_globals::{inline_globals, inline_globals2, GlobalExprMap},
+    inline_globals::{inline_globals, GlobalExprMap},
     json_parse::json_parse,
     simplify::simplifier,
 };

--- a/crates/swc_ecma_transforms_optimization/src/lib.rs
+++ b/crates/swc_ecma_transforms_optimization/src/lib.rs
@@ -5,7 +5,7 @@
 pub use self::{
     const_modules::const_modules,
     debug::{debug_assert_valid, AssertValid},
-    inline_globals::{inline_globals, GlobalExprMap},
+    inline_globals::{inline_globals, inline_globals2, GlobalExprMap},
     json_parse::json_parse,
     simplify::simplifier,
 };

--- a/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/src/inline_globals.rs/issue_10831_1.js
+++ b/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/src/inline_globals.rs/issue_10831_1.js
@@ -1,0 +1,1 @@
+console.log('https://swc.rs/');

--- a/crates/swc_node_bundler/src/loaders/swc.rs
+++ b/crates/swc_node_bundler/src/loaders/swc.rs
@@ -185,9 +185,7 @@ impl SwcLoader {
                     ));
 
                     program.mutate(&mut inline_globals(
-                        unresolved_mark,
                         self.env_map(),
-                        Default::default(),
                         Default::default(),
                         Default::default(),
                     ));
@@ -282,9 +280,7 @@ impl SwcLoader {
                         ));
 
                         program.mutate(&mut inline_globals(
-                            unresolved_mark,
                             self.env_map(),
-                            Default::default(),
                             Default::default(),
                             Default::default(),
                         ));

--- a/crates/swc_node_bundler/src/loaders/swc.rs
+++ b/crates/swc_node_bundler/src/loaders/swc.rs
@@ -188,6 +188,7 @@ impl SwcLoader {
                         self.env_map(),
                         Default::default(),
                         Default::default(),
+                        Default::default(),
                     ));
 
                     program.mutate(&mut expr_simplifier(unresolved_mark, Default::default()));
@@ -281,6 +282,7 @@ impl SwcLoader {
 
                         program.mutate(&mut inline_globals(
                             self.env_map(),
+                            Default::default(),
                             Default::default(),
                             Default::default(),
                         ));


### PR DESCRIPTION
**Description:**

Revert https://github.com/swc-project/swc/pull/10449

**BREAKING CHANGE:**

`inline_globals` API changes

**Related issue (if exists):**

fixes https://github.com/swc-project/swc/issues/10831
