### PR TITLE
fix(core): add IBM platform fallbacks for @swc/core

### DIFF
--- a/packages/core/__tests__/binding_platform_fallback_test.mjs
+++ b/packages/core/__tests__/binding_platform_fallback_test.mjs
@@ -1,0 +1,16 @@
+import { readFileSync } from "fs";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const bindingSource = readFileSync(join(__dirname, "..", "binding.js"), "utf8");
+
+it("should include linux ppc64 support in the native loader", () => {
+    expect(bindingSource).toContain("process.arch === 'ppc64'");
+    expect(bindingSource).toContain("@swc/core-linux-ppc64-gnu");
+});
+
+it("should include aix ppc64 support in the native loader", () => {
+    expect(bindingSource).toContain("process.platform === 'aix'");
+    expect(bindingSource).toContain("@swc/core-aix-ppc64");
+});

--- a/packages/core/binding.js
+++ b/packages/core/binding.js
@@ -283,6 +283,18 @@ function requireNative() {
       }
 
       }
+    } else if (process.arch === 'ppc64') {
+      try {
+        return require('./swc.linux-ppc64-gnu.node')
+      } catch (e) {
+        loadErrors.push(e)
+      }
+      try {
+        return require('@swc/core-linux-ppc64-gnu')
+      } catch (e) {
+        loadErrors.push(e)
+      }
+
     } else if (process.arch === 's390x') {
       try {
         return require('./swc.linux-s390x-gnu.node')
@@ -297,6 +309,22 @@ function requireNative() {
 
     } else {
       loadErrors.push(new Error(`Unsupported architecture on Linux: ${process.arch}`))
+    }
+  } else if (process.platform === 'aix') {
+    if (process.arch === 'ppc64') {
+      try {
+        return require('./swc.aix-ppc64.node')
+      } catch (e) {
+        loadErrors.push(e)
+      }
+      try {
+        return require('@swc/core-aix-ppc64')
+      } catch (e) {
+        loadErrors.push(e)
+      }
+
+    } else {
+      loadErrors.push(new Error(`Unsupported architecture on AIX: ${process.arch}`))
     }
   } else {
     loadErrors.push(new Error(`Unsupported OS: ${process.platform}, architecture: ${process.arch}`))

--- a/packages/core/scripts/npm/aix-ppc64/README.md
+++ b/packages/core/scripts/npm/aix-ppc64/README.md
@@ -1,0 +1,3 @@
+# `@swc/core-aix-ppc64`
+
+This package is used by `@swc/core` on **powerpc64-ibm-aix**.

--- a/packages/core/scripts/npm/aix-ppc64/package.json
+++ b/packages/core/scripts/npm/aix-ppc64/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "@swc/core-aix-ppc64",
+  "version": "1.15.17",
+  "os": [
+    "aix"
+  ],
+  "cpu": [
+    "ppc64"
+  ],
+  "main": "swc.aix-ppc64.node",
+  "files": [
+    "swc.aix-ppc64.node",
+    "swc"
+  ],
+  "description": "Super-fast alternative for babel",
+  "keywords": [
+    "swc",
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/packages/core/scripts/npm/linux-ppc64-gnu/README.md
+++ b/packages/core/scripts/npm/linux-ppc64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/core-linux-ppc64-gnu`
+
+This package is used by `@swc/core` on **powerpc64le-unknown-linux-gnu**.

--- a/packages/core/scripts/npm/linux-ppc64-gnu/package.json
+++ b/packages/core/scripts/npm/linux-ppc64-gnu/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@swc/core-linux-ppc64-gnu",
+  "version": "1.15.17",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "ppc64"
+  ],
+  "main": "swc.linux-ppc64-gnu.node",
+  "files": [
+    "swc.linux-ppc64-gnu.node",
+    "swc"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast alternative for babel",
+  "keywords": [
+    "swc",
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/packages/core/scripts/npm/linux-s390x-gnu/README.md
+++ b/packages/core/scripts/npm/linux-s390x-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/core-linux-s390x-gnu`
+
+This package is used by `@swc/core` on **s390x-unknown-linux-gnu**.

--- a/packages/core/scripts/npm/linux-s390x-gnu/package.json
+++ b/packages/core/scripts/npm/linux-s390x-gnu/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@swc/core-linux-s390x-gnu",
+  "version": "1.15.17",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "s390x"
+  ],
+  "main": "swc.linux-s390x-gnu.node",
+  "files": [
+    "swc.linux-s390x-gnu.node",
+    "swc"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast alternative for babel",
+  "keywords": [
+    "swc",
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/scripts/update_fallback_dependencies.js
+++ b/scripts/update_fallback_dependencies.js
@@ -4,6 +4,15 @@
 const path = require("path");
 const fs = require("fs");
 
+const npmDir = path.resolve(
+    __dirname,
+    "..",
+    "packages",
+    "core",
+    "scripts",
+    "npm"
+);
+
 const targets = [
     "freebsd-x64",
     "win32-ia32-msvc",
@@ -11,14 +20,27 @@ const targets = [
     "android-arm64",
     "win32-arm64-msvc",
     "android-arm-eabi",
+    "linux-ppc64-gnu",
+    "linux-s390x-gnu",
+    "aix-ppc64",
 ];
 
 (async () => {
+    if (!fs.existsSync(npmDir)) {
+        console.warn(`Skipping fallback dependency update; npm dir does not exist: ${npmDir}`);
+        return;
+    }
+
     for (const target of targets) {
-        const pkgPath = path.resolve(__dirname, "npm", target, "package.json");
+        const pkgPath = path.join(npmDir, target, "package.json");
+        if (!fs.existsSync(pkgPath)) {
+            continue;
+        }
+
         const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
         const { version } = pkg;
         pkg.dependencies = {
+            ...pkg.dependencies,
             "@swc/wasm": version,
         };
         fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2));


### PR DESCRIPTION
Fixes #11590

## Summary
- add `linux/ppc64` and `aix/ppc64` resolution paths in `@swc/core` native loader
- add npm target packages for `@swc/core-linux-ppc64-gnu`, `@swc/core-linux-s390x-gnu`, and `@swc/core-aix-ppc64`
- update fallback dependency updater to target `packages/core/scripts/npm/*`, skip missing targets safely, and include the new IBM targets
- add a unit test covering loader mapping for the new Linux/AIX cases

## Why
`@swc/core` already had partial runtime handling for `s390x` and wasm fallback, but packaging/fallback metadata did not fully cover IBM-oriented targets. This change makes fallback behavior explicit and publishable for these platforms.

## Validation
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `node --check packages/core/binding.js`
- `node --check scripts/update_fallback_dependencies.js`
- `node --check packages/core/__tests__/binding_platform_fallback_test.mjs`

`cargo clippy --all --all-targets -- -D warnings` was started but failed due to local disk exhaustion (`No space left on device`), not due to diagnostics.
