### PR TITLE
feat(es/minifier): Inline function parameters with consistent values

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -2112,6 +2112,10 @@ impl VisitMut for Optimizer<'_> {
 
         self.drop_unused_params(&mut f.function.params);
 
+        // Inline parameters that have consistent values across all call sites
+        let fn_id = f.ident.to_id();
+        self.inline_params_with_same_value(&fn_id, &mut f.function.params, &mut f.function.body);
+
         let ctx = self
             .ctx
             .clone()

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10931/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10931/config.json
@@ -1,0 +1,6 @@
+{
+    "defaults": true,
+    "toplevel": true,
+    "keep_fargs": false,
+    "unused": true
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10931/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10931/input.js
@@ -1,0 +1,9 @@
+function complex(foo, fn) {
+  // prevent inlining
+  if (Math.random() > 0.5) throw new Error()
+  return fn?.(foo)
+}
+
+console.log(complex("foo"))
+console.log(complex("bar"))
+console.log(complex("baz"))

--- a/crates/swc_ecma_minifier/tests/fixture/issues/10931/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/10931/output.js
@@ -1,0 +1,7 @@
+function complex(foo) {
+    var fn;
+    // prevent inlining
+    if (Math.random() > 0.5) throw Error();
+    return fn?.(foo);
+}
+console.log(complex("foo")), console.log(complex("bar")), console.log(complex("baz"));

--- a/crates/swc_ecma_usage_analyzer/src/analyzer/storage.rs
+++ b/crates/swc_ecma_usage_analyzer/src/analyzer/storage.rs
@@ -42,6 +42,14 @@ pub trait Storage: Sized {
     fn mark_property_mutation(&mut self, id: Id);
 
     fn get_var_data(&self, id: Id) -> Option<&Self::VarData>;
+
+    /// Register a function declaration with its number of parameters.
+    /// Default implementation does nothing.
+    fn register_fn_decl(&mut self, _fn_id: Id, _num_params: usize) {}
+
+    /// Record call site arguments for a function.
+    /// Default implementation does nothing.
+    fn record_call_site(&mut self, _fn_id: &Id, _args: &[ExprOrSpread]) {}
 }
 
 pub trait ScopeDataLike: Sized + Default + Clone {


### PR DESCRIPTION
When all call sites of a function pass the same value (or undefined) to a parameter, this optimization converts the parameter to a local variable initialized with that value.

Closes #10931

Generated with [Claude Code](https://claude.ai/claude-code)