### PR TITLE
refactor(es/transformer): Remove OptionalHook wrapper in favor of Option<H>

### DIFF
--- a/.changeset/cold-rice-divide.md
+++ b/.changeset/cold-rice-divide.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transformer: patch
+---
+
+refactor(es/transformer): Remove OptionalHook wrapper in favor of Option<H>

--- a/crates/swc_ecma_transformer/src/es2016/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2016/mod.rs
@@ -1,6 +1,6 @@
 use swc_ecma_hooks::VisitMutHook;
 
-use crate::{hook_utils::OptionalHook, TraverseCtx};
+use crate::TraverseCtx;
 
 mod exponentiation_operator;
 
@@ -11,9 +11,9 @@ pub struct Es2016Options {
 }
 
 pub fn hook(options: Es2016Options) -> impl VisitMutHook<TraverseCtx> {
-    OptionalHook(if options.exponentiation_operator {
+    if options.exponentiation_operator {
         Some(self::exponentiation_operator::hook())
     } else {
         None
-    })
+    }
 }

--- a/crates/swc_ecma_transformer/src/es2017/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2017/mod.rs
@@ -3,7 +3,7 @@ mod async_to_generator;
 use swc_common::SyntaxContext;
 use swc_ecma_hooks::VisitMutHook;
 
-use crate::{hook_utils::OptionalHook, TraverseCtx};
+use crate::TraverseCtx;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]
@@ -17,11 +17,11 @@ pub fn hook(
     ignore_function_length: bool,
 ) -> impl VisitMutHook<TraverseCtx> {
     if options.async_to_generator {
-        OptionalHook(Some(async_to_generator::hook(
+        Some(async_to_generator::hook(
             unresolved_ctxt,
             ignore_function_length,
-        )))
+        ))
     } else {
-        OptionalHook(None)
+        None
     }
 }

--- a/crates/swc_ecma_transformer/src/es2018/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2018/mod.rs
@@ -1,7 +1,7 @@
 use swc_ecma_hooks::VisitMutHook;
 use swc_ecma_transforms_base::assumptions::Assumptions;
 
-use crate::{hook_utils::OptionalHook, TraverseCtx};
+use crate::TraverseCtx;
 
 mod object_rest_spread;
 
@@ -16,8 +16,8 @@ pub(crate) fn hook(
     assumptions: Assumptions,
 ) -> impl VisitMutHook<TraverseCtx> {
     if options.object_rest_spread {
-        OptionalHook(Some(object_rest_spread::hook(assumptions)))
+        Some(object_rest_spread::hook(assumptions))
     } else {
-        OptionalHook(None)
+        None
     }
 }

--- a/crates/swc_ecma_transformer/src/es2019/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2019/mod.rs
@@ -1,6 +1,6 @@
 use swc_ecma_hooks::VisitMutHook;
 
-use crate::{hook_utils::OptionalHook, TraverseCtx};
+use crate::TraverseCtx;
 
 mod optional_catch_binding;
 
@@ -11,9 +11,9 @@ pub struct Es2019Options {
 }
 
 pub(crate) fn hook(options: Es2019Options) -> impl VisitMutHook<TraverseCtx> {
-    OptionalHook(if options.optional_catch_binding {
+    if options.optional_catch_binding {
         Some(self::optional_catch_binding::hook())
     } else {
         None
-    })
+    }
 }

--- a/crates/swc_ecma_transformer/src/es2020/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2020/mod.rs
@@ -2,7 +2,7 @@ use swc_ecma_hooks::VisitMutHook;
 use swc_ecma_transforms_base::assumptions::Assumptions;
 
 use crate::{
-    hook_utils::{HookBuilder, NoopHook, OptionalHook},
+    hook_utils::{HookBuilder, NoopHook},
     TraverseCtx,
 };
 
@@ -26,17 +26,17 @@ pub(crate) fn hook(
 ) -> impl VisitMutHook<TraverseCtx> {
     let hook = HookBuilder::new(NoopHook);
 
-    let hook = hook.chain(OptionalHook(if options.export_namespace_from {
+    let hook = hook.chain(if options.export_namespace_from {
         Some(self::export_namespace_from::hook())
     } else {
         None
-    }));
+    });
 
-    let hook = hook.chain(OptionalHook(if options.nullish_coalescing {
+    let hook = hook.chain(if options.nullish_coalescing {
         Some(self::nullish_coalescing::hook(assumptions.no_document_all))
     } else {
         None
-    }));
+    });
 
     hook.build()
 }

--- a/crates/swc_ecma_transformer/src/es2021/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2021/mod.rs
@@ -3,7 +3,7 @@ mod logical_assignment_operators;
 use swc_ecma_hooks::VisitMutHook;
 
 use crate::{
-    hook_utils::{HookBuilder, NoopHook, OptionalHook},
+    hook_utils::{HookBuilder, NoopHook},
     TraverseCtx,
 };
 
