### PR TITLE
feat(es/transformer): Add edge_default_param bugfix hook

### DIFF
--- a/crates/swc_ecma_transformer/src/bugfix/edge_default_param.rs
+++ b/crates/swc_ecma_transformer/src/bugfix/edge_default_param.rs
@@ -1,0 +1,67 @@
+//! Bugfix: Edge Default Param
+//!
+//! Converts destructured parameters with default values to non-shorthand
+//! syntax. This fixes the only arguments-related bug in ES Modules-supporting
+//! browsers (Edge 16 & 17). Use this plugin instead of
+//! @babel/plugin-transform-parameters when targeting ES Modules.
+//!
+//! ## Example
+//!
+//! Input:
+//! ```js
+//! const f = ({ a = 1 }) => a;
+//! ```
+//!
+//! Output:
+//! ```js
+//! const f = ({ a: a = 1 }) => a;
+//! ```
+
+use swc_ecma_ast::*;
+use swc_ecma_hooks::VisitMutHook;
+
+use crate::TraverseCtx;
+
+pub fn hook() -> impl VisitMutHook<TraverseCtx> {
+    EdgeDefaultParamPass { in_arrow: false }
+}
+
+struct EdgeDefaultParamPass {
+    in_arrow: bool,
+}
+
+impl VisitMutHook<TraverseCtx> for EdgeDefaultParamPass {
+    fn enter_arrow_expr(&mut self, _node: &mut ArrowExpr, _ctx: &mut TraverseCtx) {
+        self.in_arrow = true;
+    }
+
+    fn exit_arrow_expr(&mut self, _node: &mut ArrowExpr, _ctx: &mut TraverseCtx) {
+        self.in_arrow = false;
+    }
+
+    fn exit_object_pat(&mut self, n: &mut ObjectPat, _ctx: &mut TraverseCtx) {
+        if !self.in_arrow {
+            return;
+        }
+
+        for prop in n.props.iter_mut() {
+            if let ObjectPatProp::Assign(AssignPatProp {
+                value: Some(value),
+                key,
+                span,
+                ..
+            }) = prop
+            {
+                *prop = ObjectPatProp::KeyValue(KeyValuePatProp {
+                    key: PropName::Ident(key.clone().into()),
+                    value: AssignPat {
+                        span: *span,
+                        left: key.clone().into(),
+                        right: value.clone(),
+                    }
+                    .into(),
+                });
+            }
+        }
+    }
+}

--- a/crates/swc_ecma_transformer/src/bugfix/mod.rs
+++ b/crates/swc_ecma_transformer/src/bugfix/mod.rs
@@ -1,25 +1,39 @@
 use swc_ecma_hooks::VisitMutHook;
 
-use crate::TraverseCtx;
+use crate::{
+    hook_utils::{HookBuilder, NoopHook},
+    TraverseCtx,
+};
+
+mod edge_default_param;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]
-pub struct BugfixOptions {}
+pub struct BugfixOptions {
+    /// Enable edge default param bugfix.
+    ///
+    /// Converts destructured parameters with default values to non-shorthand
+    /// syntax. This fixes the only arguments-related bug in ES
+    /// Modules-supporting browsers (Edge 16 & 17).
+    pub edge_default_param: bool,
+}
 
 impl BugfixOptions {
     /// Returns true if any transform is enabled.
-    /// Currently no bugfixes are available.
     pub fn is_enabled(&self) -> bool {
-        false
+        self.edge_default_param
     }
 }
 
 pub fn hook(options: BugfixOptions) -> impl VisitMutHook<TraverseCtx> {
-    BugfixPass { options }
-}
+    let hook = HookBuilder::new(NoopHook);
 
-struct BugfixPass {
-    options: BugfixOptions,
-}
+    // Edge default param: { a = 1 } -> { a: a = 1 }
+    let hook = hook.chain(if options.edge_default_param {
+        Some(self::edge_default_param::hook())
+    } else {
+        None
+    });
 
-impl VisitMutHook<TraverseCtx> for BugfixPass {}
+    hook.build()
+}

--- a/crates/swc_ecma_transformer/src/hook_utils.rs
+++ b/crates/swc_ecma_transformer/src/hook_utils.rs
@@ -124,6 +124,9 @@ where
         exit_module_export_name,
         ModuleExportName
     );
+
+    // Bugfix hooks: object pattern handling
+    chained_method!(enter_object_pat, exit_object_pat, ObjectPat);
 }
 
 pub(crate) struct NoopHook;


### PR DESCRIPTION
## Summary

- Adds `edge_default_param` bugfix to `swc_ecma_transformer` using hook-based visitor pattern
- Converts destructured parameters with default values to non-shorthand syntax
- Fixes arguments-related bug in Edge 16 & 17


## Test plan

- [x] `cargo check -p swc_ecma_transformer` passes
- [x] `cargo test -p swc_ecma_compat_bugfixes` passes (30 tests)

Generated with [Claude Code](https://claude.ai/claude-code)