### PR TITLE
perf(es/parser): Add inline(always) to hot path methods

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/search.rs
+++ b/crates/swc_ecma_parser/src/lexer/search.rs
@@ -37,7 +37,7 @@ impl SafeByteMatchTable {
     #[inline]
     pub const fn use_table(&self) {}
 
-    #[inline]
+    #[inline(always)]
     pub const fn matches(&self, b: u8) -> bool {
         self.0[b as usize]
     }

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -303,6 +303,7 @@ impl<I: Tokens> Buffer<I> {
         self.set_cur(first_token);
     }
 
+    #[inline(always)]
     pub fn bump(&mut self) {
         let next = match self.next.take() {
             Some(next) => {


### PR DESCRIPTION
## Summary
- Add `#[inline(always)]` to `SafeByteMatchTable::matches` method
- Add `#[inline(always)]` to `Buffer::bump` method

These are hot path methods in the parser that benefit from aggressive inlining to improve performance.

## Test plan
- Existing tests should pass
- Performance benchmarks should show improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)