### PR TITLE
fix(es/minifier): Make `const_to_let` work in arrows again

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -1471,7 +1471,18 @@ impl VisitMut for Optimizer<'_> {
             n.params.visit_mut_with(&mut *self.with_ctx(ctx));
         }
 
-        n.body.visit_mut_with(self);
+        {
+            let ctx = Ctx {
+                bit_ctx: self
+                    .ctx
+                    .bit_ctx
+                    .with(BitCtx::InFnLike, true)
+                    .with(BitCtx::TopLevel, false),
+                scope: n.ctxt,
+                ..self.ctx.clone()
+            };
+            n.body.visit_mut_with(&mut *self.with_ctx(ctx));
+        }
 
         if !self.prepend_stmts.is_empty() {
             let mut stmts = self.prepend_stmts.take().take_stmts();

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8737/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8737/output.js
@@ -1,6 +1,4 @@
 d(()=>{
-    var obj = {
-        key: "some string"
-    }, b = ()=>(a, obj.key);
+    var b = ()=>(a, "some string");
     return ()=>b;
 });

--- a/crates/swc_ecma_minifier/tests/fixture/issues/8813/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/8813/output.js
@@ -1,13 +1,11 @@
-const x = 'asdf';
-let y = "PASS 1";
+let x = 'asdf', y = "PASS 1";
 switch(x){
     case x:
     default:
     case y = "FAIL":
 }
 console.log(y);
-const x1 = 'asdf';
-let y1 = "PASS 2";
+let x1 = 'asdf', y1 = "PASS 2";
 switch(x1){
     case x1:
     case y1 = "FAIL":

--- a/crates/swc_ecma_minifier/tests/fixture/issues/firebase-firestore/1/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/firebase-firestore/1/output.js
@@ -8145,7 +8145,7 @@
                     // operations. Meant to speed up recovery when we regain file system access
                     // after page comes into foreground.
                     this.Rc = ()=>{
-                        const t = Jr();
+                        let t = Jr();
                         t && $("AsyncQueue", "Visibility state changed to " + t.visibilityState), this.ar.tr();
                     };
                     const t = Jr();

--- a/crates/swc_ecma_minifier/tests/fixture/next/target-es2015/static/chunks/main-04b5934c26266542/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/next/target-es2015/static/chunks/main-04b5934c26266542/output.js
@@ -2448,10 +2448,9 @@ You should only use "next/router" on the client side of your app.
                 constructor(pathname1, query1, as1, { initialProps, pageLoader, App, wrapApp, Component, err, subscription, isFallback, locale, locales, defaultLocale, domainLocales, isPreview }){
                     // Server Data Cache
                     this.sdc = {}, this.isFirstPopStateEvent = !0, this._key = createKey(), this.onPopState = (e)=>{
-                        let forcedScroll;
-                        const { isFirstPopStateEvent } = this;
+                        let forcedScroll, { isFirstPopStateEvent } = this;
                         this.isFirstPopStateEvent = !1;
-                        const state = e.state;
+                        let state = e.state;
                         if (!state) {
                             // We get state as undefined for two reasons.
                             //  1. With older safari (< 8) and older chrome (< 34)
@@ -2462,7 +2461,7 @@ You should only use "next/router" on the client side of your app.
                             // But we can simply replace the state with the new changes.
                             // Actually, for (1) we don't need to nothing. But it's hard to detect that event.
                             // So, doing the following for (1) does no harm.
-                            const { pathname, query } = this;
+                            let { pathname, query } = this;
                             this.changeState("replaceState", _formatUrl.formatWithValidation({
                                 pathname: _addBasePath.addBasePath(pathname),
                                 query
@@ -2472,9 +2471,9 @@ You should only use "next/router" on the client side of your app.
                         // __NA is used to identify if the history entry can be handled by the app-router.
                         if (state.__NA) return void window.location.reload();
                         if (!state.__N || isFirstPopStateEvent && this.locale === state.options.locale && state.as === this.asPath) return;
-                        const { url, as, options, key } = state;
+                        let { url, as, options, key } = state;
                         this._key = key;
-                        const { pathname: pathname1 } = _parseRelativeUrl.parseRelativeUrl(url);
+                        let { pathname: pathname1 } = _parseRelativeUrl.parseRelativeUrl(url);
                         // Make sure we don't re-render on initial load,
                         // can be caused by navigating back from an external site
                         this.isSsr && as === _addBasePath.addBasePath(this.asPath) && pathname1 === _addBasePath.addBasePath(this.pathname) || (!this._bps || this._bps(state)) && this.change("replaceState", url, as, Object.assign({}, options, {

--- a/crates/swc_html_minifier/tests/fixture/element/script/output.min.html
+++ b/crates/swc_html_minifier/tests/fixture/element/script/output.min.html
@@ -42,7 +42,7 @@
     <script>alert(1)</script>
 </svg>
     <svg viewBox="0 0 10 10">
-        <script>window.addEventListener("DOMContentLoaded",()=>{document.querySelector("circle").addEventListener("click",t=>{t.target.style.fill=function(){let t=Math.round(255*Math.random()).toString(16).padStart(2,"0"),n=Math.round(255*Math.random()).toString(16).padStart(2,"0"),r=Math.round(255*Math.random()).toString(16).padStart(2,"0");return`#${t}${n}${r}`}()})})</script>
+        <script>window.addEventListener("DOMContentLoaded",()=>{document.querySelector("circle").addEventListener("click",t=>{let a,r,d;t.target.style.fill=(a=Math.round(255*Math.random()).toString(16).padStart(2,"0"),r=Math.round(255*Math.random()).toString(16).padStart(2,"0"),d=Math.round(255*Math.random()).toString(16).padStart(2,"0"),`#${a}${r}${d}`)})})</script>
 
         <circle cx=5 cy=5 r=4 />
     </svg>


### PR DESCRIPTION
**Description:**

I was seeing this snapshot test failure when trying to upgrade swc in Turbopack:
```js
--- expected
+++ actual
@@ -1,3 +1,3 @@
-module.exports=["index.js",(t,e,o)=>{let s="Hello";console.log("Hello, world!",3,s),console.log(s)}];
+module.exports=["index.js",(o,s,t)=>{const e="Hello";console.log("Hello, world!",3,e),console.log(e)}];
```

The problem was that `is_top_level` was true here, even though the code is inside an arrow function:
https://github.com/swc-project/swc/blob/0557609d6f862f7632a67ce91163571e5284163f/crates/swc_ecma_minifier/src/compress/optimize/mod.rs#L2836

Probably caused by https://github.com/swc-project/swc/pull/11035

**BREAKING CHANGE:**

**Related issue (if exists):**
