### PR TITLE
fix(es/lexer): Fix token for `&&=`

### DIFF
--- a/.changeset/spicy-eagles-cover.md
+++ b/.changeset/spicy-eagles-cover.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_lexer: patch
+---
+
+fix(swc_ecma_lexer): Fix token for `&&=`

--- a/crates/swc_ecma_lexer/src/token.rs
+++ b/crates/swc_ecma_lexer/src/token.rs
@@ -570,7 +570,7 @@ impl<'a, I: Tokens<TokenAndSpan>> crate::common::lexer::token::TokenFactory<'a, 
     const LESS_EQ: Self = Token::BinOp(BinOpToken::LtEq);
     const LET: Self = Token::Word(Word::Keyword(Keyword::Let));
     const LOGICAL_AND: Self = tok!("&&");
-    const LOGICAL_AND_EQ: Self = Token::AssignOp(AssignOp::AddAssign);
+    const LOGICAL_AND_EQ: Self = Token::AssignOp(AssignOp::AndAssign);
     const LOGICAL_OR: Self = tok!("||");
     const LOGICAL_OR_EQ: Self = Token::AssignOp(AssignOp::OrAssign);
     const LPAREN: Self = Self::LParen;


### PR DESCRIPTION
**Description:** The token was wrong here.

**Related issue (if exists):** None. I'm lazy.