### PR TITLE
fix(es/transforms): Correct span for @jsxFrag as null literal

### DIFF
--- a/.changeset/spotty-geese-relate.md
+++ b/.changeset/spotty-geese-relate.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_transforms_react: patch
+swc_core: patch
+---
+
+fix(es/transforms): Correct span for @jsxFrag as null literal

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -289,19 +289,6 @@ pub struct JsxDirectives {
     pub pragma_frag: Option<Lrc<Box<Expr>>>,
 }
 
-fn respan(e: &mut Expr, span: Span) {
-    match e {
-        Expr::Ident(i) => {
-            i.span.lo = span.lo;
-            i.span.hi = span.hi;
-        }
-        Expr::Member(e) => {
-            e.span = span;
-        }
-        _ => {}
-    }
-}
-
 impl JsxDirectives {
     pub fn from_comments(
         cm: &SourceMap,
@@ -368,7 +355,7 @@ impl JsxDirectives {
                                         cache_source(src),
                                         top_level_mark,
                                     );
-                                    respan(&mut e, cmt.span);
+                                    e.set_span(cmt.span);
                                     res.pragma_frag = Some(e.into())
                                 }
                             }
@@ -383,7 +370,7 @@ impl JsxDirectives {
                                         cache_source(src),
                                         top_level_mark,
                                     );
-                                    respan(&mut e, cmt.span);
+                                    e.set_span(cmt.span);
                                     res.pragma = Some(e.into());
                                 }
                             }


### PR DESCRIPTION
- Will fix .. https://github.com/denoland/deno/issues/30216

The expression span for `@jsxFrag null` wasn't being adjusted. This was leading to a source map panic when trying to format the error for `error: pragmaFrag cannot be set when runtime is automatic`.

If it needs a test, please let me know how to add fixtures for expected parse failures.