### PR TITLE
feat(bindings): add linux ppc64le and s390x support across npm bindings

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -179,6 +179,28 @@ jobs:
                 yarn build --target armv7-unknown-linux-gnueabihf --use-napi-cross
               fi
           - host: ubuntu-latest
+            target: powerpc64le-unknown-linux-gnu
+            build: |
+              export DISABLE_PLUGIN_E2E_TESTS=true
+              if [[ ${{ inputs.package }} == "core" ]]; then
+                yarn napi build --bin swc --release --target powerpc64le-unknown-linux-gnu --manifest-path ../../bindings/swc_cli/Cargo.toml -x --target-dir ../release -o .
+                chmod +x ./swc
+                yarn build --target powerpc64le-unknown-linux-gnu --no-default-features --features swc_v1 --use-napi-cross
+              else
+                yarn build --target powerpc64le-unknown-linux-gnu --use-napi-cross
+              fi
+          - host: ubuntu-latest
+            target: s390x-unknown-linux-gnu
+            build: |
+              export DISABLE_PLUGIN_E2E_TESTS=true
+              if [[ ${{ inputs.package }} == "core" ]]; then
+                yarn napi build --bin swc --release --target s390x-unknown-linux-gnu --manifest-path ../../bindings/swc_cli/Cargo.toml -x --target-dir ../release -o .
+                chmod +x ./swc
+                yarn build --target s390x-unknown-linux-gnu --no-default-features --features swc_v1 --use-napi-cross
+              else
+                yarn build --target s390x-unknown-linux-gnu --use-napi-cross
+              fi
+          - host: ubuntu-latest
             target: aarch64-unknown-linux-musl
             downloadTarget: aarch64-unknown-linux-musl
             docker: ghcr.io/napi-rs/napi-rs/nodejs-rust:lts-alpine

--- a/packages/core/binding.js
+++ b/packages/core/binding.js
@@ -283,6 +283,18 @@ function requireNative() {
       }
 
       }
