### PR TITLE
fix(react): preserve line breaks in quoted JSX attrs

### DIFF
--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -2169,10 +2169,7 @@ fn transform_jsx_attr_str(v: &Wtf8) -> Wtf8Buf {
     // Fast path: check if transformation is needed
     let needs_transform = v.code_points().any(|cp| {
         if let Some(c) = cp.to_char() {
-            matches!(
-                c,
-                '\u{0008}' | '\u{000c}' | '\n' | '\r' | '\t' | '\u{000b}' | '\0'
-            )
+            matches!(c, '\u{0008}' | '\u{000c}' | '\u{000b}' | '\0')
         } else {
             false
         }
@@ -2184,47 +2181,18 @@ fn transform_jsx_attr_str(v: &Wtf8) -> Wtf8Buf {
 
     let single_quote = false;
     let mut buf = Wtf8Buf::with_capacity(v.len());
-    let mut iter = v.code_points().peekable();
 
-    while let Some(code_point) = iter.next() {
+    for code_point in v.code_points() {
         if let Some(c) = code_point.to_char() {
             match c {
                 '\u{0008}' => buf.push_str("\\b"),
                 '\u{000c}' => buf.push_str("\\f"),
-                ' ' => buf.push_char(' '),
-
-                '\n' | '\r' | '\t' => {
-                    buf.push_char(' ');
-
-                    while let Some(next) = iter.peek() {
-                        if next.to_char() == Some(' ') {
-                            iter.next();
-                        } else {
-                            break;
-                        }
-                    }
-                }
                 '\u{000b}' => buf.push_str("\\v"),
                 '\0' => buf.push_str("\\x00"),
 
                 '\'' if single_quote => buf.push_str("\\'"),
                 '"' if !single_quote => buf.push_char('"'),
-
-                '\x01'..='\x0f' | '\x10'..='\x1f' => {
-                    buf.push_char(c);
-                }
-
-                '\x20'..='\x7e' => {
-                    //
-                    buf.push_char(c);
-                }
-                '\u{7f}'..='\u{ff}' => {
-                    buf.push_char(c);
-                }
-
-                _ => {
-                    buf.push_char(c);
-                }
+                _ => buf.push_char(c),
             }
         } else {
             buf.push(code_point);

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-11550/input.js
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-11550/input.js
@@ -1,0 +1,2 @@
+const hello = <div data-anything="bruh
+bruh">hello</div>;

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-11550/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-11550/output.mjs
@@ -1,0 +1,3 @@
+const hello = /*#__PURE__*/ React.createElement("div", {
+    "data-anything": "bruh\nbruh"
+}, "hello");


### PR DESCRIPTION
## Summary
- preserve line breaks in quoted JSX attribute values instead of collapsing them to spaces
- keep existing control-character escaping behavior for other special chars
- add a fixture regression test for issue #11550

## Testing
- cargo test -p swc_ecma_transforms_react issue_11550 -- --ignored --nocapture
- cargo test -p swc_ecma_transforms_react --lib

Fixes #11550
