### PR TITLE
chore(es/ast): Use `opt-level = s` for AST

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,7 +237,7 @@ opt-level = "s"
 opt-level = 3
 
 [profile.release.package.swc_ecma_ast]
-opt-level = 3
+opt-level = "s"
 
 [profile.release.package.swc_ecma_transforms_base]
 opt-level = 3


### PR DESCRIPTION
**Description:**

`swc_ecma_ast` only contains code for serialization/deserialization and some trait implementations like `Clone`