### PR TITLE
feat(bindings): add html wasm binding and publish wiring

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -41,6 +41,9 @@ on:
       skipBuild:
         type: boolean
         required: true
+      publishWasm:
+        type: boolean
+        required: true
       skipPublishing:
         type: boolean
         required: true
@@ -606,7 +609,7 @@ jobs:
   publish-wasm:
     environment: publish
     name: Build - wasm (${{ matrix.settings.npm }})
-    if: ${{ inputs.package == 'core' }}
+    if: ${{ inputs.publishWasm && inputs.package == matrix.settings.package }}
     runs-on: ubuntu-latest
     needs:
       - publish
@@ -614,22 +617,31 @@ jobs:
       fail-fast: false
       matrix:
         settings:
-          - crate: "binding_core_wasm"
+          - package: "core"
+            crate: "binding_core_wasm"
             npm: "@swc\\/wasm"
             target: nodejs
             out: "pkg"
-          - crate: "binding_core_wasm"
+          - package: "core"
+            crate: "binding_core_wasm"
             npm: "@swc\\/wasm-web"
             target: web
             out: "pkg"
-          - crate: "binding_typescript_wasm"
+          - package: "core"
+            crate: "binding_typescript_wasm"
             npm: "@swc\\/wasm-typescript"
             build: "./scripts/build.sh"
             out: "pkg"
-          - crate: "binding_typescript_wasm"
+          - package: "core"
+            crate: "binding_typescript_wasm"
             npm: "@swc\\/wasm-typescript-esm"
             build: "./scripts/esm.sh"
             out: "esm"
+          - package: "html"
+            crate: "binding_html_wasm"
+            npm: "@swc\\/wasm-html"
+            target: web
+            out: "pkg"
           # - crate: "binding_es_ast_viewer"
           #   npm: "@swc\\/es-ast-viewer"
           #   build: "./scripts/build.sh"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,6 +96,7 @@ jobs:
       version: ${{ needs.determine-nightly-version.outputs.version }}
       buildCli: true
       skipBuild: ${{ inputs.skipBuild || false }}
+      publishWasm: ${{ matrix.package == 'core' || matrix.package == 'html' }}
       skipPublishing: ${{ github.event_name == 'pull_request' }}
 
   run-ecosystem-ci-with-nightly:
@@ -164,4 +165,5 @@ jobs:
       version: ${{ inputs.version }}
       buildCli: true
       skipBuild: ${{ inputs.skipBuild || inputs.onlyNightly || false }}
