### PR TITLE
fix(regexp): downlevel named capture group syntax

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6293,6 +6293,7 @@ name = "swc_ecma_compat_regexp"
 version = "2.0.0"
 dependencies = [
  "icu_properties 2.1.2",
+ "swc_atoms",
  "swc_ecma_regexp",
  "swc_ecma_regexp_ast",
  "swc_ecma_regexp_visit",

--- a/crates/swc/tests/babel-exec/packages/babel-plugin-transform-named-capturing-groups-regex/test/fixtures/runtime/replace/exec.js
+++ b/crates/swc/tests/babel-exec/packages/babel-plugin-transform-named-capturing-groups-regex/test/fixtures/runtime/replace/exec.js
@@ -1,0 +1,7 @@
+const regex = /(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/;
+
+expect("2017-12-23".replace(regex, "$<day>.$<month>.$<year>")).toBe("23.12.2017");
+
+expect("2017-12-23".replace(regex, (match, year, month, day, offset, input, groups) => {
+  return `${groups.day}.${groups.month}.${groups.year}`;
+})).toBe("23.12.2017");

--- a/crates/swc_ecma_compat_regexp/Cargo.toml
+++ b/crates/swc_ecma_compat_regexp/Cargo.toml
@@ -15,6 +15,7 @@ bench = false
 [dependencies]
 icu_properties = { version = "2.0.0", default-features = false, features = ["compiled_data", "alloc"] }
 
+swc_atoms             = { version = "9.0.0", path = "../swc_atoms" }
 swc_ecma_regexp_ast   = { version = "0.8.0", path = "../swc_ecma_regexp_ast" }
 swc_ecma_regexp_visit = { version = "0.8.0", path = "../swc_ecma_regexp_visit" }
 

--- a/crates/swc_ecma_compat_regexp/src/lib.rs
+++ b/crates/swc_ecma_compat_regexp/src/lib.rs
@@ -9,5 +9,7 @@
 mod named_capture;
 mod unicode_property;
 
-pub use named_capture::transform_named_capture_groups;
+pub use named_capture::{
+    transform_named_capture_groups, transform_named_capture_groups_with_info, NamedCaptureGroups,
+};
 pub use unicode_property::transform_unicode_property_escapes;

--- a/crates/swc_ecma_compat_regexp/src/lib.rs
+++ b/crates/swc_ecma_compat_regexp/src/lib.rs
@@ -2,9 +2,12 @@
 //!
 //! This crate provides transformations for:
 //! - Unicode property escapes (`\p{Letter}`, `\P{Script=Greek}`)
+//! - Named capture groups (`(?<name>...)`, `\k<name>`)
 
 #![deny(clippy::all)]
 
+mod named_capture;
 mod unicode_property;
 
+pub use named_capture::transform_named_capture_groups;
 pub use unicode_property::transform_unicode_property_escapes;

--- a/crates/swc_ecma_compat_regexp/src/named_capture.rs
+++ b/crates/swc_ecma_compat_regexp/src/named_capture.rs
@@ -9,6 +9,12 @@ use swc_atoms::Atom;
 use swc_ecma_regexp_ast::{CapturingGroup, IndexedReference, Pattern, Term};
 use swc_ecma_regexp_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
+/// Named capture group mapping used for runtime group reconstruction.
+///
+/// Each entry contains the group name and the list of positional capture
+/// indices associated with that name.
+pub type NamedCaptureGroups = Vec<(Atom, Vec<u32>)>;
+
 /// Transforms named capture groups and named backreferences in a regex pattern.
 ///
 /// This transformation is syntax-only:
@@ -17,23 +23,33 @@ use swc_ecma_regexp_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 ///
 /// If a named backreference cannot be resolved, it is left unchanged.
 pub fn transform_named_capture_groups(pattern: &mut Pattern) {
+    let _ = transform_named_capture_groups_with_info(pattern);
+}
+
+/// Transforms named capture groups and named backreferences while collecting
+/// positional indices for each named capture group.
+pub fn transform_named_capture_groups_with_info(pattern: &mut Pattern) -> NamedCaptureGroups {
     let mut collector = CaptureGroupCollector::default();
     pattern.visit_with(&mut collector);
 
-    if collector.name_to_index.is_empty() {
-        return;
+    if collector.first_index_by_name.is_empty() {
+        return Vec::new();
     }
 
     let mut transformer = NamedCaptureGroupTransformer {
-        name_to_index: &collector.name_to_index,
+        first_index_by_name: &collector.first_index_by_name,
     };
     pattern.visit_mut_with(&mut transformer);
+
+    collector.named_groups
 }
 
 #[derive(Default)]
 struct CaptureGroupCollector {
     next_index: u32,
-    name_to_index: HashMap<Atom, u32>,
+    first_index_by_name: HashMap<Atom, u32>,
+    name_to_slot: HashMap<Atom, usize>,
+    named_groups: NamedCaptureGroups,
 }
 
 impl Visit for CaptureGroupCollector {
@@ -41,9 +57,16 @@ impl Visit for CaptureGroupCollector {
         self.next_index += 1;
 
         if let Some(name) = &group.name {
-            self.name_to_index
+            self.first_index_by_name
                 .entry(name.clone())
                 .or_insert(self.next_index);
+
+            let slot = *self.name_to_slot.entry(name.clone()).or_insert_with(|| {
+                let slot = self.named_groups.len();
+                self.named_groups.push((name.clone(), Vec::new()));
+                slot
+            });
+            self.named_groups[slot].1.push(self.next_index);
         }
 
         group.body.visit_with(self);
@@ -51,7 +74,7 @@ impl Visit for CaptureGroupCollector {
 }
 
 struct NamedCaptureGroupTransformer<'a> {
-    name_to_index: &'a HashMap<Atom, u32>,
+    first_index_by_name: &'a HashMap<Atom, u32>,
 }
 
 impl VisitMut for NamedCaptureGroupTransformer<'_> {
@@ -62,7 +85,7 @@ impl VisitMut for NamedCaptureGroupTransformer<'_> {
                 group.body.visit_mut_with(self);
             }
             Term::NamedReference(named_ref) => {
-                if let Some(&index) = self.name_to_index.get(&named_ref.name) {
+                if let Some(&index) = self.first_index_by_name.get(&named_ref.name) {
                     *term = Term::IndexedReference(Box::new(IndexedReference {
                         span: named_ref.span,
                         index,
@@ -78,9 +101,10 @@ impl VisitMut for NamedCaptureGroupTransformer<'_> {
 
 #[cfg(test)]
 mod tests {
+    use swc_atoms::Atom;
     use swc_ecma_regexp::{LiteralParser, Options};
 
-    use super::transform_named_capture_groups;
+    use super::{transform_named_capture_groups, transform_named_capture_groups_with_info};
 
     fn parse_and_transform(pattern: &str, flags: &str) -> String {
         let mut ast = LiteralParser::new(pattern, Some(flags), Options::default())
@@ -88,6 +112,14 @@ mod tests {
             .unwrap();
         transform_named_capture_groups(&mut ast);
         ast.to_string()
+    }
+
+    fn parse_transform_and_collect(pattern: &str, flags: &str) -> (String, Vec<(Atom, Vec<u32>)>) {
+        let mut ast = LiteralParser::new(pattern, Some(flags), Options::default())
+            .parse()
+            .unwrap();
+        let named_groups = transform_named_capture_groups_with_info(&mut ast);
+        (ast.to_string(), named_groups)
     }
 
     #[test]
@@ -106,5 +138,13 @@ mod tests {
     fn keeps_mixed_capture_indices_stable() {
         let actual = parse_and_transform(r"(.)(?<a>b)(?<b>c)\k<a>\k<b>", "");
         assert_eq!(actual, r"(.)(b)(c)\2\3");
+    }
+
+    #[test]
+    fn collects_named_capture_group_indices_for_runtime_mapping() {
+        let (actual, named_groups) = parse_transform_and_collect(r"(?<left>a)|(?<left>b)", "");
+
+        assert_eq!(actual, r"(a)|(b)");
+        assert_eq!(named_groups, vec![(Atom::from("left"), vec![1, 2])]);
     }
 }

--- a/crates/swc_ecma_compat_regexp/src/named_capture.rs
+++ b/crates/swc_ecma_compat_regexp/src/named_capture.rs
@@ -1,0 +1,110 @@
+//! Named capture groups transformation.
+//!
+//! Transforms named capture groups and named backreferences to their indexed
+//! forms for broader syntax compatibility.
+
+use std::collections::HashMap;
+
+use swc_atoms::Atom;
+use swc_ecma_regexp_ast::{CapturingGroup, IndexedReference, Pattern, Term};
+use swc_ecma_regexp_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
+
+/// Transforms named capture groups and named backreferences in a regex pattern.
+///
+/// This transformation is syntax-only:
+/// - `(?<name>...)` -> `(...)`
+/// - `\k<name>` -> `\N`
+///
+/// If a named backreference cannot be resolved, it is left unchanged.
+pub fn transform_named_capture_groups(pattern: &mut Pattern) {
+    let mut collector = CaptureGroupCollector::default();
+    pattern.visit_with(&mut collector);
+
+    if collector.name_to_index.is_empty() {
+        return;
+    }
+
+    let mut transformer = NamedCaptureGroupTransformer {
+        name_to_index: &collector.name_to_index,
+    };
+    pattern.visit_mut_with(&mut transformer);
+}
+
+#[derive(Default)]
+struct CaptureGroupCollector {
+    next_index: u32,
+    name_to_index: HashMap<Atom, u32>,
+}
+
+impl Visit for CaptureGroupCollector {
+    fn visit_capturing_group(&mut self, group: &CapturingGroup) {
+        self.next_index += 1;
+
+        if let Some(name) = &group.name {
+            self.name_to_index
+                .entry(name.clone())
+                .or_insert(self.next_index);
+        }
+
+        group.body.visit_with(self);
+    }
+}
+
+struct NamedCaptureGroupTransformer<'a> {
+    name_to_index: &'a HashMap<Atom, u32>,
+}
+
+impl VisitMut for NamedCaptureGroupTransformer<'_> {
+    fn visit_mut_term(&mut self, term: &mut Term) {
+        match term {
+            Term::CapturingGroup(group) => {
+                group.name = None;
+                group.body.visit_mut_with(self);
+            }
+            Term::NamedReference(named_ref) => {
+                if let Some(&index) = self.name_to_index.get(&named_ref.name) {
+                    *term = Term::IndexedReference(Box::new(IndexedReference {
+                        span: named_ref.span,
+                        index,
+                    }));
+                }
+            }
+            _ => {
+                term.visit_mut_children_with(self);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_ecma_regexp::{LiteralParser, Options};
+
+    use super::transform_named_capture_groups;
+
+    fn parse_and_transform(pattern: &str, flags: &str) -> String {
+        let mut ast = LiteralParser::new(pattern, Some(flags), Options::default())
+            .parse()
+            .unwrap();
+        transform_named_capture_groups(&mut ast);
+        ast.to_string()
+    }
+
+    #[test]
+    fn removes_named_capture_group_syntax() {
+        let actual = parse_and_transform(r"(?<year>\d{4})-(?<month>\d{2})", "");
+        assert_eq!(actual, r"(\d{4})-(\d{2})");
+    }
+
+    #[test]
+    fn transforms_named_backreference_to_indexed_reference() {
+        let actual = parse_and_transform(r"(?<tag>a)\k<tag>", "");
+        assert_eq!(actual, r"(a)\1");
+    }
+
+    #[test]
+    fn keeps_mixed_capture_indices_stable() {
+        let actual = parse_and_transform(r"(.)(?<a>b)(?<b>c)\k<a>\k<b>", "");
+        assert_eq!(actual, r"(.)(b)(c)\2\3");
+    }
+}

--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs3/usage-regexp/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs3/usage-regexp/output.mjs
@@ -1,7 +1,11 @@
 import "core-js/modules/es.regexp.constructor.js";
 import "core-js/modules/es.regexp.exec.js";
 import "core-js/modules/es.regexp.to-string.js";
-var a = RegExp("(\\d{4})-(\\d{2})-(\\d{2})", "u");
+var a = _wrap_regexp(RegExp("(\\d{4})-(\\d{2})-(\\d{2})", "u"), {
+    "year": 1,
+    "month": 2,
+    "day": 3
+});
 var b = RegExp(".", "s");
 var c = RegExp(".", "imsuy");
 console.log(a.unicode);

--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs3/usage-regexp/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs3/usage-regexp/output.mjs
@@ -1,7 +1,7 @@
 import "core-js/modules/es.regexp.constructor.js";
 import "core-js/modules/es.regexp.exec.js";
 import "core-js/modules/es.regexp.to-string.js";
-var a = RegExp("(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})", "u");
+var a = RegExp("(\\d{4})-(\\d{2})-(\\d{2})", "u");
 var b = RegExp(".", "s");
 var c = RegExp(".", "imsuy");
 console.log(a.unicode);

--- a/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-11608/input.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-11608/input.mjs
@@ -1,0 +1,1 @@
+const match = "IJobHeader[[ModuleName]]".match(/IJobHeader\[\[(?<moduleName>[A-Za-z]+)\]\]/);

--- a/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-11608/options.json
+++ b/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-11608/options.json
@@ -1,0 +1,11 @@
+{
+  "presets": [
+    [
+      "../../../../lib",
+      {
+        "targets": "chrome 120",
+        "include": ["transform-named-capturing-groups-regex"]
+      }
+    ]
+  ]
+}

--- a/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-11608/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-11608/output.mjs
@@ -1,1 +1,3 @@
-const match = "IJobHeader[[ModuleName]]".match(RegExp("IJobHeader\\[\\[([A-Za-z]+)\\]\\]"));
+const match = "IJobHeader[[ModuleName]]".match(_wrap_regexp(RegExp("IJobHeader\\[\\[([A-Za-z]+)\\]\\]"), {
+    "moduleName": 1
+}));

--- a/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-11608/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-11608/output.mjs
@@ -1,0 +1,1 @@
+const match = "IJobHeader[[ModuleName]]".match(RegExp("IJobHeader\\[\\[([A-Za-z]+)\\]\\]"));

--- a/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-runtime-replace/input.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-runtime-replace/input.mjs
@@ -1,0 +1,1 @@
+const out = "2017-12-23".replace(/(?<year>\d{4})-(?<month>\d{2})-(?<day>\d{2})/, "$<day>.$<month>.$<year>");

--- a/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-runtime-replace/options.json
+++ b/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-runtime-replace/options.json
@@ -1,0 +1,8 @@
+{
+    "presets": [
+        ["@babel/preset-env", {
+            "targets": { "chrome": "49" },
+            "include": ["transform-named-capturing-groups-regex"]
+        }]
+    ]
+}

--- a/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-runtime-replace/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex-runtime-replace/output.mjs
@@ -1,0 +1,5 @@
+var out = "2017-12-23".replace(_wrap_regexp(RegExp("(\\d{4})-(\\d{2})-(\\d{2})"), {
+    "year": 1,
+    "month": 2,
+    "day": 3
+}), "$<day>.$<month>.$<year>");

--- a/crates/swc_ecma_transformer/src/regexp.rs
+++ b/crates/swc_ecma_transformer/src/regexp.rs
@@ -1,9 +1,13 @@
 use swc_atoms::Atom;
-use swc_common::util::take::Take;
+use swc_common::{util::take::Take, Span, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_compat_regexp::{transform_named_capture_groups, transform_unicode_property_escapes};
+use swc_ecma_compat_regexp::{
+    transform_named_capture_groups_with_info, transform_unicode_property_escapes,
+    NamedCaptureGroups,
+};
 use swc_ecma_hooks::VisitMutHook;
 use swc_ecma_regexp::{LiteralParser, Options as RegexpOptions};
+use swc_ecma_transforms_base::helper;
 use swc_ecma_utils::{quote_ident, ExprFactory};
 
 use crate::TraverseCtx;
@@ -64,6 +68,11 @@ struct RegexpPass {
     options: RegExpOptions,
 }
 
+struct PatternTransformResult {
+    transformed_pattern: String,
+    named_capture_groups: NamedCaptureGroups,
+}
+
 impl RegexpPass {
     fn contains_named_capture_group(pattern: &str) -> bool {
         let bytes = pattern.as_bytes();
@@ -95,8 +104,7 @@ impl RegexpPass {
     }
 
     /// Transform the regex pattern if it contains supported syntax.
-    /// Returns the transformed pattern string.
-    fn transform_pattern(&self, pattern: &str, flags: &str) -> Option<String> {
+    fn transform_pattern(&self, pattern: &str, flags: &str) -> Option<PatternTransformResult> {
         let should_transform_unicode_property =
             self.should_transform_unicode_property(pattern, flags);
         let should_transform_named_capture = self.should_transform_named_capture(pattern);
@@ -114,60 +122,124 @@ impl RegexpPass {
             transform_unicode_property_escapes(&mut ast);
         }
 
-        if should_transform_named_capture {
-            transform_named_capture_groups(&mut ast);
-        }
+        let named_capture_groups = if should_transform_named_capture {
+            transform_named_capture_groups_with_info(&mut ast)
+        } else {
+            Vec::new()
+        };
 
-        // Serialize back to string
-        Some(ast.to_string())
+        Some(PatternTransformResult {
+            transformed_pattern: ast.to_string(),
+            named_capture_groups,
+        })
     }
 
-    fn transform_regexp_args(&self, args: &mut [ExprOrSpread]) {
+    fn transform_regexp_args(&self, args: &mut [ExprOrSpread]) -> Option<NamedCaptureGroups> {
         if !self.options.unicode_property_regex && !self.options.named_capturing_groups_regex {
-            return;
+            return None;
         }
 
-        let Some((pattern_arg, rest_args)) = args.split_first_mut() else {
-            return;
-        };
+        let (pattern_arg, rest_args) = args.split_first_mut()?;
         if pattern_arg.spread.is_some() {
-            return;
+            return None;
         }
 
         let Expr::Lit(Lit::Str(pattern_lit)) = &*pattern_arg.expr else {
-            return;
+            return None;
         };
-        let Some(pattern) = pattern_lit.value.as_str() else {
-            return;
-        };
+        let pattern = pattern_lit.value.as_str()?;
 
         let flags = match rest_args.first() {
             Some(flags_arg) => {
                 if flags_arg.spread.is_some() {
-                    return;
+                    return None;
                 }
 
                 let Expr::Lit(Lit::Str(flags_lit)) = &*flags_arg.expr else {
-                    return;
+                    return None;
                 };
-                let Some(flags) = flags_lit.value.as_str() else {
-                    return;
-                };
+                let flags = flags_lit.value.as_str()?;
 
                 flags
             }
             None => "",
         };
 
-        let Some(transformed_pattern) = self.transform_pattern(pattern, flags) else {
-            return;
-        };
+        let transformed = self.transform_pattern(pattern, flags)?;
+
+        let PatternTransformResult {
+            transformed_pattern,
+            named_capture_groups,
+        } = transformed;
 
         let Expr::Lit(Lit::Str(pattern_lit)) = &mut *pattern_arg.expr else {
-            return;
+            return None;
         };
         pattern_lit.value = transformed_pattern.into();
         pattern_lit.raw = None;
+
+        Some(named_capture_groups)
+    }
+
+    fn number_literal(index: u32) -> Expr {
+        Expr::Lit(Lit::Num(Number {
+            span: DUMMY_SP,
+            value: f64::from(index),
+            raw: None,
+        }))
+    }
+
+    fn build_named_capture_groups_object(named_capture_groups: NamedCaptureGroups) -> Expr {
+        let props = named_capture_groups
+            .into_iter()
+            .map(|(name, indices)| {
+                let value = if indices.len() == 1 {
+                    Self::number_literal(indices[0])
+                } else {
+                    Expr::Array(ArrayLit {
+                        span: DUMMY_SP,
+                        elems: indices
+                            .into_iter()
+                            .map(|index| Some(Self::number_literal(index).as_arg()))
+                            .collect(),
+                    })
+                };
+
+                PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                    key: PropName::Str(Str {
+                        span: DUMMY_SP,
+                        value: name.into(),
+                        raw: None,
+                    }),
+                    value: Box::new(value),
+                })))
+            })
+            .collect();
+
+        Expr::Object(ObjectLit {
+            span: DUMMY_SP,
+            props,
+        })
+    }
+
+    fn wrap_regexp_with_named_capture_groups(
+        &self,
+        span: Span,
+        regexp_expr: Expr,
+        named_capture_groups: NamedCaptureGroups,
+    ) -> Expr {
+        if named_capture_groups.is_empty() {
+            return regexp_expr;
+        }
+
+        let groups = Self::build_named_capture_groups_object(named_capture_groups);
+
+        Expr::Call(CallExpr {
+            span,
+            callee: helper!(span, wrap_regexp),
+            args: vec![regexp_expr.as_arg(), groups.as_arg()],
+            ..Default::default()
+        })
     }
 }
 
@@ -188,10 +260,14 @@ impl VisitMutHook<TraverseCtx> for RegexpPass {
                 if needs_transform {
                     let Regex { exp, flags, span } = regex.take();
 
-                    // Transform the pattern if it contains unicode property escapes
-                    let transformed_pattern = self
-                        .transform_pattern(&exp, &flags)
-                        .unwrap_or_else(|| exp.to_string());
+                    let (transformed_pattern, named_capture_groups) =
+                        match self.transform_pattern(&exp, &flags) {
+                            Some(transformed) => (
+                                transformed.transformed_pattern,
+                                transformed.named_capture_groups,
+                            ),
+                            None => (exp.to_string(), Vec::new()),
+                        };
 
                     let exp: Expr = Atom::from(transformed_pattern).into();
                     let mut args = vec![exp.into()];
@@ -201,28 +277,68 @@ impl VisitMutHook<TraverseCtx> for RegexpPass {
                         args.push(flags.into());
                     }
 
-                    *expr = CallExpr {
+                    let regexp_expr: Expr = CallExpr {
                         span,
                         callee: quote_ident!("RegExp").as_callee(),
                         args,
                         ..Default::default()
                     }
-                    .into()
+                    .into();
+
+                    *expr = self.wrap_regexp_with_named_capture_groups(
+                        span,
+                        regexp_expr,
+                        named_capture_groups,
+                    );
                 }
             }
-            Expr::Call(CallExpr {
-                callee: Callee::Expr(callee),
-                args,
-                ..
-            }) if callee.is_ident_ref_to("RegExp") => {
-                self.transform_regexp_args(args);
+            Expr::Call(call_expr) => {
+                let Callee::Expr(callee) = &call_expr.callee else {
+                    return;
+                };
+                if !callee.is_ident_ref_to("RegExp") {
+                    return;
+                }
+
+                let Some(named_capture_groups) = self.transform_regexp_args(&mut call_expr.args)
+                else {
+                    return;
+                };
+
+                if named_capture_groups.is_empty() {
+                    return;
+                }
+
+                let span = call_expr.span;
+                *expr = self.wrap_regexp_with_named_capture_groups(
+                    span,
+                    Expr::Call(call_expr.take()),
+                    named_capture_groups,
+                );
             }
-            Expr::New(NewExpr {
-                callee,
-                args: Some(args),
-                ..
-            }) if callee.is_ident_ref_to("RegExp") => {
-                self.transform_regexp_args(args);
+            Expr::New(new_expr) => {
+                if !new_expr.callee.is_ident_ref_to("RegExp") {
+                    return;
+                }
+
+                let Some(args) = new_expr.args.as_mut() else {
+                    return;
+                };
+
+                let Some(named_capture_groups) = self.transform_regexp_args(args) else {
+                    return;
+                };
+
+                if named_capture_groups.is_empty() {
+                    return;
+                }
+
+                let span = new_expr.span;
+                *expr = self.wrap_regexp_with_named_capture_groups(
+                    span,
+                    Expr::New(new_expr.take()),
+                    named_capture_groups,
+                );
             }
             _ => {}
         }

--- a/crates/swc_ecma_transformer/src/regexp.rs
+++ b/crates/swc_ecma_transformer/src/regexp.rs
@@ -1,7 +1,7 @@
 use swc_atoms::Atom;
 use swc_common::util::take::Take;
 use swc_ecma_ast::*;
-use swc_ecma_compat_regexp::transform_unicode_property_escapes;
+use swc_ecma_compat_regexp::{transform_named_capture_groups, transform_unicode_property_escapes};
 use swc_ecma_hooks::VisitMutHook;
 use swc_ecma_regexp::{LiteralParser, Options as RegexpOptions};
 use swc_ecma_utils::{quote_ident, ExprFactory};
@@ -65,15 +65,43 @@ struct RegexpPass {
 }
 
 impl RegexpPass {
-    /// Transform the regex pattern if it contains unicode property escapes.
+    fn contains_named_capture_group(pattern: &str) -> bool {
+        let bytes = pattern.as_bytes();
+        let mut i = 0;
+
+        while i + 2 < bytes.len() {
+            if bytes[i] == b'(' && bytes[i + 1] == b'?' && bytes[i + 2] == b'<' {
+                let lookbehind_marker = bytes.get(i + 3).copied();
+                if !matches!(lookbehind_marker, Some(b'=') | Some(b'!')) {
+                    return true;
+                }
+            }
+
+            i += 1;
+        }
+
+        false
+    }
+
+    fn should_transform_named_capture(&self, pattern: &str) -> bool {
+        self.options.named_capturing_groups_regex
+            && (Self::contains_named_capture_group(pattern) || pattern.contains("\\k<"))
+    }
+
+    fn should_transform_unicode_property(&self, pattern: &str, flags: &str) -> bool {
+        self.options.unicode_property_regex
+            && flags.contains(['u', 'v'])
+            && (pattern.contains("\\p{") || pattern.contains("\\P{"))
+    }
+
+    /// Transform the regex pattern if it contains supported syntax.
     /// Returns the transformed pattern string.
     fn transform_pattern(&self, pattern: &str, flags: &str) -> Option<String> {
-        // Only transform if unicode_property_regex is enabled and pattern contains
-        // \p{ or \P{
-        if !self.options.unicode_property_regex {
-            return None;
-        }
-        if !pattern.contains("\\p{") && !pattern.contains("\\P{") {
+        let should_transform_unicode_property =
+            self.should_transform_unicode_property(pattern, flags);
+        let should_transform_named_capture = self.should_transform_named_capture(pattern);
+
+        if !should_transform_unicode_property && !should_transform_named_capture {
             return None;
         }
 
@@ -82,15 +110,20 @@ impl RegexpPass {
             .parse()
             .ok()?;
 
-        // Transform unicode property escapes
-        transform_unicode_property_escapes(&mut ast);
+        if should_transform_unicode_property {
+            transform_unicode_property_escapes(&mut ast);
+        }
+
+        if should_transform_named_capture {
+            transform_named_capture_groups(&mut ast);
+        }
 
         // Serialize back to string
         Some(ast.to_string())
     }
 
     fn transform_regexp_args(&self, args: &mut [ExprOrSpread]) {
-        if !self.options.unicode_property_regex {
+        if !self.options.unicode_property_regex && !self.options.named_capturing_groups_regex {
             return;
         }
 
@@ -126,10 +159,6 @@ impl RegexpPass {
             None => "",
         };
 
-        if !flags.contains(['u', 'v']) {
-            return;
-        }
-
         let Some(transformed_pattern) = self.transform_pattern(pattern, flags) else {
             return;
         };
@@ -151,11 +180,10 @@ impl VisitMutHook<TraverseCtx> for RegexpPass {
                     || (self.options.unicode_regex && regex.flags.contains('u'))
                     || (self.options.unicode_sets_regex && regex.flags.contains('v'))
                     || (self.options.has_indices && regex.flags.contains('d'))
-                    || (self.options.named_capturing_groups_regex && regex.exp.contains("(?<"))
+                    || self.should_transform_named_capture(&regex.exp)
                     || (self.options.lookbehind_assertion
                         && (regex.exp.contains("(?<=") || regex.exp.contains("(?<!")))
-                    || (self.options.unicode_property_regex
-                        && (regex.exp.contains("\\p{") || regex.exp.contains("\\P{")));
+                    || self.should_transform_unicode_property(&regex.exp, &regex.flags);
 
                 if needs_transform {
                     let Regex { exp, flags, span } = regex.take();

--- a/crates/swc_ecma_transforms_base/src/helpers/_wrap_regexp.js
+++ b/crates/swc_ecma_transforms_base/src/helpers/_wrap_regexp.js
@@ -1,0 +1,84 @@
+function _wrap_regexp(re, groups) {
+    _wrap_regexp = function wrapRegExp(re, groups) {
+        return new BabelRegExp(re, undefined, groups);
+    };
+    var _super = RegExp.prototype;
+    var _groups = new WeakMap();
+    function BabelRegExp(re, flags, groups) {
+        var result = new RegExp(re, flags);
+        _groups.set(result, groups || _groups.get(re));
+        return _set_prototype_of(result, BabelRegExp.prototype);
+    }
+    function buildGroups(result, re) {
+        var g = _groups.get(re);
+        if (!g) {
+            return result.groups;
+        }
+        var groups = Object.create(null);
+        var keys = Object.keys(g);
+        for (var i = 0; i < keys.length; i++) {
+            var name = keys[i];
+            var value = g[name];
+            if (Array.isArray(value)) {
+                var capture;
+                for (var j = 0; j < value.length; j++) {
+                    var match = result[value[j]];
+                    if (match !== undefined) {
+                        capture = match;
+                        break;
+                    }
+                }
+                groups[name] = capture;
+            } else {
+                groups[name] = result[value];
+            }
+        }
+        return groups;
+    }
+    _inherits(BabelRegExp, RegExp);
+    BabelRegExp.prototype.exec = function(str) {
+        var result = _super.exec.call(this, str);
+        if (result) {
+            result.groups = buildGroups(result, this);
+            if (result.indices && typeof result.indices === "object") {
+                result.indices.groups = buildGroups(result.indices, this);
+            }
+        }
+        return result;
+    };
+    if (typeof Symbol !== "undefined" && Symbol.replace) {
+        BabelRegExp.prototype[Symbol.replace] = function(str, substitution) {
+            if (typeof substitution === "string") {
+                var groups = _groups.get(this);
+                if (!groups) {
+                    return _super[Symbol.replace].call(this, str, substitution);
+                }
+                return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)(>|$)/g, function(_, name, trailing) {
+                    if (trailing === "") {
+                        return "$<" + name;
+                    }
+                    var group = groups[name];
+                    if (Array.isArray(group)) {
+                        return group.map(function(group) {
+                            return "$" + group;
+                        }).join("");
+                    }
+                    return group == null ? "" : "$" + group;
+                }));
+            }
+            if (typeof substitution === "function") {
+                var _this = this;
+                return _super[Symbol.replace].call(this, str, function() {
+                    var args = arguments;
+                    if (typeof args[args.length - 1] !== "object") {
+                        args = Array.prototype.slice.call(args);
+                        args.push(buildGroups(args, _this));
+                    }
+                    return substitution.apply(this, args);
+                });
+            }
+            return _super[Symbol.replace].call(this, str, substitution);
+        };
+    }
+    return _wrap_regexp(re, groups);
+}

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -373,6 +373,7 @@ define_helpers!(Helpers {
     type_of: (),
     unsupported_iterable_to_array: (array_like_to_array),
     wrap_async_generator: (async_generator),
+    wrap_regexp: (inherits, set_prototype_of),
     wrap_native_super: (
         construct,
         get_prototype_of,

--- a/packages/helpers/esm/_wrap_regexp.js
+++ b/packages/helpers/esm/_wrap_regexp.js
@@ -1,0 +1,88 @@
+import { _ as _inherits } from "./_inherits.js";
+import { _ as _set_prototype_of } from "./_set_prototype_of.js";
+
+function _wrap_regexp(re, groups) {
+    _wrap_regexp = function wrapRegExp(re, groups) {
+        return new BabelRegExp(re, undefined, groups);
+    };
+    var _super = RegExp.prototype;
+    var _groups = new WeakMap();
+    function BabelRegExp(re, flags, groups) {
+        var result = new RegExp(re, flags);
+        _groups.set(result, groups || _groups.get(re));
+        return _set_prototype_of(result, BabelRegExp.prototype);
+    }
+    function buildGroups(result, re) {
+        var g = _groups.get(re);
+        if (!g) {
+            return result.groups;
+        }
+        var groups = Object.create(null);
+        var keys = Object.keys(g);
+        for (var i = 0; i < keys.length; i++) {
+            var name = keys[i];
+            var value = g[name];
+            if (Array.isArray(value)) {
+                var capture;
+                for (var j = 0; j < value.length; j++) {
+                    var match = result[value[j]];
+                    if (match !== undefined) {
+                        capture = match;
+                        break;
+                    }
+                }
+                groups[name] = capture;
+            } else {
+                groups[name] = result[value];
+            }
+        }
+        return groups;
+    }
+    _inherits(BabelRegExp, RegExp);
+    BabelRegExp.prototype.exec = function(str) {
+        var result = _super.exec.call(this, str);
+        if (result) {
+            result.groups = buildGroups(result, this);
+            if (result.indices && typeof result.indices === "object") {
+                result.indices.groups = buildGroups(result.indices, this);
+            }
+        }
+        return result;
+    };
+    if (typeof Symbol !== "undefined" && Symbol.replace) {
+        BabelRegExp.prototype[Symbol.replace] = function(str, substitution) {
+            if (typeof substitution === "string") {
+                var groups = _groups.get(this);
+                if (!groups) {
+                    return _super[Symbol.replace].call(this, str, substitution);
+                }
+                return _super[Symbol.replace].call(this, str, substitution.replace(/\$<([^>]+)(>|$)/g, function(_, name, trailing) {
+                    if (trailing === "") {
+                        return "$<" + name;
+                    }
+                    var group = groups[name];
+                    if (Array.isArray(group)) {
+                        return group.map(function(group) {
+                            return "$" + group;
+                        }).join("");
+                    }
+                    return group == null ? "" : "$" + group;
+                }));
+            }
+            if (typeof substitution === "function") {
+                var _this = this;
+                return _super[Symbol.replace].call(this, str, function() {
+                    var args = arguments;
+                    if (typeof args[args.length - 1] !== "object") {
+                        args = Array.prototype.slice.call(args);
+                        args.push(buildGroups(args, _this));
+                    }
+                    return substitution.apply(this, args);
+                });
+            }
+            return _super[Symbol.replace].call(this, str, substitution);
+        };
+    }
+    return _wrap_regexp(re, groups);
+}
+export { _wrap_regexp as _ };

--- a/packages/helpers/esm/index.js
+++ b/packages/helpers/esm/index.js
@@ -105,4 +105,5 @@ export { _ as _using } from "./_using.js";
 export { _ as _using_ctx } from "./_using_ctx.js";
 export { _ as _wrap_async_generator } from "./_wrap_async_generator.js";
 export { _ as _wrap_native_super } from "./_wrap_native_super.js";
+export { _ as _wrap_regexp } from "./_wrap_regexp.js";
 export { _ as _write_only_error } from "./_write_only_error.js";

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -678,6 +678,12 @@
             "import": "./esm/_wrap_native_super.js",
             "default": "./cjs/_wrap_native_super.cjs"
         },
+        "./_/_wrap_regexp": {
+            "module-sync": "./esm/_wrap_regexp.js",
+            "webpack": "./esm/_wrap_regexp.js",
+            "import": "./esm/_wrap_regexp.js",
+            "default": "./cjs/_wrap_regexp.cjs"
+        },
         "./_/_write_only_error": {
             "module-sync": "./esm/_write_only_error.js",
             "webpack": "./esm/_write_only_error.js",


### PR DESCRIPTION
## Summary
- add syntax-level named capture group transform in `swc_ecma_compat_regexp`
- apply named-capture and unicode-property transforms in a single regexp parse pipeline
- avoid false positives for lookbehind forms `(?<=`/`(?<!)` when deciding named-capture transform
- add preset-env fixture for issue 11608 and update existing regexp fixture output

## Details
- transform `(?<name>...)` to `(...)`
- transform `\k<name>` to indexed backreferences (`\1`, `\2`, ...)
- keep unresolved named backreferences unchanged (no panic)
- support both regex literals and `RegExp(...)` / `new RegExp(...)` string pattern paths

Fixes #11608

## Test
- `git submodule update --init --recursive`
- `cargo test -p swc_ecma_compat_regexp`
- `cargo test -p swc_ecma_preset_env --test test`
- `cargo test -p swc_ecma_transformer`
- `cargo test -p swc_ecma_preset_env --test test -- --ignored fixture_tests__fixtures__transform__named_capturing_groups_regex_11608__input_mjs`
- `cargo test -p swc_ecma_preset_env --test test -- --ignored fixture_tests__fixtures__corejs3__usage_regexp__input_mjs`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
