### PR TITLE
fix(es/codegen): don't unescape unicode after a backslash

### DIFF
--- a/crates/swc_ecma_codegen/src/tests.rs
+++ b/crates/swc_ecma_codegen/src/tests.rs
@@ -776,6 +776,14 @@ module.exports = '\u0009\u000A\u000B\u000C\u000D\u0020\u00A0\u1680\u2000\u2001\u
     );
 }
 
+#[test]
+fn issue_11098() {
+    assert_min(
+        r#"JSON.parse('{"bug": " \\"\\\\uD83D\\\\uDC49\\""}')"#,
+        r#"JSON.parse('{"bug": " \\"\\\\uD83D\\\\uDC49\\""}')"#,
+    );
+}
+
 fn test_all(src: &str, expected: &str, expected_minified: &str, config: Config) {
     {
         let out = parse_then_emit(


### PR DESCRIPTION
**Description:**

We should not unescape strings like '\\uD830' because the second backslash is escaped by (or **associated with**) the first backslash. 

**Related issue (if exists):**

closes https://github.com/swc-project/swc/issues/11098