### PR TITLE
fix: avoid false uncovered branches for jest decorator metadata

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -834,6 +834,7 @@ impl Options {
                     DecoratorVersion::V202112 => Box::new(decorators(decorators::Config {
                         legacy: transform.legacy_decorator.into_bool(),
                         emit_metadata: transform.decorator_metadata.into_bool(),
+                        emit_coverage_ignores: transform.hidden.jest.into_bool(),
                         use_define_for_class_fields: !assumptions.set_public_class_fields,
                     })),
                     DecoratorVersion::V202203 => Box::new(

--- a/crates/swc/tests/fixture/sourcemap/issue-3854/3-jest-decorator-metadata/input/.swcrc
+++ b/crates/swc/tests/fixture/sourcemap/issue-3854/3-jest-decorator-metadata/input/.swcrc
@@ -1,0 +1,22 @@
+{
+    "test": ".*.ts$",
+    "jsc": {
+        "target": "es2020",
+        "parser": {
+            "syntax": "typescript",
+            "decorators": true
+        },
+        "externalHelpers": true,
+        "transform": {
+            "legacyDecorator": true,
+            "decoratorMetadata": true,
+            "hidden": {
+                "jest": true
+            }
+        }
+    },
+    "module": {
+        "type": "commonjs"
+    },
+    "sourceMaps": true
+}

--- a/crates/swc/tests/fixture/sourcemap/issue-3854/3-jest-decorator-metadata/input/index.ts
+++ b/crates/swc/tests/fixture/sourcemap/issue-3854/3-jest-decorator-metadata/input/index.ts
@@ -1,0 +1,9 @@
+import { Inject } from "@nestjs/common";
+import { AppService } from "./app.service";
+
+export class AppController {
+    constructor(
+        @Inject(AppService)
+        private readonly appService: AppService
+    ) {}
+}

--- a/crates/swc/tests/fixture/sourcemap/issue-3854/3-jest-decorator-metadata/output/index.map
+++ b/crates/swc/tests/fixture/sourcemap/issue-3854/3-jest-decorator-metadata/output/index.map
@@ -1,0 +1,14 @@
+{
+  "mappings": ";;;;+BAGaA;;;eAAAA;;;;;;;wBAHU;4BACI;AAEpB,MAAMA;IACT,YACI,AACiBC,UAAsB,CACzC;;aADmBA,aAAAA;IAClB;AACP",
+  "names": [
+    "AppController",
+    "appService"
+  ],
+  "sources": [
+    "../input/index.ts"
+  ],
+  "sourcesContent": [
+    "import { Inject } from \"@nestjs/common\";\nimport { AppService } from \"./app.service\";\n\nexport class AppController {\n    constructor(\n        @Inject(AppService)\n        private readonly appService: AppService\n    ) {}\n}\n"
+  ],
+  "version": 3
+}

--- a/crates/swc/tests/fixture/sourcemap/issue-3854/3-jest-decorator-metadata/output/index.ts
+++ b/crates/swc/tests/fixture/sourcemap/issue-3854/3-jest-decorator-metadata/output/index.ts
@@ -1,0 +1,29 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+Object.defineProperty(exports, "AppController", {
+    enumerable: true,
+    get: function() {
+        return AppController;
+    }
+});
+const _define_property = require("@swc/helpers/_/_define_property");
+const _ts_decorate = require("@swc/helpers/_/_ts_decorate");
+const _ts_metadata = require("@swc/helpers/_/_ts_metadata");
+const _ts_param = require("@swc/helpers/_/_ts_param");
+const _common = require("@nestjs/common");
+const _appservice = require("./app.service");
+class AppController {
+    constructor(appService){
+        _define_property._(this, "appService", void 0);
+        this.appService = appService;
+    }
+}
+AppController = _ts_decorate._([
+    _ts_param._(0, (0, _common.Inject)(_appservice.AppService)),
+    _ts_metadata._("design:type", Function),
+    _ts_metadata._("design:paramtypes", [
+        /*istanbul ignore next*/ typeof _appservice.AppService === "undefined" ? Object : _appservice.AppService
+    ])
+], AppController);

--- a/crates/swc_bundler/tests/common/mod.rs
+++ b/crates/swc_bundler/tests/common/mod.rs
@@ -138,6 +138,7 @@ impl Load for Loader {
                 .apply(decorators(decorators::Config {
                     legacy: true,
                     emit_metadata: Default::default(),
+                    emit_coverage_ignores: false,
                     use_define_for_class_fields: false,
                 }))
                 .apply(strip(unresolved_mark, top_level_mark))

--- a/crates/swc_common/src/lib.rs
+++ b/crates/swc_common/src/lib.rs
@@ -42,7 +42,7 @@ pub use self::{
     pos::{
         hygiene, BytePos, CharPos, FileName, Globals, Loc, LocWithOpt, Mark, MultiSpan, SourceFile,
         SourceFileAndBytePos, SourceFileAndLine, Span, SpanLinesError, Spanned, SyntaxContext,
-        DUMMY_SP, GLOBALS, NO_EXPANSION,
+        COVERAGE_IGNORE_SP, DUMMY_SP, GLOBALS, NO_EXPANSION,
     },
     source_map::{FileLines, FileLoader, FilePathMapping, SourceMap, SpanSnippetError},
     syntax_pos::LineCol,

--- a/crates/swc_common/src/pos.rs
+++ b/crates/swc_common/src/pos.rs
@@ -2,8 +2,8 @@ use std::{borrow::Cow, rc::Rc, sync::Arc};
 
 pub use crate::syntax_pos::{
     hygiene, BytePos, CharPos, FileName, Globals, Loc, LocWithOpt, Mark, MultiSpan, SourceFile,
-    SourceFileAndBytePos, SourceFileAndLine, Span, SpanLinesError, SyntaxContext, DUMMY_SP,
-    GLOBALS, NO_EXPANSION,
+    SourceFileAndBytePos, SourceFileAndLine, Span, SpanLinesError, SyntaxContext,
+    COVERAGE_IGNORE_SP, DUMMY_SP, GLOBALS, NO_EXPANSION,
 };
 
 ///

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -93,6 +93,12 @@ pub const PURE_SP: Span = Span {
     hi: BytePos::PURE,
 };
 
+/// Coverage-ignore span, will emit `/* istanbul ignore next */` in codegen.
+pub const COVERAGE_IGNORE_SP: Span = Span {
+    lo: BytePos::COVERAGE_IGNORE,
+    hi: BytePos::COVERAGE_IGNORE,
+};
+
 /// Used for some special cases. e.g. mark the generated AST.
 pub const PLACEHOLDER_SP: Span = Span {
     lo: BytePos::PLACEHOLDER,
@@ -547,6 +553,11 @@ impl Span {
     #[inline]
     pub fn is_pure(self) -> bool {
         self.lo.is_pure()
+    }
+
+    #[inline]
+    pub fn is_coverage_ignore(self) -> bool {
+        self.lo.is_coverage_ignore()
     }
 
     #[inline]
@@ -1155,6 +1166,8 @@ impl<'de> cbor4ii::core::dec::Decode<'de> for BytePos {
 }
 
 impl BytePos {
+    /// Reserved for coverage ignore comments. e.g. `/* istanbul ignore next */`
+    pub const COVERAGE_IGNORE: Self = BytePos(u32::MAX - 3);
     /// Dummy position. This is reserved for synthesized spans.
     pub const DUMMY: Self = BytePos(0);
     const MIN_RESERVED: Self = BytePos(DUMMY_RESERVE);
@@ -1178,6 +1191,10 @@ impl BytePos {
 
     pub const fn is_pure(self) -> bool {
         self.0 == Self::PURE.0
+    }
+
+    pub const fn is_coverage_ignore(self) -> bool {
+        self.0 == Self::COVERAGE_IGNORE.0
     }
 
     pub const fn is_placeholder(self) -> bool {

--- a/crates/swc_ecma_codegen/src/comments.rs
+++ b/crates/swc_ecma_codegen/src/comments.rs
@@ -114,6 +114,18 @@ where
             );
         }
 
+        if pos.is_coverage_ignore() {
+            write_comments!(
+                self,
+                false,
+                Some(vec![Comment {
+                    kind: CommentKind::Block,
+                    span: DUMMY_SP,
+                    text: atom!("istanbul ignore next"),
+                }])
+            );
+        }
+
         let comments = match self.comments {
             Some(ref comments) => comments,
             None => return Ok(()),

--- a/crates/swc_ecma_transforms/tests/decorators.rs
+++ b/crates/swc_ecma_transforms/tests/decorators.rs
@@ -3925,6 +3925,7 @@ test_exec!(
         Config {
             legacy: true,
             emit_metadata: true,
+            emit_coverage_ignores: false,
             use_define_for_class_fields: false,
         }
     ),
@@ -3958,6 +3959,7 @@ fn fixture_exec(input: PathBuf) {
                 decorators(Config {
                     legacy: true,
                     emit_metadata: true,
+                    emit_coverage_ignores: false,
                     use_define_for_class_fields: false,
                 }),
                 strip(unresolved_mark, top_level_mark),
@@ -3983,6 +3985,7 @@ fn legacy_only(input: PathBuf) {
                 decorators(Config {
                     legacy: true,
                     emit_metadata: false,
+                    emit_coverage_ignores: false,
                     use_define_for_class_fields: false,
                 }),
             )
@@ -4008,6 +4011,7 @@ fn legacy_metadata(input: PathBuf) {
                 decorators(Config {
                     legacy: true,
                     emit_metadata: true,
+                    emit_coverage_ignores: false,
                     use_define_for_class_fields: false,
                 }),
             )

--- a/crates/swc_ecma_transforms_optimization/tests/simplify_dce.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/simplify_dce.rs
@@ -386,6 +386,7 @@ test!(
             decorators(decorators::Config {
                 legacy: true,
                 emit_metadata: false,
+                emit_coverage_ignores: false,
                 use_define_for_class_fields: false,
             }),
             resolver(unresolved_mark, top_level_mark, false),
@@ -418,6 +419,7 @@ test!(
             decorators(decorators::Config {
                 legacy: true,
                 emit_metadata: false,
+                emit_coverage_ignores: false,
                 use_define_for_class_fields: false,
             }),
             resolver(unresolved_mark, top_level_mark, false),

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
@@ -4,7 +4,7 @@ use rustc_hash::FxHashMap;
 use swc_atoms::{atom, Atom};
 use swc_common::{
     util::{move_map::MoveMap, take::Take},
-    BytePos, Spanned, DUMMY_SP,
+    BytePos, Spanned, COVERAGE_IGNORE_SP, DUMMY_SP,
 };
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
@@ -134,6 +134,7 @@ pub(super) struct Metadata<'a> {
     pub(super) enums: EnumMap<'a>,
 
     pub(super) class_name: Option<&'a Ident>,
+    pub(super) emit_coverage_ignores: bool,
 }
 
 impl VisitMut for Metadata<'_> {
@@ -178,7 +179,8 @@ impl VisitMut for Metadata<'_> {
                                 Some(if let Some(kind) = self.enums.get_kind_as_str(ann) {
                                     quote_ident!(kind).as_arg()
                                 } else {
-                                    serialize_type(self.class_name, ann).as_arg()
+                                    serialize_type(self.class_name, ann, self.emit_coverage_ignores)
+                                        .as_arg()
                                 })
                             }
                             ParamOrTsParamProp::Param(p) => {
@@ -186,7 +188,12 @@ impl VisitMut for Metadata<'_> {
                                 Some(if let Some(kind) = self.enums.get_kind_as_str(param_type) {
                                     quote_ident!(kind).as_arg()
                                 } else {
-                                    serialize_type(self.class_name, param_type).as_arg()
+                                    serialize_type(
+                                        self.class_name,
+                                        param_type,
+                                        self.emit_coverage_ignores,
+                                    )
+                                    .as_arg()
                                 })
                             }
                             #[cfg(swc_ast_unknown)]
@@ -214,12 +221,14 @@ impl VisitMut for Metadata<'_> {
                     if let Some(kind) = self.enums.get_kind_as_str(return_type) {
                         quote_ident!(kind).as_arg()
                     } else {
-                        serialize_type(self.class_name, return_type).as_arg()
+                        serialize_type(self.class_name, return_type, self.emit_coverage_ignores)
+                            .as_arg()
                     }
                 }
                 MethodKind::Setter => serialize_type(
                     self.class_name,
                     get_type_ann_of_pat(&m.function.params[0].pat),
+                    self.emit_coverage_ignores,
                 )
                 .as_arg(),
                 #[cfg(swc_ast_unknown)]
@@ -243,7 +252,12 @@ impl VisitMut for Metadata<'_> {
                             Some(if let Some(kind) = self.enums.get_kind_as_str(param_type) {
                                 quote_ident!(kind).as_arg()
                             } else {
-                                serialize_type(self.class_name, param_type).as_arg()
+                                serialize_type(
+                                    self.class_name,
+                                    param_type,
+                                    self.emit_coverage_ignores,
+                                )
+                                .as_arg()
                             })
                         })
                         .collect(),
@@ -267,7 +281,8 @@ impl VisitMut for Metadata<'_> {
                     if let Some(kind) = self.enums.get_kind_as_str(return_type) {
                         quote_ident!(kind).as_arg()
                     } else {
-                        serialize_type(self.class_name, return_type).as_arg()
+                        serialize_type(self.class_name, return_type, self.emit_coverage_ignores)
+                            .as_arg()
                     }
                 },
             );
@@ -286,7 +301,7 @@ impl VisitMut for Metadata<'_> {
             if let Some(kind) = self.enums.get_kind_as_str(prop_type) {
                 quote_ident!(kind).as_arg()
             } else {
-                serialize_type(self.class_name, prop_type).as_arg()
+                serialize_type(self.class_name, prop_type, self.emit_coverage_ignores).as_arg()
             }
         });
         p.decorators.push(dec);
@@ -294,10 +309,15 @@ impl VisitMut for Metadata<'_> {
 }
 
 impl<'a> Metadata<'a> {
-    pub(super) fn new(enums: &'a EnumMapType, class_name: Option<&'a Ident>) -> Self {
+    pub(super) fn new(
+        enums: &'a EnumMapType,
+        class_name: Option<&'a Ident>,
+        emit_coverage_ignores: bool,
+    ) -> Self {
         Self {
             enums: EnumMap(enums),
             class_name,
+            emit_coverage_ignores,
         }
     }
 
@@ -315,7 +335,11 @@ impl<'a> Metadata<'a> {
     }
 }
 
-fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr {
+fn serialize_type(
+    class_name: Option<&Ident>,
+    param: Option<&TsTypeAnn>,
+    emit_coverage_ignores: bool,
+) -> Expr {
     fn check_object_existed(expr: Box<Expr>) -> Box<Expr> {
         match *expr {
             Expr::Member(ref member_expr) => {
@@ -368,7 +392,7 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
         }
     }
 
-    fn serialize_type_ref(class_name: &str, ty: &TsTypeRef) -> Expr {
+    fn serialize_type_ref(class_name: &str, ty: &TsTypeRef, emit_coverage_ignores: bool) -> Expr {
         match &ty.type_name {
             // We should omit references to self (class) since it will throw a ReferenceError at
             // runtime due to babel transpile output.
@@ -387,7 +411,11 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
         // fallback is just `Object`.
 
         CondExpr {
-            span: DUMMY_SP,
+            span: if emit_coverage_ignores {
+                COVERAGE_IGNORE_SP
+            } else {
+                DUMMY_SP
+            },
             test: check_object_existed(Box::new(member_expr.clone())),
             cons: Box::new(quote_ident!("Object").into()),
             alt: Box::new(member_expr),
@@ -395,7 +423,11 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
         .into()
     }
 
-    fn serialize_type_list(class_name: &str, types: &[Box<TsType>]) -> Expr {
+    fn serialize_type_list(
+        class_name: &str,
+        types: &[Box<TsType>],
+        emit_coverage_ignores: bool,
+    ) -> Expr {
         let mut u = None;
         for ty in types {
             // Skip parens if need be
@@ -428,7 +460,7 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
                 _ => {}
             }
 
-            let item = serialize_type_node(class_name, ty);
+            let item = serialize_type_node(class_name, ty, emit_coverage_ignores);
 
             // One of the individual is global object, return immediately
             if item.is_ident_ref_to("Object") {
@@ -465,7 +497,7 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
         }
     }
 
-    fn serialize_type_node(class_name: &str, ty: &TsType) -> Expr {
+    fn serialize_type_node(class_name: &str, ty: &TsType, emit_coverage_ignores: bool) -> Expr {
         let span = ty.span();
         match ty {
             TsType::TsKeywordType(TsKeywordType {
@@ -485,7 +517,9 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
                 ..
             }) => *Expr::undefined(span),
 
-            TsType::TsParenthesizedType(ty) => serialize_type_node(class_name, &ty.type_ann),
+            TsType::TsParenthesizedType(ty) => {
+                serialize_type_node(class_name, &ty.type_ann, emit_coverage_ignores)
+            }
 
             TsType::TsFnOrConstructorType(_) => quote_ident!("Function").into(),
 
@@ -521,7 +555,11 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
                 kind: TsKeywordTypeKind::TsBigIntKeyword,
                 ..
             }) => CondExpr {
-                span: DUMMY_SP,
+                span: if emit_coverage_ignores {
+                    COVERAGE_IGNORE_SP
+                } else {
+                    DUMMY_SP
+                },
                 test: check_object_existed(quote_ident!("BigInt").into()),
                 cons: quote_ident!("Object").into(),
                 alt: quote_ident!("BigInt").into(),
@@ -555,20 +593,22 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
 
             TsType::TsUnionOrIntersectionType(ty) => match ty {
                 TsUnionOrIntersectionType::TsUnionType(ty) => {
-                    serialize_type_list(class_name, &ty.types)
+                    serialize_type_list(class_name, &ty.types, emit_coverage_ignores)
                 }
                 TsUnionOrIntersectionType::TsIntersectionType(ty) => {
-                    serialize_type_list(class_name, &ty.types)
+                    serialize_type_list(class_name, &ty.types, emit_coverage_ignores)
                 }
                 #[cfg(swc_ast_unknown)]
                 _ => panic!("unable to access unknown nodes"),
             },
 
-            TsType::TsConditionalType(ty) => {
-                serialize_type_list(class_name, &[ty.true_type.clone(), ty.false_type.clone()])
-            }
+            TsType::TsConditionalType(ty) => serialize_type_list(
+                class_name,
+                &[ty.true_type.clone(), ty.false_type.clone()],
+                emit_coverage_ignores,
+            ),
 
-            TsType::TsTypeRef(ty) => serialize_type_ref(class_name, ty),
+            TsType::TsTypeRef(ty) => serialize_type_ref(class_name, ty, emit_coverage_ignores),
 
             _ => panic!("Bad type for decorator: {ty:?}"),
         }
@@ -579,7 +619,11 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
         None => return *Expr::undefined(DUMMY_SP),
     };
 
-    serialize_type_node(class_name.map(|v| &*v.sym).unwrap_or(""), param)
+    serialize_type_node(
+        class_name.map(|v| &*v.sym).unwrap_or(""),
+        param,
+        emit_coverage_ignores,
+    )
 }
 
 fn ts_entity_to_member_expr(type_name: &TsEntityName) -> Expr {

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/mod.rs
@@ -21,9 +21,10 @@ enum EnumKind {
     Num,
 }
 
-pub(super) fn new(metadata: bool) -> TscDecorator {
+pub(super) fn new(metadata: bool, emit_coverage_ignores: bool) -> TscDecorator {
     TscDecorator {
         metadata,
+        emit_coverage_ignores,
         enums: Default::default(),
         vars: Default::default(),
         appended_exprs: Default::default(),
@@ -37,6 +38,7 @@ pub(super) fn new(metadata: bool) -> TscDecorator {
 
 pub(super) struct TscDecorator {
     metadata: bool,
+    emit_coverage_ignores: bool,
 
     enums: FxHashMap<Atom, EnumKind>,
 
@@ -270,7 +272,11 @@ impl VisitMut for TscDecorator {
         if self.metadata {
             let i = self.class_name.clone();
 
-            n.visit_mut_with(&mut Metadata::new(&self.enums, i.as_ref()));
+            n.visit_mut_with(&mut Metadata::new(
+                &self.enums,
+                i.as_ref(),
+                self.emit_coverage_ignores,
+            ));
         }
 
         n.visit_mut_children_with(self);

--- a/crates/swc_ecma_transforms_proposal/src/decorators/mod.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/mod.rs
@@ -59,7 +59,10 @@ mod legacy;
 /// ```
 pub fn decorators(c: Config) -> impl Pass {
     if c.legacy {
-        Either::Left(visit_mut_pass(self::legacy::new(c.emit_metadata)))
+        Either::Left(visit_mut_pass(self::legacy::new(
+            c.emit_metadata,
+            c.emit_coverage_ignores,
+        )))
     } else {
         if c.emit_metadata {
             unimplemented!("emitting decorator metadata while using new proposal")
@@ -77,6 +80,8 @@ pub struct Config {
     pub legacy: bool,
     #[serde(default)]
     pub emit_metadata: bool,
+    #[serde(default)]
+    pub emit_coverage_ignores: bool,
 
     pub use_define_for_class_fields: bool,
 }


### PR DESCRIPTION
Fixes #3854.

## Summary
- add a dedicated coverage-ignore span marker that codegen emits as `/*istanbul ignore next*/`
- apply that marker to generated decorator-metadata `typeof ... === "undefined" ? ...` guards only when Jest hidden transform mode is enabled
- add a regression fixture for issue 3854 under `crates/swc/tests/fixture/sourcemap/issue-3854/3-jest-decorator-metadata`

## Verification
- `cargo fmt --all`
- `cargo test -p swc --test projects issue_3854 -- --ignored --nocapture`
- `cargo test -p swc_ecma_transforms`
- `cargo clippy -p swc_common --lib -- -D warnings`
- `cargo clippy -p swc_ecma_codegen --lib -- -D warnings`
- `cargo clippy -p swc_ecma_transforms_proposal --all-targets -- -D warnings`
- `cargo clippy -p swc --lib -- -D warnings`
- `cargo clippy -p swc_ecma_transforms --all-targets -- -D warnings`
- `cargo clippy -p swc_ecma_transforms_optimization --all-targets -- -D warnings`