### PR TITLE
refactor(es/transforms): Add VisitMutHook-based TypeScript transforms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6581,6 +6581,7 @@ dependencies = [
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
+ "swc_ecma_hooks",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_compat",

--- a/crates/swc_ecma_transforms_typescript/Cargo.toml
+++ b/crates/swc_ecma_transforms_typescript/Cargo.toml
@@ -26,6 +26,7 @@ serde      = { workspace = true, features = ["derive"] }
 swc_atoms                 = { version = "9.0.0", path = "../swc_atoms" }
 swc_common                = { version = "18.0.1", path = "../swc_common" }
 swc_ecma_ast              = { version = "19.0.0", path = "../swc_ecma_ast" }
+swc_ecma_hooks            = { version = "0.3.0", path = "../swc_ecma_hooks" }
 swc_ecma_transforms_base  = { version = "35.0.0", path = "../swc_ecma_transforms_base" }
 swc_ecma_transforms_react = { version = "38.0.0", path = "../swc_ecma_transforms_react" }
 swc_ecma_utils            = { version = "25.0.0", path = "../swc_ecma_utils" }

--- a/crates/swc_ecma_transforms_typescript/src/lib.rs
+++ b/crates/swc_ecma_transforms_typescript/src/lib.rs
@@ -2,12 +2,17 @@
 #![allow(clippy::vec_box)]
 #![allow(clippy::mutable_key_type)]
 
-pub use self::{strip_type::*, typescript::*};
-mod config;
+// Re-export the main functions, but be explicit about which `hook` to use
+pub use self::{
+    config::{ImportsNotUsedAsValues, TsImportExportAssignConfig},
+    strip_type::{strip_type, StripTypeHook},
+    typescript::{hook, hook_with_id_usage, strip, tsx, typescript, Config, TsxConfig},
+};
+pub mod config;
 mod macros;
-mod strip_import_export;
-mod strip_type;
-mod transform;
+pub mod strip_import_export;
+pub mod strip_type;
+pub mod transform;
 mod ts_enum;
 pub mod typescript;
 mod utils;

--- a/crates/swc_ecma_transforms_typescript/src/strip_import_export.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip_import_export.rs
@@ -1,9 +1,25 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_ecma_ast::*;
+use swc_ecma_hooks::VisitMutHook;
 use swc_ecma_utils::stack_size::maybe_grow_default;
 use swc_ecma_visit::{noop_visit_type, Visit, VisitMut, VisitMutWith, VisitWith};
 
-use crate::{strip_type::IsConcrete, ImportsNotUsedAsValues};
+use crate::{config::ImportsNotUsedAsValues, strip_type::IsConcrete};
+
+/// Returns a hook for stripping unused imports/exports based on usage
+/// analysis.
+pub fn hook(
+    import_not_used_as_values: ImportsNotUsedAsValues,
+    initial_id_usage: FxHashSet<Id>,
+) -> StripImportExportHook {
+    StripImportExportHook {
+        import_not_used_as_values,
+        initial_id_usage,
+        usage_info: Default::default(),
+        declare_info: Default::default(),
+        collected: false,
+    }
+}
 
 #[derive(Debug, Default)]
 pub(crate) struct UsageCollect {
@@ -477,6 +493,162 @@ impl VisitMut for StripTsImportEquals {
         if let ModuleItem::Stmt(Stmt::Decl(Decl::TsModule(ref ts_module))) = n {
             if ts_module.body.is_some() {
                 n.visit_mut_children_with(self)
+            }
+        }
+    }
+}
+
+/// A hook for stripping unused imports/exports based on usage analysis.
+///
+/// This hook collects usage information and strips imports/exports that are
+/// only used as types.
+pub struct StripImportExportHook {
+    import_not_used_as_values: ImportsNotUsedAsValues,
+    initial_id_usage: FxHashSet<Id>,
+    usage_info: UsageCollect,
+    declare_info: DeclareCollect,
+    collected: bool,
+}
+
+impl<C> VisitMutHook<C> for StripImportExportHook {
+    #[inline]
+    fn enter_module(&mut self, n: &mut Module, _ctx: &mut C) {
+        if !self.collected {
+            // Initialize usage_info with initial_id_usage
+            self.usage_info = std::mem::take(&mut self.initial_id_usage).into();
+
+            // Collect usage and declare info
+            n.visit_with(&mut self.usage_info);
+            n.visit_with(&mut self.declare_info);
+            self.usage_info.analyze_import_chain();
+
+            self.collected = true;
+        }
+    }
+
+    #[inline]
+    fn enter_module_items(&mut self, n: &mut Vec<ModuleItem>, _ctx: &mut C) {
+        if !self.collected {
+            return;
+        }
+
+        let mut strip_ts_import_equals = StripTsImportEquals;
+
+        n.retain_mut(|module_item| match module_item {
+            ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+                specifiers,
+                type_only: false,
+                ..
+            })) if !specifiers.is_empty() => {
+                specifiers.retain(|import_specifier| match import_specifier {
+                    ImportSpecifier::Named(named) => {
+                        if named.is_type_only {
+                            return false;
+                        }
+
+                        let id = named.local.to_id();
+
+                        if self.declare_info.has_value(&id) {
+                            return false;
+                        }
+
+                        self.usage_info.has_usage(&id)
+                    }
+                    ImportSpecifier::Default(default) => {
+                        let id = default.local.to_id();
+
+                        if self.declare_info.has_value(&id) {
+                            return false;
+                        }
+
+                        self.usage_info.has_usage(&id)
+                    }
+                    ImportSpecifier::Namespace(namespace) => {
+                        let id = namespace.local.to_id();
+
+                        if self.declare_info.has_value(&id) {
+                            return false;
+                        }
+
+                        self.usage_info.has_usage(&id)
+                    }
+                    #[cfg(swc_ast_unknown)]
+                    _ => panic!("unable to access unknown nodes"),
+                });
+
+                self.import_not_used_as_values == ImportsNotUsedAsValues::Preserve
+                    || !specifiers.is_empty()
+            }
+            ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
+                specifiers,
+                src,
+                type_only: false,
+                ..
+            })) => {
+                specifiers.retain(|export_specifier| match export_specifier {
+                    ExportSpecifier::Namespace(..) => true,
+                    ExportSpecifier::Default(..) => true,
+
+                    ExportSpecifier::Named(ExportNamedSpecifier {
+                        orig: ModuleExportName::Ident(ident),
+                        is_type_only: false,
+                        ..
+                    }) if src.is_none() => {
+                        let id = ident.to_id();
+
+                        !self.declare_info.has_pure_type(&id)
+                    }
+                    ExportSpecifier::Named(ExportNamedSpecifier { is_type_only, .. }) => {
+                        !is_type_only
+                    }
+                    #[cfg(swc_ast_unknown)]
+                    _ => panic!("unable to access unknown nodes"),
+                });
+
+                !specifiers.is_empty()
+            }
+            ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
+                ref type_only, ..
+            })) => !type_only,
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(ExportDefaultExpr {
+                ref expr,
+                ..
+            })) => expr
+                .as_ident()
+                .map(|ident| {
+                    let id = ident.to_id();
+
+                    !self.declare_info.has_pure_type(&id)
+                })
+                .unwrap_or(true),
+            ModuleItem::ModuleDecl(ModuleDecl::TsImportEquals(ts_import_equals_decl)) => {
+                if ts_import_equals_decl.is_type_only {
+                    return false;
+                }
+
+                if ts_import_equals_decl.is_export {
+                    return true;
+                }
+
+                self.usage_info.has_usage(&ts_import_equals_decl.id.to_id())
+            }
+            ModuleItem::Stmt(Stmt::Decl(Decl::TsModule(ref ts_module)))
+                if ts_module.body.is_some() =>
+            {
+                module_item.visit_mut_with(&mut strip_ts_import_equals);
+
+                true
+            }
+            _ => true,
+        });
+    }
+
+    #[inline]
+    fn enter_script(&mut self, n: &mut Script, _ctx: &mut C) {
+        let mut visitor = StripTsImportEquals;
+        for stmt in n.body.iter_mut() {
+            if let Stmt::Decl(Decl::TsModule(..)) = stmt {
+                stmt.visit_mut_with(&mut visitor);
             }
         }
     }

