### PR TITLE
fix(es/compat): should not transform typeof symbol in loose mode

### DIFF
--- a/.changeset/mostly-hoshi-sofa.md
+++ b/.changeset/mostly-hoshi-sofa.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_compat_es2015: patch
+swc_ecma_preset_env: patch
+---
+
+fix(es/compat): don't transform typeof symbol in loose mode

--- a/crates/swc_ecma_compat_es2015/src/lib.rs
+++ b/crates/swc_ecma_compat_es2015/src/lib.rs
@@ -34,7 +34,7 @@ mod shorthand_property;
 pub mod spread;
 mod sticky_regex;
 pub mod template_literal;
-mod typeof_symbol;
+pub mod typeof_symbol;
 
 fn exprs(unresolved_mark: Mark) -> impl Pass {
     (
@@ -42,7 +42,6 @@ fn exprs(unresolved_mark: Mark) -> impl Pass {
         duplicate_keys(),
         sticky_regex(),
         instance_of(),
-        typeof_symbol(),
     )
 }
 
@@ -91,6 +90,7 @@ where
         parameters(c.parameters, unresolved_mark),
         (
             exprs(unresolved_mark),
+            typeof_symbol(c.typeof_symbol),
             computed_properties(c.computed_props),
             destructuring(c.destructuring),
             block_scoping(unresolved_mark),
@@ -113,6 +113,9 @@ pub struct Config {
 
     #[serde(flatten)]
     pub destructuring: destructuring::Config,
+
+    #[serde(flatten)]
+    pub typeof_symbol: typeof_symbol::Config,
 
     #[serde(flatten)]
     pub spread: spread::Config,

--- a/crates/swc_ecma_compat_es2015/tests/__swc_snapshots__/src/typeof_symbol.rs/dont_touch_in_loose_mode.js
+++ b/crates/swc_ecma_compat_es2015/tests/__swc_snapshots__/src/typeof_symbol.rs/dont_touch_in_loose_mode.js
@@ -1,0 +1,1 @@
+typeof sym;

--- a/crates/swc_ecma_preset_env/src/lib.rs
+++ b/crates/swc_ecma_preset_env/src/lib.rs
@@ -282,7 +282,11 @@ where
     let pass = add!(pass, DuplicateKeys, es2015::duplicate_keys());
     let pass = add!(pass, StickyRegex, es2015::sticky_regex());
     let pass = add!(pass, TypeOfSymbol, es2015::instance_of());
-    let pass = add!(pass, TypeOfSymbol, es2015::typeof_symbol());
+    let pass = add!(
+        pass,
+        TypeOfSymbol,
+        es2015::typeof_symbol(es2015::typeof_symbol::Config { loose })
+    );
     let pass = add!(
         pass,
         ComputedProperties,


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

difference: [swc](https://play.swc.rs/?version=1.13.5&code=H4sIAAAAAAAAAyupLEjNT1Morsy1BgDpDOhmCwAAAA%3D%3D&config=H4sIAAAAAAAAAy1LOwqFMBCsk1PI1LY2goJHCbqIIknYXR9PJHc3K04xzPf2DrvM6JvbO4cjJaFqlE9qLciBhfirHeSKGv7VQq9MMvOWFa1vKkrlYhIUf%2B%2FBUmjglVTsMsWF07aMQwfb%2BvIACta33n0AAAA%3D) - [babel](https://babeljs.io/repl#?config_lz=N4IgZglgNgpgdgQwLYxALhAJxgBygOgCsBnEAGhB22JgBdS0BtRkeAN3NFoUwHM6GIAIJwAJpgD2EUQAIAfAF4ZAVnIgkE0QFdYDMAig0KUCRJrpamLTAC-AXTsViErZgDGMACoBPHKgwa2rAgNkA&code_lz=C4TwDgpg9gZgBAZxAWwNxA&lineWrap=true&version=7.28.4)

reference: ["transform-typeof-symbol" is excluded in loose mode](https://babeljs.io/docs/assumptions#migrating-from-babelpreset-envs-loose-and-spec-modes)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

N/A
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**

N/A