### PR TITLE
perf(es/parser): postpone merging `module_errors` into `errors`

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/capturing.rs
+++ b/crates/swc_ecma_parser/src/lexer/capturing.rs
@@ -112,10 +112,6 @@ impl<I: Tokens> Tokens for Capturing<I> {
         self.inner.target()
     }
 
-    fn set_expr_allowed(&mut self, allow: bool) {
-        self.inner.set_expr_allowed(allow);
-    }
-
     fn set_next_regexp(&mut self, start: Option<swc_common::BytePos>) {
         self.inner.set_next_regexp(start);
     }
@@ -138,6 +134,10 @@ impl<I: Tokens> Tokens for Capturing<I> {
 
     fn take_script_module_errors(&mut self) -> Vec<Error> {
         self.inner.take_script_module_errors()
+    }
+
+    fn merge_errors(&mut self) {
+        self.inner.merge_errors();
     }
 
     fn update_token_flags(&mut self, f: impl FnOnce(&mut TokenFlags)) {

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -74,9 +74,6 @@ impl crate::input::Tokens for Lexer<'_> {
 
     #[inline]
     fn set_ctx(&mut self, ctx: Context) {
-        if ctx.contains(Context::Module) && !self.module_errors.is_empty() {
-            self.errors.append(&mut self.module_errors);
-        }
         self.ctx = ctx
     }
 
@@ -106,22 +103,17 @@ impl crate::input::Tokens for Lexer<'_> {
     }
 
     #[inline]
-    fn set_expr_allowed(&mut self, _: bool) {}
-
-    #[inline]
     fn set_next_regexp(&mut self, start: Option<BytePos>) {
         self.state.next_regexp = start;
     }
 
+    #[inline]
     fn add_error(&mut self, error: Error) {
         self.errors.push(error);
     }
 
+    #[inline]
     fn add_module_mode_error(&mut self, error: Error) {
-        if self.ctx.contains(Context::Module) {
-            self.add_error(error);
-            return;
-        }
         self.module_errors.push(error);
     }
 
@@ -133,6 +125,13 @@ impl crate::input::Tokens for Lexer<'_> {
     #[inline]
     fn take_script_module_errors(&mut self) -> Vec<Error> {
         take(&mut self.module_errors)
+    }
+
+    #[inline]
+    fn merge_errors(&mut self) {
+        if !self.module_errors.is_empty() {
+            self.errors.append(&mut self.module_errors);
+        }
     }
 
     #[inline]

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1083,7 +1083,6 @@ impl<I: Tokens> Parser<I> {
 
         if self.input().syntax().typescript() {
             if !self.input().had_line_break_before_cur() && self.input().is(Token::Bang) {
-                self.input_mut().set_expr_allowed(false);
                 self.assert_and_bump(Token::Bang);
 
                 let expr = Box::new(Expr::TsNonNull(TsNonNullExpr {

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -203,6 +203,8 @@ impl<I: Tokens> Parser<I> {
                 shebang,
             })?;
 
+        self.input_mut().iter_mut().merge_errors();
+
         debug_assert!(self.input().cur() == Token::Eof);
         self.input_mut().bump();
 
@@ -259,6 +261,10 @@ impl<I: Tokens> Parser<I> {
             })
         };
 
+        if has_module_item {
+            self.input_mut().iter_mut().merge_errors();
+        }
+
         debug_assert!(self.input().cur() == Token::Eof);
         self.input_mut().bump();
 
@@ -284,6 +290,8 @@ impl<I: Tokens> Parser<I> {
                 body,
                 shebang,
             })?;
+
+        self.input_mut().iter_mut().merge_errors();
 
         debug_assert!(self.input().cur() == Token::Eof);
         self.input_mut().bump();

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -480,7 +480,6 @@ impl<I: Tokens> Parser<I> {
         // This reads the next token after the `>` too, so do this in the enclosing
         // context. But be sure not to parse a regex in the jsx expression
         // `<C<number> />`, so set exprAllowed = false
-        self.input_mut().set_expr_allowed(false);
         self.expect_without_advance(Token::Gt)?;
         let span = Span::new_with_checked(start, self.input().cur_span().hi);
 


### PR DESCRIPTION
**Description:**

Currently the lexer tries to merge `module_errors` into `errors` in `set_ctx`. I think it's better to merge it at once after parsing.