--- a/crates/swc_ecma_transforms_typescript/src/strip_type.rs
+++ b/crates/swc_ecma_transforms_typescript/src/strip_type.rs
@@ -2,6 +2,7 @@ use std::mem;
 
 use swc_common::util::take::Take;
 use swc_ecma_ast::*;
+use swc_ecma_hooks::VisitMutHook;
 use swc_ecma_utils::stack_size::maybe_grow_default;
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
@@ -9,6 +10,11 @@ use crate::type_to_none;
 
 pub fn strip_type() -> impl VisitMut {
     StripType::default()
+}
+
+/// Returns a hook that strips TypeScript types.
+pub fn hook() -> StripTypeHook {
+    StripTypeHook::default()
 }
 
 /// This Module will strip all types/generics/interface/declares
@@ -379,6 +385,258 @@ impl IsDeclare for Decl {
             Decl::TsModule(ts_module) => ts_module.declare || ts_module.global,
             #[cfg(swc_ast_unknown)]
             _ => panic!("unable to access unknown nodes"),
+        }
+    }
+}
+
+/// A hook that strips TypeScript types.
+///
+/// This hook strips all types/generics/interface/declares and type
+/// import/export. `export declare var` in a namespace will be retained.
+#[derive(Default)]
+pub struct StripTypeHook {
+    in_namespace: bool,
+}
+
+impl<C> VisitMutHook<C> for StripTypeHook {
+    // Type annotations - set to None in enter (before children traversal)
+    #[inline]
+    fn enter_opt_ts_type(&mut self, node: &mut Option<Box<TsType>>, _ctx: &mut C) {
+        *node = None;
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_ann(&mut self, node: &mut Option<Box<TsTypeAnn>>, _ctx: &mut C) {
+        *node = None;
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_param_decl(
+        &mut self,
+        node: &mut Option<Box<TsTypeParamDecl>>,
+        _ctx: &mut C,
+    ) {
+        *node = None;
+    }
+
+    #[inline]
+    fn enter_opt_ts_type_param_instantiation(
+        &mut self,
+        node: &mut Option<Box<TsTypeParamInstantiation>>,
+        _ctx: &mut C,
+    ) {
+        *node = None;
+    }
+
+    // Array pattern - set optional = false after children
+    #[inline]
+    fn exit_array_pat(&mut self, n: &mut ArrayPat, _ctx: &mut C) {
+        n.optional = false;
+    }
+
+    // Auto accessor - strip TS-specific fields before children
+    #[inline]
+    fn enter_auto_accessor(&mut self, n: &mut AutoAccessor, _ctx: &mut C) {
+        n.type_ann = None;
+        n.accessibility = None;
+        n.definite = false;
+        n.is_override = false;
+        n.is_abstract = false;
+    }
+
+    // Class - strip TS-specific fields before children
+    #[inline]
+    fn enter_class(&mut self, n: &mut Class, _ctx: &mut C) {
+        n.is_abstract = false;
+        n.implements.clear();
+    }
+
+    // Class members - retain only non-TS members before children
+    #[inline]
+    fn enter_class_members(&mut self, n: &mut Vec<ClassMember>, _ctx: &mut C) {
+        n.retain(|member| match member {
+            ClassMember::TsIndexSignature(..) => false,
+            ClassMember::Constructor(Constructor { body: None, .. }) => false,
+
+            ClassMember::Method(ClassMethod {
+                is_abstract,
+                function,
+                ..
+            })
+            | ClassMember::PrivateMethod(PrivateMethod {
+                is_abstract,
+                function,
+                ..
+            }) => !is_abstract && function.body.is_some(),
+
+            ClassMember::ClassProp(
+                ClassProp { declare: true, .. }
+                | ClassProp {
+                    is_abstract: true, ..
+                },
+            )
+            | ClassMember::AutoAccessor(AutoAccessor {
+                is_abstract: true, ..
+            }) => false,
+
+            _ => true,
+        });
+    }
+
+    // Class method - strip TS-specific fields before children
+    #[inline]
+    fn enter_class_method(&mut self, n: &mut ClassMethod, _ctx: &mut C) {
+        n.accessibility = None;
+        n.is_override = false;
+        n.is_abstract = false;
+        n.is_optional = false;
+    }
+
+    // Class prop - strip TS-specific fields before children
+    #[inline]
+    fn enter_class_prop(&mut self, prop: &mut ClassProp, _ctx: &mut C) {
+        prop.declare = false;
+        prop.readonly = false;
+        prop.is_override = false;
+        prop.is_optional = false;
+        prop.is_abstract = false;
+        prop.definite = false;
+        prop.accessibility = None;
+    }
+
+    // Private method - strip TS-specific fields before children
+    #[inline]
+    fn enter_private_method(&mut self, n: &mut PrivateMethod, _ctx: &mut C) {
+        n.accessibility = None;
+        n.is_abstract = false;
+        n.is_optional = false;
+        n.is_override = false;
+    }
+
+    // Constructor - strip accessibility before children
+    #[inline]
+    fn enter_constructor(&mut self, n: &mut Constructor, _ctx: &mut C) {
+        n.accessibility = None;
+    }
+
+    // Export specifiers - retain only non-type exports before children
+    #[inline]
+    fn enter_export_specifiers(&mut self, n: &mut Vec<ExportSpecifier>, _ctx: &mut C) {
+        n.retain(|s| match s {
+            ExportSpecifier::Named(ExportNamedSpecifier { is_type_only, .. }) => !is_type_only,
+            _ => true,
+        });
+    }
+
+    // Expression - unwrap TS type expressions before children
+    #[inline]
+    fn enter_expr(&mut self, n: &mut Expr, _ctx: &mut C) {
+        while let Expr::TsAs(TsAsExpr { expr, .. })
+        | Expr::TsNonNull(TsNonNullExpr { expr, .. })
+        | Expr::TsTypeAssertion(TsTypeAssertion { expr, .. })
+        | Expr::TsConstAssertion(TsConstAssertion { expr, .. })
+        | Expr::TsInstantiation(TsInstantiation { expr, .. })
+        | Expr::TsSatisfies(TsSatisfiesExpr { expr, .. }) = n
+        {
+            *n = *expr.take();
+        }
+    }
+
+    // Ident - set optional = false
+    #[inline]
+    fn enter_ident(&mut self, n: &mut Ident, _ctx: &mut C) {
+        n.optional = false;
+    }
+
+    // Import specifiers - retain only non-type imports before children
+    #[inline]
+    fn enter_import_specifiers(&mut self, n: &mut Vec<ImportSpecifier>, _ctx: &mut C) {
+        n.retain(|s| !matches!(s, ImportSpecifier::Named(named) if named.is_type_only));
+    }
+
+    // TsModuleBlock - set in_namespace before children, restore after
+    #[inline]
+    fn enter_ts_module_block(&mut self, _node: &mut TsModuleBlock, _ctx: &mut C) {
+        self.in_namespace = true;
+    }
+
+    #[inline]
+    fn exit_ts_module_block(&mut self, _node: &mut TsModuleBlock, _ctx: &mut C) {
+        self.in_namespace = false;
+    }
+
+    // Module items - retain only concrete items before children
+    #[inline]
+    fn enter_module_items(&mut self, n: &mut Vec<ModuleItem>, _ctx: &mut C) {
+        let in_namespace = self.in_namespace;
+        n.retain(|item| should_retain_module_item(item, in_namespace));
+    }
+
+    // Object pattern - set optional = false after children
+    #[inline]
+    fn exit_object_pat(&mut self, pat: &mut ObjectPat, _ctx: &mut C) {
+        pat.optional = false;
+    }
+
+    // Params - remove `this` parameter before children
+    #[inline]
+    fn enter_params(&mut self, n: &mut Vec<Param>, _ctx: &mut C) {
+        if n.first()
+            .filter(|param| {
+                matches!(
+                    &param.pat,
+                    Pat::Ident(BindingIdent {
+                        id: Ident { sym, .. },
+                        ..
+                    }) if &**sym == "this"
+                )
+            })
+            .is_some()
+        {
+            n.drain(0..1);
+        }
+    }
+
+    // Private prop - strip TS-specific fields before children
+    #[inline]
+    fn enter_private_prop(&mut self, prop: &mut PrivateProp, _ctx: &mut C) {
+        prop.readonly = false;
+        prop.is_override = false;
+        prop.is_optional = false;
+        prop.definite = false;
+        prop.accessibility = None;
+    }
+
+    // Setter prop - remove this_param before children
+    #[inline]
+    fn enter_setter_prop(&mut self, n: &mut SetterProp, _ctx: &mut C) {
+        n.this_param = None;
+    }
+
+    // Simple assign target - unwrap TS type expressions before children
+    #[inline]
+    fn enter_simple_assign_target(&mut self, n: &mut SimpleAssignTarget, _ctx: &mut C) {
+        while let SimpleAssignTarget::TsAs(TsAsExpr { expr, .. })
+        | SimpleAssignTarget::TsNonNull(TsNonNullExpr { expr, .. })
+        | SimpleAssignTarget::TsTypeAssertion(TsTypeAssertion { expr, .. })
+        | SimpleAssignTarget::TsInstantiation(TsInstantiation { expr, .. })
+        | SimpleAssignTarget::TsSatisfies(TsSatisfiesExpr { expr, .. }) = n
+        {
+            *n = expr.take().try_into().unwrap();
+        }
+    }
+
+    // Stmts - remove empty statements after children
+    #[inline]
+    fn exit_stmts(&mut self, n: &mut Vec<Stmt>, _ctx: &mut C) {
+        n.retain(|s| !matches!(s, Stmt::Empty(e) if e.span.is_dummy()));
+    }
+
+    // Stmt - remove non-concrete statements before children
+    #[inline]
+    fn enter_stmt(&mut self, n: &mut Stmt, _ctx: &mut C) {
+        if !should_retain_stmt(n) && !n.is_empty() {
+            n.take();
         }
     }
 }


### PR DESCRIPTION
**Description:**

Add hook-based implementations for TypeScript transforms:
- `StripTypeHook` for stripping TypeScript types
- `StripImportExportHook` for stripping unused imports/exports
- `TransformHook` for transforming enums, namespaces, parameter properties
- `EsmContextHook` for preserving ESM module context

The hooks are chained using `CompositeHook` and exposed via `typescript::hook()`. Conditional transforms use `Either<Hook, NoopHook>` for type safety.


**Related issue (if exists):**
