### PR TITLE
chore(deps): Update browserslist-data to v0.1.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -572,9 +572,9 @@ dependencies = [
 
 [[package]]
 name = "browserslist-data"
-version = "0.1.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f42db7dd1800856ac32d4a08c2915de9a9a2a72ce1fdd86189daed368729fd4"
+checksum = "21d369bf3fe9811518eead42e2cdf9ed9915579242864297689894c0f1089712"
 dependencies = [
  "ahash 0.8.12",
  "chrono",

--- a/crates/preset_env_base/src/query.rs
+++ b/crates/preset_env_base/src/query.rs
@@ -183,4 +183,12 @@ mod tests {
             "empty query should return non-empty result"
         );
     }
+
+    #[test]
+    fn test_node_20_19() {
+        let res = Query::Single("node 20.19".into()).exec().unwrap();
+        let node_version = res.node.expect("node version should be resolved");
+        assert_eq!(node_version.major, 20, "major version should be 20");
+        assert_eq!(node_version.minor, 19, "minor version should be 19");
+    }
 }

--- a/crates/swc_core/tests/fixture/stub_napi/Cargo.lock
+++ b/crates/swc_core/tests/fixture/stub_napi/Cargo.lock
@@ -109,7 +109,7 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ast_node"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "quote",
  "swc_macros_common",
