### PR TITLE
fix(es/decorators): Invoke addInitializer callbacks for decorated fields

### DIFF
--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-classes--to-es2015/decorator-access-modified-fields/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-classes--to-es2015/decorator-access-modified-fields/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_m;
+var _initClass, _init_m, _initProto;
 var value;
 const classDec = (Class)=>{
     value = (new Class).p;
@@ -8,10 +8,10 @@ const memberDec = ()=>()=>42;
 let _C;
 class C {
     constructor(){
-        _define_property(this, "m", _init_m(this));
+        _define_property(this, "m", (_initProto(this), _init_m(this)));
     }
 }
-({ e: [_init_m], c: [_C, _initClass] } = _apply_decs_2203_r(C, [
+({ e: [_init_m, _initProto], c: [_C, _initClass] } = _apply_decs_2203_r(C, [
     [
         memberDec,
         0,

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-classes/decorator-access-modified-fields/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-classes/decorator-access-modified-fields/output.js
@@ -1,4 +1,4 @@
-var _initClass, _init_m;
+var _initClass, _init_m, _initProto;
 var value;
 const classDec = (Class)=>{
     value = (new Class).p;
@@ -8,7 +8,7 @@ const memberDec = ()=>()=>42;
 let _C;
 class C {
     static{
-        ({ e: [_init_m] , c: [_C, _initClass]  } = _apply_decs_2203_r(this, [
+        ({ e: [_init_m, _initProto], c: [_C, _initClass] } = _apply_decs_2203_r(this, [
             [
                 memberDec,
                 0,
@@ -18,7 +18,7 @@ class C {
             classDec
         ]));
     }
-    m = _init_m(this);
+    m = (_initProto(this), _init_m(this));
     static{
         _initClass();
     }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-exported/member-decorator/output.mjs
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-exported/member-decorator/output.mjs
@@ -1,13 +1,13 @@
-var _init_x;
+var _init_x, _initProto;
 export class A {
-  static{
-    ({ e: [_init_x] } = _apply_decs_2203_r(this, [
-        [
-            dec,
-            0,
-            "x"
-        ]
-    ], []));
-  }
-  x = _init_x(this);
+    static{
+        ({ e: [_init_x, _initProto] } = _apply_decs_2203_r(this, [
+            [
+                dec,
+                0,
+                "x"
+            ]
+        ], []));
+    }
+    x = (_initProto(this), _init_x(this));
 }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields--to-es2015/private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields--to-es2015/private/output.js
@@ -1,11 +1,11 @@
-var _init_a, _init_b;
+var _init_a, _init_b, _initProto;
 const dec = ()=>{};
 var _a = /*#__PURE__*/ new WeakMap(), _b = /*#__PURE__*/ new WeakMap();
 class Foo {
     constructor(){
         _class_private_field_init(this, _a, {
             writable: true,
-            value: _init_a(this)
+            value: (_initProto(this), _init_a(this))
         });
         _class_private_field_init(this, _b, {
             writable: true,
@@ -13,7 +13,7 @@ class Foo {
         });
     }
 }
-({ e: [_init_a, _init_b] } = _apply_decs_2203_r(Foo, [
+({ e: [_init_a, _init_b, _initProto] } = _apply_decs_2203_r(Foo, [
     [
         dec,
         0,

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields--to-es2015/public/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields--to-es2015/public/output.js
@@ -1,15 +1,15 @@
-var _computedKey, _init_a, _init_b, _init__computedKey;
+var _computedKey, _init_a, _init_b, _init__computedKey, _initProto;
 const dec = ()=>{};
 _computedKey = 'c';
 let _computedKey1 = _computedKey;
 class Foo {
     constructor(){
-        _define_property(this, "a", _init_a(this));
+        _define_property(this, "a", (_initProto(this), _init_a(this)));
         _define_property(this, "b", _init_b(this, 123));
         _define_property(this, _computedKey1, _init__computedKey(this, 456));
     }
 }
-({ e: [_init_a, _init_b, _init__computedKey] } = _apply_decs_2203_r(Foo, [
+({ e: [_init_a, _init_b, _init__computedKey, _initProto] } = _apply_decs_2203_r(Foo, [
     [
         dec,
         0,

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields--to-es2015/static-private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields--to-es2015/static-private/output.js
@@ -1,31 +1,34 @@
-var _init_a, _init_b;
+var _init_a, _init_b, _initStatic;
 const dec = ()=>{};
 class Foo {
 }
-({ e: [_init_a, _init_b] } = _apply_decs_2203_r(Foo, [
-    [
-        dec,
-        5,
-        "a",
-        function() {
-            return _class_static_private_field_spec_get(this, Foo, _a);
-        },
-        function(value) {
-            _class_static_private_field_spec_set(this, Foo, _a, value);
-        }
-    ],
-    [
-        dec,
-        5,
-        "b",
-        function() {
-            return _class_static_private_field_spec_get(this, Foo, _b);
-        },
-        function(value) {
-            _class_static_private_field_spec_set(this, Foo, _b, value);
-        }
-    ]
-], []));
+(()=>{
+    ({ e: [_init_a, _init_b, _initStatic] } = _apply_decs_2203_r(Foo, [
+        [
+            dec,
+            5,
+            "a",
+            function() {
+                return _class_static_private_field_spec_get(this, Foo, _a);
+            },
+            function(value) {
+                _class_static_private_field_spec_set(this, Foo, _a, value);
+            }
+        ],
+        [
+            dec,
+            5,
+            "b",
+            function() {
+                return _class_static_private_field_spec_get(this, Foo, _b);
+            },
+            function(value) {
+                _class_static_private_field_spec_set(this, Foo, _b, value);
+            }
+        ]
+    ], []));
+    _initStatic(Foo);
+})();
 var _a = {
     writable: true,
     value: _init_a(Foo)

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields--to-es2015/static-public/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields--to-es2015/static-public/output.js
@@ -1,25 +1,28 @@
-var _computedKey, _init_a, _init_b, _init__computedKey;
+var _computedKey, _init_a, _init_b, _init__computedKey, _initStatic;
 const dec = ()=>{};
 _computedKey = 'c';
 class Foo {
 }
-({ e: [_init_a, _init_b, _init__computedKey] } = _apply_decs_2203_r(Foo, [
-    [
-        dec,
-        5,
-        "a"
-    ],
-    [
-        dec,
-        5,
-        "b"
-    ],
-    [
-        dec,
-        5,
-        _computedKey
-    ]
-], []));
+(()=>{
+    ({ e: [_init_a, _init_b, _init__computedKey, _initStatic] } = _apply_decs_2203_r(Foo, [
+        [
+            dec,
+            5,
+            "a"
+        ],
+        [
+            dec,
+            5,
+            "b"
+        ],
+        [
+            dec,
+            5,
+            _computedKey
+        ]
+    ], []));
+    _initStatic(Foo);
+})();
 _define_property(Foo, "a", _init_a(Foo));
 _define_property(Foo, "b", _init_b(Foo, 123));
 _define_property(Foo, _computedKey, _init__computedKey(Foo, 456));

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields/private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields/private/output.js
@@ -1,8 +1,8 @@
-var _init_a, _init_b;
+var _init_a, _init_b, _initProto;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_init_a, _init_b]  } = _apply_decs_2203_r(this, [
+        ({ e: [_init_a, _init_b, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 0,
@@ -27,6 +27,6 @@ class Foo {
             ]
         ], []));
     }
-    #a = _init_a(this);
+    #a = (_initProto(this), _init_a(this));
     #b = _init_b(this, 123);
 }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields/public/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields/public/output.js
@@ -1,9 +1,9 @@
-var _computedKey, _init_a, _init_b, _init__computedKey;
+var _computedKey, _init_a, _init_b, _init__computedKey, _initProto;
 const dec = ()=>{};
 _computedKey = 'c';
 class Foo {
     static{
-        ({ e: [_init_a, _init_b, _init__computedKey]  } = _apply_decs_2203_r(this, [
+        ({ e: [_init_a, _init_b, _init__computedKey, _initProto] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 0,
@@ -21,7 +21,7 @@ class Foo {
             ]
         ], []));
     }
-    a = _init_a(this);
+    a = (_initProto(this), _init_a(this));
     b = _init_b(this, 123);
     [_computedKey] = _init__computedKey(this, 456);
 }

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields/static-private/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields/static-private/output.js
@@ -1,8 +1,8 @@
-var _init_a, _init_b;
+var _init_a, _init_b, _initStatic;
 const dec = ()=>{};
 class Foo {
     static{
-        ({ e: [_init_a, _init_b]  } = _apply_decs_2203_r(this, [
+        ({ e: [_init_a, _init_b, _initStatic] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 5,
@@ -26,6 +26,7 @@ class Foo {
                 }
             ]
         ], []));
+        _initStatic(this);
     }
     static #a = _init_a(this);
     static #b = _init_b(this, 123);

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields/static-public/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-fields/static-public/output.js
@@ -1,9 +1,9 @@
-var _computedKey, _init_a, _init_b, _init__computedKey;
+var _computedKey, _init_a, _init_b, _init__computedKey, _initStatic;
 const dec = ()=>{};
 _computedKey = 'c';
 class Foo {
     static{
-        ({ e: [_init_a, _init_b, _init__computedKey]  } = _apply_decs_2203_r(this, [
+        ({ e: [_init_a, _init_b, _init__computedKey, _initStatic] } = _apply_decs_2203_r(this, [
             [
                 dec,
                 5,
@@ -20,6 +20,7 @@ class Foo {
                 _computedKey
             ]
         ], []));
+        _initStatic(this);
     }
     static a = _init_a(this);
     static b = _init_b(this, 123);

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc--to-es2015/valid-expression-formats/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc--to-es2015/valid-expression-formats/output.js
@@ -7,13 +7,13 @@ class Foo {
     method() {}
     makeClass() {
         var _Nested;
-        var _dec, _init_bar;
+        var _dec, _init_bar, _initProto;
         _dec = _class_private_field_get(this, _a);
         return _Nested = class Nested {
             constructor(){
-                _define_property(this, "bar", _init_bar(this));
+                _define_property(this, "bar", (_initProto(this), _init_bar(this)));
             }
-        }, { e: [_init_bar] } = _apply_decs_2203_r(_Nested, [
+        }, { e: [_init_bar, _initProto] } = _apply_decs_2203_r(_Nested, [
             [
                 _dec,
                 0,

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/valid-expression-formats/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-misc/valid-expression-formats/output.js
@@ -30,11 +30,11 @@ class Foo {
     #a;
     method() {}
     makeClass() {
-        var _dec, _init_bar;
+        var _dec, _init_bar, _initProto;
         _dec = this.#a;
         return class Nested {
             static{
-                ({ e: [_init_bar] } = _apply_decs_2203_r(this, [
+                ({ e: [_init_bar, _initProto] } = _apply_decs_2203_r(this, [
                     [
                         _dec,
                         0,
@@ -42,7 +42,7 @@ class Foo {
                     ]
                 ], []));
             }
-            bar = _init_bar(this);
+            bar = (_initProto(this), _init_bar(this));
         };
     }
     static{


### PR DESCRIPTION
## Summary

- Fixed issue where `addInitializer` callbacks registered by field decorators were never invoked
- Added `init_proto`/`init_static` initialization for both public and private decorated fields

## Test plan

- [x] All 194 decorator tests pass
- [x] Test fixtures updated to reflect correct output

Closes #9565

Generated with [Claude Code](https://claude.ai/claude-code)