### PR TITLE
chore(ci): Refactor binary size workflow to use secure workflow_run pattern

### DIFF
--- a/.github/workflows/binary-size-comment.yml
+++ b/.github/workflows/binary-size-comment.yml
@@ -1,0 +1,51 @@
+name: Binary Size Check - Comment
+
+on:
+  workflow_run:
+    workflows: ["Binary Size Check - Build"]
+    types:
+      - completed
+
+env:
+  CI: 1
+
+jobs:
+  comment-on-pr:
+    name: Comment on PR
+    runs-on: ubuntu-latest
+    # This workflow needs write permissions to comment on PRs
+    # It's safe because it doesn't execute any code from the PR
+    permissions:
+      pull-requests: write
+      contents: read
+    # Only run on successful builds
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: size-report
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+
+      - name: Read PR number
+        id: pr
+        run: |
+          PR_NUMBER=$(cat pr_number.txt)
+          echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v3
+        id: find-comment
+        with:
+          issue-number: ${{ steps.pr.outputs.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: "## Binary Sizes"
+
+      - name: Create or update PR comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.pr.outputs.number }}
+          body-path: size_report.md
+          edit-mode: replace

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -1,12 +1,8 @@
-name: Binary Size Check
+name: Binary Size Check - Build
 
 on:
   pull_request:
     types: ["opened", "reopened", "synchronize"]
-  # Disable push events for now because of the permission issue
-  # push:
-  #   branches:
-  #     - main
 
 env:
   CI: 1
@@ -23,8 +19,8 @@ jobs:
   measure-binary-size:
     name: Measure Binary Size
     runs-on: ubuntu-latest
+    # No special permissions needed - this workflow only reads and uploads artifacts
     permissions:
-      pull-requests: write
       contents: read
     steps:
       - uses: actions/checkout@v4
@@ -77,56 +73,15 @@ jobs:
           echo "" >> size_report.md
           echo "*Commit: ${{ github.sha }}*" >> size_report.md
 
-      - name: Find existing comment
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/find-comment@v3
-        id: find-comment
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: "github-actions[bot]"
-          body-includes: "## Binary Sizes"
-
-      - name: Create or update PR comment
-        if: github.event_name == 'pull_request'
-        uses: peter-evans/create-or-update-comment@v4
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          body-path: size_report.md
-          edit-mode: replace
-
-      - name: Find existing commit comment
-        if: github.event_name == 'push'
-        id: find-commit-comment
+      - name: Save PR number
         run: |
-          COMMENTS=$(gh api repos/${{ github.repository }}/commits/${{ github.sha }}/comments \
-            --jq '.[] | select(.body | contains("## Binary Sizes")) | .id' | head -n 1)
+          echo "${{ github.event.pull_request.number }}" > pr_number.txt
 
-          if [ -n "$COMMENTS" ]; then
-            echo "comment_id=$COMMENTS" >> $GITHUB_OUTPUT
-          else
-            echo "comment_id=" >> $GITHUB_OUTPUT
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
-
-      - name: Create or update commit comment
-        if: github.event_name == 'push'
-        run: |
-          BODY=$(cat size_report.md)
-
-          if [ -n "${{ steps.find-commit-comment.outputs.comment_id }}" ]; then
-            gh api \
-              --method PATCH \
-              -H "Accept: application/vnd.github+json" \
-              repos/${{ github.repository }}/comments/${{ steps.find-commit-comment.outputs.comment_id }} \
-              -f body="$BODY"
-          else
-            gh api \
-              --method POST \
-              -H "Accept: application/vnd.github+json" \
-              repos/${{ github.repository }}/commits/${{ github.sha }}/comments \
-              -f body="$BODY"
-          fi
-        env:
-          GH_TOKEN: ${{ github.token }}
+      - name: Upload size report and PR info
+        uses: actions/upload-artifact@v4
+        with:
+          name: size-report
+          path: |
+            size_report.md
+            pr_number.txt
+          retention-days: 1


### PR DESCRIPTION
## Summary

Refactored the binary size check workflow to follow [GitHub Security Lab best practices](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/) by splitting it into two workflows using the secure `workflow_run` pattern.

### Security Improvements

**Before:** Single workflow using `pull_request` trigger with `pull-requests: write` permission
- ❌ Untrusted PR code executed with write permissions
- ❌ Potential privilege escalation attack vector
- ❌ Risk of malicious PRs compromising the repository

**After:** Two-workflow architecture with privilege separation
- ✅ `binary-size.yml`: Runs on `pull_request` with read-only permissions, builds code and uploads artifacts
- ✅ `binary-size-comment.yml`: Runs on `workflow_run` with write permissions, downloads artifacts and posts comments
- ✅ Untrusted PR code never executes with write permissions or secrets access

### Changes

1. **binary-size.yml** (Build workflow)
   - Triggers on `pull_request` events
   - Permission: `contents: read` only
   - Builds binaries and measures sizes
   - Uploads results as workflow artifacts
   - Removed direct PR commenting logic

2. **binary-size-comment.yml** (Comment workflow)
   - Triggers on `workflow_run` completion
   - Permission: `pull-requests: write`
   - Downloads artifacts from build workflow
   - Posts/updates PR comments
   - Never executes PR code

### Why This Pattern?

The `workflow_run` pattern ensures:
- **Isolation**: PR code runs in unprivileged environment
- **Token security**: Write tokens unavailable during PR code execution
- **Defense in depth**: Even if PR code is malicious, it cannot access repository secrets or modify anything

This follows the principle recommended by GitHub Security Lab: "untrusted PR data should be treated as untrusted when handled in privileged contexts."

## Test plan

- [ ] Verify the build workflow runs successfully on PR events
- [ ] Confirm artifacts are uploaded correctly
- [ ] Check that the comment workflow triggers after build completion
- [ ] Ensure PR comments are created/updated properly
- [ ] Validate that no permissions errors occur

🤖 Generated with [Claude Code](https://claude.com/claude-code)