### PR TITLE
refactor(es/react): Inline dev jsx metadata into jsx hook

### DIFF
--- a/crates/swc_ecma_transforms_react/src/lib.rs
+++ b/crates/swc_ecma_transforms_react/src/lib.rs
@@ -92,29 +92,26 @@ where
     let refresh_options = options.refresh.take();
 
     let hook = CompositeHook {
-        first: jsx_src::hook(development, cm.clone()),
+        first: refresh::hook(
+            development,
+            refresh_options.clone(),
+            cm.clone(),
+            comments.clone(),
+            top_level_mark,
+        ),
         second: CompositeHook {
-            first: jsx_self::hook(development),
+            first: jsx::hook(
+                cm.clone(),
+                comments.clone(),
+                options,
+                top_level_mark,
+                unresolved_mark,
+            ),
             second: CompositeHook {
-                first: refresh::hook(
-                    development,
-                    refresh_options.clone(),
-                    cm.clone(),
-                    comments.clone(),
-                    top_level_mark,
-                ),
+                first: display_name::hook(),
                 second: CompositeHook {
-                    first: jsx::hook(
-                        cm.clone(),
-                        comments.clone(),
-                        options,
-                        top_level_mark,
-                        unresolved_mark,
-                    ),
-                    second: CompositeHook {
-                        first: display_name::hook(),
-                        second: pure_annotations::hook(comments.clone()),
-                    },
+                    first: pure_annotations::hook(comments.clone()),
+                    second: swc_ecma_hooks::NoopHook,
                 },
             },
         },


### PR DESCRIPTION
## Summary
- inline development JSX metadata generation (__source, __self) into the main jsx hook
- simplify react() hook composition by removing separate jsx_src and jsx_self passes from the react pipeline
- preserve automatic-runtime createElement fallback behavior for source/self metadata and constructor-safe this handling

## Testing
- cargo fmt --all
- cargo test -p swc_ecma_transforms_typescript -p swc_ecma_transforms_react -p swc_ecma_transforms
- cargo test -p swc --test projects --test tsc