### PR TITLE
fix(es/lexer): Update regexp token span

### DIFF
--- a/crates/swc_ecma_lexer/src/lexer/state.rs
+++ b/crates/swc_ecma_lexer/src/lexer/state.rs
@@ -750,8 +750,9 @@ impl Tokens<TokenAndSpan> for Lexer<'_> {
 
 impl Lexer<'_> {
     fn next_token(&mut self, start: &mut BytePos) -> Result<Token, Error> {
-        if let Some(start) = self.state.next_regexp {
-            return self.read_regexp(start);
+        if let Some(next_regexp) = self.state.next_regexp {
+            *start = next_regexp;
+            return self.read_regexp(next_regexp);
         }
 
         if self.state.is_first {

--- a/crates/swc_ecma_parser/src/lexer/capturing.rs
+++ b/crates/swc_ecma_parser/src/lexer/capturing.rs
@@ -51,7 +51,18 @@ impl<I: Iterator<Item = TokenAndSpan>> Iterator for Capturing<I> {
         match next {
             Some(ts) => {
                 let v = &mut self.captured;
+
+                // remove tokens that could change due to backtracing
+                while let Some(last) = v.last() {
+                    if last.span.lo >= ts.span.lo {
+                        v.pop();
+                    } else {
+                        break;
+                    }
+                }
+
                 v.push(ts);
+
                 Some(ts)
             }
             None => None,

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -392,8 +392,9 @@ impl crate::input::Tokens for Lexer<'_> {
 
 impl Lexer<'_> {
     fn next_token(&mut self, start: &mut BytePos) -> Result<Token, Error> {
-        if let Some(start) = self.state.next_regexp {
-            return self.read_regexp(start);
+        if let Some(next_regexp) = self.state.next_regexp {
+            *start = next_regexp;
+            return self.read_regexp(next_regexp);
         }
 
         if self.state.is_first {

--- a/crates/swc_ecma_parser/tests/jsx/errors/adjacent-tags/input.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/jsx/errors/adjacent-tags/input.js.swc-stderr
@@ -1,7 +1,7 @@
   x Expression expected
    ,-[$DIR/tests/jsx/errors/adjacent-tags/input.js:1:1]
  1 | var x = <div>one</div><div>two</div>;
-   :                                 ^^^^^
+   :                                ^^^^^^
    `----
   x Unterminated regexp literal
    ,-[$DIR/tests/jsx/errors/adjacent-tags/input.js:1:1]

--- a/crates/swc_ts_fast_strip/src/lib.rs
+++ b/crates/swc_ts_fast_strip/src/lib.rs
@@ -684,7 +684,7 @@ impl TsStrip {
             | Token::NoSubstitutionTemplateLiteral
             | Token::Plus
             | Token::Minus
-            | Token::Slash => {
+            | Token::Regex => {
                 if prev_token == &Token::Semi {
                     self.add_overwrite(prev_span.lo, b';');
                     return;


### PR DESCRIPTION
**Description:**

For `/a/g`, before:
<img width="341" height="254" alt="image" src="https://github.com/user-attachments/assets/5729c1f1-a1d1-4469-ade8-1a56e9efa37a" />

After:
<img width="954" height="148" alt="image" src="https://github.com/user-attachments/assets/a9d4a2ff-48d6-45b5-b69d-81b5e4cf3024" />

Also revert some of https://github.com/swc-project/swc/pull/11058, which is a mistake in this case.
