### PR TITLE
feat: add opt-in ECMA-426 source map scopes emission

### DIFF
--- a/bindings/binding_core_node/src/bundle.rs
+++ b/bindings/binding_core_node/src/bundle.rs
@@ -131,6 +131,7 @@ impl Task for BundleTask {
                                     inline_sources_content: true,
                                     source_map: SourceMapsConfig::Bool(true),
                                     emit_source_map_columns: true,
+                                    emit_source_map_scopes: false,
                                     codegen_config: swc_core::ecma::codegen::Config::default()
                                         .with_target(codegen_target)
                                         .with_minify(minify),

--- a/bindings/binding_core_node/src/print.rs
+++ b/bindings/binding_core_node/src/print.rs
@@ -45,6 +45,7 @@ impl Task for PrintTask {
                             .clone()
                             .unwrap_or(SourceMapsConfig::Bool(false)),
                         emit_source_map_columns: options.config.emit_source_map_columns.into_bool(),
+                        emit_source_map_scopes: options.config.emit_source_map_scopes.into_bool(),
                         codegen_config: swc_core::ecma::codegen::Config::default()
                             .with_target(options.config.jsc.target.unwrap_or(EsVersion::Es2020))
                             .with_minify(options.config.minify.into_bool()),
@@ -106,6 +107,7 @@ pub fn print_sync(program: String, options: Buffer) -> napi::Result<TransformOut
                     .clone()
                     .unwrap_or(SourceMapsConfig::Bool(false)),
                 emit_source_map_columns: options.config.emit_source_map_columns.into_bool(),
+                emit_source_map_scopes: options.config.emit_source_map_scopes.into_bool(),
                 codegen_config: swc_core::ecma::codegen::Config::default()
                     .with_target(codegen_target)
                     .with_minify(options.config.minify.into_bool()),

--- a/bindings/binding_core_wasm/src/types.rs
+++ b/bindings/binding_core_wasm/src/types.rs
@@ -52,6 +52,8 @@ export interface JsMinifyOptions {
   outputPath?: string
 
   inlineSourcesContent?: boolean
+
+  emitSourceMapScopes?: boolean
 }
 
 /**
@@ -594,6 +596,8 @@ export interface Config {
   sourceMaps?: boolean | "inline";
 
   inlineSourcesContent?: boolean
+
+  emitSourceMapScopes?: boolean
 }
 
 /**

--- a/bindings/binding_minifier_node/src/minify.rs
+++ b/bindings/binding_minifier_node/src/minify.rs
@@ -199,6 +199,7 @@ fn do_work(
                 orig,
                 comments: Some(&comments),
                 emit_source_map_columns: options.emit_source_map_columns,
+                emit_source_map_scopes: options.emit_source_map_scopes,
                 preamble: &options.format.preamble,
                 codegen_config: swc_core::ecma::codegen::Config::default()
                     .with_target(target)

--- a/bindings/binding_minifier_wasm/src/types.rs
+++ b/bindings/binding_minifier_wasm/src/types.rs
@@ -52,6 +52,8 @@ export interface JsMinifyOptions {
   outputPath?: string
 
   inlineSourcesContent?: boolean
+
+  emitSourceMapScopes?: boolean
 }
 
 /**
@@ -594,6 +596,8 @@ export interface Config {
   sourceMaps?: boolean | "inline";
 
   inlineSourcesContent?: boolean
+
+  emitSourceMapScopes?: boolean
 }
 
 /**

--- a/crates/binding_macros/src/wasm.rs
+++ b/crates/binding_macros/src/wasm.rs
@@ -260,6 +260,7 @@ macro_rules! build_print_sync {
                               .clone()
                               .unwrap_or($crate::wasm::SourceMapsConfig::Bool(false)),
                           emit_source_map_columns: opts.config.emit_source_map_columns.into_bool(),
+                          emit_source_map_scopes: opts.config.emit_source_map_scopes.into_bool(),
                           codegen_config: swc_core::ecma::codegen::Config::default()
                               .with_target(opts.codegen_target().unwrap_or($crate::wasm::EsVersion::Es2020))
                               .with_minify(opts.config.minify.into()),

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -968,6 +968,7 @@ impl Options {
             comments: comments.cloned(),
             preserve_comments,
             emit_source_map_columns: cfg.emit_source_map_columns.into_bool(),
+            emit_source_map_scopes: cfg.emit_source_map_scopes.into_bool(),
             output: JscOutputConfig {
                 charset,
                 preamble,
@@ -1170,6 +1171,9 @@ pub struct Config {
     pub emit_source_map_columns: BoolConfig<true>,
 
     #[serde(default)]
+    pub emit_source_map_scopes: BoolConfig<false>,
+
+    #[serde(default)]
     pub error: ErrorConfig,
 
     #[serde(default)]
@@ -1292,6 +1296,7 @@ pub struct BuiltInput<P: Pass> {
 
     pub inline_sources_content: bool,
     pub emit_source_map_columns: bool,
+    pub emit_source_map_scopes: bool,
 
     pub output: JscOutputConfig,
     pub emit_assert_for_import_attributes: bool,
@@ -1329,6 +1334,7 @@ where
             preserve_comments: self.preserve_comments,
             inline_sources_content: self.inline_sources_content,
             emit_source_map_columns: self.emit_source_map_columns,
+            emit_source_map_scopes: self.emit_source_map_scopes,
             output: self.output,
             emit_assert_for_import_attributes: self.emit_assert_for_import_attributes,
             codegen_inline_script: self.codegen_inline_script,

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -452,7 +452,7 @@ impl Compiler {
     #[allow(clippy::too_many_arguments)]
     pub fn print<T>(&self, node: &T, args: PrintArgs) -> Result<TransformOutput, Error>
     where
-        T: Node + VisitWith<swc_compiler_base::IdentCollector>,
+        T: Node + VisitWith<swc_compiler_base::IdentCollector> + 'static,
     {
         swc_compiler_base::print(self.cm.clone(), node, args)
     }
@@ -925,6 +925,7 @@ impl Compiler {
                     orig,
                     comments: Some(&comments),
                     emit_source_map_columns: opts.emit_source_map_columns,
+                    emit_source_map_scopes: opts.emit_source_map_scopes,
                     preamble: &opts.format.preamble,
                     codegen_config: swc_ecma_codegen::Config::default()
                         .with_target(target)
@@ -1083,6 +1084,7 @@ impl Compiler {
                     orig,
                     comments: config.comments.as_ref().map(|v| v as _),
                     emit_source_map_columns: config.emit_source_map_columns,
+                    emit_source_map_scopes: config.emit_source_map_scopes,
                     preamble: &config.output.preamble,
                     codegen_config: swc_ecma_codegen::Config::default()
                         .with_target(config.target)

--- a/crates/swc/tests/source_map.rs
+++ b/crates/swc/tests/source_map.rs
@@ -10,11 +10,14 @@ use std::{
 };
 
 use anyhow::{Context, Error};
+use base64::prelude::{Engine, BASE64_STANDARD};
+use serde_json::Value;
 use swc::{
     config::{
-        Config, InputSourceMap, IsModule, JscConfig, ModuleConfig, Options, SourceMapsConfig,
+        Config, InputSourceMap, IsModule, JsMinifyOptions, JscConfig, ModuleConfig, Options,
+        SourceMapsConfig,
     },
-    Compiler,
+    BoolOrDataConfig, Compiler,
 };
 use swc_ecma_parser::Syntax;
 use testing::{assert_eq, NormalizedOutput, StdErr, Tester};
@@ -531,6 +534,205 @@ export const fixupRiskConfigData = (data: any): types.RiskConfigType => {
                 panic!("Error: {err:#?}");
             }
         }
+
+        Ok(())
+    });
+}
+
+#[test]
+fn source_map_scopes_off_by_default() {
+    Tester::new().print_errors(|cm, handler| {
+        let c = Compiler::new(cm.clone());
+        let fm = cm.new_source_file(
+            swc_common::FileName::Real("./scopes-off.js".into()).into(),
+            "function keep(v) { return v + 1; }",
+        );
+
+        let output = c
+            .process_js_file(
+                fm,
+                &handler,
+                &Options {
+                    swcrc: false,
+                    source_maps: Some(SourceMapsConfig::Bool(true)),
+                    ..Default::default()
+                },
+            )
+            .expect("failed to process file");
+
+        let map = output.map.expect("source map should be emitted");
+        let json: Value = serde_json::from_str(&map).expect("invalid source map json");
+        assert!(json.get("scopes").is_none());
+
+        Ok(())
+    });
+}
+
+#[test]
+fn source_map_scopes_enabled_emits_scopes_field() {
+    Tester::new().print_errors(|cm, handler| {
+        let c = Compiler::new(cm.clone());
+        let fm = cm.new_source_file(
+            swc_common::FileName::Real("./scopes-on.js".into()).into(),
+            "function scoped(value) { return value * 2; }",
+        );
+
+        let output = c
+            .process_js_file(
+                fm,
+                &handler,
+                &Options {
+                    swcrc: false,
+                    source_maps: Some(SourceMapsConfig::Bool(true)),
+                    config: Config {
+                        emit_source_map_scopes: true.into(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("failed to process file");
+
+        let map = output.map.expect("source map should be emitted");
+        let json: Value = serde_json::from_str(&map).expect("invalid source map json");
+        let scopes = json
+            .get("scopes")
+            .and_then(Value::as_str)
+            .expect("source map should include scopes");
+        assert!(!scopes.is_empty());
+
+        swc_sourcemap::SourceMap::from_slice(map.as_bytes())
+            .expect("source map should remain parseable");
+
+        Ok(())
+    });
+}
+
+#[test]
+fn source_map_scopes_are_skipped_for_input_source_maps() {
+    Tester::new().print_errors(|cm, handler| {
+        let c = Compiler::new(cm.clone());
+        let input_map = r#"{"version":3,"sources":["input.js"],"names":[],"mappings":"AAAA"}"#;
+        let encoded_input_map = BASE64_STANDARD.encode(input_map.as_bytes());
+        let fm = cm.new_source_file(
+            swc_common::FileName::Real("./scopes-input-map.js".into()).into(),
+            format!(
+                "const value = 1;\n//# \
+                 sourceMappingURL=data:application/json;base64,{encoded_input_map}"
+            ),
+        );
+
+        let output = c
+            .process_js_file(
+                fm,
+                &handler,
+                &Options {
+                    swcrc: false,
+                    source_maps: Some(SourceMapsConfig::Bool(true)),
+                    config: Config {
+                        emit_source_map_scopes: true.into(),
+                        input_source_map: Some(InputSourceMap::Str("inline".into())),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("failed to process file");
+
+        let map = output.map.expect("source map should be emitted");
+        let json: Value = serde_json::from_str(&map).expect("invalid source map json");
+        assert!(json.get("scopes").is_none());
+
+        Ok(())
+    });
+}
+
+#[test]
+fn source_map_scopes_are_emitted_for_inline_source_maps() {
+    Tester::new().print_errors(|cm, handler| {
+        let c = Compiler::new(cm.clone());
+        let fm = cm.new_source_file(
+            swc_common::FileName::Real("./scopes-inline.js".into()).into(),
+            "function wrap(arg) { return arg; }",
+        );
+
+        let output = c
+            .process_js_file(
+                fm,
+                &handler,
+                &Options {
+                    swcrc: false,
+                    source_maps: Some(SourceMapsConfig::Str("inline".to_string())),
+                    config: Config {
+                        emit_source_map_scopes: true.into(),
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                },
+            )
+            .expect("failed to process file");
+
+        assert!(
+            output.map.is_none(),
+            "inline map should be embedded in output code"
+        );
+
+        let marker = "sourceMappingURL=data:application/json;base64,";
+        let encoded = output
+            .code
+            .split_once(marker)
+            .map(|(_, v)| v.trim())
+            .expect("inline source map should be present");
+        let decoded = BASE64_STANDARD
+            .decode(encoded.as_bytes())
+            .expect("inline source map should decode");
+        let json: Value = serde_json::from_slice(&decoded).expect("inline map should be json");
+
+        let scopes = json
+            .get("scopes")
+            .and_then(Value::as_str)
+            .expect("inline source map should include scopes");
+        assert!(!scopes.is_empty());
+
+        Ok(())
+    });
+}
+
+#[test]
+fn source_map_scopes_minify_emits_binding_sections() {
+    Tester::new().print_errors(|cm, handler| {
+        let c = Compiler::new(cm.clone());
+        let fm = cm.new_source_file(
+            swc_common::FileName::Real("./scopes-minify.js".into()).into(),
+            "function add(longName) { return longName + 1; } add(1);",
+        );
+
+        let output = c
+            .minify(
+                fm,
+                &handler,
+                &JsMinifyOptions {
+                    compress: BoolOrDataConfig::from_bool(false),
+                    mangle: BoolOrDataConfig::from_bool(true),
+                    source_map: BoolOrDataConfig::from_bool(true),
+                    emit_source_map_scopes: true,
+                    ..Default::default()
+                },
+                Default::default(),
+            )
+            .expect("failed to minify file");
+
+        let map = output.map.expect("source map should be emitted");
+        let json: Value = serde_json::from_str(&map).expect("invalid source map json");
+        let scopes = json
+            .get("scopes")
+            .and_then(Value::as_str)
+            .expect("minify source map should include scopes");
+
+        assert!(
+            scopes.contains('G'),
+            "scopes should include binding records in minify mode"
+        );
 
         Ok(())
     });

--- a/crates/swc_compiler_base/src/lib.rs
+++ b/crates/swc_compiler_base/src/lib.rs
@@ -29,6 +29,8 @@ use swc_ecma_parser::{
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 use swc_timer::timer;
 
+mod source_map_scopes;
+
 #[cfg(feature = "node")]
 #[napi_derive::napi(object)]
 #[derive(Debug, Serialize)]
@@ -123,6 +125,7 @@ pub struct PrintArgs<'a> {
     pub orig: Option<swc_sourcemap::SourceMap>,
     pub comments: Option<&'a dyn Comments>,
     pub emit_source_map_columns: bool,
+    pub emit_source_map_scopes: bool,
     pub preamble: &'a str,
     pub codegen_config: swc_ecma_codegen::Config,
     pub output: Option<FxHashMap<String, String>>,
@@ -144,6 +147,7 @@ impl Default for PrintArgs<'_> {
             orig: None,
             comments: None,
             emit_source_map_columns: false,
+            emit_source_map_scopes: false,
             preamble: "",
             codegen_config: Default::default(),
             output: None,
@@ -176,6 +180,7 @@ pub fn print<T>(
         orig,
         comments,
         emit_source_map_columns,
+        emit_source_map_scopes,
         preamble,
         codegen_config,
         output,
@@ -184,7 +189,7 @@ pub fn print<T>(
     }: PrintArgs,
 ) -> Result<TransformOutput, Error>
 where
-    T: Node + VisitWith<IdentCollector>,
+    T: Node + VisitWith<IdentCollector> + 'static,
 {
     let _timer = timer!("Compiler::print");
 
@@ -233,6 +238,8 @@ where
         panic!("The module contains only dummy spans\n{src}");
     }
 
+    let should_emit_source_map_scopes = emit_source_map_scopes && orig.is_none();
+
     let mut map = if source_map.enabled() {
         Some(cm.build_source_map(
             &src_map_buf,
@@ -256,15 +263,40 @@ where
         }
     }
 
+    let mut serialized_map = if source_map.enabled() {
+        let map_ref = map
+            .as_ref()
+            .expect("source map should be present if source map output is enabled");
+
+        let mut map_buf = std::vec::Vec::new();
+        map_ref
+            .to_writer(&mut map_buf)
+            .context("failed to write source map")?;
+        let mut serialized = String::from_utf8(map_buf).context("source map is not utf-8")?;
+
+        if should_emit_source_map_scopes {
+            serialized = source_map_scopes::augment_source_map_with_scopes(
+                cm.clone(),
+                node as &dyn std::any::Any,
+                map_ref,
+                &serialized,
+                source_file_name,
+                output_path.as_deref(),
+            )
+            .context("failed to augment source map with scopes")?;
+        }
+
+        Some(serialized)
+    } else {
+        None
+    };
+
     let (code, map) = match source_map {
         SourceMapsConfig::Bool(v) => {
             if v {
-                let mut buf = std::vec::Vec::new();
-
-                map.unwrap()
-                    .to_writer(&mut buf)
-                    .context("failed to write source map")?;
-                let map = String::from_utf8(buf).context("source map is not utf-8")?;
+                let map = serialized_map
+                    .take()
+                    .expect("source map should be serialized if source maps are enabled");
 
                 if let Some(source_map_url) = source_map_url {
                     src.push_str("\n//# sourceMappingURL=");
@@ -277,12 +309,9 @@ where
             }
         }
         SourceMapsConfig::Str(_) => {
-            let mut buf = std::vec::Vec::new();
-
-            map.unwrap()
-                .to_writer(&mut buf)
-                .context("failed to write source map file")?;
-            let map = String::from_utf8(buf).context("source map is not utf-8")?;
+            let map = serialized_map
+                .take()
+                .expect("source map should be serialized if source maps are enabled");
 
             src.push_str("\n//# sourceMappingURL=data:application/json;base64,");
             BASE64_STANDARD.encode_string(map.as_bytes(), &mut src);

--- a/crates/swc_compiler_base/src/source_map_scopes/bindings.rs
+++ b/crates/swc_compiler_base/src/source_map_scopes/bindings.rs
@@ -1,0 +1,65 @@
+use super::{
+    collect::CollectedScope,
+    encode::{BindingTransition, BindingValue, ScopePosition},
+    positions::{points_in_original_range, position_in_generated_range, MappingIndex},
+};
+
+pub(crate) fn build_scope_bindings(
+    scope: &CollectedScope,
+    source_idx: u32,
+    generated_start: ScopePosition,
+    generated_end: ScopePosition,
+    mappings: &MappingIndex,
+) -> Vec<BindingValue> {
+    scope
+        .variables
+        .iter()
+        .map(|variable| {
+            let mut samples =
+                points_in_original_range(mappings, source_idx, variable.start, variable.end)
+                    .into_iter()
+                    .filter(|point| {
+                        position_in_generated_range(point.generated, generated_start, generated_end)
+                    })
+                    .filter_map(|point| {
+                        point
+                            .generated_name
+                            .as_ref()
+                            .map(|name| (point.generated, name.clone()))
+                    })
+                    .collect::<Vec<_>>();
+
+            if samples.is_empty() {
+                return BindingValue::Simple(None);
+            }
+
+            samples.sort_by_key(|sample| sample.0);
+            samples.dedup_by(|lhs, rhs| lhs.0 == rhs.0 && lhs.1 == rhs.1);
+
+            let initial = samples[0].1.clone();
+            let mut current = initial.clone();
+            let mut transitions = Vec::new();
+
+            for (from, name) in samples.into_iter().skip(1) {
+                if name == current {
+                    continue;
+                }
+
+                current = name.clone();
+                transitions.push(BindingTransition {
+                    from,
+                    value: Some(name),
+                });
+            }
+
+            if transitions.is_empty() {
+                BindingValue::Simple(Some(initial))
+            } else {
+                BindingValue::WithSubRanges {
+                    initial: Some(initial),
+                    transitions,
+                }
+            }
+        })
+        .collect()
+}

--- a/crates/swc_compiler_base/src/source_map_scopes/collect.rs
+++ b/crates/swc_compiler_base/src/source_map_scopes/collect.rs
@@ -1,0 +1,511 @@
+use swc_common::{sync::Lrc, BytePos, SourceMap, Span};
+use swc_ecma_ast::{
+    ArrowExpr, BindingIdent, CatchClause, ClassDecl, ClassExpr, ClassMethod, Constructor, FnDecl,
+    FnExpr, Function, GetterProp, ImportDecl, ImportSpecifier, MethodProp, Module, ObjectPatProp,
+    ParamOrTsParamProp, Pat, PrivateMethod, Program, PropName, Script, SetterProp, StaticBlock,
+    TsParamPropParam, VarDecl, VarDeclKind,
+};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
+
+use crate::source_map_scopes::{encode::ScopePosition, SourceResolver};
+
+#[derive(Debug, Clone)]
+pub(crate) struct CollectedVariable {
+    pub name: String,
+    pub start: ScopePosition,
+    pub end: ScopePosition,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CollectedScope {
+    pub source_idx: Option<u32>,
+    pub start: ScopePosition,
+    pub end: ScopePosition,
+    pub name: Option<String>,
+    pub kind: Option<String>,
+    pub is_stack_frame: bool,
+    pub is_function_boundary: bool,
+    pub parent: Option<usize>,
+    pub children: Vec<usize>,
+    pub variables: Vec<CollectedVariable>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct CollectedScopes {
+    pub scopes: Vec<CollectedScope>,
+    pub roots_by_source: Vec<Option<usize>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum VariableTarget {
+    Current,
+    Var,
+}
+
+pub(crate) fn collect_scopes<T>(
+    cm: Lrc<SourceMap>,
+    node: &T,
+    resolver: SourceResolver,
+    sources_len: usize,
+) -> CollectedScopes
+where
+    T: VisitWith<ScopeCollector>,
+{
+    let mut collector = ScopeCollector::new(cm, resolver, sources_len);
+    node.visit_with(&mut collector);
+    collector.finish()
+}
+
+pub(crate) struct ScopeCollector {
+    cm: Lrc<SourceMap>,
+    resolver: SourceResolver,
+
+    scopes: Vec<CollectedScope>,
+    scope_stack: Vec<usize>,
+    roots_by_source: Vec<Option<usize>>,
+}
+
+impl ScopeCollector {
+    fn new(cm: Lrc<SourceMap>, resolver: SourceResolver, sources_len: usize) -> Self {
+        Self {
+            cm,
+            resolver,
+            scopes: Vec::new(),
+            scope_stack: Vec::new(),
+            roots_by_source: vec![None; sources_len],
+        }
+    }
+
+    fn finish(mut self) -> CollectedScopes {
+        for scope_idx in 0..self.scopes.len() {
+            let Some(source_idx) = self.scopes[scope_idx].source_idx else {
+                continue;
+            };
+
+            let mut top = scope_idx;
+            while let Some(parent) = self.scopes[top].parent {
+                if self.scopes[parent].source_idx == Some(source_idx) {
+                    top = parent;
+                } else {
+                    break;
+                }
+            }
+
+            let root_slot = &mut self.roots_by_source[source_idx as usize];
+            if root_slot.is_none() {
+                *root_slot = Some(top);
+            }
+        }
+
+        CollectedScopes {
+            scopes: self.scopes,
+            roots_by_source: self.roots_by_source,
+        }
+    }
+
+    fn push_scope(
+        &mut self,
+        span: Span,
+        kind: Option<&'static str>,
+        name: Option<String>,
+        is_stack_frame: bool,
+        is_function_boundary: bool,
+    ) {
+        let parent = self.scope_stack.last().copied();
+        let source_idx = self.resolver.source_index_for_pos(&self.cm, span.lo());
+        let start = self.byte_pos_to_scope_position(span.lo());
+        let end = self.byte_pos_to_scope_position(span.hi());
+
+        let scope_idx = self.scopes.len();
+        self.scopes.push(CollectedScope {
+            source_idx,
+            start,
+            end,
+            name,
+            kind: kind.map(str::to_string),
+            is_stack_frame,
+            is_function_boundary,
+            parent,
+            children: Vec::new(),
+            variables: Vec::new(),
+        });
+
+        if let Some(parent_idx) = parent {
+            self.scopes[parent_idx].children.push(scope_idx);
+        } else if let Some(source_idx) = source_idx {
+            let root_slot = &mut self.roots_by_source[source_idx as usize];
+            if root_slot.is_none() {
+                *root_slot = Some(scope_idx);
+            }
+        }
+
+        self.scope_stack.push(scope_idx);
+    }
+
+    fn pop_scope(&mut self) {
+        self.scope_stack.pop();
+    }
+
+    fn byte_pos_to_scope_position(&self, pos: BytePos) -> ScopePosition {
+        match self.cm.try_lookup_char_pos(pos) {
+            Ok(loc) => ScopePosition {
+                line: loc.line.saturating_sub(1) as u32,
+                column: loc.col.0 as u32,
+            },
+            Err(_) => ScopePosition::default(),
+        }
+    }
+
+    fn add_variable(&mut self, name: String, span: Span, target: VariableTarget) {
+        let Some(current) = self.scope_stack.last().copied() else {
+            return;
+        };
+
+        let target_scope = match target {
+            VariableTarget::Current => current,
+            VariableTarget::Var => self.find_var_target_scope(current),
+        };
+
+        if self.scopes[target_scope]
+            .variables
+            .iter()
+            .any(|v| v.name == name)
+        {
+            return;
+        }
+
+        let start = self.byte_pos_to_scope_position(span.lo());
+        let end = self.byte_pos_to_scope_position(span.hi());
+
+        self.scopes[target_scope]
+            .variables
+            .push(CollectedVariable { name, start, end });
+    }
+
+    fn find_var_target_scope(&self, mut scope_idx: usize) -> usize {
+        loop {
+            let scope = &self.scopes[scope_idx];
+            if scope.is_function_boundary {
+                return scope_idx;
+            }
+
+            match scope.parent {
+                Some(parent) => scope_idx = parent,
+                None => return scope_idx,
+            }
+        }
+    }
+
+    fn add_pat_variables(&mut self, pat: &Pat, target: VariableTarget) {
+        collect_pat_bindings(pat, &mut |ident| {
+            self.add_variable(ident.id.sym.to_string(), ident.span, target);
+        });
+    }
+
+    fn add_constructor_param_variables(&mut self, param: &ParamOrTsParamProp) {
+        match param {
+            ParamOrTsParamProp::Param(param) => {
+                self.add_pat_variables(&param.pat, VariableTarget::Current)
+            }
+            ParamOrTsParamProp::TsParamProp(param) => match &param.param {
+                TsParamPropParam::Ident(ident) => self.add_variable(
+                    ident.id.sym.to_string(),
+                    ident.span,
+                    VariableTarget::Current,
+                ),
+                TsParamPropParam::Assign(assign) => {
+                    self.add_pat_variables(&Pat::Assign(assign.clone()), VariableTarget::Current)
+                }
+            },
+        }
+    }
+
+    fn visit_function_like(
+        &mut self,
+        function: &Function,
+        scope_name: Option<String>,
+        function_name_binding: Option<BindingIdent>,
+    ) {
+        self.push_scope(function.span, Some("Function"), scope_name, true, true);
+
+        if let Some(ident) = function_name_binding {
+            self.add_variable(
+                ident.id.sym.to_string(),
+                ident.span,
+                VariableTarget::Current,
+            );
+        }
+
+        for param in &function.params {
+            self.add_pat_variables(&param.pat, VariableTarget::Current);
+        }
+
+        function.visit_children_with(self);
+
+        self.pop_scope();
+    }
+
+    fn prop_name_as_label(name: &PropName) -> Option<String> {
+        match name {
+            PropName::Ident(ident) => Some(ident.sym.to_string()),
+            PropName::Str(s) => Some(s.value.to_string_lossy().into_owned()),
+            PropName::Num(n) => Some(n.value.to_string()),
+            PropName::BigInt(b) => Some(b.value.to_string()),
+            PropName::Computed(_) => None,
+        }
+    }
+}
+
+impl Visit for ScopeCollector {
+    noop_visit_type!();
+
+    fn visit_program(&mut self, n: &Program) {
+        n.visit_children_with(self);
+    }
+
+    fn visit_module(&mut self, n: &Module) {
+        self.push_scope(n.span, Some("Module"), None, false, true);
+        for item in &n.body {
+            item.visit_with(self);
+        }
+        self.pop_scope();
+    }
+
+    fn visit_script(&mut self, n: &Script) {
+        self.push_scope(n.span, Some("Global"), None, false, true);
+        for stmt in &n.body {
+            stmt.visit_with(self);
+        }
+        self.pop_scope();
+    }
+
+    fn visit_fn_decl(&mut self, n: &FnDecl) {
+        self.add_variable(
+            n.ident.sym.to_string(),
+            n.ident.span,
+            VariableTarget::Current,
+        );
+
+        self.visit_function_like(&n.function, Some(n.ident.sym.to_string()), None);
+    }
+
+    fn visit_fn_expr(&mut self, n: &FnExpr) {
+        self.visit_function_like(
+            &n.function,
+            n.ident.as_ref().map(|v| v.sym.to_string()),
+            n.ident.clone().map(From::from),
+        );
+    }
+
+    fn visit_arrow_expr(&mut self, n: &ArrowExpr) {
+        self.push_scope(n.span, Some("Function"), None, true, true);
+
+        for pat in &n.params {
+            self.add_pat_variables(pat, VariableTarget::Current);
+        }
+
+        n.visit_children_with(self);
+
+        self.pop_scope();
+    }
+
+    fn visit_class_decl(&mut self, n: &ClassDecl) {
+        self.add_variable(
+            n.ident.sym.to_string(),
+            n.ident.span,
+            VariableTarget::Current,
+        );
+
+        self.push_scope(
+            n.class.span,
+            Some("Class"),
+            Some(n.ident.sym.to_string()),
+            false,
+            false,
+        );
+        n.class.visit_children_with(self);
+        self.pop_scope();
+    }
+
+    fn visit_class_expr(&mut self, n: &ClassExpr) {
+        self.push_scope(
+            n.class.span,
+            Some("Class"),
+            n.ident.as_ref().map(|v| v.sym.to_string()),
+            false,
+            false,
+        );
+
+        if let Some(ident) = &n.ident {
+            self.add_variable(ident.sym.to_string(), ident.span, VariableTarget::Current);
+        }
+
+        n.class.visit_children_with(self);
+        self.pop_scope();
+    }
+
+    fn visit_class_method(&mut self, n: &ClassMethod) {
+        self.visit_function_like(&n.function, Self::prop_name_as_label(&n.key), None);
+    }
+
+    fn visit_private_method(&mut self, n: &PrivateMethod) {
+        self.visit_function_like(&n.function, Some(n.key.name.to_string()), None);
+    }
+
+    fn visit_constructor(&mut self, n: &Constructor) {
+        self.push_scope(
+            n.span,
+            Some("Function"),
+            Some("constructor".into()),
+            true,
+            true,
+        );
+
+        for param in &n.params {
+            self.add_constructor_param_variables(param);
+            param.visit_with(self);
+        }
+
+        if let Some(body) = &n.body {
+            body.visit_with(self);
+        }
+
+        self.pop_scope();
+    }
+
+    fn visit_method_prop(&mut self, n: &MethodProp) {
+        self.visit_function_like(&n.function, Self::prop_name_as_label(&n.key), None);
+    }
+
+    fn visit_getter_prop(&mut self, n: &GetterProp) {
+        self.push_scope(
+            n.span,
+            Some("Function"),
+            Self::prop_name_as_label(&n.key),
+            true,
+            true,
+        );
+
+        if let Some(body) = &n.body {
+            body.visit_with(self);
+        }
+
+        self.pop_scope();
+    }
+
+    fn visit_setter_prop(&mut self, n: &SetterProp) {
+        self.push_scope(
+            n.span,
+            Some("Function"),
+            Self::prop_name_as_label(&n.key),
+            true,
+            true,
+        );
+
+        self.add_pat_variables(&n.param, VariableTarget::Current);
+
+        if let Some(body) = &n.body {
+            body.visit_with(self);
+        }
+
+        self.pop_scope();
+    }
+
+    fn visit_static_block(&mut self, n: &StaticBlock) {
+        self.push_scope(n.span, Some("Block"), None, false, false);
+        for stmt in &n.body.stmts {
+            stmt.visit_with(self);
+        }
+        self.pop_scope();
+    }
+
+    fn visit_block_stmt(&mut self, n: &swc_ecma_ast::BlockStmt) {
+        self.push_scope(n.span, Some("Block"), None, false, false);
+        for stmt in &n.stmts {
+            stmt.visit_with(self);
+        }
+        self.pop_scope();
+    }
+
+    fn visit_catch_clause(&mut self, n: &CatchClause) {
+        self.push_scope(n.span, Some("Block"), None, false, false);
+
+        if let Some(param) = &n.param {
+            self.add_pat_variables(param, VariableTarget::Current);
+        }
+
+        for stmt in &n.body.stmts {
+            stmt.visit_with(self);
+        }
+
+        self.pop_scope();
+    }
+
+    fn visit_var_decl(&mut self, n: &VarDecl) {
+        let target = if n.kind == VarDeclKind::Var {
+            VariableTarget::Var
+        } else {
+            VariableTarget::Current
+        };
+
+        for decl in &n.decls {
+            self.add_pat_variables(&decl.name, target);
+            if let Some(init) = &decl.init {
+                init.visit_with(self);
+            }
+        }
+    }
+
+    fn visit_import_decl(&mut self, n: &ImportDecl) {
+        for specifier in &n.specifiers {
+            match specifier {
+                ImportSpecifier::Named(named) => {
+                    self.add_variable(
+                        named.local.sym.to_string(),
+                        named.local.span,
+                        VariableTarget::Current,
+                    );
+                }
+                ImportSpecifier::Default(default) => {
+                    self.add_variable(
+                        default.local.sym.to_string(),
+                        default.local.span,
+                        VariableTarget::Current,
+                    );
+                }
+                ImportSpecifier::Namespace(namespace) => {
+                    self.add_variable(
+                        namespace.local.sym.to_string(),
+                        namespace.local.span,
+                        VariableTarget::Current,
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn collect_pat_bindings<'a>(pat: &'a Pat, op: &mut impl FnMut(&'a BindingIdent)) {
+    match pat {
+        Pat::Ident(ident) => op(ident),
+        Pat::Array(array) => {
+            for elem in array.elems.iter().flatten() {
+                collect_pat_bindings(elem, op);
+            }
+        }
+        Pat::Object(object) => {
+            for prop in &object.props {
+                match prop {
+                    ObjectPatProp::KeyValue(key_value) => {
+                        collect_pat_bindings(&key_value.value, op);
+                    }
+                    ObjectPatProp::Assign(assign) => op(&assign.key),
+                    ObjectPatProp::Rest(rest) => collect_pat_bindings(&rest.arg, op),
+                }
+            }
+        }
+        Pat::Assign(assign) => collect_pat_bindings(&assign.left, op),
+        Pat::Rest(rest) => collect_pat_bindings(&rest.arg, op),
+        Pat::Expr(_) | Pat::Invalid(_) => {}
+    }
+}

--- a/crates/swc_compiler_base/src/source_map_scopes/encode.rs
+++ b/crates/swc_compiler_base/src/source_map_scopes/encode.rs
@@ -1,0 +1,582 @@
+use anyhow::{bail, Context, Error};
+use rustc_hash::FxHashMap;
+
+use crate::source_map_scopes::vlq::{encode_signed_to, encode_unsigned_to};
+
+const TAG_EMPTY: &str = "A";
+const TAG_ORIGINAL_SCOPE_START: &str = "B";
+const TAG_ORIGINAL_SCOPE_END: &str = "C";
+const TAG_ORIGINAL_SCOPE_VARIABLES: &str = "D";
+const TAG_GENERATED_RANGE_START: &str = "E";
+const TAG_GENERATED_RANGE_END: &str = "F";
+const TAG_GENERATED_RANGE_BINDINGS: &str = "G";
+const TAG_GENERATED_RANGE_SUBRANGE_BINDING: &str = "H";
+const TAG_GENERATED_RANGE_CALL_SITE: &str = "I";
+
+const ORIGINAL_SCOPE_FLAG_HAS_NAME: u32 = 0x1;
+const ORIGINAL_SCOPE_FLAG_HAS_KIND: u32 = 0x2;
+const ORIGINAL_SCOPE_FLAG_IS_STACK_FRAME: u32 = 0x4;
+
+const GENERATED_RANGE_FLAG_HAS_LINE: u32 = 0x1;
+const GENERATED_RANGE_FLAG_HAS_DEFINITION: u32 = 0x2;
+const GENERATED_RANGE_FLAG_IS_STACK_FRAME: u32 = 0x4;
+const GENERATED_RANGE_FLAG_IS_HIDDEN: u32 = 0x8;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct ScopePosition {
+    pub line: u32,
+    pub column: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct OriginalScope {
+    pub id: usize,
+    pub start: ScopePosition,
+    pub end: ScopePosition,
+    pub name: Option<String>,
+    pub kind: Option<String>,
+    pub is_stack_frame: bool,
+    pub variables: Vec<String>,
+    pub children: Vec<OriginalScope>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct GeneratedRange {
+    pub start: ScopePosition,
+    pub end: ScopePosition,
+    pub is_stack_frame: bool,
+    pub is_hidden: bool,
+    pub original_scope_id: Option<usize>,
+    pub callsite: Option<Callsite>,
+    pub values: Vec<BindingValue>,
+    pub children: Vec<GeneratedRange>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct Callsite {
+    pub source_idx: u32,
+    pub line: u32,
+    pub column: u32,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum BindingValue {
+    Simple(Option<String>),
+    WithSubRanges {
+        initial: Option<String>,
+        transitions: Vec<BindingTransition>,
+    },
+}
+
+impl BindingValue {
+    fn initial_value(&self) -> Option<&str> {
+        match self {
+            BindingValue::Simple(value) => value.as_deref(),
+            BindingValue::WithSubRanges { initial, .. } => initial.as_deref(),
+        }
+    }
+
+    fn transitions(&self) -> &[BindingTransition] {
+        match self {
+            BindingValue::Simple(_) => &[],
+            BindingValue::WithSubRanges { transitions, .. } => transitions,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BindingTransition {
+    pub from: ScopePosition,
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ScopeInfo {
+    pub scopes: Vec<Option<OriginalScope>>,
+    pub ranges: Vec<GeneratedRange>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct ScopeState {
+    line: i64,
+    column: i64,
+    name: i64,
+    kind: i64,
+    variable: i64,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct RangeState {
+    line: i64,
+    column: i64,
+    definition: i64,
+}
+
+#[derive(Debug)]
+struct Encoder<'a> {
+    names: &'a mut Vec<String>,
+    names_to_idx: FxHashMap<String, i64>,
+
+    scope_state: ScopeState,
+    range_state: RangeState,
+
+    items: Vec<String>,
+    current: String,
+
+    scope_to_definition_idx: FxHashMap<usize, i64>,
+    scope_counter: i64,
+}
+
+impl<'a> Encoder<'a> {
+    fn new(names: &'a mut Vec<String>) -> Self {
+        let mut names_to_idx = FxHashMap::default();
+        for (idx, name) in names.iter().enumerate() {
+            names_to_idx.insert(name.clone(), idx as i64);
+        }
+
+        Self {
+            names,
+            names_to_idx,
+            scope_state: ScopeState::default(),
+            range_state: RangeState::default(),
+            items: Vec::new(),
+            current: String::new(),
+            scope_to_definition_idx: FxHashMap::default(),
+            scope_counter: 0,
+        }
+    }
+
+    fn encode(mut self, info: &ScopeInfo) -> Result<String, Error> {
+        for scope in &info.scopes {
+            self.scope_state.line = 0;
+            self.scope_state.column = 0;
+
+            match scope {
+                Some(scope) => self.encode_original_scope(scope)?,
+                None => self.items.push(TAG_EMPTY.to_string()),
+            }
+        }
+
+        for range in &info.ranges {
+            self.encode_generated_range(range)?;
+        }
+
+        Ok(self.items.join(","))
+    }
+
+    fn encode_original_scope(&mut self, scope: &OriginalScope) -> Result<(), Error> {
+        self.current.clear();
+        self.current.push_str(TAG_ORIGINAL_SCOPE_START);
+
+        let mut flags = 0;
+        if scope.name.is_some() {
+            flags |= ORIGINAL_SCOPE_FLAG_HAS_NAME;
+        }
+        if scope.kind.is_some() {
+            flags |= ORIGINAL_SCOPE_FLAG_HAS_KIND;
+        }
+        if scope.is_stack_frame {
+            flags |= ORIGINAL_SCOPE_FLAG_IS_STACK_FRAME;
+        }
+
+        encode_unsigned_to(&mut self.current, i64::from(flags));
+
+        let line = i64::from(scope.start.line);
+        let col = i64::from(scope.start.column);
+        let line_delta = line - self.scope_state.line;
+        if line_delta < 0 {
+            bail!("original scope starts out of order")
+        }
+        encode_unsigned_to(&mut self.current, line_delta);
+        if line_delta == 0 {
+            let col_delta = col - self.scope_state.column;
+            if col_delta < 0 {
+                bail!("original scope columns out of order")
+            }
+            encode_unsigned_to(&mut self.current, col_delta);
+        } else {
+            encode_unsigned_to(&mut self.current, col);
+        }
+        self.scope_state.line = line;
+        self.scope_state.column = col;
+
+        if let Some(name) = &scope.name {
+            let idx = self.resolve_name_idx(name);
+            encode_signed_to(&mut self.current, idx - self.scope_state.name);
+            self.scope_state.name = idx;
+        }
+
+        if let Some(kind) = &scope.kind {
+            let idx = self.resolve_name_idx(kind);
+            encode_signed_to(&mut self.current, idx - self.scope_state.kind);
+            self.scope_state.kind = idx;
+        }
+
+        self.finish_item();
+
+        self.scope_to_definition_idx
+            .insert(scope.id, self.scope_counter);
+        self.scope_counter += 1;
+
+        if !scope.variables.is_empty() {
+            self.current.clear();
+            self.current.push_str(TAG_ORIGINAL_SCOPE_VARIABLES);
+
+            for variable in &scope.variables {
+                let idx = self.resolve_name_idx(variable);
+                encode_signed_to(&mut self.current, idx - self.scope_state.variable);
+                self.scope_state.variable = idx;
+            }
+
+            self.finish_item();
+        }
+
+        for child in &scope.children {
+            self.encode_original_scope(child)?;
+        }
+
+        self.current.clear();
+        self.current.push_str(TAG_ORIGINAL_SCOPE_END);
+
+        let end_line = i64::from(scope.end.line);
+        let end_col = i64::from(scope.end.column);
+        let end_line_delta = end_line - self.scope_state.line;
+        if end_line_delta < 0 {
+            bail!("original scope end out of order")
+        }
+        encode_unsigned_to(&mut self.current, end_line_delta);
+        if end_line_delta == 0 {
+            let end_col_delta = end_col - self.scope_state.column;
+            if end_col_delta < 0 {
+                bail!("original scope end columns out of order")
+            }
+            encode_unsigned_to(&mut self.current, end_col_delta);
+        } else {
+            encode_unsigned_to(&mut self.current, end_col);
+        }
+
+        self.scope_state.line = end_line;
+        self.scope_state.column = end_col;
+
+        self.finish_item();
+
+        Ok(())
+    }
+
+    fn encode_generated_range(&mut self, range: &GeneratedRange) -> Result<(), Error> {
+        self.current.clear();
+        self.current.push_str(TAG_GENERATED_RANGE_START);
+
+        let start_line = i64::from(range.start.line);
+        let start_col = i64::from(range.start.column);
+
+        let line_delta = start_line - self.range_state.line;
+        if line_delta < 0 {
+            bail!("generated range starts out of order")
+        }
+
+        let mut flags = 0;
+        if line_delta > 0 {
+            flags |= GENERATED_RANGE_FLAG_HAS_LINE;
+        }
+        if range.original_scope_id.is_some() {
+            flags |= GENERATED_RANGE_FLAG_HAS_DEFINITION;
+        }
+        if range.is_stack_frame {
+            flags |= GENERATED_RANGE_FLAG_IS_STACK_FRAME;
+        }
+        if range.is_hidden {
+            flags |= GENERATED_RANGE_FLAG_IS_HIDDEN;
+        }
+
+        encode_unsigned_to(&mut self.current, i64::from(flags));
+
+        if line_delta > 0 {
+            encode_unsigned_to(&mut self.current, line_delta);
+            encode_unsigned_to(&mut self.current, start_col);
+        } else {
+            let col_delta = start_col - self.range_state.column;
+            if col_delta < 0 {
+                bail!("generated range columns out of order")
+            }
+            encode_unsigned_to(&mut self.current, col_delta);
+        }
+
+        self.range_state.line = start_line;
+        self.range_state.column = start_col;
+
+        if let Some(scope_id) = range.original_scope_id {
+            let def_idx = *self
+                .scope_to_definition_idx
+                .get(&scope_id)
+                .with_context(|| format!("unknown original scope id: {scope_id}"))?;
+            encode_signed_to(&mut self.current, def_idx - self.range_state.definition);
+            self.range_state.definition = def_idx;
+        }
+
+        self.finish_item();
+
+        self.encode_generated_bindings(range)?;
+        self.encode_generated_sub_range_bindings(range)?;
+
+        if let Some(callsite) = range.callsite {
+            self.current.clear();
+            self.current.push_str(TAG_GENERATED_RANGE_CALL_SITE);
+            encode_unsigned_to(&mut self.current, i64::from(callsite.source_idx));
+            encode_unsigned_to(&mut self.current, i64::from(callsite.line));
+            encode_unsigned_to(&mut self.current, i64::from(callsite.column));
+            self.finish_item();
+        }
+
+        for child in &range.children {
+            self.encode_generated_range(child)?;
+        }
+
+        self.current.clear();
+        self.current.push_str(TAG_GENERATED_RANGE_END);
+
+        let end_line = i64::from(range.end.line);
+        let end_col = i64::from(range.end.column);
+        let end_line_delta = end_line - self.range_state.line;
+        if end_line_delta < 0 {
+            bail!("generated range end out of order")
+        }
+
+        if end_line_delta > 0 {
+            encode_unsigned_to(&mut self.current, end_line_delta);
+            encode_unsigned_to(&mut self.current, end_col);
+        } else {
+            let end_col_delta = end_col - self.range_state.column;
+            if end_col_delta < 0 {
+                bail!("generated range end columns out of order")
+            }
+            encode_unsigned_to(&mut self.current, end_col_delta);
+        }
+
+        self.range_state.line = end_line;
+        self.range_state.column = end_col;
+
+        self.finish_item();
+
+        Ok(())
+    }
+
+    fn encode_generated_bindings(&mut self, range: &GeneratedRange) -> Result<(), Error> {
+        if range.values.is_empty() {
+            return Ok(());
+        }
+
+        if range.original_scope_id.is_none() {
+            bail!("generated range has bindings but no original scope definition");
+        }
+
+        self.current.clear();
+        self.current.push_str(TAG_GENERATED_RANGE_BINDINGS);
+
+        for binding in &range.values {
+            let encoded = match binding.initial_value() {
+                Some(value) => self.resolve_name_idx(value) + 1,
+                None => 0,
+            };
+            encode_unsigned_to(&mut self.current, encoded);
+        }
+
+        self.finish_item();
+
+        Ok(())
+    }
+
+    fn encode_generated_sub_range_bindings(&mut self, range: &GeneratedRange) -> Result<(), Error> {
+        if range.values.is_empty() {
+            return Ok(());
+        }
+
+        let mut prev_variable_idx = 0i64;
+
+        for (variable_idx, binding) in range.values.iter().enumerate() {
+            let transitions = binding.transitions();
+            if transitions.is_empty() {
+                continue;
+            }
+
+            self.current.clear();
+            self.current.push_str(TAG_GENERATED_RANGE_SUBRANGE_BINDING);
+
+            let variable_idx = variable_idx as i64;
+            let delta = variable_idx - prev_variable_idx;
+            if delta < 0 {
+                bail!("generated range sub-range binding index order is invalid");
+            }
+            encode_unsigned_to(&mut self.current, delta);
+            prev_variable_idx = variable_idx;
+
+            let mut prev_line = i64::from(range.start.line);
+            let mut prev_col = i64::from(range.start.column);
+
+            for transition in transitions {
+                let encoded_binding = match &transition.value {
+                    Some(value) => self.resolve_name_idx(value) + 1,
+                    None => 0,
+                };
+                encode_unsigned_to(&mut self.current, encoded_binding);
+
+                let line = i64::from(transition.from.line);
+                let col = i64::from(transition.from.column);
+                let line_delta = line - prev_line;
+                if line_delta < 0 {
+                    bail!("generated range sub-range bindings must be sorted");
+                }
+                encode_unsigned_to(&mut self.current, line_delta);
+
+                if line_delta == 0 {
+                    let col_delta = col - prev_col;
+                    if col_delta < 0 {
+                        bail!("generated range sub-range binding columns must be sorted");
+                    }
+                    encode_unsigned_to(&mut self.current, col_delta);
+                } else {
+                    encode_unsigned_to(&mut self.current, col);
+                }
+
+                prev_line = line;
+                prev_col = col;
+            }
+
+            self.finish_item();
+        }
+
+        Ok(())
+    }
+
+    fn resolve_name_idx(&mut self, value: &str) -> i64 {
+        if let Some(idx) = self.names_to_idx.get(value) {
+            return *idx;
+        }
+
+        let idx = self.names.len() as i64;
+        let owned = value.to_string();
+        self.names.push(owned.clone());
+        self.names_to_idx.insert(owned, idx);
+        idx
+    }
+
+    fn finish_item(&mut self) {
+        self.items.push(std::mem::take(&mut self.current));
+    }
+}
+
+pub(crate) fn encode_scopes(info: &ScopeInfo, names: &mut Vec<String>) -> Result<String, Error> {
+    Encoder::new(names).encode(info)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_empty_original_scopes() {
+        let mut names = Vec::new();
+        let info = ScopeInfo {
+            scopes: vec![None, None, None],
+            ranges: vec![],
+        };
+
+        assert_eq!(encode_scopes(&info, &mut names).unwrap(), "A,A,A");
+        assert!(names.is_empty());
+    }
+
+    #[test]
+    fn encode_simple_original_scope() {
+        let mut names = Vec::new();
+        let info = ScopeInfo {
+            scopes: vec![
+                Some(OriginalScope {
+                    id: 0,
+                    start: ScopePosition { line: 0, column: 0 },
+                    end: ScopePosition { line: 0, column: 1 },
+                    name: None,
+                    kind: None,
+                    is_stack_frame: false,
+                    variables: vec![],
+                    children: vec![],
+                }),
+                Some(OriginalScope {
+                    id: 1,
+                    start: ScopePosition { line: 0, column: 0 },
+                    end: ScopePosition { line: 0, column: 2 },
+                    name: None,
+                    kind: None,
+                    is_stack_frame: false,
+                    variables: vec![],
+                    children: vec![],
+                }),
+            ],
+            ranges: vec![],
+        };
+
+        assert_eq!(
+            encode_scopes(&info, &mut names).unwrap(),
+            "BAAA,CAB,BAAA,CAC"
+        );
+    }
+
+    #[test]
+    fn encode_bindings_and_sub_ranges() {
+        let mut names = Vec::new();
+        let info = ScopeInfo {
+            scopes: vec![Some(OriginalScope {
+                id: 10,
+                start: ScopePosition { line: 0, column: 0 },
+                end: ScopePosition {
+                    line: 0,
+                    column: 10,
+                },
+                name: Some("foo".into()),
+                kind: Some("Function".into()),
+                is_stack_frame: true,
+                variables: vec!["x".into()],
+                children: vec![],
+            })],
+            ranges: vec![GeneratedRange {
+                start: ScopePosition { line: 0, column: 0 },
+                end: ScopePosition {
+                    line: 0,
+                    column: 10,
+                },
+                is_stack_frame: true,
+                is_hidden: false,
+                original_scope_id: Some(10),
+                callsite: None,
+                values: vec![BindingValue::WithSubRanges {
+                    initial: Some("a".into()),
+                    transitions: vec![
+                        BindingTransition {
+                            from: ScopePosition { line: 0, column: 5 },
+                            value: Some("b".into()),
+                        },
+                        BindingTransition {
+                            from: ScopePosition { line: 0, column: 8 },
+                            value: None,
+                        },
+                    ],
+                }],
+                children: vec![],
+            }],
+        };
+
+        let encoded = encode_scopes(&info, &mut names).unwrap();
+
+        assert!(encoded.contains('B'));
+        assert!(encoded.contains('D'));
+        assert!(encoded.contains('E'));
+        assert!(encoded.contains('G'));
+        assert!(encoded.contains('H'));
+        assert!(encoded.contains('F'));
+
+        assert!(names.contains(&"foo".to_string()));
+        assert!(names.contains(&"Function".to_string()));
+        assert!(names.contains(&"x".to_string()));
+        assert!(names.contains(&"a".to_string()));
+        assert!(names.contains(&"b".to_string()));
+    }
+}

--- a/crates/swc_compiler_base/src/source_map_scopes/mod.rs
+++ b/crates/swc_compiler_base/src/source_map_scopes/mod.rs
@@ -1,0 +1,360 @@
+use std::{
+    any::Any,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Error};
+use rustc_hash::FxHashMap;
+use serde_json::{Map, Value};
+use swc_common::{sync::Lrc, BytePos, FileName, SourceMap};
+use swc_ecma_ast::{Module, Program, Script};
+use swc_ecma_codegen::Node;
+use swc_ecma_visit::VisitWith;
+
+use self::{
+    bindings::build_scope_bindings,
+    collect::{collect_scopes, CollectedScopes, ScopeCollector},
+    encode::{encode_scopes, GeneratedRange, OriginalScope, ScopeInfo, ScopePosition},
+    positions::{build_mapping_index, resolve_generated_interval, MappingIndex},
+};
+
+mod bindings;
+pub(crate) mod collect;
+mod encode;
+mod positions;
+#[cfg(test)]
+mod tests;
+mod vlq;
+
+#[derive(Debug, Clone)]
+pub(crate) struct SourceResolver {
+    source_file_name: Option<String>,
+    output_path: Option<PathBuf>,
+    source_to_idx: FxHashMap<String, u32>,
+}
+
+impl SourceResolver {
+    pub(crate) fn new(
+        source_file_name: Option<&str>,
+        output_path: Option<&Path>,
+        sources: &[String],
+    ) -> Self {
+        let mut source_to_idx = FxHashMap::default();
+        for (idx, source) in sources.iter().enumerate() {
+            source_to_idx.entry(source.clone()).or_insert(idx as u32);
+        }
+
+        Self {
+            source_file_name: source_file_name.map(str::to_string),
+            output_path: output_path.map(Path::to_path_buf),
+            source_to_idx,
+        }
+    }
+
+    pub(crate) fn source_index_for_pos(&self, cm: &SourceMap, pos: BytePos) -> Option<u32> {
+        let file = cm.try_lookup_source_file(pos).ok().flatten()?;
+        if self.skip(&file.name) {
+            return None;
+        }
+
+        let source = self.file_name_to_source(&file.name);
+        self.source_to_idx.get(&source).copied()
+    }
+
+    fn file_name_to_source(&self, file_name: &FileName) -> String {
+        if let Some(source_file_name) = &self.source_file_name {
+            return source_file_name.clone();
+        }
+
+        let Some(base_path) = self.output_path.as_ref().and_then(|v| v.parent()) else {
+            return file_name.to_string();
+        };
+        let target = match file_name {
+            FileName::Real(path) => path,
+            _ => return file_name.to_string(),
+        };
+
+        match pathdiff::diff_paths(target, base_path) {
+            Some(path) => {
+                let path = path.to_string_lossy().to_string();
+                if cfg!(target_os = "windows") {
+                    path.replace('\\', "/")
+                } else {
+                    path
+                }
+            }
+            None => file_name.to_string(),
+        }
+    }
+
+    fn skip(&self, file_name: &FileName) -> bool {
+        match file_name {
+            FileName::Internal(..) => true,
+            FileName::Custom(name) => name.starts_with('<'),
+            _ => false,
+        }
+    }
+}
+
+pub(crate) fn augment_source_map_with_scopes(
+    cm: Lrc<SourceMap>,
+    node: &dyn Any,
+    map: &swc_sourcemap::SourceMap,
+    serialized_map: &str,
+    source_file_name: Option<&str>,
+    output_path: Option<&Path>,
+) -> Result<String, Error> {
+    if let Some(program) = node.downcast_ref::<Program>() {
+        return augment_source_map_with_scopes_for_node(
+            cm,
+            program,
+            map,
+            serialized_map,
+            source_file_name,
+            output_path,
+        );
+    }
+
+    if let Some(module) = node.downcast_ref::<Module>() {
+        return augment_source_map_with_scopes_for_node(
+            cm,
+            module,
+            map,
+            serialized_map,
+            source_file_name,
+            output_path,
+        );
+    }
+
+    if let Some(script) = node.downcast_ref::<Script>() {
+        return augment_source_map_with_scopes_for_node(
+            cm,
+            script,
+            map,
+            serialized_map,
+            source_file_name,
+            output_path,
+        );
+    }
+
+    Ok(serialized_map.to_string())
+}
+
+fn augment_source_map_with_scopes_for_node<T>(
+    cm: Lrc<SourceMap>,
+    node: &T,
+    map: &swc_sourcemap::SourceMap,
+    serialized_map: &str,
+    source_file_name: Option<&str>,
+    output_path: Option<&Path>,
+) -> Result<String, Error>
+where
+    T: Node + VisitWith<ScopeCollector>,
+{
+    let mut json = serde_json::from_str::<Value>(serialized_map)
+        .context("failed to parse generated source map json")?;
+    let object = json
+        .as_object_mut()
+        .context("generated source map should be a json object")?;
+
+    let sources = get_string_array(object, "sources");
+    let mut names = get_string_array(object, "names");
+
+    let resolver = SourceResolver::new(source_file_name, output_path, &sources);
+    let collected = collect_scopes(cm, node, resolver, sources.len());
+    let mapping_index = build_mapping_index(map, sources.len());
+
+    let (scopes, original_scope_ids) = build_original_scopes(&collected, sources.len());
+    let ranges = build_generated_ranges(&collected, &original_scope_ids, &mapping_index);
+    let scope_info = ScopeInfo { scopes, ranges };
+
+    let scopes = encode_scopes(&scope_info, &mut names).context("failed to encode scopes")?;
+
+    object.insert("names".into(), Value::Array(to_value_array(names)));
+    object.insert("scopes".into(), Value::String(scopes));
+
+    serde_json::to_string(&json).context("failed to serialize source map with scopes")
+}
+
+fn get_string_array(object: &Map<String, Value>, key: &str) -> Vec<String> {
+    object
+        .get(key)
+        .and_then(Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter_map(Value::as_str)
+        .map(str::to_string)
+        .collect()
+}
+
+fn to_value_array(items: Vec<String>) -> Vec<Value> {
+    items.into_iter().map(Value::String).collect()
+}
+
+fn build_original_scopes(
+    collected: &CollectedScopes,
+    sources_len: usize,
+) -> (Vec<Option<OriginalScope>>, Vec<Option<usize>>) {
+    let mut scopes = vec![None; sources_len];
+    let mut next_scope_id = 0usize;
+    let mut scope_ids = vec![None; collected.scopes.len()];
+
+    for (source_idx, scope_slot) in scopes.iter_mut().enumerate().take(sources_len) {
+        let Some(root_idx) = collected.roots_by_source[source_idx] else {
+            continue;
+        };
+
+        *scope_slot = Some(build_original_scope(
+            collected,
+            root_idx,
+            source_idx as u32,
+            &mut next_scope_id,
+            &mut scope_ids,
+        ));
+    }
+
+    (scopes, scope_ids)
+}
+
+fn build_original_scope(
+    collected: &CollectedScopes,
+    scope_idx: usize,
+    source_idx: u32,
+    next_scope_id: &mut usize,
+    scope_ids: &mut [Option<usize>],
+) -> OriginalScope {
+    let scope = &collected.scopes[scope_idx];
+    let current_scope_id = *next_scope_id;
+    *next_scope_id += 1;
+    scope_ids[scope_idx] = Some(current_scope_id);
+
+    let mut children = scope
+        .children
+        .iter()
+        .copied()
+        .filter(|child_idx| collected.scopes[*child_idx].source_idx == Some(source_idx))
+        .map(|child_idx| {
+            build_original_scope(collected, child_idx, source_idx, next_scope_id, scope_ids)
+        })
+        .collect::<Vec<_>>();
+
+    children.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| a.end.cmp(&b.end)));
+
+    OriginalScope {
+        id: current_scope_id,
+        start: scope.start,
+        end: scope.end,
+        name: scope.name.clone(),
+        kind: scope.kind.clone(),
+        is_stack_frame: scope.is_stack_frame,
+        variables: scope.variables.iter().map(|v| v.name.clone()).collect(),
+        children,
+    }
+}
+
+fn build_generated_ranges(
+    collected: &CollectedScopes,
+    original_scope_ids: &[Option<usize>],
+    mapping_index: &MappingIndex,
+) -> Vec<GeneratedRange> {
+    let mut ranges = Vec::new();
+
+    for (scope_idx, scope) in collected.scopes.iter().enumerate() {
+        let Some(source_idx) = scope.source_idx else {
+            continue;
+        };
+        let Some(original_scope_id) = original_scope_ids[scope_idx] else {
+            continue;
+        };
+
+        let Some(interval) =
+            resolve_generated_interval(mapping_index, source_idx, scope.start, scope.end)
+        else {
+            continue;
+        };
+
+        ranges.push(GeneratedRange {
+            start: interval.start,
+            end: interval.end,
+            is_stack_frame: scope.is_stack_frame,
+            is_hidden: false,
+            original_scope_id: Some(original_scope_id),
+            callsite: None,
+            values: build_scope_bindings(
+                scope,
+                source_idx,
+                interval.start,
+                interval.end,
+                mapping_index,
+            ),
+            children: Vec::new(),
+        });
+    }
+
+    ranges.sort_by(|a, b| a.start.cmp(&b.start).then_with(|| b.end.cmp(&a.end)));
+
+    let mut roots = Vec::new();
+    for range in ranges {
+        insert_generated_range(&mut roots, range);
+    }
+
+    roots
+}
+
+fn insert_generated_range(target: &mut Vec<GeneratedRange>, mut candidate: GeneratedRange) {
+    normalize_range(&mut candidate);
+
+    for child in target.iter_mut() {
+        if range_contains(child, &candidate) {
+            insert_generated_range(&mut child.children, candidate);
+            return;
+        }
+
+        if range_overlaps(child, &candidate) {
+            return;
+        }
+    }
+
+    let mut idx = 0;
+    while idx < target.len() {
+        if range_contains(&candidate, &target[idx]) {
+            let existing = target.remove(idx);
+            candidate.children.push(existing);
+            continue;
+        }
+
+        if range_overlaps(&candidate, &target[idx]) {
+            return;
+        }
+
+        idx += 1;
+    }
+
+    candidate
+        .children
+        .sort_by(|a, b| a.start.cmp(&b.start).then_with(|| b.end.cmp(&a.end)));
+
+    let insert_at = target.partition_point(|item| item.start <= candidate.start);
+    target.insert(insert_at, candidate);
+}
+
+fn normalize_range(range: &mut GeneratedRange) {
+    if range.end <= range.start {
+        range.end = bump_position(range.start);
+    }
+}
+
+fn bump_position(pos: ScopePosition) -> ScopePosition {
+    ScopePosition {
+        line: pos.line,
+        column: pos.column.saturating_add(1),
+    }
+}
+
+fn range_contains(parent: &GeneratedRange, child: &GeneratedRange) -> bool {
+    parent.start <= child.start && child.end <= parent.end
+}
+
+fn range_overlaps(lhs: &GeneratedRange, rhs: &GeneratedRange) -> bool {
+    lhs.start < rhs.end && rhs.start < lhs.end
+}

--- a/crates/swc_compiler_base/src/source_map_scopes/positions.rs
+++ b/crates/swc_compiler_base/src/source_map_scopes/positions.rs
@@ -1,0 +1,155 @@
+use super::encode::ScopePosition;
+
+#[derive(Debug, Clone)]
+pub(crate) struct MappingPoint {
+    pub original: ScopePosition,
+    pub generated: ScopePosition,
+    pub generated_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct MappingIndex {
+    per_source: Vec<Vec<MappingPoint>>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct GeneratedInterval {
+    pub start: ScopePosition,
+    pub end: ScopePosition,
+}
+
+impl MappingIndex {
+    pub(crate) fn source_points(&self, source_idx: u32) -> &[MappingPoint] {
+        self.per_source
+            .get(source_idx as usize)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn from_points(per_source: Vec<Vec<MappingPoint>>) -> Self {
+        Self { per_source }
+    }
+}
+
+pub(crate) fn build_mapping_index(
+    map: &swc_sourcemap::SourceMap,
+    sources_len: usize,
+) -> MappingIndex {
+    let mut per_source = vec![Vec::new(); sources_len];
+
+    for token in map.tokens() {
+        if !token.has_source() {
+            continue;
+        }
+
+        let source_idx = token.get_src_id() as usize;
+        if source_idx >= sources_len {
+            continue;
+        }
+
+        let src_line = token.get_src_line();
+        let src_col = token.get_src_col();
+        if src_line == u32::MAX || src_col == u32::MAX {
+            continue;
+        }
+
+        per_source[source_idx].push(MappingPoint {
+            original: ScopePosition {
+                line: src_line,
+                column: src_col,
+            },
+            generated: ScopePosition {
+                line: token.get_dst_line(),
+                column: token.get_dst_col(),
+            },
+            generated_name: token.get_name().map(|name| name.to_string()),
+        });
+    }
+
+    for points in &mut per_source {
+        points.sort_by(|a, b| {
+            a.original
+                .cmp(&b.original)
+                .then_with(|| a.generated.cmp(&b.generated))
+        });
+        points.dedup_by(|a, b| {
+            a.original == b.original
+                && a.generated == b.generated
+                && a.generated_name == b.generated_name
+        });
+    }
+
+    MappingIndex { per_source }
+}
+
+pub(crate) fn resolve_generated_interval(
+    mappings: &MappingIndex,
+    source_idx: u32,
+    start: ScopePosition,
+    end: ScopePosition,
+) -> Option<GeneratedInterval> {
+    let points = mappings.source_points(source_idx);
+    if points.is_empty() {
+        return None;
+    }
+
+    let mut min_generated = None;
+    let mut max_generated = None;
+
+    for point in points_in_original_range(mappings, source_idx, start, end) {
+        min_generated = Some(match min_generated {
+            Some(current) => std::cmp::min(current, point.generated),
+            None => point.generated,
+        });
+        max_generated = Some(match max_generated {
+            Some(current) => std::cmp::max(current, point.generated),
+            None => point.generated,
+        });
+    }
+
+    let start = min_generated?;
+    let mut end = bump_position(max_generated?);
+    if end <= start {
+        end = bump_position(start);
+    }
+
+    Some(GeneratedInterval { start, end })
+}
+
+pub(crate) fn points_in_original_range(
+    mappings: &MappingIndex,
+    source_idx: u32,
+    start: ScopePosition,
+    end: ScopePosition,
+) -> Vec<&MappingPoint> {
+    let points = mappings.source_points(source_idx);
+    if points.is_empty() {
+        return Vec::new();
+    }
+
+    let mut rv = Vec::new();
+    let mut idx = points.partition_point(|point| point.original < start);
+
+    while idx < points.len() && points[idx].original <= end {
+        rv.push(&points[idx]);
+        idx += 1;
+    }
+
+    rv
+}
+
+pub(crate) fn position_in_generated_range(
+    pos: ScopePosition,
+    start: ScopePosition,
+    end: ScopePosition,
+) -> bool {
+    start <= pos && pos < end
+}
+
+fn bump_position(pos: ScopePosition) -> ScopePosition {
+    ScopePosition {
+        line: pos.line,
+        column: pos.column.saturating_add(1),
+    }
+}

--- a/crates/swc_compiler_base/src/source_map_scopes/tests.rs
+++ b/crates/swc_compiler_base/src/source_map_scopes/tests.rs
@@ -1,0 +1,208 @@
+use swc_common::{sync::Lrc, FileName, FilePathMapping, SourceMap};
+use swc_ecma_ast::EsVersion;
+use swc_ecma_parser::{parse_file_as_program, EsSyntax, Syntax};
+
+use super::{
+    bindings::build_scope_bindings,
+    collect::{collect_scopes, CollectedScope, CollectedVariable},
+    encode::{
+        encode_scopes, BindingTransition, BindingValue, Callsite, GeneratedRange, OriginalScope,
+        ScopeInfo, ScopePosition,
+    },
+    positions::{MappingIndex, MappingPoint},
+    SourceResolver,
+};
+
+#[test]
+fn codec_emits_tags_in_spec_order() {
+    let mut names = Vec::new();
+    let info = ScopeInfo {
+        scopes: vec![Some(OriginalScope {
+            id: 0,
+            start: ScopePosition { line: 0, column: 0 },
+            end: ScopePosition {
+                line: 0,
+                column: 20,
+            },
+            name: Some("f".into()),
+            kind: Some("Function".into()),
+            is_stack_frame: true,
+            variables: vec!["x".into()],
+            children: vec![],
+        })],
+        ranges: vec![GeneratedRange {
+            start: ScopePosition { line: 0, column: 0 },
+            end: ScopePosition {
+                line: 0,
+                column: 20,
+            },
+            is_stack_frame: true,
+            is_hidden: false,
+            original_scope_id: Some(0),
+            callsite: Some(Callsite {
+                source_idx: 0,
+                line: 0,
+                column: 0,
+            }),
+            values: vec![BindingValue::WithSubRanges {
+                initial: Some("x".into()),
+                transitions: vec![BindingTransition {
+                    from: ScopePosition {
+                        line: 0,
+                        column: 10,
+                    },
+                    value: Some("a".into()),
+                }],
+            }],
+            children: vec![],
+        }],
+    };
+
+    let encoded = encode_scopes(&info, &mut names).unwrap();
+    let tags = encoded
+        .split(',')
+        .filter_map(|part| part.chars().next())
+        .collect::<Vec<_>>();
+
+    assert_eq!(tags, vec!['B', 'D', 'C', 'E', 'G', 'H', 'I', 'F']);
+    assert!(names.iter().any(|name| name == "f"));
+    assert!(names.iter().any(|name| name == "Function"));
+    assert!(names.iter().any(|name| name == "x"));
+    assert!(names.iter().any(|name| name == "a"));
+}
+
+#[test]
+fn collect_scopes_tracks_nested_shadowed_bindings() {
+    let cm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
+    let fm = cm.new_source_file(
+        FileName::Real("input.js".into()).into(),
+        "function outer(a) { let x = 1; { let x = 2; } catchIt(); }",
+    );
+
+    let mut errors = Vec::new();
+    let program = parse_file_as_program(
+        &fm,
+        Syntax::Es(EsSyntax::default()),
+        EsVersion::Es2022,
+        None,
+        &mut errors,
+    )
+    .unwrap();
+    assert!(errors.is_empty());
+
+    let resolver = SourceResolver::new(None, None, &["input.js".into()]);
+    let collected = collect_scopes(cm, &program, resolver, 1);
+
+    let x_scope_count = collected
+        .scopes
+        .iter()
+        .filter(|scope| scope.variables.iter().any(|variable| variable.name == "x"))
+        .count();
+    assert!(x_scope_count >= 2);
+
+    let has_outer_function = collected.scopes.iter().any(|scope| {
+        scope.kind.as_deref() == Some("Function") && scope.name.as_deref() == Some("outer")
+    });
+    assert!(has_outer_function);
+}
+
+#[test]
+fn bindings_emit_sub_ranges_when_generated_name_changes() {
+    let scope = CollectedScope {
+        source_idx: Some(0),
+        start: ScopePosition { line: 0, column: 0 },
+        end: ScopePosition {
+            line: 0,
+            column: 10,
+        },
+        name: Some("scope".into()),
+        kind: Some("Function".into()),
+        is_stack_frame: true,
+        is_function_boundary: true,
+        parent: None,
+        children: vec![],
+        variables: vec![CollectedVariable {
+            name: "value".into(),
+            start: ScopePosition { line: 0, column: 0 },
+            end: ScopePosition {
+                line: 0,
+                column: 10,
+            },
+        }],
+    };
+    let mappings = MappingIndex::from_points(vec![vec![
+        MappingPoint {
+            original: ScopePosition { line: 0, column: 1 },
+            generated: ScopePosition { line: 0, column: 1 },
+            generated_name: Some("a".into()),
+        },
+        MappingPoint {
+            original: ScopePosition { line: 0, column: 5 },
+            generated: ScopePosition { line: 0, column: 5 },
+            generated_name: Some("a".into()),
+        },
+        MappingPoint {
+            original: ScopePosition { line: 0, column: 8 },
+            generated: ScopePosition { line: 0, column: 8 },
+            generated_name: Some("b".into()),
+        },
+    ]]);
+
+    let values = build_scope_bindings(
+        &scope,
+        0,
+        ScopePosition { line: 0, column: 0 },
+        ScopePosition {
+            line: 0,
+            column: 12,
+        },
+        &mappings,
+    );
+
+    match &values[0] {
+        BindingValue::WithSubRanges {
+            initial,
+            transitions,
+        } => {
+            assert_eq!(initial.as_deref(), Some("a"));
+            assert_eq!(transitions.len(), 1);
+            assert_eq!(transitions[0].value.as_deref(), Some("b"));
+        }
+        other => panic!("expected sub-range binding, got {other:?}"),
+    }
+}
+
+#[test]
+fn bindings_emit_unavailable_when_name_is_missing() {
+    let scope = CollectedScope {
+        source_idx: Some(0),
+        start: ScopePosition { line: 0, column: 0 },
+        end: ScopePosition { line: 0, column: 5 },
+        name: None,
+        kind: Some("Block".into()),
+        is_stack_frame: false,
+        is_function_boundary: false,
+        parent: None,
+        children: vec![],
+        variables: vec![CollectedVariable {
+            name: "value".into(),
+            start: ScopePosition { line: 0, column: 0 },
+            end: ScopePosition { line: 0, column: 5 },
+        }],
+    };
+    let mappings = MappingIndex::from_points(vec![vec![MappingPoint {
+        original: ScopePosition { line: 0, column: 1 },
+        generated: ScopePosition { line: 0, column: 1 },
+        generated_name: None,
+    }]]);
+
+    let values = build_scope_bindings(
+        &scope,
+        0,
+        ScopePosition { line: 0, column: 0 },
+        ScopePosition { line: 0, column: 6 },
+        &mappings,
+    );
+
+    assert!(matches!(values[0], BindingValue::Simple(None)));
+}

--- a/crates/swc_compiler_base/src/source_map_scopes/vlq.rs
+++ b/crates/swc_compiler_base/src/source_map_scopes/vlq.rs
@@ -1,0 +1,69 @@
+use std::fmt::Write;
+
+const BASE64: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+const VLQ_BASE_SHIFT: i64 = 5;
+const VLQ_BASE_MASK: i64 = (1 << VLQ_BASE_SHIFT) - 1;
+const VLQ_CONTINUATION_BIT: i64 = 1 << VLQ_BASE_SHIFT;
+
+#[inline]
+pub(crate) fn encode_unsigned_to(out: &mut String, mut value: i64) {
+    loop {
+        let mut digit = value & VLQ_BASE_MASK;
+        value >>= VLQ_BASE_SHIFT;
+
+        if value > 0 {
+            digit |= VLQ_CONTINUATION_BIT;
+        }
+
+        let _ = out.write_char(BASE64[digit as usize] as char);
+
+        if value == 0 {
+            break;
+        }
+    }
+}
+
+#[inline]
+pub(crate) fn encode_signed_to(out: &mut String, value: i64) {
+    let zigzag = if value < 0 {
+        ((-value) << 1) + 1
+    } else {
+        value << 1
+    };
+
+    encode_unsigned_to(out, zigzag);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn encode_unsigned(value: i64) -> String {
+        let mut out = String::new();
+        encode_unsigned_to(&mut out, value);
+        out
+    }
+
+    fn encode_signed(value: i64) -> String {
+        let mut out = String::new();
+        encode_signed_to(&mut out, value);
+        out
+    }
+
+    #[test]
+    fn unsigned_vlq() {
+        assert_eq!(encode_unsigned(0), "A");
+        assert_eq!(encode_unsigned(1), "B");
+        assert_eq!(encode_unsigned(2), "C");
+        assert_eq!(encode_unsigned(16), "Q");
+    }
+
+    #[test]
+    fn signed_vlq() {
+        assert_eq!(encode_signed(0), "A");
+        assert_eq!(encode_signed(1), "C");
+        assert_eq!(encode_signed(-1), "D");
+        assert_eq!(encode_signed(2), "E");
+        assert_eq!(encode_signed(-2), "F");
+    }
+}

--- a/crates/swc_ecma_minifier/src/js.rs
+++ b/crates/swc_ecma_minifier/src/js.rs
@@ -59,6 +59,9 @@ pub struct JsMinifyOptions {
 
     #[serde(default = "true_by_default")]
     pub emit_source_map_columns: bool,
+
+    #[serde(default)]
+    pub emit_source_map_scopes: bool,
 }
 
 fn true_by_default() -> bool {

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -40,6 +40,8 @@ export interface JsMinifyOptions {
     outputPath?: string;
 
     inlineSourcesContent?: boolean;
+
+    emitSourceMapScopes?: boolean;
 }
 
 /**
@@ -563,6 +565,8 @@ export interface Config {
     sourceMaps?: boolean | "inline";
 
     inlineSourcesContent?: boolean;
+
+    emitSourceMapScopes?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary
- add an ECMA-426-compatible source map scopes pipeline in swc_compiler_base (collection, position resolution, bindings, VLQ codec)
- gate scope emission behind emitSourceMapScopes (default off) and skip emission when composing with input source maps
- thread emitSourceMapScopes through Rust config/runtime/minifier paths plus node/wasm/types surfaces
- add unit and integration coverage for scope encoding and sourcemap behavior

Fixes #11424.

## Testing
- git submodule update --init --recursive
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings
- cargo test -p swc_compiler_base
- cargo test -p swc_ecma_minifier
- cargo test -p swc --test source_map source_map_scopes_
- (cd bindings/binding_core_wasm && ./scripts/test.sh)
- (cd bindings/binding_minifier_wasm && ./scripts/test.sh)
- (cd bindings/binding_typescript_wasm && ./scripts/test.sh)
- (cd bindings/binding_es_ast_viewer && ./scripts/test.sh)
- (cd packages/core && yarn build:dev && yarn test)

## Notes
- full cargo test -p swc still has one pre-existing failure in source_map::issue_622 (sourcemap-validator asserts empty mappings), unrelated to this change set.