@@ -259,9 +259,9 @@ dependencies = [
 
 [[package]]
 name = "browserslist-data"
-version = "0.1.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f42db7dd1800856ac32d4a08c2915de9a9a2a72ce1fdd86189daed368729fd4"
+checksum = "21d369bf3fe9811518eead42e2cdf9ed9915579242864297689894c0f1089712"
 dependencies = [
  "ahash",
  "chrono",
@@ -434,6 +434,12 @@ checksum = "0abae9be0aaf9ea96a3b1b8b1b55c602ca751eba1b1500220cea4ecbafe7c0d5"
 dependencies = [
  "rustversion",
 ]
+
+[[package]]
+name = "cbor4ii"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faed1a83001dc2c9201451030cc317e35bef36c84d3781d7c5bb9f343c397da8"
 
 [[package]]
 name = "cc"
@@ -1033,6 +1039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dragonbox_ecma"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5577f010d4e1bb3f3c4d6081e05718eb6992cf20119cab4d3abadff198b5ae"
+
+[[package]]
 name = "dtor"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1197,7 +1209,7 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "2.0.2"
+version = "3.0.0"
 dependencies = [
  "swc_macros_common",
  "syn 2.0.102",
@@ -1474,7 +1486,7 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hstr"
-version = "3.0.1"
+version = "3.0.4"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
@@ -2491,7 +2503,7 @@ checksum = "84350ffee5cedfabf9bee3e8825721f651da8ff79d50fe7a37cf0ca015c428ee"
 
 [[package]]
 name = "preset_env_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "browserslist-rs",
@@ -3275,7 +3287,7 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "44.0.0"
+version = "53.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3339,9 +3351,10 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "8.0.2"
+version = "9.0.0"
 dependencies = [
  "bytecheck 0.8.1",
+ "cbor4ii",
  "hstr",
  "once_cell",
  "rancor",
@@ -3351,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "swc_bundler"
-version = "34.0.0"
+version = "41.0.0"
 dependencies = [
  "anyhow",
  "crc",
@@ -3380,16 +3393,16 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "16.0.0"
+version = "18.0.1"
 dependencies = [
  "anyhow",
  "ast_node",
  "better_scoped_tls",
  "bytecheck 0.8.1",
  "bytes-str",
+ "cbor4ii",
  "either",
  "from_variant",
- "new_debug_unreachable",
  "num-bigint",
  "once_cell",
  "parking_lot",
@@ -3409,7 +3422,7 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "38.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -3464,7 +3477,7 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "46.0.3"
+version = "55.0.0"
 dependencies = [
  "swc",
  "swc_allocator",
@@ -3484,16 +3497,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "17.0.0"
+version = "20.0.0"
 dependencies = [
  "bitflags 2.9.1",
- "bytecheck 0.8.1",
+ "cbor4ii",
  "is-macro",
  "num-bigint",
  "once_cell",
  "phf",
- "rancor",
- "rkyv",
  "rustc-hash 2.1.1",
  "serde",
  "string_enum",
@@ -3505,23 +3516,22 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "19.0.0"
+version = "22.0.0"
 dependencies = [
  "ascii",
  "compact_str",
+ "dragonbox_ecma",
  "memchr",
  "num-bigint",
  "once_cell",
  "regex",
  "rustc-hash 2.1.1",
- "ryu-js",
  "serde",
  "swc_allocator",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen_macros",
- "swc_sourcemap",
  "tracing",
 ]
 
@@ -3536,7 +3546,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "32.0.0"
+version = "40.0.0"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
@@ -3552,17 +3562,17 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "23.0.0"
+version = "31.0.0"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_transformer",
  "swc_ecma_utils",
- "swc_ecma_visit",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "32.0.0"
+version = "40.0.0"
 dependencies = [
  "arrayvec",
  "indexmap",
@@ -3587,70 +3597,61 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
- "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
- "swc_ecma_transforms_macros",
  "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "serde",
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "29.0.0"
+version = "37.0.0"
 dependencies = [
  "serde",
- "swc_common",
  "swc_ecma_ast",
- "swc_ecma_compat_common",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
- "swc_ecma_transforms_macros",
  "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "30.0.0"
+version = "38.0.0"
 dependencies = [
  "serde",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_compat_es2022",
- "swc_ecma_compiler",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
  "swc_ecma_visit",
@@ -3659,10 +3660,10 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "swc_ecma_ast",
- "swc_ecma_compiler",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
  "tracing",
@@ -3670,14 +3671,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "30.0.0"
+version = "38.0.0"
 dependencies = [
  "rustc-hash 2.1.1",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_compat_common",
- "swc_ecma_compiler",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
@@ -3689,26 +3689,10 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "24.0.0"
+version = "27.0.0"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compiler"
-version = "7.0.0"
-dependencies = [
- "bitflags 2.9.1",
- "rustc-hash 2.1.1",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_trace_macro",
@@ -3717,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "23.0.0"
+version = "26.0.0"
 dependencies = [
  "phf",
  "swc_common",
@@ -3727,8 +3711,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_hooks"
+version = "0.4.0"
+dependencies = [
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
+]
+
+[[package]]
 name = "swc_ecma_lints"
-version = "24.0.0"
+version = "27.0.0"
 dependencies = [
  "auto_impl",
  "dashmap 5.5.3",
@@ -3747,7 +3741,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_loader"
-version = "16.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "dashmap 5.5.3",
@@ -3767,7 +3761,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "35.0.0"
+version = "43.0.0"
 dependencies = [
  "arrayvec",
  "bitflags 2.9.1",
@@ -3801,7 +3795,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "26.0.1"
+version = "33.0.0"
 dependencies = [
  "bitflags 2.9.1",
  "either",
@@ -3819,7 +3813,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "38.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "foldhash 0.1.5",
@@ -3834,15 +3828,30 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_compiler",
+ "swc_ecma_transformer",
  "swc_ecma_transforms",
  "swc_ecma_utils",
  "swc_ecma_visit",
 ]
 
 [[package]]
+name = "swc_ecma_transformer"
+version = "7.0.0"
+dependencies = [
+ "rustc-hash 2.1.1",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_hooks",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "tracing",
+]
+
+[[package]]
 name = "swc_ecma_transforms"
-version = "37.0.0"
+version = "45.0.0"
 dependencies = [
  "par-core",
  "swc_common",
@@ -3859,7 +3868,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "better_scoped_tls",
  "indexmap",
@@ -3880,7 +3889,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -3891,7 +3900,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "33.0.0"
+version = "41.0.0"
 dependencies = [
  "indexmap",
  "par-core",
@@ -3928,7 +3937,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "32.0.0"
+version = "39.0.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -3954,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "31.0.0"
+version = "38.0.0"
 dependencies = [
  "bytes-str",
  "dashmap 5.5.3",
@@ -3976,7 +3985,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "either",
  "rustc-hash 2.1.1",
@@ -3992,7 +4001,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "32.0.0"
+version = "39.0.0"
 dependencies = [
  "base64",
  "bytes-str",
@@ -4006,6 +4015,7 @@ dependencies = [
  "swc_common",
  "swc_config",
  "swc_ecma_ast",
+ "swc_ecma_hooks",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
@@ -4014,7 +4024,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "32.0.0"
+version = "39.0.0"
 dependencies = [
  "bytes-str",
  "rustc-hash 2.1.1",
@@ -4030,7 +4040,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "24.0.0"
+version = "28.0.0"
 dependencies = [
  "bitflags 2.9.1",
  "indexmap",
@@ -4046,14 +4056,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "23.0.0"
+version = "26.0.0"
 dependencies = [
+ "dragonbox_ecma",
  "indexmap",
  "num_cpus",
  "once_cell",
  "par-core",
  "rustc-hash 2.1.1",
- "ryu-js",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -4063,7 +4073,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "17.0.0"
+version = "20.0.0"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -4085,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "18.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "miette",
@@ -4123,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "swc_node_bundler"
-version = "45.0.0"
+version = "54.0.0"
 dependencies = [
  "anyhow",
  "rustc-hash 2.1.1",
@@ -4145,7 +4155,7 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "16.0.0"
+version = "18.0.0"
 dependencies = [
  "dashmap 5.5.3",
  "rustc-hash 2.1.1",
@@ -4166,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_backend_wasmer"
-version = "4.0.0"
+version = "7.0.0"
 dependencies = [
  "anyhow",
  "enumset",
@@ -4180,12 +4190,10 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "17.0.0"
+version = "20.0.0"
 dependencies = [
  "better_scoped_tls",
- "bytecheck 0.8.1",
- "rancor",
- "rkyv",
+ "cbor4ii",
  "rustc-hash 2.1.1",
  "swc_common",
  "swc_ecma_ast",
@@ -4195,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_runner"
-version = "21.0.0"
+version = "24.0.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -4248,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "better_scoped_tls",
  "rustc-hash 2.1.1",
@@ -4258,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "swc_typescript"
-version = "22.0.0"
+version = "25.0.0"
 dependencies = [
  "bitflags 2.9.1",
  "petgraph",

--- a/crates/swc_core/tests/fixture/stub_wasm/Cargo.lock
+++ b/crates/swc_core/tests/fixture/stub_wasm/Cargo.lock
@@ -76,7 +76,7 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "ast_node"
-version = "4.0.0"
+version = "5.0.0"
 dependencies = [
  "quote",
  "swc_macros_common",
@@ -114,7 +114,7 @@ dependencies = [
 
 [[package]]
 name = "binding_macros"
-version = "44.0.0"
+version = "53.0.0"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "browserslist-data"
-version = "0.1.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f42db7dd1800856ac32d4a08c2915de9a9a2a72ce1fdd86189daed368729fd4"
+checksum = "21d369bf3fe9811518eead42e2cdf9ed9915579242864297689894c0f1089712"
 dependencies = [
  "ahash",
  "chrono",
@@ -456,6 +456,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dragonbox_ecma"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a5577f010d4e1bb3f3c4d6081e05718eb6992cf20119cab4d3abadff198b5ae"
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -502,7 +508,7 @@ dependencies = [
 
 [[package]]
 name = "from_variant"
-version = "2.0.2"
+version = "3.0.0"
 dependencies = [
  "swc_macros_common",
  "syn",
@@ -596,7 +602,7 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hstr"
-version = "3.0.1"
+version = "3.0.4"
 dependencies = [
  "hashbrown 0.14.5",
  "new_debug_unreachable",
@@ -1131,7 +1137,7 @@ checksum = "84350ffee5cedfabf9bee3e8825721f651da8ff79d50fe7a37cf0ca015c428ee"
 
 [[package]]
 name = "preset_env_base"
-version = "5.0.0"
+version = "6.0.0"
 dependencies = [
  "anyhow",
  "browserslist-rs",
@@ -1458,7 +1464,7 @@ dependencies = [
 
 [[package]]
 name = "swc"
-version = "44.0.0"
+version = "53.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1514,7 +1520,7 @@ dependencies = [
 
 [[package]]
 name = "swc_atoms"
-version = "8.0.2"
+version = "9.0.0"
 dependencies = [
  "hstr",
  "once_cell",
@@ -1523,7 +1529,7 @@ dependencies = [
 
 [[package]]
 name = "swc_common"
-version = "16.0.0"
+version = "18.0.1"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -1531,7 +1537,6 @@ dependencies = [
  "bytes-str",
  "either",
  "from_variant",
- "new_debug_unreachable",
  "num-bigint",
  "once_cell",
  "parking_lot",
@@ -1549,7 +1554,7 @@ dependencies = [
 
 [[package]]
 name = "swc_compiler_base"
-version = "38.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "base64",
@@ -1602,7 +1607,7 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "46.0.3"
+version = "55.0.0"
 dependencies = [
  "binding_macros",
  "swc",
@@ -1618,7 +1623,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ast"
-version = "17.0.0"
+version = "20.0.0"
 dependencies = [
  "bitflags",
  "is-macro",
@@ -1636,23 +1641,22 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "19.0.0"
+version = "22.0.0"
 dependencies = [
  "ascii",
  "compact_str",
+ "dragonbox_ecma",
  "memchr",
  "num-bigint",
  "once_cell",
  "regex",
  "rustc-hash",
- "ryu-js",
  "serde",
  "swc_allocator",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen_macros",
- "swc_sourcemap",
  "tracing",
 ]
 
@@ -1667,7 +1671,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_bugfixes"
-version = "32.0.0"
+version = "40.0.0"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
@@ -1683,17 +1687,17 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_common"
-version = "23.0.0"
+version = "31.0.0"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_transformer",
  "swc_ecma_utils",
- "swc_ecma_visit",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2015"
-version = "32.0.0"
+version = "40.0.0"
 dependencies = [
  "arrayvec",
  "indexmap",
@@ -1718,70 +1722,61 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2016"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
- "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
- "swc_ecma_transforms_macros",
  "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2017"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "serde",
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2018"
-version = "29.0.0"
+version = "37.0.0"
 dependencies = [
  "serde",
- "swc_common",
  "swc_ecma_ast",
- "swc_ecma_compat_common",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
- "swc_ecma_transforms_macros",
  "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2019"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_compat_es2020"
-version = "30.0.0"
+version = "38.0.0"
 dependencies = [
  "serde",
  "swc_common",
  "swc_ecma_ast",
  "swc_ecma_compat_es2022",
- "swc_ecma_compiler",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
  "swc_ecma_visit",
@@ -1790,10 +1785,10 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2021"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "swc_ecma_ast",
- "swc_ecma_compiler",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
  "tracing",
@@ -1801,14 +1796,13 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es2022"
-version = "30.0.0"
+version = "38.0.0"
 dependencies = [
  "rustc-hash",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_compat_common",
- "swc_ecma_compiler",
+ "swc_ecma_transformer",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_classes",
  "swc_ecma_transforms_macros",
@@ -1820,26 +1814,10 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_compat_es3"
-version = "24.0.0"
+version = "27.0.0"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_utils",
- "swc_ecma_visit",
- "swc_trace_macro",
- "tracing",
-]
-
-[[package]]
-name = "swc_ecma_compiler"
-version = "7.0.0"
-dependencies = [
- "bitflags",
- "rustc-hash",
- "swc_atoms",
- "swc_common",
- "swc_ecma_ast",
- "swc_ecma_transforms_base",
  "swc_ecma_utils",
  "swc_ecma_visit",
  "swc_trace_macro",
@@ -1848,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_ext_transforms"
-version = "23.0.0"
+version = "26.0.0"
 dependencies = [
  "phf",
  "swc_common",
@@ -1858,8 +1836,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_hooks"
+version = "0.4.0"
+dependencies = [
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_visit",
+]
+
+[[package]]
 name = "swc_ecma_loader"
-version = "16.0.0"
+version = "18.0.0"
 dependencies = [
  "anyhow",
  "dashmap",
@@ -1879,7 +1867,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_minifier"
-version = "35.0.0"
+version = "43.0.0"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -1913,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "26.0.1"
+version = "33.0.0"
 dependencies = [
  "bitflags",
  "either",
@@ -1931,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_preset_env"
-version = "38.0.0"
+version = "46.0.0"
 dependencies = [
  "anyhow",
  "foldhash 0.1.5",
@@ -1946,15 +1934,30 @@ dependencies = [
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
- "swc_ecma_compiler",
+ "swc_ecma_transformer",
  "swc_ecma_transforms",
  "swc_ecma_utils",
  "swc_ecma_visit",
 ]
 
 [[package]]
+name = "swc_ecma_transformer"
+version = "7.0.0"
+dependencies = [
+ "rustc-hash",
+ "swc_atoms",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_hooks",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "tracing",
+]
+
+[[package]]
 name = "swc_ecma_transforms"
-version = "37.0.0"
+version = "45.0.0"
 dependencies = [
  "par-core",
  "swc_common",
@@ -1971,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "better_scoped_tls",
  "indexmap",
@@ -1991,7 +1994,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_classes"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "swc_common",
  "swc_ecma_ast",
@@ -2002,7 +2005,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_compat"
-version = "33.0.0"
+version = "41.0.0"
 dependencies = [
  "indexmap",
  "par-core",
@@ -2039,7 +2042,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_module"
-version = "32.0.0"
+version = "39.0.0"
 dependencies = [
  "Inflector",
  "anyhow",
@@ -2065,7 +2068,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "31.0.0"
+version = "38.0.0"
 dependencies = [
  "bytes-str",
  "dashmap",
@@ -2087,7 +2090,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_proposal"
-version = "29.0.0"
+version = "36.0.0"
 dependencies = [
  "either",
  "rustc-hash",
@@ -2103,7 +2106,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_react"
-version = "32.0.0"
+version = "39.0.0"
 dependencies = [
  "base64",
  "bytes-str",
@@ -2117,6 +2120,7 @@ dependencies = [
  "swc_common",
  "swc_config",
  "swc_ecma_ast",
+ "swc_ecma_hooks",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_utils",
@@ -2125,7 +2129,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_typescript"
-version = "32.0.0"
+version = "39.0.0"
 dependencies = [
  "bytes-str",
  "rustc-hash",
@@ -2141,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_usage_analyzer"
-version = "24.0.0"
+version = "28.0.0"
 dependencies = [
  "bitflags",
  "indexmap",
@@ -2157,14 +2161,14 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_utils"
-version = "23.0.0"
+version = "26.0.0"
 dependencies = [
+ "dragonbox_ecma",
  "indexmap",
  "num_cpus",
  "once_cell",
  "par-core",
  "rustc-hash",
- "ryu-js",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
@@ -2174,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_visit"
-version = "17.0.0"
+version = "20.0.0"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
@@ -2196,7 +2200,7 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "18.0.0"
+version = "20.0.0"
 dependencies = [
  "anyhow",
  "miette",
@@ -2216,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "swc_node_comments"
-version = "16.0.0"
+version = "18.0.0"
 dependencies = [
  "dashmap",
  "rustc-hash",
@@ -2260,7 +2264,7 @@ dependencies = [
 
 [[package]]
 name = "swc_transform_common"
-version = "10.0.0"
+version = "12.0.0"
 dependencies = [
  "better_scoped_tls",
  "rustc-hash",


### PR DESCRIPTION
This updates the browserslist-data crate from v0.1.0 to v0.1.5, which adds support for newer Node.js versions including 20.19.

Fixes #11451

Generated with [Claude Code](https://claude.ai/claude-code)