### PR TITLE
feat(es2015): prevent recursive instanceof helper transforms

### DIFF
--- a/crates/swc_ecma_compat_es2015/src/instanceof.rs
+++ b/crates/swc_ecma_compat_es2015/src/instanceof.rs
@@ -30,3 +30,56 @@ pub fn instance_of() -> impl Pass {
     options.env.es2015.instanceof = true;
     options.into_pass()
 }
+
+#[cfg(test)]
+mod tests {
+    use swc_ecma_parser::Syntax;
+    use swc_ecma_transforms_testing::test;
+
+    use super::*;
+
+    test!(
+        Syntax::default(),
+        |_| instance_of(),
+        basic,
+        "foo instanceof Bar;"
+    );
+
+    test!(
+        Syntax::default(),
+        |_| instance_of(),
+        skip_helper_fn_decl_by_name,
+        "
+        function _instanceof(left, right) {
+            return left instanceof right;
+        }
+        foo instanceof Bar;
+        "
+    );
+
+    test!(
+        Syntax::default(),
+        |_| instance_of(),
+        skip_helper_fn_expr_by_swc_directive,
+        "
+        const helper = function(left, right) {
+            '@swc/helpers - instanceof';
+            return left instanceof right;
+        };
+        foo instanceof Bar;
+        "
+    );
+
+    test!(
+        Syntax::default(),
+        |_| instance_of(),
+        skip_helper_fn_expr_by_babel_directive,
+        "
+        const helper = function(left, right) {
+            '@babel/helpers - instanceof';
+            return left instanceof right;
+        };
+        foo instanceof Bar;
+        "
+    );
+}

--- a/crates/swc_ecma_compat_es2015/tests/__swc_snapshots__/src/instanceof.rs/basic.js
+++ b/crates/swc_ecma_compat_es2015/tests/__swc_snapshots__/src/instanceof.rs/basic.js
@@ -1,0 +1,1 @@
+_instanceof(foo, Bar);

--- a/crates/swc_ecma_compat_es2015/tests/__swc_snapshots__/src/instanceof.rs/skip_helper_fn_decl_by_name.js
+++ b/crates/swc_ecma_compat_es2015/tests/__swc_snapshots__/src/instanceof.rs/skip_helper_fn_decl_by_name.js
@@ -1,0 +1,4 @@
+function _instanceof1(left, right) {
+    return left instanceof right;
+}
+_instanceof(foo, Bar);

--- a/crates/swc_ecma_compat_es2015/tests/__swc_snapshots__/src/instanceof.rs/skip_helper_fn_expr_by_babel_directive.js
+++ b/crates/swc_ecma_compat_es2015/tests/__swc_snapshots__/src/instanceof.rs/skip_helper_fn_expr_by_babel_directive.js
@@ -1,0 +1,5 @@
+const helper = function(left, right) {
+    '@babel/helpers - instanceof';
+    return left instanceof right;
+};
+_instanceof(foo, Bar);

--- a/crates/swc_ecma_compat_es2015/tests/__swc_snapshots__/src/instanceof.rs/skip_helper_fn_expr_by_swc_directive.js
+++ b/crates/swc_ecma_compat_es2015/tests/__swc_snapshots__/src/instanceof.rs/skip_helper_fn_expr_by_swc_directive.js
@@ -1,0 +1,5 @@
+const helper = function(left, right) {
+    '@swc/helpers - instanceof';
+    return left instanceof right;
+};
+_instanceof(foo, Bar);

--- a/crates/swc_ecma_transformer/src/es2015/instanceof.rs
+++ b/crates/swc_ecma_transformer/src/es2015/instanceof.rs
@@ -39,13 +39,22 @@ use swc_ecma_utils::ExprFactory;
 use crate::TraverseCtx;
 
 pub fn hook() -> impl VisitMutHook<TraverseCtx> {
-    InstanceOfPass
+    InstanceOfPass::default()
 }
 
