### PR TITLE
fix(html-wasm): publish @swc/html-wasm for nodejs

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -640,7 +640,7 @@ jobs:
           - package: "html"
             crate: "binding_html_wasm"
             npm: "@swc\\/html-wasm"
-            target: web
+            target: nodejs
             out: "pkg"
           # - crate: "binding_es_ast_viewer"
           #   npm: "@swc\\/es-ast-viewer"


### PR DESCRIPTION
## Summary
- change the wasm publish matrix entry for `binding_html_wasm` to use `target: nodejs`
- keep `@swc/wasm-web` on `target: web`; only `@swc/html-wasm` target is corrected
- this prevents publishing browser-only wasm glue for the Node.js package

Fixes #11599

## Testing
- git submodule update --init --recursive
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings