### PR TITLE
test(es/minifier): Add test case for merge_imports order preservation

### DIFF
--- a/crates/swc/tests/fixture/issues/11257/input/.swcrc
+++ b/crates/swc/tests/fixture/issues/11257/input/.swcrc
@@ -1,0 +1,12 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript"
+        },
+        "minify": {
+            "compress": true,
+            "mangle": false
+        }
+    },
+    "minify": true
+}

--- a/crates/swc/tests/fixture/issues/11257/input/index.ts
+++ b/crates/swc/tests/fixture/issues/11257/input/index.ts
@@ -1,0 +1,6 @@
+import { v1 } from 'a';
+import { v2 } from 'b';
+import { v3 } from 'b';
+import { v4 } from 'c';
+
+console.log(v1, v2, v3, v4);

--- a/crates/swc/tests/fixture/issues/11257/output/index.ts
+++ b/crates/swc/tests/fixture/issues/11257/output/index.ts
@@ -1,0 +1,1 @@
+import{v1}from"a";import{v2,v3}from"b";import{v4}from"c";console.log(v1,v2,v3,v4);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11257/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11257/config.json
@@ -1,0 +1,5 @@
+{
+    "defaults": true,
+    "toplevel": true,
+    "passes": 0
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11257/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11257/input.js
@@ -1,0 +1,6 @@
+import { v1 } from 'a';
+import { v2 } from 'b';
+import { v3 } from 'b';
+import { v4 } from 'c';
+
+console.log(v1, v2, v3, v4);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11257/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11257/output.js
@@ -1,0 +1,4 @@
+import { v1 } from 'a';
+import { v2, v3 } from 'b';
+import { v4 } from 'c';
+console.log(v1, v2, v3, v4);


### PR DESCRIPTION
Add test cases to verify that merge_imports correctly preserves import order
when merging multiple imports from the same source. This ensures imports are
placed at the position of the first occurrence and not reordered.

Closes #11257

Generated with [Claude Code](https://claude.ai/code)