### PR TITLE
perf(bindings): Optimize string handling by avoiding unnecessary clones

### DIFF
--- a/bindings/binding_core_node/src/minify.rs
+++ b/bindings/binding_core_node/src/minify.rs
@@ -97,8 +97,8 @@ fn minify(
     signal: Option<AbortSignal>,
 ) -> AsyncTask<MinifyTask> {
     crate::util::init_default_trace_subscriber();
-    let code = String::from_utf8_lossy(code.as_ref()).to_string();
-    let options = String::from_utf8_lossy(opts.as_ref()).to_string();
+    let code = String::from_utf8_lossy(code.as_ref()).into_owned();
+    let options = String::from_utf8_lossy(opts.as_ref()).into_owned();
     let extras = JsMinifyExtras::default()
         .with_mangle_name_cache(extras.mangle_name_cache.map(|s| (*s).clone()));
 
@@ -126,7 +126,7 @@ pub fn minify_sync(
     extras: NapiMinifyExtra,
 ) -> napi::Result<TransformOutput> {
     crate::util::init_default_trace_subscriber();
-    let code = String::from_utf8_lossy(code.as_ref()).to_string();
+    let code = String::from_utf8_lossy(code.as_ref()).into_owned();
     let input = if is_json {
         MinifyTarget::Json(code)
     } else {

--- a/bindings/binding_core_node/src/parse.rs
+++ b/bindings/binding_core_node/src/parse.rs
@@ -154,7 +154,7 @@ pub fn parse(
 
     let c = get_compiler();
     let src = stringify(src);
-    let options = String::from_utf8_lossy(options.as_ref()).to_string();
+    let options = String::from_utf8_lossy(options.as_ref()).into_owned();
     let filename = if let Some(value) = filename {
         FileName::Real(value.into())
     } else {
@@ -272,7 +272,7 @@ pub fn parse_file(
 
     let c = get_compiler();
     let path = PathBuf::from(&path);
-    let options = String::from_utf8_lossy(options.as_ref()).to_string();
+    let options = String::from_utf8_lossy(options.as_ref()).into_owned();
 
     AsyncTask::with_optional_signal(ParseFileTask { c, path, options }, signal)
 }

--- a/bindings/binding_core_node/src/print.rs
+++ b/bindings/binding_core_node/src/print.rs
@@ -70,7 +70,7 @@ pub fn print(
     crate::util::init_default_trace_subscriber();
 
     let c = get_compiler();
-    let options = String::from_utf8_lossy(&options).to_string();
+    let options = String::from_utf8_lossy(&options).into_owned();
 
     Ok(AsyncTask::with_optional_signal(
         PrintTask {

--- a/bindings/binding_core_node/src/transform.rs
+++ b/bindings/binding_core_node/src/transform.rs
@@ -75,7 +75,7 @@ impl Task for TransformTask {
                             } else {
                                 FileName::Real(options.filename.clone().into()).into()
                             },
-                            src.to_string(),
+                            src.clone(),
                         );
 
                         self.c.process_js_file(fm, handler, &options)

--- a/bindings/binding_html_node/src/lib.rs
+++ b/bindings/binding_html_node/src/lib.rs
@@ -699,7 +699,7 @@ fn minify_inner(
 
 fn to_string(code: Either<Buffer, String>) -> String {
     match code {
-        Either::A(code) => String::from_utf8_lossy(code.as_ref()).to_string(),
+        Either::A(code) => String::from_utf8_lossy(code.as_ref()).into_owned(),
         Either::B(code) => code,
     }
 }
@@ -712,7 +712,7 @@ fn minify(
     signal: Option<AbortSignal>,
 ) -> AsyncTask<MinifyTask> {
     let code = to_string(code);
-    let options = String::from_utf8_lossy(opts.as_ref()).to_string();
+    let options = String::from_utf8_lossy(opts.as_ref()).into_owned();
 
     let task = MinifyTask {
         code,
@@ -731,7 +731,7 @@ fn minify_fragment(
     signal: Option<AbortSignal>,
 ) -> AsyncTask<MinifyTask> {
     let code = to_string(code);
-    let options = String::from_utf8_lossy(opts.as_ref()).to_string();
+    let options = String::from_utf8_lossy(opts.as_ref()).into_owned();
 
     let task = MinifyTask {
         code,

--- a/bindings/binding_minifier_node/src/minify.rs
+++ b/bindings/binding_minifier_node/src/minify.rs
@@ -265,7 +265,7 @@ pub fn minify_sync(
     extras: NapiMinifyExtra,
 ) -> napi::Result<TransformOutput> {
     crate::util::init_default_trace_subscriber();
-    let code = String::from_utf8_lossy(code.as_ref()).to_string();
+    let code = String::from_utf8_lossy(code.as_ref()).into_owned();
     let opts = get_deserialized(opts)?;
 
     let cm = Lrc::new(SourceMap::default());

--- a/bindings/binding_react_compiler_node/src/support.rs
+++ b/bindings/binding_react_compiler_node/src/support.rs
@@ -50,7 +50,7 @@ fn is_react_compiler_required(
     code: Buffer,
     signal: Option<AbortSignal>,
 ) -> AsyncTask<IsReactCompilerRequiredTask> {
-    let code = String::from_utf8_lossy(code.as_ref()).to_string();
+    let code = String::from_utf8_lossy(code.as_ref()).into_owned();
 
     let task = IsReactCompilerRequiredTask { code };
 
@@ -59,7 +59,7 @@ fn is_react_compiler_required(
 
 #[napi]
 pub fn is_react_compiler_required_sync(code: Buffer) -> napi::Result<bool> {
-    let code = String::from_utf8_lossy(code.as_ref()).to_string();
+    let code = String::from_utf8_lossy(code.as_ref()).into_owned();
 
     Ok(is_react_compiler_required_inner(&code))
 }


### PR DESCRIPTION
## Summary

- Replace `.to_string()` with `.into_owned()` on `Cow<str>` results from `String::from_utf8_lossy()`
- Replace `.to_string()` with `.clone()` on `&String` to avoid Display trait allocation
- Optimizes 13 instances across 7 binding files

Fixes #10295

## Test plan

- [ ] Build passes (`cargo check` verified locally)
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)