### PR TITLE
chore(ci): Add issues write permission for milestone management

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,7 @@ env:
 permissions:
   contents: write
   id-token: write
+  issues: write
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
## Summary
- Adds `issues: write` permission to the publish workflow to fix milestone management failures

## Problem
The "Manage milestone" step in the publish workflow was failing with:
```
❌ Error managing milestone: Resource not accessible by integration
```

This occurred because the workflow lacked the necessary permissions to create and modify GitHub milestones through the API.

## Solution
Added `issues: write` permission to the workflow's permission block. This grants the workflow the required access to:
- Create new milestones for releases
- Update milestone assignments on issues and PRs
- Move items from the "Planned" milestone to version-specific milestones

## Test plan
- [x] Verified the error message in the failed workflow run: https://github.com/swc-project/swc/actions/runs/18902190295/job/53971293509
- [ ] Confirm the workflow runs successfully with the new permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)