### PR TITLE
fix(es/parser): Handle JSX attributes with keyword prefixes correctly

### DIFF
--- a/.changeset/light-cheetahs-protect.md
+++ b/.changeset/light-cheetahs-protect.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): Handle JSX attributes with keyword prefixes correctly

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -282,7 +282,7 @@ impl crate::input::Tokens for Lexer<'_> {
             }
         }
         let v = if !v.is_empty() {
-            let v = if token.is_known_ident() {
+            let v = if token.is_known_ident() || token.is_keyword() {
                 format!("{}{}", token.to_string(None), v)
             } else if let Some(TokenValue::Word(value)) = self.state.token_value.take() {
                 format!("{value}{v}")

--- a/crates/swc_ecma_parser/tests/jsx/basic/issue-11134/input.jsx
+++ b/crates/swc_ecma_parser/tests/jsx/basic/issue-11134/input.jsx
@@ -1,0 +1,1 @@
+<Component mod={{ helloworld: undefined }} if-abc="test" />

--- a/crates/swc_ecma_parser/tests/jsx/basic/issue-11134/input.jsx.json
+++ b/crates/swc_ecma_parser/tests/jsx/basic/issue-11134/input.jsx.json
@@ -1,0 +1,123 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 60
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 1,
+        "end": 60
+      },
+      "expression": {
+        "type": "JSXElement",
+        "span": {
+          "start": 1,
+          "end": 60
+        },
+        "opening": {
+          "type": "JSXOpeningElement",
+          "name": {
+            "type": "Identifier",
+            "span": {
+              "start": 2,
+              "end": 11
+            },
+            "ctxt": 0,
+            "value": "Component",
+            "optional": false
+          },
+          "span": {
+            "start": 1,
+            "end": 60
+          },
+          "attributes": [
+            {
+              "type": "JSXAttribute",
+              "span": {
+                "start": 12,
+                "end": 43
+              },
+              "name": {
+                "type": "Identifier",
+                "span": {
+                  "start": 12,
+                  "end": 15
+                },
+                "value": "mod"
+              },
+              "value": {
+                "type": "JSXExpressionContainer",
+                "span": {
+                  "start": 16,
+                  "end": 43
+                },
+                "expression": {
+                  "type": "ObjectExpression",
+                  "span": {
+                    "start": 17,
+                    "end": 42
+                  },
+                  "properties": [
+                    {
+                      "type": "KeyValueProperty",
+                      "key": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 19,
+                          "end": 29
+                        },
+                        "value": "helloworld"
+                      },
+                      "value": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 31,
+                          "end": 40
+                        },
+                        "ctxt": 0,
+                        "value": "undefined",
+                        "optional": false
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            {
+              "type": "JSXAttribute",
+              "span": {
+                "start": 44,
+                "end": 57
+              },
+              "name": {
+                "type": "Identifier",
+                "span": {
+                  "start": 44,
+                  "end": 50
+                },
+                "value": "if-abc"
+              },
+              "value": {
+                "type": "StringLiteral",
+                "span": {
+                  "start": 51,
+                  "end": 57
+                },
+                "value": "test",
+                "raw": "\"test\""
+              }
+            }
+          ],
+          "selfClosing": true,
+          "typeArguments": null
+        },
+        "children": [],
+        "closing": null
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR fixes a bug in the JSX lexer where attributes with keyword prefixes (like `if-abc`, `for-test`, etc.) were incorrectly parsed. The lexer was reusing stale identifier values from previous tokens instead of using the keyword itself.

For example, `<Component mod={{ helloworld: undefined }} if-abc="test" />` would incorrectly parse the attribute name as `helloworld-abc` instead of `if-abc`.

**BREAKING CHANGE:**

None

**Related issue (if exists):**

Fixes #11134 