### PR TITLE
chore: Improve the `bump` command

### DIFF
--- a/tools/swc-releaser/src/main.rs
+++ b/tools/swc-releaser/src/main.rs
@@ -335,7 +335,7 @@ fn get_data() -> Result<(VersionMap, InternedGraph)> {
     let mut versions = VersionMap::new();
 
     for pkg in md.workspace_packages() {
-        if pkg.publish != Some(vec![]) {
+        if pkg.publish == Some(vec![]) {
             continue;
         }
 


### PR DESCRIPTION
**Description:**

Bump command should not bump the versions of binding crates, because those are managed by https://github.com/swc-project/swc/blob/2edbd40241b3402c8542241b1f8d82a4ebadd801/scripts/publish.sh .

But before this PR, there was a bug related to packages that are not published to crates.io, so there was an issue in a commit like https://github.com/swc-project/swc/commit/5e6af6030ef8e3b15cef29913f507bfec6109ab6