+      publishWasm: ${{ matrix.package == 'core' || matrix.package == 'html' }}
       skipPublishing: ${{ github.event_name == 'pull_request' }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -445,6 +445,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "binding_html_wasm"
+version = "1.15.13"
+dependencies = [
+ "anyhow",
+ "getrandom 0.3.4",
+ "lightningcss",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "swc_atoms",
+ "swc_common",
+ "swc_config",
+ "swc_css_ast",
+ "swc_css_codegen",
+ "swc_css_minifier",
+ "swc_css_parser",
+ "swc_error_reporters",
+ "swc_html",
+ "swc_html_ast",
+ "swc_html_minifier",
+ "tracing",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "binding_macros"
 version = "55.0.0"
 dependencies = [

--- a/bindings/binding_html_wasm/Cargo.toml
+++ b/bindings/binding_html_wasm/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+authors     = ["강동윤 <kdy1997.dev@gmail.com>"]
+description = "wasm module for swc html"
+edition     = { workspace = true }
+license     = { workspace = true }
+name        = "binding_html_wasm"
+publish     = false
+repository  = { workspace = true }
+version     = "1.15.13"
+
+[lib]
+bench      = false
+crate-type = ["cdylib"]
+
+[dependencies]
+anyhow = { workspace = true }
+getrandom = { workspace = true, features = ["wasm_js"] }
+lightningcss = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde-wasm-bindgen = { workspace = true }
+serde_json = { workspace = true }
+swc_atoms = { path = "../../crates/swc_atoms" }
+swc_common = { path = "../../crates/swc_common", features = ["diagnostic-serde"] }
+swc_config = { path = "../../crates/swc_config", features = ["regex"] }
+swc_css_ast = { path = "../../crates/swc_css_ast" }
+swc_css_codegen = { path = "../../crates/swc_css_codegen" }
+swc_css_minifier = { path = "../../crates/swc_css_minifier" }
+swc_css_parser = { path = "../../crates/swc_css_parser" }
+swc_error_reporters = { path = "../../crates/swc_error_reporters" }
+swc_html = { path = "../../crates/swc_html" }
+swc_html_ast = { path = "../../crates/swc_html_ast", features = ["serde"] }
+swc_html_minifier = { path = "../../crates/swc_html_minifier", features = ["custom-css-minifier"] }
+tracing = { workspace = true, features = ["max_level_off"] }
+wasm-bindgen = { workspace = true, features = ["enable-interning"] }
+wasm-bindgen-futures = { workspace = true }
+
+[package.metadata.wasm-pack.profile.release]
+wasm-opt = false
+
+[package.metadata.cargo-shear]
+# ignored, as they are only used to enable features
+ignored = ["anyhow", "getrandom", "serde-wasm-bindgen"]

--- a/bindings/binding_html_wasm/LICENSE
+++ b/bindings/binding_html_wasm/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright 2024 SWC contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/bindings/binding_html_wasm/__tests__/simple.js
+++ b/bindings/binding_html_wasm/__tests__/simple.js
@@ -1,0 +1,38 @@
+const swc = require("../pkg");
+
+describe("html minify", () => {
+    it("supports sync minification", () => {
+        const output = swc.minifySync(
+            "<!doctype html><html><body><div class='a'>  Hello   world  </div></body></html>",
+            {
+                collapseWhitespaces: "all",
+                removeComments: true,
+            }
+        );
+
+        expect(output.code).toBe("<!doctype html><div class=a>Hello world</div>");
+        expect(output.errors).toBeUndefined();
+    });
+
+    it("supports async minification", async () => {
+        const output = await swc.minify("<div>  hello   wasm  </div>", {
+            collapseWhitespaces: "all",
+        });
+
+        expect(output.code).toBe("<div>hello wasm</div>");
+    });
+
+    it("supports fragment minification", async () => {
+        const output = await swc.minifyFragment("<span>  foo  </span>", {
+            collapseWhitespaces: "all",
+            contextElement: {
+                tagName: "template",
+                namespace: "http://www.w3.org/1999/xhtml",
+                attributes: [],
+                isSelfClosing: false,
+            },
+        });
+
+        expect(output.code).toBe("<span>foo</span>");
+    });
+});

--- a/bindings/binding_html_wasm/package.json
+++ b/bindings/binding_html_wasm/package.json
@@ -1,0 +1,5 @@
+{
+    "devDependencies": {
+        "@rstest/core": "^0.7.8"
+    }
+}

--- a/bindings/binding_html_wasm/rstest.config.mjs
+++ b/bindings/binding_html_wasm/rstest.config.mjs
@@ -1,0 +1,4 @@
+export default {
+    include: ["__tests__/**/*.{js,jsx,ts,tsx}"],
+    globals: true,
+};

--- a/bindings/binding_html_wasm/scripts/test.sh
+++ b/bindings/binding_html_wasm/scripts/test.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -eu
+
+wasm-pack build --out-name wasm --release --scope=swc --target nodejs
+npx rstest "$@"

--- a/bindings/binding_html_wasm/src/lib.rs
+++ b/bindings/binding_html_wasm/src/lib.rs
@@ -1,0 +1,783 @@
+mod tag_omission;
+mod util;
+
+use std::{backtrace::Backtrace, borrow::Cow, panic::set_hook, sync::Once};
+
+use anyhow::{bail, Context};
+use lightningcss::{printer::PrinterOptions, stylesheet::StyleSheet, targets::Targets};
+use serde::{Deserialize, Serialize};
+use swc_atoms::atom;
+use swc_common::{sync::Lrc, FileName, FilePathMapping, SourceMap, DUMMY_SP};
+use swc_config::regex::CachedRegex;
+use swc_html::{
+    ast::{DocumentMode, Namespace},
+    codegen::{
+        writer::basic::{BasicHtmlWriter, BasicHtmlWriterConfig},
+        CodeGenerator, CodegenConfig, Emit,
+    },
+    parser::{parse_file_as_document, parse_file_as_document_fragment},
+};
+use swc_html_ast::{Document, DocumentFragment};
+use swc_html_minifier::{
+    minify_document_fragment_with_custom_css_minifier, minify_document_with_custom_css_minifier,
+    option::{
+        CollapseWhitespaces, MinifierType, MinifyCssOption, MinifyJsOption, MinifyJsonOption,
+        RemoveRedundantAttributes,
+    },
+    CssMinificationMode, MinifyCss,
+};
+use wasm_bindgen::prelude::*;
+use wasm_bindgen_futures::{future_to_promise, js_sys::Promise};
+
+use crate::{tag_omission::TagOmission, util::try_with};
+
+static INIT_HOOK: Once = Once::new();
+
+#[wasm_bindgen(typescript_custom_section)]
+const INTERFACE_DEFINITIONS: &'static str = r#"
+export type MinifierType = "js-module" | "js-script" | "json" | "css" | "html";
+
+export interface Attribute {
+    namespace?: string;
+    prefix?: string;
+    name: string;
+    value?: string;
+}
+
+export interface Element {
+    tagName: string;
+    namespace: string;
+    attributes: Attribute[];
+    isSelfClosing: boolean;
+}
+
+export interface Diagnostic {
+    level: string;
+    message: string;
+    span: unknown;
+}
+
+export interface TransformOutput {
+    code: string;
+    errors?: Diagnostic[];
+}
+
+export interface Options {
+    filename?: string;
+    iframeSrcdoc?: boolean;
+    scriptingEnabled?: boolean;
+    forceSetHtml5Doctype?: boolean;
+    collapseWhitespaces?: "none" | "all" | "smart" | "conservative" | "advanced-conservative" | "only-metadata";
+    removeEmptyMetadataElements?: boolean;
+    removeComments?: boolean;
+    preserveComments?: string[];
+    minifyConditionalComments?: boolean;
+    removeEmptyAttributes?: boolean;
+    removeRedundantAttributes?: "none" | "all" | "smart";
+    collapseBooleanAttributes?: boolean;
+    normalizeAttributes?: boolean;
+    minifyJson?: boolean | { pretty?: boolean };
+    minifyJs?: boolean | { parser?: unknown; minifier?: unknown; codegen?: unknown };
+    minifyCss?: boolean | { lib: "lightningcss" } | { lib: "swc"; parser?: unknown; minifier?: unknown; codegen?: unknown };
+    minifyAdditionalScriptsContent?: [string, MinifierType][];
+    minifyAdditionalAttributes?: [string, MinifierType][];
+    sortSpaceSeparatedAttributeValues?: boolean;
+    sortAttributes?: boolean;
+    mergeMetadataElements?: boolean;
+    tagOmission?: boolean | "keep-head-and-body";
+    selfClosingVoidElements?: boolean;
+    quotes?: boolean;
+}
+
+export interface FragmentOptions extends Options {
+    mode?: "no-quirks" | "limited-quirks" | "quirks";
+    contextElement?: Element;
+    context_element?: Element;
+    formElement?: Element;
+    form_element?: Element;
+}
+
+export function minify(content: string, options?: Options): Promise<TransformOutput>;
+export function minifySync(content: string, options?: Options): TransformOutput;
+export function minifyFragment(content: string, options?: FragmentOptions): Promise<TransformOutput>;
+export function minifyFragmentSync(content: string, options?: FragmentOptions): TransformOutput;
+"#;
+
+fn init_panic_hook() {
+    if !cfg!(debug_assertions) {
+        return;
+    }
+
+    INIT_HOOK.call_once(|| {
+        set_hook(Box::new(|panic_info| {
+            let backtrace = Backtrace::force_capture();
+            println!("Panic: {panic_info:?}\nBacktrace: {backtrace:?}");
+        }));
+    });
+}
+
+#[derive(Debug, Serialize)]
+pub struct Diagnostic {
+    pub level: String,
+    pub message: String,
+    pub span: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TransformOutput {
+    pub code: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub errors: Option<Vec<Diagnostic>>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Attribute {
+    #[serde(default)]
+    pub namespace: Option<String>,
+    #[serde(default)]
+    pub prefix: Option<String>,
+    pub name: String,
+    #[serde(default)]
+    pub value: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Element {
+    pub tag_name: String,
+    pub namespace: String,
+    pub attributes: Vec<Attribute>,
+    pub is_self_closing: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MinifyOptions {
+    #[serde(default)]
+    filename: Option<String>,
+
+    // Parser options
+    #[serde(default)]
+    iframe_srcdoc: bool,
+    #[serde(default)]
+    scripting_enabled: bool,
+    /// Used only for Document Fragment
+    /// Default: NoQuirks
+    #[serde(default)]
+    mode: Option<DocumentMode>,
+    /// Used only for Document Fragment
+    /// Default: `template` in HTML namespace
+    #[serde(default, alias = "context_element")]
+    context_element: Option<Element>,
+    /// Used only for Document Fragment
+    /// Default: None
+    #[serde(default, alias = "form_element")]
+    form_element: Option<Element>,
+
+    // Minification options
+    #[serde(default)]
+    force_set_html5_doctype: bool,
+    #[serde(default = "default_collapse_whitespaces")]
+    collapse_whitespaces: CollapseWhitespaces,
+    // Remove safe empty elements with metadata content, i.e. the `script` and `style` element
+    // without content and attributes, `meta` and `link` elements without attributes and etc
+    #[serde(default = "true_by_default")]
+    remove_empty_metadata_elements: bool,
+    #[serde(default = "true_by_default")]
+    remove_comments: bool,
+    #[serde(default = "default_preserve_comments")]
+    preserve_comments: Option<Vec<CachedRegex>>,
+    #[serde(default = "true_by_default")]
+    minify_conditional_comments: bool,
+    #[serde(default = "true_by_default")]
+    remove_empty_attributes: bool,
+    #[serde(default)]
+    remove_redundant_attributes: RemoveRedundantAttributes,
+    #[serde(default = "true_by_default")]
+    collapse_boolean_attributes: bool,
+    #[serde(default = "true_by_default")]
+    normalize_attributes: bool,
+    #[serde(default = "minify_json_by_default")]
+    minify_json: MinifyJsonOption,
+    #[serde(default = "minify_js_by_default")]
+    minify_js: MinifyJsOption,
+    #[serde(default = "minify_css_by_default")]
+    minify_css: MinifyCssOption<CssMinfierOptions>,
+    #[serde(default)]
+    minify_additional_scripts_content: Option<Vec<(CachedRegex, MinifierType)>>,
+    #[serde(default)]
+    minify_additional_attributes: Option<Vec<(CachedRegex, MinifierType)>>,
+    #[serde(default = "true_by_default")]
+    sort_space_separated_attribute_values: bool,
+    #[serde(default)]
+    sort_attributes: bool,
+    #[serde(default = "true_by_default")]
+    merge_metadata_elements: bool,
+
+    // Codegen options
+    #[serde(default)]
+    tag_omission: Option<TagOmission>,
+    #[serde(default)]
+    self_closing_void_elements: Option<bool>,
+    #[serde(default)]
+    quotes: Option<bool>,
+}
+
+const fn true_by_default() -> bool {
+    true
+}
+
+const fn minify_json_by_default() -> MinifyJsonOption {
+    MinifyJsonOption::Bool(true)
+}
+
+const fn minify_js_by_default() -> MinifyJsOption {
+    MinifyJsOption::Bool(true)
+}
+
+const fn minify_css_by_default() -> MinifyCssOption<CssMinfierOptions> {
+    MinifyCssOption::Bool(true)
+}
+
+fn default_preserve_comments() -> Option<Vec<CachedRegex>> {
+    Some(vec![
+        // License comments
+        CachedRegex::new("@preserve").unwrap(),
+        CachedRegex::new("@copyright").unwrap(),
+        CachedRegex::new("@lic").unwrap(),
+        CachedRegex::new("@cc_on").unwrap(),
+        // Allow to keep custom comments
+        CachedRegex::new("^!").unwrap(),
+        // Server-side comments
+        CachedRegex::new("^\\s*#").unwrap(),
+        // Conditional IE comments
+        CachedRegex::new("^\\[if\\s[^\\]+]").unwrap(),
+        CachedRegex::new("\\[endif]").unwrap(),
+    ])
+}
+
+const fn default_collapse_whitespaces() -> CollapseWhitespaces {
+    CollapseWhitespaces::OnlyMetadata
+}
+
+enum DocumentOrDocumentFragment {
+    Document(Document),
+    DocumentFragment(DocumentFragment),
+}
+
+fn create_namespace(namespace: &str) -> anyhow::Result<Namespace> {
+    match &*namespace.to_lowercase() {
+        "http://www.w3.org/1999/xhtml" => Ok(Namespace::HTML),
+        "http://www.w3.org/1998/math/mathml" => Ok(Namespace::MATHML),
+        "http://www.w3.org/2000/svg" => Ok(Namespace::SVG),
+        "http://www.w3.org/1999/xlink" => Ok(Namespace::XLINK),
+        "http://www.w3.org/xml/1998/namespace" => Ok(Namespace::XML),
+        "http://www.w3.org/2000/xmlns/" => Ok(Namespace::XMLNS),
+        _ => {
+            bail!("failed to parse namespace of context element")
+        }
+    }
+}
+
+fn create_element(context_element: Element) -> anyhow::Result<swc_html_ast::Element> {
+    let mut attributes = Vec::with_capacity(context_element.attributes.len());
+
+    for attribute in context_element.attributes.into_iter() {
+        let namespace = match attribute.namespace {
+            Some(namespace) => Some(create_namespace(&namespace)?),
+            _ => None,
+        };
+
+        attributes.push(swc_html_ast::Attribute {
+            span: DUMMY_SP,
+            namespace,
+            prefix: attribute.prefix.map(|value| value.into()),
+            name: attribute.name.into(),
+            raw_name: None,
+            value: attribute.value.map(|value| value.into()),
+            raw_value: None,
+        })
+    }
+
+    Ok(swc_html_ast::Element {
+        span: DUMMY_SP,
+        tag_name: context_element.tag_name.into(),
+        namespace: create_namespace(&context_element.namespace)?,
+        attributes,
+        children: vec![],
+        content: None,
+        is_self_closing: context_element.is_self_closing,
+    })
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(tag = "lib")]
+pub enum CssMinfierOptions {
+    #[serde(rename = "lightningcss")]
+    LightningCss(LightningCssOptions),
+    #[serde(rename = "swc")]
+    Swc(swc_html_minifier::option::CssOptions),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct LightningCssOptions {}
+
+struct CssMinifier;
+
+impl MinifyCss for CssMinifier {
+    type Options = CssMinfierOptions;
+
+    fn minify_css(
+        &self,
+        options: &MinifyCssOption<Self::Options>,
+        data: String,
+        mode: swc_html_minifier::CssMinificationMode,
+    ) -> Option<String> {
+        let opts = match options {
+            MinifyCssOption::Bool(v) => {
+                if *v {
+                    Cow::Owned(CssMinfierOptions::LightningCss(LightningCssOptions {}))
+                } else {
+                    return None;
+                }
+            }
+            MinifyCssOption::Options(opts) => Cow::Borrowed(opts),
+        };
+
+        match &*opts {
+            CssMinfierOptions::LightningCss(_) => {
+                let mut ss = StyleSheet::parse(
+                    &data,
+                    lightningcss::stylesheet::ParserOptions {
+                        flags: lightningcss::stylesheet::ParserFlags::all(),
+                        ..Default::default()
+                    },
+                )
+                .ok()?;
+
+                let targets = Targets::default();
+
+                ss.minify(lightningcss::stylesheet::MinifyOptions {
+                    targets,
+                    ..Default::default()
+                })
+                .ok()?;
+
+                let to_css_result = ss
+                    .to_css(PrinterOptions {
+                        minify: true,
+                        targets,
+                        ..Default::default()
+                    })
+                    .ok()?;
+
+                Some(to_css_result.code)
+            }
+
+            CssMinfierOptions::Swc(options) => {
+                let mut options = options.clone();
+                let mut errors: Vec<_> = Vec::new();
+
+                let cm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
+                let fm = cm.new_source_file(FileName::Anon.into(), data);
+
+                let mut stylesheet = match mode {
+                    CssMinificationMode::Stylesheet => {
+                        match swc_css_parser::parse_file(&fm, None, options.parser, &mut errors) {
+                            Ok(stylesheet) => stylesheet,
+                            _ => return None,
+                        }
+                    }
+                    CssMinificationMode::ListOfDeclarations => {
+                        match swc_css_parser::parse_file::<Vec<swc_css_ast::DeclarationOrAtRule>>(
+                            &fm,
+                            None,
+                            options.parser,
+                            &mut errors,
+                        ) {
+                            Ok(list_of_declarations) => {
+                                let declaration_list: Vec<swc_css_ast::ComponentValue> =
+                                    list_of_declarations
+                                        .into_iter()
+                                        .map(|node| node.into())
+                                        .collect();
+
+                                swc_css_ast::Stylesheet {
+                                    span: Default::default(),
+                                    rules: vec![swc_css_ast::Rule::QualifiedRule(
+                                        swc_css_ast::QualifiedRule {
+                                            span: Default::default(),
+                                            prelude:
+                                                swc_css_ast::QualifiedRulePrelude::SelectorList(
+                                                    swc_css_ast::SelectorList {
+                                                        span: Default::default(),
+                                                        children: Vec::new(),
+                                                    },
+                                                ),
+                                            block: swc_css_ast::SimpleBlock {
+                                                span: Default::default(),
+                                                name: swc_css_ast::TokenAndSpan {
+                                                    span: DUMMY_SP,
+                                                    token: swc_css_ast::Token::LBrace,
+                                                },
+                                                value: declaration_list,
+                                            },
+                                        }
+                                        .into(),
+                                    )],
+                                }
+                            }
+                            _ => return None,
+                        }
+                    }
+                    CssMinificationMode::MediaQueryList => {
+                        match swc_css_parser::parse_file::<swc_css_ast::MediaQueryList>(
+                            &fm,
+                            None,
+                            options.parser,
+                            &mut errors,
+                        ) {
+                            Ok(media_query_list) => swc_css_ast::Stylesheet {
+                                span: Default::default(),
+                                rules: vec![swc_css_ast::Rule::AtRule(
+                                    swc_css_ast::AtRule {
+                                        span: Default::default(),
+                                        name: swc_css_ast::AtRuleName::Ident(swc_css_ast::Ident {
+                                            span: Default::default(),
+                                            value: atom!("media"),
+                                            raw: None,
+                                        }),
+                                        prelude: Some(
+                                            swc_css_ast::AtRulePrelude::MediaPrelude(
+                                                media_query_list,
+                                            )
+                                            .into(),
+                                        ),
+                                        block: Some(swc_css_ast::SimpleBlock {
+                                            span: Default::default(),
+                                            name: swc_css_ast::TokenAndSpan {
+                                                span: DUMMY_SP,
+                                                token: swc_css_ast::Token::LBrace,
+                                            },
+                                            // TODO make the `compress_empty` option for CSS
+                                            // minifier and
+                                            // remove it
+                                            value: vec![swc_css_ast::ComponentValue::Str(
+                                                Box::new(swc_css_ast::Str {
+                                                    span: Default::default(),
+                                                    value: atom!("placeholder"),
+                                                    raw: None,
+                                                }),
+                                            )],
+                                        }),
+                                    }
+                                    .into(),
+                                )],
+                            },
+                            _ => return None,
+                        }
+                    }
+                };
+
+                // Avoid compress potential invalid CSS
+                if !errors.is_empty() {
+                    return None;
+                }
+
+                swc_css_minifier::minify(&mut stylesheet, options.minifier);
+
+                let mut minified = String::new();
+                let wr = swc_css_codegen::writer::basic::BasicCssWriter::new(
+                    &mut minified,
+                    None,
+                    swc_css_codegen::writer::basic::BasicCssWriterConfig::default(),
+                );
+
+                options.codegen.minify = true;
+
+                let mut gen = swc_css_codegen::CodeGenerator::new(wr, options.codegen);
+
+                match mode {
+                    CssMinificationMode::Stylesheet => {
+                        swc_css_codegen::Emit::emit(&mut gen, &stylesheet).unwrap();
+                    }
+                    CssMinificationMode::ListOfDeclarations => {
+                        let swc_css_ast::Stylesheet { rules, .. } = &stylesheet;
+
+                        // Because CSS is grammar free, protect for fails
+                        let Some(swc_css_ast::Rule::QualifiedRule(qualified_rule)) = rules.first()
+                        else {
+                            return None;
+                        };
+
+                        let swc_css_ast::QualifiedRule { block, .. } = &**qualified_rule;
+
+                        swc_css_codegen::Emit::emit(&mut gen, &block).unwrap();
+
+                        minified = minified[1..minified.len() - 1].to_string();
+                    }
+                    CssMinificationMode::MediaQueryList => {
+                        let swc_css_ast::Stylesheet { rules, .. } = &stylesheet;
+
+                        // Because CSS is grammar free, protect for fails
+                        let Some(swc_css_ast::Rule::AtRule(at_rule)) = rules.first() else {
+                            return None;
+                        };
+
+                        let swc_css_ast::AtRule { prelude, .. } = &**at_rule;
+
+                        swc_css_codegen::Emit::emit(&mut gen, &prelude).unwrap();
+
+                        minified = minified.trim().to_string();
+                    }
+                }
+
+                Some(minified)
+            }
+        }
+    }
+}
+
+fn minify_inner(
+    code: &str,
+    opts: MinifyOptions,
+    is_fragment: bool,
+) -> anyhow::Result<TransformOutput> {
+    swc_common::GLOBALS.set(&swc_common::Globals::new(), || {
+        try_with(|cm, handler| {
+            let filename = match opts.filename {
+                Some(v) => FileName::Real(v.into()),
+                None => FileName::Anon,
+            };
+
+            let fm = cm.new_source_file(filename.into(), code.to_string());
+
+            let scripting_enabled = opts.scripting_enabled;
+            let mut errors = vec![];
+
+            let (mut document_or_document_fragment, context_element) = if is_fragment {
+                let context_element = match opts.context_element {
+                    Some(context_element) => create_element(context_element)?,
+                    _ => swc_html_ast::Element {
+                        span: DUMMY_SP,
+                        tag_name: atom!("template"),
+                        namespace: Namespace::HTML,
+                        attributes: vec![],
+                        children: vec![],
+                        content: None,
+                        is_self_closing: false,
+                    },
+                };
+                let mode = match opts.mode {
+                    Some(mode) => mode,
+                    _ => DocumentMode::NoQuirks,
+                };
+                let form_element = match opts.form_element {
+                    Some(form_element) => Some(create_element(form_element)?),
+                    _ => None,
+                };
+                let document_fragment = parse_file_as_document_fragment(
+                    &fm,
+                    &context_element,
+                    mode,
+                    form_element.as_ref(),
+                    swc_html::parser::parser::ParserConfig {
+                        scripting_enabled,
+                        iframe_srcdoc: opts.iframe_srcdoc,
+                        ..Default::default()
+                    },
+                    &mut errors,
+                );
+
+                let document_fragment = match document_fragment {
+                    Ok(v) => v,
+                    Err(err) => {
+                        err.to_diagnostics(handler).emit();
+
+                        for err in errors {
+                            err.to_diagnostics(handler).emit();
+                        }
+
+                        bail!("failed to parse input as document fragment")
+                    }
+                };
+
+                (
+                    DocumentOrDocumentFragment::DocumentFragment(document_fragment),
+                    Some(context_element),
+                )
+            } else {
+                let document = parse_file_as_document(
+                    &fm,
+                    swc_html::parser::parser::ParserConfig {
+                        scripting_enabled,
+                        iframe_srcdoc: opts.iframe_srcdoc,
+                        ..Default::default()
+                    },
+                    &mut errors,
+                );
+
+                let document = match document {
+                    Ok(v) => v,
+                    Err(err) => {
+                        err.to_diagnostics(handler).emit();
+
+                        for err in errors {
+                            err.to_diagnostics(handler).emit();
+                        }
+
+                        bail!("failed to parse input as document")
+                    }
+                };
+
+                (DocumentOrDocumentFragment::Document(document), None)
+            };
+
+            let mut returned_errors = None;
+
+            if !errors.is_empty() {
+                returned_errors = Some(Vec::with_capacity(errors.len()));
+
+                for err in errors {
+                    let mut buf = vec![];
+
+                    err.to_diagnostics(handler).buffer(&mut buf);
+
+                    for i in buf {
+                        returned_errors.as_mut().unwrap().push(Diagnostic {
+                            level: i.level.to_string(),
+                            message: i.message(),
+                            span: serde_json::to_value(&i.span)?,
+                        });
+                    }
+                }
+            }
+
+            let options = swc_html_minifier::option::MinifyOptions {
+                force_set_html5_doctype: opts.force_set_html5_doctype,
+                collapse_whitespaces: opts.collapse_whitespaces,
+                remove_empty_metadata_elements: opts.remove_empty_metadata_elements,
+                remove_comments: opts.remove_comments,
+                preserve_comments: opts.preserve_comments,
+                minify_conditional_comments: opts.minify_conditional_comments,
+                remove_empty_attributes: opts.remove_empty_attributes,
+                remove_redundant_attributes: opts.remove_redundant_attributes,
+                collapse_boolean_attributes: opts.collapse_boolean_attributes,
+                normalize_attributes: opts.normalize_attributes,
+                minify_json: opts.minify_json,
+                minify_js: opts.minify_js,
+                minify_css: opts.minify_css,
+                minify_additional_scripts_content: opts.minify_additional_scripts_content,
+                minify_additional_attributes: opts.minify_additional_attributes,
+                sort_space_separated_attribute_values: opts.sort_space_separated_attribute_values,
+                sort_attributes: opts.sort_attributes,
+                merge_metadata_elements: opts.merge_metadata_elements,
+            };
+
+            match document_or_document_fragment {
+                DocumentOrDocumentFragment::Document(ref mut document) => {
+                    minify_document_with_custom_css_minifier(document, &options, &CssMinifier);
+                }
+                DocumentOrDocumentFragment::DocumentFragment(ref mut document_fragment) => {
+                    minify_document_fragment_with_custom_css_minifier(
+                        document_fragment,
+                        context_element.as_ref().unwrap(),
+                        &options,
+                        &CssMinifier,
+                    );
+                }
+            }
+
+            let code = {
+                let mut buf = String::new();
+
+                {
+                    let mut wr = BasicHtmlWriter::new(
+                        &mut buf,
+                        None,
+                        BasicHtmlWriterConfig {
+                            ..Default::default()
+                        },
+                    );
+                    let (tag_omission, keep_head_and_body) = match opts.tag_omission {
+                        Some(TagOmission::Bool(v)) => (Some(v), Some(false)),
+                        Some(TagOmission::KeepHeadAndBody) => (Some(true), Some(true)),
+                        None => (None, None),
+                    };
+                    let mut gen = CodeGenerator::new(
+                        &mut wr,
+                        CodegenConfig {
+                            minify: true,
+                            scripting_enabled,
+                            context_element: context_element.as_ref(),
+                            tag_omission,
+                            keep_head_and_body,
+                            self_closing_void_elements: opts.self_closing_void_elements,
+                            quotes: opts.quotes,
+                        },
+                    );
+
+                    match document_or_document_fragment {
+                        DocumentOrDocumentFragment::Document(document) => {
+                            gen.emit(&document).context("failed to emit")?;
+                        }
+                        DocumentOrDocumentFragment::DocumentFragment(document_fragment) => {
+                            gen.emit(&document_fragment).context("failed to emit")?;
+                        }
+                    }
+                }
+
+                buf
+            };
+
+            Ok(TransformOutput {
+                code,
+                errors: returned_errors,
+            })
+        })
+    })
+}
+
+fn js_error(err: impl std::fmt::Display) -> JsValue {
+    JsValue::from_str(&err.to_string())
+}
+
+fn parse_options(options: JsValue) -> Result<MinifyOptions, JsValue> {
+    if options.is_undefined() || options.is_null() {
+        return serde_json::from_str("{}").map_err(js_error);
+    }
+
+    serde_wasm_bindgen::from_value(options).map_err(js_error)
+}
+
+fn minify_js(code: String, options: JsValue, is_fragment: bool) -> Result<JsValue, JsValue> {
+    init_panic_hook();
+
+    let options = parse_options(options)?;
+    let output = minify_inner(&code, options, is_fragment).map_err(js_error)?;
+
+    serde_wasm_bindgen::to_value(&output).map_err(js_error)
+}
+
+#[wasm_bindgen(skip_typescript)]
+pub fn minify(code: String, options: JsValue) -> Promise {
+    future_to_promise(async move { minify_js(code, options, false) })
+}
+
+#[wasm_bindgen(js_name = "minifyFragment", skip_typescript)]
+pub fn minify_fragment(code: String, options: JsValue) -> Promise {
+    future_to_promise(async move { minify_js(code, options, true) })
+}
+
+#[wasm_bindgen(js_name = "minifySync", skip_typescript)]
+pub fn minify_sync(code: String, options: JsValue) -> Result<JsValue, JsValue> {
+    minify_js(code, options, false)
+}
+
+#[wasm_bindgen(js_name = "minifyFragmentSync", skip_typescript)]
+pub fn minify_fragment_sync(code: String, options: JsValue) -> Result<JsValue, JsValue> {
+    minify_js(code, options, true)
+}

--- a/bindings/binding_html_wasm/src/tag_omission.rs
+++ b/bindings/binding_html_wasm/src/tag_omission.rs
@@ -1,0 +1,46 @@
+use serde::{
+    de::{Unexpected, Visitor},
+    Deserialize,
+};
+
+#[derive(Debug)]
+pub enum TagOmission {
+    Bool(bool),
+    KeepHeadAndBody,
+}
+
+struct TagOmissionVisitor;
+
+impl Visitor<'_> for TagOmissionVisitor {
+    type Value = TagOmission;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+        formatter.write_str("a boolean or 'keep-head-and-body'")
+    }
+
+    fn visit_bool<E>(self, v: bool) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        Ok(TagOmission::Bool(v))
+    }
+
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: serde::de::Error,
+    {
+        match v {
+            "keep-head-and-body" => Ok(TagOmission::KeepHeadAndBody),
+            _ => Err(serde::de::Error::invalid_value(Unexpected::Str(v), &self)),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for TagOmission {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_any(TagOmissionVisitor)
+    }
+}

--- a/bindings/binding_html_wasm/src/util.rs
+++ b/bindings/binding_html_wasm/src/util.rs
@@ -1,0 +1,36 @@
+use anyhow::{anyhow, Error};
+use swc_common::{errors::Handler, sync::Lrc, FilePathMapping, SourceMap};
+use swc_error_reporters::handler::{try_with_handler, HandlerOpts};
+
+pub fn try_with<F, Ret>(op: F) -> Result<Ret, Error>
+where
+    F: FnOnce(&Lrc<SourceMap>, &Handler) -> Result<Ret, Error>,
+{
+    let cm = Lrc::new(SourceMap::new(FilePathMapping::empty()));
+    try_with_handler(
+        cm.clone(),
+        HandlerOpts {
+            skip_filename: false,
+            ..Default::default()
+        },
+        |handler| {
+            //
+            let result =
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| op(&cm, handler)));
+
+            let p = match result {
+                Ok(v) => return v,
+                Err(v) => v,
+            };
+
+            if let Some(s) = p.downcast_ref::<String>() {
+                Err(anyhow!("failed to handle: {s}"))
+            } else if let Some(s) = p.downcast_ref::<&str>() {
+                Err(anyhow!("failed to handle: {s}"))
+            } else {
+                Err(anyhow!("failed to handle with unknown panic message"))
+            }
+        },
+    )
+    .map_err(|e| e.to_pretty_error())
+}

--- a/xtask/src/npm/util.rs
+++ b/xtask/src/npm/util.rs
@@ -44,6 +44,8 @@ pub fn set_version(version: &Version) -> Result<()> {
             .arg("-p")
             .arg("binding_core_wasm")
             .arg("-p")
+            .arg("binding_html_wasm")
+            .arg("-p")
             .arg("binding_minifier_wasm");
 
         c.status()?;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6232,6 +6232,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"binding_html_wasm-f9b7bc@workspace:bindings/binding_html_wasm":
+  version: 0.0.0-use.local
+  resolution: "binding_html_wasm-f9b7bc@workspace:bindings/binding_html_wasm"
+  dependencies:
+    "@rstest/core": "npm:^0.7.8"
+  languageName: unknown
+  linkType: soft
+
 "binding_minifier_wasm-5059cc@workspace:bindings/binding_minifier_wasm":
   version: 0.0.0-use.local
   resolution: "binding_minifier_wasm-5059cc@workspace:bindings/binding_minifier_wasm"


### PR DESCRIPTION
## Summary
- add new `binding_html_wasm` crate based on the html node binding behavior
- expose wasm-bindgen APIs for `minify`, `minifySync`, `minifyFragment`, and `minifyFragmentSync`
- wire html wasm publish into release workflows (`publish.yml` + `publish-npm-package.yml`)
- include `binding_html_wasm` in xtask wasm version bump list

## Validation
- `git submodule update --init --recursive`
- `./scripts/test.sh` (binding_html_wasm)
- `./scripts/test.sh` (binding_core_wasm)
- `./scripts/test.sh` (binding_minifier_wasm)
- `./scripts/test.sh` (binding_typescript_wasm)
- `./scripts/test.sh` (binding_es_ast_viewer)
- `cargo test -p binding_html_wasm`
- `cargo test -p xtask`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
