### PR TITLE
test(es/parser): Add error tests for import.source and import.defer with too many args

### DIFF
--- a/crates/swc_ecma_parser/tests/errors/deferred-import-evaluation/too-many-args/input.js
+++ b/crates/swc_ecma_parser/tests/errors/deferred-import-evaluation/too-many-args/input.js
@@ -1,0 +1,1 @@
+import.defer('a', 'b', 'c');

--- a/crates/swc_ecma_parser/tests/errors/deferred-import-evaluation/too-many-args/input.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/errors/deferred-import-evaluation/too-many-args/input.js.swc-stderr
@@ -1,0 +1,5 @@
+  x `import()` requires exactly one or two arguments
+   ,-[$DIR/tests/errors/deferred-import-evaluation/too-many-args/input.js:1:1]
+ 1 | import.defer('a', 'b', 'c');
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   `----

--- a/crates/swc_ecma_parser/tests/errors/source-phase-imports/too-many-args/input.js
+++ b/crates/swc_ecma_parser/tests/errors/source-phase-imports/too-many-args/input.js
@@ -1,0 +1,1 @@
+import.source('a', 'b', 'c');

--- a/crates/swc_ecma_parser/tests/errors/source-phase-imports/too-many-args/input.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/errors/source-phase-imports/too-many-args/input.js.swc-stderr
@@ -1,0 +1,5 @@
+  x `import()` requires exactly one or two arguments
+   ,-[$DIR/tests/errors/source-phase-imports/too-many-args/input.js:1:1]
+ 1 | import.source('a', 'b', 'c');
+   : ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   `----


### PR DESCRIPTION
Add test cases for `import.source('a', 'b', 'c')` and `import.defer('a', 'b', 'c')`
to verify that the parser correctly rejects these expressions with too many arguments.

These tests complement the existing test for `import('a', 'b', 'c')`.

Closes #11465

Generated with [Claude Code](https://claude.ai/claude-code)