### PR TITLE
feat(es/hooks): Add VisitHook trait for immutable AST visitors

### DIFF
--- a/crates/swc_ecma_hooks/src/generated.rs
+++ b/crates/swc_ecma_hooks/src/generated.rs
@@ -3,6 +3,17464 @@
 #![allow(clippy::all)]
 use swc_ecma_ast::*;
 use swc_ecma_visit::*;
+#[doc = r" A hook trait for composable AST visitors (immutable version)."]
+#[doc = r""]
+#[doc = r" This trait provides `enter_xxx` and `exit_xxx` methods for each AST node type."]
+#[doc = r" The enter method is called before visiting children, and the exit method is called after."]
+#[doc = r" The generic parameter `C` represents a context type that is passed through all hook methods."]
+pub trait VisitHook<C> {
+    #[doc = "Called when entering a node of type `Accessibility` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_accessibility(&mut self, node: &Accessibility, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Accessibility` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_accessibility(&mut self, node: &Accessibility, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ArrayLit` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_array_lit(&mut self, node: &ArrayLit, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ArrayLit` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_array_lit(&mut self, node: &ArrayLit, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ArrayPat` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_array_pat(&mut self, node: &ArrayPat, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ArrayPat` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_array_pat(&mut self, node: &ArrayPat, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ArrowExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_arrow_expr(&mut self, node: &ArrowExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ArrowExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_arrow_expr(&mut self, node: &ArrowExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `AssignExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_assign_expr(&mut self, node: &AssignExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `AssignExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_assign_expr(&mut self, node: &AssignExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `AssignOp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_assign_op(&mut self, node: &AssignOp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `AssignOp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_assign_op(&mut self, node: &AssignOp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `AssignPat` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_assign_pat(&mut self, node: &AssignPat, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `AssignPat` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_assign_pat(&mut self, node: &AssignPat, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `AssignPatProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_assign_pat_prop(&mut self, node: &AssignPatProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `AssignPatProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_assign_pat_prop(&mut self, node: &AssignPatProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `AssignProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_assign_prop(&mut self, node: &AssignProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `AssignProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_assign_prop(&mut self, node: &AssignProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `AssignTarget` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_assign_target(&mut self, node: &AssignTarget, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `AssignTarget` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_assign_target(&mut self, node: &AssignTarget, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `AssignTargetPat` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_assign_target_pat(&mut self, node: &AssignTargetPat, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `AssignTargetPat` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_assign_target_pat(&mut self, node: &AssignTargetPat, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `swc_atoms :: Atom` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_atom(&mut self, node: &swc_atoms::Atom, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `swc_atoms :: Atom` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_atom(&mut self, node: &swc_atoms::Atom, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `AutoAccessor` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_auto_accessor(&mut self, node: &AutoAccessor, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `AutoAccessor` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_auto_accessor(&mut self, node: &AutoAccessor, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `AwaitExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_await_expr(&mut self, node: &AwaitExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `AwaitExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_await_expr(&mut self, node: &AwaitExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `BigInt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_big_int(&mut self, node: &BigInt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `BigInt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_big_int(&mut self, node: &BigInt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `BigIntValue` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_big_int_value(&mut self, node: &BigIntValue, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `BigIntValue` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_big_int_value(&mut self, node: &BigIntValue, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `BinExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_bin_expr(&mut self, node: &BinExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `BinExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_bin_expr(&mut self, node: &BinExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `BinaryOp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_binary_op(&mut self, node: &BinaryOp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `BinaryOp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_binary_op(&mut self, node: &BinaryOp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `BindingIdent` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_binding_ident(&mut self, node: &BindingIdent, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `BindingIdent` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_binding_ident(&mut self, node: &BindingIdent, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `BlockStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_block_stmt(&mut self, node: &BlockStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `BlockStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_block_stmt(&mut self, node: &BlockStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `BlockStmtOrExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_block_stmt_or_expr(&mut self, node: &BlockStmtOrExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `BlockStmtOrExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_block_stmt_or_expr(&mut self, node: &BlockStmtOrExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Bool` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_bool(&mut self, node: &Bool, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Bool` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_bool(&mut self, node: &Bool, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `BreakStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_break_stmt(&mut self, node: &BreakStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `BreakStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_break_stmt(&mut self, node: &BreakStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `CallExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_call_expr(&mut self, node: &CallExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `CallExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_call_expr(&mut self, node: &CallExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Callee` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_callee(&mut self, node: &Callee, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Callee` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_callee(&mut self, node: &Callee, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `CatchClause` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_catch_clause(&mut self, node: &CatchClause, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `CatchClause` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_catch_clause(&mut self, node: &CatchClause, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Class` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_class(&mut self, node: &Class, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Class` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_class(&mut self, node: &Class, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ClassDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_class_decl(&mut self, node: &ClassDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ClassDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_class_decl(&mut self, node: &ClassDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ClassExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_class_expr(&mut self, node: &ClassExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ClassExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_class_expr(&mut self, node: &ClassExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ClassMember` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_class_member(&mut self, node: &ClassMember, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ClassMember` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_class_member(&mut self, node: &ClassMember, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < ClassMember >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_class_members(&mut self, node: &[ClassMember], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < ClassMember >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_class_members(&mut self, node: &[ClassMember], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ClassMethod` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_class_method(&mut self, node: &ClassMethod, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ClassMethod` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_class_method(&mut self, node: &ClassMethod, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ClassProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_class_prop(&mut self, node: &ClassProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ClassProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_class_prop(&mut self, node: &ClassProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ComputedPropName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_computed_prop_name(&mut self, node: &ComputedPropName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ComputedPropName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_computed_prop_name(&mut self, node: &ComputedPropName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `CondExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_cond_expr(&mut self, node: &CondExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `CondExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_cond_expr(&mut self, node: &CondExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Constructor` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_constructor(&mut self, node: &Constructor, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Constructor` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_constructor(&mut self, node: &Constructor, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ContinueStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_continue_stmt(&mut self, node: &ContinueStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ContinueStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_continue_stmt(&mut self, node: &ContinueStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `DebuggerStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_debugger_stmt(&mut self, node: &DebuggerStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `DebuggerStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_debugger_stmt(&mut self, node: &DebuggerStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Decl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_decl(&mut self, node: &Decl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Decl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_decl(&mut self, node: &Decl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Decorator` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_decorator(&mut self, node: &Decorator, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Decorator` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_decorator(&mut self, node: &Decorator, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < Decorator >` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_decorators(&mut self, node: &[Decorator], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < Decorator >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_decorators(&mut self, node: &[Decorator], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `DefaultDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_default_decl(&mut self, node: &DefaultDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `DefaultDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_default_decl(&mut self, node: &DefaultDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `DoWhileStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_do_while_stmt(&mut self, node: &DoWhileStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `DoWhileStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_do_while_stmt(&mut self, node: &DoWhileStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `EmptyStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_empty_stmt(&mut self, node: &EmptyStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `EmptyStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_empty_stmt(&mut self, node: &EmptyStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ExportAll` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_export_all(&mut self, node: &ExportAll, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ExportAll` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_export_all(&mut self, node: &ExportAll, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ExportDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_export_decl(&mut self, node: &ExportDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ExportDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_export_decl(&mut self, node: &ExportDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ExportDefaultDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_export_default_decl(&mut self, node: &ExportDefaultDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ExportDefaultDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_export_default_decl(&mut self, node: &ExportDefaultDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ExportDefaultExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_export_default_expr(&mut self, node: &ExportDefaultExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ExportDefaultExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_export_default_expr(&mut self, node: &ExportDefaultExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ExportDefaultSpecifier` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_export_default_specifier(&mut self, node: &ExportDefaultSpecifier, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ExportDefaultSpecifier` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_export_default_specifier(&mut self, node: &ExportDefaultSpecifier, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ExportNamedSpecifier` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_export_named_specifier(&mut self, node: &ExportNamedSpecifier, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ExportNamedSpecifier` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_export_named_specifier(&mut self, node: &ExportNamedSpecifier, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ExportNamespaceSpecifier` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_export_namespace_specifier(&mut self, node: &ExportNamespaceSpecifier, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ExportNamespaceSpecifier` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_export_namespace_specifier(&mut self, node: &ExportNamespaceSpecifier, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ExportSpecifier` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_export_specifier(&mut self, node: &ExportSpecifier, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ExportSpecifier` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_export_specifier(&mut self, node: &ExportSpecifier, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < ExportSpecifier >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_export_specifiers(&mut self, node: &[ExportSpecifier], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < ExportSpecifier >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_export_specifiers(&mut self, node: &[ExportSpecifier], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Expr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_expr(&mut self, node: &Expr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Expr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_expr(&mut self, node: &Expr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ExprOrSpread` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_expr_or_spread(&mut self, node: &ExprOrSpread, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ExprOrSpread` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_expr_or_spread(&mut self, node: &ExprOrSpread, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < ExprOrSpread >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_expr_or_spreads(&mut self, node: &[ExprOrSpread], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < ExprOrSpread >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_expr_or_spreads(&mut self, node: &[ExprOrSpread], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ExprStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_expr_stmt(&mut self, node: &ExprStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ExprStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_expr_stmt(&mut self, node: &ExprStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < Box < Expr > >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_exprs(&mut self, node: &[Box<Expr>], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < Box < Expr > >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_exprs(&mut self, node: &[Box<Expr>], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `FnDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_fn_decl(&mut self, node: &FnDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `FnDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_fn_decl(&mut self, node: &FnDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `FnExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_fn_expr(&mut self, node: &FnExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `FnExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_fn_expr(&mut self, node: &FnExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ForHead` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_for_head(&mut self, node: &ForHead, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ForHead` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_for_head(&mut self, node: &ForHead, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ForInStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_for_in_stmt(&mut self, node: &ForInStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ForInStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_for_in_stmt(&mut self, node: &ForInStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ForOfStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_for_of_stmt(&mut self, node: &ForOfStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ForOfStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_for_of_stmt(&mut self, node: &ForOfStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ForStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_for_stmt(&mut self, node: &ForStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ForStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_for_stmt(&mut self, node: &ForStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Function` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_function(&mut self, node: &Function, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Function` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_function(&mut self, node: &Function, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `GetterProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_getter_prop(&mut self, node: &GetterProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `GetterProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_getter_prop(&mut self, node: &GetterProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Ident` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ident(&mut self, node: &Ident, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Ident` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ident(&mut self, node: &Ident, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `IdentName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ident_name(&mut self, node: &IdentName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `IdentName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ident_name(&mut self, node: &IdentName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `IfStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_if_stmt(&mut self, node: &IfStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `IfStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_if_stmt(&mut self, node: &IfStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Import` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import(&mut self, node: &Import, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Import` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import(&mut self, node: &Import, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ImportDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import_decl(&mut self, node: &ImportDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ImportDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import_decl(&mut self, node: &ImportDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ImportDefaultSpecifier` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import_default_specifier(&mut self, node: &ImportDefaultSpecifier, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ImportDefaultSpecifier` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import_default_specifier(&mut self, node: &ImportDefaultSpecifier, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ImportNamedSpecifier` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import_named_specifier(&mut self, node: &ImportNamedSpecifier, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ImportNamedSpecifier` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import_named_specifier(&mut self, node: &ImportNamedSpecifier, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ImportPhase` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import_phase(&mut self, node: &ImportPhase, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ImportPhase` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import_phase(&mut self, node: &ImportPhase, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ImportSpecifier` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import_specifier(&mut self, node: &ImportSpecifier, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ImportSpecifier` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import_specifier(&mut self, node: &ImportSpecifier, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < ImportSpecifier >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import_specifiers(&mut self, node: &[ImportSpecifier], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < ImportSpecifier >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import_specifiers(&mut self, node: &[ImportSpecifier], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ImportStarAsSpecifier` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ImportStarAsSpecifier` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ImportWith` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import_with(&mut self, node: &ImportWith, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ImportWith` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import_with(&mut self, node: &ImportWith, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ImportWithItem` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import_with_item(&mut self, node: &ImportWithItem, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ImportWithItem` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import_with_item(&mut self, node: &ImportWithItem, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < ImportWithItem >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_import_with_items(&mut self, node: &[ImportWithItem], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < ImportWithItem >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_import_with_items(&mut self, node: &[ImportWithItem], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Invalid` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_invalid(&mut self, node: &Invalid, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Invalid` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_invalid(&mut self, node: &Invalid, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXAttr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_attr(&mut self, node: &JSXAttr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXAttr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_attr(&mut self, node: &JSXAttr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXAttrName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_attr_name(&mut self, node: &JSXAttrName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXAttrName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_attr_name(&mut self, node: &JSXAttrName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXAttrOrSpread` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_attr_or_spread(&mut self, node: &JSXAttrOrSpread, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXAttrOrSpread` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_attr_or_spread(&mut self, node: &JSXAttrOrSpread, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < JSXAttrOrSpread >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_attr_or_spreads(&mut self, node: &[JSXAttrOrSpread], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < JSXAttrOrSpread >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_attr_or_spreads(&mut self, node: &[JSXAttrOrSpread], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXAttrValue` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_attr_value(&mut self, node: &JSXAttrValue, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXAttrValue` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_attr_value(&mut self, node: &JSXAttrValue, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXClosingElement` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_closing_element(&mut self, node: &JSXClosingElement, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXClosingElement` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_closing_element(&mut self, node: &JSXClosingElement, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXClosingFragment` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_closing_fragment(&mut self, node: &JSXClosingFragment, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXClosingFragment` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_closing_fragment(&mut self, node: &JSXClosingFragment, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXElement` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_element(&mut self, node: &JSXElement, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXElement` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_element(&mut self, node: &JSXElement, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXElementChild` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_element_child(&mut self, node: &JSXElementChild, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXElementChild` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_element_child(&mut self, node: &JSXElementChild, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < JSXElementChild >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_element_childs(&mut self, node: &[JSXElementChild], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < JSXElementChild >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_element_childs(&mut self, node: &[JSXElementChild], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXElementName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_element_name(&mut self, node: &JSXElementName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXElementName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_element_name(&mut self, node: &JSXElementName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXEmptyExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_empty_expr(&mut self, node: &JSXEmptyExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXEmptyExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_empty_expr(&mut self, node: &JSXEmptyExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_expr(&mut self, node: &JSXExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_expr(&mut self, node: &JSXExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXExprContainer` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_expr_container(&mut self, node: &JSXExprContainer, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXExprContainer` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_expr_container(&mut self, node: &JSXExprContainer, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXFragment` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXFragment` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXMemberExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_member_expr(&mut self, node: &JSXMemberExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXMemberExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_member_expr(&mut self, node: &JSXMemberExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXNamespacedName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_namespaced_name(&mut self, node: &JSXNamespacedName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXNamespacedName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_namespaced_name(&mut self, node: &JSXNamespacedName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXObject` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_object(&mut self, node: &JSXObject, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXObject` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_object(&mut self, node: &JSXObject, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXOpeningElement` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_opening_element(&mut self, node: &JSXOpeningElement, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXOpeningElement` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_opening_element(&mut self, node: &JSXOpeningElement, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXOpeningFragment` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_opening_fragment(&mut self, node: &JSXOpeningFragment, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXOpeningFragment` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_opening_fragment(&mut self, node: &JSXOpeningFragment, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXSpreadChild` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_spread_child(&mut self, node: &JSXSpreadChild, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXSpreadChild` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_spread_child(&mut self, node: &JSXSpreadChild, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `JSXText` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_jsx_text(&mut self, node: &JSXText, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `JSXText` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_jsx_text(&mut self, node: &JSXText, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Key` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_key(&mut self, node: &Key, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Key` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_key(&mut self, node: &Key, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `KeyValuePatProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_key_value_pat_prop(&mut self, node: &KeyValuePatProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `KeyValuePatProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_key_value_pat_prop(&mut self, node: &KeyValuePatProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `KeyValueProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_key_value_prop(&mut self, node: &KeyValueProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `KeyValueProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_key_value_prop(&mut self, node: &KeyValueProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `LabeledStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_labeled_stmt(&mut self, node: &LabeledStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `LabeledStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_labeled_stmt(&mut self, node: &LabeledStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Lit` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_lit(&mut self, node: &Lit, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Lit` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_lit(&mut self, node: &Lit, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `MemberExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_member_expr(&mut self, node: &MemberExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `MemberExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_member_expr(&mut self, node: &MemberExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `MemberProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_member_prop(&mut self, node: &MemberProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `MemberProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_member_prop(&mut self, node: &MemberProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `MetaPropExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_meta_prop_expr(&mut self, node: &MetaPropExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `MetaPropExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_meta_prop_expr(&mut self, node: &MetaPropExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `MetaPropKind` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_meta_prop_kind(&mut self, node: &MetaPropKind, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `MetaPropKind` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_meta_prop_kind(&mut self, node: &MetaPropKind, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `MethodKind` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_method_kind(&mut self, node: &MethodKind, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `MethodKind` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_method_kind(&mut self, node: &MethodKind, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `MethodProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_method_prop(&mut self, node: &MethodProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `MethodProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_method_prop(&mut self, node: &MethodProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Module` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_module(&mut self, node: &Module, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Module` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_module(&mut self, node: &Module, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ModuleDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_module_decl(&mut self, node: &ModuleDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ModuleDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_module_decl(&mut self, node: &ModuleDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ModuleExportName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_module_export_name(&mut self, node: &ModuleExportName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ModuleExportName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_module_export_name(&mut self, node: &ModuleExportName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ModuleItem` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_module_item(&mut self, node: &ModuleItem, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ModuleItem` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_module_item(&mut self, node: &ModuleItem, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < ModuleItem >` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_module_items(&mut self, node: &[ModuleItem], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < ModuleItem >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_module_items(&mut self, node: &[ModuleItem], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `NamedExport` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_named_export(&mut self, node: &NamedExport, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `NamedExport` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_named_export(&mut self, node: &NamedExport, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `NewExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `NewExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Null` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_null(&mut self, node: &Null, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Null` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_null(&mut self, node: &Null, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Number` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_number(&mut self, node: &Number, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Number` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_number(&mut self, node: &Number, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ObjectLit` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_object_lit(&mut self, node: &ObjectLit, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ObjectLit` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_object_lit(&mut self, node: &ObjectLit, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ObjectPat` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_object_pat(&mut self, node: &ObjectPat, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ObjectPat` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_object_pat(&mut self, node: &ObjectPat, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ObjectPatProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_object_pat_prop(&mut self, node: &ObjectPatProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ObjectPatProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_object_pat_prop(&mut self, node: &ObjectPatProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < ObjectPatProp >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_object_pat_props(&mut self, node: &[ObjectPatProp], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < ObjectPatProp >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_object_pat_props(&mut self, node: &[ObjectPatProp], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Accessibility >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_accessibility(&mut self, node: &Option<Accessibility>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Accessibility >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_accessibility(&mut self, node: &Option<Accessibility>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < swc_atoms :: Atom >` before visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_atom(&mut self, node: &Option<swc_atoms::Atom>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < swc_atoms :: Atom >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_atom(&mut self, node: &Option<swc_atoms::Atom>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < BlockStmt >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_block_stmt(&mut self, node: &Option<BlockStmt>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < BlockStmt >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_block_stmt(&mut self, node: &Option<BlockStmt>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `OptCall` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_call(&mut self, node: &OptCall, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `OptCall` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_call(&mut self, node: &OptCall, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < CatchClause >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_catch_clause(&mut self, node: &Option<CatchClause>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < CatchClause >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_catch_clause(&mut self, node: &Option<CatchClause>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `OptChainBase` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_chain_base(&mut self, node: &OptChainBase, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `OptChainBase` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_chain_base(&mut self, node: &OptChainBase, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `OptChainExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_chain_expr(&mut self, node: &OptChainExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `OptChainExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_chain_expr(&mut self, node: &OptChainExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Box < Expr > >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_expr(&mut self, node: &Option<Box<Expr>>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Box < Expr > >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_expr(&mut self, node: &Option<Box<Expr>>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < ExprOrSpread >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_expr_or_spread(&mut self, node: &Option<ExprOrSpread>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < ExprOrSpread >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_expr_or_spread(&mut self, node: &Option<ExprOrSpread>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Vec < ExprOrSpread > >` before visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_expr_or_spreads(&mut self, node: &Option<Vec<ExprOrSpread>>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Vec < ExprOrSpread > >` after visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_expr_or_spreads(&mut self, node: &Option<Vec<ExprOrSpread>>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Ident >` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_ident(&mut self, node: &Option<Ident>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Ident >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_ident(&mut self, node: &Option<Ident>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < JSXAttrValue >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_jsx_attr_value(&mut self, node: &Option<JSXAttrValue>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < JSXAttrValue >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_jsx_attr_value(&mut self, node: &Option<JSXAttrValue>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < JSXClosingElement >` before visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_jsx_closing_element(&mut self, node: &Option<JSXClosingElement>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < JSXClosingElement >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_jsx_closing_element(&mut self, node: &Option<JSXClosingElement>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < ModuleExportName >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_module_export_name(&mut self, node: &Option<ModuleExportName>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < ModuleExportName >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_module_export_name(&mut self, node: &Option<ModuleExportName>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Box < ObjectLit > >` before visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_object_lit(&mut self, node: &Option<Box<ObjectLit>>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Box < ObjectLit > >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_object_lit(&mut self, node: &Option<Box<ObjectLit>>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Pat >` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_pat(&mut self, node: &Option<Pat>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Pat >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_pat(&mut self, node: &Option<Pat>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < swc_common :: Span >` before visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_span(&mut self, node: &Option<swc_common::Span>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < swc_common :: Span >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_span(&mut self, node: &Option<swc_common::Span>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Box < Stmt > >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_stmt(&mut self, node: &Option<Box<Stmt>>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Box < Stmt > >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_stmt(&mut self, node: &Option<Box<Stmt>>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Box < Str > >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_str(&mut self, node: &Option<Box<Str>>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Box < Str > >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_str(&mut self, node: &Option<Box<Str>>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < TruePlusMinus >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_true_plus_minus(&mut self, node: &Option<TruePlusMinus>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < TruePlusMinus >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_true_plus_minus(&mut self, node: &Option<TruePlusMinus>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < TsEntityName >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_ts_entity_name(&mut self, node: &Option<TsEntityName>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < TsEntityName >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_ts_entity_name(&mut self, node: &Option<TsEntityName>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < TsImportCallOptions >` before visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_ts_import_call_options(
+        &mut self,
+        node: &Option<TsImportCallOptions>,
+        ctx: &mut C,
+    ) {
+    }
+    #[doc = "Called when exiting a node of type `Option < TsImportCallOptions >` after visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_ts_import_call_options(&mut self, node: &Option<TsImportCallOptions>, ctx: &mut C) {
+    }
+    #[doc = "Called when entering a node of type `Option < TsNamespaceBody >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_ts_namespace_body(&mut self, node: &Option<TsNamespaceBody>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < TsNamespaceBody >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_ts_namespace_body(&mut self, node: &Option<TsNamespaceBody>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Box < TsType > >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_ts_type(&mut self, node: &Option<Box<TsType>>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Box < TsType > >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_ts_type(&mut self, node: &Option<Box<TsType>>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Box < TsTypeAnn > >` before visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_ts_type_ann(&mut self, node: &Option<Box<TsTypeAnn>>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Box < TsTypeAnn > >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_ts_type_ann(&mut self, node: &Option<Box<TsTypeAnn>>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Box < TsTypeParamDecl > >` before \
+             visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_ts_type_param_decl(&mut self, node: &Option<Box<TsTypeParamDecl>>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < Box < TsTypeParamDecl > >` after \
+             visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_ts_type_param_decl(&mut self, node: &Option<Box<TsTypeParamDecl>>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < Box < TsTypeParamInstantiation > >` \
+             before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_ts_type_param_instantiation(
+        &mut self,
+        node: &Option<Box<TsTypeParamInstantiation>>,
+        ctx: &mut C,
+    ) {
+    }
+    #[doc = "Called when exiting a node of type `Option < Box < TsTypeParamInstantiation > >` \
+             after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_ts_type_param_instantiation(
+        &mut self,
+        node: &Option<Box<TsTypeParamInstantiation>>,
+        ctx: &mut C,
+    ) {
+    }
+    #[doc = "Called when entering a node of type `Option < VarDeclOrExpr >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_var_decl_or_expr(&mut self, node: &Option<VarDeclOrExpr>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < VarDeclOrExpr >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_var_decl_or_expr(&mut self, node: &Option<VarDeclOrExpr>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < Option < ExprOrSpread > >` before visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_vec_expr_or_spreads(&mut self, node: &[Option<ExprOrSpread>], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < Option < ExprOrSpread > >` after visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_vec_expr_or_spreads(&mut self, node: &[Option<ExprOrSpread>], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < Option < Pat > >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_vec_pats(&mut self, node: &[Option<Pat>], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < Option < Pat > >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_vec_pats(&mut self, node: &[Option<Pat>], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Option < swc_atoms :: Wtf8Atom >` before \
+             visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_opt_wtf_8_atom(&mut self, node: &Option<swc_atoms::Wtf8Atom>, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Option < swc_atoms :: Wtf8Atom >` after visiting \
+             its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_opt_wtf_8_atom(&mut self, node: &Option<swc_atoms::Wtf8Atom>, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Param` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_param(&mut self, node: &Param, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Param` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_param(&mut self, node: &Param, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ParamOrTsParamProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_param_or_ts_param_prop(&mut self, node: &ParamOrTsParamProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ParamOrTsParamProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_param_or_ts_param_prop(&mut self, node: &ParamOrTsParamProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < ParamOrTsParamProp >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_param_or_ts_param_props(&mut self, node: &[ParamOrTsParamProp], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < ParamOrTsParamProp >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_param_or_ts_param_props(&mut self, node: &[ParamOrTsParamProp], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < Param >` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_params(&mut self, node: &[Param], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < Param >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_params(&mut self, node: &[Param], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ParenExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_paren_expr(&mut self, node: &ParenExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ParenExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_paren_expr(&mut self, node: &ParenExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Pat` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_pat(&mut self, node: &Pat, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Pat` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_pat(&mut self, node: &Pat, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < Pat >` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_pats(&mut self, node: &[Pat], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < Pat >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_pats(&mut self, node: &[Pat], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `PrivateMethod` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_private_method(&mut self, node: &PrivateMethod, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `PrivateMethod` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_private_method(&mut self, node: &PrivateMethod, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `PrivateName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_private_name(&mut self, node: &PrivateName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `PrivateName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_private_name(&mut self, node: &PrivateName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `PrivateProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_private_prop(&mut self, node: &PrivateProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `PrivateProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_private_prop(&mut self, node: &PrivateProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Program` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_program(&mut self, node: &Program, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Program` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_program(&mut self, node: &Program, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Prop` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_prop(&mut self, node: &Prop, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Prop` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_prop(&mut self, node: &Prop, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `PropName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_prop_name(&mut self, node: &PropName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `PropName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_prop_name(&mut self, node: &PropName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `PropOrSpread` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_prop_or_spread(&mut self, node: &PropOrSpread, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `PropOrSpread` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_prop_or_spread(&mut self, node: &PropOrSpread, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < PropOrSpread >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_prop_or_spreads(&mut self, node: &[PropOrSpread], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < PropOrSpread >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_prop_or_spreads(&mut self, node: &[PropOrSpread], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Regex` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_regex(&mut self, node: &Regex, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Regex` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_regex(&mut self, node: &Regex, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `RestPat` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_rest_pat(&mut self, node: &RestPat, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `RestPat` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_rest_pat(&mut self, node: &RestPat, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ReturnStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_return_stmt(&mut self, node: &ReturnStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ReturnStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_return_stmt(&mut self, node: &ReturnStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Script` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_script(&mut self, node: &Script, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Script` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_script(&mut self, node: &Script, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `SeqExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_seq_expr(&mut self, node: &SeqExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `SeqExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_seq_expr(&mut self, node: &SeqExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `SetterProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_setter_prop(&mut self, node: &SetterProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `SetterProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_setter_prop(&mut self, node: &SetterProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `SimpleAssignTarget` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_simple_assign_target(&mut self, node: &SimpleAssignTarget, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `SimpleAssignTarget` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_simple_assign_target(&mut self, node: &SimpleAssignTarget, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `swc_common :: Span` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_span(&mut self, node: &swc_common::Span, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `swc_common :: Span` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_span(&mut self, node: &swc_common::Span, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `SpreadElement` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_spread_element(&mut self, node: &SpreadElement, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `SpreadElement` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_spread_element(&mut self, node: &SpreadElement, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `StaticBlock` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_static_block(&mut self, node: &StaticBlock, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `StaticBlock` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_static_block(&mut self, node: &StaticBlock, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Stmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_stmt(&mut self, node: &Stmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Stmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_stmt(&mut self, node: &Stmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < Stmt >` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_stmts(&mut self, node: &[Stmt], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < Stmt >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_stmts(&mut self, node: &[Stmt], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Str` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_str(&mut self, node: &Str, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Str` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_str(&mut self, node: &Str, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Super` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_super(&mut self, node: &Super, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Super` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_super(&mut self, node: &Super, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `SuperProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_super_prop(&mut self, node: &SuperProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `SuperProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_super_prop(&mut self, node: &SuperProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `SuperPropExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_super_prop_expr(&mut self, node: &SuperPropExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `SuperPropExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_super_prop_expr(&mut self, node: &SuperPropExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `SwitchCase` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_switch_case(&mut self, node: &SwitchCase, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `SwitchCase` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_switch_case(&mut self, node: &SwitchCase, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < SwitchCase >` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_switch_cases(&mut self, node: &[SwitchCase], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < SwitchCase >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_switch_cases(&mut self, node: &[SwitchCase], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `SwitchStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_switch_stmt(&mut self, node: &SwitchStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `SwitchStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_switch_stmt(&mut self, node: &SwitchStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `swc_common :: SyntaxContext` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_syntax_context(&mut self, node: &swc_common::SyntaxContext, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `swc_common :: SyntaxContext` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_syntax_context(&mut self, node: &swc_common::SyntaxContext, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TaggedTpl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_tagged_tpl(&mut self, node: &TaggedTpl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TaggedTpl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_tagged_tpl(&mut self, node: &TaggedTpl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ThisExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_this_expr(&mut self, node: &ThisExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ThisExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_this_expr(&mut self, node: &ThisExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `ThrowStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_throw_stmt(&mut self, node: &ThrowStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `ThrowStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_throw_stmt(&mut self, node: &ThrowStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Tpl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_tpl(&mut self, node: &Tpl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Tpl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_tpl(&mut self, node: &Tpl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TplElement` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_tpl_element(&mut self, node: &TplElement, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TplElement` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_tpl_element(&mut self, node: &TplElement, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < TplElement >` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_tpl_elements(&mut self, node: &[TplElement], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < TplElement >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_tpl_elements(&mut self, node: &[TplElement], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TruePlusMinus` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_true_plus_minus(&mut self, node: &TruePlusMinus, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TruePlusMinus` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_true_plus_minus(&mut self, node: &TruePlusMinus, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TryStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_try_stmt(&mut self, node: &TryStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TryStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_try_stmt(&mut self, node: &TryStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsArrayType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_array_type(&mut self, node: &TsArrayType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsArrayType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_array_type(&mut self, node: &TsArrayType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsAsExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_as_expr(&mut self, node: &TsAsExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsAsExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_as_expr(&mut self, node: &TsAsExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsCallSignatureDecl` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_call_signature_decl(&mut self, node: &TsCallSignatureDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsCallSignatureDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_call_signature_decl(&mut self, node: &TsCallSignatureDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsConditionalType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_conditional_type(&mut self, node: &TsConditionalType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsConditionalType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_conditional_type(&mut self, node: &TsConditionalType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsConstAssertion` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_const_assertion(&mut self, node: &TsConstAssertion, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsConstAssertion` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_const_assertion(&mut self, node: &TsConstAssertion, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsConstructSignatureDecl` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_construct_signature_decl(&mut self, node: &TsConstructSignatureDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsConstructSignatureDecl` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_construct_signature_decl(&mut self, node: &TsConstructSignatureDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsConstructorType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_constructor_type(&mut self, node: &TsConstructorType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsConstructorType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_constructor_type(&mut self, node: &TsConstructorType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsEntityName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_entity_name(&mut self, node: &TsEntityName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsEntityName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_entity_name(&mut self, node: &TsEntityName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsEnumDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_enum_decl(&mut self, node: &TsEnumDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsEnumDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_enum_decl(&mut self, node: &TsEnumDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsEnumMember` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_enum_member(&mut self, node: &TsEnumMember, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsEnumMember` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_enum_member(&mut self, node: &TsEnumMember, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsEnumMemberId` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_enum_member_id(&mut self, node: &TsEnumMemberId, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsEnumMemberId` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_enum_member_id(&mut self, node: &TsEnumMemberId, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < TsEnumMember >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_enum_members(&mut self, node: &[TsEnumMember], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < TsEnumMember >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_enum_members(&mut self, node: &[TsEnumMember], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsExportAssignment` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_export_assignment(&mut self, node: &TsExportAssignment, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsExportAssignment` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_export_assignment(&mut self, node: &TsExportAssignment, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsExprWithTypeArgs` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_expr_with_type_args(&mut self, node: &TsExprWithTypeArgs, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsExprWithTypeArgs` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_expr_with_type_args(&mut self, node: &TsExprWithTypeArgs, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < TsExprWithTypeArgs >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_expr_with_type_argss(&mut self, node: &[TsExprWithTypeArgs], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < TsExprWithTypeArgs >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_expr_with_type_argss(&mut self, node: &[TsExprWithTypeArgs], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsExternalModuleRef` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_external_module_ref(&mut self, node: &TsExternalModuleRef, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsExternalModuleRef` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_external_module_ref(&mut self, node: &TsExternalModuleRef, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsFnOrConstructorType` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_fn_or_constructor_type(&mut self, node: &TsFnOrConstructorType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsFnOrConstructorType` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_fn_or_constructor_type(&mut self, node: &TsFnOrConstructorType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsFnParam` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_fn_param(&mut self, node: &TsFnParam, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsFnParam` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_fn_param(&mut self, node: &TsFnParam, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < TsFnParam >` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_fn_params(&mut self, node: &[TsFnParam], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < TsFnParam >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_fn_params(&mut self, node: &[TsFnParam], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsFnType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_fn_type(&mut self, node: &TsFnType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsFnType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_fn_type(&mut self, node: &TsFnType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsGetterSignature` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_getter_signature(&mut self, node: &TsGetterSignature, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsGetterSignature` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_getter_signature(&mut self, node: &TsGetterSignature, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsImportCallOptions` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_import_call_options(&mut self, node: &TsImportCallOptions, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsImportCallOptions` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_import_call_options(&mut self, node: &TsImportCallOptions, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsImportEqualsDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_import_equals_decl(&mut self, node: &TsImportEqualsDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsImportEqualsDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_import_equals_decl(&mut self, node: &TsImportEqualsDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsImportType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_import_type(&mut self, node: &TsImportType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsImportType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_import_type(&mut self, node: &TsImportType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsIndexSignature` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_index_signature(&mut self, node: &TsIndexSignature, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsIndexSignature` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_index_signature(&mut self, node: &TsIndexSignature, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsIndexedAccessType` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_indexed_access_type(&mut self, node: &TsIndexedAccessType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsIndexedAccessType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_indexed_access_type(&mut self, node: &TsIndexedAccessType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsInferType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_infer_type(&mut self, node: &TsInferType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsInferType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_infer_type(&mut self, node: &TsInferType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsInstantiation` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_instantiation(&mut self, node: &TsInstantiation, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsInstantiation` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_instantiation(&mut self, node: &TsInstantiation, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsInterfaceBody` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_interface_body(&mut self, node: &TsInterfaceBody, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsInterfaceBody` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_interface_body(&mut self, node: &TsInterfaceBody, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsInterfaceDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_interface_decl(&mut self, node: &TsInterfaceDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsInterfaceDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_interface_decl(&mut self, node: &TsInterfaceDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsIntersectionType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_intersection_type(&mut self, node: &TsIntersectionType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsIntersectionType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_intersection_type(&mut self, node: &TsIntersectionType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsKeywordType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_keyword_type(&mut self, node: &TsKeywordType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsKeywordType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_keyword_type(&mut self, node: &TsKeywordType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsKeywordTypeKind` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_keyword_type_kind(&mut self, node: &TsKeywordTypeKind, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsKeywordTypeKind` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_keyword_type_kind(&mut self, node: &TsKeywordTypeKind, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsLit` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_lit(&mut self, node: &TsLit, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsLit` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_lit(&mut self, node: &TsLit, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsLitType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_lit_type(&mut self, node: &TsLitType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsLitType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_lit_type(&mut self, node: &TsLitType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsMappedType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_mapped_type(&mut self, node: &TsMappedType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsMappedType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_mapped_type(&mut self, node: &TsMappedType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsMethodSignature` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_method_signature(&mut self, node: &TsMethodSignature, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsMethodSignature` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_method_signature(&mut self, node: &TsMethodSignature, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsModuleBlock` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_module_block(&mut self, node: &TsModuleBlock, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsModuleBlock` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_module_block(&mut self, node: &TsModuleBlock, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsModuleDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_module_decl(&mut self, node: &TsModuleDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsModuleDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_module_decl(&mut self, node: &TsModuleDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsModuleName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_module_name(&mut self, node: &TsModuleName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsModuleName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_module_name(&mut self, node: &TsModuleName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsModuleRef` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_module_ref(&mut self, node: &TsModuleRef, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsModuleRef` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_module_ref(&mut self, node: &TsModuleRef, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsNamespaceBody` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_namespace_body(&mut self, node: &TsNamespaceBody, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsNamespaceBody` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_namespace_body(&mut self, node: &TsNamespaceBody, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsNamespaceDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_namespace_decl(&mut self, node: &TsNamespaceDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsNamespaceDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_namespace_decl(&mut self, node: &TsNamespaceDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsNamespaceExportDecl` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_namespace_export_decl(&mut self, node: &TsNamespaceExportDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsNamespaceExportDecl` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_namespace_export_decl(&mut self, node: &TsNamespaceExportDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsNonNullExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_non_null_expr(&mut self, node: &TsNonNullExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsNonNullExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_non_null_expr(&mut self, node: &TsNonNullExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsOptionalType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_optional_type(&mut self, node: &TsOptionalType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsOptionalType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_optional_type(&mut self, node: &TsOptionalType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsParamProp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_param_prop(&mut self, node: &TsParamProp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsParamProp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_param_prop(&mut self, node: &TsParamProp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsParamPropParam` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_param_prop_param(&mut self, node: &TsParamPropParam, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsParamPropParam` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_param_prop_param(&mut self, node: &TsParamPropParam, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsParenthesizedType` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_parenthesized_type(&mut self, node: &TsParenthesizedType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsParenthesizedType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_parenthesized_type(&mut self, node: &TsParenthesizedType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsPropertySignature` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_property_signature(&mut self, node: &TsPropertySignature, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsPropertySignature` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_property_signature(&mut self, node: &TsPropertySignature, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsQualifiedName` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_qualified_name(&mut self, node: &TsQualifiedName, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsQualifiedName` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_qualified_name(&mut self, node: &TsQualifiedName, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsRestType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_rest_type(&mut self, node: &TsRestType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsRestType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_rest_type(&mut self, node: &TsRestType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsSatisfiesExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_satisfies_expr(&mut self, node: &TsSatisfiesExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsSatisfiesExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_satisfies_expr(&mut self, node: &TsSatisfiesExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsSetterSignature` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_setter_signature(&mut self, node: &TsSetterSignature, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsSetterSignature` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_setter_signature(&mut self, node: &TsSetterSignature, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsThisType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_this_type(&mut self, node: &TsThisType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsThisType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_this_type(&mut self, node: &TsThisType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsThisTypeOrIdent` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_this_type_or_ident(&mut self, node: &TsThisTypeOrIdent, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsThisTypeOrIdent` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_this_type_or_ident(&mut self, node: &TsThisTypeOrIdent, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTplLitType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_tpl_lit_type(&mut self, node: &TsTplLitType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTplLitType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_tpl_lit_type(&mut self, node: &TsTplLitType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTupleElement` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_tuple_element(&mut self, node: &TsTupleElement, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTupleElement` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_tuple_element(&mut self, node: &TsTupleElement, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < TsTupleElement >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_tuple_elements(&mut self, node: &[TsTupleElement], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < TsTupleElement >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_tuple_elements(&mut self, node: &[TsTupleElement], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTupleType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_tuple_type(&mut self, node: &TsTupleType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTupleType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_tuple_type(&mut self, node: &TsTupleType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type(&mut self, node: &TsType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type(&mut self, node: &TsType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeAliasDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_alias_decl(&mut self, node: &TsTypeAliasDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeAliasDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_alias_decl(&mut self, node: &TsTypeAliasDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeAnn` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_ann(&mut self, node: &TsTypeAnn, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeAnn` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_ann(&mut self, node: &TsTypeAnn, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeAssertion` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_assertion(&mut self, node: &TsTypeAssertion, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeAssertion` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_assertion(&mut self, node: &TsTypeAssertion, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeElement` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_element(&mut self, node: &TsTypeElement, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeElement` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_element(&mut self, node: &TsTypeElement, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < TsTypeElement >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_elements(&mut self, node: &[TsTypeElement], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < TsTypeElement >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_elements(&mut self, node: &[TsTypeElement], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeLit` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_lit(&mut self, node: &TsTypeLit, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeLit` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_lit(&mut self, node: &TsTypeLit, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeOperator` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_operator(&mut self, node: &TsTypeOperator, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeOperator` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_operator(&mut self, node: &TsTypeOperator, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeOperatorOp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_operator_op(&mut self, node: &TsTypeOperatorOp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeOperatorOp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_operator_op(&mut self, node: &TsTypeOperatorOp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeParam` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_param(&mut self, node: &TsTypeParam, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeParam` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_param(&mut self, node: &TsTypeParam, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeParamDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_param_decl(&mut self, node: &TsTypeParamDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeParamDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_param_decl(&mut self, node: &TsTypeParamDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeParamInstantiation` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_param_instantiation(&mut self, node: &TsTypeParamInstantiation, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeParamInstantiation` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_param_instantiation(&mut self, node: &TsTypeParamInstantiation, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < TsTypeParam >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_params(&mut self, node: &[TsTypeParam], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < TsTypeParam >` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_params(&mut self, node: &[TsTypeParam], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypePredicate` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_predicate(&mut self, node: &TsTypePredicate, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypePredicate` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_predicate(&mut self, node: &TsTypePredicate, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeQuery` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_query(&mut self, node: &TsTypeQuery, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeQuery` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_query(&mut self, node: &TsTypeQuery, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeQueryExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_query_expr(&mut self, node: &TsTypeQueryExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeQueryExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_query_expr(&mut self, node: &TsTypeQueryExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsTypeRef` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_type_ref(&mut self, node: &TsTypeRef, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsTypeRef` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_type_ref(&mut self, node: &TsTypeRef, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < Box < TsType > >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_types(&mut self, node: &[Box<TsType>], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < Box < TsType > >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_types(&mut self, node: &[Box<TsType>], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `TsUnionOrIntersectionType` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_union_or_intersection_type(
+        &mut self,
+        node: &TsUnionOrIntersectionType,
+        ctx: &mut C,
+    ) {
+    }
+    #[doc = "Called when exiting a node of type `TsUnionOrIntersectionType` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_union_or_intersection_type(
+        &mut self,
+        node: &TsUnionOrIntersectionType,
+        ctx: &mut C,
+    ) {
+    }
+    #[doc = "Called when entering a node of type `TsUnionType` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_ts_union_type(&mut self, node: &TsUnionType, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `TsUnionType` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_ts_union_type(&mut self, node: &TsUnionType, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `UnaryExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_unary_expr(&mut self, node: &UnaryExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `UnaryExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_unary_expr(&mut self, node: &UnaryExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `UnaryOp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_unary_op(&mut self, node: &UnaryOp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `UnaryOp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_unary_op(&mut self, node: &UnaryOp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `UpdateExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_update_expr(&mut self, node: &UpdateExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `UpdateExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_update_expr(&mut self, node: &UpdateExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `UpdateOp` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_update_op(&mut self, node: &UpdateOp, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `UpdateOp` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_update_op(&mut self, node: &UpdateOp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `UsingDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_using_decl(&mut self, node: &UsingDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `UsingDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_using_decl(&mut self, node: &UsingDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `VarDecl` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_var_decl(&mut self, node: &VarDecl, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `VarDecl` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_var_decl(&mut self, node: &VarDecl, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `VarDeclKind` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_var_decl_kind(&mut self, node: &VarDeclKind, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `VarDeclKind` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_var_decl_kind(&mut self, node: &VarDeclKind, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `VarDeclOrExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_var_decl_or_expr(&mut self, node: &VarDeclOrExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `VarDeclOrExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_var_decl_or_expr(&mut self, node: &VarDeclOrExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `VarDeclarator` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_var_declarator(&mut self, node: &VarDeclarator, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `VarDeclarator` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_var_declarator(&mut self, node: &VarDeclarator, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `Vec < VarDeclarator >` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_var_declarators(&mut self, node: &[VarDeclarator], ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `Vec < VarDeclarator >` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_var_declarators(&mut self, node: &[VarDeclarator], ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `WhileStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_while_stmt(&mut self, node: &WhileStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `WhileStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_while_stmt(&mut self, node: &WhileStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `WithStmt` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_with_stmt(&mut self, node: &WithStmt, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `WithStmt` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_with_stmt(&mut self, node: &WithStmt, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `swc_atoms :: Wtf8Atom` before visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_wtf_8_atom(&mut self, node: &swc_atoms::Wtf8Atom, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `swc_atoms :: Wtf8Atom` after visiting its \
+             children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_wtf_8_atom(&mut self, node: &swc_atoms::Wtf8Atom, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `YieldExpr` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_yield_expr(&mut self, node: &YieldExpr, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `YieldExpr` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_yield_expr(&mut self, node: &YieldExpr, ctx: &mut C) {}
+}
+#[doc = r" A composable hook that combines two hooks (immutable version)."]
+#[doc = r""]
+#[doc = r" Executes hooks in nested order:"]
+#[doc = r" - Enter: first.enter -> second.enter"]
+#[doc = r" - Exit: second.exit -> first.exit"]
+pub struct CompositeVisitHook<A, B> {
+    pub first: A,
+    pub second: B,
+}
+impl<A, B, C> VisitHook<C> for CompositeVisitHook<A, B>
+where
+    A: VisitHook<C>,
+    B: VisitHook<C>,
+{
+    #[inline]
+    fn enter_accessibility(&mut self, node: &Accessibility, ctx: &mut C) {
+        self.first.enter_accessibility(node, ctx);
+        self.second.enter_accessibility(node, ctx);
+    }
+
+    #[inline]
+    fn exit_accessibility(&mut self, node: &Accessibility, ctx: &mut C) {
+        self.second.exit_accessibility(node, ctx);
+        self.first.exit_accessibility(node, ctx);
+    }
+
+    #[inline]
+    fn enter_array_lit(&mut self, node: &ArrayLit, ctx: &mut C) {
+        self.first.enter_array_lit(node, ctx);
+        self.second.enter_array_lit(node, ctx);
+    }
+
+    #[inline]
+    fn exit_array_lit(&mut self, node: &ArrayLit, ctx: &mut C) {
+        self.second.exit_array_lit(node, ctx);
+        self.first.exit_array_lit(node, ctx);
+    }
+
+    #[inline]
+    fn enter_array_pat(&mut self, node: &ArrayPat, ctx: &mut C) {
+        self.first.enter_array_pat(node, ctx);
+        self.second.enter_array_pat(node, ctx);
+    }
+
+    #[inline]
+    fn exit_array_pat(&mut self, node: &ArrayPat, ctx: &mut C) {
+        self.second.exit_array_pat(node, ctx);
+        self.first.exit_array_pat(node, ctx);
+    }
+
+    #[inline]
+    fn enter_arrow_expr(&mut self, node: &ArrowExpr, ctx: &mut C) {
+        self.first.enter_arrow_expr(node, ctx);
+        self.second.enter_arrow_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_arrow_expr(&mut self, node: &ArrowExpr, ctx: &mut C) {
+        self.second.exit_arrow_expr(node, ctx);
+        self.first.exit_arrow_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_assign_expr(&mut self, node: &AssignExpr, ctx: &mut C) {
+        self.first.enter_assign_expr(node, ctx);
+        self.second.enter_assign_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_assign_expr(&mut self, node: &AssignExpr, ctx: &mut C) {
+        self.second.exit_assign_expr(node, ctx);
+        self.first.exit_assign_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_assign_op(&mut self, node: &AssignOp, ctx: &mut C) {
+        self.first.enter_assign_op(node, ctx);
+        self.second.enter_assign_op(node, ctx);
+    }
+
+    #[inline]
+    fn exit_assign_op(&mut self, node: &AssignOp, ctx: &mut C) {
+        self.second.exit_assign_op(node, ctx);
+        self.first.exit_assign_op(node, ctx);
+    }
+
+    #[inline]
+    fn enter_assign_pat(&mut self, node: &AssignPat, ctx: &mut C) {
+        self.first.enter_assign_pat(node, ctx);
+        self.second.enter_assign_pat(node, ctx);
+    }
+
+    #[inline]
+    fn exit_assign_pat(&mut self, node: &AssignPat, ctx: &mut C) {
+        self.second.exit_assign_pat(node, ctx);
+        self.first.exit_assign_pat(node, ctx);
+    }
+
+    #[inline]
+    fn enter_assign_pat_prop(&mut self, node: &AssignPatProp, ctx: &mut C) {
+        self.first.enter_assign_pat_prop(node, ctx);
+        self.second.enter_assign_pat_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_assign_pat_prop(&mut self, node: &AssignPatProp, ctx: &mut C) {
+        self.second.exit_assign_pat_prop(node, ctx);
+        self.first.exit_assign_pat_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_assign_prop(&mut self, node: &AssignProp, ctx: &mut C) {
+        self.first.enter_assign_prop(node, ctx);
+        self.second.enter_assign_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_assign_prop(&mut self, node: &AssignProp, ctx: &mut C) {
+        self.second.exit_assign_prop(node, ctx);
+        self.first.exit_assign_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_assign_target(&mut self, node: &AssignTarget, ctx: &mut C) {
+        self.first.enter_assign_target(node, ctx);
+        self.second.enter_assign_target(node, ctx);
+    }
+
+    #[inline]
+    fn exit_assign_target(&mut self, node: &AssignTarget, ctx: &mut C) {
+        self.second.exit_assign_target(node, ctx);
+        self.first.exit_assign_target(node, ctx);
+    }
+
+    #[inline]
+    fn enter_assign_target_pat(&mut self, node: &AssignTargetPat, ctx: &mut C) {
+        self.first.enter_assign_target_pat(node, ctx);
+        self.second.enter_assign_target_pat(node, ctx);
+    }
+
+    #[inline]
+    fn exit_assign_target_pat(&mut self, node: &AssignTargetPat, ctx: &mut C) {
+        self.second.exit_assign_target_pat(node, ctx);
+        self.first.exit_assign_target_pat(node, ctx);
+    }
+
+    #[inline]
+    fn enter_atom(&mut self, node: &swc_atoms::Atom, ctx: &mut C) {
+        self.first.enter_atom(node, ctx);
+        self.second.enter_atom(node, ctx);
+    }
+
+    #[inline]
+    fn exit_atom(&mut self, node: &swc_atoms::Atom, ctx: &mut C) {
+        self.second.exit_atom(node, ctx);
+        self.first.exit_atom(node, ctx);
+    }
+
+    #[inline]
+    fn enter_auto_accessor(&mut self, node: &AutoAccessor, ctx: &mut C) {
+        self.first.enter_auto_accessor(node, ctx);
+        self.second.enter_auto_accessor(node, ctx);
+    }
+
+    #[inline]
+    fn exit_auto_accessor(&mut self, node: &AutoAccessor, ctx: &mut C) {
+        self.second.exit_auto_accessor(node, ctx);
+        self.first.exit_auto_accessor(node, ctx);
+    }
+
+    #[inline]
+    fn enter_await_expr(&mut self, node: &AwaitExpr, ctx: &mut C) {
+        self.first.enter_await_expr(node, ctx);
+        self.second.enter_await_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_await_expr(&mut self, node: &AwaitExpr, ctx: &mut C) {
+        self.second.exit_await_expr(node, ctx);
+        self.first.exit_await_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_big_int(&mut self, node: &BigInt, ctx: &mut C) {
+        self.first.enter_big_int(node, ctx);
+        self.second.enter_big_int(node, ctx);
+    }
+
+    #[inline]
+    fn exit_big_int(&mut self, node: &BigInt, ctx: &mut C) {
+        self.second.exit_big_int(node, ctx);
+        self.first.exit_big_int(node, ctx);
+    }
+
+    #[inline]
+    fn enter_big_int_value(&mut self, node: &BigIntValue, ctx: &mut C) {
+        self.first.enter_big_int_value(node, ctx);
+        self.second.enter_big_int_value(node, ctx);
+    }
+
+    #[inline]
+    fn exit_big_int_value(&mut self, node: &BigIntValue, ctx: &mut C) {
+        self.second.exit_big_int_value(node, ctx);
+        self.first.exit_big_int_value(node, ctx);
+    }
+
+    #[inline]
+    fn enter_bin_expr(&mut self, node: &BinExpr, ctx: &mut C) {
+        self.first.enter_bin_expr(node, ctx);
+        self.second.enter_bin_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_bin_expr(&mut self, node: &BinExpr, ctx: &mut C) {
+        self.second.exit_bin_expr(node, ctx);
+        self.first.exit_bin_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_binary_op(&mut self, node: &BinaryOp, ctx: &mut C) {
+        self.first.enter_binary_op(node, ctx);
+        self.second.enter_binary_op(node, ctx);
+    }
+
+    #[inline]
+    fn exit_binary_op(&mut self, node: &BinaryOp, ctx: &mut C) {
+        self.second.exit_binary_op(node, ctx);
+        self.first.exit_binary_op(node, ctx);
+    }
+
+    #[inline]
+    fn enter_binding_ident(&mut self, node: &BindingIdent, ctx: &mut C) {
+        self.first.enter_binding_ident(node, ctx);
+        self.second.enter_binding_ident(node, ctx);
+    }
+
+    #[inline]
+    fn exit_binding_ident(&mut self, node: &BindingIdent, ctx: &mut C) {
+        self.second.exit_binding_ident(node, ctx);
+        self.first.exit_binding_ident(node, ctx);
+    }
+
+    #[inline]
+    fn enter_block_stmt(&mut self, node: &BlockStmt, ctx: &mut C) {
+        self.first.enter_block_stmt(node, ctx);
+        self.second.enter_block_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_block_stmt(&mut self, node: &BlockStmt, ctx: &mut C) {
+        self.second.exit_block_stmt(node, ctx);
+        self.first.exit_block_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_block_stmt_or_expr(&mut self, node: &BlockStmtOrExpr, ctx: &mut C) {
+        self.first.enter_block_stmt_or_expr(node, ctx);
+        self.second.enter_block_stmt_or_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_block_stmt_or_expr(&mut self, node: &BlockStmtOrExpr, ctx: &mut C) {
+        self.second.exit_block_stmt_or_expr(node, ctx);
+        self.first.exit_block_stmt_or_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_bool(&mut self, node: &Bool, ctx: &mut C) {
+        self.first.enter_bool(node, ctx);
+        self.second.enter_bool(node, ctx);
+    }
+
+    #[inline]
+    fn exit_bool(&mut self, node: &Bool, ctx: &mut C) {
+        self.second.exit_bool(node, ctx);
+        self.first.exit_bool(node, ctx);
+    }
+
+    #[inline]
+    fn enter_break_stmt(&mut self, node: &BreakStmt, ctx: &mut C) {
+        self.first.enter_break_stmt(node, ctx);
+        self.second.enter_break_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_break_stmt(&mut self, node: &BreakStmt, ctx: &mut C) {
+        self.second.exit_break_stmt(node, ctx);
+        self.first.exit_break_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_call_expr(&mut self, node: &CallExpr, ctx: &mut C) {
+        self.first.enter_call_expr(node, ctx);
+        self.second.enter_call_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_call_expr(&mut self, node: &CallExpr, ctx: &mut C) {
+        self.second.exit_call_expr(node, ctx);
+        self.first.exit_call_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_callee(&mut self, node: &Callee, ctx: &mut C) {
+        self.first.enter_callee(node, ctx);
+        self.second.enter_callee(node, ctx);
+    }
+
+    #[inline]
+    fn exit_callee(&mut self, node: &Callee, ctx: &mut C) {
+        self.second.exit_callee(node, ctx);
+        self.first.exit_callee(node, ctx);
+    }
+
+    #[inline]
+    fn enter_catch_clause(&mut self, node: &CatchClause, ctx: &mut C) {
+        self.first.enter_catch_clause(node, ctx);
+        self.second.enter_catch_clause(node, ctx);
+    }
+
+    #[inline]
+    fn exit_catch_clause(&mut self, node: &CatchClause, ctx: &mut C) {
+        self.second.exit_catch_clause(node, ctx);
+        self.first.exit_catch_clause(node, ctx);
+    }
+
+    #[inline]
+    fn enter_class(&mut self, node: &Class, ctx: &mut C) {
+        self.first.enter_class(node, ctx);
+        self.second.enter_class(node, ctx);
+    }
+
+    #[inline]
+    fn exit_class(&mut self, node: &Class, ctx: &mut C) {
+        self.second.exit_class(node, ctx);
+        self.first.exit_class(node, ctx);
+    }
+
+    #[inline]
+    fn enter_class_decl(&mut self, node: &ClassDecl, ctx: &mut C) {
+        self.first.enter_class_decl(node, ctx);
+        self.second.enter_class_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_class_decl(&mut self, node: &ClassDecl, ctx: &mut C) {
+        self.second.exit_class_decl(node, ctx);
+        self.first.exit_class_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_class_expr(&mut self, node: &ClassExpr, ctx: &mut C) {
+        self.first.enter_class_expr(node, ctx);
+        self.second.enter_class_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_class_expr(&mut self, node: &ClassExpr, ctx: &mut C) {
+        self.second.exit_class_expr(node, ctx);
+        self.first.exit_class_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_class_member(&mut self, node: &ClassMember, ctx: &mut C) {
+        self.first.enter_class_member(node, ctx);
+        self.second.enter_class_member(node, ctx);
+    }
+
+    #[inline]
+    fn exit_class_member(&mut self, node: &ClassMember, ctx: &mut C) {
+        self.second.exit_class_member(node, ctx);
+        self.first.exit_class_member(node, ctx);
+    }
+
+    #[inline]
+    fn enter_class_members(&mut self, node: &[ClassMember], ctx: &mut C) {
+        self.first.enter_class_members(node, ctx);
+        self.second.enter_class_members(node, ctx);
+    }
+
+    #[inline]
+    fn exit_class_members(&mut self, node: &[ClassMember], ctx: &mut C) {
+        self.second.exit_class_members(node, ctx);
+        self.first.exit_class_members(node, ctx);
+    }
+
+    #[inline]
+    fn enter_class_method(&mut self, node: &ClassMethod, ctx: &mut C) {
+        self.first.enter_class_method(node, ctx);
+        self.second.enter_class_method(node, ctx);
+    }
+
+    #[inline]
+    fn exit_class_method(&mut self, node: &ClassMethod, ctx: &mut C) {
+        self.second.exit_class_method(node, ctx);
+        self.first.exit_class_method(node, ctx);
+    }
+
+    #[inline]
+    fn enter_class_prop(&mut self, node: &ClassProp, ctx: &mut C) {
+        self.first.enter_class_prop(node, ctx);
+        self.second.enter_class_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_class_prop(&mut self, node: &ClassProp, ctx: &mut C) {
+        self.second.exit_class_prop(node, ctx);
+        self.first.exit_class_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_computed_prop_name(&mut self, node: &ComputedPropName, ctx: &mut C) {
+        self.first.enter_computed_prop_name(node, ctx);
+        self.second.enter_computed_prop_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_computed_prop_name(&mut self, node: &ComputedPropName, ctx: &mut C) {
+        self.second.exit_computed_prop_name(node, ctx);
+        self.first.exit_computed_prop_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_cond_expr(&mut self, node: &CondExpr, ctx: &mut C) {
+        self.first.enter_cond_expr(node, ctx);
+        self.second.enter_cond_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_cond_expr(&mut self, node: &CondExpr, ctx: &mut C) {
+        self.second.exit_cond_expr(node, ctx);
+        self.first.exit_cond_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_constructor(&mut self, node: &Constructor, ctx: &mut C) {
+        self.first.enter_constructor(node, ctx);
+        self.second.enter_constructor(node, ctx);
+    }
+
+    #[inline]
+    fn exit_constructor(&mut self, node: &Constructor, ctx: &mut C) {
+        self.second.exit_constructor(node, ctx);
+        self.first.exit_constructor(node, ctx);
+    }
+
+    #[inline]
+    fn enter_continue_stmt(&mut self, node: &ContinueStmt, ctx: &mut C) {
+        self.first.enter_continue_stmt(node, ctx);
+        self.second.enter_continue_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_continue_stmt(&mut self, node: &ContinueStmt, ctx: &mut C) {
+        self.second.exit_continue_stmt(node, ctx);
+        self.first.exit_continue_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_debugger_stmt(&mut self, node: &DebuggerStmt, ctx: &mut C) {
+        self.first.enter_debugger_stmt(node, ctx);
+        self.second.enter_debugger_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_debugger_stmt(&mut self, node: &DebuggerStmt, ctx: &mut C) {
+        self.second.exit_debugger_stmt(node, ctx);
+        self.first.exit_debugger_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_decl(&mut self, node: &Decl, ctx: &mut C) {
+        self.first.enter_decl(node, ctx);
+        self.second.enter_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_decl(&mut self, node: &Decl, ctx: &mut C) {
+        self.second.exit_decl(node, ctx);
+        self.first.exit_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_decorator(&mut self, node: &Decorator, ctx: &mut C) {
+        self.first.enter_decorator(node, ctx);
+        self.second.enter_decorator(node, ctx);
+    }
+
+    #[inline]
+    fn exit_decorator(&mut self, node: &Decorator, ctx: &mut C) {
+        self.second.exit_decorator(node, ctx);
+        self.first.exit_decorator(node, ctx);
+    }
+
+    #[inline]
+    fn enter_decorators(&mut self, node: &[Decorator], ctx: &mut C) {
+        self.first.enter_decorators(node, ctx);
+        self.second.enter_decorators(node, ctx);
+    }
+
+    #[inline]
+    fn exit_decorators(&mut self, node: &[Decorator], ctx: &mut C) {
+        self.second.exit_decorators(node, ctx);
+        self.first.exit_decorators(node, ctx);
+    }
+
+    #[inline]
+    fn enter_default_decl(&mut self, node: &DefaultDecl, ctx: &mut C) {
+        self.first.enter_default_decl(node, ctx);
+        self.second.enter_default_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_default_decl(&mut self, node: &DefaultDecl, ctx: &mut C) {
+        self.second.exit_default_decl(node, ctx);
+        self.first.exit_default_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_do_while_stmt(&mut self, node: &DoWhileStmt, ctx: &mut C) {
+        self.first.enter_do_while_stmt(node, ctx);
+        self.second.enter_do_while_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_do_while_stmt(&mut self, node: &DoWhileStmt, ctx: &mut C) {
+        self.second.exit_do_while_stmt(node, ctx);
+        self.first.exit_do_while_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_empty_stmt(&mut self, node: &EmptyStmt, ctx: &mut C) {
+        self.first.enter_empty_stmt(node, ctx);
+        self.second.enter_empty_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_empty_stmt(&mut self, node: &EmptyStmt, ctx: &mut C) {
+        self.second.exit_empty_stmt(node, ctx);
+        self.first.exit_empty_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_export_all(&mut self, node: &ExportAll, ctx: &mut C) {
+        self.first.enter_export_all(node, ctx);
+        self.second.enter_export_all(node, ctx);
+    }
+
+    #[inline]
+    fn exit_export_all(&mut self, node: &ExportAll, ctx: &mut C) {
+        self.second.exit_export_all(node, ctx);
+        self.first.exit_export_all(node, ctx);
+    }
+
+    #[inline]
+    fn enter_export_decl(&mut self, node: &ExportDecl, ctx: &mut C) {
+        self.first.enter_export_decl(node, ctx);
+        self.second.enter_export_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_export_decl(&mut self, node: &ExportDecl, ctx: &mut C) {
+        self.second.exit_export_decl(node, ctx);
+        self.first.exit_export_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_export_default_decl(&mut self, node: &ExportDefaultDecl, ctx: &mut C) {
+        self.first.enter_export_default_decl(node, ctx);
+        self.second.enter_export_default_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_export_default_decl(&mut self, node: &ExportDefaultDecl, ctx: &mut C) {
+        self.second.exit_export_default_decl(node, ctx);
+        self.first.exit_export_default_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_export_default_expr(&mut self, node: &ExportDefaultExpr, ctx: &mut C) {
+        self.first.enter_export_default_expr(node, ctx);
+        self.second.enter_export_default_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_export_default_expr(&mut self, node: &ExportDefaultExpr, ctx: &mut C) {
+        self.second.exit_export_default_expr(node, ctx);
+        self.first.exit_export_default_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_export_default_specifier(&mut self, node: &ExportDefaultSpecifier, ctx: &mut C) {
+        self.first.enter_export_default_specifier(node, ctx);
+        self.second.enter_export_default_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn exit_export_default_specifier(&mut self, node: &ExportDefaultSpecifier, ctx: &mut C) {
+        self.second.exit_export_default_specifier(node, ctx);
+        self.first.exit_export_default_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn enter_export_named_specifier(&mut self, node: &ExportNamedSpecifier, ctx: &mut C) {
+        self.first.enter_export_named_specifier(node, ctx);
+        self.second.enter_export_named_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn exit_export_named_specifier(&mut self, node: &ExportNamedSpecifier, ctx: &mut C) {
+        self.second.exit_export_named_specifier(node, ctx);
+        self.first.exit_export_named_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn enter_export_namespace_specifier(&mut self, node: &ExportNamespaceSpecifier, ctx: &mut C) {
+        self.first.enter_export_namespace_specifier(node, ctx);
+        self.second.enter_export_namespace_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn exit_export_namespace_specifier(&mut self, node: &ExportNamespaceSpecifier, ctx: &mut C) {
+        self.second.exit_export_namespace_specifier(node, ctx);
+        self.first.exit_export_namespace_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn enter_export_specifier(&mut self, node: &ExportSpecifier, ctx: &mut C) {
+        self.first.enter_export_specifier(node, ctx);
+        self.second.enter_export_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn exit_export_specifier(&mut self, node: &ExportSpecifier, ctx: &mut C) {
+        self.second.exit_export_specifier(node, ctx);
+        self.first.exit_export_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn enter_export_specifiers(&mut self, node: &[ExportSpecifier], ctx: &mut C) {
+        self.first.enter_export_specifiers(node, ctx);
+        self.second.enter_export_specifiers(node, ctx);
+    }
+
+    #[inline]
+    fn exit_export_specifiers(&mut self, node: &[ExportSpecifier], ctx: &mut C) {
+        self.second.exit_export_specifiers(node, ctx);
+        self.first.exit_export_specifiers(node, ctx);
+    }
+
+    #[inline]
+    fn enter_expr(&mut self, node: &Expr, ctx: &mut C) {
+        self.first.enter_expr(node, ctx);
+        self.second.enter_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_expr(&mut self, node: &Expr, ctx: &mut C) {
+        self.second.exit_expr(node, ctx);
+        self.first.exit_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_expr_or_spread(&mut self, node: &ExprOrSpread, ctx: &mut C) {
+        self.first.enter_expr_or_spread(node, ctx);
+        self.second.enter_expr_or_spread(node, ctx);
+    }
+
+    #[inline]
+    fn exit_expr_or_spread(&mut self, node: &ExprOrSpread, ctx: &mut C) {
+        self.second.exit_expr_or_spread(node, ctx);
+        self.first.exit_expr_or_spread(node, ctx);
+    }
+
+    #[inline]
+    fn enter_expr_or_spreads(&mut self, node: &[ExprOrSpread], ctx: &mut C) {
+        self.first.enter_expr_or_spreads(node, ctx);
+        self.second.enter_expr_or_spreads(node, ctx);
+    }
+
+    #[inline]
+    fn exit_expr_or_spreads(&mut self, node: &[ExprOrSpread], ctx: &mut C) {
+        self.second.exit_expr_or_spreads(node, ctx);
+        self.first.exit_expr_or_spreads(node, ctx);
+    }
+
+    #[inline]
+    fn enter_expr_stmt(&mut self, node: &ExprStmt, ctx: &mut C) {
+        self.first.enter_expr_stmt(node, ctx);
+        self.second.enter_expr_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_expr_stmt(&mut self, node: &ExprStmt, ctx: &mut C) {
+        self.second.exit_expr_stmt(node, ctx);
+        self.first.exit_expr_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_exprs(&mut self, node: &[Box<Expr>], ctx: &mut C) {
+        self.first.enter_exprs(node, ctx);
+        self.second.enter_exprs(node, ctx);
+    }
+
+    #[inline]
+    fn exit_exprs(&mut self, node: &[Box<Expr>], ctx: &mut C) {
+        self.second.exit_exprs(node, ctx);
+        self.first.exit_exprs(node, ctx);
+    }
+
+    #[inline]
+    fn enter_fn_decl(&mut self, node: &FnDecl, ctx: &mut C) {
+        self.first.enter_fn_decl(node, ctx);
+        self.second.enter_fn_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_fn_decl(&mut self, node: &FnDecl, ctx: &mut C) {
+        self.second.exit_fn_decl(node, ctx);
+        self.first.exit_fn_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_fn_expr(&mut self, node: &FnExpr, ctx: &mut C) {
+        self.first.enter_fn_expr(node, ctx);
+        self.second.enter_fn_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_fn_expr(&mut self, node: &FnExpr, ctx: &mut C) {
+        self.second.exit_fn_expr(node, ctx);
+        self.first.exit_fn_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_for_head(&mut self, node: &ForHead, ctx: &mut C) {
+        self.first.enter_for_head(node, ctx);
+        self.second.enter_for_head(node, ctx);
+    }
+
+    #[inline]
+    fn exit_for_head(&mut self, node: &ForHead, ctx: &mut C) {
+        self.second.exit_for_head(node, ctx);
+        self.first.exit_for_head(node, ctx);
+    }
+
+    #[inline]
+    fn enter_for_in_stmt(&mut self, node: &ForInStmt, ctx: &mut C) {
+        self.first.enter_for_in_stmt(node, ctx);
+        self.second.enter_for_in_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_for_in_stmt(&mut self, node: &ForInStmt, ctx: &mut C) {
+        self.second.exit_for_in_stmt(node, ctx);
+        self.first.exit_for_in_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_for_of_stmt(&mut self, node: &ForOfStmt, ctx: &mut C) {
+        self.first.enter_for_of_stmt(node, ctx);
+        self.second.enter_for_of_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_for_of_stmt(&mut self, node: &ForOfStmt, ctx: &mut C) {
+        self.second.exit_for_of_stmt(node, ctx);
+        self.first.exit_for_of_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_for_stmt(&mut self, node: &ForStmt, ctx: &mut C) {
+        self.first.enter_for_stmt(node, ctx);
+        self.second.enter_for_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_for_stmt(&mut self, node: &ForStmt, ctx: &mut C) {
+        self.second.exit_for_stmt(node, ctx);
+        self.first.exit_for_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_function(&mut self, node: &Function, ctx: &mut C) {
+        self.first.enter_function(node, ctx);
+        self.second.enter_function(node, ctx);
+    }
+
+    #[inline]
+    fn exit_function(&mut self, node: &Function, ctx: &mut C) {
+        self.second.exit_function(node, ctx);
+        self.first.exit_function(node, ctx);
+    }
+
+    #[inline]
+    fn enter_getter_prop(&mut self, node: &GetterProp, ctx: &mut C) {
+        self.first.enter_getter_prop(node, ctx);
+        self.second.enter_getter_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_getter_prop(&mut self, node: &GetterProp, ctx: &mut C) {
+        self.second.exit_getter_prop(node, ctx);
+        self.first.exit_getter_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ident(&mut self, node: &Ident, ctx: &mut C) {
+        self.first.enter_ident(node, ctx);
+        self.second.enter_ident(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ident(&mut self, node: &Ident, ctx: &mut C) {
+        self.second.exit_ident(node, ctx);
+        self.first.exit_ident(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ident_name(&mut self, node: &IdentName, ctx: &mut C) {
+        self.first.enter_ident_name(node, ctx);
+        self.second.enter_ident_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ident_name(&mut self, node: &IdentName, ctx: &mut C) {
+        self.second.exit_ident_name(node, ctx);
+        self.first.exit_ident_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_if_stmt(&mut self, node: &IfStmt, ctx: &mut C) {
+        self.first.enter_if_stmt(node, ctx);
+        self.second.enter_if_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_if_stmt(&mut self, node: &IfStmt, ctx: &mut C) {
+        self.second.exit_if_stmt(node, ctx);
+        self.first.exit_if_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import(&mut self, node: &Import, ctx: &mut C) {
+        self.first.enter_import(node, ctx);
+        self.second.enter_import(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import(&mut self, node: &Import, ctx: &mut C) {
+        self.second.exit_import(node, ctx);
+        self.first.exit_import(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import_decl(&mut self, node: &ImportDecl, ctx: &mut C) {
+        self.first.enter_import_decl(node, ctx);
+        self.second.enter_import_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import_decl(&mut self, node: &ImportDecl, ctx: &mut C) {
+        self.second.exit_import_decl(node, ctx);
+        self.first.exit_import_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import_default_specifier(&mut self, node: &ImportDefaultSpecifier, ctx: &mut C) {
+        self.first.enter_import_default_specifier(node, ctx);
+        self.second.enter_import_default_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import_default_specifier(&mut self, node: &ImportDefaultSpecifier, ctx: &mut C) {
+        self.second.exit_import_default_specifier(node, ctx);
+        self.first.exit_import_default_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import_named_specifier(&mut self, node: &ImportNamedSpecifier, ctx: &mut C) {
+        self.first.enter_import_named_specifier(node, ctx);
+        self.second.enter_import_named_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import_named_specifier(&mut self, node: &ImportNamedSpecifier, ctx: &mut C) {
+        self.second.exit_import_named_specifier(node, ctx);
+        self.first.exit_import_named_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import_phase(&mut self, node: &ImportPhase, ctx: &mut C) {
+        self.first.enter_import_phase(node, ctx);
+        self.second.enter_import_phase(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import_phase(&mut self, node: &ImportPhase, ctx: &mut C) {
+        self.second.exit_import_phase(node, ctx);
+        self.first.exit_import_phase(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import_specifier(&mut self, node: &ImportSpecifier, ctx: &mut C) {
+        self.first.enter_import_specifier(node, ctx);
+        self.second.enter_import_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import_specifier(&mut self, node: &ImportSpecifier, ctx: &mut C) {
+        self.second.exit_import_specifier(node, ctx);
+        self.first.exit_import_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import_specifiers(&mut self, node: &[ImportSpecifier], ctx: &mut C) {
+        self.first.enter_import_specifiers(node, ctx);
+        self.second.enter_import_specifiers(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import_specifiers(&mut self, node: &[ImportSpecifier], ctx: &mut C) {
+        self.second.exit_import_specifiers(node, ctx);
+        self.first.exit_import_specifiers(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier, ctx: &mut C) {
+        self.first.enter_import_star_as_specifier(node, ctx);
+        self.second.enter_import_star_as_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier, ctx: &mut C) {
+        self.second.exit_import_star_as_specifier(node, ctx);
+        self.first.exit_import_star_as_specifier(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import_with(&mut self, node: &ImportWith, ctx: &mut C) {
+        self.first.enter_import_with(node, ctx);
+        self.second.enter_import_with(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import_with(&mut self, node: &ImportWith, ctx: &mut C) {
+        self.second.exit_import_with(node, ctx);
+        self.first.exit_import_with(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import_with_item(&mut self, node: &ImportWithItem, ctx: &mut C) {
+        self.first.enter_import_with_item(node, ctx);
+        self.second.enter_import_with_item(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import_with_item(&mut self, node: &ImportWithItem, ctx: &mut C) {
+        self.second.exit_import_with_item(node, ctx);
+        self.first.exit_import_with_item(node, ctx);
+    }
+
+    #[inline]
+    fn enter_import_with_items(&mut self, node: &[ImportWithItem], ctx: &mut C) {
+        self.first.enter_import_with_items(node, ctx);
+        self.second.enter_import_with_items(node, ctx);
+    }
+
+    #[inline]
+    fn exit_import_with_items(&mut self, node: &[ImportWithItem], ctx: &mut C) {
+        self.second.exit_import_with_items(node, ctx);
+        self.first.exit_import_with_items(node, ctx);
+    }
+
+    #[inline]
+    fn enter_invalid(&mut self, node: &Invalid, ctx: &mut C) {
+        self.first.enter_invalid(node, ctx);
+        self.second.enter_invalid(node, ctx);
+    }
+
+    #[inline]
+    fn exit_invalid(&mut self, node: &Invalid, ctx: &mut C) {
+        self.second.exit_invalid(node, ctx);
+        self.first.exit_invalid(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_attr(&mut self, node: &JSXAttr, ctx: &mut C) {
+        self.first.enter_jsx_attr(node, ctx);
+        self.second.enter_jsx_attr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_attr(&mut self, node: &JSXAttr, ctx: &mut C) {
+        self.second.exit_jsx_attr(node, ctx);
+        self.first.exit_jsx_attr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_attr_name(&mut self, node: &JSXAttrName, ctx: &mut C) {
+        self.first.enter_jsx_attr_name(node, ctx);
+        self.second.enter_jsx_attr_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_attr_name(&mut self, node: &JSXAttrName, ctx: &mut C) {
+        self.second.exit_jsx_attr_name(node, ctx);
+        self.first.exit_jsx_attr_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_attr_or_spread(&mut self, node: &JSXAttrOrSpread, ctx: &mut C) {
+        self.first.enter_jsx_attr_or_spread(node, ctx);
+        self.second.enter_jsx_attr_or_spread(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_attr_or_spread(&mut self, node: &JSXAttrOrSpread, ctx: &mut C) {
+        self.second.exit_jsx_attr_or_spread(node, ctx);
+        self.first.exit_jsx_attr_or_spread(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_attr_or_spreads(&mut self, node: &[JSXAttrOrSpread], ctx: &mut C) {
+        self.first.enter_jsx_attr_or_spreads(node, ctx);
+        self.second.enter_jsx_attr_or_spreads(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_attr_or_spreads(&mut self, node: &[JSXAttrOrSpread], ctx: &mut C) {
+        self.second.exit_jsx_attr_or_spreads(node, ctx);
+        self.first.exit_jsx_attr_or_spreads(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_attr_value(&mut self, node: &JSXAttrValue, ctx: &mut C) {
+        self.first.enter_jsx_attr_value(node, ctx);
+        self.second.enter_jsx_attr_value(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_attr_value(&mut self, node: &JSXAttrValue, ctx: &mut C) {
+        self.second.exit_jsx_attr_value(node, ctx);
+        self.first.exit_jsx_attr_value(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_closing_element(&mut self, node: &JSXClosingElement, ctx: &mut C) {
+        self.first.enter_jsx_closing_element(node, ctx);
+        self.second.enter_jsx_closing_element(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_closing_element(&mut self, node: &JSXClosingElement, ctx: &mut C) {
+        self.second.exit_jsx_closing_element(node, ctx);
+        self.first.exit_jsx_closing_element(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_closing_fragment(&mut self, node: &JSXClosingFragment, ctx: &mut C) {
+        self.first.enter_jsx_closing_fragment(node, ctx);
+        self.second.enter_jsx_closing_fragment(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_closing_fragment(&mut self, node: &JSXClosingFragment, ctx: &mut C) {
+        self.second.exit_jsx_closing_fragment(node, ctx);
+        self.first.exit_jsx_closing_fragment(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_element(&mut self, node: &JSXElement, ctx: &mut C) {
+        self.first.enter_jsx_element(node, ctx);
+        self.second.enter_jsx_element(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_element(&mut self, node: &JSXElement, ctx: &mut C) {
+        self.second.exit_jsx_element(node, ctx);
+        self.first.exit_jsx_element(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_element_child(&mut self, node: &JSXElementChild, ctx: &mut C) {
+        self.first.enter_jsx_element_child(node, ctx);
+        self.second.enter_jsx_element_child(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_element_child(&mut self, node: &JSXElementChild, ctx: &mut C) {
+        self.second.exit_jsx_element_child(node, ctx);
+        self.first.exit_jsx_element_child(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_element_childs(&mut self, node: &[JSXElementChild], ctx: &mut C) {
+        self.first.enter_jsx_element_childs(node, ctx);
+        self.second.enter_jsx_element_childs(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_element_childs(&mut self, node: &[JSXElementChild], ctx: &mut C) {
+        self.second.exit_jsx_element_childs(node, ctx);
+        self.first.exit_jsx_element_childs(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_element_name(&mut self, node: &JSXElementName, ctx: &mut C) {
+        self.first.enter_jsx_element_name(node, ctx);
+        self.second.enter_jsx_element_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_element_name(&mut self, node: &JSXElementName, ctx: &mut C) {
+        self.second.exit_jsx_element_name(node, ctx);
+        self.first.exit_jsx_element_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_empty_expr(&mut self, node: &JSXEmptyExpr, ctx: &mut C) {
+        self.first.enter_jsx_empty_expr(node, ctx);
+        self.second.enter_jsx_empty_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_empty_expr(&mut self, node: &JSXEmptyExpr, ctx: &mut C) {
+        self.second.exit_jsx_empty_expr(node, ctx);
+        self.first.exit_jsx_empty_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_expr(&mut self, node: &JSXExpr, ctx: &mut C) {
+        self.first.enter_jsx_expr(node, ctx);
+        self.second.enter_jsx_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_expr(&mut self, node: &JSXExpr, ctx: &mut C) {
+        self.second.exit_jsx_expr(node, ctx);
+        self.first.exit_jsx_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_expr_container(&mut self, node: &JSXExprContainer, ctx: &mut C) {
+        self.first.enter_jsx_expr_container(node, ctx);
+        self.second.enter_jsx_expr_container(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_expr_container(&mut self, node: &JSXExprContainer, ctx: &mut C) {
+        self.second.exit_jsx_expr_container(node, ctx);
+        self.first.exit_jsx_expr_container(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut C) {
+        self.first.enter_jsx_fragment(node, ctx);
+        self.second.enter_jsx_fragment(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut C) {
+        self.second.exit_jsx_fragment(node, ctx);
+        self.first.exit_jsx_fragment(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_member_expr(&mut self, node: &JSXMemberExpr, ctx: &mut C) {
+        self.first.enter_jsx_member_expr(node, ctx);
+        self.second.enter_jsx_member_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_member_expr(&mut self, node: &JSXMemberExpr, ctx: &mut C) {
+        self.second.exit_jsx_member_expr(node, ctx);
+        self.first.exit_jsx_member_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_namespaced_name(&mut self, node: &JSXNamespacedName, ctx: &mut C) {
+        self.first.enter_jsx_namespaced_name(node, ctx);
+        self.second.enter_jsx_namespaced_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_namespaced_name(&mut self, node: &JSXNamespacedName, ctx: &mut C) {
+        self.second.exit_jsx_namespaced_name(node, ctx);
+        self.first.exit_jsx_namespaced_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_object(&mut self, node: &JSXObject, ctx: &mut C) {
+        self.first.enter_jsx_object(node, ctx);
+        self.second.enter_jsx_object(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_object(&mut self, node: &JSXObject, ctx: &mut C) {
+        self.second.exit_jsx_object(node, ctx);
+        self.first.exit_jsx_object(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_opening_element(&mut self, node: &JSXOpeningElement, ctx: &mut C) {
+        self.first.enter_jsx_opening_element(node, ctx);
+        self.second.enter_jsx_opening_element(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_opening_element(&mut self, node: &JSXOpeningElement, ctx: &mut C) {
+        self.second.exit_jsx_opening_element(node, ctx);
+        self.first.exit_jsx_opening_element(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_opening_fragment(&mut self, node: &JSXOpeningFragment, ctx: &mut C) {
+        self.first.enter_jsx_opening_fragment(node, ctx);
+        self.second.enter_jsx_opening_fragment(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_opening_fragment(&mut self, node: &JSXOpeningFragment, ctx: &mut C) {
+        self.second.exit_jsx_opening_fragment(node, ctx);
+        self.first.exit_jsx_opening_fragment(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_spread_child(&mut self, node: &JSXSpreadChild, ctx: &mut C) {
+        self.first.enter_jsx_spread_child(node, ctx);
+        self.second.enter_jsx_spread_child(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_spread_child(&mut self, node: &JSXSpreadChild, ctx: &mut C) {
+        self.second.exit_jsx_spread_child(node, ctx);
+        self.first.exit_jsx_spread_child(node, ctx);
+    }
+
+    #[inline]
+    fn enter_jsx_text(&mut self, node: &JSXText, ctx: &mut C) {
+        self.first.enter_jsx_text(node, ctx);
+        self.second.enter_jsx_text(node, ctx);
+    }
+
+    #[inline]
+    fn exit_jsx_text(&mut self, node: &JSXText, ctx: &mut C) {
+        self.second.exit_jsx_text(node, ctx);
+        self.first.exit_jsx_text(node, ctx);
+    }
+
+    #[inline]
+    fn enter_key(&mut self, node: &Key, ctx: &mut C) {
+        self.first.enter_key(node, ctx);
+        self.second.enter_key(node, ctx);
+    }
+
+    #[inline]
+    fn exit_key(&mut self, node: &Key, ctx: &mut C) {
+        self.second.exit_key(node, ctx);
+        self.first.exit_key(node, ctx);
+    }
+
+    #[inline]
+    fn enter_key_value_pat_prop(&mut self, node: &KeyValuePatProp, ctx: &mut C) {
+        self.first.enter_key_value_pat_prop(node, ctx);
+        self.second.enter_key_value_pat_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_key_value_pat_prop(&mut self, node: &KeyValuePatProp, ctx: &mut C) {
+        self.second.exit_key_value_pat_prop(node, ctx);
+        self.first.exit_key_value_pat_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_key_value_prop(&mut self, node: &KeyValueProp, ctx: &mut C) {
+        self.first.enter_key_value_prop(node, ctx);
+        self.second.enter_key_value_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_key_value_prop(&mut self, node: &KeyValueProp, ctx: &mut C) {
+        self.second.exit_key_value_prop(node, ctx);
+        self.first.exit_key_value_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_labeled_stmt(&mut self, node: &LabeledStmt, ctx: &mut C) {
+        self.first.enter_labeled_stmt(node, ctx);
+        self.second.enter_labeled_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_labeled_stmt(&mut self, node: &LabeledStmt, ctx: &mut C) {
+        self.second.exit_labeled_stmt(node, ctx);
+        self.first.exit_labeled_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_lit(&mut self, node: &Lit, ctx: &mut C) {
+        self.first.enter_lit(node, ctx);
+        self.second.enter_lit(node, ctx);
+    }
+
+    #[inline]
+    fn exit_lit(&mut self, node: &Lit, ctx: &mut C) {
+        self.second.exit_lit(node, ctx);
+        self.first.exit_lit(node, ctx);
+    }
+
+    #[inline]
+    fn enter_member_expr(&mut self, node: &MemberExpr, ctx: &mut C) {
+        self.first.enter_member_expr(node, ctx);
+        self.second.enter_member_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_member_expr(&mut self, node: &MemberExpr, ctx: &mut C) {
+        self.second.exit_member_expr(node, ctx);
+        self.first.exit_member_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_member_prop(&mut self, node: &MemberProp, ctx: &mut C) {
+        self.first.enter_member_prop(node, ctx);
+        self.second.enter_member_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_member_prop(&mut self, node: &MemberProp, ctx: &mut C) {
+        self.second.exit_member_prop(node, ctx);
+        self.first.exit_member_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_meta_prop_expr(&mut self, node: &MetaPropExpr, ctx: &mut C) {
+        self.first.enter_meta_prop_expr(node, ctx);
+        self.second.enter_meta_prop_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_meta_prop_expr(&mut self, node: &MetaPropExpr, ctx: &mut C) {
+        self.second.exit_meta_prop_expr(node, ctx);
+        self.first.exit_meta_prop_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_meta_prop_kind(&mut self, node: &MetaPropKind, ctx: &mut C) {
+        self.first.enter_meta_prop_kind(node, ctx);
+        self.second.enter_meta_prop_kind(node, ctx);
+    }
+
+    #[inline]
+    fn exit_meta_prop_kind(&mut self, node: &MetaPropKind, ctx: &mut C) {
+        self.second.exit_meta_prop_kind(node, ctx);
+        self.first.exit_meta_prop_kind(node, ctx);
+    }
+
+    #[inline]
+    fn enter_method_kind(&mut self, node: &MethodKind, ctx: &mut C) {
+        self.first.enter_method_kind(node, ctx);
+        self.second.enter_method_kind(node, ctx);
+    }
+
+    #[inline]
+    fn exit_method_kind(&mut self, node: &MethodKind, ctx: &mut C) {
+        self.second.exit_method_kind(node, ctx);
+        self.first.exit_method_kind(node, ctx);
+    }
+
+    #[inline]
+    fn enter_method_prop(&mut self, node: &MethodProp, ctx: &mut C) {
+        self.first.enter_method_prop(node, ctx);
+        self.second.enter_method_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_method_prop(&mut self, node: &MethodProp, ctx: &mut C) {
+        self.second.exit_method_prop(node, ctx);
+        self.first.exit_method_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_module(&mut self, node: &Module, ctx: &mut C) {
+        self.first.enter_module(node, ctx);
+        self.second.enter_module(node, ctx);
+    }
+
+    #[inline]
+    fn exit_module(&mut self, node: &Module, ctx: &mut C) {
+        self.second.exit_module(node, ctx);
+        self.first.exit_module(node, ctx);
+    }
+
+    #[inline]
+    fn enter_module_decl(&mut self, node: &ModuleDecl, ctx: &mut C) {
+        self.first.enter_module_decl(node, ctx);
+        self.second.enter_module_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_module_decl(&mut self, node: &ModuleDecl, ctx: &mut C) {
+        self.second.exit_module_decl(node, ctx);
+        self.first.exit_module_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_module_export_name(&mut self, node: &ModuleExportName, ctx: &mut C) {
+        self.first.enter_module_export_name(node, ctx);
+        self.second.enter_module_export_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_module_export_name(&mut self, node: &ModuleExportName, ctx: &mut C) {
+        self.second.exit_module_export_name(node, ctx);
+        self.first.exit_module_export_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_module_item(&mut self, node: &ModuleItem, ctx: &mut C) {
+        self.first.enter_module_item(node, ctx);
+        self.second.enter_module_item(node, ctx);
+    }
+
+    #[inline]
+    fn exit_module_item(&mut self, node: &ModuleItem, ctx: &mut C) {
+        self.second.exit_module_item(node, ctx);
+        self.first.exit_module_item(node, ctx);
+    }
+
+    #[inline]
+    fn enter_module_items(&mut self, node: &[ModuleItem], ctx: &mut C) {
+        self.first.enter_module_items(node, ctx);
+        self.second.enter_module_items(node, ctx);
+    }
+
+    #[inline]
+    fn exit_module_items(&mut self, node: &[ModuleItem], ctx: &mut C) {
+        self.second.exit_module_items(node, ctx);
+        self.first.exit_module_items(node, ctx);
+    }
+
+    #[inline]
+    fn enter_named_export(&mut self, node: &NamedExport, ctx: &mut C) {
+        self.first.enter_named_export(node, ctx);
+        self.second.enter_named_export(node, ctx);
+    }
+
+    #[inline]
+    fn exit_named_export(&mut self, node: &NamedExport, ctx: &mut C) {
+        self.second.exit_named_export(node, ctx);
+        self.first.exit_named_export(node, ctx);
+    }
+
+    #[inline]
+    fn enter_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {
+        self.first.enter_new_expr(node, ctx);
+        self.second.enter_new_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {
+        self.second.exit_new_expr(node, ctx);
+        self.first.exit_new_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_null(&mut self, node: &Null, ctx: &mut C) {
+        self.first.enter_null(node, ctx);
+        self.second.enter_null(node, ctx);
+    }
+
+    #[inline]
+    fn exit_null(&mut self, node: &Null, ctx: &mut C) {
+        self.second.exit_null(node, ctx);
+        self.first.exit_null(node, ctx);
+    }
+
+    #[inline]
+    fn enter_number(&mut self, node: &Number, ctx: &mut C) {
+        self.first.enter_number(node, ctx);
+        self.second.enter_number(node, ctx);
+    }
+
+    #[inline]
+    fn exit_number(&mut self, node: &Number, ctx: &mut C) {
+        self.second.exit_number(node, ctx);
+        self.first.exit_number(node, ctx);
+    }
+
+    #[inline]
+    fn enter_object_lit(&mut self, node: &ObjectLit, ctx: &mut C) {
+        self.first.enter_object_lit(node, ctx);
+        self.second.enter_object_lit(node, ctx);
+    }
+
+    #[inline]
+    fn exit_object_lit(&mut self, node: &ObjectLit, ctx: &mut C) {
+        self.second.exit_object_lit(node, ctx);
+        self.first.exit_object_lit(node, ctx);
+    }
+
+    #[inline]
+    fn enter_object_pat(&mut self, node: &ObjectPat, ctx: &mut C) {
+        self.first.enter_object_pat(node, ctx);
+        self.second.enter_object_pat(node, ctx);
+    }
+
+    #[inline]
+    fn exit_object_pat(&mut self, node: &ObjectPat, ctx: &mut C) {
+        self.second.exit_object_pat(node, ctx);
+        self.first.exit_object_pat(node, ctx);
+    }
+
+    #[inline]
+    fn enter_object_pat_prop(&mut self, node: &ObjectPatProp, ctx: &mut C) {
+        self.first.enter_object_pat_prop(node, ctx);
+        self.second.enter_object_pat_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_object_pat_prop(&mut self, node: &ObjectPatProp, ctx: &mut C) {
+        self.second.exit_object_pat_prop(node, ctx);
+        self.first.exit_object_pat_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_object_pat_props(&mut self, node: &[ObjectPatProp], ctx: &mut C) {
+        self.first.enter_object_pat_props(node, ctx);
+        self.second.enter_object_pat_props(node, ctx);
+    }
+
+    #[inline]
+    fn exit_object_pat_props(&mut self, node: &[ObjectPatProp], ctx: &mut C) {
+        self.second.exit_object_pat_props(node, ctx);
+        self.first.exit_object_pat_props(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_accessibility(&mut self, node: &Option<Accessibility>, ctx: &mut C) {
+        self.first.enter_opt_accessibility(node, ctx);
+        self.second.enter_opt_accessibility(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_accessibility(&mut self, node: &Option<Accessibility>, ctx: &mut C) {
+        self.second.exit_opt_accessibility(node, ctx);
+        self.first.exit_opt_accessibility(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_atom(&mut self, node: &Option<swc_atoms::Atom>, ctx: &mut C) {
+        self.first.enter_opt_atom(node, ctx);
+        self.second.enter_opt_atom(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_atom(&mut self, node: &Option<swc_atoms::Atom>, ctx: &mut C) {
+        self.second.exit_opt_atom(node, ctx);
+        self.first.exit_opt_atom(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_block_stmt(&mut self, node: &Option<BlockStmt>, ctx: &mut C) {
+        self.first.enter_opt_block_stmt(node, ctx);
+        self.second.enter_opt_block_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_block_stmt(&mut self, node: &Option<BlockStmt>, ctx: &mut C) {
+        self.second.exit_opt_block_stmt(node, ctx);
+        self.first.exit_opt_block_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_call(&mut self, node: &OptCall, ctx: &mut C) {
+        self.first.enter_opt_call(node, ctx);
+        self.second.enter_opt_call(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_call(&mut self, node: &OptCall, ctx: &mut C) {
+        self.second.exit_opt_call(node, ctx);
+        self.first.exit_opt_call(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_catch_clause(&mut self, node: &Option<CatchClause>, ctx: &mut C) {
+        self.first.enter_opt_catch_clause(node, ctx);
+        self.second.enter_opt_catch_clause(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_catch_clause(&mut self, node: &Option<CatchClause>, ctx: &mut C) {
+        self.second.exit_opt_catch_clause(node, ctx);
+        self.first.exit_opt_catch_clause(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_chain_base(&mut self, node: &OptChainBase, ctx: &mut C) {
+        self.first.enter_opt_chain_base(node, ctx);
+        self.second.enter_opt_chain_base(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_chain_base(&mut self, node: &OptChainBase, ctx: &mut C) {
+        self.second.exit_opt_chain_base(node, ctx);
+        self.first.exit_opt_chain_base(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_chain_expr(&mut self, node: &OptChainExpr, ctx: &mut C) {
+        self.first.enter_opt_chain_expr(node, ctx);
+        self.second.enter_opt_chain_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_chain_expr(&mut self, node: &OptChainExpr, ctx: &mut C) {
+        self.second.exit_opt_chain_expr(node, ctx);
+        self.first.exit_opt_chain_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_expr(&mut self, node: &Option<Box<Expr>>, ctx: &mut C) {
+        self.first.enter_opt_expr(node, ctx);
+        self.second.enter_opt_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_expr(&mut self, node: &Option<Box<Expr>>, ctx: &mut C) {
+        self.second.exit_opt_expr(node, ctx);
+        self.first.exit_opt_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_expr_or_spread(&mut self, node: &Option<ExprOrSpread>, ctx: &mut C) {
+        self.first.enter_opt_expr_or_spread(node, ctx);
+        self.second.enter_opt_expr_or_spread(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_expr_or_spread(&mut self, node: &Option<ExprOrSpread>, ctx: &mut C) {
+        self.second.exit_opt_expr_or_spread(node, ctx);
+        self.first.exit_opt_expr_or_spread(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_expr_or_spreads(&mut self, node: &Option<Vec<ExprOrSpread>>, ctx: &mut C) {
+        self.first.enter_opt_expr_or_spreads(node, ctx);
+        self.second.enter_opt_expr_or_spreads(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_expr_or_spreads(&mut self, node: &Option<Vec<ExprOrSpread>>, ctx: &mut C) {
+        self.second.exit_opt_expr_or_spreads(node, ctx);
+        self.first.exit_opt_expr_or_spreads(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_ident(&mut self, node: &Option<Ident>, ctx: &mut C) {
+        self.first.enter_opt_ident(node, ctx);
+        self.second.enter_opt_ident(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_ident(&mut self, node: &Option<Ident>, ctx: &mut C) {
+        self.second.exit_opt_ident(node, ctx);
+        self.first.exit_opt_ident(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_jsx_attr_value(&mut self, node: &Option<JSXAttrValue>, ctx: &mut C) {
+        self.first.enter_opt_jsx_attr_value(node, ctx);
+        self.second.enter_opt_jsx_attr_value(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_jsx_attr_value(&mut self, node: &Option<JSXAttrValue>, ctx: &mut C) {
+        self.second.exit_opt_jsx_attr_value(node, ctx);
+        self.first.exit_opt_jsx_attr_value(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_jsx_closing_element(&mut self, node: &Option<JSXClosingElement>, ctx: &mut C) {
+        self.first.enter_opt_jsx_closing_element(node, ctx);
+        self.second.enter_opt_jsx_closing_element(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_jsx_closing_element(&mut self, node: &Option<JSXClosingElement>, ctx: &mut C) {
+        self.second.exit_opt_jsx_closing_element(node, ctx);
+        self.first.exit_opt_jsx_closing_element(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_module_export_name(&mut self, node: &Option<ModuleExportName>, ctx: &mut C) {
+        self.first.enter_opt_module_export_name(node, ctx);
+        self.second.enter_opt_module_export_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_module_export_name(&mut self, node: &Option<ModuleExportName>, ctx: &mut C) {
+        self.second.exit_opt_module_export_name(node, ctx);
+        self.first.exit_opt_module_export_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_object_lit(&mut self, node: &Option<Box<ObjectLit>>, ctx: &mut C) {
+        self.first.enter_opt_object_lit(node, ctx);
+        self.second.enter_opt_object_lit(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_object_lit(&mut self, node: &Option<Box<ObjectLit>>, ctx: &mut C) {
+        self.second.exit_opt_object_lit(node, ctx);
+        self.first.exit_opt_object_lit(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_pat(&mut self, node: &Option<Pat>, ctx: &mut C) {
+        self.first.enter_opt_pat(node, ctx);
+        self.second.enter_opt_pat(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_pat(&mut self, node: &Option<Pat>, ctx: &mut C) {
+        self.second.exit_opt_pat(node, ctx);
+        self.first.exit_opt_pat(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_span(&mut self, node: &Option<swc_common::Span>, ctx: &mut C) {
+        self.first.enter_opt_span(node, ctx);
+        self.second.enter_opt_span(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_span(&mut self, node: &Option<swc_common::Span>, ctx: &mut C) {
+        self.second.exit_opt_span(node, ctx);
+        self.first.exit_opt_span(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_stmt(&mut self, node: &Option<Box<Stmt>>, ctx: &mut C) {
+        self.first.enter_opt_stmt(node, ctx);
+        self.second.enter_opt_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_stmt(&mut self, node: &Option<Box<Stmt>>, ctx: &mut C) {
+        self.second.exit_opt_stmt(node, ctx);
+        self.first.exit_opt_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_str(&mut self, node: &Option<Box<Str>>, ctx: &mut C) {
+        self.first.enter_opt_str(node, ctx);
+        self.second.enter_opt_str(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_str(&mut self, node: &Option<Box<Str>>, ctx: &mut C) {
+        self.second.exit_opt_str(node, ctx);
+        self.first.exit_opt_str(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_true_plus_minus(&mut self, node: &Option<TruePlusMinus>, ctx: &mut C) {
+        self.first.enter_opt_true_plus_minus(node, ctx);
+        self.second.enter_opt_true_plus_minus(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_true_plus_minus(&mut self, node: &Option<TruePlusMinus>, ctx: &mut C) {
+        self.second.exit_opt_true_plus_minus(node, ctx);
+        self.first.exit_opt_true_plus_minus(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_ts_entity_name(&mut self, node: &Option<TsEntityName>, ctx: &mut C) {
+        self.first.enter_opt_ts_entity_name(node, ctx);
+        self.second.enter_opt_ts_entity_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_ts_entity_name(&mut self, node: &Option<TsEntityName>, ctx: &mut C) {
+        self.second.exit_opt_ts_entity_name(node, ctx);
+        self.first.exit_opt_ts_entity_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_ts_import_call_options(
+        &mut self,
+        node: &Option<TsImportCallOptions>,
+        ctx: &mut C,
+    ) {
+        self.first.enter_opt_ts_import_call_options(node, ctx);
+        self.second.enter_opt_ts_import_call_options(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_ts_import_call_options(&mut self, node: &Option<TsImportCallOptions>, ctx: &mut C) {
+        self.second.exit_opt_ts_import_call_options(node, ctx);
+        self.first.exit_opt_ts_import_call_options(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_ts_namespace_body(&mut self, node: &Option<TsNamespaceBody>, ctx: &mut C) {
+        self.first.enter_opt_ts_namespace_body(node, ctx);
+        self.second.enter_opt_ts_namespace_body(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_ts_namespace_body(&mut self, node: &Option<TsNamespaceBody>, ctx: &mut C) {
+        self.second.exit_opt_ts_namespace_body(node, ctx);
+        self.first.exit_opt_ts_namespace_body(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_ts_type(&mut self, node: &Option<Box<TsType>>, ctx: &mut C) {
+        self.first.enter_opt_ts_type(node, ctx);
+        self.second.enter_opt_ts_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_ts_type(&mut self, node: &Option<Box<TsType>>, ctx: &mut C) {
+        self.second.exit_opt_ts_type(node, ctx);
+        self.first.exit_opt_ts_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_ann(&mut self, node: &Option<Box<TsTypeAnn>>, ctx: &mut C) {
+        self.first.enter_opt_ts_type_ann(node, ctx);
+        self.second.enter_opt_ts_type_ann(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_ts_type_ann(&mut self, node: &Option<Box<TsTypeAnn>>, ctx: &mut C) {
+        self.second.exit_opt_ts_type_ann(node, ctx);
+        self.first.exit_opt_ts_type_ann(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_param_decl(&mut self, node: &Option<Box<TsTypeParamDecl>>, ctx: &mut C) {
+        self.first.enter_opt_ts_type_param_decl(node, ctx);
+        self.second.enter_opt_ts_type_param_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_ts_type_param_decl(&mut self, node: &Option<Box<TsTypeParamDecl>>, ctx: &mut C) {
+        self.second.exit_opt_ts_type_param_decl(node, ctx);
+        self.first.exit_opt_ts_type_param_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_param_instantiation(
+        &mut self,
+        node: &Option<Box<TsTypeParamInstantiation>>,
+        ctx: &mut C,
+    ) {
+        self.first.enter_opt_ts_type_param_instantiation(node, ctx);
+        self.second.enter_opt_ts_type_param_instantiation(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_ts_type_param_instantiation(
+        &mut self,
+        node: &Option<Box<TsTypeParamInstantiation>>,
+        ctx: &mut C,
+    ) {
+        self.second.exit_opt_ts_type_param_instantiation(node, ctx);
+        self.first.exit_opt_ts_type_param_instantiation(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_var_decl_or_expr(&mut self, node: &Option<VarDeclOrExpr>, ctx: &mut C) {
+        self.first.enter_opt_var_decl_or_expr(node, ctx);
+        self.second.enter_opt_var_decl_or_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_var_decl_or_expr(&mut self, node: &Option<VarDeclOrExpr>, ctx: &mut C) {
+        self.second.exit_opt_var_decl_or_expr(node, ctx);
+        self.first.exit_opt_var_decl_or_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_vec_expr_or_spreads(&mut self, node: &[Option<ExprOrSpread>], ctx: &mut C) {
+        self.first.enter_opt_vec_expr_or_spreads(node, ctx);
+        self.second.enter_opt_vec_expr_or_spreads(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_vec_expr_or_spreads(&mut self, node: &[Option<ExprOrSpread>], ctx: &mut C) {
+        self.second.exit_opt_vec_expr_or_spreads(node, ctx);
+        self.first.exit_opt_vec_expr_or_spreads(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_vec_pats(&mut self, node: &[Option<Pat>], ctx: &mut C) {
+        self.first.enter_opt_vec_pats(node, ctx);
+        self.second.enter_opt_vec_pats(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_vec_pats(&mut self, node: &[Option<Pat>], ctx: &mut C) {
+        self.second.exit_opt_vec_pats(node, ctx);
+        self.first.exit_opt_vec_pats(node, ctx);
+    }
+
+    #[inline]
+    fn enter_opt_wtf_8_atom(&mut self, node: &Option<swc_atoms::Wtf8Atom>, ctx: &mut C) {
+        self.first.enter_opt_wtf_8_atom(node, ctx);
+        self.second.enter_opt_wtf_8_atom(node, ctx);
+    }
+
+    #[inline]
+    fn exit_opt_wtf_8_atom(&mut self, node: &Option<swc_atoms::Wtf8Atom>, ctx: &mut C) {
+        self.second.exit_opt_wtf_8_atom(node, ctx);
+        self.first.exit_opt_wtf_8_atom(node, ctx);
+    }
+
+    #[inline]
+    fn enter_param(&mut self, node: &Param, ctx: &mut C) {
+        self.first.enter_param(node, ctx);
+        self.second.enter_param(node, ctx);
+    }
+
+    #[inline]
+    fn exit_param(&mut self, node: &Param, ctx: &mut C) {
+        self.second.exit_param(node, ctx);
+        self.first.exit_param(node, ctx);
+    }
+
+    #[inline]
+    fn enter_param_or_ts_param_prop(&mut self, node: &ParamOrTsParamProp, ctx: &mut C) {
+        self.first.enter_param_or_ts_param_prop(node, ctx);
+        self.second.enter_param_or_ts_param_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_param_or_ts_param_prop(&mut self, node: &ParamOrTsParamProp, ctx: &mut C) {
+        self.second.exit_param_or_ts_param_prop(node, ctx);
+        self.first.exit_param_or_ts_param_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_param_or_ts_param_props(&mut self, node: &[ParamOrTsParamProp], ctx: &mut C) {
+        self.first.enter_param_or_ts_param_props(node, ctx);
+        self.second.enter_param_or_ts_param_props(node, ctx);
+    }
+
+    #[inline]
+    fn exit_param_or_ts_param_props(&mut self, node: &[ParamOrTsParamProp], ctx: &mut C) {
+        self.second.exit_param_or_ts_param_props(node, ctx);
+        self.first.exit_param_or_ts_param_props(node, ctx);
+    }
+
+    #[inline]
+    fn enter_params(&mut self, node: &[Param], ctx: &mut C) {
+        self.first.enter_params(node, ctx);
+        self.second.enter_params(node, ctx);
+    }
+
+    #[inline]
+    fn exit_params(&mut self, node: &[Param], ctx: &mut C) {
+        self.second.exit_params(node, ctx);
+        self.first.exit_params(node, ctx);
+    }
+
+    #[inline]
+    fn enter_paren_expr(&mut self, node: &ParenExpr, ctx: &mut C) {
+        self.first.enter_paren_expr(node, ctx);
+        self.second.enter_paren_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_paren_expr(&mut self, node: &ParenExpr, ctx: &mut C) {
+        self.second.exit_paren_expr(node, ctx);
+        self.first.exit_paren_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_pat(&mut self, node: &Pat, ctx: &mut C) {
+        self.first.enter_pat(node, ctx);
+        self.second.enter_pat(node, ctx);
+    }
+
+    #[inline]
+    fn exit_pat(&mut self, node: &Pat, ctx: &mut C) {
+        self.second.exit_pat(node, ctx);
+        self.first.exit_pat(node, ctx);
+    }
+
+    #[inline]
+    fn enter_pats(&mut self, node: &[Pat], ctx: &mut C) {
+        self.first.enter_pats(node, ctx);
+        self.second.enter_pats(node, ctx);
+    }
+
+    #[inline]
+    fn exit_pats(&mut self, node: &[Pat], ctx: &mut C) {
+        self.second.exit_pats(node, ctx);
+        self.first.exit_pats(node, ctx);
+    }
+
+    #[inline]
+    fn enter_private_method(&mut self, node: &PrivateMethod, ctx: &mut C) {
+        self.first.enter_private_method(node, ctx);
+        self.second.enter_private_method(node, ctx);
+    }
+
+    #[inline]
+    fn exit_private_method(&mut self, node: &PrivateMethod, ctx: &mut C) {
+        self.second.exit_private_method(node, ctx);
+        self.first.exit_private_method(node, ctx);
+    }
+
+    #[inline]
+    fn enter_private_name(&mut self, node: &PrivateName, ctx: &mut C) {
+        self.first.enter_private_name(node, ctx);
+        self.second.enter_private_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_private_name(&mut self, node: &PrivateName, ctx: &mut C) {
+        self.second.exit_private_name(node, ctx);
+        self.first.exit_private_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_private_prop(&mut self, node: &PrivateProp, ctx: &mut C) {
+        self.first.enter_private_prop(node, ctx);
+        self.second.enter_private_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_private_prop(&mut self, node: &PrivateProp, ctx: &mut C) {
+        self.second.exit_private_prop(node, ctx);
+        self.first.exit_private_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_program(&mut self, node: &Program, ctx: &mut C) {
+        self.first.enter_program(node, ctx);
+        self.second.enter_program(node, ctx);
+    }
+
+    #[inline]
+    fn exit_program(&mut self, node: &Program, ctx: &mut C) {
+        self.second.exit_program(node, ctx);
+        self.first.exit_program(node, ctx);
+    }
+
+    #[inline]
+    fn enter_prop(&mut self, node: &Prop, ctx: &mut C) {
+        self.first.enter_prop(node, ctx);
+        self.second.enter_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_prop(&mut self, node: &Prop, ctx: &mut C) {
+        self.second.exit_prop(node, ctx);
+        self.first.exit_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_prop_name(&mut self, node: &PropName, ctx: &mut C) {
+        self.first.enter_prop_name(node, ctx);
+        self.second.enter_prop_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_prop_name(&mut self, node: &PropName, ctx: &mut C) {
+        self.second.exit_prop_name(node, ctx);
+        self.first.exit_prop_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_prop_or_spread(&mut self, node: &PropOrSpread, ctx: &mut C) {
+        self.first.enter_prop_or_spread(node, ctx);
+        self.second.enter_prop_or_spread(node, ctx);
+    }
+
+    #[inline]
+    fn exit_prop_or_spread(&mut self, node: &PropOrSpread, ctx: &mut C) {
+        self.second.exit_prop_or_spread(node, ctx);
+        self.first.exit_prop_or_spread(node, ctx);
+    }
+
+    #[inline]
+    fn enter_prop_or_spreads(&mut self, node: &[PropOrSpread], ctx: &mut C) {
+        self.first.enter_prop_or_spreads(node, ctx);
+        self.second.enter_prop_or_spreads(node, ctx);
+    }
+
+    #[inline]
+    fn exit_prop_or_spreads(&mut self, node: &[PropOrSpread], ctx: &mut C) {
+        self.second.exit_prop_or_spreads(node, ctx);
+        self.first.exit_prop_or_spreads(node, ctx);
+    }
+
+    #[inline]
+    fn enter_regex(&mut self, node: &Regex, ctx: &mut C) {
+        self.first.enter_regex(node, ctx);
+        self.second.enter_regex(node, ctx);
+    }
+
+    #[inline]
+    fn exit_regex(&mut self, node: &Regex, ctx: &mut C) {
+        self.second.exit_regex(node, ctx);
+        self.first.exit_regex(node, ctx);
+    }
+
+    #[inline]
+    fn enter_rest_pat(&mut self, node: &RestPat, ctx: &mut C) {
+        self.first.enter_rest_pat(node, ctx);
+        self.second.enter_rest_pat(node, ctx);
+    }
+
+    #[inline]
+    fn exit_rest_pat(&mut self, node: &RestPat, ctx: &mut C) {
+        self.second.exit_rest_pat(node, ctx);
+        self.first.exit_rest_pat(node, ctx);
+    }
+
+    #[inline]
+    fn enter_return_stmt(&mut self, node: &ReturnStmt, ctx: &mut C) {
+        self.first.enter_return_stmt(node, ctx);
+        self.second.enter_return_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_return_stmt(&mut self, node: &ReturnStmt, ctx: &mut C) {
+        self.second.exit_return_stmt(node, ctx);
+        self.first.exit_return_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_script(&mut self, node: &Script, ctx: &mut C) {
+        self.first.enter_script(node, ctx);
+        self.second.enter_script(node, ctx);
+    }
+
+    #[inline]
+    fn exit_script(&mut self, node: &Script, ctx: &mut C) {
+        self.second.exit_script(node, ctx);
+        self.first.exit_script(node, ctx);
+    }
+
+    #[inline]
+    fn enter_seq_expr(&mut self, node: &SeqExpr, ctx: &mut C) {
+        self.first.enter_seq_expr(node, ctx);
+        self.second.enter_seq_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_seq_expr(&mut self, node: &SeqExpr, ctx: &mut C) {
+        self.second.exit_seq_expr(node, ctx);
+        self.first.exit_seq_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_setter_prop(&mut self, node: &SetterProp, ctx: &mut C) {
+        self.first.enter_setter_prop(node, ctx);
+        self.second.enter_setter_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_setter_prop(&mut self, node: &SetterProp, ctx: &mut C) {
+        self.second.exit_setter_prop(node, ctx);
+        self.first.exit_setter_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_simple_assign_target(&mut self, node: &SimpleAssignTarget, ctx: &mut C) {
+        self.first.enter_simple_assign_target(node, ctx);
+        self.second.enter_simple_assign_target(node, ctx);
+    }
+
+    #[inline]
+    fn exit_simple_assign_target(&mut self, node: &SimpleAssignTarget, ctx: &mut C) {
+        self.second.exit_simple_assign_target(node, ctx);
+        self.first.exit_simple_assign_target(node, ctx);
+    }
+
+    #[inline]
+    fn enter_span(&mut self, node: &swc_common::Span, ctx: &mut C) {
+        self.first.enter_span(node, ctx);
+        self.second.enter_span(node, ctx);
+    }
+
+    #[inline]
+    fn exit_span(&mut self, node: &swc_common::Span, ctx: &mut C) {
+        self.second.exit_span(node, ctx);
+        self.first.exit_span(node, ctx);
+    }
+
+    #[inline]
+    fn enter_spread_element(&mut self, node: &SpreadElement, ctx: &mut C) {
+        self.first.enter_spread_element(node, ctx);
+        self.second.enter_spread_element(node, ctx);
+    }
+
+    #[inline]
+    fn exit_spread_element(&mut self, node: &SpreadElement, ctx: &mut C) {
+        self.second.exit_spread_element(node, ctx);
+        self.first.exit_spread_element(node, ctx);
+    }
+
+    #[inline]
+    fn enter_static_block(&mut self, node: &StaticBlock, ctx: &mut C) {
+        self.first.enter_static_block(node, ctx);
+        self.second.enter_static_block(node, ctx);
+    }
+
+    #[inline]
+    fn exit_static_block(&mut self, node: &StaticBlock, ctx: &mut C) {
+        self.second.exit_static_block(node, ctx);
+        self.first.exit_static_block(node, ctx);
+    }
+
+    #[inline]
+    fn enter_stmt(&mut self, node: &Stmt, ctx: &mut C) {
+        self.first.enter_stmt(node, ctx);
+        self.second.enter_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_stmt(&mut self, node: &Stmt, ctx: &mut C) {
+        self.second.exit_stmt(node, ctx);
+        self.first.exit_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_stmts(&mut self, node: &[Stmt], ctx: &mut C) {
+        self.first.enter_stmts(node, ctx);
+        self.second.enter_stmts(node, ctx);
+    }
+
+    #[inline]
+    fn exit_stmts(&mut self, node: &[Stmt], ctx: &mut C) {
+        self.second.exit_stmts(node, ctx);
+        self.first.exit_stmts(node, ctx);
+    }
+
+    #[inline]
+    fn enter_str(&mut self, node: &Str, ctx: &mut C) {
+        self.first.enter_str(node, ctx);
+        self.second.enter_str(node, ctx);
+    }
+
+    #[inline]
+    fn exit_str(&mut self, node: &Str, ctx: &mut C) {
+        self.second.exit_str(node, ctx);
+        self.first.exit_str(node, ctx);
+    }
+
+    #[inline]
+    fn enter_super(&mut self, node: &Super, ctx: &mut C) {
+        self.first.enter_super(node, ctx);
+        self.second.enter_super(node, ctx);
+    }
+
+    #[inline]
+    fn exit_super(&mut self, node: &Super, ctx: &mut C) {
+        self.second.exit_super(node, ctx);
+        self.first.exit_super(node, ctx);
+    }
+
+    #[inline]
+    fn enter_super_prop(&mut self, node: &SuperProp, ctx: &mut C) {
+        self.first.enter_super_prop(node, ctx);
+        self.second.enter_super_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_super_prop(&mut self, node: &SuperProp, ctx: &mut C) {
+        self.second.exit_super_prop(node, ctx);
+        self.first.exit_super_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_super_prop_expr(&mut self, node: &SuperPropExpr, ctx: &mut C) {
+        self.first.enter_super_prop_expr(node, ctx);
+        self.second.enter_super_prop_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_super_prop_expr(&mut self, node: &SuperPropExpr, ctx: &mut C) {
+        self.second.exit_super_prop_expr(node, ctx);
+        self.first.exit_super_prop_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_switch_case(&mut self, node: &SwitchCase, ctx: &mut C) {
+        self.first.enter_switch_case(node, ctx);
+        self.second.enter_switch_case(node, ctx);
+    }
+
+    #[inline]
+    fn exit_switch_case(&mut self, node: &SwitchCase, ctx: &mut C) {
+        self.second.exit_switch_case(node, ctx);
+        self.first.exit_switch_case(node, ctx);
+    }
+
+    #[inline]
+    fn enter_switch_cases(&mut self, node: &[SwitchCase], ctx: &mut C) {
+        self.first.enter_switch_cases(node, ctx);
+        self.second.enter_switch_cases(node, ctx);
+    }
+
+    #[inline]
+    fn exit_switch_cases(&mut self, node: &[SwitchCase], ctx: &mut C) {
+        self.second.exit_switch_cases(node, ctx);
+        self.first.exit_switch_cases(node, ctx);
+    }
+
+    #[inline]
+    fn enter_switch_stmt(&mut self, node: &SwitchStmt, ctx: &mut C) {
+        self.first.enter_switch_stmt(node, ctx);
+        self.second.enter_switch_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_switch_stmt(&mut self, node: &SwitchStmt, ctx: &mut C) {
+        self.second.exit_switch_stmt(node, ctx);
+        self.first.exit_switch_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_syntax_context(&mut self, node: &swc_common::SyntaxContext, ctx: &mut C) {
+        self.first.enter_syntax_context(node, ctx);
+        self.second.enter_syntax_context(node, ctx);
+    }
+
+    #[inline]
+    fn exit_syntax_context(&mut self, node: &swc_common::SyntaxContext, ctx: &mut C) {
+        self.second.exit_syntax_context(node, ctx);
+        self.first.exit_syntax_context(node, ctx);
+    }
+
+    #[inline]
+    fn enter_tagged_tpl(&mut self, node: &TaggedTpl, ctx: &mut C) {
+        self.first.enter_tagged_tpl(node, ctx);
+        self.second.enter_tagged_tpl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_tagged_tpl(&mut self, node: &TaggedTpl, ctx: &mut C) {
+        self.second.exit_tagged_tpl(node, ctx);
+        self.first.exit_tagged_tpl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_this_expr(&mut self, node: &ThisExpr, ctx: &mut C) {
+        self.first.enter_this_expr(node, ctx);
+        self.second.enter_this_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_this_expr(&mut self, node: &ThisExpr, ctx: &mut C) {
+        self.second.exit_this_expr(node, ctx);
+        self.first.exit_this_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_throw_stmt(&mut self, node: &ThrowStmt, ctx: &mut C) {
+        self.first.enter_throw_stmt(node, ctx);
+        self.second.enter_throw_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_throw_stmt(&mut self, node: &ThrowStmt, ctx: &mut C) {
+        self.second.exit_throw_stmt(node, ctx);
+        self.first.exit_throw_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_tpl(&mut self, node: &Tpl, ctx: &mut C) {
+        self.first.enter_tpl(node, ctx);
+        self.second.enter_tpl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_tpl(&mut self, node: &Tpl, ctx: &mut C) {
+        self.second.exit_tpl(node, ctx);
+        self.first.exit_tpl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_tpl_element(&mut self, node: &TplElement, ctx: &mut C) {
+        self.first.enter_tpl_element(node, ctx);
+        self.second.enter_tpl_element(node, ctx);
+    }
+
+    #[inline]
+    fn exit_tpl_element(&mut self, node: &TplElement, ctx: &mut C) {
+        self.second.exit_tpl_element(node, ctx);
+        self.first.exit_tpl_element(node, ctx);
+    }
+
+    #[inline]
+    fn enter_tpl_elements(&mut self, node: &[TplElement], ctx: &mut C) {
+        self.first.enter_tpl_elements(node, ctx);
+        self.second.enter_tpl_elements(node, ctx);
+    }
+
+    #[inline]
+    fn exit_tpl_elements(&mut self, node: &[TplElement], ctx: &mut C) {
+        self.second.exit_tpl_elements(node, ctx);
+        self.first.exit_tpl_elements(node, ctx);
+    }
+
+    #[inline]
+    fn enter_true_plus_minus(&mut self, node: &TruePlusMinus, ctx: &mut C) {
+        self.first.enter_true_plus_minus(node, ctx);
+        self.second.enter_true_plus_minus(node, ctx);
+    }
+
+    #[inline]
+    fn exit_true_plus_minus(&mut self, node: &TruePlusMinus, ctx: &mut C) {
+        self.second.exit_true_plus_minus(node, ctx);
+        self.first.exit_true_plus_minus(node, ctx);
+    }
+
+    #[inline]
+    fn enter_try_stmt(&mut self, node: &TryStmt, ctx: &mut C) {
+        self.first.enter_try_stmt(node, ctx);
+        self.second.enter_try_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_try_stmt(&mut self, node: &TryStmt, ctx: &mut C) {
+        self.second.exit_try_stmt(node, ctx);
+        self.first.exit_try_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_array_type(&mut self, node: &TsArrayType, ctx: &mut C) {
+        self.first.enter_ts_array_type(node, ctx);
+        self.second.enter_ts_array_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_array_type(&mut self, node: &TsArrayType, ctx: &mut C) {
+        self.second.exit_ts_array_type(node, ctx);
+        self.first.exit_ts_array_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_as_expr(&mut self, node: &TsAsExpr, ctx: &mut C) {
+        self.first.enter_ts_as_expr(node, ctx);
+        self.second.enter_ts_as_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_as_expr(&mut self, node: &TsAsExpr, ctx: &mut C) {
+        self.second.exit_ts_as_expr(node, ctx);
+        self.first.exit_ts_as_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_call_signature_decl(&mut self, node: &TsCallSignatureDecl, ctx: &mut C) {
+        self.first.enter_ts_call_signature_decl(node, ctx);
+        self.second.enter_ts_call_signature_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_call_signature_decl(&mut self, node: &TsCallSignatureDecl, ctx: &mut C) {
+        self.second.exit_ts_call_signature_decl(node, ctx);
+        self.first.exit_ts_call_signature_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_conditional_type(&mut self, node: &TsConditionalType, ctx: &mut C) {
+        self.first.enter_ts_conditional_type(node, ctx);
+        self.second.enter_ts_conditional_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_conditional_type(&mut self, node: &TsConditionalType, ctx: &mut C) {
+        self.second.exit_ts_conditional_type(node, ctx);
+        self.first.exit_ts_conditional_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_const_assertion(&mut self, node: &TsConstAssertion, ctx: &mut C) {
+        self.first.enter_ts_const_assertion(node, ctx);
+        self.second.enter_ts_const_assertion(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_const_assertion(&mut self, node: &TsConstAssertion, ctx: &mut C) {
+        self.second.exit_ts_const_assertion(node, ctx);
+        self.first.exit_ts_const_assertion(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_construct_signature_decl(&mut self, node: &TsConstructSignatureDecl, ctx: &mut C) {
+        self.first.enter_ts_construct_signature_decl(node, ctx);
+        self.second.enter_ts_construct_signature_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_construct_signature_decl(&mut self, node: &TsConstructSignatureDecl, ctx: &mut C) {
+        self.second.exit_ts_construct_signature_decl(node, ctx);
+        self.first.exit_ts_construct_signature_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_constructor_type(&mut self, node: &TsConstructorType, ctx: &mut C) {
+        self.first.enter_ts_constructor_type(node, ctx);
+        self.second.enter_ts_constructor_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_constructor_type(&mut self, node: &TsConstructorType, ctx: &mut C) {
+        self.second.exit_ts_constructor_type(node, ctx);
+        self.first.exit_ts_constructor_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_entity_name(&mut self, node: &TsEntityName, ctx: &mut C) {
+        self.first.enter_ts_entity_name(node, ctx);
+        self.second.enter_ts_entity_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_entity_name(&mut self, node: &TsEntityName, ctx: &mut C) {
+        self.second.exit_ts_entity_name(node, ctx);
+        self.first.exit_ts_entity_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_enum_decl(&mut self, node: &TsEnumDecl, ctx: &mut C) {
+        self.first.enter_ts_enum_decl(node, ctx);
+        self.second.enter_ts_enum_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_enum_decl(&mut self, node: &TsEnumDecl, ctx: &mut C) {
+        self.second.exit_ts_enum_decl(node, ctx);
+        self.first.exit_ts_enum_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_enum_member(&mut self, node: &TsEnumMember, ctx: &mut C) {
+        self.first.enter_ts_enum_member(node, ctx);
+        self.second.enter_ts_enum_member(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_enum_member(&mut self, node: &TsEnumMember, ctx: &mut C) {
+        self.second.exit_ts_enum_member(node, ctx);
+        self.first.exit_ts_enum_member(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_enum_member_id(&mut self, node: &TsEnumMemberId, ctx: &mut C) {
+        self.first.enter_ts_enum_member_id(node, ctx);
+        self.second.enter_ts_enum_member_id(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_enum_member_id(&mut self, node: &TsEnumMemberId, ctx: &mut C) {
+        self.second.exit_ts_enum_member_id(node, ctx);
+        self.first.exit_ts_enum_member_id(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_enum_members(&mut self, node: &[TsEnumMember], ctx: &mut C) {
+        self.first.enter_ts_enum_members(node, ctx);
+        self.second.enter_ts_enum_members(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_enum_members(&mut self, node: &[TsEnumMember], ctx: &mut C) {
+        self.second.exit_ts_enum_members(node, ctx);
+        self.first.exit_ts_enum_members(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_export_assignment(&mut self, node: &TsExportAssignment, ctx: &mut C) {
+        self.first.enter_ts_export_assignment(node, ctx);
+        self.second.enter_ts_export_assignment(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_export_assignment(&mut self, node: &TsExportAssignment, ctx: &mut C) {
+        self.second.exit_ts_export_assignment(node, ctx);
+        self.first.exit_ts_export_assignment(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_expr_with_type_args(&mut self, node: &TsExprWithTypeArgs, ctx: &mut C) {
+        self.first.enter_ts_expr_with_type_args(node, ctx);
+        self.second.enter_ts_expr_with_type_args(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_expr_with_type_args(&mut self, node: &TsExprWithTypeArgs, ctx: &mut C) {
+        self.second.exit_ts_expr_with_type_args(node, ctx);
+        self.first.exit_ts_expr_with_type_args(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_expr_with_type_argss(&mut self, node: &[TsExprWithTypeArgs], ctx: &mut C) {
+        self.first.enter_ts_expr_with_type_argss(node, ctx);
+        self.second.enter_ts_expr_with_type_argss(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_expr_with_type_argss(&mut self, node: &[TsExprWithTypeArgs], ctx: &mut C) {
+        self.second.exit_ts_expr_with_type_argss(node, ctx);
+        self.first.exit_ts_expr_with_type_argss(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_external_module_ref(&mut self, node: &TsExternalModuleRef, ctx: &mut C) {
+        self.first.enter_ts_external_module_ref(node, ctx);
+        self.second.enter_ts_external_module_ref(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_external_module_ref(&mut self, node: &TsExternalModuleRef, ctx: &mut C) {
+        self.second.exit_ts_external_module_ref(node, ctx);
+        self.first.exit_ts_external_module_ref(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_fn_or_constructor_type(&mut self, node: &TsFnOrConstructorType, ctx: &mut C) {
+        self.first.enter_ts_fn_or_constructor_type(node, ctx);
+        self.second.enter_ts_fn_or_constructor_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_fn_or_constructor_type(&mut self, node: &TsFnOrConstructorType, ctx: &mut C) {
+        self.second.exit_ts_fn_or_constructor_type(node, ctx);
+        self.first.exit_ts_fn_or_constructor_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_fn_param(&mut self, node: &TsFnParam, ctx: &mut C) {
+        self.first.enter_ts_fn_param(node, ctx);
+        self.second.enter_ts_fn_param(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_fn_param(&mut self, node: &TsFnParam, ctx: &mut C) {
+        self.second.exit_ts_fn_param(node, ctx);
+        self.first.exit_ts_fn_param(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_fn_params(&mut self, node: &[TsFnParam], ctx: &mut C) {
+        self.first.enter_ts_fn_params(node, ctx);
+        self.second.enter_ts_fn_params(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_fn_params(&mut self, node: &[TsFnParam], ctx: &mut C) {
+        self.second.exit_ts_fn_params(node, ctx);
+        self.first.exit_ts_fn_params(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_fn_type(&mut self, node: &TsFnType, ctx: &mut C) {
+        self.first.enter_ts_fn_type(node, ctx);
+        self.second.enter_ts_fn_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_fn_type(&mut self, node: &TsFnType, ctx: &mut C) {
+        self.second.exit_ts_fn_type(node, ctx);
+        self.first.exit_ts_fn_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_getter_signature(&mut self, node: &TsGetterSignature, ctx: &mut C) {
+        self.first.enter_ts_getter_signature(node, ctx);
+        self.second.enter_ts_getter_signature(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_getter_signature(&mut self, node: &TsGetterSignature, ctx: &mut C) {
+        self.second.exit_ts_getter_signature(node, ctx);
+        self.first.exit_ts_getter_signature(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_import_call_options(&mut self, node: &TsImportCallOptions, ctx: &mut C) {
+        self.first.enter_ts_import_call_options(node, ctx);
+        self.second.enter_ts_import_call_options(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_import_call_options(&mut self, node: &TsImportCallOptions, ctx: &mut C) {
+        self.second.exit_ts_import_call_options(node, ctx);
+        self.first.exit_ts_import_call_options(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_import_equals_decl(&mut self, node: &TsImportEqualsDecl, ctx: &mut C) {
+        self.first.enter_ts_import_equals_decl(node, ctx);
+        self.second.enter_ts_import_equals_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_import_equals_decl(&mut self, node: &TsImportEqualsDecl, ctx: &mut C) {
+        self.second.exit_ts_import_equals_decl(node, ctx);
+        self.first.exit_ts_import_equals_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_import_type(&mut self, node: &TsImportType, ctx: &mut C) {
+        self.first.enter_ts_import_type(node, ctx);
+        self.second.enter_ts_import_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_import_type(&mut self, node: &TsImportType, ctx: &mut C) {
+        self.second.exit_ts_import_type(node, ctx);
+        self.first.exit_ts_import_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_index_signature(&mut self, node: &TsIndexSignature, ctx: &mut C) {
+        self.first.enter_ts_index_signature(node, ctx);
+        self.second.enter_ts_index_signature(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_index_signature(&mut self, node: &TsIndexSignature, ctx: &mut C) {
+        self.second.exit_ts_index_signature(node, ctx);
+        self.first.exit_ts_index_signature(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_indexed_access_type(&mut self, node: &TsIndexedAccessType, ctx: &mut C) {
+        self.first.enter_ts_indexed_access_type(node, ctx);
+        self.second.enter_ts_indexed_access_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_indexed_access_type(&mut self, node: &TsIndexedAccessType, ctx: &mut C) {
+        self.second.exit_ts_indexed_access_type(node, ctx);
+        self.first.exit_ts_indexed_access_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_infer_type(&mut self, node: &TsInferType, ctx: &mut C) {
+        self.first.enter_ts_infer_type(node, ctx);
+        self.second.enter_ts_infer_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_infer_type(&mut self, node: &TsInferType, ctx: &mut C) {
+        self.second.exit_ts_infer_type(node, ctx);
+        self.first.exit_ts_infer_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_instantiation(&mut self, node: &TsInstantiation, ctx: &mut C) {
+        self.first.enter_ts_instantiation(node, ctx);
+        self.second.enter_ts_instantiation(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_instantiation(&mut self, node: &TsInstantiation, ctx: &mut C) {
+        self.second.exit_ts_instantiation(node, ctx);
+        self.first.exit_ts_instantiation(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_interface_body(&mut self, node: &TsInterfaceBody, ctx: &mut C) {
+        self.first.enter_ts_interface_body(node, ctx);
+        self.second.enter_ts_interface_body(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_interface_body(&mut self, node: &TsInterfaceBody, ctx: &mut C) {
+        self.second.exit_ts_interface_body(node, ctx);
+        self.first.exit_ts_interface_body(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_interface_decl(&mut self, node: &TsInterfaceDecl, ctx: &mut C) {
+        self.first.enter_ts_interface_decl(node, ctx);
+        self.second.enter_ts_interface_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_interface_decl(&mut self, node: &TsInterfaceDecl, ctx: &mut C) {
+        self.second.exit_ts_interface_decl(node, ctx);
+        self.first.exit_ts_interface_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_intersection_type(&mut self, node: &TsIntersectionType, ctx: &mut C) {
+        self.first.enter_ts_intersection_type(node, ctx);
+        self.second.enter_ts_intersection_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_intersection_type(&mut self, node: &TsIntersectionType, ctx: &mut C) {
+        self.second.exit_ts_intersection_type(node, ctx);
+        self.first.exit_ts_intersection_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_keyword_type(&mut self, node: &TsKeywordType, ctx: &mut C) {
+        self.first.enter_ts_keyword_type(node, ctx);
+        self.second.enter_ts_keyword_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_keyword_type(&mut self, node: &TsKeywordType, ctx: &mut C) {
+        self.second.exit_ts_keyword_type(node, ctx);
+        self.first.exit_ts_keyword_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_keyword_type_kind(&mut self, node: &TsKeywordTypeKind, ctx: &mut C) {
+        self.first.enter_ts_keyword_type_kind(node, ctx);
+        self.second.enter_ts_keyword_type_kind(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_keyword_type_kind(&mut self, node: &TsKeywordTypeKind, ctx: &mut C) {
+        self.second.exit_ts_keyword_type_kind(node, ctx);
+        self.first.exit_ts_keyword_type_kind(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_lit(&mut self, node: &TsLit, ctx: &mut C) {
+        self.first.enter_ts_lit(node, ctx);
+        self.second.enter_ts_lit(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_lit(&mut self, node: &TsLit, ctx: &mut C) {
+        self.second.exit_ts_lit(node, ctx);
+        self.first.exit_ts_lit(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_lit_type(&mut self, node: &TsLitType, ctx: &mut C) {
+        self.first.enter_ts_lit_type(node, ctx);
+        self.second.enter_ts_lit_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_lit_type(&mut self, node: &TsLitType, ctx: &mut C) {
+        self.second.exit_ts_lit_type(node, ctx);
+        self.first.exit_ts_lit_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_mapped_type(&mut self, node: &TsMappedType, ctx: &mut C) {
+        self.first.enter_ts_mapped_type(node, ctx);
+        self.second.enter_ts_mapped_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_mapped_type(&mut self, node: &TsMappedType, ctx: &mut C) {
+        self.second.exit_ts_mapped_type(node, ctx);
+        self.first.exit_ts_mapped_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_method_signature(&mut self, node: &TsMethodSignature, ctx: &mut C) {
+        self.first.enter_ts_method_signature(node, ctx);
+        self.second.enter_ts_method_signature(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_method_signature(&mut self, node: &TsMethodSignature, ctx: &mut C) {
+        self.second.exit_ts_method_signature(node, ctx);
+        self.first.exit_ts_method_signature(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_module_block(&mut self, node: &TsModuleBlock, ctx: &mut C) {
+        self.first.enter_ts_module_block(node, ctx);
+        self.second.enter_ts_module_block(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_module_block(&mut self, node: &TsModuleBlock, ctx: &mut C) {
+        self.second.exit_ts_module_block(node, ctx);
+        self.first.exit_ts_module_block(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_module_decl(&mut self, node: &TsModuleDecl, ctx: &mut C) {
+        self.first.enter_ts_module_decl(node, ctx);
+        self.second.enter_ts_module_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_module_decl(&mut self, node: &TsModuleDecl, ctx: &mut C) {
+        self.second.exit_ts_module_decl(node, ctx);
+        self.first.exit_ts_module_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_module_name(&mut self, node: &TsModuleName, ctx: &mut C) {
+        self.first.enter_ts_module_name(node, ctx);
+        self.second.enter_ts_module_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_module_name(&mut self, node: &TsModuleName, ctx: &mut C) {
+        self.second.exit_ts_module_name(node, ctx);
+        self.first.exit_ts_module_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_module_ref(&mut self, node: &TsModuleRef, ctx: &mut C) {
+        self.first.enter_ts_module_ref(node, ctx);
+        self.second.enter_ts_module_ref(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_module_ref(&mut self, node: &TsModuleRef, ctx: &mut C) {
+        self.second.exit_ts_module_ref(node, ctx);
+        self.first.exit_ts_module_ref(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_namespace_body(&mut self, node: &TsNamespaceBody, ctx: &mut C) {
+        self.first.enter_ts_namespace_body(node, ctx);
+        self.second.enter_ts_namespace_body(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_namespace_body(&mut self, node: &TsNamespaceBody, ctx: &mut C) {
+        self.second.exit_ts_namespace_body(node, ctx);
+        self.first.exit_ts_namespace_body(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_namespace_decl(&mut self, node: &TsNamespaceDecl, ctx: &mut C) {
+        self.first.enter_ts_namespace_decl(node, ctx);
+        self.second.enter_ts_namespace_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_namespace_decl(&mut self, node: &TsNamespaceDecl, ctx: &mut C) {
+        self.second.exit_ts_namespace_decl(node, ctx);
+        self.first.exit_ts_namespace_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_namespace_export_decl(&mut self, node: &TsNamespaceExportDecl, ctx: &mut C) {
+        self.first.enter_ts_namespace_export_decl(node, ctx);
+        self.second.enter_ts_namespace_export_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_namespace_export_decl(&mut self, node: &TsNamespaceExportDecl, ctx: &mut C) {
+        self.second.exit_ts_namespace_export_decl(node, ctx);
+        self.first.exit_ts_namespace_export_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_non_null_expr(&mut self, node: &TsNonNullExpr, ctx: &mut C) {
+        self.first.enter_ts_non_null_expr(node, ctx);
+        self.second.enter_ts_non_null_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_non_null_expr(&mut self, node: &TsNonNullExpr, ctx: &mut C) {
+        self.second.exit_ts_non_null_expr(node, ctx);
+        self.first.exit_ts_non_null_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_optional_type(&mut self, node: &TsOptionalType, ctx: &mut C) {
+        self.first.enter_ts_optional_type(node, ctx);
+        self.second.enter_ts_optional_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_optional_type(&mut self, node: &TsOptionalType, ctx: &mut C) {
+        self.second.exit_ts_optional_type(node, ctx);
+        self.first.exit_ts_optional_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_param_prop(&mut self, node: &TsParamProp, ctx: &mut C) {
+        self.first.enter_ts_param_prop(node, ctx);
+        self.second.enter_ts_param_prop(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_param_prop(&mut self, node: &TsParamProp, ctx: &mut C) {
+        self.second.exit_ts_param_prop(node, ctx);
+        self.first.exit_ts_param_prop(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_param_prop_param(&mut self, node: &TsParamPropParam, ctx: &mut C) {
+        self.first.enter_ts_param_prop_param(node, ctx);
+        self.second.enter_ts_param_prop_param(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_param_prop_param(&mut self, node: &TsParamPropParam, ctx: &mut C) {
+        self.second.exit_ts_param_prop_param(node, ctx);
+        self.first.exit_ts_param_prop_param(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_parenthesized_type(&mut self, node: &TsParenthesizedType, ctx: &mut C) {
+        self.first.enter_ts_parenthesized_type(node, ctx);
+        self.second.enter_ts_parenthesized_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_parenthesized_type(&mut self, node: &TsParenthesizedType, ctx: &mut C) {
+        self.second.exit_ts_parenthesized_type(node, ctx);
+        self.first.exit_ts_parenthesized_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_property_signature(&mut self, node: &TsPropertySignature, ctx: &mut C) {
+        self.first.enter_ts_property_signature(node, ctx);
+        self.second.enter_ts_property_signature(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_property_signature(&mut self, node: &TsPropertySignature, ctx: &mut C) {
+        self.second.exit_ts_property_signature(node, ctx);
+        self.first.exit_ts_property_signature(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_qualified_name(&mut self, node: &TsQualifiedName, ctx: &mut C) {
+        self.first.enter_ts_qualified_name(node, ctx);
+        self.second.enter_ts_qualified_name(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_qualified_name(&mut self, node: &TsQualifiedName, ctx: &mut C) {
+        self.second.exit_ts_qualified_name(node, ctx);
+        self.first.exit_ts_qualified_name(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_rest_type(&mut self, node: &TsRestType, ctx: &mut C) {
+        self.first.enter_ts_rest_type(node, ctx);
+        self.second.enter_ts_rest_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_rest_type(&mut self, node: &TsRestType, ctx: &mut C) {
+        self.second.exit_ts_rest_type(node, ctx);
+        self.first.exit_ts_rest_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_satisfies_expr(&mut self, node: &TsSatisfiesExpr, ctx: &mut C) {
+        self.first.enter_ts_satisfies_expr(node, ctx);
+        self.second.enter_ts_satisfies_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_satisfies_expr(&mut self, node: &TsSatisfiesExpr, ctx: &mut C) {
+        self.second.exit_ts_satisfies_expr(node, ctx);
+        self.first.exit_ts_satisfies_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_setter_signature(&mut self, node: &TsSetterSignature, ctx: &mut C) {
+        self.first.enter_ts_setter_signature(node, ctx);
+        self.second.enter_ts_setter_signature(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_setter_signature(&mut self, node: &TsSetterSignature, ctx: &mut C) {
+        self.second.exit_ts_setter_signature(node, ctx);
+        self.first.exit_ts_setter_signature(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_this_type(&mut self, node: &TsThisType, ctx: &mut C) {
+        self.first.enter_ts_this_type(node, ctx);
+        self.second.enter_ts_this_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_this_type(&mut self, node: &TsThisType, ctx: &mut C) {
+        self.second.exit_ts_this_type(node, ctx);
+        self.first.exit_ts_this_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_this_type_or_ident(&mut self, node: &TsThisTypeOrIdent, ctx: &mut C) {
+        self.first.enter_ts_this_type_or_ident(node, ctx);
+        self.second.enter_ts_this_type_or_ident(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_this_type_or_ident(&mut self, node: &TsThisTypeOrIdent, ctx: &mut C) {
+        self.second.exit_ts_this_type_or_ident(node, ctx);
+        self.first.exit_ts_this_type_or_ident(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_tpl_lit_type(&mut self, node: &TsTplLitType, ctx: &mut C) {
+        self.first.enter_ts_tpl_lit_type(node, ctx);
+        self.second.enter_ts_tpl_lit_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_tpl_lit_type(&mut self, node: &TsTplLitType, ctx: &mut C) {
+        self.second.exit_ts_tpl_lit_type(node, ctx);
+        self.first.exit_ts_tpl_lit_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_tuple_element(&mut self, node: &TsTupleElement, ctx: &mut C) {
+        self.first.enter_ts_tuple_element(node, ctx);
+        self.second.enter_ts_tuple_element(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_tuple_element(&mut self, node: &TsTupleElement, ctx: &mut C) {
+        self.second.exit_ts_tuple_element(node, ctx);
+        self.first.exit_ts_tuple_element(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_tuple_elements(&mut self, node: &[TsTupleElement], ctx: &mut C) {
+        self.first.enter_ts_tuple_elements(node, ctx);
+        self.second.enter_ts_tuple_elements(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_tuple_elements(&mut self, node: &[TsTupleElement], ctx: &mut C) {
+        self.second.exit_ts_tuple_elements(node, ctx);
+        self.first.exit_ts_tuple_elements(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_tuple_type(&mut self, node: &TsTupleType, ctx: &mut C) {
+        self.first.enter_ts_tuple_type(node, ctx);
+        self.second.enter_ts_tuple_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_tuple_type(&mut self, node: &TsTupleType, ctx: &mut C) {
+        self.second.exit_ts_tuple_type(node, ctx);
+        self.first.exit_ts_tuple_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type(&mut self, node: &TsType, ctx: &mut C) {
+        self.first.enter_ts_type(node, ctx);
+        self.second.enter_ts_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type(&mut self, node: &TsType, ctx: &mut C) {
+        self.second.exit_ts_type(node, ctx);
+        self.first.exit_ts_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_alias_decl(&mut self, node: &TsTypeAliasDecl, ctx: &mut C) {
+        self.first.enter_ts_type_alias_decl(node, ctx);
+        self.second.enter_ts_type_alias_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_alias_decl(&mut self, node: &TsTypeAliasDecl, ctx: &mut C) {
+        self.second.exit_ts_type_alias_decl(node, ctx);
+        self.first.exit_ts_type_alias_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_ann(&mut self, node: &TsTypeAnn, ctx: &mut C) {
+        self.first.enter_ts_type_ann(node, ctx);
+        self.second.enter_ts_type_ann(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_ann(&mut self, node: &TsTypeAnn, ctx: &mut C) {
+        self.second.exit_ts_type_ann(node, ctx);
+        self.first.exit_ts_type_ann(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_assertion(&mut self, node: &TsTypeAssertion, ctx: &mut C) {
+        self.first.enter_ts_type_assertion(node, ctx);
+        self.second.enter_ts_type_assertion(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_assertion(&mut self, node: &TsTypeAssertion, ctx: &mut C) {
+        self.second.exit_ts_type_assertion(node, ctx);
+        self.first.exit_ts_type_assertion(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_element(&mut self, node: &TsTypeElement, ctx: &mut C) {
+        self.first.enter_ts_type_element(node, ctx);
+        self.second.enter_ts_type_element(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_element(&mut self, node: &TsTypeElement, ctx: &mut C) {
+        self.second.exit_ts_type_element(node, ctx);
+        self.first.exit_ts_type_element(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_elements(&mut self, node: &[TsTypeElement], ctx: &mut C) {
+        self.first.enter_ts_type_elements(node, ctx);
+        self.second.enter_ts_type_elements(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_elements(&mut self, node: &[TsTypeElement], ctx: &mut C) {
+        self.second.exit_ts_type_elements(node, ctx);
+        self.first.exit_ts_type_elements(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_lit(&mut self, node: &TsTypeLit, ctx: &mut C) {
+        self.first.enter_ts_type_lit(node, ctx);
+        self.second.enter_ts_type_lit(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_lit(&mut self, node: &TsTypeLit, ctx: &mut C) {
+        self.second.exit_ts_type_lit(node, ctx);
+        self.first.exit_ts_type_lit(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_operator(&mut self, node: &TsTypeOperator, ctx: &mut C) {
+        self.first.enter_ts_type_operator(node, ctx);
+        self.second.enter_ts_type_operator(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_operator(&mut self, node: &TsTypeOperator, ctx: &mut C) {
+        self.second.exit_ts_type_operator(node, ctx);
+        self.first.exit_ts_type_operator(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_operator_op(&mut self, node: &TsTypeOperatorOp, ctx: &mut C) {
+        self.first.enter_ts_type_operator_op(node, ctx);
+        self.second.enter_ts_type_operator_op(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_operator_op(&mut self, node: &TsTypeOperatorOp, ctx: &mut C) {
+        self.second.exit_ts_type_operator_op(node, ctx);
+        self.first.exit_ts_type_operator_op(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_param(&mut self, node: &TsTypeParam, ctx: &mut C) {
+        self.first.enter_ts_type_param(node, ctx);
+        self.second.enter_ts_type_param(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_param(&mut self, node: &TsTypeParam, ctx: &mut C) {
+        self.second.exit_ts_type_param(node, ctx);
+        self.first.exit_ts_type_param(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_param_decl(&mut self, node: &TsTypeParamDecl, ctx: &mut C) {
+        self.first.enter_ts_type_param_decl(node, ctx);
+        self.second.enter_ts_type_param_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_param_decl(&mut self, node: &TsTypeParamDecl, ctx: &mut C) {
+        self.second.exit_ts_type_param_decl(node, ctx);
+        self.first.exit_ts_type_param_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_param_instantiation(&mut self, node: &TsTypeParamInstantiation, ctx: &mut C) {
+        self.first.enter_ts_type_param_instantiation(node, ctx);
+        self.second.enter_ts_type_param_instantiation(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_param_instantiation(&mut self, node: &TsTypeParamInstantiation, ctx: &mut C) {
+        self.second.exit_ts_type_param_instantiation(node, ctx);
+        self.first.exit_ts_type_param_instantiation(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_params(&mut self, node: &[TsTypeParam], ctx: &mut C) {
+        self.first.enter_ts_type_params(node, ctx);
+        self.second.enter_ts_type_params(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_params(&mut self, node: &[TsTypeParam], ctx: &mut C) {
+        self.second.exit_ts_type_params(node, ctx);
+        self.first.exit_ts_type_params(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_predicate(&mut self, node: &TsTypePredicate, ctx: &mut C) {
+        self.first.enter_ts_type_predicate(node, ctx);
+        self.second.enter_ts_type_predicate(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_predicate(&mut self, node: &TsTypePredicate, ctx: &mut C) {
+        self.second.exit_ts_type_predicate(node, ctx);
+        self.first.exit_ts_type_predicate(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_query(&mut self, node: &TsTypeQuery, ctx: &mut C) {
+        self.first.enter_ts_type_query(node, ctx);
+        self.second.enter_ts_type_query(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_query(&mut self, node: &TsTypeQuery, ctx: &mut C) {
+        self.second.exit_ts_type_query(node, ctx);
+        self.first.exit_ts_type_query(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_query_expr(&mut self, node: &TsTypeQueryExpr, ctx: &mut C) {
+        self.first.enter_ts_type_query_expr(node, ctx);
+        self.second.enter_ts_type_query_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_query_expr(&mut self, node: &TsTypeQueryExpr, ctx: &mut C) {
+        self.second.exit_ts_type_query_expr(node, ctx);
+        self.first.exit_ts_type_query_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_type_ref(&mut self, node: &TsTypeRef, ctx: &mut C) {
+        self.first.enter_ts_type_ref(node, ctx);
+        self.second.enter_ts_type_ref(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_type_ref(&mut self, node: &TsTypeRef, ctx: &mut C) {
+        self.second.exit_ts_type_ref(node, ctx);
+        self.first.exit_ts_type_ref(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_types(&mut self, node: &[Box<TsType>], ctx: &mut C) {
+        self.first.enter_ts_types(node, ctx);
+        self.second.enter_ts_types(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_types(&mut self, node: &[Box<TsType>], ctx: &mut C) {
+        self.second.exit_ts_types(node, ctx);
+        self.first.exit_ts_types(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_union_or_intersection_type(
+        &mut self,
+        node: &TsUnionOrIntersectionType,
+        ctx: &mut C,
+    ) {
+        self.first.enter_ts_union_or_intersection_type(node, ctx);
+        self.second.enter_ts_union_or_intersection_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_union_or_intersection_type(
+        &mut self,
+        node: &TsUnionOrIntersectionType,
+        ctx: &mut C,
+    ) {
+        self.second.exit_ts_union_or_intersection_type(node, ctx);
+        self.first.exit_ts_union_or_intersection_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_ts_union_type(&mut self, node: &TsUnionType, ctx: &mut C) {
+        self.first.enter_ts_union_type(node, ctx);
+        self.second.enter_ts_union_type(node, ctx);
+    }
+
+    #[inline]
+    fn exit_ts_union_type(&mut self, node: &TsUnionType, ctx: &mut C) {
+        self.second.exit_ts_union_type(node, ctx);
+        self.first.exit_ts_union_type(node, ctx);
+    }
+
+    #[inline]
+    fn enter_unary_expr(&mut self, node: &UnaryExpr, ctx: &mut C) {
+        self.first.enter_unary_expr(node, ctx);
+        self.second.enter_unary_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_unary_expr(&mut self, node: &UnaryExpr, ctx: &mut C) {
+        self.second.exit_unary_expr(node, ctx);
+        self.first.exit_unary_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_unary_op(&mut self, node: &UnaryOp, ctx: &mut C) {
+        self.first.enter_unary_op(node, ctx);
+        self.second.enter_unary_op(node, ctx);
+    }
+
+    #[inline]
+    fn exit_unary_op(&mut self, node: &UnaryOp, ctx: &mut C) {
+        self.second.exit_unary_op(node, ctx);
+        self.first.exit_unary_op(node, ctx);
+    }
+
+    #[inline]
+    fn enter_update_expr(&mut self, node: &UpdateExpr, ctx: &mut C) {
+        self.first.enter_update_expr(node, ctx);
+        self.second.enter_update_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_update_expr(&mut self, node: &UpdateExpr, ctx: &mut C) {
+        self.second.exit_update_expr(node, ctx);
+        self.first.exit_update_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_update_op(&mut self, node: &UpdateOp, ctx: &mut C) {
+        self.first.enter_update_op(node, ctx);
+        self.second.enter_update_op(node, ctx);
+    }
+
+    #[inline]
+    fn exit_update_op(&mut self, node: &UpdateOp, ctx: &mut C) {
+        self.second.exit_update_op(node, ctx);
+        self.first.exit_update_op(node, ctx);
+    }
+
+    #[inline]
+    fn enter_using_decl(&mut self, node: &UsingDecl, ctx: &mut C) {
+        self.first.enter_using_decl(node, ctx);
+        self.second.enter_using_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_using_decl(&mut self, node: &UsingDecl, ctx: &mut C) {
+        self.second.exit_using_decl(node, ctx);
+        self.first.exit_using_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_var_decl(&mut self, node: &VarDecl, ctx: &mut C) {
+        self.first.enter_var_decl(node, ctx);
+        self.second.enter_var_decl(node, ctx);
+    }
+
+    #[inline]
+    fn exit_var_decl(&mut self, node: &VarDecl, ctx: &mut C) {
+        self.second.exit_var_decl(node, ctx);
+        self.first.exit_var_decl(node, ctx);
+    }
+
+    #[inline]
+    fn enter_var_decl_kind(&mut self, node: &VarDeclKind, ctx: &mut C) {
+        self.first.enter_var_decl_kind(node, ctx);
+        self.second.enter_var_decl_kind(node, ctx);
+    }
+
+    #[inline]
+    fn exit_var_decl_kind(&mut self, node: &VarDeclKind, ctx: &mut C) {
+        self.second.exit_var_decl_kind(node, ctx);
+        self.first.exit_var_decl_kind(node, ctx);
+    }
+
+    #[inline]
+    fn enter_var_decl_or_expr(&mut self, node: &VarDeclOrExpr, ctx: &mut C) {
+        self.first.enter_var_decl_or_expr(node, ctx);
+        self.second.enter_var_decl_or_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_var_decl_or_expr(&mut self, node: &VarDeclOrExpr, ctx: &mut C) {
+        self.second.exit_var_decl_or_expr(node, ctx);
+        self.first.exit_var_decl_or_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_var_declarator(&mut self, node: &VarDeclarator, ctx: &mut C) {
+        self.first.enter_var_declarator(node, ctx);
+        self.second.enter_var_declarator(node, ctx);
+    }
+
+    #[inline]
+    fn exit_var_declarator(&mut self, node: &VarDeclarator, ctx: &mut C) {
+        self.second.exit_var_declarator(node, ctx);
+        self.first.exit_var_declarator(node, ctx);
+    }
+
+    #[inline]
+    fn enter_var_declarators(&mut self, node: &[VarDeclarator], ctx: &mut C) {
+        self.first.enter_var_declarators(node, ctx);
+        self.second.enter_var_declarators(node, ctx);
+    }
+
+    #[inline]
+    fn exit_var_declarators(&mut self, node: &[VarDeclarator], ctx: &mut C) {
+        self.second.exit_var_declarators(node, ctx);
+        self.first.exit_var_declarators(node, ctx);
+    }
+
+    #[inline]
+    fn enter_while_stmt(&mut self, node: &WhileStmt, ctx: &mut C) {
+        self.first.enter_while_stmt(node, ctx);
+        self.second.enter_while_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_while_stmt(&mut self, node: &WhileStmt, ctx: &mut C) {
+        self.second.exit_while_stmt(node, ctx);
+        self.first.exit_while_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_with_stmt(&mut self, node: &WithStmt, ctx: &mut C) {
+        self.first.enter_with_stmt(node, ctx);
+        self.second.enter_with_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn exit_with_stmt(&mut self, node: &WithStmt, ctx: &mut C) {
+        self.second.exit_with_stmt(node, ctx);
+        self.first.exit_with_stmt(node, ctx);
+    }
+
+    #[inline]
+    fn enter_wtf_8_atom(&mut self, node: &swc_atoms::Wtf8Atom, ctx: &mut C) {
+        self.first.enter_wtf_8_atom(node, ctx);
+        self.second.enter_wtf_8_atom(node, ctx);
+    }
+
+    #[inline]
+    fn exit_wtf_8_atom(&mut self, node: &swc_atoms::Wtf8Atom, ctx: &mut C) {
+        self.second.exit_wtf_8_atom(node, ctx);
+        self.first.exit_wtf_8_atom(node, ctx);
+    }
+
+    #[inline]
+    fn enter_yield_expr(&mut self, node: &YieldExpr, ctx: &mut C) {
+        self.first.enter_yield_expr(node, ctx);
+        self.second.enter_yield_expr(node, ctx);
+    }
+
+    #[inline]
+    fn exit_yield_expr(&mut self, node: &YieldExpr, ctx: &mut C) {
+        self.second.exit_yield_expr(node, ctx);
+        self.first.exit_yield_expr(node, ctx);
+    }
+}
+impl<L, R, C> VisitHook<C> for swc_common::pass::Either<L, R>
+where
+    L: VisitHook<C>,
+    R: VisitHook<C>,
+{
+    #[inline]
+    fn enter_accessibility(&mut self, node: &Accessibility, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_accessibility(node, ctx),
+            Self::Right(hook) => hook.enter_accessibility(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_accessibility(&mut self, node: &Accessibility, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_accessibility(node, ctx),
+            Self::Right(hook) => hook.exit_accessibility(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_array_lit(&mut self, node: &ArrayLit, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_array_lit(node, ctx),
+            Self::Right(hook) => hook.enter_array_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_array_lit(&mut self, node: &ArrayLit, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_array_lit(node, ctx),
+            Self::Right(hook) => hook.exit_array_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_array_pat(&mut self, node: &ArrayPat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_array_pat(node, ctx),
+            Self::Right(hook) => hook.enter_array_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_array_pat(&mut self, node: &ArrayPat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_array_pat(node, ctx),
+            Self::Right(hook) => hook.exit_array_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_arrow_expr(&mut self, node: &ArrowExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_arrow_expr(node, ctx),
+            Self::Right(hook) => hook.enter_arrow_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_arrow_expr(&mut self, node: &ArrowExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_arrow_expr(node, ctx),
+            Self::Right(hook) => hook.exit_arrow_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_assign_expr(&mut self, node: &AssignExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_assign_expr(node, ctx),
+            Self::Right(hook) => hook.enter_assign_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_assign_expr(&mut self, node: &AssignExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_assign_expr(node, ctx),
+            Self::Right(hook) => hook.exit_assign_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_assign_op(&mut self, node: &AssignOp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_assign_op(node, ctx),
+            Self::Right(hook) => hook.enter_assign_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_assign_op(&mut self, node: &AssignOp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_assign_op(node, ctx),
+            Self::Right(hook) => hook.exit_assign_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_assign_pat(&mut self, node: &AssignPat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_assign_pat(node, ctx),
+            Self::Right(hook) => hook.enter_assign_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_assign_pat(&mut self, node: &AssignPat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_assign_pat(node, ctx),
+            Self::Right(hook) => hook.exit_assign_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_assign_pat_prop(&mut self, node: &AssignPatProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_assign_pat_prop(node, ctx),
+            Self::Right(hook) => hook.enter_assign_pat_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_assign_pat_prop(&mut self, node: &AssignPatProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_assign_pat_prop(node, ctx),
+            Self::Right(hook) => hook.exit_assign_pat_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_assign_prop(&mut self, node: &AssignProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_assign_prop(node, ctx),
+            Self::Right(hook) => hook.enter_assign_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_assign_prop(&mut self, node: &AssignProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_assign_prop(node, ctx),
+            Self::Right(hook) => hook.exit_assign_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_assign_target(&mut self, node: &AssignTarget, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_assign_target(node, ctx),
+            Self::Right(hook) => hook.enter_assign_target(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_assign_target(&mut self, node: &AssignTarget, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_assign_target(node, ctx),
+            Self::Right(hook) => hook.exit_assign_target(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_assign_target_pat(&mut self, node: &AssignTargetPat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_assign_target_pat(node, ctx),
+            Self::Right(hook) => hook.enter_assign_target_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_assign_target_pat(&mut self, node: &AssignTargetPat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_assign_target_pat(node, ctx),
+            Self::Right(hook) => hook.exit_assign_target_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_atom(&mut self, node: &swc_atoms::Atom, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_atom(node, ctx),
+            Self::Right(hook) => hook.enter_atom(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_atom(&mut self, node: &swc_atoms::Atom, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_atom(node, ctx),
+            Self::Right(hook) => hook.exit_atom(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_auto_accessor(&mut self, node: &AutoAccessor, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_auto_accessor(node, ctx),
+            Self::Right(hook) => hook.enter_auto_accessor(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_auto_accessor(&mut self, node: &AutoAccessor, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_auto_accessor(node, ctx),
+            Self::Right(hook) => hook.exit_auto_accessor(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_await_expr(&mut self, node: &AwaitExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_await_expr(node, ctx),
+            Self::Right(hook) => hook.enter_await_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_await_expr(&mut self, node: &AwaitExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_await_expr(node, ctx),
+            Self::Right(hook) => hook.exit_await_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_big_int(&mut self, node: &BigInt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_big_int(node, ctx),
+            Self::Right(hook) => hook.enter_big_int(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_big_int(&mut self, node: &BigInt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_big_int(node, ctx),
+            Self::Right(hook) => hook.exit_big_int(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_big_int_value(&mut self, node: &BigIntValue, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_big_int_value(node, ctx),
+            Self::Right(hook) => hook.enter_big_int_value(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_big_int_value(&mut self, node: &BigIntValue, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_big_int_value(node, ctx),
+            Self::Right(hook) => hook.exit_big_int_value(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_bin_expr(&mut self, node: &BinExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_bin_expr(node, ctx),
+            Self::Right(hook) => hook.enter_bin_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_bin_expr(&mut self, node: &BinExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_bin_expr(node, ctx),
+            Self::Right(hook) => hook.exit_bin_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_binary_op(&mut self, node: &BinaryOp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_binary_op(node, ctx),
+            Self::Right(hook) => hook.enter_binary_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_binary_op(&mut self, node: &BinaryOp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_binary_op(node, ctx),
+            Self::Right(hook) => hook.exit_binary_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_binding_ident(&mut self, node: &BindingIdent, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_binding_ident(node, ctx),
+            Self::Right(hook) => hook.enter_binding_ident(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_binding_ident(&mut self, node: &BindingIdent, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_binding_ident(node, ctx),
+            Self::Right(hook) => hook.exit_binding_ident(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_block_stmt(&mut self, node: &BlockStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_block_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_block_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_block_stmt(&mut self, node: &BlockStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_block_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_block_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_block_stmt_or_expr(&mut self, node: &BlockStmtOrExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_block_stmt_or_expr(node, ctx),
+            Self::Right(hook) => hook.enter_block_stmt_or_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_block_stmt_or_expr(&mut self, node: &BlockStmtOrExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_block_stmt_or_expr(node, ctx),
+            Self::Right(hook) => hook.exit_block_stmt_or_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_bool(&mut self, node: &Bool, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_bool(node, ctx),
+            Self::Right(hook) => hook.enter_bool(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_bool(&mut self, node: &Bool, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_bool(node, ctx),
+            Self::Right(hook) => hook.exit_bool(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_break_stmt(&mut self, node: &BreakStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_break_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_break_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_break_stmt(&mut self, node: &BreakStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_break_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_break_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_call_expr(&mut self, node: &CallExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_call_expr(node, ctx),
+            Self::Right(hook) => hook.enter_call_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_call_expr(&mut self, node: &CallExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_call_expr(node, ctx),
+            Self::Right(hook) => hook.exit_call_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_callee(&mut self, node: &Callee, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_callee(node, ctx),
+            Self::Right(hook) => hook.enter_callee(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_callee(&mut self, node: &Callee, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_callee(node, ctx),
+            Self::Right(hook) => hook.exit_callee(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_catch_clause(&mut self, node: &CatchClause, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_catch_clause(node, ctx),
+            Self::Right(hook) => hook.enter_catch_clause(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_catch_clause(&mut self, node: &CatchClause, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_catch_clause(node, ctx),
+            Self::Right(hook) => hook.exit_catch_clause(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_class(&mut self, node: &Class, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_class(node, ctx),
+            Self::Right(hook) => hook.enter_class(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_class(&mut self, node: &Class, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_class(node, ctx),
+            Self::Right(hook) => hook.exit_class(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_class_decl(&mut self, node: &ClassDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_class_decl(node, ctx),
+            Self::Right(hook) => hook.enter_class_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_class_decl(&mut self, node: &ClassDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_class_decl(node, ctx),
+            Self::Right(hook) => hook.exit_class_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_class_expr(&mut self, node: &ClassExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_class_expr(node, ctx),
+            Self::Right(hook) => hook.enter_class_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_class_expr(&mut self, node: &ClassExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_class_expr(node, ctx),
+            Self::Right(hook) => hook.exit_class_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_class_member(&mut self, node: &ClassMember, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_class_member(node, ctx),
+            Self::Right(hook) => hook.enter_class_member(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_class_member(&mut self, node: &ClassMember, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_class_member(node, ctx),
+            Self::Right(hook) => hook.exit_class_member(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_class_members(&mut self, node: &[ClassMember], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_class_members(node, ctx),
+            Self::Right(hook) => hook.enter_class_members(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_class_members(&mut self, node: &[ClassMember], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_class_members(node, ctx),
+            Self::Right(hook) => hook.exit_class_members(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_class_method(&mut self, node: &ClassMethod, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_class_method(node, ctx),
+            Self::Right(hook) => hook.enter_class_method(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_class_method(&mut self, node: &ClassMethod, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_class_method(node, ctx),
+            Self::Right(hook) => hook.exit_class_method(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_class_prop(&mut self, node: &ClassProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_class_prop(node, ctx),
+            Self::Right(hook) => hook.enter_class_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_class_prop(&mut self, node: &ClassProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_class_prop(node, ctx),
+            Self::Right(hook) => hook.exit_class_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_computed_prop_name(&mut self, node: &ComputedPropName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_computed_prop_name(node, ctx),
+            Self::Right(hook) => hook.enter_computed_prop_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_computed_prop_name(&mut self, node: &ComputedPropName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_computed_prop_name(node, ctx),
+            Self::Right(hook) => hook.exit_computed_prop_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_cond_expr(&mut self, node: &CondExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_cond_expr(node, ctx),
+            Self::Right(hook) => hook.enter_cond_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_cond_expr(&mut self, node: &CondExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_cond_expr(node, ctx),
+            Self::Right(hook) => hook.exit_cond_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_constructor(&mut self, node: &Constructor, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_constructor(node, ctx),
+            Self::Right(hook) => hook.enter_constructor(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_constructor(&mut self, node: &Constructor, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_constructor(node, ctx),
+            Self::Right(hook) => hook.exit_constructor(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_continue_stmt(&mut self, node: &ContinueStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_continue_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_continue_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_continue_stmt(&mut self, node: &ContinueStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_continue_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_continue_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_debugger_stmt(&mut self, node: &DebuggerStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_debugger_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_debugger_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_debugger_stmt(&mut self, node: &DebuggerStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_debugger_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_debugger_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_decl(&mut self, node: &Decl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_decl(node, ctx),
+            Self::Right(hook) => hook.enter_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_decl(&mut self, node: &Decl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_decl(node, ctx),
+            Self::Right(hook) => hook.exit_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_decorator(&mut self, node: &Decorator, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_decorator(node, ctx),
+            Self::Right(hook) => hook.enter_decorator(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_decorator(&mut self, node: &Decorator, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_decorator(node, ctx),
+            Self::Right(hook) => hook.exit_decorator(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_decorators(&mut self, node: &[Decorator], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_decorators(node, ctx),
+            Self::Right(hook) => hook.enter_decorators(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_decorators(&mut self, node: &[Decorator], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_decorators(node, ctx),
+            Self::Right(hook) => hook.exit_decorators(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_default_decl(&mut self, node: &DefaultDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_default_decl(node, ctx),
+            Self::Right(hook) => hook.enter_default_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_default_decl(&mut self, node: &DefaultDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_default_decl(node, ctx),
+            Self::Right(hook) => hook.exit_default_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_do_while_stmt(&mut self, node: &DoWhileStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_do_while_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_do_while_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_do_while_stmt(&mut self, node: &DoWhileStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_do_while_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_do_while_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_empty_stmt(&mut self, node: &EmptyStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_empty_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_empty_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_empty_stmt(&mut self, node: &EmptyStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_empty_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_empty_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_export_all(&mut self, node: &ExportAll, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_export_all(node, ctx),
+            Self::Right(hook) => hook.enter_export_all(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_export_all(&mut self, node: &ExportAll, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_export_all(node, ctx),
+            Self::Right(hook) => hook.exit_export_all(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_export_decl(&mut self, node: &ExportDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_export_decl(node, ctx),
+            Self::Right(hook) => hook.enter_export_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_export_decl(&mut self, node: &ExportDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_export_decl(node, ctx),
+            Self::Right(hook) => hook.exit_export_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_export_default_decl(&mut self, node: &ExportDefaultDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_export_default_decl(node, ctx),
+            Self::Right(hook) => hook.enter_export_default_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_export_default_decl(&mut self, node: &ExportDefaultDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_export_default_decl(node, ctx),
+            Self::Right(hook) => hook.exit_export_default_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_export_default_expr(&mut self, node: &ExportDefaultExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_export_default_expr(node, ctx),
+            Self::Right(hook) => hook.enter_export_default_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_export_default_expr(&mut self, node: &ExportDefaultExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_export_default_expr(node, ctx),
+            Self::Right(hook) => hook.exit_export_default_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_export_default_specifier(&mut self, node: &ExportDefaultSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_export_default_specifier(node, ctx),
+            Self::Right(hook) => hook.enter_export_default_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_export_default_specifier(&mut self, node: &ExportDefaultSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_export_default_specifier(node, ctx),
+            Self::Right(hook) => hook.exit_export_default_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_export_named_specifier(&mut self, node: &ExportNamedSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_export_named_specifier(node, ctx),
+            Self::Right(hook) => hook.enter_export_named_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_export_named_specifier(&mut self, node: &ExportNamedSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_export_named_specifier(node, ctx),
+            Self::Right(hook) => hook.exit_export_named_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_export_namespace_specifier(&mut self, node: &ExportNamespaceSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_export_namespace_specifier(node, ctx),
+            Self::Right(hook) => hook.enter_export_namespace_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_export_namespace_specifier(&mut self, node: &ExportNamespaceSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_export_namespace_specifier(node, ctx),
+            Self::Right(hook) => hook.exit_export_namespace_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_export_specifier(&mut self, node: &ExportSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_export_specifier(node, ctx),
+            Self::Right(hook) => hook.enter_export_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_export_specifier(&mut self, node: &ExportSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_export_specifier(node, ctx),
+            Self::Right(hook) => hook.exit_export_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_export_specifiers(&mut self, node: &[ExportSpecifier], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_export_specifiers(node, ctx),
+            Self::Right(hook) => hook.enter_export_specifiers(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_export_specifiers(&mut self, node: &[ExportSpecifier], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_export_specifiers(node, ctx),
+            Self::Right(hook) => hook.exit_export_specifiers(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_expr(&mut self, node: &Expr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_expr(node, ctx),
+            Self::Right(hook) => hook.enter_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_expr(&mut self, node: &Expr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_expr(node, ctx),
+            Self::Right(hook) => hook.exit_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_expr_or_spread(&mut self, node: &ExprOrSpread, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_expr_or_spread(node, ctx),
+            Self::Right(hook) => hook.enter_expr_or_spread(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_expr_or_spread(&mut self, node: &ExprOrSpread, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_expr_or_spread(node, ctx),
+            Self::Right(hook) => hook.exit_expr_or_spread(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_expr_or_spreads(&mut self, node: &[ExprOrSpread], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_expr_or_spreads(node, ctx),
+            Self::Right(hook) => hook.enter_expr_or_spreads(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_expr_or_spreads(&mut self, node: &[ExprOrSpread], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_expr_or_spreads(node, ctx),
+            Self::Right(hook) => hook.exit_expr_or_spreads(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_expr_stmt(&mut self, node: &ExprStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_expr_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_expr_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_expr_stmt(&mut self, node: &ExprStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_expr_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_expr_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_exprs(&mut self, node: &[Box<Expr>], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_exprs(node, ctx),
+            Self::Right(hook) => hook.enter_exprs(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_exprs(&mut self, node: &[Box<Expr>], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_exprs(node, ctx),
+            Self::Right(hook) => hook.exit_exprs(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_fn_decl(&mut self, node: &FnDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_fn_decl(node, ctx),
+            Self::Right(hook) => hook.enter_fn_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_fn_decl(&mut self, node: &FnDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_fn_decl(node, ctx),
+            Self::Right(hook) => hook.exit_fn_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_fn_expr(&mut self, node: &FnExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_fn_expr(node, ctx),
+            Self::Right(hook) => hook.enter_fn_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_fn_expr(&mut self, node: &FnExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_fn_expr(node, ctx),
+            Self::Right(hook) => hook.exit_fn_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_for_head(&mut self, node: &ForHead, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_for_head(node, ctx),
+            Self::Right(hook) => hook.enter_for_head(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_for_head(&mut self, node: &ForHead, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_for_head(node, ctx),
+            Self::Right(hook) => hook.exit_for_head(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_for_in_stmt(&mut self, node: &ForInStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_for_in_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_for_in_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_for_in_stmt(&mut self, node: &ForInStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_for_in_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_for_in_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_for_of_stmt(&mut self, node: &ForOfStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_for_of_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_for_of_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_for_of_stmt(&mut self, node: &ForOfStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_for_of_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_for_of_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_for_stmt(&mut self, node: &ForStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_for_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_for_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_for_stmt(&mut self, node: &ForStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_for_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_for_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_function(&mut self, node: &Function, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_function(node, ctx),
+            Self::Right(hook) => hook.enter_function(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_function(&mut self, node: &Function, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_function(node, ctx),
+            Self::Right(hook) => hook.exit_function(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_getter_prop(&mut self, node: &GetterProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_getter_prop(node, ctx),
+            Self::Right(hook) => hook.enter_getter_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_getter_prop(&mut self, node: &GetterProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_getter_prop(node, ctx),
+            Self::Right(hook) => hook.exit_getter_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ident(&mut self, node: &Ident, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ident(node, ctx),
+            Self::Right(hook) => hook.enter_ident(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ident(&mut self, node: &Ident, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ident(node, ctx),
+            Self::Right(hook) => hook.exit_ident(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ident_name(&mut self, node: &IdentName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ident_name(node, ctx),
+            Self::Right(hook) => hook.enter_ident_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ident_name(&mut self, node: &IdentName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ident_name(node, ctx),
+            Self::Right(hook) => hook.exit_ident_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_if_stmt(&mut self, node: &IfStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_if_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_if_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_if_stmt(&mut self, node: &IfStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_if_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_if_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import(&mut self, node: &Import, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import(node, ctx),
+            Self::Right(hook) => hook.enter_import(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import(&mut self, node: &Import, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import(node, ctx),
+            Self::Right(hook) => hook.exit_import(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import_decl(&mut self, node: &ImportDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import_decl(node, ctx),
+            Self::Right(hook) => hook.enter_import_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import_decl(&mut self, node: &ImportDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import_decl(node, ctx),
+            Self::Right(hook) => hook.exit_import_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import_default_specifier(&mut self, node: &ImportDefaultSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import_default_specifier(node, ctx),
+            Self::Right(hook) => hook.enter_import_default_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import_default_specifier(&mut self, node: &ImportDefaultSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import_default_specifier(node, ctx),
+            Self::Right(hook) => hook.exit_import_default_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import_named_specifier(&mut self, node: &ImportNamedSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import_named_specifier(node, ctx),
+            Self::Right(hook) => hook.enter_import_named_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import_named_specifier(&mut self, node: &ImportNamedSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import_named_specifier(node, ctx),
+            Self::Right(hook) => hook.exit_import_named_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import_phase(&mut self, node: &ImportPhase, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import_phase(node, ctx),
+            Self::Right(hook) => hook.enter_import_phase(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import_phase(&mut self, node: &ImportPhase, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import_phase(node, ctx),
+            Self::Right(hook) => hook.exit_import_phase(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import_specifier(&mut self, node: &ImportSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import_specifier(node, ctx),
+            Self::Right(hook) => hook.enter_import_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import_specifier(&mut self, node: &ImportSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import_specifier(node, ctx),
+            Self::Right(hook) => hook.exit_import_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import_specifiers(&mut self, node: &[ImportSpecifier], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import_specifiers(node, ctx),
+            Self::Right(hook) => hook.enter_import_specifiers(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import_specifiers(&mut self, node: &[ImportSpecifier], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import_specifiers(node, ctx),
+            Self::Right(hook) => hook.exit_import_specifiers(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import_star_as_specifier(node, ctx),
+            Self::Right(hook) => hook.enter_import_star_as_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import_star_as_specifier(node, ctx),
+            Self::Right(hook) => hook.exit_import_star_as_specifier(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import_with(&mut self, node: &ImportWith, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import_with(node, ctx),
+            Self::Right(hook) => hook.enter_import_with(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import_with(&mut self, node: &ImportWith, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import_with(node, ctx),
+            Self::Right(hook) => hook.exit_import_with(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import_with_item(&mut self, node: &ImportWithItem, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import_with_item(node, ctx),
+            Self::Right(hook) => hook.enter_import_with_item(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import_with_item(&mut self, node: &ImportWithItem, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import_with_item(node, ctx),
+            Self::Right(hook) => hook.exit_import_with_item(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_import_with_items(&mut self, node: &[ImportWithItem], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_import_with_items(node, ctx),
+            Self::Right(hook) => hook.enter_import_with_items(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_import_with_items(&mut self, node: &[ImportWithItem], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_import_with_items(node, ctx),
+            Self::Right(hook) => hook.exit_import_with_items(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_invalid(&mut self, node: &Invalid, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_invalid(node, ctx),
+            Self::Right(hook) => hook.enter_invalid(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_invalid(&mut self, node: &Invalid, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_invalid(node, ctx),
+            Self::Right(hook) => hook.exit_invalid(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_attr(&mut self, node: &JSXAttr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_attr(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_attr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_attr(&mut self, node: &JSXAttr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_attr(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_attr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_attr_name(&mut self, node: &JSXAttrName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_attr_name(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_attr_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_attr_name(&mut self, node: &JSXAttrName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_attr_name(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_attr_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_attr_or_spread(&mut self, node: &JSXAttrOrSpread, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_attr_or_spread(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_attr_or_spread(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_attr_or_spread(&mut self, node: &JSXAttrOrSpread, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_attr_or_spread(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_attr_or_spread(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_attr_or_spreads(&mut self, node: &[JSXAttrOrSpread], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_attr_or_spreads(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_attr_or_spreads(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_attr_or_spreads(&mut self, node: &[JSXAttrOrSpread], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_attr_or_spreads(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_attr_or_spreads(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_attr_value(&mut self, node: &JSXAttrValue, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_attr_value(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_attr_value(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_attr_value(&mut self, node: &JSXAttrValue, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_attr_value(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_attr_value(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_closing_element(&mut self, node: &JSXClosingElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_closing_element(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_closing_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_closing_element(&mut self, node: &JSXClosingElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_closing_element(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_closing_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_closing_fragment(&mut self, node: &JSXClosingFragment, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_closing_fragment(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_closing_fragment(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_closing_fragment(&mut self, node: &JSXClosingFragment, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_closing_fragment(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_closing_fragment(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_element(&mut self, node: &JSXElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_element(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_element(&mut self, node: &JSXElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_element(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_element_child(&mut self, node: &JSXElementChild, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_element_child(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_element_child(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_element_child(&mut self, node: &JSXElementChild, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_element_child(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_element_child(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_element_childs(&mut self, node: &[JSXElementChild], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_element_childs(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_element_childs(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_element_childs(&mut self, node: &[JSXElementChild], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_element_childs(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_element_childs(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_element_name(&mut self, node: &JSXElementName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_element_name(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_element_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_element_name(&mut self, node: &JSXElementName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_element_name(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_element_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_empty_expr(&mut self, node: &JSXEmptyExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_empty_expr(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_empty_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_empty_expr(&mut self, node: &JSXEmptyExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_empty_expr(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_empty_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_expr(&mut self, node: &JSXExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_expr(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_expr(&mut self, node: &JSXExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_expr(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_expr_container(&mut self, node: &JSXExprContainer, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_expr_container(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_expr_container(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_expr_container(&mut self, node: &JSXExprContainer, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_expr_container(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_expr_container(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_fragment(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_fragment(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_fragment(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_fragment(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_member_expr(&mut self, node: &JSXMemberExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_member_expr(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_member_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_member_expr(&mut self, node: &JSXMemberExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_member_expr(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_member_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_namespaced_name(&mut self, node: &JSXNamespacedName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_namespaced_name(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_namespaced_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_namespaced_name(&mut self, node: &JSXNamespacedName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_namespaced_name(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_namespaced_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_object(&mut self, node: &JSXObject, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_object(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_object(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_object(&mut self, node: &JSXObject, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_object(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_object(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_opening_element(&mut self, node: &JSXOpeningElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_opening_element(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_opening_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_opening_element(&mut self, node: &JSXOpeningElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_opening_element(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_opening_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_opening_fragment(&mut self, node: &JSXOpeningFragment, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_opening_fragment(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_opening_fragment(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_opening_fragment(&mut self, node: &JSXOpeningFragment, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_opening_fragment(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_opening_fragment(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_spread_child(&mut self, node: &JSXSpreadChild, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_spread_child(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_spread_child(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_spread_child(&mut self, node: &JSXSpreadChild, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_spread_child(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_spread_child(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_text(&mut self, node: &JSXText, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_jsx_text(node, ctx),
+            Self::Right(hook) => hook.enter_jsx_text(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_text(&mut self, node: &JSXText, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_jsx_text(node, ctx),
+            Self::Right(hook) => hook.exit_jsx_text(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_key(&mut self, node: &Key, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_key(node, ctx),
+            Self::Right(hook) => hook.enter_key(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_key(&mut self, node: &Key, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_key(node, ctx),
+            Self::Right(hook) => hook.exit_key(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_key_value_pat_prop(&mut self, node: &KeyValuePatProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_key_value_pat_prop(node, ctx),
+            Self::Right(hook) => hook.enter_key_value_pat_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_key_value_pat_prop(&mut self, node: &KeyValuePatProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_key_value_pat_prop(node, ctx),
+            Self::Right(hook) => hook.exit_key_value_pat_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_key_value_prop(&mut self, node: &KeyValueProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_key_value_prop(node, ctx),
+            Self::Right(hook) => hook.enter_key_value_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_key_value_prop(&mut self, node: &KeyValueProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_key_value_prop(node, ctx),
+            Self::Right(hook) => hook.exit_key_value_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_labeled_stmt(&mut self, node: &LabeledStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_labeled_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_labeled_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_labeled_stmt(&mut self, node: &LabeledStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_labeled_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_labeled_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_lit(&mut self, node: &Lit, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_lit(node, ctx),
+            Self::Right(hook) => hook.enter_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_lit(&mut self, node: &Lit, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_lit(node, ctx),
+            Self::Right(hook) => hook.exit_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_member_expr(&mut self, node: &MemberExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_member_expr(node, ctx),
+            Self::Right(hook) => hook.enter_member_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_member_expr(&mut self, node: &MemberExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_member_expr(node, ctx),
+            Self::Right(hook) => hook.exit_member_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_member_prop(&mut self, node: &MemberProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_member_prop(node, ctx),
+            Self::Right(hook) => hook.enter_member_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_member_prop(&mut self, node: &MemberProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_member_prop(node, ctx),
+            Self::Right(hook) => hook.exit_member_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_meta_prop_expr(&mut self, node: &MetaPropExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_meta_prop_expr(node, ctx),
+            Self::Right(hook) => hook.enter_meta_prop_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_meta_prop_expr(&mut self, node: &MetaPropExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_meta_prop_expr(node, ctx),
+            Self::Right(hook) => hook.exit_meta_prop_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_meta_prop_kind(&mut self, node: &MetaPropKind, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_meta_prop_kind(node, ctx),
+            Self::Right(hook) => hook.enter_meta_prop_kind(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_meta_prop_kind(&mut self, node: &MetaPropKind, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_meta_prop_kind(node, ctx),
+            Self::Right(hook) => hook.exit_meta_prop_kind(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_method_kind(&mut self, node: &MethodKind, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_method_kind(node, ctx),
+            Self::Right(hook) => hook.enter_method_kind(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_method_kind(&mut self, node: &MethodKind, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_method_kind(node, ctx),
+            Self::Right(hook) => hook.exit_method_kind(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_method_prop(&mut self, node: &MethodProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_method_prop(node, ctx),
+            Self::Right(hook) => hook.enter_method_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_method_prop(&mut self, node: &MethodProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_method_prop(node, ctx),
+            Self::Right(hook) => hook.exit_method_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_module(&mut self, node: &Module, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_module(node, ctx),
+            Self::Right(hook) => hook.enter_module(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_module(&mut self, node: &Module, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_module(node, ctx),
+            Self::Right(hook) => hook.exit_module(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_module_decl(&mut self, node: &ModuleDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_module_decl(node, ctx),
+            Self::Right(hook) => hook.enter_module_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_module_decl(&mut self, node: &ModuleDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_module_decl(node, ctx),
+            Self::Right(hook) => hook.exit_module_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_module_export_name(&mut self, node: &ModuleExportName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_module_export_name(node, ctx),
+            Self::Right(hook) => hook.enter_module_export_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_module_export_name(&mut self, node: &ModuleExportName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_module_export_name(node, ctx),
+            Self::Right(hook) => hook.exit_module_export_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_module_item(&mut self, node: &ModuleItem, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_module_item(node, ctx),
+            Self::Right(hook) => hook.enter_module_item(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_module_item(&mut self, node: &ModuleItem, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_module_item(node, ctx),
+            Self::Right(hook) => hook.exit_module_item(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_module_items(&mut self, node: &[ModuleItem], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_module_items(node, ctx),
+            Self::Right(hook) => hook.enter_module_items(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_module_items(&mut self, node: &[ModuleItem], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_module_items(node, ctx),
+            Self::Right(hook) => hook.exit_module_items(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_named_export(&mut self, node: &NamedExport, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_named_export(node, ctx),
+            Self::Right(hook) => hook.enter_named_export(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_named_export(&mut self, node: &NamedExport, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_named_export(node, ctx),
+            Self::Right(hook) => hook.exit_named_export(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_new_expr(node, ctx),
+            Self::Right(hook) => hook.enter_new_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_new_expr(node, ctx),
+            Self::Right(hook) => hook.exit_new_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_null(&mut self, node: &Null, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_null(node, ctx),
+            Self::Right(hook) => hook.enter_null(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_null(&mut self, node: &Null, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_null(node, ctx),
+            Self::Right(hook) => hook.exit_null(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_number(&mut self, node: &Number, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_number(node, ctx),
+            Self::Right(hook) => hook.enter_number(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_number(&mut self, node: &Number, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_number(node, ctx),
+            Self::Right(hook) => hook.exit_number(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_object_lit(&mut self, node: &ObjectLit, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_object_lit(node, ctx),
+            Self::Right(hook) => hook.enter_object_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_object_lit(&mut self, node: &ObjectLit, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_object_lit(node, ctx),
+            Self::Right(hook) => hook.exit_object_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_object_pat(&mut self, node: &ObjectPat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_object_pat(node, ctx),
+            Self::Right(hook) => hook.enter_object_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_object_pat(&mut self, node: &ObjectPat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_object_pat(node, ctx),
+            Self::Right(hook) => hook.exit_object_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_object_pat_prop(&mut self, node: &ObjectPatProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_object_pat_prop(node, ctx),
+            Self::Right(hook) => hook.enter_object_pat_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_object_pat_prop(&mut self, node: &ObjectPatProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_object_pat_prop(node, ctx),
+            Self::Right(hook) => hook.exit_object_pat_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_object_pat_props(&mut self, node: &[ObjectPatProp], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_object_pat_props(node, ctx),
+            Self::Right(hook) => hook.enter_object_pat_props(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_object_pat_props(&mut self, node: &[ObjectPatProp], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_object_pat_props(node, ctx),
+            Self::Right(hook) => hook.exit_object_pat_props(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_accessibility(&mut self, node: &Option<Accessibility>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_accessibility(node, ctx),
+            Self::Right(hook) => hook.enter_opt_accessibility(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_accessibility(&mut self, node: &Option<Accessibility>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_accessibility(node, ctx),
+            Self::Right(hook) => hook.exit_opt_accessibility(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_atom(&mut self, node: &Option<swc_atoms::Atom>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_atom(node, ctx),
+            Self::Right(hook) => hook.enter_opt_atom(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_atom(&mut self, node: &Option<swc_atoms::Atom>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_atom(node, ctx),
+            Self::Right(hook) => hook.exit_opt_atom(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_block_stmt(&mut self, node: &Option<BlockStmt>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_block_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_opt_block_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_block_stmt(&mut self, node: &Option<BlockStmt>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_block_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_opt_block_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_call(&mut self, node: &OptCall, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_call(node, ctx),
+            Self::Right(hook) => hook.enter_opt_call(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_call(&mut self, node: &OptCall, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_call(node, ctx),
+            Self::Right(hook) => hook.exit_opt_call(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_catch_clause(&mut self, node: &Option<CatchClause>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_catch_clause(node, ctx),
+            Self::Right(hook) => hook.enter_opt_catch_clause(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_catch_clause(&mut self, node: &Option<CatchClause>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_catch_clause(node, ctx),
+            Self::Right(hook) => hook.exit_opt_catch_clause(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_chain_base(&mut self, node: &OptChainBase, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_chain_base(node, ctx),
+            Self::Right(hook) => hook.enter_opt_chain_base(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_chain_base(&mut self, node: &OptChainBase, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_chain_base(node, ctx),
+            Self::Right(hook) => hook.exit_opt_chain_base(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_chain_expr(&mut self, node: &OptChainExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_chain_expr(node, ctx),
+            Self::Right(hook) => hook.enter_opt_chain_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_chain_expr(&mut self, node: &OptChainExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_chain_expr(node, ctx),
+            Self::Right(hook) => hook.exit_opt_chain_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_expr(&mut self, node: &Option<Box<Expr>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_expr(node, ctx),
+            Self::Right(hook) => hook.enter_opt_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_expr(&mut self, node: &Option<Box<Expr>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_expr(node, ctx),
+            Self::Right(hook) => hook.exit_opt_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_expr_or_spread(&mut self, node: &Option<ExprOrSpread>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_expr_or_spread(node, ctx),
+            Self::Right(hook) => hook.enter_opt_expr_or_spread(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_expr_or_spread(&mut self, node: &Option<ExprOrSpread>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_expr_or_spread(node, ctx),
+            Self::Right(hook) => hook.exit_opt_expr_or_spread(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_expr_or_spreads(&mut self, node: &Option<Vec<ExprOrSpread>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_expr_or_spreads(node, ctx),
+            Self::Right(hook) => hook.enter_opt_expr_or_spreads(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_expr_or_spreads(&mut self, node: &Option<Vec<ExprOrSpread>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_expr_or_spreads(node, ctx),
+            Self::Right(hook) => hook.exit_opt_expr_or_spreads(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ident(&mut self, node: &Option<Ident>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_ident(node, ctx),
+            Self::Right(hook) => hook.enter_opt_ident(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ident(&mut self, node: &Option<Ident>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_ident(node, ctx),
+            Self::Right(hook) => hook.exit_opt_ident(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_jsx_attr_value(&mut self, node: &Option<JSXAttrValue>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_jsx_attr_value(node, ctx),
+            Self::Right(hook) => hook.enter_opt_jsx_attr_value(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_jsx_attr_value(&mut self, node: &Option<JSXAttrValue>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_jsx_attr_value(node, ctx),
+            Self::Right(hook) => hook.exit_opt_jsx_attr_value(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_jsx_closing_element(&mut self, node: &Option<JSXClosingElement>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_jsx_closing_element(node, ctx),
+            Self::Right(hook) => hook.enter_opt_jsx_closing_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_jsx_closing_element(&mut self, node: &Option<JSXClosingElement>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_jsx_closing_element(node, ctx),
+            Self::Right(hook) => hook.exit_opt_jsx_closing_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_module_export_name(&mut self, node: &Option<ModuleExportName>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_module_export_name(node, ctx),
+            Self::Right(hook) => hook.enter_opt_module_export_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_module_export_name(&mut self, node: &Option<ModuleExportName>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_module_export_name(node, ctx),
+            Self::Right(hook) => hook.exit_opt_module_export_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_object_lit(&mut self, node: &Option<Box<ObjectLit>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_object_lit(node, ctx),
+            Self::Right(hook) => hook.enter_opt_object_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_object_lit(&mut self, node: &Option<Box<ObjectLit>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_object_lit(node, ctx),
+            Self::Right(hook) => hook.exit_opt_object_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_pat(&mut self, node: &Option<Pat>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_pat(node, ctx),
+            Self::Right(hook) => hook.enter_opt_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_pat(&mut self, node: &Option<Pat>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_pat(node, ctx),
+            Self::Right(hook) => hook.exit_opt_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_span(&mut self, node: &Option<swc_common::Span>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_span(node, ctx),
+            Self::Right(hook) => hook.enter_opt_span(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_span(&mut self, node: &Option<swc_common::Span>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_span(node, ctx),
+            Self::Right(hook) => hook.exit_opt_span(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_stmt(&mut self, node: &Option<Box<Stmt>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_opt_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_stmt(&mut self, node: &Option<Box<Stmt>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_opt_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_str(&mut self, node: &Option<Box<Str>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_str(node, ctx),
+            Self::Right(hook) => hook.enter_opt_str(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_str(&mut self, node: &Option<Box<Str>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_str(node, ctx),
+            Self::Right(hook) => hook.exit_opt_str(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_true_plus_minus(&mut self, node: &Option<TruePlusMinus>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_true_plus_minus(node, ctx),
+            Self::Right(hook) => hook.enter_opt_true_plus_minus(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_true_plus_minus(&mut self, node: &Option<TruePlusMinus>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_true_plus_minus(node, ctx),
+            Self::Right(hook) => hook.exit_opt_true_plus_minus(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_entity_name(&mut self, node: &Option<TsEntityName>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_ts_entity_name(node, ctx),
+            Self::Right(hook) => hook.enter_opt_ts_entity_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_entity_name(&mut self, node: &Option<TsEntityName>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_ts_entity_name(node, ctx),
+            Self::Right(hook) => hook.exit_opt_ts_entity_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_import_call_options(
+        &mut self,
+        node: &Option<TsImportCallOptions>,
+        ctx: &mut C,
+    ) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_ts_import_call_options(node, ctx),
+            Self::Right(hook) => hook.enter_opt_ts_import_call_options(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_import_call_options(&mut self, node: &Option<TsImportCallOptions>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_ts_import_call_options(node, ctx),
+            Self::Right(hook) => hook.exit_opt_ts_import_call_options(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_namespace_body(&mut self, node: &Option<TsNamespaceBody>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_ts_namespace_body(node, ctx),
+            Self::Right(hook) => hook.enter_opt_ts_namespace_body(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_namespace_body(&mut self, node: &Option<TsNamespaceBody>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_ts_namespace_body(node, ctx),
+            Self::Right(hook) => hook.exit_opt_ts_namespace_body(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_type(&mut self, node: &Option<Box<TsType>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_ts_type(node, ctx),
+            Self::Right(hook) => hook.enter_opt_ts_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_type(&mut self, node: &Option<Box<TsType>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_ts_type(node, ctx),
+            Self::Right(hook) => hook.exit_opt_ts_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_ann(&mut self, node: &Option<Box<TsTypeAnn>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_ts_type_ann(node, ctx),
+            Self::Right(hook) => hook.enter_opt_ts_type_ann(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_type_ann(&mut self, node: &Option<Box<TsTypeAnn>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_ts_type_ann(node, ctx),
+            Self::Right(hook) => hook.exit_opt_ts_type_ann(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_param_decl(&mut self, node: &Option<Box<TsTypeParamDecl>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_ts_type_param_decl(node, ctx),
+            Self::Right(hook) => hook.enter_opt_ts_type_param_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_type_param_decl(&mut self, node: &Option<Box<TsTypeParamDecl>>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_ts_type_param_decl(node, ctx),
+            Self::Right(hook) => hook.exit_opt_ts_type_param_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_param_instantiation(
+        &mut self,
+        node: &Option<Box<TsTypeParamInstantiation>>,
+        ctx: &mut C,
+    ) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_ts_type_param_instantiation(node, ctx),
+            Self::Right(hook) => hook.enter_opt_ts_type_param_instantiation(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_type_param_instantiation(
+        &mut self,
+        node: &Option<Box<TsTypeParamInstantiation>>,
+        ctx: &mut C,
+    ) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_ts_type_param_instantiation(node, ctx),
+            Self::Right(hook) => hook.exit_opt_ts_type_param_instantiation(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_var_decl_or_expr(&mut self, node: &Option<VarDeclOrExpr>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_var_decl_or_expr(node, ctx),
+            Self::Right(hook) => hook.enter_opt_var_decl_or_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_var_decl_or_expr(&mut self, node: &Option<VarDeclOrExpr>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_var_decl_or_expr(node, ctx),
+            Self::Right(hook) => hook.exit_opt_var_decl_or_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_vec_expr_or_spreads(&mut self, node: &[Option<ExprOrSpread>], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_vec_expr_or_spreads(node, ctx),
+            Self::Right(hook) => hook.enter_opt_vec_expr_or_spreads(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_vec_expr_or_spreads(&mut self, node: &[Option<ExprOrSpread>], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_vec_expr_or_spreads(node, ctx),
+            Self::Right(hook) => hook.exit_opt_vec_expr_or_spreads(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_vec_pats(&mut self, node: &[Option<Pat>], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_vec_pats(node, ctx),
+            Self::Right(hook) => hook.enter_opt_vec_pats(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_vec_pats(&mut self, node: &[Option<Pat>], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_vec_pats(node, ctx),
+            Self::Right(hook) => hook.exit_opt_vec_pats(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_opt_wtf_8_atom(&mut self, node: &Option<swc_atoms::Wtf8Atom>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_opt_wtf_8_atom(node, ctx),
+            Self::Right(hook) => hook.enter_opt_wtf_8_atom(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_opt_wtf_8_atom(&mut self, node: &Option<swc_atoms::Wtf8Atom>, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_opt_wtf_8_atom(node, ctx),
+            Self::Right(hook) => hook.exit_opt_wtf_8_atom(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_param(&mut self, node: &Param, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_param(node, ctx),
+            Self::Right(hook) => hook.enter_param(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_param(&mut self, node: &Param, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_param(node, ctx),
+            Self::Right(hook) => hook.exit_param(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_param_or_ts_param_prop(&mut self, node: &ParamOrTsParamProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_param_or_ts_param_prop(node, ctx),
+            Self::Right(hook) => hook.enter_param_or_ts_param_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_param_or_ts_param_prop(&mut self, node: &ParamOrTsParamProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_param_or_ts_param_prop(node, ctx),
+            Self::Right(hook) => hook.exit_param_or_ts_param_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_param_or_ts_param_props(&mut self, node: &[ParamOrTsParamProp], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_param_or_ts_param_props(node, ctx),
+            Self::Right(hook) => hook.enter_param_or_ts_param_props(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_param_or_ts_param_props(&mut self, node: &[ParamOrTsParamProp], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_param_or_ts_param_props(node, ctx),
+            Self::Right(hook) => hook.exit_param_or_ts_param_props(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_params(&mut self, node: &[Param], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_params(node, ctx),
+            Self::Right(hook) => hook.enter_params(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_params(&mut self, node: &[Param], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_params(node, ctx),
+            Self::Right(hook) => hook.exit_params(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_paren_expr(&mut self, node: &ParenExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_paren_expr(node, ctx),
+            Self::Right(hook) => hook.enter_paren_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_paren_expr(&mut self, node: &ParenExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_paren_expr(node, ctx),
+            Self::Right(hook) => hook.exit_paren_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_pat(&mut self, node: &Pat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_pat(node, ctx),
+            Self::Right(hook) => hook.enter_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_pat(&mut self, node: &Pat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_pat(node, ctx),
+            Self::Right(hook) => hook.exit_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_pats(&mut self, node: &[Pat], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_pats(node, ctx),
+            Self::Right(hook) => hook.enter_pats(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_pats(&mut self, node: &[Pat], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_pats(node, ctx),
+            Self::Right(hook) => hook.exit_pats(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_private_method(&mut self, node: &PrivateMethod, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_private_method(node, ctx),
+            Self::Right(hook) => hook.enter_private_method(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_private_method(&mut self, node: &PrivateMethod, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_private_method(node, ctx),
+            Self::Right(hook) => hook.exit_private_method(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_private_name(&mut self, node: &PrivateName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_private_name(node, ctx),
+            Self::Right(hook) => hook.enter_private_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_private_name(&mut self, node: &PrivateName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_private_name(node, ctx),
+            Self::Right(hook) => hook.exit_private_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_private_prop(&mut self, node: &PrivateProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_private_prop(node, ctx),
+            Self::Right(hook) => hook.enter_private_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_private_prop(&mut self, node: &PrivateProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_private_prop(node, ctx),
+            Self::Right(hook) => hook.exit_private_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_program(&mut self, node: &Program, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_program(node, ctx),
+            Self::Right(hook) => hook.enter_program(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_program(&mut self, node: &Program, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_program(node, ctx),
+            Self::Right(hook) => hook.exit_program(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_prop(&mut self, node: &Prop, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_prop(node, ctx),
+            Self::Right(hook) => hook.enter_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_prop(&mut self, node: &Prop, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_prop(node, ctx),
+            Self::Right(hook) => hook.exit_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_prop_name(&mut self, node: &PropName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_prop_name(node, ctx),
+            Self::Right(hook) => hook.enter_prop_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_prop_name(&mut self, node: &PropName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_prop_name(node, ctx),
+            Self::Right(hook) => hook.exit_prop_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_prop_or_spread(&mut self, node: &PropOrSpread, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_prop_or_spread(node, ctx),
+            Self::Right(hook) => hook.enter_prop_or_spread(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_prop_or_spread(&mut self, node: &PropOrSpread, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_prop_or_spread(node, ctx),
+            Self::Right(hook) => hook.exit_prop_or_spread(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_prop_or_spreads(&mut self, node: &[PropOrSpread], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_prop_or_spreads(node, ctx),
+            Self::Right(hook) => hook.enter_prop_or_spreads(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_prop_or_spreads(&mut self, node: &[PropOrSpread], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_prop_or_spreads(node, ctx),
+            Self::Right(hook) => hook.exit_prop_or_spreads(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_regex(&mut self, node: &Regex, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_regex(node, ctx),
+            Self::Right(hook) => hook.enter_regex(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_regex(&mut self, node: &Regex, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_regex(node, ctx),
+            Self::Right(hook) => hook.exit_regex(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_rest_pat(&mut self, node: &RestPat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_rest_pat(node, ctx),
+            Self::Right(hook) => hook.enter_rest_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_rest_pat(&mut self, node: &RestPat, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_rest_pat(node, ctx),
+            Self::Right(hook) => hook.exit_rest_pat(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_return_stmt(&mut self, node: &ReturnStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_return_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_return_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_return_stmt(&mut self, node: &ReturnStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_return_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_return_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_script(&mut self, node: &Script, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_script(node, ctx),
+            Self::Right(hook) => hook.enter_script(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_script(&mut self, node: &Script, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_script(node, ctx),
+            Self::Right(hook) => hook.exit_script(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_seq_expr(&mut self, node: &SeqExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_seq_expr(node, ctx),
+            Self::Right(hook) => hook.enter_seq_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_seq_expr(&mut self, node: &SeqExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_seq_expr(node, ctx),
+            Self::Right(hook) => hook.exit_seq_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_setter_prop(&mut self, node: &SetterProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_setter_prop(node, ctx),
+            Self::Right(hook) => hook.enter_setter_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_setter_prop(&mut self, node: &SetterProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_setter_prop(node, ctx),
+            Self::Right(hook) => hook.exit_setter_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_simple_assign_target(&mut self, node: &SimpleAssignTarget, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_simple_assign_target(node, ctx),
+            Self::Right(hook) => hook.enter_simple_assign_target(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_simple_assign_target(&mut self, node: &SimpleAssignTarget, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_simple_assign_target(node, ctx),
+            Self::Right(hook) => hook.exit_simple_assign_target(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_span(&mut self, node: &swc_common::Span, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_span(node, ctx),
+            Self::Right(hook) => hook.enter_span(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_span(&mut self, node: &swc_common::Span, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_span(node, ctx),
+            Self::Right(hook) => hook.exit_span(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_spread_element(&mut self, node: &SpreadElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_spread_element(node, ctx),
+            Self::Right(hook) => hook.enter_spread_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_spread_element(&mut self, node: &SpreadElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_spread_element(node, ctx),
+            Self::Right(hook) => hook.exit_spread_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_static_block(&mut self, node: &StaticBlock, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_static_block(node, ctx),
+            Self::Right(hook) => hook.enter_static_block(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_static_block(&mut self, node: &StaticBlock, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_static_block(node, ctx),
+            Self::Right(hook) => hook.exit_static_block(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_stmt(&mut self, node: &Stmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_stmt(&mut self, node: &Stmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_stmts(&mut self, node: &[Stmt], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_stmts(node, ctx),
+            Self::Right(hook) => hook.enter_stmts(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_stmts(&mut self, node: &[Stmt], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_stmts(node, ctx),
+            Self::Right(hook) => hook.exit_stmts(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_str(&mut self, node: &Str, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_str(node, ctx),
+            Self::Right(hook) => hook.enter_str(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_str(&mut self, node: &Str, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_str(node, ctx),
+            Self::Right(hook) => hook.exit_str(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_super(&mut self, node: &Super, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_super(node, ctx),
+            Self::Right(hook) => hook.enter_super(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_super(&mut self, node: &Super, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_super(node, ctx),
+            Self::Right(hook) => hook.exit_super(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_super_prop(&mut self, node: &SuperProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_super_prop(node, ctx),
+            Self::Right(hook) => hook.enter_super_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_super_prop(&mut self, node: &SuperProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_super_prop(node, ctx),
+            Self::Right(hook) => hook.exit_super_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_super_prop_expr(&mut self, node: &SuperPropExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_super_prop_expr(node, ctx),
+            Self::Right(hook) => hook.enter_super_prop_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_super_prop_expr(&mut self, node: &SuperPropExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_super_prop_expr(node, ctx),
+            Self::Right(hook) => hook.exit_super_prop_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_switch_case(&mut self, node: &SwitchCase, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_switch_case(node, ctx),
+            Self::Right(hook) => hook.enter_switch_case(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_switch_case(&mut self, node: &SwitchCase, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_switch_case(node, ctx),
+            Self::Right(hook) => hook.exit_switch_case(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_switch_cases(&mut self, node: &[SwitchCase], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_switch_cases(node, ctx),
+            Self::Right(hook) => hook.enter_switch_cases(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_switch_cases(&mut self, node: &[SwitchCase], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_switch_cases(node, ctx),
+            Self::Right(hook) => hook.exit_switch_cases(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_switch_stmt(&mut self, node: &SwitchStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_switch_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_switch_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_switch_stmt(&mut self, node: &SwitchStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_switch_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_switch_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_syntax_context(&mut self, node: &swc_common::SyntaxContext, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_syntax_context(node, ctx),
+            Self::Right(hook) => hook.enter_syntax_context(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_syntax_context(&mut self, node: &swc_common::SyntaxContext, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_syntax_context(node, ctx),
+            Self::Right(hook) => hook.exit_syntax_context(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_tagged_tpl(&mut self, node: &TaggedTpl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_tagged_tpl(node, ctx),
+            Self::Right(hook) => hook.enter_tagged_tpl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_tagged_tpl(&mut self, node: &TaggedTpl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_tagged_tpl(node, ctx),
+            Self::Right(hook) => hook.exit_tagged_tpl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_this_expr(&mut self, node: &ThisExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_this_expr(node, ctx),
+            Self::Right(hook) => hook.enter_this_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_this_expr(&mut self, node: &ThisExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_this_expr(node, ctx),
+            Self::Right(hook) => hook.exit_this_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_throw_stmt(&mut self, node: &ThrowStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_throw_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_throw_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_throw_stmt(&mut self, node: &ThrowStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_throw_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_throw_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_tpl(&mut self, node: &Tpl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_tpl(node, ctx),
+            Self::Right(hook) => hook.enter_tpl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_tpl(&mut self, node: &Tpl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_tpl(node, ctx),
+            Self::Right(hook) => hook.exit_tpl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_tpl_element(&mut self, node: &TplElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_tpl_element(node, ctx),
+            Self::Right(hook) => hook.enter_tpl_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_tpl_element(&mut self, node: &TplElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_tpl_element(node, ctx),
+            Self::Right(hook) => hook.exit_tpl_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_tpl_elements(&mut self, node: &[TplElement], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_tpl_elements(node, ctx),
+            Self::Right(hook) => hook.enter_tpl_elements(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_tpl_elements(&mut self, node: &[TplElement], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_tpl_elements(node, ctx),
+            Self::Right(hook) => hook.exit_tpl_elements(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_true_plus_minus(&mut self, node: &TruePlusMinus, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_true_plus_minus(node, ctx),
+            Self::Right(hook) => hook.enter_true_plus_minus(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_true_plus_minus(&mut self, node: &TruePlusMinus, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_true_plus_minus(node, ctx),
+            Self::Right(hook) => hook.exit_true_plus_minus(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_try_stmt(&mut self, node: &TryStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_try_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_try_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_try_stmt(&mut self, node: &TryStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_try_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_try_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_array_type(&mut self, node: &TsArrayType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_array_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_array_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_array_type(&mut self, node: &TsArrayType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_array_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_array_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_as_expr(&mut self, node: &TsAsExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_as_expr(node, ctx),
+            Self::Right(hook) => hook.enter_ts_as_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_as_expr(&mut self, node: &TsAsExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_as_expr(node, ctx),
+            Self::Right(hook) => hook.exit_ts_as_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_call_signature_decl(&mut self, node: &TsCallSignatureDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_call_signature_decl(node, ctx),
+            Self::Right(hook) => hook.enter_ts_call_signature_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_call_signature_decl(&mut self, node: &TsCallSignatureDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_call_signature_decl(node, ctx),
+            Self::Right(hook) => hook.exit_ts_call_signature_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_conditional_type(&mut self, node: &TsConditionalType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_conditional_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_conditional_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_conditional_type(&mut self, node: &TsConditionalType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_conditional_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_conditional_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_const_assertion(&mut self, node: &TsConstAssertion, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_const_assertion(node, ctx),
+            Self::Right(hook) => hook.enter_ts_const_assertion(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_const_assertion(&mut self, node: &TsConstAssertion, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_const_assertion(node, ctx),
+            Self::Right(hook) => hook.exit_ts_const_assertion(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_construct_signature_decl(&mut self, node: &TsConstructSignatureDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_construct_signature_decl(node, ctx),
+            Self::Right(hook) => hook.enter_ts_construct_signature_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_construct_signature_decl(&mut self, node: &TsConstructSignatureDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_construct_signature_decl(node, ctx),
+            Self::Right(hook) => hook.exit_ts_construct_signature_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_constructor_type(&mut self, node: &TsConstructorType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_constructor_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_constructor_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_constructor_type(&mut self, node: &TsConstructorType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_constructor_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_constructor_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_entity_name(&mut self, node: &TsEntityName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_entity_name(node, ctx),
+            Self::Right(hook) => hook.enter_ts_entity_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_entity_name(&mut self, node: &TsEntityName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_entity_name(node, ctx),
+            Self::Right(hook) => hook.exit_ts_entity_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_enum_decl(&mut self, node: &TsEnumDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_enum_decl(node, ctx),
+            Self::Right(hook) => hook.enter_ts_enum_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_enum_decl(&mut self, node: &TsEnumDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_enum_decl(node, ctx),
+            Self::Right(hook) => hook.exit_ts_enum_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_enum_member(&mut self, node: &TsEnumMember, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_enum_member(node, ctx),
+            Self::Right(hook) => hook.enter_ts_enum_member(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_enum_member(&mut self, node: &TsEnumMember, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_enum_member(node, ctx),
+            Self::Right(hook) => hook.exit_ts_enum_member(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_enum_member_id(&mut self, node: &TsEnumMemberId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_enum_member_id(node, ctx),
+            Self::Right(hook) => hook.enter_ts_enum_member_id(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_enum_member_id(&mut self, node: &TsEnumMemberId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_enum_member_id(node, ctx),
+            Self::Right(hook) => hook.exit_ts_enum_member_id(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_enum_members(&mut self, node: &[TsEnumMember], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_enum_members(node, ctx),
+            Self::Right(hook) => hook.enter_ts_enum_members(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_enum_members(&mut self, node: &[TsEnumMember], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_enum_members(node, ctx),
+            Self::Right(hook) => hook.exit_ts_enum_members(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_export_assignment(&mut self, node: &TsExportAssignment, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_export_assignment(node, ctx),
+            Self::Right(hook) => hook.enter_ts_export_assignment(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_export_assignment(&mut self, node: &TsExportAssignment, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_export_assignment(node, ctx),
+            Self::Right(hook) => hook.exit_ts_export_assignment(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_expr_with_type_args(&mut self, node: &TsExprWithTypeArgs, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_expr_with_type_args(node, ctx),
+            Self::Right(hook) => hook.enter_ts_expr_with_type_args(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_expr_with_type_args(&mut self, node: &TsExprWithTypeArgs, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_expr_with_type_args(node, ctx),
+            Self::Right(hook) => hook.exit_ts_expr_with_type_args(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_expr_with_type_argss(&mut self, node: &[TsExprWithTypeArgs], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_expr_with_type_argss(node, ctx),
+            Self::Right(hook) => hook.enter_ts_expr_with_type_argss(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_expr_with_type_argss(&mut self, node: &[TsExprWithTypeArgs], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_expr_with_type_argss(node, ctx),
+            Self::Right(hook) => hook.exit_ts_expr_with_type_argss(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_external_module_ref(&mut self, node: &TsExternalModuleRef, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_external_module_ref(node, ctx),
+            Self::Right(hook) => hook.enter_ts_external_module_ref(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_external_module_ref(&mut self, node: &TsExternalModuleRef, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_external_module_ref(node, ctx),
+            Self::Right(hook) => hook.exit_ts_external_module_ref(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_fn_or_constructor_type(&mut self, node: &TsFnOrConstructorType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_fn_or_constructor_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_fn_or_constructor_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_fn_or_constructor_type(&mut self, node: &TsFnOrConstructorType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_fn_or_constructor_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_fn_or_constructor_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_fn_param(&mut self, node: &TsFnParam, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_fn_param(node, ctx),
+            Self::Right(hook) => hook.enter_ts_fn_param(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_fn_param(&mut self, node: &TsFnParam, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_fn_param(node, ctx),
+            Self::Right(hook) => hook.exit_ts_fn_param(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_fn_params(&mut self, node: &[TsFnParam], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_fn_params(node, ctx),
+            Self::Right(hook) => hook.enter_ts_fn_params(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_fn_params(&mut self, node: &[TsFnParam], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_fn_params(node, ctx),
+            Self::Right(hook) => hook.exit_ts_fn_params(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_fn_type(&mut self, node: &TsFnType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_fn_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_fn_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_fn_type(&mut self, node: &TsFnType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_fn_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_fn_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_getter_signature(&mut self, node: &TsGetterSignature, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_getter_signature(node, ctx),
+            Self::Right(hook) => hook.enter_ts_getter_signature(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_getter_signature(&mut self, node: &TsGetterSignature, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_getter_signature(node, ctx),
+            Self::Right(hook) => hook.exit_ts_getter_signature(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_import_call_options(&mut self, node: &TsImportCallOptions, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_import_call_options(node, ctx),
+            Self::Right(hook) => hook.enter_ts_import_call_options(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_import_call_options(&mut self, node: &TsImportCallOptions, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_import_call_options(node, ctx),
+            Self::Right(hook) => hook.exit_ts_import_call_options(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_import_equals_decl(&mut self, node: &TsImportEqualsDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_import_equals_decl(node, ctx),
+            Self::Right(hook) => hook.enter_ts_import_equals_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_import_equals_decl(&mut self, node: &TsImportEqualsDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_import_equals_decl(node, ctx),
+            Self::Right(hook) => hook.exit_ts_import_equals_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_import_type(&mut self, node: &TsImportType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_import_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_import_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_import_type(&mut self, node: &TsImportType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_import_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_import_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_index_signature(&mut self, node: &TsIndexSignature, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_index_signature(node, ctx),
+            Self::Right(hook) => hook.enter_ts_index_signature(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_index_signature(&mut self, node: &TsIndexSignature, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_index_signature(node, ctx),
+            Self::Right(hook) => hook.exit_ts_index_signature(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_indexed_access_type(&mut self, node: &TsIndexedAccessType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_indexed_access_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_indexed_access_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_indexed_access_type(&mut self, node: &TsIndexedAccessType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_indexed_access_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_indexed_access_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_infer_type(&mut self, node: &TsInferType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_infer_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_infer_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_infer_type(&mut self, node: &TsInferType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_infer_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_infer_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_instantiation(&mut self, node: &TsInstantiation, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_instantiation(node, ctx),
+            Self::Right(hook) => hook.enter_ts_instantiation(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_instantiation(&mut self, node: &TsInstantiation, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_instantiation(node, ctx),
+            Self::Right(hook) => hook.exit_ts_instantiation(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_interface_body(&mut self, node: &TsInterfaceBody, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_interface_body(node, ctx),
+            Self::Right(hook) => hook.enter_ts_interface_body(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_interface_body(&mut self, node: &TsInterfaceBody, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_interface_body(node, ctx),
+            Self::Right(hook) => hook.exit_ts_interface_body(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_interface_decl(&mut self, node: &TsInterfaceDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_interface_decl(node, ctx),
+            Self::Right(hook) => hook.enter_ts_interface_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_interface_decl(&mut self, node: &TsInterfaceDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_interface_decl(node, ctx),
+            Self::Right(hook) => hook.exit_ts_interface_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_intersection_type(&mut self, node: &TsIntersectionType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_intersection_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_intersection_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_intersection_type(&mut self, node: &TsIntersectionType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_intersection_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_intersection_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_keyword_type(&mut self, node: &TsKeywordType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_keyword_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_keyword_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_keyword_type(&mut self, node: &TsKeywordType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_keyword_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_keyword_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_keyword_type_kind(&mut self, node: &TsKeywordTypeKind, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_keyword_type_kind(node, ctx),
+            Self::Right(hook) => hook.enter_ts_keyword_type_kind(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_keyword_type_kind(&mut self, node: &TsKeywordTypeKind, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_keyword_type_kind(node, ctx),
+            Self::Right(hook) => hook.exit_ts_keyword_type_kind(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_lit(&mut self, node: &TsLit, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_lit(node, ctx),
+            Self::Right(hook) => hook.enter_ts_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_lit(&mut self, node: &TsLit, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_lit(node, ctx),
+            Self::Right(hook) => hook.exit_ts_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_lit_type(&mut self, node: &TsLitType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_lit_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_lit_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_lit_type(&mut self, node: &TsLitType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_lit_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_lit_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_mapped_type(&mut self, node: &TsMappedType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_mapped_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_mapped_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_mapped_type(&mut self, node: &TsMappedType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_mapped_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_mapped_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_method_signature(&mut self, node: &TsMethodSignature, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_method_signature(node, ctx),
+            Self::Right(hook) => hook.enter_ts_method_signature(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_method_signature(&mut self, node: &TsMethodSignature, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_method_signature(node, ctx),
+            Self::Right(hook) => hook.exit_ts_method_signature(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_module_block(&mut self, node: &TsModuleBlock, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_module_block(node, ctx),
+            Self::Right(hook) => hook.enter_ts_module_block(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_module_block(&mut self, node: &TsModuleBlock, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_module_block(node, ctx),
+            Self::Right(hook) => hook.exit_ts_module_block(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_module_decl(&mut self, node: &TsModuleDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_module_decl(node, ctx),
+            Self::Right(hook) => hook.enter_ts_module_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_module_decl(&mut self, node: &TsModuleDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_module_decl(node, ctx),
+            Self::Right(hook) => hook.exit_ts_module_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_module_name(&mut self, node: &TsModuleName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_module_name(node, ctx),
+            Self::Right(hook) => hook.enter_ts_module_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_module_name(&mut self, node: &TsModuleName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_module_name(node, ctx),
+            Self::Right(hook) => hook.exit_ts_module_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_module_ref(&mut self, node: &TsModuleRef, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_module_ref(node, ctx),
+            Self::Right(hook) => hook.enter_ts_module_ref(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_module_ref(&mut self, node: &TsModuleRef, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_module_ref(node, ctx),
+            Self::Right(hook) => hook.exit_ts_module_ref(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_namespace_body(&mut self, node: &TsNamespaceBody, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_namespace_body(node, ctx),
+            Self::Right(hook) => hook.enter_ts_namespace_body(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_namespace_body(&mut self, node: &TsNamespaceBody, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_namespace_body(node, ctx),
+            Self::Right(hook) => hook.exit_ts_namespace_body(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_namespace_decl(&mut self, node: &TsNamespaceDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_namespace_decl(node, ctx),
+            Self::Right(hook) => hook.enter_ts_namespace_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_namespace_decl(&mut self, node: &TsNamespaceDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_namespace_decl(node, ctx),
+            Self::Right(hook) => hook.exit_ts_namespace_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_namespace_export_decl(&mut self, node: &TsNamespaceExportDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_namespace_export_decl(node, ctx),
+            Self::Right(hook) => hook.enter_ts_namespace_export_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_namespace_export_decl(&mut self, node: &TsNamespaceExportDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_namespace_export_decl(node, ctx),
+            Self::Right(hook) => hook.exit_ts_namespace_export_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_non_null_expr(&mut self, node: &TsNonNullExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_non_null_expr(node, ctx),
+            Self::Right(hook) => hook.enter_ts_non_null_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_non_null_expr(&mut self, node: &TsNonNullExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_non_null_expr(node, ctx),
+            Self::Right(hook) => hook.exit_ts_non_null_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_optional_type(&mut self, node: &TsOptionalType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_optional_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_optional_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_optional_type(&mut self, node: &TsOptionalType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_optional_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_optional_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_param_prop(&mut self, node: &TsParamProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_param_prop(node, ctx),
+            Self::Right(hook) => hook.enter_ts_param_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_param_prop(&mut self, node: &TsParamProp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_param_prop(node, ctx),
+            Self::Right(hook) => hook.exit_ts_param_prop(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_param_prop_param(&mut self, node: &TsParamPropParam, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_param_prop_param(node, ctx),
+            Self::Right(hook) => hook.enter_ts_param_prop_param(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_param_prop_param(&mut self, node: &TsParamPropParam, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_param_prop_param(node, ctx),
+            Self::Right(hook) => hook.exit_ts_param_prop_param(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_parenthesized_type(&mut self, node: &TsParenthesizedType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_parenthesized_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_parenthesized_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_parenthesized_type(&mut self, node: &TsParenthesizedType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_parenthesized_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_parenthesized_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_property_signature(&mut self, node: &TsPropertySignature, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_property_signature(node, ctx),
+            Self::Right(hook) => hook.enter_ts_property_signature(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_property_signature(&mut self, node: &TsPropertySignature, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_property_signature(node, ctx),
+            Self::Right(hook) => hook.exit_ts_property_signature(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_qualified_name(&mut self, node: &TsQualifiedName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_qualified_name(node, ctx),
+            Self::Right(hook) => hook.enter_ts_qualified_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_qualified_name(&mut self, node: &TsQualifiedName, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_qualified_name(node, ctx),
+            Self::Right(hook) => hook.exit_ts_qualified_name(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_rest_type(&mut self, node: &TsRestType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_rest_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_rest_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_rest_type(&mut self, node: &TsRestType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_rest_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_rest_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_satisfies_expr(&mut self, node: &TsSatisfiesExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_satisfies_expr(node, ctx),
+            Self::Right(hook) => hook.enter_ts_satisfies_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_satisfies_expr(&mut self, node: &TsSatisfiesExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_satisfies_expr(node, ctx),
+            Self::Right(hook) => hook.exit_ts_satisfies_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_setter_signature(&mut self, node: &TsSetterSignature, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_setter_signature(node, ctx),
+            Self::Right(hook) => hook.enter_ts_setter_signature(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_setter_signature(&mut self, node: &TsSetterSignature, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_setter_signature(node, ctx),
+            Self::Right(hook) => hook.exit_ts_setter_signature(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_this_type(&mut self, node: &TsThisType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_this_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_this_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_this_type(&mut self, node: &TsThisType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_this_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_this_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_this_type_or_ident(&mut self, node: &TsThisTypeOrIdent, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_this_type_or_ident(node, ctx),
+            Self::Right(hook) => hook.enter_ts_this_type_or_ident(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_this_type_or_ident(&mut self, node: &TsThisTypeOrIdent, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_this_type_or_ident(node, ctx),
+            Self::Right(hook) => hook.exit_ts_this_type_or_ident(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_tpl_lit_type(&mut self, node: &TsTplLitType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_tpl_lit_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_tpl_lit_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_tpl_lit_type(&mut self, node: &TsTplLitType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_tpl_lit_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_tpl_lit_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_tuple_element(&mut self, node: &TsTupleElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_tuple_element(node, ctx),
+            Self::Right(hook) => hook.enter_ts_tuple_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_tuple_element(&mut self, node: &TsTupleElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_tuple_element(node, ctx),
+            Self::Right(hook) => hook.exit_ts_tuple_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_tuple_elements(&mut self, node: &[TsTupleElement], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_tuple_elements(node, ctx),
+            Self::Right(hook) => hook.enter_ts_tuple_elements(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_tuple_elements(&mut self, node: &[TsTupleElement], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_tuple_elements(node, ctx),
+            Self::Right(hook) => hook.exit_ts_tuple_elements(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_tuple_type(&mut self, node: &TsTupleType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_tuple_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_tuple_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_tuple_type(&mut self, node: &TsTupleType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_tuple_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_tuple_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type(&mut self, node: &TsType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type(&mut self, node: &TsType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_alias_decl(&mut self, node: &TsTypeAliasDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_alias_decl(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_alias_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_alias_decl(&mut self, node: &TsTypeAliasDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_alias_decl(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_alias_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_ann(&mut self, node: &TsTypeAnn, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_ann(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_ann(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_ann(&mut self, node: &TsTypeAnn, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_ann(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_ann(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_assertion(&mut self, node: &TsTypeAssertion, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_assertion(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_assertion(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_assertion(&mut self, node: &TsTypeAssertion, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_assertion(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_assertion(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_element(&mut self, node: &TsTypeElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_element(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_element(&mut self, node: &TsTypeElement, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_element(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_element(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_elements(&mut self, node: &[TsTypeElement], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_elements(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_elements(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_elements(&mut self, node: &[TsTypeElement], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_elements(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_elements(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_lit(&mut self, node: &TsTypeLit, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_lit(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_lit(&mut self, node: &TsTypeLit, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_lit(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_lit(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_operator(&mut self, node: &TsTypeOperator, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_operator(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_operator(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_operator(&mut self, node: &TsTypeOperator, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_operator(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_operator(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_operator_op(&mut self, node: &TsTypeOperatorOp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_operator_op(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_operator_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_operator_op(&mut self, node: &TsTypeOperatorOp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_operator_op(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_operator_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_param(&mut self, node: &TsTypeParam, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_param(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_param(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_param(&mut self, node: &TsTypeParam, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_param(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_param(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_param_decl(&mut self, node: &TsTypeParamDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_param_decl(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_param_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_param_decl(&mut self, node: &TsTypeParamDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_param_decl(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_param_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_param_instantiation(&mut self, node: &TsTypeParamInstantiation, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_param_instantiation(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_param_instantiation(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_param_instantiation(&mut self, node: &TsTypeParamInstantiation, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_param_instantiation(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_param_instantiation(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_params(&mut self, node: &[TsTypeParam], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_params(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_params(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_params(&mut self, node: &[TsTypeParam], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_params(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_params(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_predicate(&mut self, node: &TsTypePredicate, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_predicate(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_predicate(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_predicate(&mut self, node: &TsTypePredicate, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_predicate(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_predicate(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_query(&mut self, node: &TsTypeQuery, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_query(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_query(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_query(&mut self, node: &TsTypeQuery, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_query(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_query(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_query_expr(&mut self, node: &TsTypeQueryExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_query_expr(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_query_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_query_expr(&mut self, node: &TsTypeQueryExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_query_expr(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_query_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_ref(&mut self, node: &TsTypeRef, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_type_ref(node, ctx),
+            Self::Right(hook) => hook.enter_ts_type_ref(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_ref(&mut self, node: &TsTypeRef, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_type_ref(node, ctx),
+            Self::Right(hook) => hook.exit_ts_type_ref(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_types(&mut self, node: &[Box<TsType>], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_types(node, ctx),
+            Self::Right(hook) => hook.enter_ts_types(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_types(&mut self, node: &[Box<TsType>], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_types(node, ctx),
+            Self::Right(hook) => hook.exit_ts_types(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_union_or_intersection_type(
+        &mut self,
+        node: &TsUnionOrIntersectionType,
+        ctx: &mut C,
+    ) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_union_or_intersection_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_union_or_intersection_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_union_or_intersection_type(
+        &mut self,
+        node: &TsUnionOrIntersectionType,
+        ctx: &mut C,
+    ) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_union_or_intersection_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_union_or_intersection_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_ts_union_type(&mut self, node: &TsUnionType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_ts_union_type(node, ctx),
+            Self::Right(hook) => hook.enter_ts_union_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_ts_union_type(&mut self, node: &TsUnionType, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_ts_union_type(node, ctx),
+            Self::Right(hook) => hook.exit_ts_union_type(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_unary_expr(&mut self, node: &UnaryExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_unary_expr(node, ctx),
+            Self::Right(hook) => hook.enter_unary_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_unary_expr(&mut self, node: &UnaryExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_unary_expr(node, ctx),
+            Self::Right(hook) => hook.exit_unary_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_unary_op(&mut self, node: &UnaryOp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_unary_op(node, ctx),
+            Self::Right(hook) => hook.enter_unary_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_unary_op(&mut self, node: &UnaryOp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_unary_op(node, ctx),
+            Self::Right(hook) => hook.exit_unary_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_update_expr(&mut self, node: &UpdateExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_update_expr(node, ctx),
+            Self::Right(hook) => hook.enter_update_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_update_expr(&mut self, node: &UpdateExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_update_expr(node, ctx),
+            Self::Right(hook) => hook.exit_update_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_update_op(&mut self, node: &UpdateOp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_update_op(node, ctx),
+            Self::Right(hook) => hook.enter_update_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_update_op(&mut self, node: &UpdateOp, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_update_op(node, ctx),
+            Self::Right(hook) => hook.exit_update_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_using_decl(&mut self, node: &UsingDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_using_decl(node, ctx),
+            Self::Right(hook) => hook.enter_using_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_using_decl(&mut self, node: &UsingDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_using_decl(node, ctx),
+            Self::Right(hook) => hook.exit_using_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_var_decl(&mut self, node: &VarDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_var_decl(node, ctx),
+            Self::Right(hook) => hook.enter_var_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_var_decl(&mut self, node: &VarDecl, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_var_decl(node, ctx),
+            Self::Right(hook) => hook.exit_var_decl(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_var_decl_kind(&mut self, node: &VarDeclKind, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_var_decl_kind(node, ctx),
+            Self::Right(hook) => hook.enter_var_decl_kind(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_var_decl_kind(&mut self, node: &VarDeclKind, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_var_decl_kind(node, ctx),
+            Self::Right(hook) => hook.exit_var_decl_kind(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_var_decl_or_expr(&mut self, node: &VarDeclOrExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_var_decl_or_expr(node, ctx),
+            Self::Right(hook) => hook.enter_var_decl_or_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_var_decl_or_expr(&mut self, node: &VarDeclOrExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_var_decl_or_expr(node, ctx),
+            Self::Right(hook) => hook.exit_var_decl_or_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_var_declarator(&mut self, node: &VarDeclarator, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_var_declarator(node, ctx),
+            Self::Right(hook) => hook.enter_var_declarator(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_var_declarator(&mut self, node: &VarDeclarator, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_var_declarator(node, ctx),
+            Self::Right(hook) => hook.exit_var_declarator(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_var_declarators(&mut self, node: &[VarDeclarator], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_var_declarators(node, ctx),
+            Self::Right(hook) => hook.enter_var_declarators(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_var_declarators(&mut self, node: &[VarDeclarator], ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_var_declarators(node, ctx),
+            Self::Right(hook) => hook.exit_var_declarators(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_while_stmt(&mut self, node: &WhileStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_while_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_while_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_while_stmt(&mut self, node: &WhileStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_while_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_while_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_with_stmt(&mut self, node: &WithStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_with_stmt(node, ctx),
+            Self::Right(hook) => hook.enter_with_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_with_stmt(&mut self, node: &WithStmt, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_with_stmt(node, ctx),
+            Self::Right(hook) => hook.exit_with_stmt(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_wtf_8_atom(&mut self, node: &swc_atoms::Wtf8Atom, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_wtf_8_atom(node, ctx),
+            Self::Right(hook) => hook.enter_wtf_8_atom(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_wtf_8_atom(&mut self, node: &swc_atoms::Wtf8Atom, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_wtf_8_atom(node, ctx),
+            Self::Right(hook) => hook.exit_wtf_8_atom(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_yield_expr(&mut self, node: &YieldExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_yield_expr(node, ctx),
+            Self::Right(hook) => hook.enter_yield_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_yield_expr(&mut self, node: &YieldExpr, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_yield_expr(node, ctx),
+            Self::Right(hook) => hook.exit_yield_expr(node, ctx),
+        }
+    }
+}
+impl<H, C> VisitHook<C> for Option<H>
+where
+    H: VisitHook<C>,
+{
+    #[inline]
+    fn enter_accessibility(&mut self, node: &Accessibility, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_accessibility(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_accessibility(&mut self, node: &Accessibility, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_accessibility(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_array_lit(&mut self, node: &ArrayLit, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_array_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_array_lit(&mut self, node: &ArrayLit, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_array_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_array_pat(&mut self, node: &ArrayPat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_array_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_array_pat(&mut self, node: &ArrayPat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_array_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_arrow_expr(&mut self, node: &ArrowExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_arrow_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_arrow_expr(&mut self, node: &ArrowExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_arrow_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_assign_expr(&mut self, node: &AssignExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_assign_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_assign_expr(&mut self, node: &AssignExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_assign_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_assign_op(&mut self, node: &AssignOp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_assign_op(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_assign_op(&mut self, node: &AssignOp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_assign_op(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_assign_pat(&mut self, node: &AssignPat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_assign_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_assign_pat(&mut self, node: &AssignPat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_assign_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_assign_pat_prop(&mut self, node: &AssignPatProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_assign_pat_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_assign_pat_prop(&mut self, node: &AssignPatProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_assign_pat_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_assign_prop(&mut self, node: &AssignProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_assign_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_assign_prop(&mut self, node: &AssignProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_assign_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_assign_target(&mut self, node: &AssignTarget, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_assign_target(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_assign_target(&mut self, node: &AssignTarget, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_assign_target(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_assign_target_pat(&mut self, node: &AssignTargetPat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_assign_target_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_assign_target_pat(&mut self, node: &AssignTargetPat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_assign_target_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_atom(&mut self, node: &swc_atoms::Atom, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_atom(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_atom(&mut self, node: &swc_atoms::Atom, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_atom(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_auto_accessor(&mut self, node: &AutoAccessor, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_auto_accessor(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_auto_accessor(&mut self, node: &AutoAccessor, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_auto_accessor(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_await_expr(&mut self, node: &AwaitExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_await_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_await_expr(&mut self, node: &AwaitExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_await_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_big_int(&mut self, node: &BigInt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_big_int(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_big_int(&mut self, node: &BigInt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_big_int(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_big_int_value(&mut self, node: &BigIntValue, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_big_int_value(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_big_int_value(&mut self, node: &BigIntValue, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_big_int_value(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_bin_expr(&mut self, node: &BinExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_bin_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_bin_expr(&mut self, node: &BinExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_bin_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_binary_op(&mut self, node: &BinaryOp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_binary_op(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_binary_op(&mut self, node: &BinaryOp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_binary_op(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_binding_ident(&mut self, node: &BindingIdent, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_binding_ident(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_binding_ident(&mut self, node: &BindingIdent, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_binding_ident(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_block_stmt(&mut self, node: &BlockStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_block_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_block_stmt(&mut self, node: &BlockStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_block_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_block_stmt_or_expr(&mut self, node: &BlockStmtOrExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_block_stmt_or_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_block_stmt_or_expr(&mut self, node: &BlockStmtOrExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_block_stmt_or_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_bool(&mut self, node: &Bool, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_bool(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_bool(&mut self, node: &Bool, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_bool(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_break_stmt(&mut self, node: &BreakStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_break_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_break_stmt(&mut self, node: &BreakStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_break_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_call_expr(&mut self, node: &CallExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_call_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_call_expr(&mut self, node: &CallExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_call_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_callee(&mut self, node: &Callee, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_callee(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_callee(&mut self, node: &Callee, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_callee(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_catch_clause(&mut self, node: &CatchClause, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_catch_clause(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_catch_clause(&mut self, node: &CatchClause, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_catch_clause(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_class(&mut self, node: &Class, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_class(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_class(&mut self, node: &Class, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_class(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_class_decl(&mut self, node: &ClassDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_class_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_class_decl(&mut self, node: &ClassDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_class_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_class_expr(&mut self, node: &ClassExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_class_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_class_expr(&mut self, node: &ClassExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_class_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_class_member(&mut self, node: &ClassMember, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_class_member(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_class_member(&mut self, node: &ClassMember, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_class_member(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_class_members(&mut self, node: &[ClassMember], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_class_members(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_class_members(&mut self, node: &[ClassMember], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_class_members(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_class_method(&mut self, node: &ClassMethod, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_class_method(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_class_method(&mut self, node: &ClassMethod, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_class_method(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_class_prop(&mut self, node: &ClassProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_class_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_class_prop(&mut self, node: &ClassProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_class_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_computed_prop_name(&mut self, node: &ComputedPropName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_computed_prop_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_computed_prop_name(&mut self, node: &ComputedPropName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_computed_prop_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_cond_expr(&mut self, node: &CondExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_cond_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_cond_expr(&mut self, node: &CondExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_cond_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_constructor(&mut self, node: &Constructor, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_constructor(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_constructor(&mut self, node: &Constructor, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_constructor(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_continue_stmt(&mut self, node: &ContinueStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_continue_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_continue_stmt(&mut self, node: &ContinueStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_continue_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_debugger_stmt(&mut self, node: &DebuggerStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_debugger_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_debugger_stmt(&mut self, node: &DebuggerStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_debugger_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_decl(&mut self, node: &Decl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_decl(&mut self, node: &Decl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_decorator(&mut self, node: &Decorator, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_decorator(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_decorator(&mut self, node: &Decorator, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_decorator(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_decorators(&mut self, node: &[Decorator], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_decorators(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_decorators(&mut self, node: &[Decorator], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_decorators(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_default_decl(&mut self, node: &DefaultDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_default_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_default_decl(&mut self, node: &DefaultDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_default_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_do_while_stmt(&mut self, node: &DoWhileStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_do_while_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_do_while_stmt(&mut self, node: &DoWhileStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_do_while_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_empty_stmt(&mut self, node: &EmptyStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_empty_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_empty_stmt(&mut self, node: &EmptyStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_empty_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_export_all(&mut self, node: &ExportAll, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_export_all(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_export_all(&mut self, node: &ExportAll, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_export_all(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_export_decl(&mut self, node: &ExportDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_export_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_export_decl(&mut self, node: &ExportDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_export_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_export_default_decl(&mut self, node: &ExportDefaultDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_export_default_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_export_default_decl(&mut self, node: &ExportDefaultDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_export_default_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_export_default_expr(&mut self, node: &ExportDefaultExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_export_default_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_export_default_expr(&mut self, node: &ExportDefaultExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_export_default_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_export_default_specifier(&mut self, node: &ExportDefaultSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_export_default_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_export_default_specifier(&mut self, node: &ExportDefaultSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_export_default_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_export_named_specifier(&mut self, node: &ExportNamedSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_export_named_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_export_named_specifier(&mut self, node: &ExportNamedSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_export_named_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_export_namespace_specifier(&mut self, node: &ExportNamespaceSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_export_namespace_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_export_namespace_specifier(&mut self, node: &ExportNamespaceSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_export_namespace_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_export_specifier(&mut self, node: &ExportSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_export_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_export_specifier(&mut self, node: &ExportSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_export_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_export_specifiers(&mut self, node: &[ExportSpecifier], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_export_specifiers(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_export_specifiers(&mut self, node: &[ExportSpecifier], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_export_specifiers(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_expr(&mut self, node: &Expr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_expr(&mut self, node: &Expr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_expr_or_spread(&mut self, node: &ExprOrSpread, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_expr_or_spread(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_expr_or_spread(&mut self, node: &ExprOrSpread, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_expr_or_spread(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_expr_or_spreads(&mut self, node: &[ExprOrSpread], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_expr_or_spreads(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_expr_or_spreads(&mut self, node: &[ExprOrSpread], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_expr_or_spreads(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_expr_stmt(&mut self, node: &ExprStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_expr_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_expr_stmt(&mut self, node: &ExprStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_expr_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_exprs(&mut self, node: &[Box<Expr>], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_exprs(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_exprs(&mut self, node: &[Box<Expr>], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_exprs(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_fn_decl(&mut self, node: &FnDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_fn_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_fn_decl(&mut self, node: &FnDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_fn_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_fn_expr(&mut self, node: &FnExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_fn_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_fn_expr(&mut self, node: &FnExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_fn_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_for_head(&mut self, node: &ForHead, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_for_head(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_for_head(&mut self, node: &ForHead, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_for_head(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_for_in_stmt(&mut self, node: &ForInStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_for_in_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_for_in_stmt(&mut self, node: &ForInStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_for_in_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_for_of_stmt(&mut self, node: &ForOfStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_for_of_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_for_of_stmt(&mut self, node: &ForOfStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_for_of_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_for_stmt(&mut self, node: &ForStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_for_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_for_stmt(&mut self, node: &ForStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_for_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_function(&mut self, node: &Function, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_function(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_function(&mut self, node: &Function, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_function(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_getter_prop(&mut self, node: &GetterProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_getter_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_getter_prop(&mut self, node: &GetterProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_getter_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ident(&mut self, node: &Ident, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ident(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ident(&mut self, node: &Ident, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ident(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ident_name(&mut self, node: &IdentName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ident_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ident_name(&mut self, node: &IdentName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ident_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_if_stmt(&mut self, node: &IfStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_if_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_if_stmt(&mut self, node: &IfStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_if_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import(&mut self, node: &Import, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import(&mut self, node: &Import, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import_decl(&mut self, node: &ImportDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import_decl(&mut self, node: &ImportDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import_default_specifier(&mut self, node: &ImportDefaultSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import_default_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import_default_specifier(&mut self, node: &ImportDefaultSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import_default_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import_named_specifier(&mut self, node: &ImportNamedSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import_named_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import_named_specifier(&mut self, node: &ImportNamedSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import_named_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import_phase(&mut self, node: &ImportPhase, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import_phase(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import_phase(&mut self, node: &ImportPhase, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import_phase(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import_specifier(&mut self, node: &ImportSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import_specifier(&mut self, node: &ImportSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import_specifiers(&mut self, node: &[ImportSpecifier], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import_specifiers(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import_specifiers(&mut self, node: &[ImportSpecifier], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import_specifiers(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import_star_as_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import_star_as_specifier(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import_with(&mut self, node: &ImportWith, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import_with(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import_with(&mut self, node: &ImportWith, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import_with(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import_with_item(&mut self, node: &ImportWithItem, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import_with_item(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import_with_item(&mut self, node: &ImportWithItem, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import_with_item(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_import_with_items(&mut self, node: &[ImportWithItem], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_import_with_items(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_import_with_items(&mut self, node: &[ImportWithItem], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_import_with_items(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_invalid(&mut self, node: &Invalid, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_invalid(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_invalid(&mut self, node: &Invalid, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_invalid(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_attr(&mut self, node: &JSXAttr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_attr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_attr(&mut self, node: &JSXAttr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_attr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_attr_name(&mut self, node: &JSXAttrName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_attr_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_attr_name(&mut self, node: &JSXAttrName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_attr_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_attr_or_spread(&mut self, node: &JSXAttrOrSpread, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_attr_or_spread(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_attr_or_spread(&mut self, node: &JSXAttrOrSpread, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_attr_or_spread(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_attr_or_spreads(&mut self, node: &[JSXAttrOrSpread], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_attr_or_spreads(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_attr_or_spreads(&mut self, node: &[JSXAttrOrSpread], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_attr_or_spreads(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_attr_value(&mut self, node: &JSXAttrValue, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_attr_value(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_attr_value(&mut self, node: &JSXAttrValue, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_attr_value(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_closing_element(&mut self, node: &JSXClosingElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_closing_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_closing_element(&mut self, node: &JSXClosingElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_closing_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_closing_fragment(&mut self, node: &JSXClosingFragment, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_closing_fragment(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_closing_fragment(&mut self, node: &JSXClosingFragment, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_closing_fragment(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_element(&mut self, node: &JSXElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_element(&mut self, node: &JSXElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_element_child(&mut self, node: &JSXElementChild, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_element_child(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_element_child(&mut self, node: &JSXElementChild, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_element_child(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_element_childs(&mut self, node: &[JSXElementChild], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_element_childs(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_element_childs(&mut self, node: &[JSXElementChild], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_element_childs(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_element_name(&mut self, node: &JSXElementName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_element_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_element_name(&mut self, node: &JSXElementName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_element_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_empty_expr(&mut self, node: &JSXEmptyExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_empty_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_empty_expr(&mut self, node: &JSXEmptyExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_empty_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_expr(&mut self, node: &JSXExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_expr(&mut self, node: &JSXExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_expr_container(&mut self, node: &JSXExprContainer, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_expr_container(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_expr_container(&mut self, node: &JSXExprContainer, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_expr_container(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_fragment(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_fragment(&mut self, node: &JSXFragment, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_fragment(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_member_expr(&mut self, node: &JSXMemberExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_member_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_member_expr(&mut self, node: &JSXMemberExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_member_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_namespaced_name(&mut self, node: &JSXNamespacedName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_namespaced_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_namespaced_name(&mut self, node: &JSXNamespacedName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_namespaced_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_object(&mut self, node: &JSXObject, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_object(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_object(&mut self, node: &JSXObject, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_object(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_opening_element(&mut self, node: &JSXOpeningElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_opening_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_opening_element(&mut self, node: &JSXOpeningElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_opening_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_opening_fragment(&mut self, node: &JSXOpeningFragment, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_opening_fragment(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_opening_fragment(&mut self, node: &JSXOpeningFragment, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_opening_fragment(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_spread_child(&mut self, node: &JSXSpreadChild, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_spread_child(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_spread_child(&mut self, node: &JSXSpreadChild, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_spread_child(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_jsx_text(&mut self, node: &JSXText, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_jsx_text(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_jsx_text(&mut self, node: &JSXText, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_jsx_text(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_key(&mut self, node: &Key, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_key(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_key(&mut self, node: &Key, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_key(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_key_value_pat_prop(&mut self, node: &KeyValuePatProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_key_value_pat_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_key_value_pat_prop(&mut self, node: &KeyValuePatProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_key_value_pat_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_key_value_prop(&mut self, node: &KeyValueProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_key_value_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_key_value_prop(&mut self, node: &KeyValueProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_key_value_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_labeled_stmt(&mut self, node: &LabeledStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_labeled_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_labeled_stmt(&mut self, node: &LabeledStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_labeled_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_lit(&mut self, node: &Lit, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_lit(&mut self, node: &Lit, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_member_expr(&mut self, node: &MemberExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_member_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_member_expr(&mut self, node: &MemberExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_member_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_member_prop(&mut self, node: &MemberProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_member_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_member_prop(&mut self, node: &MemberProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_member_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_meta_prop_expr(&mut self, node: &MetaPropExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_meta_prop_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_meta_prop_expr(&mut self, node: &MetaPropExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_meta_prop_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_meta_prop_kind(&mut self, node: &MetaPropKind, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_meta_prop_kind(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_meta_prop_kind(&mut self, node: &MetaPropKind, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_meta_prop_kind(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_method_kind(&mut self, node: &MethodKind, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_method_kind(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_method_kind(&mut self, node: &MethodKind, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_method_kind(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_method_prop(&mut self, node: &MethodProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_method_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_method_prop(&mut self, node: &MethodProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_method_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_module(&mut self, node: &Module, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_module(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_module(&mut self, node: &Module, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_module(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_module_decl(&mut self, node: &ModuleDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_module_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_module_decl(&mut self, node: &ModuleDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_module_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_module_export_name(&mut self, node: &ModuleExportName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_module_export_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_module_export_name(&mut self, node: &ModuleExportName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_module_export_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_module_item(&mut self, node: &ModuleItem, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_module_item(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_module_item(&mut self, node: &ModuleItem, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_module_item(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_module_items(&mut self, node: &[ModuleItem], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_module_items(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_module_items(&mut self, node: &[ModuleItem], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_module_items(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_named_export(&mut self, node: &NamedExport, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_named_export(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_named_export(&mut self, node: &NamedExport, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_named_export(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_new_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_new_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_null(&mut self, node: &Null, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_null(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_null(&mut self, node: &Null, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_null(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_number(&mut self, node: &Number, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_number(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_number(&mut self, node: &Number, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_number(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_object_lit(&mut self, node: &ObjectLit, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_object_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_object_lit(&mut self, node: &ObjectLit, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_object_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_object_pat(&mut self, node: &ObjectPat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_object_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_object_pat(&mut self, node: &ObjectPat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_object_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_object_pat_prop(&mut self, node: &ObjectPatProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_object_pat_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_object_pat_prop(&mut self, node: &ObjectPatProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_object_pat_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_object_pat_props(&mut self, node: &[ObjectPatProp], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_object_pat_props(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_object_pat_props(&mut self, node: &[ObjectPatProp], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_object_pat_props(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_accessibility(&mut self, node: &Option<Accessibility>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_accessibility(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_accessibility(&mut self, node: &Option<Accessibility>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_accessibility(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_atom(&mut self, node: &Option<swc_atoms::Atom>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_atom(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_atom(&mut self, node: &Option<swc_atoms::Atom>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_atom(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_block_stmt(&mut self, node: &Option<BlockStmt>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_block_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_block_stmt(&mut self, node: &Option<BlockStmt>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_block_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_call(&mut self, node: &OptCall, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_call(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_call(&mut self, node: &OptCall, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_call(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_catch_clause(&mut self, node: &Option<CatchClause>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_catch_clause(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_catch_clause(&mut self, node: &Option<CatchClause>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_catch_clause(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_chain_base(&mut self, node: &OptChainBase, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_chain_base(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_chain_base(&mut self, node: &OptChainBase, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_chain_base(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_chain_expr(&mut self, node: &OptChainExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_chain_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_chain_expr(&mut self, node: &OptChainExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_chain_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_expr(&mut self, node: &Option<Box<Expr>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_expr(&mut self, node: &Option<Box<Expr>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_expr_or_spread(&mut self, node: &Option<ExprOrSpread>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_expr_or_spread(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_expr_or_spread(&mut self, node: &Option<ExprOrSpread>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_expr_or_spread(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_expr_or_spreads(&mut self, node: &Option<Vec<ExprOrSpread>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_expr_or_spreads(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_expr_or_spreads(&mut self, node: &Option<Vec<ExprOrSpread>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_expr_or_spreads(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ident(&mut self, node: &Option<Ident>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_ident(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ident(&mut self, node: &Option<Ident>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_ident(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_jsx_attr_value(&mut self, node: &Option<JSXAttrValue>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_jsx_attr_value(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_jsx_attr_value(&mut self, node: &Option<JSXAttrValue>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_jsx_attr_value(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_jsx_closing_element(&mut self, node: &Option<JSXClosingElement>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_jsx_closing_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_jsx_closing_element(&mut self, node: &Option<JSXClosingElement>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_jsx_closing_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_module_export_name(&mut self, node: &Option<ModuleExportName>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_module_export_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_module_export_name(&mut self, node: &Option<ModuleExportName>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_module_export_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_object_lit(&mut self, node: &Option<Box<ObjectLit>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_object_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_object_lit(&mut self, node: &Option<Box<ObjectLit>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_object_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_pat(&mut self, node: &Option<Pat>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_pat(&mut self, node: &Option<Pat>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_span(&mut self, node: &Option<swc_common::Span>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_span(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_span(&mut self, node: &Option<swc_common::Span>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_span(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_stmt(&mut self, node: &Option<Box<Stmt>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_stmt(&mut self, node: &Option<Box<Stmt>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_str(&mut self, node: &Option<Box<Str>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_str(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_str(&mut self, node: &Option<Box<Str>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_str(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_true_plus_minus(&mut self, node: &Option<TruePlusMinus>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_true_plus_minus(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_true_plus_minus(&mut self, node: &Option<TruePlusMinus>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_true_plus_minus(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_entity_name(&mut self, node: &Option<TsEntityName>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_ts_entity_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_entity_name(&mut self, node: &Option<TsEntityName>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_ts_entity_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_import_call_options(
+        &mut self,
+        node: &Option<TsImportCallOptions>,
+        ctx: &mut C,
+    ) {
+        if let Some(hook) = self {
+            hook.enter_opt_ts_import_call_options(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_import_call_options(&mut self, node: &Option<TsImportCallOptions>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_ts_import_call_options(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_namespace_body(&mut self, node: &Option<TsNamespaceBody>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_ts_namespace_body(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_namespace_body(&mut self, node: &Option<TsNamespaceBody>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_ts_namespace_body(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_type(&mut self, node: &Option<Box<TsType>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_ts_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_type(&mut self, node: &Option<Box<TsType>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_ts_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_ann(&mut self, node: &Option<Box<TsTypeAnn>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_ts_type_ann(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_type_ann(&mut self, node: &Option<Box<TsTypeAnn>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_ts_type_ann(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_param_decl(&mut self, node: &Option<Box<TsTypeParamDecl>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_ts_type_param_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_type_param_decl(&mut self, node: &Option<Box<TsTypeParamDecl>>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_ts_type_param_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_param_instantiation(
+        &mut self,
+        node: &Option<Box<TsTypeParamInstantiation>>,
+        ctx: &mut C,
+    ) {
+        if let Some(hook) = self {
+            hook.enter_opt_ts_type_param_instantiation(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_ts_type_param_instantiation(
+        &mut self,
+        node: &Option<Box<TsTypeParamInstantiation>>,
+        ctx: &mut C,
+    ) {
+        if let Some(hook) = self {
+            hook.exit_opt_ts_type_param_instantiation(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_var_decl_or_expr(&mut self, node: &Option<VarDeclOrExpr>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_var_decl_or_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_var_decl_or_expr(&mut self, node: &Option<VarDeclOrExpr>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_var_decl_or_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_vec_expr_or_spreads(&mut self, node: &[Option<ExprOrSpread>], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_vec_expr_or_spreads(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_vec_expr_or_spreads(&mut self, node: &[Option<ExprOrSpread>], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_vec_expr_or_spreads(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_vec_pats(&mut self, node: &[Option<Pat>], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_vec_pats(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_vec_pats(&mut self, node: &[Option<Pat>], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_vec_pats(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_opt_wtf_8_atom(&mut self, node: &Option<swc_atoms::Wtf8Atom>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_opt_wtf_8_atom(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_opt_wtf_8_atom(&mut self, node: &Option<swc_atoms::Wtf8Atom>, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_opt_wtf_8_atom(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_param(&mut self, node: &Param, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_param(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_param(&mut self, node: &Param, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_param(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_param_or_ts_param_prop(&mut self, node: &ParamOrTsParamProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_param_or_ts_param_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_param_or_ts_param_prop(&mut self, node: &ParamOrTsParamProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_param_or_ts_param_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_param_or_ts_param_props(&mut self, node: &[ParamOrTsParamProp], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_param_or_ts_param_props(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_param_or_ts_param_props(&mut self, node: &[ParamOrTsParamProp], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_param_or_ts_param_props(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_params(&mut self, node: &[Param], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_params(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_params(&mut self, node: &[Param], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_params(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_paren_expr(&mut self, node: &ParenExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_paren_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_paren_expr(&mut self, node: &ParenExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_paren_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_pat(&mut self, node: &Pat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_pat(&mut self, node: &Pat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_pats(&mut self, node: &[Pat], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_pats(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_pats(&mut self, node: &[Pat], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_pats(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_private_method(&mut self, node: &PrivateMethod, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_private_method(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_private_method(&mut self, node: &PrivateMethod, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_private_method(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_private_name(&mut self, node: &PrivateName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_private_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_private_name(&mut self, node: &PrivateName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_private_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_private_prop(&mut self, node: &PrivateProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_private_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_private_prop(&mut self, node: &PrivateProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_private_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_program(&mut self, node: &Program, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_program(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_program(&mut self, node: &Program, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_program(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_prop(&mut self, node: &Prop, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_prop(&mut self, node: &Prop, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_prop_name(&mut self, node: &PropName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_prop_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_prop_name(&mut self, node: &PropName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_prop_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_prop_or_spread(&mut self, node: &PropOrSpread, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_prop_or_spread(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_prop_or_spread(&mut self, node: &PropOrSpread, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_prop_or_spread(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_prop_or_spreads(&mut self, node: &[PropOrSpread], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_prop_or_spreads(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_prop_or_spreads(&mut self, node: &[PropOrSpread], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_prop_or_spreads(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_regex(&mut self, node: &Regex, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_regex(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_regex(&mut self, node: &Regex, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_regex(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_rest_pat(&mut self, node: &RestPat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_rest_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_rest_pat(&mut self, node: &RestPat, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_rest_pat(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_return_stmt(&mut self, node: &ReturnStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_return_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_return_stmt(&mut self, node: &ReturnStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_return_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_script(&mut self, node: &Script, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_script(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_script(&mut self, node: &Script, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_script(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_seq_expr(&mut self, node: &SeqExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_seq_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_seq_expr(&mut self, node: &SeqExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_seq_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_setter_prop(&mut self, node: &SetterProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_setter_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_setter_prop(&mut self, node: &SetterProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_setter_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_simple_assign_target(&mut self, node: &SimpleAssignTarget, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_simple_assign_target(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_simple_assign_target(&mut self, node: &SimpleAssignTarget, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_simple_assign_target(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_span(&mut self, node: &swc_common::Span, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_span(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_span(&mut self, node: &swc_common::Span, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_span(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_spread_element(&mut self, node: &SpreadElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_spread_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_spread_element(&mut self, node: &SpreadElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_spread_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_static_block(&mut self, node: &StaticBlock, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_static_block(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_static_block(&mut self, node: &StaticBlock, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_static_block(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_stmt(&mut self, node: &Stmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_stmt(&mut self, node: &Stmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_stmts(&mut self, node: &[Stmt], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_stmts(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_stmts(&mut self, node: &[Stmt], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_stmts(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_str(&mut self, node: &Str, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_str(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_str(&mut self, node: &Str, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_str(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_super(&mut self, node: &Super, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_super(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_super(&mut self, node: &Super, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_super(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_super_prop(&mut self, node: &SuperProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_super_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_super_prop(&mut self, node: &SuperProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_super_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_super_prop_expr(&mut self, node: &SuperPropExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_super_prop_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_super_prop_expr(&mut self, node: &SuperPropExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_super_prop_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_switch_case(&mut self, node: &SwitchCase, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_switch_case(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_switch_case(&mut self, node: &SwitchCase, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_switch_case(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_switch_cases(&mut self, node: &[SwitchCase], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_switch_cases(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_switch_cases(&mut self, node: &[SwitchCase], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_switch_cases(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_switch_stmt(&mut self, node: &SwitchStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_switch_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_switch_stmt(&mut self, node: &SwitchStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_switch_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_syntax_context(&mut self, node: &swc_common::SyntaxContext, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_syntax_context(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_syntax_context(&mut self, node: &swc_common::SyntaxContext, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_syntax_context(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_tagged_tpl(&mut self, node: &TaggedTpl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_tagged_tpl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_tagged_tpl(&mut self, node: &TaggedTpl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_tagged_tpl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_this_expr(&mut self, node: &ThisExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_this_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_this_expr(&mut self, node: &ThisExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_this_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_throw_stmt(&mut self, node: &ThrowStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_throw_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_throw_stmt(&mut self, node: &ThrowStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_throw_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_tpl(&mut self, node: &Tpl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_tpl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_tpl(&mut self, node: &Tpl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_tpl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_tpl_element(&mut self, node: &TplElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_tpl_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_tpl_element(&mut self, node: &TplElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_tpl_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_tpl_elements(&mut self, node: &[TplElement], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_tpl_elements(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_tpl_elements(&mut self, node: &[TplElement], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_tpl_elements(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_true_plus_minus(&mut self, node: &TruePlusMinus, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_true_plus_minus(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_true_plus_minus(&mut self, node: &TruePlusMinus, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_true_plus_minus(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_try_stmt(&mut self, node: &TryStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_try_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_try_stmt(&mut self, node: &TryStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_try_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_array_type(&mut self, node: &TsArrayType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_array_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_array_type(&mut self, node: &TsArrayType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_array_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_as_expr(&mut self, node: &TsAsExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_as_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_as_expr(&mut self, node: &TsAsExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_as_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_call_signature_decl(&mut self, node: &TsCallSignatureDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_call_signature_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_call_signature_decl(&mut self, node: &TsCallSignatureDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_call_signature_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_conditional_type(&mut self, node: &TsConditionalType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_conditional_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_conditional_type(&mut self, node: &TsConditionalType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_conditional_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_const_assertion(&mut self, node: &TsConstAssertion, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_const_assertion(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_const_assertion(&mut self, node: &TsConstAssertion, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_const_assertion(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_construct_signature_decl(&mut self, node: &TsConstructSignatureDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_construct_signature_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_construct_signature_decl(&mut self, node: &TsConstructSignatureDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_construct_signature_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_constructor_type(&mut self, node: &TsConstructorType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_constructor_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_constructor_type(&mut self, node: &TsConstructorType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_constructor_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_entity_name(&mut self, node: &TsEntityName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_entity_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_entity_name(&mut self, node: &TsEntityName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_entity_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_enum_decl(&mut self, node: &TsEnumDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_enum_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_enum_decl(&mut self, node: &TsEnumDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_enum_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_enum_member(&mut self, node: &TsEnumMember, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_enum_member(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_enum_member(&mut self, node: &TsEnumMember, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_enum_member(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_enum_member_id(&mut self, node: &TsEnumMemberId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_enum_member_id(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_enum_member_id(&mut self, node: &TsEnumMemberId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_enum_member_id(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_enum_members(&mut self, node: &[TsEnumMember], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_enum_members(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_enum_members(&mut self, node: &[TsEnumMember], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_enum_members(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_export_assignment(&mut self, node: &TsExportAssignment, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_export_assignment(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_export_assignment(&mut self, node: &TsExportAssignment, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_export_assignment(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_expr_with_type_args(&mut self, node: &TsExprWithTypeArgs, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_expr_with_type_args(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_expr_with_type_args(&mut self, node: &TsExprWithTypeArgs, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_expr_with_type_args(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_expr_with_type_argss(&mut self, node: &[TsExprWithTypeArgs], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_expr_with_type_argss(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_expr_with_type_argss(&mut self, node: &[TsExprWithTypeArgs], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_expr_with_type_argss(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_external_module_ref(&mut self, node: &TsExternalModuleRef, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_external_module_ref(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_external_module_ref(&mut self, node: &TsExternalModuleRef, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_external_module_ref(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_fn_or_constructor_type(&mut self, node: &TsFnOrConstructorType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_fn_or_constructor_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_fn_or_constructor_type(&mut self, node: &TsFnOrConstructorType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_fn_or_constructor_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_fn_param(&mut self, node: &TsFnParam, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_fn_param(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_fn_param(&mut self, node: &TsFnParam, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_fn_param(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_fn_params(&mut self, node: &[TsFnParam], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_fn_params(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_fn_params(&mut self, node: &[TsFnParam], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_fn_params(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_fn_type(&mut self, node: &TsFnType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_fn_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_fn_type(&mut self, node: &TsFnType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_fn_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_getter_signature(&mut self, node: &TsGetterSignature, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_getter_signature(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_getter_signature(&mut self, node: &TsGetterSignature, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_getter_signature(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_import_call_options(&mut self, node: &TsImportCallOptions, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_import_call_options(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_import_call_options(&mut self, node: &TsImportCallOptions, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_import_call_options(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_import_equals_decl(&mut self, node: &TsImportEqualsDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_import_equals_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_import_equals_decl(&mut self, node: &TsImportEqualsDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_import_equals_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_import_type(&mut self, node: &TsImportType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_import_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_import_type(&mut self, node: &TsImportType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_import_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_index_signature(&mut self, node: &TsIndexSignature, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_index_signature(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_index_signature(&mut self, node: &TsIndexSignature, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_index_signature(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_indexed_access_type(&mut self, node: &TsIndexedAccessType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_indexed_access_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_indexed_access_type(&mut self, node: &TsIndexedAccessType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_indexed_access_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_infer_type(&mut self, node: &TsInferType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_infer_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_infer_type(&mut self, node: &TsInferType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_infer_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_instantiation(&mut self, node: &TsInstantiation, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_instantiation(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_instantiation(&mut self, node: &TsInstantiation, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_instantiation(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_interface_body(&mut self, node: &TsInterfaceBody, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_interface_body(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_interface_body(&mut self, node: &TsInterfaceBody, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_interface_body(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_interface_decl(&mut self, node: &TsInterfaceDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_interface_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_interface_decl(&mut self, node: &TsInterfaceDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_interface_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_intersection_type(&mut self, node: &TsIntersectionType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_intersection_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_intersection_type(&mut self, node: &TsIntersectionType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_intersection_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_keyword_type(&mut self, node: &TsKeywordType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_keyword_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_keyword_type(&mut self, node: &TsKeywordType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_keyword_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_keyword_type_kind(&mut self, node: &TsKeywordTypeKind, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_keyword_type_kind(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_keyword_type_kind(&mut self, node: &TsKeywordTypeKind, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_keyword_type_kind(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_lit(&mut self, node: &TsLit, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_lit(&mut self, node: &TsLit, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_lit_type(&mut self, node: &TsLitType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_lit_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_lit_type(&mut self, node: &TsLitType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_lit_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_mapped_type(&mut self, node: &TsMappedType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_mapped_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_mapped_type(&mut self, node: &TsMappedType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_mapped_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_method_signature(&mut self, node: &TsMethodSignature, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_method_signature(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_method_signature(&mut self, node: &TsMethodSignature, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_method_signature(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_module_block(&mut self, node: &TsModuleBlock, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_module_block(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_module_block(&mut self, node: &TsModuleBlock, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_module_block(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_module_decl(&mut self, node: &TsModuleDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_module_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_module_decl(&mut self, node: &TsModuleDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_module_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_module_name(&mut self, node: &TsModuleName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_module_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_module_name(&mut self, node: &TsModuleName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_module_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_module_ref(&mut self, node: &TsModuleRef, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_module_ref(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_module_ref(&mut self, node: &TsModuleRef, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_module_ref(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_namespace_body(&mut self, node: &TsNamespaceBody, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_namespace_body(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_namespace_body(&mut self, node: &TsNamespaceBody, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_namespace_body(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_namespace_decl(&mut self, node: &TsNamespaceDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_namespace_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_namespace_decl(&mut self, node: &TsNamespaceDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_namespace_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_namespace_export_decl(&mut self, node: &TsNamespaceExportDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_namespace_export_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_namespace_export_decl(&mut self, node: &TsNamespaceExportDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_namespace_export_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_non_null_expr(&mut self, node: &TsNonNullExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_non_null_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_non_null_expr(&mut self, node: &TsNonNullExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_non_null_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_optional_type(&mut self, node: &TsOptionalType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_optional_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_optional_type(&mut self, node: &TsOptionalType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_optional_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_param_prop(&mut self, node: &TsParamProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_param_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_param_prop(&mut self, node: &TsParamProp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_param_prop(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_param_prop_param(&mut self, node: &TsParamPropParam, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_param_prop_param(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_param_prop_param(&mut self, node: &TsParamPropParam, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_param_prop_param(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_parenthesized_type(&mut self, node: &TsParenthesizedType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_parenthesized_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_parenthesized_type(&mut self, node: &TsParenthesizedType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_parenthesized_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_property_signature(&mut self, node: &TsPropertySignature, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_property_signature(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_property_signature(&mut self, node: &TsPropertySignature, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_property_signature(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_qualified_name(&mut self, node: &TsQualifiedName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_qualified_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_qualified_name(&mut self, node: &TsQualifiedName, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_qualified_name(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_rest_type(&mut self, node: &TsRestType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_rest_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_rest_type(&mut self, node: &TsRestType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_rest_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_satisfies_expr(&mut self, node: &TsSatisfiesExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_satisfies_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_satisfies_expr(&mut self, node: &TsSatisfiesExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_satisfies_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_setter_signature(&mut self, node: &TsSetterSignature, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_setter_signature(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_setter_signature(&mut self, node: &TsSetterSignature, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_setter_signature(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_this_type(&mut self, node: &TsThisType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_this_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_this_type(&mut self, node: &TsThisType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_this_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_this_type_or_ident(&mut self, node: &TsThisTypeOrIdent, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_this_type_or_ident(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_this_type_or_ident(&mut self, node: &TsThisTypeOrIdent, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_this_type_or_ident(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_tpl_lit_type(&mut self, node: &TsTplLitType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_tpl_lit_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_tpl_lit_type(&mut self, node: &TsTplLitType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_tpl_lit_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_tuple_element(&mut self, node: &TsTupleElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_tuple_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_tuple_element(&mut self, node: &TsTupleElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_tuple_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_tuple_elements(&mut self, node: &[TsTupleElement], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_tuple_elements(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_tuple_elements(&mut self, node: &[TsTupleElement], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_tuple_elements(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_tuple_type(&mut self, node: &TsTupleType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_tuple_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_tuple_type(&mut self, node: &TsTupleType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_tuple_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type(&mut self, node: &TsType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type(&mut self, node: &TsType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_alias_decl(&mut self, node: &TsTypeAliasDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_alias_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_alias_decl(&mut self, node: &TsTypeAliasDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_alias_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_ann(&mut self, node: &TsTypeAnn, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_ann(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_ann(&mut self, node: &TsTypeAnn, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_ann(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_assertion(&mut self, node: &TsTypeAssertion, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_assertion(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_assertion(&mut self, node: &TsTypeAssertion, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_assertion(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_element(&mut self, node: &TsTypeElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_element(&mut self, node: &TsTypeElement, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_element(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_elements(&mut self, node: &[TsTypeElement], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_elements(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_elements(&mut self, node: &[TsTypeElement], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_elements(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_lit(&mut self, node: &TsTypeLit, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_lit(&mut self, node: &TsTypeLit, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_lit(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_operator(&mut self, node: &TsTypeOperator, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_operator(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_operator(&mut self, node: &TsTypeOperator, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_operator(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_operator_op(&mut self, node: &TsTypeOperatorOp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_operator_op(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_operator_op(&mut self, node: &TsTypeOperatorOp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_operator_op(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_param(&mut self, node: &TsTypeParam, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_param(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_param(&mut self, node: &TsTypeParam, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_param(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_param_decl(&mut self, node: &TsTypeParamDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_param_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_param_decl(&mut self, node: &TsTypeParamDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_param_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_param_instantiation(&mut self, node: &TsTypeParamInstantiation, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_param_instantiation(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_param_instantiation(&mut self, node: &TsTypeParamInstantiation, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_param_instantiation(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_params(&mut self, node: &[TsTypeParam], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_params(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_params(&mut self, node: &[TsTypeParam], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_params(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_predicate(&mut self, node: &TsTypePredicate, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_predicate(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_predicate(&mut self, node: &TsTypePredicate, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_predicate(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_query(&mut self, node: &TsTypeQuery, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_query(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_query(&mut self, node: &TsTypeQuery, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_query(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_query_expr(&mut self, node: &TsTypeQueryExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_query_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_query_expr(&mut self, node: &TsTypeQueryExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_query_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_type_ref(&mut self, node: &TsTypeRef, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_type_ref(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_type_ref(&mut self, node: &TsTypeRef, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_type_ref(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_types(&mut self, node: &[Box<TsType>], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_types(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_types(&mut self, node: &[Box<TsType>], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_types(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_union_or_intersection_type(
+        &mut self,
+        node: &TsUnionOrIntersectionType,
+        ctx: &mut C,
+    ) {
+        if let Some(hook) = self {
+            hook.enter_ts_union_or_intersection_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_union_or_intersection_type(
+        &mut self,
+        node: &TsUnionOrIntersectionType,
+        ctx: &mut C,
+    ) {
+        if let Some(hook) = self {
+            hook.exit_ts_union_or_intersection_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_ts_union_type(&mut self, node: &TsUnionType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_ts_union_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_ts_union_type(&mut self, node: &TsUnionType, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_ts_union_type(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_unary_expr(&mut self, node: &UnaryExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_unary_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_unary_expr(&mut self, node: &UnaryExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_unary_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_unary_op(&mut self, node: &UnaryOp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_unary_op(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_unary_op(&mut self, node: &UnaryOp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_unary_op(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_update_expr(&mut self, node: &UpdateExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_update_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_update_expr(&mut self, node: &UpdateExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_update_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_update_op(&mut self, node: &UpdateOp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_update_op(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_update_op(&mut self, node: &UpdateOp, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_update_op(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_using_decl(&mut self, node: &UsingDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_using_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_using_decl(&mut self, node: &UsingDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_using_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_var_decl(&mut self, node: &VarDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_var_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_var_decl(&mut self, node: &VarDecl, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_var_decl(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_var_decl_kind(&mut self, node: &VarDeclKind, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_var_decl_kind(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_var_decl_kind(&mut self, node: &VarDeclKind, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_var_decl_kind(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_var_decl_or_expr(&mut self, node: &VarDeclOrExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_var_decl_or_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_var_decl_or_expr(&mut self, node: &VarDeclOrExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_var_decl_or_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_var_declarator(&mut self, node: &VarDeclarator, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_var_declarator(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_var_declarator(&mut self, node: &VarDeclarator, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_var_declarator(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_var_declarators(&mut self, node: &[VarDeclarator], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_var_declarators(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_var_declarators(&mut self, node: &[VarDeclarator], ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_var_declarators(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_while_stmt(&mut self, node: &WhileStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_while_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_while_stmt(&mut self, node: &WhileStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_while_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_with_stmt(&mut self, node: &WithStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_with_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_with_stmt(&mut self, node: &WithStmt, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_with_stmt(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_wtf_8_atom(&mut self, node: &swc_atoms::Wtf8Atom, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_wtf_8_atom(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_wtf_8_atom(&mut self, node: &swc_atoms::Wtf8Atom, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_wtf_8_atom(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn enter_yield_expr(&mut self, node: &YieldExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_yield_expr(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_yield_expr(&mut self, node: &YieldExpr, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_yield_expr(node, ctx);
+        }
+    }
+}
+#[doc = r" An adapter that implements Visit using a VisitHook."]
+#[doc = r""]
+#[doc = r" This allows any hook to be used as a visitor by calling:"]
+#[doc = r" - hook.enter_xxx before visiting children"]
+#[doc = r" - hook.exit_xxx after visiting children"]
+pub struct VisitWithHook<H, C> {
+    pub hook: H,
+    pub context: C,
+}
+impl<H: VisitHook<C>, C> Visit for VisitWithHook<H, C> {
+    #[doc = "Visits a node of type `Accessibility` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_accessibility(&mut self, node: &Accessibility) {
+        self.hook.enter_accessibility(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_accessibility(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ArrayLit` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_array_lit(&mut self, node: &ArrayLit) {
+        self.hook.enter_array_lit(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_array_lit(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ArrayPat` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_array_pat(&mut self, node: &ArrayPat) {
+        self.hook.enter_array_pat(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_array_pat(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ArrowExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_arrow_expr(&mut self, node: &ArrowExpr) {
+        self.hook.enter_arrow_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_arrow_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `AssignExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_assign_expr(&mut self, node: &AssignExpr) {
+        self.hook.enter_assign_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_assign_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `AssignOp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_assign_op(&mut self, node: &AssignOp) {
+        self.hook.enter_assign_op(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_assign_op(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `AssignPat` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_assign_pat(&mut self, node: &AssignPat) {
+        self.hook.enter_assign_pat(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_assign_pat(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `AssignPatProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_assign_pat_prop(&mut self, node: &AssignPatProp) {
+        self.hook.enter_assign_pat_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_assign_pat_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `AssignProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_assign_prop(&mut self, node: &AssignProp) {
+        self.hook.enter_assign_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_assign_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `AssignTarget` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_assign_target(&mut self, node: &AssignTarget) {
+        self.hook.enter_assign_target(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_assign_target(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `AssignTargetPat` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_assign_target_pat(&mut self, node: &AssignTargetPat) {
+        self.hook.enter_assign_target_pat(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_assign_target_pat(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `swc_atoms :: Atom` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_atom(&mut self, node: &swc_atoms::Atom) {
+        self.hook.enter_atom(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_atom(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `AutoAccessor` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_auto_accessor(&mut self, node: &AutoAccessor) {
+        self.hook.enter_auto_accessor(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_auto_accessor(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `AwaitExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_await_expr(&mut self, node: &AwaitExpr) {
+        self.hook.enter_await_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_await_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `BigInt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_big_int(&mut self, node: &BigInt) {
+        self.hook.enter_big_int(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_big_int(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `BigIntValue` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_big_int_value(&mut self, node: &BigIntValue) {
+        self.hook.enter_big_int_value(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_big_int_value(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `BinExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_bin_expr(&mut self, node: &BinExpr) {
+        self.hook.enter_bin_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_bin_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `BinaryOp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_binary_op(&mut self, node: &BinaryOp) {
+        self.hook.enter_binary_op(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_binary_op(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `BindingIdent` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_binding_ident(&mut self, node: &BindingIdent) {
+        self.hook.enter_binding_ident(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_binding_ident(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `BlockStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_block_stmt(&mut self, node: &BlockStmt) {
+        self.hook.enter_block_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_block_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `BlockStmtOrExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_block_stmt_or_expr(&mut self, node: &BlockStmtOrExpr) {
+        self.hook.enter_block_stmt_or_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_block_stmt_or_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Bool` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_bool(&mut self, node: &Bool) {
+        self.hook.enter_bool(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_bool(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `BreakStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_break_stmt(&mut self, node: &BreakStmt) {
+        self.hook.enter_break_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_break_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `CallExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_call_expr(&mut self, node: &CallExpr) {
+        self.hook.enter_call_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_call_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Callee` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_callee(&mut self, node: &Callee) {
+        self.hook.enter_callee(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_callee(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `CatchClause` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_catch_clause(&mut self, node: &CatchClause) {
+        self.hook.enter_catch_clause(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_catch_clause(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Class` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_class(&mut self, node: &Class) {
+        self.hook.enter_class(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_class(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ClassDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_class_decl(&mut self, node: &ClassDecl) {
+        self.hook.enter_class_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_class_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ClassExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_class_expr(&mut self, node: &ClassExpr) {
+        self.hook.enter_class_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_class_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ClassMember` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_class_member(&mut self, node: &ClassMember) {
+        self.hook.enter_class_member(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_class_member(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < ClassMember >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_class_members(&mut self, node: &[ClassMember]) {
+        self.hook.enter_class_members(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_class_members(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ClassMethod` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_class_method(&mut self, node: &ClassMethod) {
+        self.hook.enter_class_method(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_class_method(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ClassProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_class_prop(&mut self, node: &ClassProp) {
+        self.hook.enter_class_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_class_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ComputedPropName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_computed_prop_name(&mut self, node: &ComputedPropName) {
+        self.hook.enter_computed_prop_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_computed_prop_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `CondExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_cond_expr(&mut self, node: &CondExpr) {
+        self.hook.enter_cond_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_cond_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Constructor` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_constructor(&mut self, node: &Constructor) {
+        self.hook.enter_constructor(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_constructor(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ContinueStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_continue_stmt(&mut self, node: &ContinueStmt) {
+        self.hook.enter_continue_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_continue_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `DebuggerStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_debugger_stmt(&mut self, node: &DebuggerStmt) {
+        self.hook.enter_debugger_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_debugger_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Decl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_decl(&mut self, node: &Decl) {
+        self.hook.enter_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Decorator` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_decorator(&mut self, node: &Decorator) {
+        self.hook.enter_decorator(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_decorator(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < Decorator >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_decorators(&mut self, node: &[Decorator]) {
+        self.hook.enter_decorators(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_decorators(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `DefaultDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_default_decl(&mut self, node: &DefaultDecl) {
+        self.hook.enter_default_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_default_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `DoWhileStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_do_while_stmt(&mut self, node: &DoWhileStmt) {
+        self.hook.enter_do_while_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_do_while_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `EmptyStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_empty_stmt(&mut self, node: &EmptyStmt) {
+        self.hook.enter_empty_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_empty_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ExportAll` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_export_all(&mut self, node: &ExportAll) {
+        self.hook.enter_export_all(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_export_all(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ExportDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_export_decl(&mut self, node: &ExportDecl) {
+        self.hook.enter_export_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_export_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ExportDefaultDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_export_default_decl(&mut self, node: &ExportDefaultDecl) {
+        self.hook.enter_export_default_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_export_default_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ExportDefaultExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_export_default_expr(&mut self, node: &ExportDefaultExpr) {
+        self.hook.enter_export_default_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_export_default_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ExportDefaultSpecifier` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_export_default_specifier(&mut self, node: &ExportDefaultSpecifier) {
+        self.hook
+            .enter_export_default_specifier(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_export_default_specifier(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ExportNamedSpecifier` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_export_named_specifier(&mut self, node: &ExportNamedSpecifier) {
+        self.hook
+            .enter_export_named_specifier(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_export_named_specifier(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ExportNamespaceSpecifier` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_export_namespace_specifier(&mut self, node: &ExportNamespaceSpecifier) {
+        self.hook
+            .enter_export_namespace_specifier(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_export_namespace_specifier(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ExportSpecifier` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_export_specifier(&mut self, node: &ExportSpecifier) {
+        self.hook.enter_export_specifier(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_export_specifier(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < ExportSpecifier >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_export_specifiers(&mut self, node: &[ExportSpecifier]) {
+        self.hook.enter_export_specifiers(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_export_specifiers(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Expr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_expr(&mut self, node: &Expr) {
+        self.hook.enter_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ExprOrSpread` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_expr_or_spread(&mut self, node: &ExprOrSpread) {
+        self.hook.enter_expr_or_spread(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_expr_or_spread(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < ExprOrSpread >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_expr_or_spreads(&mut self, node: &[ExprOrSpread]) {
+        self.hook.enter_expr_or_spreads(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_expr_or_spreads(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ExprStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_expr_stmt(&mut self, node: &ExprStmt) {
+        self.hook.enter_expr_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_expr_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < Box < Expr > >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_exprs(&mut self, node: &[Box<Expr>]) {
+        self.hook.enter_exprs(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_exprs(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `FnDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_fn_decl(&mut self, node: &FnDecl) {
+        self.hook.enter_fn_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_fn_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `FnExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_fn_expr(&mut self, node: &FnExpr) {
+        self.hook.enter_fn_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_fn_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ForHead` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_for_head(&mut self, node: &ForHead) {
+        self.hook.enter_for_head(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_for_head(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ForInStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_for_in_stmt(&mut self, node: &ForInStmt) {
+        self.hook.enter_for_in_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_for_in_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ForOfStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_for_of_stmt(&mut self, node: &ForOfStmt) {
+        self.hook.enter_for_of_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_for_of_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ForStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_for_stmt(&mut self, node: &ForStmt) {
+        self.hook.enter_for_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_for_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Function` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_function(&mut self, node: &Function) {
+        self.hook.enter_function(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_function(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `GetterProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_getter_prop(&mut self, node: &GetterProp) {
+        self.hook.enter_getter_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_getter_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Ident` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ident(&mut self, node: &Ident) {
+        self.hook.enter_ident(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ident(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `IdentName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ident_name(&mut self, node: &IdentName) {
+        self.hook.enter_ident_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ident_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `IfStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_if_stmt(&mut self, node: &IfStmt) {
+        self.hook.enter_if_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_if_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Import` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_import(&mut self, node: &Import) {
+        self.hook.enter_import(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_import(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ImportDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_import_decl(&mut self, node: &ImportDecl) {
+        self.hook.enter_import_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_import_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ImportDefaultSpecifier` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_import_default_specifier(&mut self, node: &ImportDefaultSpecifier) {
+        self.hook
+            .enter_import_default_specifier(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_import_default_specifier(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ImportNamedSpecifier` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_import_named_specifier(&mut self, node: &ImportNamedSpecifier) {
+        self.hook
+            .enter_import_named_specifier(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_import_named_specifier(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ImportPhase` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_import_phase(&mut self, node: &ImportPhase) {
+        self.hook.enter_import_phase(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_import_phase(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ImportSpecifier` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_import_specifier(&mut self, node: &ImportSpecifier) {
+        self.hook.enter_import_specifier(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_import_specifier(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < ImportSpecifier >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_import_specifiers(&mut self, node: &[ImportSpecifier]) {
+        self.hook.enter_import_specifiers(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_import_specifiers(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ImportStarAsSpecifier` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier) {
+        self.hook
+            .enter_import_star_as_specifier(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_import_star_as_specifier(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ImportWith` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_import_with(&mut self, node: &ImportWith) {
+        self.hook.enter_import_with(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_import_with(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ImportWithItem` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_import_with_item(&mut self, node: &ImportWithItem) {
+        self.hook.enter_import_with_item(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_import_with_item(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < ImportWithItem >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_import_with_items(&mut self, node: &[ImportWithItem]) {
+        self.hook.enter_import_with_items(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_import_with_items(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Invalid` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_invalid(&mut self, node: &Invalid) {
+        self.hook.enter_invalid(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_invalid(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXAttr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_attr(&mut self, node: &JSXAttr) {
+        self.hook.enter_jsx_attr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_attr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXAttrName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_attr_name(&mut self, node: &JSXAttrName) {
+        self.hook.enter_jsx_attr_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_attr_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXAttrOrSpread` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_attr_or_spread(&mut self, node: &JSXAttrOrSpread) {
+        self.hook.enter_jsx_attr_or_spread(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_attr_or_spread(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < JSXAttrOrSpread >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_jsx_attr_or_spreads(&mut self, node: &[JSXAttrOrSpread]) {
+        self.hook.enter_jsx_attr_or_spreads(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_attr_or_spreads(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXAttrValue` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_attr_value(&mut self, node: &JSXAttrValue) {
+        self.hook.enter_jsx_attr_value(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_attr_value(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXClosingElement` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_closing_element(&mut self, node: &JSXClosingElement) {
+        self.hook.enter_jsx_closing_element(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_closing_element(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXClosingFragment` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_closing_fragment(&mut self, node: &JSXClosingFragment) {
+        self.hook
+            .enter_jsx_closing_fragment(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_closing_fragment(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXElement` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_element(&mut self, node: &JSXElement) {
+        self.hook.enter_jsx_element(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_element(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXElementChild` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_element_child(&mut self, node: &JSXElementChild) {
+        self.hook.enter_jsx_element_child(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_element_child(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < JSXElementChild >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_jsx_element_childs(&mut self, node: &[JSXElementChild]) {
+        self.hook.enter_jsx_element_childs(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_element_childs(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXElementName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_element_name(&mut self, node: &JSXElementName) {
+        self.hook.enter_jsx_element_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_element_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXEmptyExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_empty_expr(&mut self, node: &JSXEmptyExpr) {
+        self.hook.enter_jsx_empty_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_empty_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_expr(&mut self, node: &JSXExpr) {
+        self.hook.enter_jsx_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXExprContainer` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_expr_container(&mut self, node: &JSXExprContainer) {
+        self.hook.enter_jsx_expr_container(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_expr_container(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXFragment` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_fragment(&mut self, node: &JSXFragment) {
+        self.hook.enter_jsx_fragment(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_fragment(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXMemberExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_member_expr(&mut self, node: &JSXMemberExpr) {
+        self.hook.enter_jsx_member_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_member_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXNamespacedName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_namespaced_name(&mut self, node: &JSXNamespacedName) {
+        self.hook.enter_jsx_namespaced_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_namespaced_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXObject` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_object(&mut self, node: &JSXObject) {
+        self.hook.enter_jsx_object(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_object(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXOpeningElement` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_opening_element(&mut self, node: &JSXOpeningElement) {
+        self.hook.enter_jsx_opening_element(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_opening_element(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXOpeningFragment` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_opening_fragment(&mut self, node: &JSXOpeningFragment) {
+        self.hook
+            .enter_jsx_opening_fragment(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_opening_fragment(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXSpreadChild` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_spread_child(&mut self, node: &JSXSpreadChild) {
+        self.hook.enter_jsx_spread_child(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_spread_child(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `JSXText` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_jsx_text(&mut self, node: &JSXText) {
+        self.hook.enter_jsx_text(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_jsx_text(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Key` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_key(&mut self, node: &Key) {
+        self.hook.enter_key(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_key(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `KeyValuePatProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_key_value_pat_prop(&mut self, node: &KeyValuePatProp) {
+        self.hook.enter_key_value_pat_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_key_value_pat_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `KeyValueProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_key_value_prop(&mut self, node: &KeyValueProp) {
+        self.hook.enter_key_value_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_key_value_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `LabeledStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_labeled_stmt(&mut self, node: &LabeledStmt) {
+        self.hook.enter_labeled_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_labeled_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Lit` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_lit(&mut self, node: &Lit) {
+        self.hook.enter_lit(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_lit(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `MemberExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_member_expr(&mut self, node: &MemberExpr) {
+        self.hook.enter_member_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_member_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `MemberProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_member_prop(&mut self, node: &MemberProp) {
+        self.hook.enter_member_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_member_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `MetaPropExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_meta_prop_expr(&mut self, node: &MetaPropExpr) {
+        self.hook.enter_meta_prop_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_meta_prop_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `MetaPropKind` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_meta_prop_kind(&mut self, node: &MetaPropKind) {
+        self.hook.enter_meta_prop_kind(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_meta_prop_kind(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `MethodKind` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_method_kind(&mut self, node: &MethodKind) {
+        self.hook.enter_method_kind(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_method_kind(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `MethodProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_method_prop(&mut self, node: &MethodProp) {
+        self.hook.enter_method_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_method_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Module` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_module(&mut self, node: &Module) {
+        self.hook.enter_module(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_module(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ModuleDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_module_decl(&mut self, node: &ModuleDecl) {
+        self.hook.enter_module_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_module_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ModuleExportName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_module_export_name(&mut self, node: &ModuleExportName) {
+        self.hook.enter_module_export_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_module_export_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ModuleItem` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_module_item(&mut self, node: &ModuleItem) {
+        self.hook.enter_module_item(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_module_item(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < ModuleItem >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_module_items(&mut self, node: &[ModuleItem]) {
+        self.hook.enter_module_items(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_module_items(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `NamedExport` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_named_export(&mut self, node: &NamedExport) {
+        self.hook.enter_named_export(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_named_export(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `NewExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_new_expr(&mut self, node: &NewExpr) {
+        self.hook.enter_new_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_new_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Null` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_null(&mut self, node: &Null) {
+        self.hook.enter_null(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_null(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Number` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_number(&mut self, node: &Number) {
+        self.hook.enter_number(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_number(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ObjectLit` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_object_lit(&mut self, node: &ObjectLit) {
+        self.hook.enter_object_lit(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_object_lit(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ObjectPat` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_object_pat(&mut self, node: &ObjectPat) {
+        self.hook.enter_object_pat(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_object_pat(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ObjectPatProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_object_pat_prop(&mut self, node: &ObjectPatProp) {
+        self.hook.enter_object_pat_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_object_pat_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < ObjectPatProp >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_object_pat_props(&mut self, node: &[ObjectPatProp]) {
+        self.hook.enter_object_pat_props(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_object_pat_props(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Accessibility >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_accessibility(&mut self, node: &Option<Accessibility>) {
+        self.hook.enter_opt_accessibility(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_accessibility(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < swc_atoms :: Atom >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_atom(&mut self, node: &Option<swc_atoms::Atom>) {
+        self.hook.enter_opt_atom(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_atom(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < BlockStmt >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_opt_block_stmt(&mut self, node: &Option<BlockStmt>) {
+        self.hook.enter_opt_block_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_block_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `OptCall` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_opt_call(&mut self, node: &OptCall) {
+        self.hook.enter_opt_call(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_call(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < CatchClause >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_catch_clause(&mut self, node: &Option<CatchClause>) {
+        self.hook.enter_opt_catch_clause(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_catch_clause(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `OptChainBase` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_opt_chain_base(&mut self, node: &OptChainBase) {
+        self.hook.enter_opt_chain_base(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_chain_base(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `OptChainExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_opt_chain_expr(&mut self, node: &OptChainExpr) {
+        self.hook.enter_opt_chain_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_chain_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Box < Expr > >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_expr(&mut self, node: &Option<Box<Expr>>) {
+        self.hook.enter_opt_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < ExprOrSpread >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_expr_or_spread(&mut self, node: &Option<ExprOrSpread>) {
+        self.hook.enter_opt_expr_or_spread(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_expr_or_spread(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Vec < ExprOrSpread > >` using the hook's enter and \
+             exit methods."]
+    #[inline]
+    fn visit_opt_expr_or_spreads(&mut self, node: &Option<Vec<ExprOrSpread>>) {
+        self.hook.enter_opt_expr_or_spreads(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_expr_or_spreads(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Ident >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_opt_ident(&mut self, node: &Option<Ident>) {
+        self.hook.enter_opt_ident(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_ident(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < JSXAttrValue >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_jsx_attr_value(&mut self, node: &Option<JSXAttrValue>) {
+        self.hook.enter_opt_jsx_attr_value(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_jsx_attr_value(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < JSXClosingElement >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_jsx_closing_element(&mut self, node: &Option<JSXClosingElement>) {
+        self.hook
+            .enter_opt_jsx_closing_element(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_opt_jsx_closing_element(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < ModuleExportName >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_module_export_name(&mut self, node: &Option<ModuleExportName>) {
+        self.hook
+            .enter_opt_module_export_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_opt_module_export_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Box < ObjectLit > >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_object_lit(&mut self, node: &Option<Box<ObjectLit>>) {
+        self.hook.enter_opt_object_lit(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_object_lit(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Pat >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_opt_pat(&mut self, node: &Option<Pat>) {
+        self.hook.enter_opt_pat(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_pat(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < swc_common :: Span >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_span(&mut self, node: &Option<swc_common::Span>) {
+        self.hook.enter_opt_span(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_span(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Box < Stmt > >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_stmt(&mut self, node: &Option<Box<Stmt>>) {
+        self.hook.enter_opt_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Box < Str > >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_str(&mut self, node: &Option<Box<Str>>) {
+        self.hook.enter_opt_str(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_str(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < TruePlusMinus >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_true_plus_minus(&mut self, node: &Option<TruePlusMinus>) {
+        self.hook.enter_opt_true_plus_minus(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_true_plus_minus(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < TsEntityName >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_ts_entity_name(&mut self, node: &Option<TsEntityName>) {
+        self.hook.enter_opt_ts_entity_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_ts_entity_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < TsImportCallOptions >` using the hook's enter and \
+             exit methods."]
+    #[inline]
+    fn visit_opt_ts_import_call_options(&mut self, node: &Option<TsImportCallOptions>) {
+        self.hook
+            .enter_opt_ts_import_call_options(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_opt_ts_import_call_options(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < TsNamespaceBody >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_ts_namespace_body(&mut self, node: &Option<TsNamespaceBody>) {
+        self.hook
+            .enter_opt_ts_namespace_body(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_opt_ts_namespace_body(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Box < TsType > >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_ts_type(&mut self, node: &Option<Box<TsType>>) {
+        self.hook.enter_opt_ts_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_ts_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Box < TsTypeAnn > >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_ts_type_ann(&mut self, node: &Option<Box<TsTypeAnn>>) {
+        self.hook.enter_opt_ts_type_ann(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_ts_type_ann(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Box < TsTypeParamDecl > >` using the hook's enter and \
+             exit methods."]
+    #[inline]
+    fn visit_opt_ts_type_param_decl(&mut self, node: &Option<Box<TsTypeParamDecl>>) {
+        self.hook
+            .enter_opt_ts_type_param_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_opt_ts_type_param_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < Box < TsTypeParamInstantiation > >` using the hook's \
+             enter and exit methods."]
+    #[inline]
+    fn visit_opt_ts_type_param_instantiation(
+        &mut self,
+        node: &Option<Box<TsTypeParamInstantiation>>,
+    ) {
+        self.hook
+            .enter_opt_ts_type_param_instantiation(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_opt_ts_type_param_instantiation(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < VarDeclOrExpr >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_var_decl_or_expr(&mut self, node: &Option<VarDeclOrExpr>) {
+        self.hook
+            .enter_opt_var_decl_or_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_var_decl_or_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < Option < ExprOrSpread > >` using the hook's enter and \
+             exit methods."]
+    #[inline]
+    fn visit_opt_vec_expr_or_spreads(&mut self, node: &[Option<ExprOrSpread>]) {
+        self.hook
+            .enter_opt_vec_expr_or_spreads(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_opt_vec_expr_or_spreads(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < Option < Pat > >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_opt_vec_pats(&mut self, node: &[Option<Pat>]) {
+        self.hook.enter_opt_vec_pats(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_vec_pats(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Option < swc_atoms :: Wtf8Atom >` using the hook's enter and \
+             exit methods."]
+    #[inline]
+    fn visit_opt_wtf_8_atom(&mut self, node: &Option<swc_atoms::Wtf8Atom>) {
+        self.hook.enter_opt_wtf_8_atom(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_opt_wtf_8_atom(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Param` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_param(&mut self, node: &Param) {
+        self.hook.enter_param(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_param(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ParamOrTsParamProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_param_or_ts_param_prop(&mut self, node: &ParamOrTsParamProp) {
+        self.hook
+            .enter_param_or_ts_param_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_param_or_ts_param_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < ParamOrTsParamProp >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_param_or_ts_param_props(&mut self, node: &[ParamOrTsParamProp]) {
+        self.hook
+            .enter_param_or_ts_param_props(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_param_or_ts_param_props(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < Param >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_params(&mut self, node: &[Param]) {
+        self.hook.enter_params(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_params(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ParenExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_paren_expr(&mut self, node: &ParenExpr) {
+        self.hook.enter_paren_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_paren_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Pat` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_pat(&mut self, node: &Pat) {
+        self.hook.enter_pat(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_pat(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < Pat >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_pats(&mut self, node: &[Pat]) {
+        self.hook.enter_pats(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_pats(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `PrivateMethod` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_private_method(&mut self, node: &PrivateMethod) {
+        self.hook.enter_private_method(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_private_method(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `PrivateName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_private_name(&mut self, node: &PrivateName) {
+        self.hook.enter_private_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_private_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `PrivateProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_private_prop(&mut self, node: &PrivateProp) {
+        self.hook.enter_private_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_private_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Program` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_program(&mut self, node: &Program) {
+        self.hook.enter_program(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_program(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Prop` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_prop(&mut self, node: &Prop) {
+        self.hook.enter_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `PropName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_prop_name(&mut self, node: &PropName) {
+        self.hook.enter_prop_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_prop_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `PropOrSpread` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_prop_or_spread(&mut self, node: &PropOrSpread) {
+        self.hook.enter_prop_or_spread(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_prop_or_spread(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < PropOrSpread >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_prop_or_spreads(&mut self, node: &[PropOrSpread]) {
+        self.hook.enter_prop_or_spreads(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_prop_or_spreads(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Regex` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_regex(&mut self, node: &Regex) {
+        self.hook.enter_regex(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_regex(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `RestPat` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_rest_pat(&mut self, node: &RestPat) {
+        self.hook.enter_rest_pat(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_rest_pat(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ReturnStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_return_stmt(&mut self, node: &ReturnStmt) {
+        self.hook.enter_return_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_return_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Script` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_script(&mut self, node: &Script) {
+        self.hook.enter_script(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_script(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `SeqExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_seq_expr(&mut self, node: &SeqExpr) {
+        self.hook.enter_seq_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_seq_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `SetterProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_setter_prop(&mut self, node: &SetterProp) {
+        self.hook.enter_setter_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_setter_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `SimpleAssignTarget` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_simple_assign_target(&mut self, node: &SimpleAssignTarget) {
+        self.hook
+            .enter_simple_assign_target(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_simple_assign_target(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `swc_common :: Span` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_span(&mut self, node: &swc_common::Span) {
+        self.hook.enter_span(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_span(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `SpreadElement` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_spread_element(&mut self, node: &SpreadElement) {
+        self.hook.enter_spread_element(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_spread_element(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `StaticBlock` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_static_block(&mut self, node: &StaticBlock) {
+        self.hook.enter_static_block(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_static_block(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Stmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_stmt(&mut self, node: &Stmt) {
+        self.hook.enter_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < Stmt >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_stmts(&mut self, node: &[Stmt]) {
+        self.hook.enter_stmts(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_stmts(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Str` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_str(&mut self, node: &Str) {
+        self.hook.enter_str(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_str(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Super` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_super(&mut self, node: &Super) {
+        self.hook.enter_super(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_super(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `SuperProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_super_prop(&mut self, node: &SuperProp) {
+        self.hook.enter_super_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_super_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `SuperPropExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_super_prop_expr(&mut self, node: &SuperPropExpr) {
+        self.hook.enter_super_prop_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_super_prop_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `SwitchCase` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_switch_case(&mut self, node: &SwitchCase) {
+        self.hook.enter_switch_case(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_switch_case(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < SwitchCase >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_switch_cases(&mut self, node: &[SwitchCase]) {
+        self.hook.enter_switch_cases(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_switch_cases(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `SwitchStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_switch_stmt(&mut self, node: &SwitchStmt) {
+        self.hook.enter_switch_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_switch_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `swc_common :: SyntaxContext` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_syntax_context(&mut self, node: &swc_common::SyntaxContext) {
+        self.hook.enter_syntax_context(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_syntax_context(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TaggedTpl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_tagged_tpl(&mut self, node: &TaggedTpl) {
+        self.hook.enter_tagged_tpl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_tagged_tpl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ThisExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_this_expr(&mut self, node: &ThisExpr) {
+        self.hook.enter_this_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_this_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `ThrowStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_throw_stmt(&mut self, node: &ThrowStmt) {
+        self.hook.enter_throw_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_throw_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Tpl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_tpl(&mut self, node: &Tpl) {
+        self.hook.enter_tpl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_tpl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TplElement` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_tpl_element(&mut self, node: &TplElement) {
+        self.hook.enter_tpl_element(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_tpl_element(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < TplElement >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_tpl_elements(&mut self, node: &[TplElement]) {
+        self.hook.enter_tpl_elements(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_tpl_elements(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TruePlusMinus` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_true_plus_minus(&mut self, node: &TruePlusMinus) {
+        self.hook.enter_true_plus_minus(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_true_plus_minus(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TryStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_try_stmt(&mut self, node: &TryStmt) {
+        self.hook.enter_try_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_try_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsArrayType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_array_type(&mut self, node: &TsArrayType) {
+        self.hook.enter_ts_array_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_array_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsAsExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_as_expr(&mut self, node: &TsAsExpr) {
+        self.hook.enter_ts_as_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_as_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsCallSignatureDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_call_signature_decl(&mut self, node: &TsCallSignatureDecl) {
+        self.hook
+            .enter_ts_call_signature_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_call_signature_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsConditionalType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_conditional_type(&mut self, node: &TsConditionalType) {
+        self.hook.enter_ts_conditional_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_conditional_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsConstAssertion` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_const_assertion(&mut self, node: &TsConstAssertion) {
+        self.hook.enter_ts_const_assertion(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_const_assertion(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsConstructSignatureDecl` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_ts_construct_signature_decl(&mut self, node: &TsConstructSignatureDecl) {
+        self.hook
+            .enter_ts_construct_signature_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_construct_signature_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsConstructorType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_constructor_type(&mut self, node: &TsConstructorType) {
+        self.hook.enter_ts_constructor_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_constructor_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsEntityName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_entity_name(&mut self, node: &TsEntityName) {
+        self.hook.enter_ts_entity_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_entity_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsEnumDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_enum_decl(&mut self, node: &TsEnumDecl) {
+        self.hook.enter_ts_enum_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_enum_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsEnumMember` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_enum_member(&mut self, node: &TsEnumMember) {
+        self.hook.enter_ts_enum_member(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_enum_member(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsEnumMemberId` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_enum_member_id(&mut self, node: &TsEnumMemberId) {
+        self.hook.enter_ts_enum_member_id(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_enum_member_id(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < TsEnumMember >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_enum_members(&mut self, node: &[TsEnumMember]) {
+        self.hook.enter_ts_enum_members(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_enum_members(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsExportAssignment` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_export_assignment(&mut self, node: &TsExportAssignment) {
+        self.hook
+            .enter_ts_export_assignment(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_export_assignment(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsExprWithTypeArgs` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_expr_with_type_args(&mut self, node: &TsExprWithTypeArgs) {
+        self.hook
+            .enter_ts_expr_with_type_args(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_expr_with_type_args(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < TsExprWithTypeArgs >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_ts_expr_with_type_argss(&mut self, node: &[TsExprWithTypeArgs]) {
+        self.hook
+            .enter_ts_expr_with_type_argss(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_expr_with_type_argss(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsExternalModuleRef` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_external_module_ref(&mut self, node: &TsExternalModuleRef) {
+        self.hook
+            .enter_ts_external_module_ref(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_external_module_ref(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsFnOrConstructorType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_fn_or_constructor_type(&mut self, node: &TsFnOrConstructorType) {
+        self.hook
+            .enter_ts_fn_or_constructor_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_fn_or_constructor_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsFnParam` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_fn_param(&mut self, node: &TsFnParam) {
+        self.hook.enter_ts_fn_param(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_fn_param(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < TsFnParam >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_fn_params(&mut self, node: &[TsFnParam]) {
+        self.hook.enter_ts_fn_params(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_fn_params(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsFnType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_fn_type(&mut self, node: &TsFnType) {
+        self.hook.enter_ts_fn_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_fn_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsGetterSignature` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_getter_signature(&mut self, node: &TsGetterSignature) {
+        self.hook.enter_ts_getter_signature(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_getter_signature(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsImportCallOptions` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_import_call_options(&mut self, node: &TsImportCallOptions) {
+        self.hook
+            .enter_ts_import_call_options(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_import_call_options(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsImportEqualsDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_import_equals_decl(&mut self, node: &TsImportEqualsDecl) {
+        self.hook
+            .enter_ts_import_equals_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_import_equals_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsImportType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_import_type(&mut self, node: &TsImportType) {
+        self.hook.enter_ts_import_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_import_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsIndexSignature` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_index_signature(&mut self, node: &TsIndexSignature) {
+        self.hook.enter_ts_index_signature(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_index_signature(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsIndexedAccessType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_indexed_access_type(&mut self, node: &TsIndexedAccessType) {
+        self.hook
+            .enter_ts_indexed_access_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_indexed_access_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsInferType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_infer_type(&mut self, node: &TsInferType) {
+        self.hook.enter_ts_infer_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_infer_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsInstantiation` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_instantiation(&mut self, node: &TsInstantiation) {
+        self.hook.enter_ts_instantiation(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_instantiation(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsInterfaceBody` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_interface_body(&mut self, node: &TsInterfaceBody) {
+        self.hook.enter_ts_interface_body(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_interface_body(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsInterfaceDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_interface_decl(&mut self, node: &TsInterfaceDecl) {
+        self.hook.enter_ts_interface_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_interface_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsIntersectionType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_intersection_type(&mut self, node: &TsIntersectionType) {
+        self.hook
+            .enter_ts_intersection_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_intersection_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsKeywordType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_keyword_type(&mut self, node: &TsKeywordType) {
+        self.hook.enter_ts_keyword_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_keyword_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsKeywordTypeKind` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_keyword_type_kind(&mut self, node: &TsKeywordTypeKind) {
+        self.hook
+            .enter_ts_keyword_type_kind(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_keyword_type_kind(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsLit` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_lit(&mut self, node: &TsLit) {
+        self.hook.enter_ts_lit(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_lit(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsLitType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_lit_type(&mut self, node: &TsLitType) {
+        self.hook.enter_ts_lit_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_lit_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsMappedType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_mapped_type(&mut self, node: &TsMappedType) {
+        self.hook.enter_ts_mapped_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_mapped_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsMethodSignature` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_method_signature(&mut self, node: &TsMethodSignature) {
+        self.hook.enter_ts_method_signature(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_method_signature(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsModuleBlock` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_module_block(&mut self, node: &TsModuleBlock) {
+        self.hook.enter_ts_module_block(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_module_block(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsModuleDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_module_decl(&mut self, node: &TsModuleDecl) {
+        self.hook.enter_ts_module_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_module_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsModuleName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_module_name(&mut self, node: &TsModuleName) {
+        self.hook.enter_ts_module_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_module_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsModuleRef` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_module_ref(&mut self, node: &TsModuleRef) {
+        self.hook.enter_ts_module_ref(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_module_ref(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsNamespaceBody` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_namespace_body(&mut self, node: &TsNamespaceBody) {
+        self.hook.enter_ts_namespace_body(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_namespace_body(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsNamespaceDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_namespace_decl(&mut self, node: &TsNamespaceDecl) {
+        self.hook.enter_ts_namespace_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_namespace_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsNamespaceExportDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_namespace_export_decl(&mut self, node: &TsNamespaceExportDecl) {
+        self.hook
+            .enter_ts_namespace_export_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_namespace_export_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsNonNullExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_non_null_expr(&mut self, node: &TsNonNullExpr) {
+        self.hook.enter_ts_non_null_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_non_null_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsOptionalType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_optional_type(&mut self, node: &TsOptionalType) {
+        self.hook.enter_ts_optional_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_optional_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsParamProp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_param_prop(&mut self, node: &TsParamProp) {
+        self.hook.enter_ts_param_prop(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_param_prop(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsParamPropParam` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_param_prop_param(&mut self, node: &TsParamPropParam) {
+        self.hook.enter_ts_param_prop_param(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_param_prop_param(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsParenthesizedType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_parenthesized_type(&mut self, node: &TsParenthesizedType) {
+        self.hook
+            .enter_ts_parenthesized_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_parenthesized_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsPropertySignature` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_property_signature(&mut self, node: &TsPropertySignature) {
+        self.hook
+            .enter_ts_property_signature(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_property_signature(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsQualifiedName` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_qualified_name(&mut self, node: &TsQualifiedName) {
+        self.hook.enter_ts_qualified_name(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_qualified_name(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsRestType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_rest_type(&mut self, node: &TsRestType) {
+        self.hook.enter_ts_rest_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_rest_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsSatisfiesExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_satisfies_expr(&mut self, node: &TsSatisfiesExpr) {
+        self.hook.enter_ts_satisfies_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_satisfies_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsSetterSignature` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_setter_signature(&mut self, node: &TsSetterSignature) {
+        self.hook.enter_ts_setter_signature(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_setter_signature(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsThisType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_this_type(&mut self, node: &TsThisType) {
+        self.hook.enter_ts_this_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_this_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsThisTypeOrIdent` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_this_type_or_ident(&mut self, node: &TsThisTypeOrIdent) {
+        self.hook
+            .enter_ts_this_type_or_ident(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_this_type_or_ident(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTplLitType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_tpl_lit_type(&mut self, node: &TsTplLitType) {
+        self.hook.enter_ts_tpl_lit_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_tpl_lit_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTupleElement` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_tuple_element(&mut self, node: &TsTupleElement) {
+        self.hook.enter_ts_tuple_element(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_tuple_element(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < TsTupleElement >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_ts_tuple_elements(&mut self, node: &[TsTupleElement]) {
+        self.hook.enter_ts_tuple_elements(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_tuple_elements(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTupleType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_tuple_type(&mut self, node: &TsTupleType) {
+        self.hook.enter_ts_tuple_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_tuple_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type(&mut self, node: &TsType) {
+        self.hook.enter_ts_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeAliasDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_alias_decl(&mut self, node: &TsTypeAliasDecl) {
+        self.hook.enter_ts_type_alias_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_alias_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeAnn` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_ann(&mut self, node: &TsTypeAnn) {
+        self.hook.enter_ts_type_ann(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_ann(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeAssertion` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_assertion(&mut self, node: &TsTypeAssertion) {
+        self.hook.enter_ts_type_assertion(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_assertion(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeElement` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_element(&mut self, node: &TsTypeElement) {
+        self.hook.enter_ts_type_element(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_element(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < TsTypeElement >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_elements(&mut self, node: &[TsTypeElement]) {
+        self.hook.enter_ts_type_elements(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_elements(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeLit` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_lit(&mut self, node: &TsTypeLit) {
+        self.hook.enter_ts_type_lit(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_lit(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeOperator` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_operator(&mut self, node: &TsTypeOperator) {
+        self.hook.enter_ts_type_operator(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_operator(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeOperatorOp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_operator_op(&mut self, node: &TsTypeOperatorOp) {
+        self.hook.enter_ts_type_operator_op(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_operator_op(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeParam` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_param(&mut self, node: &TsTypeParam) {
+        self.hook.enter_ts_type_param(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_param(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeParamDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_param_decl(&mut self, node: &TsTypeParamDecl) {
+        self.hook.enter_ts_type_param_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_param_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeParamInstantiation` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_ts_type_param_instantiation(&mut self, node: &TsTypeParamInstantiation) {
+        self.hook
+            .enter_ts_type_param_instantiation(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_type_param_instantiation(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < TsTypeParam >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_params(&mut self, node: &[TsTypeParam]) {
+        self.hook.enter_ts_type_params(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_params(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypePredicate` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_predicate(&mut self, node: &TsTypePredicate) {
+        self.hook.enter_ts_type_predicate(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_predicate(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeQuery` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_query(&mut self, node: &TsTypeQuery) {
+        self.hook.enter_ts_type_query(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_query(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeQueryExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_query_expr(&mut self, node: &TsTypeQueryExpr) {
+        self.hook.enter_ts_type_query_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_query_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsTypeRef` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_type_ref(&mut self, node: &TsTypeRef) {
+        self.hook.enter_ts_type_ref(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_type_ref(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < Box < TsType > >` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_ts_types(&mut self, node: &[Box<TsType>]) {
+        self.hook.enter_ts_types(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_types(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsUnionOrIntersectionType` using the hook's enter and exit \
+             methods."]
+    #[inline]
+    fn visit_ts_union_or_intersection_type(&mut self, node: &TsUnionOrIntersectionType) {
+        self.hook
+            .enter_ts_union_or_intersection_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook
+            .exit_ts_union_or_intersection_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `TsUnionType` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_ts_union_type(&mut self, node: &TsUnionType) {
+        self.hook.enter_ts_union_type(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_ts_union_type(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `UnaryExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_unary_expr(&mut self, node: &UnaryExpr) {
+        self.hook.enter_unary_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_unary_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `UnaryOp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_unary_op(&mut self, node: &UnaryOp) {
+        self.hook.enter_unary_op(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_unary_op(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `UpdateExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_update_expr(&mut self, node: &UpdateExpr) {
+        self.hook.enter_update_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_update_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `UpdateOp` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_update_op(&mut self, node: &UpdateOp) {
+        self.hook.enter_update_op(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_update_op(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `UsingDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_using_decl(&mut self, node: &UsingDecl) {
+        self.hook.enter_using_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_using_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `VarDecl` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_var_decl(&mut self, node: &VarDecl) {
+        self.hook.enter_var_decl(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_var_decl(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `VarDeclKind` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_var_decl_kind(&mut self, node: &VarDeclKind) {
+        self.hook.enter_var_decl_kind(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_var_decl_kind(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `VarDeclOrExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_var_decl_or_expr(&mut self, node: &VarDeclOrExpr) {
+        self.hook.enter_var_decl_or_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_var_decl_or_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `VarDeclarator` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_var_declarator(&mut self, node: &VarDeclarator) {
+        self.hook.enter_var_declarator(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_var_declarator(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `Vec < VarDeclarator >` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_var_declarators(&mut self, node: &[VarDeclarator]) {
+        self.hook.enter_var_declarators(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_var_declarators(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `WhileStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_while_stmt(&mut self, node: &WhileStmt) {
+        self.hook.enter_while_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_while_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `WithStmt` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_with_stmt(&mut self, node: &WithStmt) {
+        self.hook.enter_with_stmt(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_with_stmt(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `swc_atoms :: Wtf8Atom` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_wtf_8_atom(&mut self, node: &swc_atoms::Wtf8Atom) {
+        self.hook.enter_wtf_8_atom(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_wtf_8_atom(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `YieldExpr` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_yield_expr(&mut self, node: &YieldExpr) {
+        self.hook.enter_yield_expr(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_yield_expr(node, &mut self.context);
+    }
+}
 #[doc = r" A hook trait for composable AST visitors."]
 #[doc = r""]
 #[doc = r" This trait provides `enter_xxx` and `exit_xxx` methods for each AST node type."]

--- a/crates/swc_ecma_hooks/src/lib.rs
+++ b/crates/swc_ecma_hooks/src/lib.rs
@@ -19,4 +19,6 @@ pub fn noop_hook() -> NoopHook {
 
 pub struct NoopHook;
 
+impl<C> VisitHook<C> for NoopHook {}
+
 impl<C> VisitMutHook<C> for NoopHook {}


### PR DESCRIPTION
## Summary
- Add `VisitHook<C>` trait as the immutable counterpart to `VisitMutHook<C>`
- Add `CompositeVisitHook<A, B>` for composing multiple hooks
- Add `VisitWithHook<H, C>` adapter that implements `Visit` trait using a hook

## Test plan
- [x] `cargo check -p swc_ecma_hooks` passes
- [x] `cargo test -p generate-code test_ecmascript` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)