### PR TITLE
chore: Update bytes to 1.11.1 to fix RUSTSEC-2026-0007

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,9 +681,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.10.1"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]


### PR DESCRIPTION
Update bytes dependency from 1.10.1 to 1.11.1 to fix an integer overflow vulnerability in `BytesMut::reserve` (RUSTSEC-2026-0007).

Closes #11527

Generated with [Claude Code](https://claude.ai/code)