### PR TITLE
test(es/parser): Check `handler.has_errors()` in test error parsing

### DIFF
--- a/crates/swc_ecma_parser/tests/errors.rs
+++ b/crates/swc_ecma_parser/tests/errors.rs
@@ -64,6 +64,10 @@ where
         e.into_diagnostic(handler).emit();
     }
 
+    if handler.has_errors() {
+        return Err(());
+    }
+
     res
 }
 


### PR DESCRIPTION
Fix CI behavior inconsistency where test262 error tests would falsely pass when the parser successfully parses code but emits recoverable errors.

The `with_parser` function in `errors.rs` was not checking `handler.has_errors()` before returning the result, unlike the similar function in `test262.rs`. This caused tests like `08bafe059b17ac92.js` (`[+{a = 0}];`) to pass even though they should fail.

Fixes #10378

Generated with [Claude Code](https://claude.ai/claude-code)