+    } else if (process.arch === 'ppc64') {
+      try {
+        return require('./swc.linux-ppc64-gnu.node')
+      } catch (e) {
+        loadErrors.push(e)
+      }
+      try {
+        return require('@swc/core-linux-ppc64-gnu')
+      } catch (e) {
+        loadErrors.push(e)
+      }
+
     } else if (process.arch === 's390x') {
       try {
         return require('./swc.linux-s390x-gnu.node')

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,8 @@
             "x86_64-apple-darwin",
             "x86_64-pc-windows-msvc",
             "x86_64-unknown-linux-gnu",
+            "powerpc64le-unknown-linux-gnu",
+            "s390x-unknown-linux-gnu",
             "x86_64-unknown-linux-musl",
             "i686-pc-windows-msvc",
             "armv7-unknown-linux-gnueabihf",

--- a/packages/core/scripts/npm/linux-ppc64-gnu/README.md
+++ b/packages/core/scripts/npm/linux-ppc64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/core-linux-ppc64-gnu`
+
+This is the **powerpc64le-unknown-linux-gnu** binary for `@swc/core`

--- a/packages/core/scripts/npm/linux-ppc64-gnu/package.json
+++ b/packages/core/scripts/npm/linux-ppc64-gnu/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@swc/core-linux-ppc64-gnu",
+  "version": "1.15.18",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "ppc64"
+  ],
+  "main": "swc.linux-ppc64-gnu.node",
+  "files": [
+    "swc.linux-ppc64-gnu.node",
+    "swc"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast alternative for babel",
+  "keywords": [
+    "swc",
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/packages/core/scripts/npm/linux-s390x-gnu/README.md
+++ b/packages/core/scripts/npm/linux-s390x-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/core-linux-s390x-gnu`
+
+This is the **s390x-unknown-linux-gnu** binary for `@swc/core`

--- a/packages/core/scripts/npm/linux-s390x-gnu/package.json
+++ b/packages/core/scripts/npm/linux-s390x-gnu/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@swc/core-linux-s390x-gnu",
+  "version": "1.15.18",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "s390x"
+  ],
+  "main": "swc.linux-s390x-gnu.node",
+  "files": [
+    "swc.linux-s390x-gnu.node",
+    "swc"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast alternative for babel",
+  "keywords": [
+    "swc",
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/packages/html/binding.js
+++ b/packages/html/binding.js
@@ -284,6 +284,17 @@ function requireNative() {
                     loadErrors.push(e);
                 }
             }
+        } else if (process.arch === "ppc64") {
+            try {
+                return require("./swc-html.linux-ppc64-gnu.node");
+            } catch (e) {
+                loadErrors.push(e);
+            }
+            try {
+                return require("@swc/html-linux-ppc64-gnu");
+            } catch (e) {
+                loadErrors.push(e);
+            }
         } else if (process.arch === "s390x") {
             try {
                 return require("./swc-html.linux-s390x-gnu.node");

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -27,6 +27,8 @@
             "x86_64-apple-darwin",
             "x86_64-pc-windows-msvc",
             "x86_64-unknown-linux-gnu",
+            "powerpc64le-unknown-linux-gnu",
+            "s390x-unknown-linux-gnu",
             "x86_64-unknown-linux-musl",
             "i686-pc-windows-msvc",
             "armv7-unknown-linux-gnueabihf",

--- a/packages/html/scripts/npm/linux-ppc64-gnu/README.md
+++ b/packages/html/scripts/npm/linux-ppc64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/html-linux-ppc64-gnu`
+
+This is the **powerpc64le-unknown-linux-gnu** binary for `@swc/html`

--- a/packages/html/scripts/npm/linux-ppc64-gnu/package.json
+++ b/packages/html/scripts/npm/linux-ppc64-gnu/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@swc/html-linux-ppc64-gnu",
+  "version": "1.15.18",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "ppc64"
+  ],
+  "main": "swc-html.linux-ppc64-gnu.node",
+  "files": [
+    "swc-html.linux-ppc64-gnu.node"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast HTML minifier",
+  "keywords": [
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/packages/html/scripts/npm/linux-s390x-gnu/README.md
+++ b/packages/html/scripts/npm/linux-s390x-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/html-linux-s390x-gnu`
+
+This is the **s390x-unknown-linux-gnu** binary for `@swc/html`

--- a/packages/html/scripts/npm/linux-s390x-gnu/package.json
+++ b/packages/html/scripts/npm/linux-s390x-gnu/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@swc/html-linux-s390x-gnu",
+  "version": "1.15.18",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "s390x"
+  ],
+  "main": "swc-html.linux-s390x-gnu.node",
+  "files": [
+    "swc-html.linux-s390x-gnu.node"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast HTML minifier",
+  "keywords": [
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/packages/minifier/package.json
+++ b/packages/minifier/package.json
@@ -28,6 +28,8 @@
             "x86_64-apple-darwin",
             "x86_64-pc-windows-msvc",
             "x86_64-unknown-linux-gnu",
+            "powerpc64le-unknown-linux-gnu",
+            "s390x-unknown-linux-gnu",
             "x86_64-unknown-linux-musl",
             "i686-pc-windows-msvc",
             "armv7-unknown-linux-gnueabihf",

--- a/packages/minifier/scripts/npm/linux-ppc64-gnu/README.md
+++ b/packages/minifier/scripts/npm/linux-ppc64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/minifier-linux-ppc64-gnu`
+
+This is the **powerpc64le-unknown-linux-gnu** binary for `@swc/minifier`

--- a/packages/minifier/scripts/npm/linux-ppc64-gnu/package.json
+++ b/packages/minifier/scripts/npm/linux-ppc64-gnu/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@swc/minifier-linux-ppc64-gnu",
+  "version": "1.15.18",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "ppc64"
+  ],
+  "main": "minifier.linux-ppc64-gnu.node",
+  "files": [
+    "minifier.linux-ppc64-gnu.node",
+    "swc"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast alternative for babel",
+  "keywords": [
+    "swc",
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/packages/minifier/scripts/npm/linux-s390x-gnu/README.md
+++ b/packages/minifier/scripts/npm/linux-s390x-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/minifier-linux-s390x-gnu`
+
+This is the **s390x-unknown-linux-gnu** binary for `@swc/minifier`

--- a/packages/minifier/scripts/npm/linux-s390x-gnu/package.json
+++ b/packages/minifier/scripts/npm/linux-s390x-gnu/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@swc/minifier-linux-s390x-gnu",
+  "version": "1.15.18",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "s390x"
+  ],
+  "main": "minifier.linux-s390x-gnu.node",
+  "files": [
+    "minifier.linux-s390x-gnu.node",
+    "swc"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast alternative for babel",
+  "keywords": [
+    "swc",
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -28,6 +28,8 @@
       "x86_64-apple-darwin",
       "x86_64-pc-windows-msvc",
       "x86_64-unknown-linux-gnu",
+      "powerpc64le-unknown-linux-gnu",
+      "s390x-unknown-linux-gnu",
       "x86_64-unknown-linux-musl",
       "i686-pc-windows-msvc",
       "armv7-unknown-linux-gnueabihf",

--- a/packages/react-compiler/scripts/npm/linux-ppc64-gnu/README.md
+++ b/packages/react-compiler/scripts/npm/linux-ppc64-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/react-compiler-linux-ppc64-gnu`
+
+This is the **powerpc64le-unknown-linux-gnu** binary for `@swc/react-compiler`

--- a/packages/react-compiler/scripts/npm/linux-ppc64-gnu/package.json
+++ b/packages/react-compiler/scripts/npm/linux-ppc64-gnu/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@swc/react-compiler-linux-ppc64-gnu",
+  "version": "1.15.18",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "ppc64"
+  ],
+  "main": "react-compiler.linux-ppc64-gnu.node",
+  "files": [
+    "react-compiler.linux-ppc64-gnu.node",
+    "swc"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast alternative for babel",
+  "keywords": [
+    "swc",
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/packages/react-compiler/scripts/npm/linux-s390x-gnu/README.md
+++ b/packages/react-compiler/scripts/npm/linux-s390x-gnu/README.md
@@ -1,0 +1,3 @@
+# `@swc/react-compiler-linux-s390x-gnu`
+
+This is the **s390x-unknown-linux-gnu** binary for `@swc/react-compiler`

--- a/packages/react-compiler/scripts/npm/linux-s390x-gnu/package.json
+++ b/packages/react-compiler/scripts/npm/linux-s390x-gnu/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@swc/react-compiler-linux-s390x-gnu",
+  "version": "1.15.18",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "s390x"
+  ],
+  "main": "react-compiler.linux-s390x-gnu.node",
+  "files": [
+    "react-compiler.linux-s390x-gnu.node",
+    "swc"
+  ],
+  "libc": [
+    "glibc"
+  ],
+  "description": "Super-fast alternative for babel",
+  "keywords": [
+    "swc",
+    "swcpack",
+    "babel",
+    "typescript",
+    "rust",
+    "webpack",
+    "tsc"
+  ],
+  "author": "강동윤 <kdy1997.dev@gmail.com>",
+  "homepage": "https://swc.rs",
+  "license": "Apache-2.0 AND MIT",
+  "engines": {
+    "node": ">=10"
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public",
+    "provenance": true
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/swc-project/swc.git"
+  },
+  "bugs": {
+    "url": "https://github.com/swc-project/swc/issues"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4457,6 +4457,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@swc/core-linux-ppc64-gnu@workspace:packages/core/scripts/npm/linux-ppc64-gnu":
+  version: 0.0.0-use.local
+  resolution: "@swc/core-linux-ppc64-gnu@workspace:packages/core/scripts/npm/linux-ppc64-gnu"
+  languageName: unknown
+  linkType: soft
+
+"@swc/core-linux-s390x-gnu@workspace:packages/core/scripts/npm/linux-s390x-gnu":
+  version: 0.0.0-use.local
+  resolution: "@swc/core-linux-s390x-gnu@workspace:packages/core/scripts/npm/linux-s390x-gnu"
+  languageName: unknown
+  linkType: soft
+
 "@swc/core-linux-x64-gnu@workspace:packages/core/scripts/npm/linux-x64-gnu":
   version: 0.0.0-use.local
   resolution: "@swc/core-linux-x64-gnu@workspace:packages/core/scripts/npm/linux-x64-gnu"
@@ -4578,6 +4590,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@swc/html-linux-ppc64-gnu@workspace:packages/html/scripts/npm/linux-ppc64-gnu":
+  version: 0.0.0-use.local
+  resolution: "@swc/html-linux-ppc64-gnu@workspace:packages/html/scripts/npm/linux-ppc64-gnu"
+  languageName: unknown
+  linkType: soft
+
+"@swc/html-linux-s390x-gnu@workspace:packages/html/scripts/npm/linux-s390x-gnu":
+  version: 0.0.0-use.local
+  resolution: "@swc/html-linux-s390x-gnu@workspace:packages/html/scripts/npm/linux-s390x-gnu"
+  languageName: unknown
+  linkType: soft
+
 "@swc/html-linux-x64-gnu@workspace:packages/html/scripts/npm/linux-x64-gnu":
   version: 0.0.0-use.local
   resolution: "@swc/html-linux-x64-gnu@workspace:packages/html/scripts/npm/linux-x64-gnu"
@@ -4645,6 +4669,18 @@ __metadata:
 "@swc/minifier-linux-arm64-musl@workspace:packages/minifier/scripts/npm/linux-arm64-musl":
   version: 0.0.0-use.local
   resolution: "@swc/minifier-linux-arm64-musl@workspace:packages/minifier/scripts/npm/linux-arm64-musl"
+  languageName: unknown
+  linkType: soft
+
+"@swc/minifier-linux-ppc64-gnu@workspace:packages/minifier/scripts/npm/linux-ppc64-gnu":
+  version: 0.0.0-use.local
+  resolution: "@swc/minifier-linux-ppc64-gnu@workspace:packages/minifier/scripts/npm/linux-ppc64-gnu"
+  languageName: unknown
+  linkType: soft
+
+"@swc/minifier-linux-s390x-gnu@workspace:packages/minifier/scripts/npm/linux-s390x-gnu":
+  version: 0.0.0-use.local
+  resolution: "@swc/minifier-linux-s390x-gnu@workspace:packages/minifier/scripts/npm/linux-s390x-gnu"
   languageName: unknown
   linkType: soft
 
@@ -4727,6 +4763,18 @@ __metadata:
 "@swc/react-compiler-linux-arm64-musl@workspace:packages/react-compiler/scripts/npm/linux-arm64-musl":
   version: 0.0.0-use.local
   resolution: "@swc/react-compiler-linux-arm64-musl@workspace:packages/react-compiler/scripts/npm/linux-arm64-musl"
+  languageName: unknown
+  linkType: soft
+
+"@swc/react-compiler-linux-ppc64-gnu@workspace:packages/react-compiler/scripts/npm/linux-ppc64-gnu":
+  version: 0.0.0-use.local
+  resolution: "@swc/react-compiler-linux-ppc64-gnu@workspace:packages/react-compiler/scripts/npm/linux-ppc64-gnu"
+  languageName: unknown
+  linkType: soft
+
+"@swc/react-compiler-linux-s390x-gnu@workspace:packages/react-compiler/scripts/npm/linux-s390x-gnu":
+  version: 0.0.0-use.local
+  resolution: "@swc/react-compiler-linux-s390x-gnu@workspace:packages/react-compiler/scripts/npm/linux-s390x-gnu"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary
- add `powerpc64le-unknown-linux-gnu` and `s390x-unknown-linux-gnu` N-API targets to `@swc/core`, `@swc/html`, `@swc/minifier`, and `@swc/react-compiler`
- add missing runtime loader branches for `ppc64` in `@swc/core` and `@swc/html` to match published binary packages
- add new npm binary package stubs for `linux-ppc64-gnu` and `linux-s390x-gnu` across all four bindings
- extend npm publish workflow build matrix with `powerpc64le-unknown-linux-gnu` and `s390x-unknown-linux-gnu`

## Testing
- git submodule update --init --recursive
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings

## Notes
- this PR covers Linux IBM targets (`ppc64le`, `s390x`) across all npm bindings
- AIX native target support is not included in this PR

Refs #11590