-struct InstanceOfPass;
+#[derive(Default)]
+struct InstanceOfPass {
+    /// When non-zero, we're inside a helper function and should skip
+    /// transformation.
+    in_helper_fn: u32,
+}
 
 impl VisitMutHook<TraverseCtx> for InstanceOfPass {
     fn exit_expr(&mut self, expr: &mut Expr, _ctx: &mut TraverseCtx) {
+        if self.in_helper_fn > 0 {
+            return;
+        }
+
         if let Expr::Bin(BinExpr {
             span,
             left,
@@ -65,6 +74,52 @@ impl VisitMutHook<TraverseCtx> for InstanceOfPass {
                 ..Default::default()
             }
             .into();
+        }
+    }
+
+    fn enter_fn_decl(&mut self, f: &mut FnDecl, _ctx: &mut TraverseCtx) {
+        if &f.ident.sym == "_instanceof" {
+            self.in_helper_fn += 1;
+        }
+    }
+
+    fn exit_fn_decl(&mut self, f: &mut FnDecl, _ctx: &mut TraverseCtx) {
+        if &f.ident.sym == "_instanceof" {
+            self.in_helper_fn = self.in_helper_fn.saturating_sub(1);
+        }
+    }
+
+    fn enter_function(&mut self, f: &mut Function, _ctx: &mut TraverseCtx) {
+        if let Some(body) = &f.body {
+            if let Some(Stmt::Expr(first)) = body.stmts.first() {
+                if let Expr::Lit(Lit::Str(s)) = &*first.expr {
+                    if let Some(text) = s.value.as_str() {
+                        if matches!(
+                            text,
+                            "@swc/helpers - instanceof" | "@babel/helpers - instanceof"
+                        ) {
+                            self.in_helper_fn += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fn exit_function(&mut self, f: &mut Function, _ctx: &mut TraverseCtx) {
+        if let Some(body) = &f.body {
+            if let Some(Stmt::Expr(first)) = body.stmts.first() {
+                if let Expr::Lit(Lit::Str(s)) = &*first.expr {
+                    if let Some(text) = s.value.as_str() {
+                        if matches!(
+                            text,
+                            "@swc/helpers - instanceof" | "@babel/helpers - instanceof"
+                        ) {
+                            self.in_helper_fn = self.in_helper_fn.saturating_sub(1);
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/swc_ecma_transforms_base/src/helpers/_instanceof.js
+++ b/crates/swc_ecma_transforms_base/src/helpers/_instanceof.js
@@ -1,4 +1,6 @@
 function _instanceof(left, right) {
+    "@swc/helpers - instanceof";
+
     if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) {
         return !!right[Symbol.hasInstance](left);
     } else {

--- a/packages/helpers/esm/_instanceof.js
+++ b/packages/helpers/esm/_instanceof.js
@@ -1,4 +1,6 @@
 function _instanceof(left, right) {
+    "@swc/helpers - instanceof";
+
     if (right != null && typeof Symbol !== "undefined" && right[Symbol.hasInstance]) {
         return !!right[Symbol.hasInstance](left);
     } else return left instanceof right;


### PR DESCRIPTION
## Summary
- add helper recursion detection to the ES2015 `instanceof` transform, matching `typeof` behavior
- skip transforming `instanceof` inside helper bodies by function name (`_instanceof`) and helper directives (`@swc/helpers - instanceof`, `@babel/helpers - instanceof`)
- add `@swc/helpers - instanceof` directive to both helper sources
- add regression tests and snapshots for basic transform + helper-skip scenarios

## Testing
- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_compat_es2015` (new tests passed; existing `test_exec` cases requiring `mocha` failed in local env)
- `cargo test -p swc_ecma_compat_es2015` (same existing `mocha` env limitation)
- `cargo test -p swc_ecma_transformer`
- `cargo test -p swc_ecma_transforms_base`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
