### PR TITLE
perf(es/bugfix): Port edge_default_param to hook-based visitors

### DIFF
--- a/crates/swc_ecma_transformer/src/bugfix/edge_default_param.rs
+++ b/crates/swc_ecma_transformer/src/bugfix/edge_default_param.rs
@@ -1,0 +1,88 @@
+//! Bugfix: Edge Default Param
+//!
+//! A bugfix pass for Edge.
+//!
+//! Converts destructured parameters with default values to non-shorthand
+//! syntax. This fixes the only arguments-related bug in ES Modules-supporting
+//! browsers (Edge 16 & 17). Use this plugin instead of
+//! @babel/plugin-transform-parameters when targeting ES Modules.
+//!
+//! ## Example
+//!
+//! Input:
+//! ```js
+//! const f = ({ a = 1 }) => a;
+//! ```
+//!
+//! Output:
+//! ```js
+//! const f = ({ a: a = 1 }) => a;
+//! ```
+//!
+//! ## Implementation
+//!
+//! Implementation based on [@babel/plugin-bugfix-edge-default-param](https://babel.dev/docs/babel-plugin-bugfix-edge-default-param).
+
+use swc_ecma_ast::*;
+use swc_ecma_hooks::VisitMutHook;
+
+use crate::TraverseCtx;
+
+pub fn hook() -> impl VisitMutHook<TraverseCtx> {
+    EdgeDefaultParamPass {
+        arrow_param_depth: 0,
+    }
+}
+
+struct EdgeDefaultParamPass {
+    /// Depth counter for arrow params.
+    /// > 0 when inside arrow params, 0 when not.
+    /// We increment when entering an ArrowExpr (before visiting params)
+    /// and decrement when entering BlockStmtOrExpr (the body).
+    arrow_param_depth: u32,
+}
+
+impl VisitMutHook<TraverseCtx> for EdgeDefaultParamPass {
+    fn enter_arrow_expr(&mut self, _node: &mut ArrowExpr, _ctx: &mut TraverseCtx) {
+        // Entering arrow expression, we're now in params context
+        self.arrow_param_depth += 1;
+    }
+
+    fn enter_block_stmt_or_expr(&mut self, _node: &mut BlockStmtOrExpr, _ctx: &mut TraverseCtx) {
+        // Entering arrow body, we're no longer in params context
+        if self.arrow_param_depth > 0 {
+            self.arrow_param_depth -= 1;
+        }
+    }
+
+    fn exit_object_pat(&mut self, n: &mut ObjectPat, _ctx: &mut TraverseCtx) {
+        // Only transform when inside arrow params (not in body)
+        if self.arrow_param_depth == 0 {
+            return;
+        }
+
+        for idx in 0..n.props.len() {
+            let prop = &(n.props[idx]);
+
+            if let ObjectPatProp::Assign(AssignPatProp {
+                value: Some(value),
+                key,
+                span,
+                ..
+            }) = prop
+            {
+                let prop = ObjectPatProp::KeyValue(KeyValuePatProp {
+                    key: PropName::Ident(key.clone().into()),
+                    value: AssignPat {
+                        span: *span,
+                        left: key.clone().into(),
+                        right: value.clone(),
+                    }
+                    .into(),
+                });
+
+                n.props[idx] = prop;
+            }
+        }
+    }
+}

--- a/crates/swc_ecma_transformer/src/bugfix/mod.rs
+++ b/crates/swc_ecma_transformer/src/bugfix/mod.rs
@@ -1,25 +1,39 @@
 use swc_ecma_hooks::VisitMutHook;
 
-use crate::TraverseCtx;
+use crate::{
+    hook_utils::{HookBuilder, NoopHook},
+    TraverseCtx,
+};
+
+mod edge_default_param;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]
-pub struct BugfixOptions {}
+pub struct BugfixOptions {
+    /// Enable Edge default param bugfix.
+    ///
+    /// Converts destructured parameters with default values to non-shorthand
+    /// syntax. This fixes the only arguments-related bug in ES
+    /// Modules-supporting browsers (Edge 16 & 17).
+    pub edge_default_param: bool,
+}
 
 impl BugfixOptions {
     /// Returns true if any transform is enabled.
-    /// Currently no bugfixes are available.
     pub fn is_enabled(&self) -> bool {
-        false
+        self.edge_default_param
     }
 }
 
 pub fn hook(options: BugfixOptions) -> impl VisitMutHook<TraverseCtx> {
-    BugfixPass { options }
-}
+    let hook = HookBuilder::new(NoopHook);
 
-struct BugfixPass {
-    options: BugfixOptions,
-}
+    // Edge default param: { a = 1 } -> { a: a = 1 }
+    let hook = hook.chain(if options.edge_default_param {
+        Some(self::edge_default_param::hook())
+    } else {
+        None
+    });
 
-impl VisitMutHook<TraverseCtx> for BugfixPass {}
+    hook.build()
+}

--- a/crates/swc_ecma_transformer/src/hook_utils.rs
+++ b/crates/swc_ecma_transformer/src/hook_utils.rs
@@ -91,6 +91,14 @@ where
     chained_method!(enter_bin_expr, exit_bin_expr, BinExpr);
 
     chained_method!(enter_fn_decl, exit_fn_decl, FnDecl);
+
+    chained_method!(enter_object_pat, exit_object_pat, ObjectPat);
+
+    chained_method!(
+        enter_block_stmt_or_expr,
+        exit_block_stmt_or_expr,
+        BlockStmtOrExpr
+    );
 }
 
 pub(crate) struct NoopHook;


### PR DESCRIPTION
## Summary

- Ports `edge_default_param` bugfix from `swc_ecma_compat_bugfixes` to hook-based visitor system
- Reduces AST traversal overhead by allowing multiple transforms to be composed into a single traversal
- Adds `ObjectPat` and `BlockStmtOrExpr` to `OrderedChain` for hook support

Closes #10470

## Test plan

- [x] Build succeeded with `cargo build -p swc_ecma_transformer`
- [x] Tests pass with `cargo test -p swc_ecma_transformer`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)