### PR TITLE
chore(ci): bump cargo-mono to 0.5.0

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install cargo-mono
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mono@0.4.1
+          tool: cargo-mono@0.5.0
 
       - name: Update constant of swc_core
         run: npx ts-node .github/bot/src/cargo/update-constants.ts


### PR DESCRIPTION
## Summary
- update .github/workflows/publish-crates.yml to install cargo-mono@0.5.0 instead of 0.4.1

## Testing
- not run (CI workflow version bump only)