### PR TITLE
feat(es/parser): Add an error for empty type args for generic

### DIFF
--- a/.changeset/afraid-coats-judge.md
+++ b/.changeset/afraid-coats-judge.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+Fixed Parser error for empty type args for generic

--- a/crates/swc_ecma_lexer/src/common/parser/typescript.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/typescript.rs
@@ -488,6 +488,12 @@ pub fn parse_ts_type_args<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<TsTypePar
     p.input_mut().set_expr_allowed(false);
     p.expect_without_advance(&P::Token::GREATER)?;
     let span = Span::new_with_checked(start, p.input().cur_span().hi);
+
+    // Report grammar error for empty type argument list like `I<>`.
+    if params.is_empty() {
+        p.emit_err(span, SyntaxError::TypeArgumentListCannotBeEmpty);
+    }
+
     Ok(Box::new(TsTypeParamInstantiation { span, params }))
 }
 

--- a/crates/swc_ecma_lexer/src/common/parser/typescript.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/typescript.rs
@@ -491,7 +491,7 @@ pub fn parse_ts_type_args<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<TsTypePar
 
     // Report grammar error for empty type argument list like `I<>`.
     if params.is_empty() {
-        p.emit_err(span, SyntaxError::TypeArgumentListCannotBeEmpty);
+        p.emit_err(span, SyntaxError::EmptyTypeArgumentList);
     }
 
     Ok(Box::new(TsTypeParamInstantiation { span, params }))

--- a/crates/swc_ecma_lexer/src/error.rs
+++ b/crates/swc_ecma_lexer/src/error.rs
@@ -290,7 +290,7 @@ pub enum SyntaxError {
 
     ReservedTypeAssertion,
     ReservedArrowTypeParam,
-    TypeArgumentListCannotBeEmpty,
+    EmptyTypeArgumentList,
 }
 
 impl SyntaxError {
@@ -745,9 +745,7 @@ impl SyntaxError {
                                                     .mts or .cts extension. Add a trailing comma, \
                                                     as in `<T,>() => ...`."
                 .into(),
-            SyntaxError::TypeArgumentListCannotBeEmpty => {
-                "Type argument list cannot be empty.".into()
-            }
+            SyntaxError::EmptyTypeArgumentList => "Type argument list cannot be empty.".into(),
             SyntaxError::InvalidAssignTarget => "Invalid assignment target".into(),
         }
     }

--- a/crates/swc_ecma_lexer/src/error.rs
+++ b/crates/swc_ecma_lexer/src/error.rs
@@ -290,6 +290,7 @@ pub enum SyntaxError {
 
     ReservedTypeAssertion,
     ReservedArrowTypeParam,
+    TypeArgumentListCannotBeEmpty,
 }
 
 impl SyntaxError {
@@ -744,6 +745,9 @@ impl SyntaxError {
                                                     .mts or .cts extension. Add a trailing comma, \
                                                     as in `<T,>() => ...`."
                 .into(),
+            SyntaxError::TypeArgumentListCannotBeEmpty => {
+                "Type argument list cannot be empty.".into()
+            }
             SyntaxError::InvalidAssignTarget => "Invalid assignment target".into(),
         }
     }

--- a/crates/swc_ecma_parser/tests/typescript-errors/type-args-empty/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript-errors/type-args-empty/input.ts
@@ -1,0 +1,2 @@
+class I<T> { }
+var x: I<>;

--- a/crates/swc_ecma_parser/tests/typescript-errors/type-args-empty/input.ts.swc-stderr
+++ b/crates/swc_ecma_parser/tests/typescript-errors/type-args-empty/input.ts.swc-stderr
@@ -1,0 +1,6 @@
+  x Type argument list cannot be empty.
+   ,-[$DIR/tests/typescript-errors/type-args-empty/input.ts:2:1]
+ 1 | class I<T> { }
+ 2 | var x: I<>;
+   :         ^^
+   `----


### PR DESCRIPTION
Add new diagnostic SyntaxError::TypeArgumentListCannotBeEmpty. Add regression test to assert parse error for empty generic list. Issue fixed: #11119

<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
 #11119