### PR TITLE
fix(es/minifier): Preserve `__proto__` shorthand property behavior

### DIFF
--- a/.changeset/dry-queens-clean.md
+++ b/.changeset/dry-queens-clean.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_minifier: patch
+swc_core: patch
+---
+
+fix(es/minifier): Preserve `__proto__` shorthand property behavior

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -590,10 +590,7 @@ impl VisitMut for NormalMultiReplacer<'_> {
                 } else {
                     PropName::Ident(IdentName::new(i.sym.clone(), i.span))
                 };
-                *p = Prop::KeyValue(KeyValueProp {
-                    key,
-                    value,
-                });
+                *p = Prop::KeyValue(KeyValueProp { key, value });
             }
         }
     }
@@ -678,10 +675,7 @@ impl VisitMut for ExprReplacer {
                 } else {
                     PropName::Ident(i.clone().into())
                 };
-                *p = Prop::KeyValue(KeyValueProp {
-                    key,
-                    value,
-                });
+                *p = Prop::KeyValue(KeyValueProp { key, value });
             }
         }
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -469,8 +469,20 @@ impl VisitMut for Finalizer<'_> {
 
         if let Prop::Shorthand(i) = n {
             if let Some(expr) = self.lits.get(&i.to_id()) {
+                let key = if i.sym == "__proto__" {
+                    PropName::Computed(ComputedPropName {
+                        span: i.span,
+                        expr: Box::new(Expr::Lit(Lit::Str(Str {
+                            span: i.span,
+                            value: i.sym.clone(),
+                            raw: None,
+                        }))),
+                    })
+                } else {
+                    i.take().into()
+                };
                 *n = Prop::KeyValue(KeyValueProp {
-                    key: i.take().into(),
+                    key,
                     value: expr.clone(),
                 });
                 self.changed = true;
@@ -566,8 +578,20 @@ impl VisitMut for NormalMultiReplacer<'_> {
                 debug!("multi-replacer: Replaced `{}` as shorthand", i);
                 self.changed = true;
 
+                let key = if i.sym == "__proto__" {
+                    PropName::Computed(ComputedPropName {
+                        span: i.span,
+                        expr: Box::new(Expr::Lit(Lit::Str(Str {
+                            span: i.span,
+                            value: i.sym.clone(),
+                            raw: None,
+                        }))),
+                    })
+                } else {
+                    PropName::Ident(IdentName::new(i.sym.clone(), i.span))
+                };
                 *p = Prop::KeyValue(KeyValueProp {
-                    key: PropName::Ident(IdentName::new(i.sym.clone(), i.span)),
+                    key,
                     value,
                 });
             }
@@ -642,8 +666,20 @@ impl VisitMut for ExprReplacer {
                 } else {
                     unreachable!("`{}` is already taken", i)
                 };
+                let key = if i.sym == "__proto__" {
+                    PropName::Computed(ComputedPropName {
+                        span: i.span,
+                        expr: Box::new(Expr::Lit(Lit::Str(Str {
+                            span: i.span,
+                            value: i.sym.clone(),
+                            raw: None,
+                        }))),
+                    })
+                } else {
+                    PropName::Ident(i.clone().into())
+                };
                 *p = Prop::KeyValue(KeyValueProp {
-                    key: PropName::Ident(i.clone().into()),
+                    key,
                     value,
                 });
             }

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -469,18 +469,7 @@ impl VisitMut for Finalizer<'_> {
 
         if let Prop::Shorthand(i) = n {
             if let Some(expr) = self.lits.get(&i.to_id()) {
-                let key = if i.sym == "__proto__" {
-                    PropName::Computed(ComputedPropName {
-                        span: i.span,
-                        expr: Box::new(Expr::Lit(Lit::Str(Str {
-                            span: i.span,
-                            value: i.sym.clone(),
-                            raw: None,
-                        }))),
-                    })
-                } else {
-                    i.take().into()
-                };
+                let key = prop_name_from_ident(i.take());
                 *n = Prop::KeyValue(KeyValueProp {
                     key,
                     value: expr.clone(),
@@ -578,18 +567,7 @@ impl VisitMut for NormalMultiReplacer<'_> {
                 debug!("multi-replacer: Replaced `{}` as shorthand", i);
                 self.changed = true;
 
-                let key = if i.sym == "__proto__" {
-                    PropName::Computed(ComputedPropName {
-                        span: i.span,
-                        expr: Box::new(Expr::Lit(Lit::Str(Str {
-                            span: i.span,
-                            value: i.sym.clone(),
-                            raw: None,
-                        }))),
-                    })
-                } else {
-                    PropName::Ident(IdentName::new(i.sym.clone(), i.span))
-                };
+                let key = prop_name_from_ident(i.take());
                 *p = Prop::KeyValue(KeyValueProp { key, value });
             }
         }
@@ -663,18 +641,7 @@ impl VisitMut for ExprReplacer {
                 } else {
                     unreachable!("`{}` is already taken", i)
                 };
-                let key = if i.sym == "__proto__" {
-                    PropName::Computed(ComputedPropName {
-                        span: i.span,
-                        expr: Box::new(Expr::Lit(Lit::Str(Str {
-                            span: i.span,
-                            value: i.sym.clone(),
-                            raw: None,
-                        }))),
-                    })
-                } else {
-                    PropName::Ident(i.clone().into())
-                };
+                let key = prop_name_from_ident(i.take());
                 *p = Prop::KeyValue(KeyValueProp { key, value });
             }
         }
@@ -849,4 +816,22 @@ pub fn get_ids_of_pat(pat: &Pat) -> Vec<Id> {
     let mut idents = vec![];
     append(pat, &mut idents);
     idents
+}
+
+/// Creates a PropName for a shorthand property, handling the special case of
+/// `__proto__`. When the property name is `__proto__`, it must be converted to
+/// a computed property to preserve JavaScript semantics.
+fn prop_name_from_ident(ident: Ident) -> PropName {
+    if ident.sym == "__proto__" {
+        PropName::Computed(ComputedPropName {
+            span: ident.span,
+            expr: Box::new(Expr::Lit(Lit::Str(Str {
+                span: ident.span,
+                value: ident.sym.clone(),
+                raw: None,
+            }))),
+        })
+    } else {
+        ident.into()
+    }
 }

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11105/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11105/input.js
@@ -1,0 +1,1 @@
+var __proto__ = []; console.log({ __proto__ } instanceof Array) // false

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11105/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11105/output.js
@@ -1,0 +1,3 @@
+console.log(({
+    ["__proto__"]: []
+}) instanceof Array); // false


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When minifying object shorthand properties, the `__proto__` property should be converted to a computed property `["__proto__"]` instead of a regular key-value pair to preserve the original object behavior. This prevents changing the object's prototype chain during minification.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
- Closes: #11105
