### PR TITLE
feat(es_parser): Complete parity suite with zero ignores

### DIFF
--- a/crates/swc_es_parser/README.md
+++ b/crates/swc_es_parser/README.md
@@ -1,6 +1,6 @@
 # swc_es_parser
 
-`swc_es_parser` is a bootstrap ECMAScript parser that builds arena-backed nodes from `swc_es_ast`.
+`swc_es_parser` is an ECMAScript parser that builds arena-backed nodes from `swc_es_ast`.
 
 ## Goals
 
@@ -11,20 +11,16 @@
 ## Current Status
 
 - Script/module/program entry points are available.
-- Core statements and expression parsing are implemented.
-- `import`/`export` bootstrap parsing is included.
-- Structured `for` head parsing is available (`classic`, `for..in`, `for..of`).
-- JSX parsing supports qualified tag names and reports opening/closing tag mismatches.
-- TypeScript parsing builds structured type nodes (function/union/intersection/tuple/array/type-literal/type-args) for `type` aliases and `as` assertions.
+- Core statements, expressions, module declarations, JSX, and TypeScript constructs are parsed.
+- Parity pass/fail behavior is continuously validated against reused `swc_ecma_parser` fixture corpora.
 
-## Fixture Harness
+## Parity Harness
 
 - `swc_ecma_parser` inputs are reused from `crates/swc_ecma_parser/tests`.
-- `swc_es_parser` snapshots are stored under `crates/swc_es_parser/tests/fixtures`.
-- Generate or refresh snapshots with:
+- Run parity checks with:
 
 ```bash
-UPDATE=1 cargo test -p swc_es_parser --test fixture_harness
+cargo test -p swc_es_parser --test parity_suite
 ```
 
 ## API Sketch

--- a/crates/swc_es_parser/src/lexer.rs
+++ b/crates/swc_es_parser/src/lexer.rs
@@ -8,7 +8,7 @@ use swc_common::{
 use crate::{
     error::{Error, ErrorCode, Severity},
     syntax::Syntax,
-    token::{Keyword, Token, TokenKind, TokenValue},
+    token::{Keyword, Token, TokenFlags, TokenKind, TokenValue},
 };
 
 /// Checkpoint for lexer backtracking.
@@ -105,6 +105,7 @@ impl<'a> Lexer<'a> {
                         span,
                         had_line_break_before,
                         value: Some(TokenValue::Ident(Atom::new(ch.to_string()))),
+                        flags: TokenFlags::default(),
                     };
                 }
 
@@ -224,6 +225,7 @@ impl<'a> Lexer<'a> {
                         span,
                         had_line_break_before,
                         value: Some(TokenValue::Ident(Atom::new(ch.to_string()))),
+                        flags: TokenFlags::default(),
                     }
                 }
             }
@@ -462,6 +464,22 @@ impl<'a> Lexer<'a> {
         )
     }
 
+    fn value_token(
+        &self,
+        kind: TokenKind,
+        span: Span,
+        had_line_break_before: bool,
+        value: TokenValue,
+    ) -> Token {
+        Token {
+            kind,
+            span,
+            had_line_break_before,
+            value: Some(value),
+            flags: TokenFlags::default(),
+        }
+    }
+
     fn read_number(&mut self, had_line_break_before: bool) -> Token {
         let start = self.input.cur_pos();
         let mut radix = 10u32;
@@ -537,12 +555,12 @@ impl<'a> Lexer<'a> {
             if radix != 10 && value.len() >= 2 {
                 value = value[2..].to_string();
             }
-            return Token {
-                kind: TokenKind::BigInt,
-                span: Span::new_with_checked(start, end),
+            return self.value_token(
+                TokenKind::BigInt,
+                Span::new_with_checked(start, end),
                 had_line_break_before,
-                value: Some(TokenValue::BigInt(Atom::new(value))),
-            };
+                TokenValue::BigInt(Atom::new(value)),
+            );
         }
 
         let end = self.input.cur_pos();
@@ -573,12 +591,12 @@ impl<'a> Lexer<'a> {
                 })
         };
 
-        Token {
-            kind: TokenKind::Num,
-            span: Span::new_with_checked(start, end),
+        self.value_token(
+            TokenKind::Num,
+            Span::new_with_checked(start, end),
             had_line_break_before,
-            value: Some(TokenValue::Num(value)),
-        }
+            TokenValue::Num(value),
+        )
     }
 
     fn read_number_after_dot(
@@ -613,12 +631,12 @@ impl<'a> Lexer<'a> {
             0.0
         });
 
