### PR TITLE
chore: Add provenance to  sub packages

### DIFF
--- a/packages/core/scripts/npm/darwin-arm64/package.json
+++ b/packages/core/scripts/npm/darwin-arm64/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/core/scripts/npm/darwin-x64/package.json
+++ b/packages/core/scripts/npm/darwin-x64/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/core/scripts/npm/linux-arm-gnueabihf/package.json
+++ b/packages/core/scripts/npm/linux-arm-gnueabihf/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/core/scripts/npm/linux-arm64-gnu/package.json
+++ b/packages/core/scripts/npm/linux-arm64-gnu/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/core/scripts/npm/linux-arm64-musl/package.json
+++ b/packages/core/scripts/npm/linux-arm64-musl/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/core/scripts/npm/linux-x64-gnu/package.json
+++ b/packages/core/scripts/npm/linux-x64-gnu/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/core/scripts/npm/linux-x64-musl/package.json
+++ b/packages/core/scripts/npm/linux-x64-musl/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/core/scripts/npm/win32-arm64-msvc/package.json
+++ b/packages/core/scripts/npm/win32-arm64-msvc/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/core/scripts/npm/win32-ia32-msvc/package.json
+++ b/packages/core/scripts/npm/win32-ia32-msvc/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/core/scripts/npm/win32-x64-msvc/package.json
+++ b/packages/core/scripts/npm/win32-x64-msvc/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/html/scripts/npm/darwin-arm64/package.json
+++ b/packages/html/scripts/npm/darwin-arm64/package.json
@@ -28,7 +28,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/html/scripts/npm/darwin-x64/package.json
+++ b/packages/html/scripts/npm/darwin-x64/package.json
@@ -28,7 +28,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/html/scripts/npm/linux-arm-gnueabihf/package.json
+++ b/packages/html/scripts/npm/linux-arm-gnueabihf/package.json
@@ -28,7 +28,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/html/scripts/npm/linux-arm64-gnu/package.json
+++ b/packages/html/scripts/npm/linux-arm64-gnu/package.json
@@ -31,7 +31,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/html/scripts/npm/linux-arm64-musl/package.json
+++ b/packages/html/scripts/npm/linux-arm64-musl/package.json
@@ -31,7 +31,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/html/scripts/npm/linux-x64-gnu/package.json
+++ b/packages/html/scripts/npm/linux-x64-gnu/package.json
@@ -31,7 +31,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/html/scripts/npm/linux-x64-musl/package.json
+++ b/packages/html/scripts/npm/linux-x64-musl/package.json
@@ -31,7 +31,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/html/scripts/npm/win32-arm64-msvc/package.json
+++ b/packages/html/scripts/npm/win32-arm64-msvc/package.json
@@ -28,7 +28,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/html/scripts/npm/win32-ia32-msvc/package.json
+++ b/packages/html/scripts/npm/win32-ia32-msvc/package.json
@@ -28,7 +28,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/html/scripts/npm/win32-x64-msvc/package.json
+++ b/packages/html/scripts/npm/win32-x64-msvc/package.json
@@ -28,7 +28,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/minifier/scripts/npm/darwin-arm64/package.json
+++ b/packages/minifier/scripts/npm/darwin-arm64/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/minifier/scripts/npm/darwin-x64/package.json
+++ b/packages/minifier/scripts/npm/darwin-x64/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/minifier/scripts/npm/linux-arm-gnueabihf/package.json
+++ b/packages/minifier/scripts/npm/linux-arm-gnueabihf/package.json
@@ -26,7 +26,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/minifier/scripts/npm/linux-arm64-gnu/package.json
+++ b/packages/minifier/scripts/npm/linux-arm64-gnu/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/minifier/scripts/npm/linux-arm64-musl/package.json
+++ b/packages/minifier/scripts/npm/linux-arm64-musl/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/minifier/scripts/npm/linux-x64-gnu/package.json
+++ b/packages/minifier/scripts/npm/linux-x64-gnu/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/minifier/scripts/npm/linux-x64-musl/package.json
+++ b/packages/minifier/scripts/npm/linux-x64-musl/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/minifier/scripts/npm/win32-arm64-msvc/package.json
+++ b/packages/minifier/scripts/npm/win32-arm64-msvc/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/minifier/scripts/npm/win32-ia32-msvc/package.json
+++ b/packages/minifier/scripts/npm/win32-ia32-msvc/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/minifier/scripts/npm/win32-x64-msvc/package.json
+++ b/packages/minifier/scripts/npm/win32-x64-msvc/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react-compiler/scripts/npm/darwin-arm64/package.json
+++ b/packages/react-compiler/scripts/npm/darwin-arm64/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react-compiler/scripts/npm/darwin-x64/package.json
+++ b/packages/react-compiler/scripts/npm/darwin-x64/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react-compiler/scripts/npm/linux-arm-gnueabihf/package.json
+++ b/packages/react-compiler/scripts/npm/linux-arm-gnueabihf/package.json
@@ -26,7 +26,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react-compiler/scripts/npm/linux-arm64-gnu/package.json
+++ b/packages/react-compiler/scripts/npm/linux-arm64-gnu/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react-compiler/scripts/npm/linux-arm64-musl/package.json
+++ b/packages/react-compiler/scripts/npm/linux-arm64-musl/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react-compiler/scripts/npm/linux-x64-gnu/package.json
+++ b/packages/react-compiler/scripts/npm/linux-x64-gnu/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react-compiler/scripts/npm/linux-x64-musl/package.json
+++ b/packages/react-compiler/scripts/npm/linux-x64-musl/package.json
@@ -33,7 +33,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react-compiler/scripts/npm/win32-arm64-msvc/package.json
+++ b/packages/react-compiler/scripts/npm/win32-arm64-msvc/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react-compiler/scripts/npm/win32-ia32-msvc/package.json
+++ b/packages/react-compiler/scripts/npm/win32-ia32-msvc/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",

--- a/packages/react-compiler/scripts/npm/win32-x64-msvc/package.json
+++ b/packages/react-compiler/scripts/npm/win32-x64-msvc/package.json
@@ -30,7 +30,8 @@
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",
-    "access": "public"
+    "access": "public",
+    "provenance": true
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
Follow-up to https://github.com/swc-project/swc/pull/11268
This PR adds `"provenance": true` to the `publishConfig` section of all sub packages except `@swc/types` and `@swc/helpers`.
For an unknown reason, provenance was removed from all packages in commit 8c3d528.

**Related issue (if exists):**
- Closes: https://github.com/swc-project/swc/issues/11342
