### PR TITLE
feat(es/parser): Revert `no_paren` parser option

### DIFF
--- a/.changeset/chatty-dragons-turn.md
+++ b/.changeset/chatty-dragons-turn.md
@@ -1,5 +1,0 @@
----
-swc_ecma_parser: major
----
-
-feat(es/parser): support `no_paren` parser option

--- a/crates/swc/tests/rust_api.rs
+++ b/crates/swc/tests/rust_api.rs
@@ -130,7 +130,6 @@ fn shopify_2_same_opt() {
                         tsx: true,
                         decorators: false,
                         dts: false,
-                        no_paren: false,
                         no_early_errors: false,
                         disallow_ambiguous_jsx_like: false,
                     })),

--- a/crates/swc/tests/tsc.rs
+++ b/crates/swc/tests/tsc.rs
@@ -389,7 +389,6 @@ fn matrix(input: &Path) -> Vec<TestUnitData> {
                                 tsx: is_jsx,
                                 decorators,
                                 dts: false,
-                                no_paren: false,
                                 no_early_errors: false,
                                 disallow_ambiguous_jsx_like: false,
                             })),

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2416,11 +2416,6 @@ impl<I: Tokens> Parser<I> {
                 } => syntax_error!(self, expr.span(), SyntaxError::SpreadInParenExpr),
                 ExprOrSpread { expr, .. } => expr,
             };
-
-            if self.syntax().no_paren() {
-                return Ok(expr);
-            }
-
             Ok(ParenExpr {
                 span: self.span(expr_start),
                 expr,
@@ -2450,11 +2445,6 @@ impl<I: Tokens> Parser<I> {
                 exprs,
             }
             .into();
-
-            if self.syntax().no_paren() {
-                return Ok(seq_expr);
-            }
-
             Ok(ParenExpr {
                 span: self.span(expr_start),
                 expr: seq_expr,

--- a/crates/swc_ecma_parser/src/syntax.rs
+++ b/crates/swc_ecma_parser/src/syntax.rs
@@ -176,13 +176,6 @@ pub struct TsSyntax {
     #[serde(skip, default)]
     pub dts: bool,
 
-    #[serde(default)]
-    /// When enabled, the parser will not create ParenExpr nodes for
-    /// parenthesized expressions. Instead, it returns the inner expression
-    /// directly. This aligns with the ESTree spec, which does not have a
-    /// ParenthesizedExpression type.
-    pub no_paren: bool,
-
     #[serde(skip, default)]
     pub no_early_errors: bool,
 
@@ -210,9 +203,6 @@ impl TsSyntax {
         if self.decorators {
             flags |= SyntaxFlags::DECORATORS;
         }
-        if self.no_paren {
-            flags |= SyntaxFlags::NO_PAREN;
-        }
         if self.dts {
             flags |= SyntaxFlags::DTS;
         }
@@ -236,13 +226,6 @@ pub struct EsSyntax {
     #[serde(rename = "functionBind")]
     #[serde(default)]
     pub fn_bind: bool,
-
-    #[serde(default)]
-    /// When enabled, the parser will not create ParenExpr nodes for
-    /// parenthesized expressions. Instead, it returns the inner expression
-    /// directly. This aligns with the ESTree spec, which does not have a
-    /// ParenthesizedExpression type.
-    pub no_paren: bool,
 
     /// Enable decorators.
     #[serde(default)]
@@ -287,9 +270,6 @@ impl EsSyntax {
         }
         if self.decorators {
             flags |= SyntaxFlags::DECORATORS;
-        }
-        if self.no_paren {
-            flags |= SyntaxFlags::NO_PAREN;
         }
         if self.decorators_before_export {
             flags |= SyntaxFlags::DECORATORS_BEFORE_EXPORT;
@@ -336,11 +316,6 @@ impl SyntaxFlags {
     #[inline(always)]
     pub const fn fn_bind(&self) -> bool {
         self.contains(SyntaxFlags::FN_BIND)
-    }
-
-    #[inline(always)]
-    pub const fn no_paren(&self) -> bool {
-        self.contains(SyntaxFlags::NO_PAREN)
     }
 
     #[inline(always)]
@@ -420,6 +395,5 @@ bitflags::bitflags! {
         const NO_EARLY_ERRORS = 1 << 11;
         const DISALLOW_AMBIGUOUS_JSX_LIKE = 1 << 12;
         const TS = 1 << 13;
-        const NO_PAREN = 1 << 14;
     }
 }

--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -23,8 +23,6 @@ pub fn fixer(comments: Option<&dyn Comments>) -> impl '_ + Pass + VisitMut {
     })
 }
 
-/// [swc_ecma_parser::EsSyntax::no_paren] is another straightforward way to get
-/// the AST without [swc_ecma_ast::ParenExpr]
 pub fn paren_remover(comments: Option<&dyn Comments>) -> impl '_ + Pass + VisitMut {
     visit_mut_pass(Fixer {
         comments,

--- a/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
@@ -85,7 +85,6 @@ fn identity(entry: PathBuf) {
                 tsx: file_name.contains("tsx"),
                 decorators: true,
                 dts: false,
-                no_paren: false,
                 no_early_errors: false,
                 disallow_ambiguous_jsx_like: false,
             }),


### PR DESCRIPTION
**Description:**

This is introduced in https://github.com/swc-project/swc/pull/11359. But I find some problems that are not easy to fix. So I revert it for now.
