### PR TITLE
perf(es/parser): Inline `skip_space`

### DIFF
--- a/.changeset/old-monkeys-dance.md
+++ b/.changeset/old-monkeys-dance.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+perf(es/parser): inline `skip_space`

--- a/crates/swc_ecma_parser/src/lexer/whitespace.rs
+++ b/crates/swc_ecma_parser/src/lexer/whitespace.rs
@@ -146,7 +146,7 @@ impl<'a> Lexer<'a> {
     /// Skip comments or whitespaces.
     ///
     /// See https://tc39.github.io/ecma262/#sec-white-space
-    #[inline(never)]
+    #[inline]
     pub fn skip_space(&mut self) {
         loop {
             let byte = match self.input.as_str().as_bytes().first() {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

I think it's worth to inline `skip_space` after https://github.com/swc-project/swc/pull/11225, which made `skip_space` simple  and short.