### PR TITLE
chore: triage main CI breakage

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -45,6 +45,8 @@ ignore = [
   "RUSTSEC-2025-0068", # serde_yml is unsound and unmaintained
   "RUSTSEC-2026-0001", # rkyv 0.7.45 OOM issue (transitive dep via parcel_sourcemap)
   "RUSTSEC-2026-0006", # wasmtime f64.copysign segfault (transitive dep via swc_plugin_runner)
+  "RUSTSEC-2026-0020", # wasmtime 38 has no patched release in this major line (transitive dep via swc_plugin_runner)
+  "RUSTSEC-2026-0021", # wasmtime 38 has no patched release in this major line (transitive dep via swc_plugin_runner)
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
This draft PR is created with an empty commit to reproduce and fix current main CI failures.