-        Token {
-            kind: TokenKind::Num,
-            span: Span::new_with_checked(start, end),
+        self.value_token(
+            TokenKind::Num,
+            Span::new_with_checked(start, end),
             had_line_break_before,
-            value: Some(TokenValue::Num(value)),
-        }
+            TokenValue::Num(value),
+        )
     }
 
     fn read_string(&mut self, had_line_break_before: bool) -> Token {
@@ -630,6 +648,7 @@ impl<'a> Lexer<'a> {
         let mut out = String::new();
         let mut terminated = false;
         let mut saw_lt = false;
+        let mut flags = TokenFlags::default();
 
         while let Some(ch) = self.input.cur_as_char() {
             if ch as u32 <= 0x7f && ch as u8 == quote {
@@ -639,7 +658,10 @@ impl<'a> Lexer<'a> {
             }
 
             if ch == '\\' {
+                let esc_start = self.input.cur_pos();
                 self.bump_char();
+                flags.escaped = true;
+
                 match self.input.cur_as_char() {
                     Some('n') => {
                         self.bump_char();
@@ -653,6 +675,18 @@ impl<'a> Lexer<'a> {
                         self.bump_char();
                         out.push('\t');
                     }
+                    Some('b') => {
+                        self.bump_char();
+                        out.push('\u{0008}');
+                    }
+                    Some('f') => {
+                        self.bump_char();
+                        out.push('\u{000C}');
+                    }
+                    Some('v') => {
+                        self.bump_char();
+                        out.push('\u{000B}');
+                    }
                     Some('\\') => {
                         self.bump_char();
                         out.push('\\');
@@ -664,6 +698,65 @@ impl<'a> Lexer<'a> {
                     Some('\'') => {
                         self.bump_char();
                         out.push('\'');
+                    }
+                    Some('x') => {
+                        let checkpoint = self.input.clone();
+                        if let Some(decoded) = self.read_hex_escape(2) {
+                            out.push(decoded);
+                        } else {
+                            self.input = checkpoint;
+                            self.bump_char();
+                            flags.contains_invalid_escape = true;
+                            self.errors.push(Error::new(
+                                Span::new_with_checked(esc_start, self.input.cur_pos()),
+                                Severity::Error,
+                                ErrorCode::InvalidEscape,
+                                "invalid hexadecimal escape sequence",
+                            ));
+                        }
+                    }
+                    Some('u') => {
+                        let checkpoint = self.input.clone();
+                        if let Some(decoded) = self.read_unicode_escape_after_u() {
+                            out.push(decoded);
+                        } else {
+                            self.input = checkpoint;
+                            self.bump_char();
+                            flags.contains_invalid_escape = true;
+                            self.errors.push(Error::new(
+                                Span::new_with_checked(esc_start, self.input.cur_pos()),
+                                Severity::Error,
+                                ErrorCode::InvalidEscape,
+                                "invalid unicode escape sequence",
+                            ));
+                        }
+                    }
+                    Some('0') => {
+                        if matches!(self.input.peek(), Some(b'0'..=b'9')) {
+                            let decoded = self.read_legacy_octal_escape();
+                            flags.contains_legacy_octal_escape = true;
+                            out.push(decoded);
+                        } else {
+                            self.bump_char();
+                            out.push('\0');
+                        }
+                    }
+                    Some('1'..='7') => {
+                        let decoded = self.read_legacy_octal_escape();
+                        flags.contains_legacy_octal_escape = true;
+                        out.push(decoded);
+                    }
+                    Some('8' | '9') => {
+                        let value = self.input.cur_as_char().unwrap_or('\0');
+                        self.bump_char();
+                        flags.contains_invalid_escape = true;
+                        self.errors.push(Error::new(
+                            Span::new_with_checked(esc_start, self.input.cur_pos()),
+                            Severity::Error,
+                            ErrorCode::InvalidEscape,
+                            "invalid decimal escape sequence",
+                        ));
+                        out.push(value);
                     }
                     Some('\n') => {
                         self.bump_char();
@@ -711,6 +804,7 @@ impl<'a> Lexer<'a> {
                     span: Span::new_with_checked(start, end),
                     had_line_break_before,
                     value: Some(TokenValue::Ident(Atom::new("'"))),
+                    flags: TokenFlags::default(),
                 };
             }
             self.errors.push(Error::new(
@@ -726,6 +820,7 @@ impl<'a> Lexer<'a> {
             span: Span::new_with_checked(start, end),
             had_line_break_before,
             value: Some(TokenValue::Str(Atom::new(out))),
+            flags,
         }
     }
 
@@ -736,6 +831,7 @@ impl<'a> Lexer<'a> {
         let mut out = String::new();
         let mut terminated = false;
         let mut expr_depth = 0usize;
+        let mut flags = TokenFlags::default();
 
         while let Some(ch) = self.input.cur_as_char() {
             if ch == '`' && expr_depth == 0 {
@@ -745,8 +841,93 @@ impl<'a> Lexer<'a> {
             }
 
             if ch == '\\' {
+                let esc_start = self.input.cur_pos();
                 self.bump_char();
+                flags.escaped = true;
                 match self.input.cur_as_char() {
+                    Some('n') => {
+                        self.bump_char();
+                        out.push('\n');
+                    }
+                    Some('r') => {
+                        self.bump_char();
+                        out.push('\r');
+                    }
+                    Some('t') => {
+                        self.bump_char();
+                        out.push('\t');
+                    }
+                    Some('b') => {
+                        self.bump_char();
+                        out.push('\u{0008}');
+                    }
+                    Some('f') => {
+                        self.bump_char();
+                        out.push('\u{000C}');
+                    }
+                    Some('v') => {
+                        self.bump_char();
+                        out.push('\u{000B}');
+                    }
+                    Some('x') => {
+                        let checkpoint = self.input.clone();
+                        if let Some(decoded) = self.read_hex_escape(2) {
+                            out.push(decoded);
+                        } else {
+                            self.input = checkpoint;
+                            self.bump_char();
+                            flags.contains_invalid_escape = true;
+                            self.errors.push(Error::new(
+                                Span::new_with_checked(esc_start, self.input.cur_pos()),
+                                Severity::Error,
+                                ErrorCode::InvalidEscape,
+                                "invalid hexadecimal escape sequence",
+                            ));
+                        }
+                    }
+                    Some('u') => {
+                        let checkpoint = self.input.clone();
+                        if let Some(decoded) = self.read_unicode_escape_after_u() {
+                            out.push(decoded);
+                        } else {
+                            self.input = checkpoint;
+                            self.bump_char();
+                            flags.contains_invalid_escape = true;
+                            self.errors.push(Error::new(
+                                Span::new_with_checked(esc_start, self.input.cur_pos()),
+                                Severity::Error,
+                                ErrorCode::InvalidEscape,
+                                "invalid unicode escape sequence",
+                            ));
+                        }
+                    }
+                    Some('0') => {
+                        if matches!(self.input.peek(), Some(b'0'..=b'9')) {
+                            let decoded = self.read_legacy_octal_escape();
+                            flags.contains_legacy_octal_escape = true;
+                            out.push(decoded);
+                        } else {
+                            self.bump_char();
+                            out.push('\0');
+                        }
+                    }
+                    Some('1'..='7') => {
+                        let decoded = self.read_legacy_octal_escape();
+                        flags.contains_legacy_octal_escape = true;
+                        out.push(decoded);
+                    }
+                    Some('8' | '9') => {
+                        let value = self.input.cur_as_char().unwrap_or('\0');
+                        self.bump_char();
+                        flags.contains_invalid_escape = true;
+                        self.errors.push(Error::new(
+                            Span::new_with_checked(esc_start, self.input.cur_pos()),
+                            Severity::Error,
+                            ErrorCode::InvalidEscape,
+                            "invalid decimal escape sequence",
+                        ));
+                        out.push(value);
+                    }
                     Some(next) => {
                         self.bump_char();
                         out.push(next);
@@ -798,6 +979,48 @@ impl<'a> Lexer<'a> {
             span: Span::new_with_checked(start, end),
             had_line_break_before,
             value: Some(TokenValue::Str(Atom::new(out))),
+            flags,
+        }
+    }
+
+    fn read_legacy_octal_escape(&mut self) -> char {
+        let first = self.input.cur_as_char().unwrap_or('0');
+        let mut value = first.to_digit(8).unwrap_or(0);
+        self.bump_char();
+
+        let max_extra_digits = if first <= '3' { 2 } else { 1 };
+        for _ in 0..max_extra_digits {
+            let Some(ch) = self.input.cur_as_char() else {
+                break;
+            };
+            if !matches!(ch, '0'..='7') {
+                break;
+            }
+            value = value
+                .saturating_mul(8)
+                .saturating_add(ch.to_digit(8).unwrap_or(0));
+            self.bump_char();
+        }
+
+        char::from_u32(value).unwrap_or('\0')
+    }
+
+    fn read_hex_escape(&mut self, digits: usize) -> Option<char> {
+        if self.input.cur_as_char() != Some('x') {
+            return None;
+        }
+        self.bump_char();
+        let mut value = 0u32;
+        for _ in 0..digits {
+            let ch = self.input.cur_as_char()?;
+            let digit = ch.to_digit(16)?;
+            value = value.saturating_mul(16).saturating_add(digit);
+            self.bump_char();
+        }
+        match char::from_u32(value) {
+            Some(ch) => Some(ch),
+            None if (0xd800..=0xdfff).contains(&value) => Some('\u{FFFD}'),
+            None => None,
         }
     }
 
@@ -845,6 +1068,7 @@ impl<'a> Lexer<'a> {
                 span: Span::new_with_checked(start, end),
                 had_line_break_before,
                 value: Some(TokenValue::Ident(Atom::new(raw))),
+                flags: TokenFlags::default(),
             };
         }
 
@@ -862,12 +1086,12 @@ impl<'a> Lexer<'a> {
             kind: TokenKind::Ident,
             span: Span::new_with_checked(start, end),
             had_line_break_before,
-            value: Some(TokenValue::Ident(if has_escape {
-                let raw = unsafe { self.input.slice_str(start, end) };
-                Atom::new(raw)
-            } else {
-                Atom::new(out)
-            })),
+            value: Some(TokenValue::Ident(Atom::new(out))),
+            flags: TokenFlags {
+                escaped: has_escape,
+                contains_legacy_octal_escape: false,
+                contains_invalid_escape: false,
+            },
         }
     }
 
@@ -876,6 +1100,13 @@ impl<'a> Lexer<'a> {
             return None;
         }
         self.bump_ascii();
+        self.read_unicode_escape_after_u()
+    }
+
+    fn read_unicode_escape_after_u(&mut self) -> Option<char> {
+        if self.input.cur_as_ascii() != Some(b'u') {
+            return None;
+        }
         self.bump_ascii();
 
         let value = if self.input.cur_as_ascii() == Some(b'{') {
@@ -907,7 +1138,11 @@ impl<'a> Lexer<'a> {
             value
         };
 
-        char::from_u32(value)
+        match char::from_u32(value) {
+            Some(ch) => Some(ch),
+            None if (0xd800..=0xdfff).contains(&value) => Some('\u{FFFD}'),
+            None => None,
+        }
     }
 
     fn skip_space_and_comments(&mut self) {

--- a/crates/swc_es_parser/src/parser.rs
+++ b/crates/swc_es_parser/src/parser.rs
@@ -17,7 +17,7 @@ use crate::{
     context::Context,
     error::{Error, ErrorCode, Severity},
     lexer::Lexer,
-    token::{Keyword, Token, TokenKind, TokenValue},
+    token::{Keyword, Token, TokenFlags, TokenKind, TokenValue},
     Syntax,
 };
 
@@ -33,6 +33,19 @@ pub struct ParsedProgram {
     pub program: ProgramId,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegexAtomKind {
+    None,
+    Atom,
+    Assertion,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RegexGroupKind {
+    Group,
+    Assertion,
+}
+
 /// ECMAScript parser producing `swc_es_ast` nodes.
 pub struct Parser<'a> {
     lexer: Lexer<'a>,
@@ -42,6 +55,7 @@ pub struct Parser<'a> {
     errors: Vec<Error>,
     ctx: Context,
     pending_decorators: Vec<Decorator>,
+    string_token_flags: Vec<(Span, TokenFlags)>,
 }
 
 impl<'a> Parser<'a> {
@@ -56,6 +70,7 @@ impl<'a> Parser<'a> {
             errors: Vec::new(),
             ctx: Context::TOP_LEVEL | Context::CAN_BE_MODULE,
             pending_decorators: Vec::new(),
+            string_token_flags: Vec::new(),
         }
     }
 
@@ -81,7 +96,7 @@ impl<'a> Parser<'a> {
         self.ctx.insert(Context::TOP_LEVEL);
         self.ctx.remove(Context::MODULE | Context::CAN_BE_MODULE);
         let start = self.cur.span.lo;
-        let body = self.parse_stmt_list(false)?;
+        let (body, _) = self.parse_stmt_list(false, true)?;
         let program = self.store.alloc_program(Program {
             span: Span::new_with_checked(start, self.last_pos()),
             kind: ProgramKind::Script,
@@ -99,7 +114,7 @@ impl<'a> Parser<'a> {
         self.ctx
             .insert(Context::MODULE | Context::TOP_LEVEL | Context::STRICT);
         let start = self.cur.span.lo;
-        let body = self.parse_stmt_list(true)?;
+        let (body, _) = self.parse_stmt_list(true, true)?;
         let program = self.store.alloc_program(Program {
             span: Span::new_with_checked(start, self.last_pos()),
             kind: ProgramKind::Module,
@@ -116,29 +131,7 @@ impl<'a> Parser<'a> {
     pub fn parse_program(&mut self) -> PResult<ParsedProgram> {
         self.ctx.insert(Context::CAN_BE_MODULE);
         let start = self.cur.span.lo;
-        let mut body = Vec::new();
-        let mut has_module_item = false;
-
-        while self.cur.kind != TokenKind::Eof {
-            let parsed = if self.is_module_start() {
-                has_module_item = true;
-                self.parse_module_decl_stmt()
-            } else {
-                self.parse_stmt()
-            };
-            match parsed {
-                Ok(stmt) => body.push(stmt),
-                Err(err) => {
-                    if err.severity() == Severity::Fatal && self.syntax().early_errors() {
-                        return Err(err);
-                    }
-                    if self.syntax().early_errors() {
-                        self.errors.push(err);
-                    }
-                    self.recover_stmt();
-                }
-            }
-        }
+        let (body, has_module_item) = self.parse_stmt_list(true, true)?;
 
         let kind = if has_module_item {
             ProgramKind::Module
@@ -158,18 +151,35 @@ impl<'a> Parser<'a> {
         })
     }
 
-    fn parse_stmt_list(&mut self, allow_module: bool) -> PResult<Vec<swc_es_ast::StmtId>> {
+    fn parse_stmt_list(
+        &mut self,
+        allow_module: bool,
+        enable_directive_prologue: bool,
+    ) -> PResult<(Vec<swc_es_ast::StmtId>, bool)> {
         let mut body = Vec::new();
+        let mut has_module_item = false;
+        let mut in_directive_prologue = enable_directive_prologue;
+        let mut directive_octal_spans = Vec::new();
 
         while self.cur.kind != TokenKind::Eof {
             let parsed = if allow_module && self.is_module_start() {
+                has_module_item = true;
                 self.parse_module_decl_stmt()
             } else {
                 self.parse_stmt()
             };
 
             match parsed {
-                Ok(stmt) => body.push(stmt),
+                Ok(stmt) => {
+                    if in_directive_prologue {
+                        self.update_directive_prologue(
+                            stmt,
+                            &mut in_directive_prologue,
+                            &mut directive_octal_spans,
+                        );
+                    }
+                    body.push(stmt);
+                }
                 Err(err) => {
                     if err.severity() == Severity::Fatal && self.syntax().early_errors() {
                         return Err(err);
@@ -177,12 +187,13 @@ impl<'a> Parser<'a> {
                     if self.syntax().early_errors() {
                         self.errors.push(err);
                     }
+                    in_directive_prologue = false;
                     self.recover_stmt();
                 }
             }
         }
 
-        Ok(body)
+        Ok((body, has_module_item))
     }
 
     fn parse_stmt(&mut self) -> PResult<swc_es_ast::StmtId> {
@@ -712,14 +723,46 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_block_stmt(&mut self) -> PResult<swc_es_ast::StmtId> {
+        self.parse_block_stmt_with_directives(false)
+    }
+
+    fn parse_block_stmt_with_directives(
+        &mut self,
+        enable_directive_prologue: bool,
+    ) -> PResult<swc_es_ast::StmtId> {
         let start = self.cur.span.lo;
         let _ = self.expect(TokenKind::LBrace, "{")?;
         let mut stmts = Vec::new();
+        let mut in_directive_prologue = enable_directive_prologue;
+        let mut directive_octal_spans = Vec::new();
         while self.cur.kind != TokenKind::RBrace && self.cur.kind != TokenKind::Eof {
-            if self.ctx.contains(Context::MODULE) && self.is_module_start() {
-                stmts.push(self.parse_module_decl_stmt()?);
+            let parsed = if self.ctx.contains(Context::MODULE) && self.is_module_start() {
+                self.parse_module_decl_stmt()
             } else {
-                stmts.push(self.parse_stmt()?);
+                self.parse_stmt()
+            };
+
+            match parsed {
+                Ok(stmt) => {
+                    if in_directive_prologue {
+                        self.update_directive_prologue(
+                            stmt,
+                            &mut in_directive_prologue,
+                            &mut directive_octal_spans,
+                        );
+                    }
+                    stmts.push(stmt);
+                }
+                Err(err) => {
+                    if err.severity() == Severity::Fatal && self.syntax().early_errors() {
+                        return Err(err);
+                    }
+                    if self.syntax().early_errors() {
+                        self.errors.push(err);
+                    }
+                    in_directive_prologue = false;
+                    self.recover_stmt();
+                }
             }
         }
         let _ = self.expect(TokenKind::RBrace, "}")?;
@@ -999,6 +1042,7 @@ impl<'a> Parser<'a> {
             false
         };
         let _ = self.expect(TokenKind::LParen, "(")?;
+        let starts_with_let_keyword = self.cur.kind == TokenKind::Keyword(Keyword::Let);
 
         let head = if self.cur.kind == TokenKind::Semi {
             self.bump();
@@ -1032,6 +1076,19 @@ impl<'a> Parser<'a> {
                     right,
                 })
             } else if self.cur_ident_is("of") {
+                if starts_with_let_keyword
+                    && matches!(
+                        init,
+                        ForInit::Expr(expr) if self.expr_is_let_member(expr)
+                    )
+                {
+                    return Err(Error::new(
+                        self.cur.span,
+                        Severity::Fatal,
+                        ErrorCode::InvalidStatement,
+                        "invalid left-hand side in for-of statement",
+                    ));
+                }
                 self.bump();
                 let right = self.parse_expr()?;
                 ForHead::Of(ForOfHead {
@@ -1217,7 +1274,7 @@ impl<'a> Parser<'a> {
         if is_generator {
             self.ctx.insert(Context::IN_GENERATOR);
         }
-        let body_stmt = self.parse_block_stmt()?;
+        let body_stmt = self.parse_block_stmt_with_directives(true)?;
         self.ctx = old_ctx;
 
         let body = match self.store.stmt(body_stmt).cloned() {
@@ -1955,6 +2012,18 @@ impl<'a> Parser<'a> {
                     sym: ident.sym,
                 }));
 
+                if matches!(
+                    self.cur.kind,
+                    TokenKind::Dot | TokenKind::QuestionDot | TokenKind::LBracket
+                ) {
+                    return Err(Error::new(
+                        self.cur.span,
+                        Severity::Fatal,
+                        ErrorCode::InvalidAssignTarget,
+                        "member access is not allowed in binding patterns",
+                    ));
+                }
+
                 if self.cur.kind == TokenKind::Eq {
                     let start = self.cur.span.lo;
                     self.bump();
@@ -2325,7 +2394,7 @@ impl<'a> Parser<'a> {
         let body = if self.cur.kind == TokenKind::LBrace {
             let old_ctx = self.ctx;
             self.ctx.insert(Context::IN_FUNCTION);
-            let body_stmt = self.parse_block_stmt()?;
+            let body_stmt = self.parse_block_stmt_with_directives(true)?;
             self.ctx = old_ctx;
             let stmts = match self.store.stmt(body_stmt).cloned() {
                 Some(Stmt::Block(block)) => block.stmts,
@@ -2906,7 +2975,12 @@ impl<'a> Parser<'a> {
 
         if self.cur.kind == TokenKind::Dot {
             self.bump();
-            if self.cur.kind == TokenKind::Ident && self.cur_ident_is("target") {
+            if self.cur.kind == TokenKind::Ident
+                && matches!(
+                    &self.cur.value,
+                    Some(TokenValue::Ident(sym)) if sym.as_ref() == "target"
+                )
+            {
                 self.bump();
                 return Ok(self
                     .store
@@ -2915,16 +2989,12 @@ impl<'a> Parser<'a> {
                         kind: swc_es_ast::MetaPropKind::NewTarget,
                     })));
             }
-            let prop = self.expect_ident()?;
-            let obj = self.store.alloc_expr(Expr::Ident(Ident {
-                span: Span::new_with_checked(start, start),
-                sym: Atom::new("new"),
-            }));
-            return Ok(self.store.alloc_expr(Expr::Member(MemberExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                obj,
-                prop: MemberProp::Ident(prop),
-            })));
+            return Err(Error::new(
+                self.cur.span,
+                Severity::Fatal,
+                ErrorCode::UnexpectedToken,
+                "expected `target` after `new.`",
+            ));
         }
 
         let callee = self.parse_postfix_expr()?;
@@ -2979,12 +3049,19 @@ impl<'a> Parser<'a> {
             }
             TokenKind::Str => {
                 let lit = self.cur_string_value();
+                let flags = self.cur.flags;
+                self.record_string_token_flags(lit.span, flags);
+                if flags.contains_legacy_octal_escape && self.ctx.contains(Context::STRICT) {
+                    self.push_strict_octal_error(lit.span);
+                }
                 self.bump();
                 Ok(self.store.alloc_expr(Expr::Lit(Lit::Str(lit))))
             }
             TokenKind::Template => {
                 let lit = self.cur_string_value();
                 let span = self.cur.span;
+                let flags = self.cur.flags;
+                self.record_string_token_flags(lit.span, flags);
                 self.bump();
                 Ok(self
                     .store
@@ -3070,13 +3147,13 @@ impl<'a> Parser<'a> {
                             }
                             self.bump();
                         }
-                        return Ok(self.store.alloc_expr(Expr::Lit(Lit::Regex(
-                            swc_es_ast::RegexLit {
-                                span: Span::new_with_checked(start, self.last_pos()),
-                                exp: Atom::new(pattern),
-                                flags,
-                            },
-                        ))));
+                        let lit = swc_es_ast::RegexLit {
+                            span: Span::new_with_checked(start, self.last_pos()),
+                            exp: Atom::new(pattern),
+                            flags,
+                        };
+                        self.validate_regex_literal(&lit);
+                        return Ok(self.store.alloc_expr(Expr::Lit(Lit::Regex(lit))));
                     }
 
                     if let Some(part) = self.regex_token_text_for_current() {
@@ -3100,13 +3177,13 @@ impl<'a> Parser<'a> {
 
                     self.bump();
                 }
-                Ok(self
-                    .store
-                    .alloc_expr(Expr::Lit(Lit::Regex(swc_es_ast::RegexLit {
-                        span: Span::new_with_checked(start, self.last_pos()),
-                        exp: Atom::new(pattern),
-                        flags: Atom::new(""),
-                    }))))
+                let lit = swc_es_ast::RegexLit {
+                    span: Span::new_with_checked(start, self.last_pos()),
+                    exp: Atom::new(pattern),
+                    flags: Atom::new(""),
+                };
+                self.validate_regex_literal(&lit);
+                Ok(self.store.alloc_expr(Expr::Lit(Lit::Regex(lit))))
             }
             TokenKind::LParen => {
                 let start = self.cur.span.lo;
@@ -3335,6 +3412,14 @@ impl<'a> Parser<'a> {
                 } else {
                     None
                 };
+                if !self.syntax().typescript() && ident.is_none() {
+                    self.errors.push(Error::new(
+                        Span::new_with_checked(member_start, self.last_pos()),
+                        Severity::Error,
+                        ErrorCode::UnexpectedToken,
+                        "class fields are not enabled in this syntax mode",
+                    ));
+                }
                 self.eat_semi();
                 members.push(self.store.alloc_class_member(swc_es_ast::ClassMember::Prop(
                     swc_es_ast::ClassProp {
@@ -3392,7 +3477,7 @@ impl<'a> Parser<'a> {
         if is_generator {
             self.ctx.insert(Context::IN_GENERATOR);
         }
-        let body_stmt = self.parse_block_stmt()?;
+        let body_stmt = self.parse_block_stmt_with_directives(true)?;
         self.ctx = old_ctx;
 
         let body = match self.store.stmt(body_stmt).cloned() {
@@ -3427,6 +3512,15 @@ impl<'a> Parser<'a> {
             }
             let expr = self.parse_assignment_expr()?;
             elems.push(Some(ExprOrSpread { spread, expr }));
+
+            if spread && self.cur.kind == TokenKind::Comma {
+                self.errors.push(Error::new(
+                    self.cur.span,
+                    Severity::Error,
+                    ErrorCode::InvalidStatement,
+                    "rest element must be the last element",
+                ));
+            }
 
             if self.cur.kind == TokenKind::Comma {
                 self.bump();
@@ -4628,6 +4722,276 @@ impl<'a> Parser<'a> {
         attrs
     }
 
+    fn update_directive_prologue(
+        &mut self,
+        stmt: swc_es_ast::StmtId,
+        in_directive_prologue: &mut bool,
+        directive_octal_spans: &mut Vec<Span>,
+    ) {
+        let Some((lit, flags)) = self.directive_string_literal(stmt) else {
+            *in_directive_prologue = false;
+            directive_octal_spans.clear();
+            return;
+        };
+
+        if flags.contains_legacy_octal_escape {
+            directive_octal_spans.push(lit.span);
+        }
+
+        if !flags.escaped && lit.value.as_ref() == "use strict" {
+            self.ctx.insert(Context::STRICT);
+
+            if flags.contains_legacy_octal_escape {
+                self.push_strict_octal_error(lit.span);
+            }
+            for span in directive_octal_spans.drain(..) {
+                self.push_strict_octal_error(span);
+            }
+        }
+    }
+
+    fn directive_string_literal(&self, stmt: swc_es_ast::StmtId) -> Option<(StrLit, TokenFlags)> {
+        let Stmt::Expr(expr_stmt) = self.store.stmt(stmt)?.clone() else {
+            return None;
+        };
+        let Expr::Lit(Lit::Str(lit)) = self.store.expr(expr_stmt.expr)?.clone() else {
+            return None;
+        };
+        let flags = self.string_token_flags(lit.span);
+        Some((lit, flags))
+    }
+
+    fn push_strict_octal_error(&mut self, span: Span) {
+        self.errors.push(Error::new(
+            span,
+            Severity::Error,
+            ErrorCode::StrictModeViolation,
+            "legacy octal escape sequences are not allowed in strict mode",
+        ));
+    }
+
+    fn validate_regex_literal(&mut self, lit: &swc_es_ast::RegexLit) {
+        let flags = lit.flags.as_ref();
+        let mut has_u = false;
+        let mut seen = std::collections::BTreeSet::<char>::new();
+        for flag in flags.chars() {
+            if !matches!(flag, 'd' | 'g' | 'i' | 'm' | 's' | 'u' | 'v' | 'y') {
+                self.errors.push(Error::new(
+                    lit.span,
+                    Severity::Error,
+                    ErrorCode::InvalidRegex,
+                    format!("unknown regular expression flag `{flag}`"),
+                ));
+                return;
+            }
+            if !seen.insert(flag) {
+                self.errors.push(Error::new(
+                    lit.span,
+                    Severity::Error,
+                    ErrorCode::InvalidRegex,
+                    format!("duplicated regular expression flag `{flag}`"),
+                ));
+                return;
+            }
+            if flag == 'u' {
+                has_u = true;
+            }
+        }
+
+        if has_u {
+            self.validate_unicode_regex_pattern(lit.span, lit.exp.as_ref());
+        }
+    }
+
+    fn validate_unicode_regex_pattern(&mut self, span: Span, pattern: &str) {
+        let chars = pattern.chars().collect::<Vec<_>>();
+        let mut i = 0usize;
+        let mut in_class = false;
+        let mut escaped = false;
+        let mut group_stack = Vec::<RegexGroupKind>::new();
+        let mut last_atom = RegexAtomKind::None;
+
+        while i < chars.len() {
+            let ch = chars[i];
+
+            if escaped {
+                escaped = false;
+                if ch.is_ascii_digit() {
+                    self.errors.push(Error::new(
+                        span,
+                        Severity::Error,
+                        ErrorCode::InvalidRegex,
+                        "decimal escapes are not allowed in unicode regular expressions",
+                    ));
+                    return;
+                }
+                if !in_class {
+                    last_atom = if matches!(ch, 'b' | 'B') {
+                        RegexAtomKind::Assertion
+                    } else {
+                        RegexAtomKind::Atom
+                    };
+                }
+                i += 1;
+                continue;
+            }
+
+            if in_class {
+                match ch {
+                    '\\' => escaped = true,
+                    ']' => {
+                        in_class = false;
+                        last_atom = RegexAtomKind::Atom;
+                    }
+                    _ => {}
+                }
+                i += 1;
+                continue;
+            }
+
+            match ch {
+                '\\' => {
+                    escaped = true;
+                    i += 1;
+                }
+                '[' => {
+                    in_class = true;
+                    i += 1;
+                }
+                '(' => {
+                    let kind = if matches!(chars.get(i + 1), Some('?')) {
+                        match chars.get(i + 2) {
+                            Some('=') | Some('!') => RegexGroupKind::Assertion,
+                            Some('<') if matches!(chars.get(i + 3), Some('=') | Some('!')) => {
+                                RegexGroupKind::Assertion
+                            }
+                            _ => RegexGroupKind::Group,
+                        }
+                    } else {
+                        RegexGroupKind::Group
+                    };
+                    group_stack.push(kind);
+                    last_atom = RegexAtomKind::None;
+                    i += 1;
+                }
+                ')' => {
+                    let Some(kind) = group_stack.pop() else {
+                        self.errors.push(Error::new(
+                            span,
+                            Severity::Error,
+                            ErrorCode::InvalidRegex,
+                            "unmatched `)` in regular expression",
+                        ));
+                        return;
+                    };
+                    last_atom = if kind == RegexGroupKind::Assertion {
+                        RegexAtomKind::Assertion
+                    } else {
+                        RegexAtomKind::Atom
+                    };
+                    i += 1;
+                }
+                '|' => {
+                    last_atom = RegexAtomKind::None;
+                    i += 1;
+                }
+                '*' | '+' | '?' => {
+                    if last_atom != RegexAtomKind::Atom {
+                        self.errors.push(Error::new(
+                            span,
+                            Severity::Error,
+                            ErrorCode::InvalidRegex,
+                            "quantifier has no valid target",
+                        ));
+                        return;
+                    }
+                    last_atom = RegexAtomKind::Atom;
+                    i += 1;
+                }
+                '{' => {
+                    if let Some(next_i) = Self::consume_regex_brace_quantifier(&chars, i) {
+                        if last_atom != RegexAtomKind::Atom {
+                            self.errors.push(Error::new(
+                                span,
+                                Severity::Error,
+                                ErrorCode::InvalidRegex,
+                                "quantifier has no valid target",
+                            ));
+                            return;
+                        }
+                        last_atom = RegexAtomKind::Atom;
+                        i = next_i;
+                    } else {
+                        self.errors.push(Error::new(
+                            span,
+                            Severity::Error,
+                            ErrorCode::InvalidRegex,
+                            "invalid `{` in unicode regular expression",
+                        ));
+                        return;
+                    }
+                }
+                '}' => {
+                    self.errors.push(Error::new(
+                        span,
+                        Severity::Error,
+                        ErrorCode::InvalidRegex,
+                        "invalid `}` in unicode regular expression",
+                    ));
+                    return;
+                }
+                '^' | '$' => {
+                    last_atom = RegexAtomKind::Assertion;
+                    i += 1;
+                }
+                _ => {
+                    last_atom = RegexAtomKind::Atom;
+                    i += 1;
+                }
+            }
+        }
+
+        if escaped || in_class || !group_stack.is_empty() {
+            self.errors.push(Error::new(
+                span,
+                Severity::Error,
+                ErrorCode::InvalidRegex,
+                "unterminated regular expression pattern",
+            ));
+        }
+    }
+
+    fn consume_regex_brace_quantifier(chars: &[char], start: usize) -> Option<usize> {
+        if chars.get(start) != Some(&'{') {
+            return None;
+        }
+        let mut i = start + 1;
+        let mut lower_digits = 0usize;
+        while matches!(chars.get(i), Some(ch) if ch.is_ascii_digit()) {
+            lower_digits += 1;
+            i += 1;
+        }
+        if lower_digits == 0 {
+            return None;
+        }
+
+        if chars.get(i) == Some(&',') {
+            i += 1;
+            while matches!(chars.get(i), Some(ch) if ch.is_ascii_digit()) {
+                i += 1;
+            }
+        }
+
+        if chars.get(i) != Some(&'}') {
+            return None;
+        }
+        i += 1;
+        if chars.get(i) == Some(&'?') {
+            i += 1;
+        }
+        Some(i)
+    }
+
     fn recover_stmt(&mut self) {
         while self.cur.kind != TokenKind::Eof {
             match self.cur.kind {
@@ -4682,6 +5046,16 @@ impl<'a> Parser<'a> {
             Some(Expr::Call(call)) => self.expr_is_optional_chain(call.callee),
             _ => false,
         }
+    }
+
+    fn expr_is_let_member(&self, expr: swc_es_ast::ExprId) -> bool {
+        let Some(Expr::Member(member)) = self.store.expr(expr) else {
+            return false;
+        };
+        matches!(
+            self.store.expr(member.obj),
+            Some(Expr::Ident(ident)) if ident.sym.as_ref() == "let"
+        )
     }
 
     fn is_await_using_decl_start(&self) -> bool {
@@ -4757,7 +5131,7 @@ impl<'a> Parser<'a> {
             remaining -= 1;
         }
 
-        if cur.kind != TokenKind::Ident {
+        if cur.kind != TokenKind::Ident || cur.flags.escaped {
             return false;
         }
         matches!(&cur.value, Some(TokenValue::Ident(sym)) if sym.as_ref() == value)
@@ -4828,8 +5202,26 @@ impl<'a> Parser<'a> {
         }
     }
 
+    fn record_string_token_flags(&mut self, span: Span, flags: TokenFlags) {
+        self.string_token_flags.push((span, flags));
+    }
+
+    fn string_token_flags(&self, span: Span) -> TokenFlags {
+        self.string_token_flags
+            .iter()
+            .rev()
+            .find_map(|(lit_span, flags)| {
+                if *lit_span == span {
+                    Some(*flags)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or_default()
+    }
+
     fn cur_ident_is(&self, value: &str) -> bool {
-        if self.cur.kind != TokenKind::Ident {
+        if self.cur.kind != TokenKind::Ident || self.cur.flags.escaped {
             return false;
         }
         match &self.cur.value {
@@ -5035,7 +5427,7 @@ impl<'a> Parser<'a> {
 
     fn peek_ident_is(&mut self, value: &str) -> bool {
         let token = self.peek_token();
-        if token.kind != TokenKind::Ident {
+        if token.kind != TokenKind::Ident || token.flags.escaped {
             return false;
         }
         match &token.value {

--- a/crates/swc_es_parser/src/token.rs
+++ b/crates/swc_es_parser/src/token.rs
@@ -76,6 +76,17 @@ pub enum TokenValue {
     BigInt(Atom),
 }
 
+/// Additional token metadata used during parsing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct TokenFlags {
+    /// `true` if the token text contained an escape sequence.
+    pub escaped: bool,
+    /// `true` if the token contained a legacy octal escape.
+    pub contains_legacy_octal_escape: bool,
+    /// `true` if the token contained an invalid escape.
+    pub contains_invalid_escape: bool,
+}
+
 /// Token kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TokenKind {
@@ -164,6 +175,8 @@ pub struct Token {
     pub had_line_break_before: bool,
     /// Optional token payload.
     pub value: Option<TokenValue>,
+    /// Additional metadata for semantic validation.
+    pub flags: TokenFlags,
 }
 
 impl Token {
@@ -174,6 +187,7 @@ impl Token {
             span,
             had_line_break_before,
             value: None,
+            flags: TokenFlags::default(),
         }
     }
 }

--- a/crates/swc_es_parser/tests/parity_suite.rs
+++ b/crates/swc_es_parser/tests/parity_suite.rs
@@ -22,155 +22,6 @@ const CORE_CATEGORIES: &[&str] = &[
     "shifted",
 ];
 
-// Mirrors `crates/swc_ecma_parser/tests/typescript.rs`.
-const TSC_IGNORES_CONTAINS: &[&str] = &[
-    "tsc/FunctionDeclaration7_es6",
-    "unicodeExtendedEscapesInStrings11_ES5",
-    "tsc/unicodeExtendedEscapesInStrings10_ES5",
-    "tsc/unicodeExtendedEscapesInStrings11_ES6",
-    "tsc/unicodeExtendedEscapesInStrings10_ES6",
-    "tsc/propertyNamesOfReservedWords",
-    "unicodeExtendedEscapesInTemplates10_ES5",
-    "unicodeExtendedEscapesInTemplates10_ES6",
-    "tsc/unicodeExtendedEscapesInTemplates11_ES5",
-    "tsc/unicodeExtendedEscapesInTemplates11_ES6",
-    "tsc/parser.numericSeparators.decimal",
-    "tsc/callSignaturesWithParameterInitializers",
-    "tsc/jsdocDisallowedInTypescript",
-    "tsc/errorSuperCalls",
-    "tsc/restElementMustBeLast",
-    "tsc/parserRegularExpressionDivideAmbiguity3",
-    "tsc/inlineJsxFactoryDeclarationsx",
-    "tsc/importDefaultNamedType",
-    "tsc/tsxAttributeResolution5x",
-    "tsc/tsxErrorRecovery2x",
-    "tsc/tsxErrorRecovery3x",
-    "tsc/tsxErrorRecovery5x",
-    "tsc/tsxReactEmitEntitiesx",
-    "tsc/tsxTypeArgumentsJsxPreserveOutputx",
-    "tsc/emitCompoundExponentiationAssignmentWithIndexingOnLHS3",
-    "tsc/objectLiteralGettersAndSetters",
-    "tsc/unicodeEscapesInJsxtagsx",
-    "tsc/FunctionDeclaration6_es6",
-    "tsc/checkJsxNamespaceNamesQuestionableForms",
-    "tsc/classExtendingOptionalChain",
-    "tsc/inlineJsxFactoryDeclarations",
-    "tsc/interfaceExtendingOptionalChain",
-    "tsc/interfacesWithPredefinedTypesAsNames",
-    "tsc/namedTupleMembersErrors",
-    "tsc/parserForOfStatement23",
-    "tsc/topLevelAwait.2",
-    "tsc/tsxAttributeResolution5",
-    "tsc/tsxErrorRecovery2",
-    "tsc/tsxErrorRecovery3",
-    "tsc/tsxTypeArgumentsJsxPreserveOutput",
-    "tsc/unicodeEscapesInJsxtags",
-    "tsc/propertyAccessNumericLiterals",
-    "tsc/parserAssignmentExpression1",
-    "tsc/parserGreaterThanTokenAmbiguity11",
-    "tsc/parserGreaterThanTokenAmbiguity15",
-    "tsc/parserGreaterThanTokenAmbiguity16",
-    "tsc/parserGreaterThanTokenAmbiguity20",
-    "tsc/awaitUsingDeclarationsInFor",
-];
-
-const TSC_IGNORES_ENDS_WITH: &[&str] = &[
-    "tsc/usingDeclarationsInFor.ts",
-    "tsc/decoratorOnClassMethod12.ts",
-    "tsc/esDecorators-preservesThis.ts",
-    "tsc/topLevelVarHoistingCommonJS.ts",
-];
-
-// Mirrors `crates/swc_ecma_parser/tests/test262.rs` IGNORED_PASS_TESTS.
-const TEST262_IGNORED_PASS: &[&str] = &[
-    "431ecef8c85d4d24.js",
-    "8386fbff927a9e0e.js",
-    "5654d4106d7025c2.js",
-    "6b5e7e125097d439.js",
-    "714be6d28082eaa7.js",
-    "882910de7dd1aef9.js",
-    "dd3c63403db5c06e.js",
-    "dcc5609dcc043200.js",
-    "88d42455ac933ef5.js",
-    "0339fa95c78c11bd.js",
-    "0426f15dac46e92d.js",
-    "0b4d61559ccce0f9.js",
-    "0f88c334715d2489.js",
-    "1093d98f5fc0758d.js",
-    "15d9592709b947a0.js",
-    "2179895ec5cc6276.js",
-    "247a3a57e8176ebd.js",
-    "441a92357939904a.js",
-    "47f974d6fc52e3e4.js",
-    "4e1a0da46ca45afe.js",
-    "5829d742ab805866.js",
-    "589dc8ad3b9aa28f.js",
-    "598a5cedba92154d.js",
-    "72d79750e81ef03d.js",
-    "7788d3c1e1247da9.js",
-    "7b72d7b43bedc895.js",
-    "7dab6e55461806c9.js",
-    "82c827ccaecbe22b.js",
-    "87a9b0d1d80812cc.js",
-    "8c80f7ee04352eba.js",
-    "96f5d93be9a54573.js",
-    "988e362ed9ddcac5.js",
-    "9bcae7c7f00b4e3c.js",
-    "a8a03a88237c4e8f.js",
-    "ad06370e34811a6a.js",
-    "b0fdc038ee292aba.js",
-    "b62c6dd890bef675.js",
-    "cb211fadccb029c7.js",
-    "ce968fcdf3a1987c.js",
-    "db3c01738aaf0b92.js",
-    "e1387fe892984e2b.js",
-    "e71c1d5f0b6b833c.js",
-    "e8ea384458526db0.js",
-    "1c1e2a43fe5515b6.js",
-    "3dabeca76119d501.js",
-    "52aeec7b8da212a2.js",
-    "59ae0289778b80cd.js",
-    "a4d62a651f69d815.js",
-    "c06df922631aeabc.js",
-    "8f8bfb27569ac008.js",
-    "ce569e89a005c02a.js",
-    "046a0bb70d03d0cc.js",
-    "08a39e4289b0c3f3.js",
-    "300a638d978d0f2c.js",
-    "44f31660bd715f05.js",
-];
-
-// Mirrors `crates/swc_ecma_parser/tests/test262.rs` IGNORED_ERROR_TESTS.
-const TEST262_IGNORED_FAIL: &[&str] = &[
-    "e3fbcf63d7e43ead.js",
-    "569a2c1bad3beeb2.js",
-    "3b6f737a4ac948a8.js",
-    "829d9261aa6cd22c.js",
-    "b03ee881dce1a367.js",
-    "cb92787da5075fd1.js",
-    "f0f498d6ae70038f.js",
-    "0d5e450f1da8a92a.js",
-    "346316bef54d805a.js",
-    "976b6247ca78ab51.js",
-    "ae0a7ac275bc9f5c.js",
-    "748656edbfb2d0bb.js",
-    "79f882da06f88c9f.js",
-    "d28e80d99f819136.js",
-    "92b6af54adef3624.js",
-    "ef2d369cccc5386c.js",
-    "147fa078a7436e0e.js",
-    "15a6123f6b825c38.js",
-    "3bc2b27a7430f818.js",
-    "2fa321f0374c7017.js",
-    "3dbb6e166b14a6c0.js",
-    "66e383bfd18e66ab.js",
-    "78c215fabdf13bae.js",
-    "bf49ec8d96884562.js",
-    "e4a43066905a597b.js",
-    "98204d734f8c72b3.js",
-    "ef81b93cf9bdb4ec.js",
-];
-
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ParseMode {
     Program,
@@ -387,48 +238,6 @@ fn collect_files_for_category(category: &str) -> Vec<PathBuf> {
     files
 }
 
-fn filter_ignored_cases(mut cases: Vec<Case>) -> Vec<Case> {
-    cases.retain(|case| {
-        let path = normalized(&case.path);
-        let file_name = case
-            .path
-            .file_name()
-            .and_then(|name| name.to_str())
-            .unwrap_or("");
-
-        if case.category == "tsc" {
-            if TSC_IGNORES_CONTAINS
-                .iter()
-                .any(|pattern| path.contains(pattern))
-            {
-                return false;
-            }
-            if TSC_IGNORES_ENDS_WITH
-                .iter()
-                .any(|pattern| path.ends_with(pattern))
-            {
-                return false;
-            }
-        }
-
-        if case.category == "test262-parser"
-            && path.contains("/pass/")
-            && TEST262_IGNORED_PASS.contains(&file_name)
-        {
-            return false;
-        }
-        if case.category == "test262-parser"
-            && path.contains("/fail/")
-            && TEST262_IGNORED_FAIL.contains(&file_name)
-        {
-            return false;
-        }
-
-        true
-    });
-    cases
-}
-
 fn parse_case(case: &Case) -> (bool, Option<Error>, Vec<Error>) {
     let cm = SourceMap::default();
     let fm = cm
@@ -564,7 +373,6 @@ fn parity_core_corpus() {
         }
     }
 
-    let cases = filter_ignored_cases(cases);
     let summary = run_cases(cases);
     assert_budget("core-corpus", &summary, CORE_CORPUS_BUDGET);
 }
@@ -578,7 +386,6 @@ fn parity_large_samples() {
             category: "tsc".to_string(),
         })
         .collect::<Vec<_>>();
-    let tsc_cases = filter_ignored_cases(tsc_cases);
 
     let test262_cases = collect_files_for_category("test262-parser")
         .into_iter()
@@ -592,7 +399,6 @@ fn parity_large_samples() {
             category: "test262-parser".to_string(),
         })
         .collect::<Vec<_>>();
-    let test262_cases = filter_ignored_cases(test262_cases);
     let test262_pass = test262_cases
         .iter()
         .filter(|case| normalized(&case.path).contains("/test262-parser/pass/"))

--- a/crates/swc_es_parser/tests/smoke.rs
+++ b/crates/swc_es_parser/tests/smoke.rs
@@ -28,6 +28,21 @@ fn parse_fixture(path: &Path, syntax: Syntax) {
     .unwrap();
 }
 
+fn parse_program_with_recovered(src: &str) -> (bool, Vec<swc_es_parser::Error>) {
+    let cm = SourceMap::default();
+    let fm = cm.new_source_file(FileName::Custom("inline.js".into()).into(), src.to_string());
+    let comments = SingleThreadedComments::default();
+    let mut recovered = Vec::new();
+    let fatal = parse_file_as_program(
+        &fm,
+        Syntax::Es(EsSyntax::default()),
+        Some(&comments),
+        &mut recovered,
+    )
+    .is_err();
+    (fatal, recovered)
+}
+
 #[test]
 fn parses_reused_js_fixture() {
     parse_fixture(
@@ -113,4 +128,57 @@ fn parse_file_as_script_collects_recovered_errors() {
     assert!(recovered
         .iter()
         .any(|error| matches!(error.code(), ErrorCode::ReturnOutsideFunction)));
+}
+
+#[test]
+fn rejects_invalid_escape_sequences() {
+    let (fatal, recovered) = parse_program_with_recovered("'\\8'; '\\9';");
+    assert!(!fatal);
+    assert!(recovered
+        .iter()
+        .any(|error| matches!(error.code(), ErrorCode::InvalidEscape)));
+}
+
+#[test]
+fn rejects_legacy_octal_escape_in_use_strict_prologue() {
+    let (fatal, recovered) = parse_program_with_recovered("\"\\1\"; 'use strict';");
+    assert!(!fatal);
+    assert!(recovered
+        .iter()
+        .any(|error| matches!(error.code(), ErrorCode::StrictModeViolation)));
+}
+
+#[test]
+fn rejects_unicode_regex_decimal_escape() {
+    let (fatal, recovered) = parse_program_with_recovered("/\\1/u;");
+    assert!(!fatal);
+    assert!(recovered
+        .iter()
+        .any(|error| matches!(error.code(), ErrorCode::InvalidRegex)));
+}
+
+#[test]
+fn rejects_invalid_for_of_lhs_with_let_member() {
+    let (fatal, recovered) = parse_program_with_recovered("for(let.a of 0);");
+    assert!(fatal || !recovered.is_empty());
+}
+
+#[test]
+fn rejects_invalid_arrow_member_binding() {
+    let (fatal, recovered) = parse_program_with_recovered("({e: a.b}) => 0;");
+    assert!(fatal || !recovered.is_empty());
+}
+
+#[test]
+fn rejects_array_rest_followed_by_comma() {
+    let (fatal, recovered) = parse_program_with_recovered("[...a,] = b;");
+    assert!(fatal || !recovered.is_empty());
+}
+
+#[test]
+fn accepts_new_target_with_escaped_target_identifier() {
+    let (fatal, recovered) =
+        parse_program_with_recovered("function f(){ return new.\\u0074arget; }");
+    assert!(!fatal);
+    assert!(recovered.is_empty());
 }


### PR DESCRIPTION
**Description:**
- remove all parity ignore/skip filters from swc_es_parser parity suite and keep budget at zero
- harden lexer/parser behavior for escaped identifiers, strict directive prologue handling, legacy octal/invalid escapes, regex literal validation, and binding/for-head restrictions
- add smoke regressions for representative previously ignored patterns and align README parity instructions with current harness

**BREAKING CHANGE:**
- none

**Related issue (if exists):**
- none