@@ -16,11 +16,11 @@ pub struct Es2021Options {
 pub fn hook(options: Es2021Options) -> impl VisitMutHook<TraverseCtx> {
     let hook = HookBuilder::new(NoopHook);
 
-    let hook = hook.chain(OptionalHook(if options.logical_assignment_operators {
+    let hook = hook.chain(if options.logical_assignment_operators {
         Some(self::logical_assignment_operators::hook())
     } else {
         None
-    }));
+    });
 
     hook.build()
 }

--- a/crates/swc_ecma_transformer/src/es2022/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2022/mod.rs
@@ -1,7 +1,7 @@
 use swc_ecma_hooks::VisitMutHook;
 
 use crate::{
-    hook_utils::{HookBuilder, NoopHook, OptionalHook},
+    hook_utils::{HookBuilder, NoopHook},
     TraverseCtx,
 };
 
@@ -22,17 +22,17 @@ pub struct Es2022Options {
 pub fn hook(options: Es2022Options) -> impl VisitMutHook<TraverseCtx> {
     let hook = HookBuilder::new(NoopHook);
 
-    let hook = hook.chain(OptionalHook(if options.class_static_block {
+    let hook = hook.chain(if options.class_static_block {
         Some(self::class_static_block::hook())
     } else {
         None
-    }));
+    });
 
-    let hook = hook.chain(OptionalHook(if options.private_property_in_object {
+    let hook = hook.chain(if options.private_property_in_object {
         Some(self::private_property_in_object::hook())
     } else {
         None
-    }));
+    });
 
     hook.build()
 }

--- a/crates/swc_ecma_transformer/src/hook_utils.rs
+++ b/crates/swc_ecma_transformer/src/hook_utils.rs
@@ -3,85 +3,6 @@ use swc_ecma_hooks::VisitMutHook;
 
 use crate::TraverseCtx;
 
-pub(crate) struct OptionalHook<H>(pub Option<H>)
-where
-    H: VisitMutHook<TraverseCtx>;
-
-macro_rules! optional_method {
-    ($enter_name:ident, $exit_name:ident, $T:ty) => {
-        fn $enter_name(&mut self, node: &mut $T, ctx: &mut TraverseCtx) {
-            if let Some(hook) = &mut self.0 {
-                hook.$enter_name(node, ctx);
-            }
-        }
-
-        fn $exit_name(&mut self, node: &mut $T, ctx: &mut TraverseCtx) {
-            if let Some(hook) = &mut self.0 {
-                hook.$exit_name(node, ctx);
-            }
-        }
-    };
-}
-
-impl<H> VisitMutHook<TraverseCtx> for OptionalHook<H>
-where
-    H: VisitMutHook<TraverseCtx>,
-{
-    // TODO: Implement lots of hooks, or move it to `swc_ecma_hooks`
-
-    optional_method!(enter_expr, exit_expr, Expr);
-
-    optional_method!(enter_expr_stmt, exit_expr_stmt, ExprStmt);
-
-    optional_method!(enter_pat, exit_pat, Pat);
-
-    optional_method!(enter_stmt, exit_stmt, Stmt);
-
-    optional_method!(enter_stmts, exit_stmts, Vec<Stmt>);
-
-    optional_method!(enter_block_stmt, exit_block_stmt, BlockStmt);
-
-    optional_method!(enter_module_item, exit_module_item, ModuleItem);
-
-    optional_method!(enter_module_items, exit_module_items, Vec<ModuleItem>);
-
-    optional_method!(enter_module, exit_module, Module);
-
-    optional_method!(enter_script, exit_script, Script);
-
-    optional_method!(enter_program, exit_program, Program);
-
-    optional_method!(enter_catch_clause, exit_catch_clause, CatchClause);
-
-    optional_method!(enter_function, exit_function, Function);
-
-    optional_method!(enter_arrow_expr, exit_arrow_expr, ArrowExpr);
-
-    optional_method!(enter_class, exit_class, Class);
-
-    optional_method!(enter_constructor, exit_constructor, Constructor);
-
-    optional_method!(enter_getter_prop, exit_getter_prop, GetterProp);
-
-    optional_method!(enter_setter_prop, exit_setter_prop, SetterProp);
-
-    optional_method!(enter_super, exit_super, Super);
-
-    optional_method!(enter_var_decl, exit_var_decl, VarDecl);
-
-    optional_method!(enter_for_in_stmt, exit_for_in_stmt, ForInStmt);
-
-    optional_method!(enter_for_of_stmt, exit_for_of_stmt, ForOfStmt);
-
-    optional_method!(enter_class_decl, exit_class_decl, ClassDecl);
-
-    optional_method!(enter_class_expr, exit_class_expr, ClassExpr);
-
-    optional_method!(enter_assign_pat, exit_assign_pat, AssignPat);
-
-    optional_method!(enter_private_prop, exit_private_prop, PrivateProp);
-}
-
 macro_rules! chained_method {
     ($enter_name:ident, $exit_name:ident, $T:ty) => {
         fn $enter_name(&mut self, node: &mut $T, ctx: &mut TraverseCtx) {
@@ -192,7 +113,7 @@ where
     where
         B: VisitMutHook<TraverseCtx>,
     {
-        self.chain(OptionalHook(hook))
+        self.chain(hook)
     }
 
     pub fn build(self) -> impl VisitMutHook<TraverseCtx> {


### PR DESCRIPTION
## Summary
- Removed the `OptionalHook<H>` wrapper struct and its 80-line `VisitMutHook` implementation
- Updated `chain_if_some` to use `Option<H>` directly instead of wrapping it in `OptionalHook`
- Simplifies the codebase by leveraging the existing `VisitMutHook` implementation for `Option<H>` (added in #11429)

## Test plan
- Existing tests should pass as this is a refactor that maintains the same behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)