### PR TITLE
feat(es_codegen): add high-performance swc_es_codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6943,6 +6943,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_es_codegen"
+version = "0.1.0"
+dependencies = [
+ "codspeed-criterion-compat",
+ "dragonbox_ecma",
+ "swc_common",
+ "swc_es_ast",
+ "swc_es_parser",
+ "swc_malloc",
+ "testing",
+ "walkdir",
+]
+
+[[package]]
 name = "swc_es_parser"
 version = "0.1.0"
 dependencies = [

--- a/crates/swc_es_codegen/Cargo.toml
+++ b/crates/swc_es_codegen/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
+description   = "ECMAScript code generator for swc_es_ast"
+documentation = "https://rustdoc.swc.rs/swc_es_codegen/"
+edition       = { workspace = true }
+include       = ["Cargo.toml", "src/**/*.rs", "tests/**/*.rs", "benches/**/*.rs"]
+license       = { workspace = true }
+name          = "swc_es_codegen"
+repository    = { workspace = true }
+version       = "0.1.0"
+
+[lib]
+bench = false
+
+[dependencies]
+dragonbox_ecma = { workspace = true }
+
+swc_es_ast = { version = "0.1.0", path = "../swc_es_ast" }
+
+[dev-dependencies]
+codspeed-criterion-compat = { workspace = true }
+testing = { version = "20.0.0", path = "../testing" }
+walkdir = { workspace = true }
+
+swc_common = { version = "19.0.0", path = "../swc_common" }
+swc_es_parser = { version = "0.1.0", path = "../swc_es_parser" }
+swc_malloc = { version = "1.2.5", path = "../swc_malloc" }
+
+[[bench]]
+harness = false
+name    = "with_parse"

--- a/crates/swc_es_codegen/benches/with_parse.rs
+++ b/crates/swc_es_codegen/benches/with_parse.rs
@@ -1,0 +1,79 @@
+extern crate swc_malloc;
+
+use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+use swc_common::{comments::SingleThreadedComments, FileName};
+use swc_es_codegen::{to_code, Config};
+use swc_es_parser::{parse_file_as_program, EsSyntax, Syntax, TsSyntax};
+
+fn bench_with_parse(b: &mut Bencher, syntax: Syntax, source: &'static str, minify: bool) {
+    let _ = testing::run_test(false, |cm, _| {
+        let fm = cm.new_source_file(FileName::Anon.into(), source.to_string());
+
+        b.iter(|| {
+            let comments = SingleThreadedComments::default();
+            let mut recovered = Vec::new();
+            let parsed = parse_file_as_program(&fm, syntax, Some(&comments), &mut recovered)
+                .expect("fixture should parse");
+            assert!(recovered.is_empty());
+
+            let output = to_code(&parsed.store, parsed.program, Config { minify });
+            black_box(output);
+        });
+
+        Ok(())
+    });
+}
+
+fn bench_cases(c: &mut Criterion) {
+    let js_syntax = Syntax::Es(EsSyntax {
+        decorators: true,
+        import_attributes: true,
+        explicit_resource_management: true,
+        ..Default::default()
+    });
+
+    let tsx_syntax = Syntax::Typescript(TsSyntax {
+        tsx: true,
+        decorators: true,
+        ..Default::default()
+    });
+
+    c.bench_function("es/codegen/with-parser/js-pretty", |b| {
+        bench_with_parse(
+            b,
+            js_syntax,
+            include_str!("../../swc_ecma_parser/benches/files/angular-1.2.5.js"),
+            false,
+        )
+    });
+
+    c.bench_function("es/codegen/with-parser/js-minify", |b| {
+        bench_with_parse(
+            b,
+            js_syntax,
+            include_str!("../../swc_ecma_parser/benches/files/angular-1.2.5.js"),
+            true,
+        )
+    });
+
+    c.bench_function("es/codegen/with-parser/tsx-pretty", |b| {
+        bench_with_parse(
+            b,
+            tsx_syntax,
+            include_str!("../../swc_ecma_parser/benches/files/cal.com.tsx"),
+            false,
+        )
+    });
+
+    c.bench_function("es/codegen/with-parser/tsx-minify", |b| {
+        bench_with_parse(
+            b,
+            tsx_syntax,
+            include_str!("../../swc_ecma_parser/benches/files/cal.com.tsx"),
+            true,
+        )
+    });
+}
+
+criterion_group!(benches, bench_cases);
+criterion_main!(benches);

--- a/crates/swc_es_codegen/benches/with_parse.rs
+++ b/crates/swc_es_codegen/benches/with_parse.rs
@@ -42,7 +42,7 @@ fn bench_cases(c: &mut Criterion) {
         bench_with_parse(
             b,
             js_syntax,
-            include_str!("../../swc_ecma_parser/benches/files/angular-1.2.5.js"),
+            include_str!("../tests/fixture/module-attrs/input.js"),
             false,
         )
     });
@@ -51,7 +51,7 @@ fn bench_cases(c: &mut Criterion) {
         bench_with_parse(
             b,
             js_syntax,
-            include_str!("../../swc_ecma_parser/benches/files/angular-1.2.5.js"),
+            include_str!("../tests/fixture/module-attrs/input.js"),
             true,
         )
     });
@@ -60,7 +60,7 @@ fn bench_cases(c: &mut Criterion) {
         bench_with_parse(
             b,
             tsx_syntax,
-            include_str!("../../swc_ecma_parser/benches/files/cal.com.tsx"),
+            include_str!("../tests/fixture/tsx-basic/input.tsx"),
             false,
         )
     });
@@ -69,7 +69,7 @@ fn bench_cases(c: &mut Criterion) {
         bench_with_parse(
             b,
             tsx_syntax,
-            include_str!("../../swc_ecma_parser/benches/files/cal.com.tsx"),
+            include_str!("../tests/fixture/tsx-basic/input.tsx"),
             true,
         )
     });

--- a/crates/swc_es_codegen/src/config.rs
+++ b/crates/swc_es_codegen/src/config.rs
@@ -1,0 +1,6 @@
+/// Code generation configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Config {
+    /// Emits compact output when set to `true`.
+    pub minify: bool,
+}

--- a/crates/swc_es_codegen/src/emitter/class.rs
+++ b/crates/swc_es_codegen/src/emitter/class.rs
@@ -1,0 +1,213 @@
+use swc_es_ast::{ClassDecl, ClassMember, FunctionId, MethodKind, PropName};
+
+use super::Emitter;
+use crate::Result;
+
+impl<W> Emitter<'_, W>
+where
+    W: crate::WriteJs,
+{
+    pub(super) fn emit_class_decl(&mut self, decl: &ClassDecl) -> Result {
+        let class = self.class(decl.class).clone();
+        self.emit_decorators(&class.decorators, true)?;
+        self.keyword("class")?;
+        self.write_space_pretty()?;
+        self.emit_ident(&decl.ident)?;
+
+        if let Some(super_class) = class.super_class {
+            self.write_space_pretty()?;
+            self.keyword("extends")?;
+            self.write_space_pretty()?;
+            self.emit_expr(super_class)?;
+        }
+
+        self.write_space_pretty()?;
+        self.emit_class_body_members(&class.body)
+    }
+
+    pub(super) fn emit_class_expr(&mut self, class_id: swc_es_ast::ClassId) -> Result {
+        let class = self.class(class_id).clone();
+
+        self.emit_decorators(&class.decorators, true)?;
+        self.keyword("class")?;
+
+        if let Some(name) = &class.ident {
+            self.write_space_pretty()?;
+            self.emit_ident(name)?;
+        }
+
+        if let Some(super_class) = class.super_class {
+            self.write_space_pretty()?;
+            self.keyword("extends")?;
+            self.write_space_pretty()?;
+            self.emit_expr(super_class)?;
+        }
+
+        self.write_space_pretty()?;
+        self.emit_class_body_members(&class.body)
+    }
+
+    fn emit_class_body_members(&mut self, members: &[swc_es_ast::ClassMemberId]) -> Result {
+        self.punct("{")?;
+
+        if !members.is_empty() {
+            self.indent();
+            self.write_line()?;
+        }
+
+        for (index, member) in members.iter().enumerate() {
+            if index != 0 {
+                self.write_line()?;
+            }
+            self.emit_class_member(*member)?;
+        }
+
+        if !members.is_empty() {
+            self.dedent();
+            self.write_line()?;
+        }
+
+        self.punct("}")
+    }
+
+    pub(super) fn emit_class_member(&mut self, member_id: swc_es_ast::ClassMemberId) -> Result {
+        match self.class_member(member_id).clone() {
+            ClassMember::Method(method) => {
+                self.emit_decorators(&method.decorators, true)?;
+
+                let function = self.function(method.function).clone();
+
+                if method.is_static {
+                    self.keyword("static")?;
+                    self.write_space_pretty()?;
+                }
+
+                match method.kind {
+                    MethodKind::Getter => {
+                        self.keyword("get")?;
+                        self.write_space_pretty()?;
+                    }
+                    MethodKind::Setter => {
+                        self.keyword("set")?;
+                        self.write_space_pretty()?;
+                    }
+                    MethodKind::Method | MethodKind::Constructor => {
+                        if function.is_async {
+                            self.keyword("async")?;
+                            self.write_space_force()?;
+                        }
+                        if function.is_generator {
+                            self.punct("*")?;
+                        }
+                    }
+                }
+
+                self.emit_prop_name_as_class_key(&method.key)?;
+                self.emit_function_signature_and_body(method.function)
+            }
+            ClassMember::Prop(prop) => {
+                self.emit_decorators(&prop.decorators, true)?;
+
+                if prop.is_static {
+                    self.keyword("static")?;
+                    self.write_space_pretty()?;
+                }
+
+                self.emit_prop_name_as_class_key(&prop.key)?;
+
+                if let Some(value) = prop.value {
+                    self.write_space_pretty()?;
+                    self.punct("=")?;
+                    self.write_space_pretty()?;
+                    self.emit_expr(value)?;
+                }
+
+                self.punct(";")
+            }
+            ClassMember::StaticBlock(block) => {
+                self.keyword("static")?;
+                self.write_space_pretty()?;
+                self.emit_block_stmt_list(&block.body)
+            }
+        }
+    }
+
+    pub(super) fn emit_function_expr(&mut self, function_id: FunctionId) -> Result {
+        let function = self.function(function_id).clone();
+
+        if function.is_async {
+            self.keyword("async")?;
+            self.write_space_force()?;
+        }
+
+        self.keyword("function")?;
+
+        if function.is_generator {
+            self.punct("*")?;
+        }
+
+        self.emit_function_signature_and_body(function_id)
+    }
+
+    pub(super) fn emit_function_signature_and_body(&mut self, function_id: FunctionId) -> Result {
+        let function = self.function(function_id).clone();
+
+        self.punct("(")?;
+        for (index, param) in function.params.iter().enumerate() {
+            if index != 0 {
+                self.punct(",")?;
+                self.write_space_pretty()?;
+            }
+            self.emit_decorators(&param.decorators, false)?;
+            self.emit_pat(param.pat)?;
+        }
+        self.punct(")")?;
+        self.write_space_pretty()?;
+
+        self.emit_block_stmt_list(&function.body)
+    }
+
+    fn emit_prop_name_as_class_key(&mut self, key: &PropName) -> Result {
+        match key {
+            PropName::Computed(expr) => {
+                self.punct("[")?;
+                self.emit_expr(*expr)?;
+                self.punct("]")
+            }
+            _ => self.emit_prop_name(key),
+        }
+    }
+
+    pub(super) fn emit_decorators(
+        &mut self,
+        decorators: &[swc_es_ast::Decorator],
+        end_with_gap: bool,
+    ) -> Result {
+        if decorators.is_empty() {
+            return Ok(());
+        }
+
+        for (index, decorator) in decorators.iter().enumerate() {
+            self.punct("@")?;
+            self.emit_expr(decorator.expr)?;
+
+            if index + 1 != decorators.len() {
+                if self.cfg.minify {
+                    self.write_space_force()?;
+                } else {
+                    self.write_line()?;
+                }
+            }
+        }
+
+        if end_with_gap {
+            if self.cfg.minify {
+                self.write_space_force()?;
+            } else {
+                self.write_line()?;
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/decl.rs
+++ b/crates/swc_es_codegen/src/emitter/decl.rs
@@ -1,0 +1,248 @@
+use swc_es_ast::{Decl, DeclId, TsEnumMemberName, VarDeclKind};
+
+use super::Emitter;
+use crate::Result;
+
+impl<W> Emitter<'_, W>
+where
+    W: crate::WriteJs,
+{
+    pub(crate) fn emit_decl(&mut self, decl: DeclId) -> Result {
+        self.emit_decl_with_mode(decl, false)
+    }
+
+    pub(super) fn emit_decl_in_for_head(&mut self, decl: DeclId) -> Result {
+        self.emit_decl_with_mode(decl, true)
+    }
+
+    fn emit_decl_with_mode(&mut self, decl: DeclId, in_for_head: bool) -> Result {
+        match self.decl(decl).clone() {
+            Decl::Var(decl) => {
+                if decl.declare {
+                    self.keyword("declare")?;
+                    self.write_space_force()?;
+                }
+
+                self.keyword(var_decl_kind_text(decl.kind))?;
+                self.write_space_pretty()?;
+
+                for (index, declarator) in decl.declarators.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_space_pretty()?;
+                    }
+
+                    self.emit_pat(declarator.name)?;
+                    if let Some(init) = declarator.init {
+                        self.write_space_pretty()?;
+                        self.punct("=")?;
+                        self.write_space_pretty()?;
+                        self.emit_expr(init)?;
+                    }
+                }
+
+                if !in_for_head {
+                    self.punct(";")?;
+                }
+
+                Ok(())
+            }
+            Decl::Fn(decl) => {
+                if decl.declare {
+                    self.keyword("declare")?;
+                    self.write_space_force()?;
+                }
+
+                self.keyword("function")?;
+                self.write_space_pretty()?;
+                self.emit_ident(&decl.ident)?;
+                self.punct("(")?;
+                for (index, param) in decl.params.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_space_pretty()?;
+                    }
+                    self.emit_pat(*param)?;
+                }
+                self.punct(")")?;
+                self.write_space_pretty()?;
+                self.emit_block_stmt_list(&decl.body)?;
+                Ok(())
+            }
+            Decl::Class(decl) => {
+                self.emit_class_decl(&decl)?;
+                Ok(())
+            }
+            Decl::TsTypeAlias(decl) => {
+                if decl.declare {
+                    self.keyword("declare")?;
+                    self.write_space_force()?;
+                }
+                self.keyword("type")?;
+                self.write_space_pretty()?;
+                self.emit_ident(&decl.ident)?;
+                if !decl.type_params.is_empty() {
+                    self.punct("<")?;
+                    for (index, param) in decl.type_params.iter().enumerate() {
+                        if index != 0 {
+                            self.punct(",")?;
+                            self.write_space_pretty()?;
+                        }
+                        self.emit_ident(param)?;
+                    }
+                    self.punct(">")?;
+                }
+                self.write_space_pretty()?;
+                self.punct("=")?;
+                self.write_space_pretty()?;
+                self.emit_ts_type(decl.ty)?;
+                if !in_for_head {
+                    self.punct(";")?;
+                }
+                Ok(())
+            }
+            Decl::TsInterface(decl) => {
+                if decl.declare {
+                    self.keyword("declare")?;
+                    self.write_space_force()?;
+                }
+                self.keyword("interface")?;
+                self.write_space_pretty()?;
+                self.emit_ident(&decl.ident)?;
+                if !decl.type_params.is_empty() {
+                    self.punct("<")?;
+                    for (index, param) in decl.type_params.iter().enumerate() {
+                        if index != 0 {
+                            self.punct(",")?;
+                            self.write_space_pretty()?;
+                        }
+                        self.emit_ident(param)?;
+                    }
+                    self.punct(">")?;
+                }
+                if !decl.extends.is_empty() {
+                    self.write_space_pretty()?;
+                    self.keyword("extends")?;
+                    self.write_space_pretty()?;
+                    for (index, ext) in decl.extends.iter().enumerate() {
+                        if index != 0 {
+                            self.punct(",")?;
+                            self.write_space_pretty()?;
+                        }
+                        self.emit_ident(ext)?;
+                    }
+                }
+                self.write_space_pretty()?;
+                self.emit_ts_type_members(&decl.body)?;
+                Ok(())
+            }
+            Decl::TsEnum(decl) => {
+                if decl.declare {
+                    self.keyword("declare")?;
+                    self.write_space_force()?;
+                }
+                if decl.is_const {
+                    self.keyword("const")?;
+                    self.write_space_force()?;
+                }
+                self.keyword("enum")?;
+                self.write_space_pretty()?;
+                self.emit_ident(&decl.ident)?;
+                self.write_space_pretty()?;
+                self.punct("{")?;
+                for (index, member) in decl.members.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_space_pretty()?;
+                    }
+
+                    match &member.name {
+                        TsEnumMemberName::Ident(ident) => self.emit_ident(ident)?,
+                        TsEnumMemberName::Str(value) => {
+                            self.emit_string_literal(value.value.as_ref())?
+                        }
+                        TsEnumMemberName::Num(value) => self.emit_number_literal(value.value)?,
+                    }
+
+                    if let Some(init) = member.init {
+                        self.write_space_pretty()?;
+                        self.punct("=")?;
+                        self.write_space_pretty()?;
+                        self.emit_expr(init)?;
+                    }
+                }
+                self.punct("}")
+            }
+            Decl::TsModule(decl) => {
+                if decl.declare {
+                    self.keyword("declare")?;
+                    self.write_space_force()?;
+                }
+                if decl.global {
+                    self.keyword("global")?;
+                    self.write_space_force()?;
+                }
+                if decl.namespace {
+                    self.keyword("namespace")?;
+                } else {
+                    self.keyword("module")?;
+                }
+                self.write_space_pretty()?;
+                self.emit_ts_module_name(&decl.id)?;
+
+                if let Some(body) = &decl.body {
+                    match body {
+                        swc_es_ast::TsNamespaceBody::ModuleBlock(stmts) => {
+                            self.write_space_pretty()?;
+                            self.emit_block_stmt_list(stmts)?;
+                        }
+                        swc_es_ast::TsNamespaceBody::Namespace(namespace) => {
+                            let mut names = vec![namespace.id.clone()];
+                            let mut cursor = &*namespace.body;
+                            while let swc_es_ast::TsNamespaceBody::Namespace(next) = cursor {
+                                names.push(next.id.clone());
+                                cursor = &*next.body;
+                            }
+
+                            if let (Some(first), swc_es_ast::TsModuleName::Ident(root)) =
+                                (names.first(), &decl.id)
+                            {
+                                if first.sym == root.sym {
+                                    names.remove(0);
+                                }
+                            }
+
+                            for name in names {
+                                self.punct(".")?;
+                                self.emit_ident(&name)?;
+                            }
+                            self.write_space_pretty()?;
+
+                            match cursor {
+                                swc_es_ast::TsNamespaceBody::ModuleBlock(stmts) => {
+                                    self.emit_block_stmt_list(stmts)?;
+                                }
+                                swc_es_ast::TsNamespaceBody::Namespace(_) => unreachable!(),
+                            }
+                        }
+                    }
+                } else {
+                    self.punct(";")?;
+                }
+
+                Ok(())
+            }
+        }
+    }
+}
+
+#[inline]
+fn var_decl_kind_text(kind: VarDeclKind) -> &'static str {
+    match kind {
+        VarDeclKind::Var => "var",
+        VarDeclKind::Let => "let",
+        VarDeclKind::Const => "const",
+        VarDeclKind::Using => "using",
+        VarDeclKind::AwaitUsing => "await using",
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/expr.rs
+++ b/crates/swc_es_codegen/src/emitter/expr.rs
@@ -1,0 +1,411 @@
+use swc_es_ast::{
+    AssignOp, BinaryOp, Expr, ExprId, Lit, MemberProp, MetaPropKind, UnaryOp, UpdateOp,
+};
+
+use super::Emitter;
+use crate::{
+    precedence::{binary_precedence, is_right_associative_binary, Precedence},
+    Result,
+};
+
+impl<W> Emitter<'_, W>
+where
+    W: crate::WriteJs,
+{
+    #[inline]
+    pub(crate) fn emit_expr(&mut self, expr: ExprId) -> Result {
+        self.emit_expr_with_parens_if_needed(expr, Precedence::Lowest)
+    }
+
+    pub(super) fn emit_expr_inner(&mut self, expr: ExprId) -> Result {
+        match self.expr(expr).clone() {
+            Expr::Ident(ident) => self.emit_ident(&ident),
+            Expr::Lit(lit) => self.emit_lit(&lit),
+            Expr::Function(function) => self.emit_function_expr(function),
+            Expr::Class(class) => self.emit_class_expr(class),
+            Expr::JSXElement(element) => self.emit_jsx_element(element),
+            Expr::TsAs(expr) => {
+                self.emit_expr_with_parens_if_needed(expr.expr, Precedence::Relational)?;
+                self.write_space_pretty()?;
+                self.keyword("as")?;
+                self.write_space_pretty()?;
+                self.emit_ts_type(expr.ty)
+            }
+            Expr::Array(expr) => {
+                self.punct("[")?;
+                for (index, elem) in expr.elems.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_space_pretty()?;
+                    }
+
+                    if let Some(elem) = elem {
+                        if elem.spread {
+                            self.punct("...")?;
+                        }
+                        self.emit_expr(elem.expr)?;
+                    }
+                }
+                self.punct("]")
+            }
+            Expr::Object(expr) => {
+                self.punct("{")?;
+                if !expr.props.is_empty() {
+                    self.indent();
+                    self.write_line()?;
+                }
+
+                for (index, prop) in expr.props.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_line()?;
+                    }
+
+                    self.emit_prop_name(&prop.key)?;
+                    self.punct(":")?;
+                    self.write_space_pretty()?;
+                    self.emit_expr(prop.value)?;
+                }
+
+                if !expr.props.is_empty() {
+                    self.dedent();
+                    self.write_line()?;
+                }
+
+                self.punct("}")
+            }
+            Expr::Unary(expr) => {
+                let op = unary_op_text(expr.op);
+                self.operator(op)?;
+                if matches!(expr.op, UnaryOp::TypeOf | UnaryOp::Void | UnaryOp::Delete) {
+                    self.write_space_pretty()?;
+                }
+                self.emit_expr_with_parens_if_needed(expr.arg, Precedence::Prefix)
+            }
+            Expr::Binary(expr) => {
+                let precedence = binary_precedence(expr.op);
+                let left_prec = if is_right_associative_binary(expr.op) {
+                    precedence.next()
+                } else {
+                    precedence
+                };
+                let right_prec = if is_right_associative_binary(expr.op) {
+                    precedence
+                } else {
+                    precedence.next()
+                };
+
+                self.emit_expr_with_parens_if_needed(expr.left, left_prec)?;
+                self.write_space_pretty()?;
+                self.operator(binary_op_text(expr.op))?;
+                self.write_space_pretty()?;
+                self.emit_expr_with_parens_if_needed(expr.right, right_prec)
+            }
+            Expr::Assign(expr) => {
+                self.emit_pat(expr.left)?;
+                self.write_space_pretty()?;
+                self.operator(assign_op_text(expr.op))?;
+                self.write_space_pretty()?;
+                self.emit_expr_with_parens_if_needed(expr.right, Precedence::Assignment)
+            }
+            Expr::Call(expr) => {
+                self.emit_expr_with_parens_if_needed(expr.callee, Precedence::Call)?;
+                self.punct("(")?;
+                self.emit_call_args(&expr.args)?;
+                self.punct(")")
+            }
+            Expr::Member(expr) => {
+                self.emit_expr_with_parens_if_needed(expr.obj, Precedence::Member)?;
+                match expr.prop {
+                    MemberProp::Ident(ident) | MemberProp::Private(ident) => {
+                        self.punct(".")?;
+                        self.emit_ident(&ident)
+                    }
+                    MemberProp::Computed(prop) => {
+                        self.punct("[")?;
+                        self.emit_expr(prop)?;
+                        self.punct("]")
+                    }
+                }
+            }
+            Expr::Cond(expr) => {
+                self.emit_expr_with_parens_if_needed(expr.test, Precedence::Conditional.next())?;
+                self.punct("?")?;
+                self.write_space_pretty()?;
+                self.emit_expr_with_parens_if_needed(expr.cons, Precedence::Assignment)?;
+                self.punct(":")?;
+                self.write_space_pretty()?;
+                self.emit_expr_with_parens_if_needed(expr.alt, Precedence::Assignment)
+            }
+            Expr::Seq(expr) => {
+                for (index, item) in expr.exprs.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_space_pretty()?;
+                    }
+                    self.emit_expr_with_parens_if_needed(*item, Precedence::Assignment)?;
+                }
+                Ok(())
+            }
+            Expr::New(expr) => {
+                self.keyword("new")?;
+                self.write_space_pretty()?;
+                self.emit_expr_with_parens_if_needed(expr.callee, Precedence::Call)?;
+                self.punct("(")?;
+                self.emit_call_args(&expr.args)?;
+                self.punct(")")
+            }
+            Expr::Update(expr) => {
+                let op = update_op_text(expr.op);
+                if expr.prefix {
+                    self.operator(op)?;
+                    self.emit_expr_with_parens_if_needed(expr.arg, Precedence::Prefix)
+                } else {
+                    self.emit_expr_with_parens_if_needed(expr.arg, Precedence::Postfix)?;
+                    self.operator(op)
+                }
+            }
+            Expr::Await(expr) => {
+                self.keyword("await")?;
+                self.write_space_pretty()?;
+                self.emit_expr_with_parens_if_needed(expr.arg, Precedence::Prefix)
+            }
+            Expr::Arrow(expr) => {
+                if expr.is_async {
+                    self.keyword("async")?;
+                    self.write_space_force()?;
+                }
+                self.punct("(")?;
+                for (index, param) in expr.params.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_space_pretty()?;
+                    }
+                    self.emit_pat(*param)?;
+                }
+                self.punct(")")?;
+                self.write_space_pretty()?;
+                self.punct("=>")?;
+
+                match expr.body {
+                    swc_es_ast::ArrowBody::Expr(expr) => {
+                        self.write_space_pretty()?;
+                        self.emit_expr_with_parens_if_needed(expr, Precedence::Assignment)
+                    }
+                    swc_es_ast::ArrowBody::Block(stmts) => {
+                        self.write_space_pretty()?;
+                        self.emit_block_stmt_list(&stmts)
+                    }
+                }
+            }
+            Expr::Template(expr) => {
+                self.punct("`")?;
+                for (index, quasi) in expr.quasis.iter().enumerate() {
+                    self.emit_template_quasi(quasi.value.as_ref())?;
+                    if let Some(value) = expr.exprs.get(index) {
+                        self.punct("${")?;
+                        self.emit_expr(*value)?;
+                        self.punct("}")?;
+                    }
+                }
+                self.punct("`")
+            }
+            Expr::Yield(expr) => {
+                self.keyword("yield")?;
+                if expr.delegate {
+                    self.operator("*")?;
+                }
+                if let Some(arg) = expr.arg {
+                    self.write_space_pretty()?;
+                    self.emit_expr_with_parens_if_needed(arg, Precedence::Assignment)?;
+                }
+                Ok(())
+            }
+            Expr::TaggedTemplate(expr) => {
+                self.emit_expr_with_parens_if_needed(expr.tag, Precedence::Call)?;
+                self.punct("`")?;
+                for (index, quasi) in expr.template.quasis.iter().enumerate() {
+                    self.emit_template_quasi(quasi.value.as_ref())?;
+                    if let Some(value) = expr.template.exprs.get(index) {
+                        self.punct("${")?;
+                        self.emit_expr(*value)?;
+                        self.punct("}")?;
+                    }
+                }
+                self.punct("`")
+            }
+            Expr::MetaProp(expr) => match expr.kind {
+                MetaPropKind::NewTarget => self.write_token("new.target"),
+                MetaPropKind::ImportMeta => self.write_token("import.meta"),
+            },
+            Expr::OptChain(expr) => self.emit_opt_chain(expr.base),
+            Expr::Paren(expr) => {
+                self.punct("(")?;
+                self.emit_expr(expr.expr)?;
+                self.punct(")")
+            }
+        }
+    }
+
+    fn emit_call_args(&mut self, args: &[swc_es_ast::ExprOrSpread]) -> Result {
+        for (index, arg) in args.iter().enumerate() {
+            if index != 0 {
+                self.punct(",")?;
+                self.write_space_pretty()?;
+            }
+
+            if arg.spread {
+                self.punct("...")?;
+            }
+            self.emit_expr(arg.expr)?;
+        }
+
+        Ok(())
+    }
+
+    fn emit_lit(&mut self, lit: &Lit) -> Result {
+        match lit {
+            Lit::Str(value) => self.emit_string_literal(value.value.as_ref()),
+            Lit::Bool(value) => {
+                if value.value {
+                    self.keyword("true")
+                } else {
+                    self.keyword("false")
+                }
+            }
+            Lit::Null(_) => self.keyword("null"),
+            Lit::Num(value) => self.emit_number_literal(value.value),
+            Lit::BigInt(value) => {
+                self.write_token(value.value.as_ref())?;
+                self.punct("n")
+            }
+            Lit::Regex(value) => {
+                self.punct("/")?;
+                self.write_raw(&escape_regex_pattern(value.exp.as_ref()))?;
+                self.punct("/")?;
+                self.write_token(value.flags.as_ref())
+            }
+        }
+    }
+
+    fn emit_opt_chain(&mut self, base: ExprId) -> Result {
+        match self.expr(base).clone() {
+            Expr::Member(member) => {
+                self.emit_expr_with_parens_if_needed(member.obj, Precedence::Member)?;
+                match member.prop {
+                    MemberProp::Ident(ident) | MemberProp::Private(ident) => {
+                        self.punct("?.")?;
+                        self.emit_ident(&ident)
+                    }
+                    MemberProp::Computed(prop) => {
+                        self.punct("?.[")?;
+                        self.emit_expr(prop)?;
+                        self.punct("]")
+                    }
+                }
+            }
+            Expr::Call(call) => {
+                self.emit_expr_with_parens_if_needed(call.callee, Precedence::Call)?;
+                self.punct("?.(")?;
+                self.emit_call_args(&call.args)?;
+                self.punct(")")
+            }
+            _ => {
+                self.emit_expr_with_parens_if_needed(base, Precedence::Call)?;
+                self.punct("?.")
+            }
+        }
+    }
+}
+
+#[inline]
+fn unary_op_text(op: UnaryOp) -> &'static str {
+    match op {
+        UnaryOp::Plus => "+",
+        UnaryOp::Minus => "-",
+        UnaryOp::Bang => "!",
+        UnaryOp::Tilde => "~",
+        UnaryOp::TypeOf => "typeof",
+        UnaryOp::Void => "void",
+        UnaryOp::Delete => "delete",
+    }
+}
+
+#[inline]
+fn binary_op_text(op: BinaryOp) -> &'static str {
+    match op {
+        BinaryOp::Add => "+",
+        BinaryOp::Sub => "-",
+        BinaryOp::Mul => "*",
+        BinaryOp::Div => "/",
+        BinaryOp::Mod => "%",
+        BinaryOp::EqEq => "==",
+        BinaryOp::EqEqEq => "===",
+        BinaryOp::NotEq => "!=",
+        BinaryOp::NotEqEq => "!==",
+        BinaryOp::Lt => "<",
+        BinaryOp::LtEq => "<=",
+        BinaryOp::Gt => ">",
+        BinaryOp::GtEq => ">=",
+        BinaryOp::LShift => "<<",
+        BinaryOp::RShift => ">>",
+        BinaryOp::ZeroFillRShift => ">>>",
+        BinaryOp::LogicalAnd => "&&",
+        BinaryOp::LogicalOr => "||",
+        BinaryOp::BitOr => "|",
+        BinaryOp::BitXor => "^",
+        BinaryOp::BitAnd => "&",
+        BinaryOp::In => "in",
+        BinaryOp::InstanceOf => "instanceof",
+        BinaryOp::Exp => "**",
+        BinaryOp::NullishCoalescing => "??",
+    }
+}
+
+#[inline]
+fn assign_op_text(op: AssignOp) -> &'static str {
+    match op {
+        AssignOp::Assign => "=",
+        AssignOp::AddAssign => "+=",
+        AssignOp::SubAssign => "-=",
+        AssignOp::MulAssign => "*=",
+        AssignOp::DivAssign => "/=",
+        AssignOp::ModAssign => "%=",
+        AssignOp::LShiftAssign => "<<=",
+        AssignOp::RShiftAssign => ">>=",
+        AssignOp::ZeroFillRShiftAssign => ">>>=",
+        AssignOp::BitOrAssign => "|=",
+        AssignOp::BitXorAssign => "^=",
+        AssignOp::BitAndAssign => "&=",
+        AssignOp::ExpAssign => "**=",
+        AssignOp::AndAssign => "&&=",
+        AssignOp::OrAssign => "||=",
+        AssignOp::NullishAssign => "??=",
+    }
+}
+
+#[inline]
+fn update_op_text(op: UpdateOp) -> &'static str {
+    match op {
+        UpdateOp::PlusPlus => "++",
+        UpdateOp::MinusMinus => "--",
+    }
+}
+
+#[inline]
+fn escape_regex_pattern(pattern: &str) -> String {
+    let mut out = String::with_capacity(pattern.len());
+
+    for c in pattern.chars() {
+        match c {
+            '/' => out.push_str("\\/"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            c => out.push(c),
+        }
+    }
+
+    out
+}

--- a/crates/swc_es_codegen/src/emitter/jsx.rs
+++ b/crates/swc_es_codegen/src/emitter/jsx.rs
@@ -1,0 +1,78 @@
+use swc_es_ast::{Expr, JSXElementChild, JSXElementId, JSXElementName, Lit};
+
+use super::Emitter;
+use crate::Result;
+
+impl<W> Emitter<'_, W>
+where
+    W: crate::WriteJs,
+{
+    pub(super) fn emit_jsx_element(&mut self, element_id: JSXElementId) -> Result {
+        let element = self.jsx_element(element_id).clone();
+
+        self.punct("<")?;
+        self.emit_jsx_name(&element.opening.name)?;
+
+        for attr in &element.opening.attrs {
+            self.write_space_force()?;
+            if attr.name.as_ref() == "..." {
+                self.punct("{")?;
+                self.punct("...")?;
+                if let Some(value) = attr.value {
+                    self.emit_expr(value)?;
+                }
+                self.punct("}")?;
+                continue;
+            }
+
+            self.write_token(attr.name.as_ref())?;
+            if let Some(value) = attr.value {
+                self.punct("=")?;
+                match self.expr(value).clone() {
+                    Expr::Lit(Lit::Str(value)) => {
+                        self.emit_string_literal(value.value.as_ref())?;
+                    }
+                    _ => {
+                        self.punct("{")?;
+                        self.emit_expr(value)?;
+                        self.punct("}")?;
+                    }
+                }
+            }
+        }
+
+        if element.opening.self_closing {
+            self.punct(" />")?;
+            return Ok(());
+        }
+
+        self.punct(">")?;
+
+        for child in &element.children {
+            match child {
+                JSXElementChild::Element(element) => self.emit_jsx_element(*element)?,
+                JSXElementChild::Text(text) => self.write_raw(text.as_ref())?,
+                JSXElementChild::Expr(expr) => {
+                    self.punct("{")?;
+                    self.emit_expr(*expr)?;
+                    self.punct("}")?;
+                }
+            }
+        }
+
+        self.punct("</")?;
+        if let Some(name) = &element.closing {
+            self.emit_jsx_name(name)?;
+        } else {
+            self.emit_jsx_name(&element.opening.name)?;
+        }
+        self.punct(">")
+    }
+
+    fn emit_jsx_name(&mut self, name: &JSXElementName) -> Result {
+        match name {
+            JSXElementName::Ident(ident) => self.emit_ident(ident),
+            JSXElementName::Qualified(name) => self.write_token(name.as_ref()),
+        }
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/mod.rs
+++ b/crates/swc_es_codegen/src/emitter/mod.rs
@@ -1,0 +1,329 @@
+use dragonbox_ecma::Buffer;
+use swc_es_ast::{
+    AstStore, Class, ClassId, ClassMember, ClassMemberId, Decl, DeclId, Expr, ExprId, Function,
+    FunctionId, Ident, JSXElement, JSXElementId, ModuleDecl, ModuleDeclId, Pat, PatId, Program,
+    ProgramId, PropName, Stmt, StmtId, TsType, TsTypeId,
+};
+
+use crate::{
+    precedence::{expr_precedence, Precedence},
+    token_spacing, Config, Result, WriteJs,
+};
+
+mod class;
+mod decl;
+mod expr;
+mod jsx;
+mod module_decl;
+mod pat;
+mod stmt;
+mod typescript;
+
+/// Emits JavaScript/TypeScript text from `swc_es_ast` arenas.
+pub struct Emitter<'a, W>
+where
+    W: WriteJs,
+{
+    pub cfg: Config,
+    pub store: &'a AstStore,
+    pub wr: W,
+    last_char: Option<char>,
+}
+
+impl<'a, W> Emitter<'a, W>
+where
+    W: WriteJs,
+{
+    #[inline]
+    pub fn new(cfg: Config, store: &'a AstStore, wr: W) -> Self {
+        Self {
+            cfg,
+            store,
+            wr,
+            last_char: None,
+        }
+    }
+
+    #[inline]
+    pub fn emit_program(&mut self, program: ProgramId) -> Result {
+        let body = self.program(program).body.clone();
+        self.emit_stmt_list(&body)
+    }
+
+    #[inline]
+    fn program(&self, id: ProgramId) -> &Program {
+        self.store
+            .program(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing ProgramId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn stmt(&self, id: StmtId) -> &Stmt {
+        self.store
+            .stmt(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing StmtId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn decl(&self, id: DeclId) -> &Decl {
+        self.store
+            .decl(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing DeclId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn pat(&self, id: PatId) -> &Pat {
+        self.store
+            .pat(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing PatId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn expr(&self, id: ExprId) -> &Expr {
+        self.store
+            .expr(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing ExprId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn module_decl(&self, id: ModuleDeclId) -> &ModuleDecl {
+        self.store
+            .module_decl(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing ModuleDeclId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn function(&self, id: FunctionId) -> &Function {
+        self.store
+            .function(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing FunctionId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn class(&self, id: ClassId) -> &Class {
+        self.store
+            .class(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing ClassId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn class_member(&self, id: ClassMemberId) -> &ClassMember {
+        self.store
+            .class_member(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing ClassMemberId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn jsx_element(&self, id: JSXElementId) -> &JSXElement {
+        self.store
+            .jsx_element(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing JSXElementId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn ts_type(&self, id: TsTypeId) -> &TsType {
+        self.store
+            .ts_type(id)
+            .unwrap_or_else(|| panic!("swc_es_codegen: missing TsTypeId {}", id.as_raw()))
+    }
+
+    #[inline]
+    fn write_raw(&mut self, text: &str) -> Result {
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        self.wr.write_raw(text)?;
+        self.last_char = text.chars().next_back();
+        Ok(())
+    }
+
+    #[inline]
+    fn write_token(&mut self, text: &str) -> Result {
+        if self.cfg.minify && token_spacing::needs_space(self.last_char, text) {
+            self.write_space_force()?;
+        }
+
+        self.write_raw(text)
+    }
+
+    #[inline]
+    fn write_space_force(&mut self) -> Result {
+        self.wr.write_space()?;
+        self.last_char = Some(' ');
+        Ok(())
+    }
+
+    #[inline]
+    fn write_space_pretty(&mut self) -> Result {
+        if !self.cfg.minify {
+            self.write_space_force()?;
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    fn write_line(&mut self) -> Result {
+        if !self.cfg.minify {
+            self.wr.write_newline()?;
+            self.last_char = Some('\n');
+        }
+
+        Ok(())
+    }
+
+    #[inline]
+    fn indent(&mut self) {
+        if !self.cfg.minify {
+            self.wr.increase_indent();
+        }
+    }
+
+    #[inline]
+    fn dedent(&mut self) {
+        if !self.cfg.minify {
+            self.wr.decrease_indent();
+        }
+    }
+
+    #[inline]
+    fn punct(&mut self, text: &'static str) -> Result {
+        self.write_token(text)
+    }
+
+    #[inline]
+    fn keyword(&mut self, text: &'static str) -> Result {
+        self.write_token(text)
+    }
+
+    #[inline]
+    fn operator(&mut self, text: &'static str) -> Result {
+        self.write_token(text)
+    }
+
+    #[inline]
+    fn emit_ident(&mut self, ident: &Ident) -> Result {
+        self.write_token(ident.sym.as_ref())
+    }
+
+    #[inline]
+    fn emit_prop_name(&mut self, name: &PropName) -> Result {
+        match name {
+            PropName::Ident(ident) | PropName::Private(ident) => self.emit_ident(ident),
+            PropName::Str(value) => self.emit_string_literal(value.value.as_ref()),
+            PropName::Num(value) => self.emit_number_literal(value.value),
+            PropName::Computed(expr) => {
+                self.punct("[")?;
+                self.emit_expr(*expr)?;
+                self.punct("]")
+            }
+        }
+    }
+
+    #[inline]
+    fn emit_number_literal(&mut self, value: f64) -> Result {
+        if value == 0.0f64 && value.is_sign_negative() {
+            return self.write_token("-0");
+        }
+
+        let mut buf = Buffer::new();
+        self.write_token(buf.format(value))
+    }
+
+    #[inline]
+    fn emit_string_literal(&mut self, value: &str) -> Result {
+        self.punct("\"")?;
+        self.write_raw(&escape_string_literal(value))?;
+        self.punct("\"")
+    }
+
+    #[inline]
+    fn emit_template_quasi(&mut self, value: &str) -> Result {
+        self.write_raw(&escape_template_quasi(value))
+    }
+
+    #[inline]
+    fn emit_expr_with_parens_if_needed(&mut self, expr: ExprId, parent: Precedence) -> Result {
+        let precedence = expr_precedence(self.expr(expr));
+        let needs_paren = precedence < parent;
+
+        if needs_paren {
+            self.punct("(")?;
+        }
+
+        self.emit_expr_inner(expr)?;
+
+        if needs_paren {
+            self.punct(")")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[inline]
+fn escape_string_literal(value: &str) -> String {
+    let mut out = String::with_capacity(value.len() + 2);
+
+    for c in value.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0C}' => out.push_str("\\f"),
+            '\0' => out.push_str("\\0"),
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            c if c < ' ' => {
+                out.push_str("\\u");
+                push_hex4(&mut out, c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+
+    out
+}
+
+#[inline]
+fn escape_template_quasi(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    let mut chars = value.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '`' => out.push_str("\\`"),
+            '$' => {
+                if matches!(chars.peek(), Some('{')) {
+                    out.push_str("\\$");
+                } else {
+                    out.push('$');
+                }
+            }
+            '\u{2028}' => out.push_str("\\u2028"),
+            '\u{2029}' => out.push_str("\\u2029"),
+            c => out.push(c),
+        }
+    }
+
+    out
+}
+
+#[inline]
+fn push_hex4(buf: &mut String, code: u32) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let n3 = ((code >> 12) & 0xf) as usize;
+    let n2 = ((code >> 8) & 0xf) as usize;
+    let n1 = ((code >> 4) & 0xf) as usize;
+    let n0 = (code & 0xf) as usize;
+
+    buf.push(HEX[n3] as char);
+    buf.push(HEX[n2] as char);
+    buf.push(HEX[n1] as char);
+    buf.push(HEX[n0] as char);
+}

--- a/crates/swc_es_codegen/src/emitter/module_decl.rs
+++ b/crates/swc_es_codegen/src/emitter/module_decl.rs
@@ -1,0 +1,212 @@
+use swc_es_ast::{
+    ExportSpecifier, ImportAttribute, ImportAttributeName, ImportSpecifier, ModuleDecl,
+    ModuleDeclId,
+};
+
+use super::Emitter;
+use crate::Result;
+
+impl<W> Emitter<'_, W>
+where
+    W: crate::WriteJs,
+{
+    pub(crate) fn emit_module_decl(&mut self, module_decl: ModuleDeclId) -> Result {
+        match self.module_decl(module_decl).clone() {
+            ModuleDecl::Import(decl) => {
+                self.keyword("import")?;
+
+                if decl.specifiers.is_empty() {
+                    self.write_space_pretty()?;
+                    self.emit_string_literal(decl.src.value.as_ref())?;
+                } else {
+                    self.write_space_pretty()?;
+                    self.emit_import_specifiers(&decl.specifiers)?;
+                    self.write_space_pretty()?;
+                    self.keyword("from")?;
+                    self.write_space_pretty()?;
+                    self.emit_string_literal(decl.src.value.as_ref())?;
+                }
+
+                self.emit_import_attributes(&decl.with)?;
+                self.punct(";")
+            }
+            ModuleDecl::ExportNamed(decl) => {
+                self.keyword("export")?;
+                self.write_space_pretty()?;
+
+                if let Some(inline_decl) = decl.decl {
+                    self.emit_decl(inline_decl)?;
+                    return Ok(());
+                }
+
+                self.punct("{")?;
+                for (index, specifier) in decl.specifiers.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_space_pretty()?;
+                    }
+                    self.emit_export_specifier(specifier)?;
+                }
+                self.punct("}")?;
+
+                if let Some(src) = decl.src {
+                    self.write_space_pretty()?;
+                    self.keyword("from")?;
+                    self.write_space_pretty()?;
+                    self.emit_string_literal(src.value.as_ref())?;
+                }
+
+                self.emit_import_attributes(&decl.with)?;
+                self.punct(";")
+            }
+            ModuleDecl::ExportDefaultExpr(decl) => {
+                self.keyword("export")?;
+                self.write_space_pretty()?;
+                self.keyword("default")?;
+                self.write_space_pretty()?;
+                self.emit_expr(decl.expr)?;
+                self.punct(";")
+            }
+            ModuleDecl::ExportDefaultDecl(decl) => {
+                self.keyword("export")?;
+                self.write_space_pretty()?;
+                self.keyword("default")?;
+                self.write_space_pretty()?;
+                self.emit_decl(decl.decl)
+            }
+            ModuleDecl::ExportAll(decl) => {
+                self.keyword("export")?;
+                self.write_space_pretty()?;
+                self.punct("*")?;
+                if let Some(exported) = decl.exported {
+                    self.write_space_pretty()?;
+                    self.keyword("as")?;
+                    self.write_space_pretty()?;
+                    self.emit_ident(&exported)?;
+                }
+                self.write_space_pretty()?;
+                self.keyword("from")?;
+                self.write_space_pretty()?;
+                self.emit_string_literal(decl.src.value.as_ref())?;
+                self.emit_import_attributes(&decl.with)?;
+                self.punct(";")
+            }
+            ModuleDecl::ExportDecl(decl) => {
+                self.keyword("export")?;
+                self.write_space_pretty()?;
+                self.emit_decl(decl.decl)
+            }
+        }
+    }
+
+    fn emit_import_specifiers(&mut self, specifiers: &[ImportSpecifier]) -> Result {
+        let mut default = None;
+        let mut namespace = None;
+        let mut named = Vec::new();
+
+        for specifier in specifiers {
+            match specifier {
+                ImportSpecifier::Default(specifier) => default = Some(specifier.local.clone()),
+                ImportSpecifier::Namespace(specifier) => {
+                    namespace = Some(specifier.local.clone());
+                }
+                ImportSpecifier::Named(specifier) => named.push(specifier.clone()),
+            }
+        }
+
+        let mut need_comma = false;
+
+        if let Some(local) = default {
+            self.emit_ident(&local)?;
+            need_comma = true;
+        }
+
+        if let Some(local) = namespace {
+            if need_comma {
+                self.punct(",")?;
+                self.write_space_pretty()?;
+            }
+            self.punct("*")?;
+            self.write_space_pretty()?;
+            self.keyword("as")?;
+            self.write_space_pretty()?;
+            self.emit_ident(&local)?;
+            need_comma = true;
+        }
+
+        if !named.is_empty() {
+            if need_comma {
+                self.punct(",")?;
+                self.write_space_pretty()?;
+            }
+            self.punct("{")?;
+            for (index, specifier) in named.iter().enumerate() {
+                if index != 0 {
+                    self.punct(",")?;
+                    self.write_space_pretty()?;
+                }
+
+                if let Some(imported) = &specifier.imported {
+                    self.emit_ident(imported)?;
+                    if imported.sym != specifier.local.sym {
+                        self.write_space_pretty()?;
+                        self.keyword("as")?;
+                        self.write_space_pretty()?;
+                        self.emit_ident(&specifier.local)?;
+                    }
+                } else {
+                    self.emit_ident(&specifier.local)?;
+                }
+            }
+            self.punct("}")?;
+        }
+
+        Ok(())
+    }
+
+    fn emit_export_specifier(&mut self, specifier: &ExportSpecifier) -> Result {
+        self.emit_ident(&specifier.local)?;
+
+        if let Some(exported) = &specifier.exported {
+            if exported.sym != specifier.local.sym {
+                self.write_space_pretty()?;
+                self.keyword("as")?;
+                self.write_space_pretty()?;
+                self.emit_ident(exported)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn emit_import_attributes(&mut self, attrs: &[ImportAttribute]) -> Result {
+        if attrs.is_empty() {
+            return Ok(());
+        }
+
+        self.write_space_pretty()?;
+        self.keyword("with")?;
+        self.write_space_pretty()?;
+        self.punct("{")?;
+
+        for (index, attr) in attrs.iter().enumerate() {
+            if index != 0 {
+                self.punct(",")?;
+                self.write_space_pretty()?;
+            }
+
+            match &attr.key {
+                ImportAttributeName::Ident(ident) => self.emit_ident(ident)?,
+                ImportAttributeName::Str(value) => {
+                    self.emit_string_literal(value.value.as_ref())?
+                }
+            }
+
+            self.punct(":")?;
+            self.write_space_pretty()?;
+            self.emit_string_literal(attr.value.value.as_ref())?;
+        }
+
+        self.punct("}")
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/pat.rs
+++ b/crates/swc_es_codegen/src/emitter/pat.rs
@@ -1,0 +1,73 @@
+use swc_es_ast::{ObjectPatProp, Pat, PatId};
+
+use super::Emitter;
+use crate::Result;
+
+impl<W> Emitter<'_, W>
+where
+    W: crate::WriteJs,
+{
+    pub(crate) fn emit_pat(&mut self, pat: PatId) -> Result {
+        match self.pat(pat).clone() {
+            Pat::Ident(ident) => self.emit_ident(&ident),
+            Pat::Expr(expr) => self.emit_expr(expr),
+            Pat::Array(array) => {
+                self.punct("[")?;
+                for (index, elem) in array.elems.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_space_pretty()?;
+                    }
+
+                    if let Some(elem) = elem {
+                        self.emit_pat(*elem)?;
+                    }
+                }
+                self.punct("]")
+            }
+            Pat::Object(object) => {
+                self.punct("{")?;
+                for (index, prop) in object.props.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_space_pretty()?;
+                    }
+
+                    match prop {
+                        ObjectPatProp::KeyValue(prop) => {
+                            self.emit_prop_name(&prop.key)?;
+                            self.punct(":")?;
+                            self.write_space_pretty()?;
+                            self.emit_pat(prop.value)?;
+                        }
+                        ObjectPatProp::Assign(prop) => {
+                            self.emit_ident(&prop.key)?;
+                            if let Some(value) = prop.value {
+                                self.write_space_pretty()?;
+                                self.punct("=")?;
+                                self.write_space_pretty()?;
+                                self.emit_expr(value)?;
+                            }
+                        }
+                        ObjectPatProp::Rest(rest) => {
+                            self.punct("...")?;
+                            self.emit_pat(rest.arg)?;
+                        }
+                    }
+                }
+                self.punct("}")
+            }
+            Pat::Rest(rest) => {
+                self.punct("...")?;
+                self.emit_pat(rest.arg)
+            }
+            Pat::Assign(assign) => {
+                self.emit_pat(assign.left)?;
+                self.write_space_pretty()?;
+                self.punct("=")?;
+                self.write_space_pretty()?;
+                self.emit_expr(assign.right)
+            }
+        }
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/stmt.rs
+++ b/crates/swc_es_codegen/src/emitter/stmt.rs
@@ -1,0 +1,276 @@
+use swc_es_ast::{ForBinding, ForHead, ForInit, Stmt, StmtId};
+
+use super::Emitter;
+use crate::Result;
+
+impl<W> Emitter<'_, W>
+where
+    W: crate::WriteJs,
+{
+    pub(super) fn emit_stmt_list(&mut self, stmts: &[StmtId]) -> Result {
+        for (index, stmt) in stmts.iter().enumerate() {
+            self.emit_stmt(*stmt)?;
+
+            if index + 1 != stmts.len() {
+                self.write_line()?;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn emit_block_stmt_list(&mut self, stmts: &[StmtId]) -> Result {
+        self.punct("{")?;
+
+        if !stmts.is_empty() {
+            self.indent();
+            self.write_line()?;
+            self.emit_stmt_list(stmts)?;
+            self.dedent();
+            self.write_line()?;
+        }
+
+        self.punct("}")
+    }
+
+    pub(crate) fn emit_stmt(&mut self, stmt_id: StmtId) -> Result {
+        match self.stmt(stmt_id).clone() {
+            Stmt::Empty(_) => self.punct(";"),
+            Stmt::Block(block) => self.emit_block_stmt_list(&block.stmts),
+            Stmt::Expr(stmt) => {
+                self.emit_expr(stmt.expr)?;
+                self.punct(";")
+            }
+            Stmt::Return(stmt) => {
+                self.keyword("return")?;
+                if let Some(arg) = stmt.arg {
+                    self.write_space_pretty()?;
+                    self.emit_expr(arg)?;
+                }
+                self.punct(";")
+            }
+            Stmt::If(stmt) => {
+                self.keyword("if")?;
+                self.write_space_pretty()?;
+                self.punct("(")?;
+                self.emit_expr(stmt.test)?;
+                self.punct(")")?;
+                self.write_space_pretty()?;
+                self.emit_stmt_as_body(stmt.cons)?;
+                if let Some(alt) = stmt.alt {
+                    self.write_space_pretty()?;
+                    self.keyword("else")?;
+                    self.write_space_pretty()?;
+                    self.emit_stmt_as_body(alt)?;
+                }
+                Ok(())
+            }
+            Stmt::While(stmt) => {
+                self.keyword("while")?;
+                self.write_space_pretty()?;
+                self.punct("(")?;
+                self.emit_expr(stmt.test)?;
+                self.punct(")")?;
+                self.write_space_pretty()?;
+                self.emit_stmt_as_body(stmt.body)
+            }
+            Stmt::For(stmt) => {
+                self.keyword("for")?;
+                self.write_space_pretty()?;
+                self.punct("(")?;
+                match stmt.head {
+                    ForHead::Classic(head) => {
+                        if let Some(init) = head.init {
+                            match init {
+                                ForInit::Decl(decl) => self.emit_decl_in_for_head(decl)?,
+                                ForInit::Expr(expr) => self.emit_expr(expr)?,
+                            }
+                        }
+                        self.punct(";")?;
+                        if let Some(test) = head.test {
+                            self.write_space_pretty()?;
+                            self.emit_expr(test)?;
+                        }
+                        self.punct(";")?;
+                        if let Some(update) = head.update {
+                            self.write_space_pretty()?;
+                            self.emit_expr(update)?;
+                        }
+                    }
+                    ForHead::In(head) => {
+                        self.emit_for_binding(&head.left)?;
+                        self.write_space_pretty()?;
+                        self.keyword("in")?;
+                        self.write_space_pretty()?;
+                        self.emit_expr(head.right)?;
+                    }
+                    ForHead::Of(head) => {
+                        if head.is_await {
+                            self.keyword("await")?;
+                            self.write_space_pretty()?;
+                        }
+                        self.emit_for_binding(&head.left)?;
+                        self.write_space_pretty()?;
+                        self.keyword("of")?;
+                        self.write_space_pretty()?;
+                        self.emit_expr(head.right)?;
+                    }
+                }
+                self.punct(")")?;
+                self.write_space_pretty()?;
+                self.emit_stmt_as_body(stmt.body)
+            }
+            Stmt::DoWhile(stmt) => {
+                self.keyword("do")?;
+                self.write_space_pretty()?;
+                self.emit_stmt_as_body(stmt.body)?;
+                self.write_space_pretty()?;
+                self.keyword("while")?;
+                self.write_space_pretty()?;
+                self.punct("(")?;
+                self.emit_expr(stmt.test)?;
+                self.punct(")")?;
+                self.punct(";")
+            }
+            Stmt::Switch(stmt) => {
+                self.keyword("switch")?;
+                self.write_space_pretty()?;
+                self.punct("(")?;
+                self.emit_expr(stmt.discriminant)?;
+                self.punct(")")?;
+                self.write_space_pretty()?;
+                self.punct("{")?;
+
+                if !stmt.cases.is_empty() {
+                    self.indent();
+                    self.write_line()?;
+                }
+
+                for (index, case) in stmt.cases.iter().enumerate() {
+                    if index != 0 {
+                        self.write_line()?;
+                    }
+
+                    if let Some(test) = case.test {
+                        self.keyword("case")?;
+                        self.write_space_pretty()?;
+                        self.emit_expr(test)?;
+                        self.punct(":")?;
+                    } else {
+                        self.keyword("default")?;
+                        self.punct(":")?;
+                    }
+
+                    if !case.cons.is_empty() {
+                        self.indent();
+                        self.write_line()?;
+                        self.emit_stmt_list(&case.cons)?;
+                        self.dedent();
+                    }
+                }
+
+                if !stmt.cases.is_empty() {
+                    self.dedent();
+                    self.write_line()?;
+                }
+
+                self.punct("}")
+            }
+            Stmt::Try(stmt) => {
+                self.keyword("try")?;
+                self.write_space_pretty()?;
+                self.emit_stmt_as_body(stmt.block)?;
+
+                if let Some(handler) = stmt.handler {
+                    self.write_space_pretty()?;
+                    self.keyword("catch")?;
+                    if let Some(param) = handler.param {
+                        self.write_space_pretty()?;
+                        self.punct("(")?;
+                        self.emit_pat(param)?;
+                        self.punct(")")?;
+                    }
+                    self.write_space_pretty()?;
+                    self.emit_stmt_as_body(handler.body)?;
+                }
+
+                if let Some(finalizer) = stmt.finalizer {
+                    self.write_space_pretty()?;
+                    self.keyword("finally")?;
+                    self.write_space_pretty()?;
+                    self.emit_stmt_as_body(finalizer)?;
+                }
+
+                Ok(())
+            }
+            Stmt::Throw(stmt) => {
+                self.keyword("throw")?;
+                self.write_space_pretty()?;
+                self.emit_expr(stmt.arg)?;
+                self.punct(";")
+            }
+            Stmt::With(stmt) => {
+                self.keyword("with")?;
+                self.write_space_pretty()?;
+                self.punct("(")?;
+                self.emit_expr(stmt.obj)?;
+                self.punct(")")?;
+                self.write_space_pretty()?;
+                self.emit_stmt_as_body(stmt.body)
+            }
+            Stmt::Break(stmt) => {
+                self.keyword("break")?;
+                if let Some(label) = stmt.label {
+                    self.write_space_pretty()?;
+                    self.emit_ident(&label)?;
+                }
+                self.punct(";")
+            }
+            Stmt::Continue(stmt) => {
+                self.keyword("continue")?;
+                if let Some(label) = stmt.label {
+                    self.write_space_pretty()?;
+                    self.emit_ident(&label)?;
+                }
+                self.punct(";")
+            }
+            Stmt::Debugger(_) => {
+                self.keyword("debugger")?;
+                self.punct(";")
+            }
+            Stmt::Labeled(stmt) => {
+                self.emit_ident(&stmt.label)?;
+                self.punct(":")?;
+                self.write_space_pretty()?;
+                self.emit_stmt_as_body(stmt.body)
+            }
+            Stmt::Decl(decl) => self.emit_decl(decl),
+            Stmt::ModuleDecl(module_decl) => self.emit_module_decl(module_decl),
+        }
+    }
+
+    fn emit_for_binding(&mut self, binding: &ForBinding) -> Result {
+        match binding {
+            ForBinding::Decl(decl) => self.emit_decl_in_for_head(*decl),
+            ForBinding::Pat(pat) => self.emit_pat(*pat),
+            ForBinding::Expr(expr) => self.emit_expr(*expr),
+        }
+    }
+
+    fn emit_stmt_as_body(&mut self, stmt: StmtId) -> Result {
+        match self.stmt(stmt) {
+            Stmt::Block(_) => self.emit_stmt(stmt),
+            _ => {
+                if self.cfg.minify {
+                    self.emit_stmt(stmt)
+                } else {
+                    self.indent();
+                    self.write_line()?;
+                    self.emit_stmt(stmt)?;
+                    self.dedent();
+                    Ok(())
+                }
+            }
+        }
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/typescript.rs
+++ b/crates/swc_es_codegen/src/emitter/typescript.rs
@@ -1,0 +1,373 @@
+use swc_es_ast::{
+    TsKeywordType, TsLitType, TsModuleName, TsType, TsTypeId, TsTypeMember, TsTypeMemberKind,
+    TsTypeOperatorOp,
+};
+
+use super::Emitter;
+use crate::Result;
+
+impl<W> Emitter<'_, W>
+where
+    W: crate::WriteJs,
+{
+    pub(crate) fn emit_ts_type(&mut self, ty: TsTypeId) -> Result {
+        match self.ts_type(ty).clone() {
+            TsType::Keyword(ty) => self.keyword(ts_keyword_text(ty)),
+            TsType::TypeRef(ty) => {
+                self.emit_ident(&ty.name)?;
+                if !ty.type_args.is_empty() {
+                    self.punct("<")?;
+                    for (index, arg) in ty.type_args.iter().enumerate() {
+                        if index != 0 {
+                            self.punct(",")?;
+                            self.write_space_pretty()?;
+                        }
+                        self.emit_ts_type(*arg)?;
+                    }
+                    self.punct(">")?;
+                }
+                Ok(())
+            }
+            TsType::Lit(lit) => match lit {
+                TsLitType::Str(str_lit) => self.emit_string_literal(str_lit.value.as_ref()),
+                TsLitType::Num(num_lit) => self.emit_number_literal(num_lit.value),
+                TsLitType::Bool(bool_lit) => {
+                    if bool_lit.value {
+                        self.keyword("true")
+                    } else {
+                        self.keyword("false")
+                    }
+                }
+            },
+            TsType::Array(ty) => {
+                let needs_paren = matches!(
+                    self.ts_type(ty.elem_type),
+                    TsType::Union(_)
+                        | TsType::Intersection(_)
+                        | TsType::Fn(_)
+                        | TsType::Conditional(_)
+                        | TsType::Mapped(_)
+                );
+
+                if needs_paren {
+                    self.punct("(")?;
+                }
+                self.emit_ts_type(ty.elem_type)?;
+                if needs_paren {
+                    self.punct(")")?;
+                }
+                self.punct("[]")
+            }
+            TsType::Tuple(ty) => {
+                self.punct("[")?;
+                for (index, item) in ty.elem_types.iter().enumerate() {
+                    if index != 0 {
+                        self.punct(",")?;
+                        self.write_space_pretty()?;
+                    }
+                    self.emit_ts_type(*item)?;
+                }
+                self.punct("]")
+            }
+            TsType::Union(ty) => {
+                for (index, item) in ty.types.iter().enumerate() {
+                    if index != 0 {
+                        self.write_space_pretty()?;
+                        self.punct("|")?;
+                        self.write_space_pretty()?;
+                    }
+                    self.emit_ts_type(*item)?;
+                }
+                Ok(())
+            }
+            TsType::Intersection(ty) => {
+                for (index, item) in ty.types.iter().enumerate() {
+                    if index != 0 {
+                        self.write_space_pretty()?;
+                        self.punct("&")?;
+                        self.write_space_pretty()?;
+                    }
+                    self.emit_ts_type(*item)?;
+                }
+                Ok(())
+            }
+            TsType::Parenthesized(ty) => {
+                self.punct("(")?;
+                self.emit_ts_type(ty.ty)?;
+                self.punct(")")
+            }
+            TsType::TypeLit(ty) => self.emit_ts_type_members(&ty.members),
+            TsType::Fn(ty) => {
+                self.emit_ts_fn_params(&ty.params)?;
+                self.write_space_pretty()?;
+                self.punct("=>")?;
+                self.write_space_pretty()?;
+                self.emit_ts_type(ty.return_type)
+            }
+            TsType::Conditional(ty) => {
+                self.emit_ts_type(ty.check_type)?;
+                self.write_space_pretty()?;
+                self.keyword("extends")?;
+                self.write_space_pretty()?;
+                self.emit_ts_type(ty.extends_type)?;
+                self.write_space_pretty()?;
+                self.punct("?")?;
+                self.write_space_pretty()?;
+                self.emit_ts_type(ty.true_type)?;
+                self.write_space_pretty()?;
+                self.punct(":")?;
+                self.write_space_pretty()?;
+                self.emit_ts_type(ty.false_type)
+            }
+            TsType::IndexedAccess(ty) => {
+                self.emit_ts_type(ty.obj_type)?;
+                self.punct("[")?;
+                self.emit_ts_type(ty.index_type)?;
+                self.punct("]")
+            }
+            TsType::TypeOperator(ty) => {
+                self.keyword(ts_type_operator_text(ty.op))?;
+                self.write_space_pretty()?;
+                self.emit_ts_type(ty.ty)
+            }
+            TsType::Infer(ty) => {
+                self.keyword("infer")?;
+                self.write_space_pretty()?;
+                self.emit_ident(&ty.type_param)
+            }
+            TsType::Import(ty) => {
+                self.keyword("import")?;
+                self.punct("(")?;
+                self.emit_string_literal(ty.arg.value.as_ref())?;
+                self.punct(")")?;
+                if let Some(qualifier) = ty.qualifier {
+                    self.punct(".")?;
+                    self.emit_ident(&qualifier)?;
+                }
+                if !ty.type_args.is_empty() {
+                    self.punct("<")?;
+                    for (index, arg) in ty.type_args.iter().enumerate() {
+                        if index != 0 {
+                            self.punct(",")?;
+                            self.write_space_pretty()?;
+                        }
+                        self.emit_ts_type(*arg)?;
+                    }
+                    self.punct(">")?;
+                }
+                Ok(())
+            }
+            TsType::TypeQuery(ty) => {
+                self.keyword("typeof")?;
+                self.write_space_pretty()?;
+                self.emit_ident(&ty.expr_name)?;
+                if !ty.type_args.is_empty() {
+                    self.punct("<")?;
+                    for (index, arg) in ty.type_args.iter().enumerate() {
+                        if index != 0 {
+                            self.punct(",")?;
+                            self.write_space_pretty()?;
+                        }
+                        self.emit_ts_type(*arg)?;
+                    }
+                    self.punct(">")?;
+                }
+                Ok(())
+            }
+            TsType::Mapped(ty) => {
+                self.punct("{")?;
+                if let Some(readonly) = ty.readonly {
+                    if readonly {
+                        self.keyword("readonly")?;
+                        self.write_space_pretty()?;
+                    } else {
+                        self.punct("-readonly")?;
+                        self.write_space_pretty()?;
+                    }
+                }
+                self.punct("[")?;
+                self.emit_ident(&ty.type_param)?;
+                self.write_space_pretty()?;
+                self.keyword("in")?;
+                self.write_space_pretty()?;
+                self.emit_ts_type(ty.constraint)?;
+                self.punct("]")?;
+                if let Some(optional) = ty.optional {
+                    if optional {
+                        self.punct("?")?;
+                    } else {
+                        self.punct("-?")?;
+                    }
+                }
+                if let Some(value) = ty.ty {
+                    self.punct(":")?;
+                    self.write_space_pretty()?;
+                    self.emit_ts_type(value)?;
+                }
+                self.punct("}")
+            }
+        }
+    }
+
+    pub(super) fn emit_ts_fn_params(&mut self, params: &[swc_es_ast::TsFnParam]) -> Result {
+        self.punct("(")?;
+        for (index, param) in params.iter().enumerate() {
+            if index != 0 {
+                self.punct(",")?;
+                self.write_space_pretty()?;
+            }
+            if param.is_rest {
+                self.punct("...")?;
+            }
+            if let Some(name) = &param.name {
+                self.emit_ident(name)?;
+                if param.optional {
+                    self.punct("?")?;
+                }
+            }
+            if let Some(ty) = param.ty {
+                if param.name.is_some() {
+                    self.punct(":")?;
+                    self.write_space_pretty()?;
+                }
+                self.emit_ts_type(ty)?;
+            }
+        }
+        self.punct(")")
+    }
+
+    pub(super) fn emit_ts_type_members(&mut self, members: &[TsTypeMember]) -> Result {
+        self.punct("{")?;
+        if !members.is_empty() {
+            self.indent();
+            self.write_line()?;
+        }
+
+        for (index, member) in members.iter().enumerate() {
+            if index != 0 {
+                self.write_line()?;
+            }
+
+            match member.kind {
+                TsTypeMemberKind::Property => {
+                    if member.readonly {
+                        self.keyword("readonly")?;
+                        self.write_space_force()?;
+                    }
+                    if let Some(name) = &member.name {
+                        self.emit_prop_name(name)?;
+                    }
+                    if member.optional {
+                        self.punct("?")?;
+                    }
+                    if let Some(ty) = member.ty {
+                        self.punct(":")?;
+                        self.write_space_pretty()?;
+                        self.emit_ts_type(ty)?;
+                    }
+                    self.punct(";")?;
+                }
+                TsTypeMemberKind::Method => {
+                    if member.readonly {
+                        self.keyword("readonly")?;
+                        self.write_space_force()?;
+                    }
+                    if let Some(name) = &member.name {
+                        self.emit_prop_name(name)?;
+                    }
+                    if member.optional {
+                        self.punct("?")?;
+                    }
+                    self.emit_ts_fn_params(&member.params)?;
+                    if let Some(ty) = member.ty {
+                        self.punct(":")?;
+                        self.write_space_pretty()?;
+                        self.emit_ts_type(ty)?;
+                    }
+                    self.punct(";")?;
+                }
+                TsTypeMemberKind::Call => {
+                    self.emit_ts_fn_params(&member.params)?;
+                    if let Some(ty) = member.ty {
+                        self.punct(":")?;
+                        self.write_space_pretty()?;
+                        self.emit_ts_type(ty)?;
+                    }
+                    self.punct(";")?;
+                }
+                TsTypeMemberKind::Construct => {
+                    self.keyword("new")?;
+                    self.write_space_pretty()?;
+                    self.emit_ts_fn_params(&member.params)?;
+                    if let Some(ty) = member.ty {
+                        self.punct(":")?;
+                        self.write_space_pretty()?;
+                        self.emit_ts_type(ty)?;
+                    }
+                    self.punct(";")?;
+                }
+                TsTypeMemberKind::Index => {
+                    self.punct("[")?;
+                    if let Some(first) = member.params.first() {
+                        if let Some(name) = &first.name {
+                            self.emit_ident(name)?;
+                        }
+                        if let Some(ty) = first.ty {
+                            self.punct(":")?;
+                            self.write_space_pretty()?;
+                            self.emit_ts_type(ty)?;
+                        }
+                    }
+                    self.punct("]")?;
+                    if let Some(ty) = member.ty {
+                        self.punct(":")?;
+                        self.write_space_pretty()?;
+                        self.emit_ts_type(ty)?;
+                    }
+                    self.punct(";")?;
+                }
+            }
+        }
+
+        if !members.is_empty() {
+            self.dedent();
+            self.write_line()?;
+        }
+
+        self.punct("}")
+    }
+
+    pub(super) fn emit_ts_module_name(&mut self, name: &TsModuleName) -> Result {
+        match name {
+            TsModuleName::Ident(ident) => self.emit_ident(ident),
+            TsModuleName::Str(value) => self.emit_string_literal(value.value.as_ref()),
+        }
+    }
+}
+
+#[inline]
+fn ts_keyword_text(ty: TsKeywordType) -> &'static str {
+    match ty {
+        TsKeywordType::Any => "any",
+        TsKeywordType::Unknown => "unknown",
+        TsKeywordType::Never => "never",
+        TsKeywordType::Void => "void",
+        TsKeywordType::String => "string",
+        TsKeywordType::Number => "number",
+        TsKeywordType::Boolean => "boolean",
+        TsKeywordType::Symbol => "symbol",
+        TsKeywordType::Object => "object",
+        TsKeywordType::BigInt => "bigint",
+        TsKeywordType::Undefined => "undefined",
+        TsKeywordType::Intrinsic => "intrinsic",
+    }
+}
+
+#[inline]
+fn ts_type_operator_text(op: TsTypeOperatorOp) -> &'static str {
+    match op {
+        TsTypeOperatorOp::KeyOf => "keyof",
+        TsTypeOperatorOp::ReadOnly => "readonly",
+        TsTypeOperatorOp::Unique => "unique",
+    }
+}

--- a/crates/swc_es_codegen/src/lib.rs
+++ b/crates/swc_es_codegen/src/lib.rs
@@ -1,0 +1,39 @@
+#![deny(clippy::all)]
+
+use swc_es_ast::{AstStore, ProgramId};
+
+pub use crate::{
+    config::Config,
+    emitter::Emitter,
+    writer::{basic::BasicJsWriter, WriteJs},
+};
+
+mod config;
+mod emitter;
+mod precedence;
+mod token_spacing;
+pub mod writer;
+
+pub type Result = std::fmt::Result;
+
+/// Generates source text from an arena-backed program.
+#[inline]
+pub fn to_code(store: &AstStore, program: ProgramId, cfg: Config) -> String {
+    let mut output = String::new();
+
+    {
+        let writer = BasicJsWriter::new(&mut output);
+        let mut emitter = Emitter::new(cfg, store, writer);
+        emitter
+            .emit_program(program)
+            .expect("swc_es_codegen: failed to emit program");
+    }
+
+    output
+}
+
+/// Generates source text using the default configuration.
+#[inline]
+pub fn to_code_default(store: &AstStore, program: ProgramId) -> String {
+    to_code(store, program, Config::default())
+}

--- a/crates/swc_es_codegen/src/precedence.rs
+++ b/crates/swc_es_codegen/src/precedence.rs
@@ -1,0 +1,115 @@
+use swc_es_ast::{BinaryOp, Expr};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum Precedence {
+    Lowest = 0,
+    Sequence,
+    Assignment,
+    Conditional,
+    LogicalOr,
+    LogicalAnd,
+    BitOr,
+    BitXor,
+    BitAnd,
+    Equality,
+    Relational,
+    Shift,
+    Additive,
+    Multiplicative,
+    Exponential,
+    Prefix,
+    Postfix,
+    Call,
+    Member,
+    Primary,
+}
+
+impl Precedence {
+    #[inline]
+    pub fn next(self) -> Self {
+        match self {
+            Precedence::Lowest => Precedence::Sequence,
+            Precedence::Sequence => Precedence::Assignment,
+            Precedence::Assignment => Precedence::Conditional,
+            Precedence::Conditional => Precedence::LogicalOr,
+            Precedence::LogicalOr => Precedence::LogicalAnd,
+            Precedence::LogicalAnd => Precedence::BitOr,
+            Precedence::BitOr => Precedence::BitXor,
+            Precedence::BitXor => Precedence::BitAnd,
+            Precedence::BitAnd => Precedence::Equality,
+            Precedence::Equality => Precedence::Relational,
+            Precedence::Relational => Precedence::Shift,
+            Precedence::Shift => Precedence::Additive,
+            Precedence::Additive => Precedence::Multiplicative,
+            Precedence::Multiplicative => Precedence::Exponential,
+            Precedence::Exponential => Precedence::Prefix,
+            Precedence::Prefix => Precedence::Postfix,
+            Precedence::Postfix => Precedence::Call,
+            Precedence::Call => Precedence::Member,
+            Precedence::Member => Precedence::Primary,
+            Precedence::Primary => Precedence::Primary,
+        }
+    }
+}
+
+#[inline]
+pub fn binary_precedence(op: BinaryOp) -> Precedence {
+    match op {
+        BinaryOp::LogicalOr | BinaryOp::NullishCoalescing => Precedence::LogicalOr,
+        BinaryOp::LogicalAnd => Precedence::LogicalAnd,
+        BinaryOp::BitOr => Precedence::BitOr,
+        BinaryOp::BitXor => Precedence::BitXor,
+        BinaryOp::BitAnd => Precedence::BitAnd,
+        BinaryOp::EqEq | BinaryOp::EqEqEq | BinaryOp::NotEq | BinaryOp::NotEqEq => {
+            Precedence::Equality
+        }
+        BinaryOp::Lt
+        | BinaryOp::LtEq
+        | BinaryOp::Gt
+        | BinaryOp::GtEq
+        | BinaryOp::In
+        | BinaryOp::InstanceOf => Precedence::Relational,
+        BinaryOp::LShift | BinaryOp::RShift | BinaryOp::ZeroFillRShift => Precedence::Shift,
+        BinaryOp::Add | BinaryOp::Sub => Precedence::Additive,
+        BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod => Precedence::Multiplicative,
+        BinaryOp::Exp => Precedence::Exponential,
+    }
+}
+
+#[inline]
+pub fn expr_precedence(expr: &Expr) -> Precedence {
+    match expr {
+        Expr::Seq(_) => Precedence::Sequence,
+        Expr::Assign(_) | Expr::Arrow(_) | Expr::Yield(_) => Precedence::Assignment,
+        Expr::Cond(_) => Precedence::Conditional,
+        Expr::Binary(expr) => binary_precedence(expr.op),
+        Expr::TsAs(_) => Precedence::Relational,
+        Expr::Unary(_) | Expr::Await(_) => Precedence::Prefix,
+        Expr::Update(expr) => {
+            if expr.prefix {
+                Precedence::Prefix
+            } else {
+                Precedence::Postfix
+            }
+        }
+        Expr::Call(_) | Expr::New(_) | Expr::TaggedTemplate(_) | Expr::OptChain(_) => {
+            Precedence::Call
+        }
+        Expr::Member(_) => Precedence::Member,
+        Expr::Paren(_) => Precedence::Primary,
+        Expr::Ident(_)
+        | Expr::Lit(_)
+        | Expr::Function(_)
+        | Expr::Class(_)
+        | Expr::JSXElement(_)
+        | Expr::Array(_)
+        | Expr::Object(_)
+        | Expr::Template(_)
+        | Expr::MetaProp(_) => Precedence::Primary,
+    }
+}
+
+#[inline]
+pub fn is_right_associative_binary(op: BinaryOp) -> bool {
+    matches!(op, BinaryOp::Exp)
+}

--- a/crates/swc_es_codegen/src/token_spacing.rs
+++ b/crates/swc_es_codegen/src/token_spacing.rs
@@ -1,0 +1,67 @@
+#[inline]
+fn first_non_ws(text: &str) -> Option<char> {
+    text.chars().find(|c| !c.is_whitespace())
+}
+
+#[inline]
+fn is_ident_like(c: char) -> bool {
+    c == '_' || c == '$' || c == '#' || c.is_ascii_alphanumeric()
+}
+
+#[inline]
+fn forms_merged_punct(prev: char, next: char) -> bool {
+    matches!(
+        (prev, next),
+        ('>', '=')
+            | ('<', '=')
+            | ('=', '>')
+            | ('!', '=')
+            | ('=', '=')
+            | ('&', '&')
+            | ('|', '|')
+            | ('?', '?')
+            | ('*', '*')
+    )
+}
+
+/// Returns `true` when an explicit space is required before `next`.
+#[inline]
+pub fn needs_space(prev: Option<char>, next: &str) -> bool {
+    let Some(prev) = prev else {
+        return false;
+    };
+
+    if prev.is_whitespace() {
+        return false;
+    }
+
+    let Some(next) = first_non_ws(next) else {
+        return false;
+    };
+
+    if is_ident_like(prev) && is_ident_like(next) {
+        return true;
+    }
+
+    if (prev == '+' && next == '+') || (prev == '-' && next == '-') {
+        return true;
+    }
+
+    if forms_merged_punct(prev, next) {
+        return true;
+    }
+
+    if prev == '/' && (next == '/' || next == '*') {
+        return true;
+    }
+
+    if prev == '<' && next == '!' {
+        return true;
+    }
+
+    if prev == '.' && next.is_ascii_digit() {
+        return true;
+    }
+
+    false
+}

--- a/crates/swc_es_codegen/src/writer/basic.rs
+++ b/crates/swc_es_codegen/src/writer/basic.rs
@@ -1,0 +1,78 @@
+use std::fmt::Write;
+
+use crate::{writer::WriteJs, Result};
+
+/// Basic in-memory JS writer with indentation support.
+pub struct BasicJsWriter<W>
+where
+    W: Write,
+{
+    out: W,
+    indent_level: usize,
+    indent_str: &'static str,
+    linefeed: &'static str,
+    line_start: bool,
+}
+
+impl<W> BasicJsWriter<W>
+where
+    W: Write,
+{
+    /// Creates a writer using two-space indentation and LF line feeds.
+    #[inline]
+    pub fn new(out: W) -> Self {
+        Self {
+            out,
+            indent_level: 0,
+            indent_str: "  ",
+            linefeed: "\n",
+            line_start: true,
+        }
+    }
+
+    #[inline]
+    fn write_indent(&mut self) -> Result {
+        if self.line_start {
+            for _ in 0..self.indent_level {
+                self.out.write_str(self.indent_str)?;
+            }
+            self.line_start = false;
+        }
+
+        Ok(())
+    }
+}
+
+impl<W> WriteJs for BasicJsWriter<W>
+where
+    W: Write,
+{
+    #[inline]
+    fn write_raw(&mut self, text: &str) -> Result {
+        if text.is_empty() {
+            return Ok(());
+        }
+
+        self.write_indent()?;
+        self.out.write_str(text)?;
+
+        Ok(())
+    }
+
+    #[inline]
+    fn write_newline(&mut self) -> Result {
+        self.out.write_str(self.linefeed)?;
+        self.line_start = true;
+        Ok(())
+    }
+
+    #[inline]
+    fn increase_indent(&mut self) {
+        self.indent_level += 1;
+    }
+
+    #[inline]
+    fn decrease_indent(&mut self) {
+        self.indent_level = self.indent_level.saturating_sub(1);
+    }
+}

--- a/crates/swc_es_codegen/src/writer/mod.rs
+++ b/crates/swc_es_codegen/src/writer/mod.rs
@@ -1,0 +1,48 @@
+use crate::Result;
+
+pub mod basic;
+
+/// JavaScript text output interface.
+pub trait WriteJs {
+    fn write_raw(&mut self, text: &str) -> Result;
+
+    fn write_space(&mut self) -> Result {
+        self.write_raw(" ")
+    }
+
+    fn write_newline(&mut self) -> Result;
+
+    fn increase_indent(&mut self);
+
+    fn decrease_indent(&mut self);
+}
+
+impl<W> WriteJs for Box<W>
+where
+    W: ?Sized + WriteJs,
+{
+    #[inline]
+    fn write_raw(&mut self, text: &str) -> Result {
+        (**self).write_raw(text)
+    }
+
+    #[inline]
+    fn write_space(&mut self) -> Result {
+        (**self).write_space()
+    }
+
+    #[inline]
+    fn write_newline(&mut self) -> Result {
+        (**self).write_newline()
+    }
+
+    #[inline]
+    fn increase_indent(&mut self) {
+        (**self).increase_indent()
+    }
+
+    #[inline]
+    fn decrease_indent(&mut self) {
+        (**self).decrease_indent()
+    }
+}

--- a/crates/swc_es_codegen/tests/fixture.rs
+++ b/crates/swc_es_codegen/tests/fixture.rs
@@ -1,0 +1,147 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use swc_common::{comments::SingleThreadedComments, FileName, SourceMap};
+use swc_es_codegen::{to_code, Config};
+use swc_es_parser::{parse_file_as_program, EsSyntax, Syntax, TsSyntax};
+use testing::NormalizedOutput;
+use walkdir::WalkDir;
+
+fn syntax_for_file(path: &Path) -> Syntax {
+    let ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
+    match ext {
+        "ts" => Syntax::Typescript(TsSyntax {
+            decorators: true,
+            ..Default::default()
+        }),
+        "tsx" => Syntax::Typescript(TsSyntax {
+            tsx: true,
+            decorators: true,
+            ..Default::default()
+        }),
+        "jsx" => Syntax::Es(EsSyntax {
+            jsx: true,
+            decorators: true,
+            import_attributes: true,
+            explicit_resource_management: true,
+            ..Default::default()
+        }),
+        _ => Syntax::Es(EsSyntax {
+            decorators: true,
+            import_attributes: true,
+            explicit_resource_management: true,
+            ..Default::default()
+        }),
+    }
+}
+
+fn parse_source(src: &str, syntax: Syntax, file_name: &str) -> swc_es_parser::ParsedProgram {
+    let cm = SourceMap::default();
+    let fm = cm.new_source_file(FileName::Custom(file_name.into()).into(), src.to_string());
+    let comments = SingleThreadedComments::default();
+    let mut recovered = Vec::new();
+    let parsed = parse_file_as_program(&fm, syntax, Some(&comments), &mut recovered)
+        .unwrap_or_else(|err| panic!("failed to parse {file_name}: {err:?}"));
+
+    assert!(
+        recovered.is_empty(),
+        "expected no recovered errors for {file_name}, got: {recovered:?}"
+    );
+
+    parsed
+}
+
+fn parse_fixture(path: &Path) -> swc_es_parser::ParsedProgram {
+    let src = fs::read_to_string(path)
+        .unwrap_or_else(|err| panic!("failed to read fixture {}: {err}", path.display()));
+    let syntax = syntax_for_file(path);
+    parse_source(&src, syntax, &path.display().to_string())
+}
+
+fn ensure_snapshot(path: &Path, actual: &str) {
+    NormalizedOutput::from(actual.to_string())
+        .compare_to_file(path)
+        .unwrap_or_else(|_| panic!("snapshot mismatch: {}", path.display()));
+}
+
+fn assert_idempotent(code: &str, syntax: Syntax, minify: bool, label: &str) {
+    let parsed = parse_source(code, syntax, label);
+    let emitted = to_code(&parsed.store, parsed.program, Config { minify });
+
+    assert_eq!(
+        code, emitted,
+        "idempotence failed ({label}, minify={minify})"
+    );
+}
+
+fn run_fixture(path: &Path) {
+    let parsed = parse_fixture(path);
+
+    let pretty = to_code(&parsed.store, parsed.program, Config { minify: false });
+    let minified = to_code(&parsed.store, parsed.program, Config { minify: true });
+
+    let ext = path
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or_else(|| panic!("fixture has no extension: {}", path.display()));
+    let dir = path
+        .parent()
+        .unwrap_or_else(|| panic!("fixture has no parent: {}", path.display()));
+
+    let pretty_path = dir.join(format!("output.{ext}"));
+    let minified_path = dir.join(format!("output.min.{ext}"));
+
+    ensure_snapshot(&pretty_path, &pretty);
+    ensure_snapshot(&minified_path, &minified);
+
+    let syntax = syntax_for_file(path);
+    assert_idempotent(
+        &pretty,
+        syntax,
+        false,
+        &format!("{}:pretty", path.display()),
+    );
+    assert_idempotent(
+        &minified,
+        syntax_for_file(path),
+        true,
+        &format!("{}:min", path.display()),
+    );
+}
+
+#[test]
+fn fixture_snapshots() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixture");
+    let mut inputs = Vec::new();
+
+    for entry in WalkDir::new(&root).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let path = entry.path();
+        if path.file_name().and_then(|name| name.to_str()) != Some("input.js")
+            && path.file_name().and_then(|name| name.to_str()) != Some("input.jsx")
+            && path.file_name().and_then(|name| name.to_str()) != Some("input.ts")
+            && path.file_name().and_then(|name| name.to_str()) != Some("input.tsx")
+        {
+            continue;
+        }
+
+        inputs.push(path.to_path_buf());
+    }
+
+    inputs.sort();
+
+    assert!(
+        !inputs.is_empty(),
+        "no fixtures found under {}",
+        root.display()
+    );
+
+    for input in inputs {
+        run_fixture(&input);
+    }
+}

--- a/crates/swc_es_codegen/tests/fixture/class-and-optional/input.ts
+++ b/crates/swc_es_codegen/tests/fixture/class-and-optional/input.ts
@@ -1,0 +1,14 @@
+@dec
+class A extends B {
+  @logged
+  static value = 1;
+
+  @trace
+  method(a, b) {
+    return a?.b?.(b);
+  }
+
+  static {
+    this.value = this.value + 1;
+  }
+}

--- a/crates/swc_es_codegen/tests/fixture/class-and-optional/output.min.ts
+++ b/crates/swc_es_codegen/tests/fixture/class-and-optional/output.min.ts
@@ -1,0 +1,1 @@
+@dec class A extends B{@logged static value=1;@trace method(a,b){return a?.b?.(b);}static{this.value=this.value+1;}}

--- a/crates/swc_es_codegen/tests/fixture/class-and-optional/output.ts
+++ b/crates/swc_es_codegen/tests/fixture/class-and-optional/output.ts
@@ -1,0 +1,12 @@
+@dec
+class A extends B {
+  @logged
+  static value = 1;
+  @trace
+  method(a, b) {
+    return a?.b?.(b);
+  }
+  static {
+    this.value = this.value + 1;
+  }
+}

--- a/crates/swc_es_codegen/tests/fixture/jsx-spread/input.jsx
+++ b/crates/swc_es_codegen/tests/fixture/jsx-spread/input.jsx
@@ -1,0 +1,1 @@
+const el = <Box a="x" {...props}>{child}<Inner x={1} /></Box>;

--- a/crates/swc_es_codegen/tests/fixture/jsx-spread/output.jsx
+++ b/crates/swc_es_codegen/tests/fixture/jsx-spread/output.jsx
@@ -1,0 +1,1 @@
+const el = <Box a="x" {...props}>{child}<Inner x={1} /></Box>;

--- a/crates/swc_es_codegen/tests/fixture/jsx-spread/output.min.jsx
+++ b/crates/swc_es_codegen/tests/fixture/jsx-spread/output.min.jsx
@@ -1,0 +1,1 @@
+const el=<Box a="x" {...props}>{child}<Inner x={1} /></Box>;

--- a/crates/swc_es_codegen/tests/fixture/module-attrs/input.js
+++ b/crates/swc_es_codegen/tests/fixture/module-attrs/input.js
@@ -1,0 +1,3 @@
+import foo, { bar as baz, qux } from "pkg" with { type: "json", mode: "strict" };
+export { baz as fooExport } from "pkg" with { type: "json" };
+export * as ns from "pkg2" with { type: "json" };

--- a/crates/swc_es_codegen/tests/fixture/module-attrs/output.js
+++ b/crates/swc_es_codegen/tests/fixture/module-attrs/output.js
@@ -1,0 +1,3 @@
+import foo, {bar as baz, qux} from "pkg" with {type: "json", mode: "strict"};
+export {baz as fooExport} from "pkg" with {type: "json"};
+export * as ns from "pkg2" with {type: "json"};

--- a/crates/swc_es_codegen/tests/fixture/module-attrs/output.min.js
+++ b/crates/swc_es_codegen/tests/fixture/module-attrs/output.min.js
@@ -1,0 +1,1 @@
+import foo,{bar as baz,qux}from"pkg"with{type:"json",mode:"strict"};export{baz as fooExport}from"pkg"with{type:"json"};export*as ns from"pkg2"with{type:"json"};

--- a/crates/swc_es_codegen/tests/fixture/tsx-basic/input.tsx
+++ b/crates/swc_es_codegen/tests/fixture/tsx-basic/input.tsx
@@ -1,0 +1,3 @@
+type Props = { value: string | number };
+
+const view = <Comp foo={value as Props} bar="ok" />;

--- a/crates/swc_es_codegen/tests/fixture/tsx-basic/output.min.tsx
+++ b/crates/swc_es_codegen/tests/fixture/tsx-basic/output.min.tsx
@@ -1,0 +1,1 @@
+type Props={value:string|number;};const view=<Comp foo={value as Props} bar="ok" />;

--- a/crates/swc_es_codegen/tests/fixture/tsx-basic/output.tsx
+++ b/crates/swc_es_codegen/tests/fixture/tsx-basic/output.tsx
@@ -1,0 +1,4 @@
+type Props = {
+  value: string | number;
+};
+const view = <Comp foo={value as Props} bar="ok" />;

--- a/crates/swc_es_codegen/tests/fixture/types-and-namespace/input.ts
+++ b/crates/swc_es_codegen/tests/fixture/types-and-namespace/input.ts
@@ -1,0 +1,14 @@
+type T<K> = import("pkg").Foo<K | number> & { readonly a?: string; [k: string]: number; };
+
+interface I extends Base {
+  readonly p?: string;
+  m(x?: number): T<string>;
+  (value: string): number;
+  new (value: string): I;
+}
+
+declare namespace N.M {
+  interface Box {
+    value: T<string>;
+  }
+}

--- a/crates/swc_es_codegen/tests/fixture/types-and-namespace/output.min.ts
+++ b/crates/swc_es_codegen/tests/fixture/types-and-namespace/output.min.ts
@@ -1,0 +1,1 @@
+type T<K> =import("pkg").Foo<K|number>&{readonly a?:string;[k:string]:number;};interface I extends Base{readonly p?:string;m(x?:number):T<string>;(value:string):number;new(value:string):I;}declare namespace N.M{interface Box{value:T<string>;}}

--- a/crates/swc_es_codegen/tests/fixture/types-and-namespace/output.ts
+++ b/crates/swc_es_codegen/tests/fixture/types-and-namespace/output.ts
@@ -1,0 +1,15 @@
+type T<K> = import("pkg").Foo<K | number> & {
+  readonly a?: string;
+  [k: string]: number;
+};
+interface I extends Base {
+  readonly p?: string;
+  m(x?: number): T<string>;
+  (value: string): number;
+  new (value: string): I;
+}
+declare namespace N.M {
+  interface Box {
+    value: T<string>;
+  }
+}

--- a/crates/swc_es_codegen/tests/no_ecma_dependency.rs
+++ b/crates/swc_es_codegen/tests/no_ecma_dependency.rs
@@ -1,0 +1,89 @@
+use std::{fs, path::PathBuf};
+
+use walkdir::WalkDir;
+
+fn contains_swc_ecma_import(source: &str) -> bool {
+    source.contains("use swc_ecma_")
+        || source.contains("extern crate swc_ecma_")
+        || source.contains("::swc_ecma_")
+}
+
+#[test]
+fn src_does_not_reference_swc_ecma_crates() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+
+    for entry in WalkDir::new(&root).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        if path.file_name().and_then(|name| name.to_str()) == Some("no_ecma_dependency.rs") {
+            continue;
+        }
+
+        let source = fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+        assert!(
+            !source.contains("swc_ecma_"),
+            "source file {} must not reference swc_ecma_* crates",
+            path.display()
+        );
+    }
+}
+
+#[test]
+fn tests_do_not_import_swc_ecma_crates() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+
+    for entry in WalkDir::new(&root).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        if path.file_name().and_then(|name| name.to_str()) == Some("no_ecma_dependency.rs") {
+            continue;
+        }
+
+        let source = fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+
+        assert!(
+            !contains_swc_ecma_import(&source),
+            "test file {} must not import swc_ecma_* crates",
+            path.display()
+        );
+    }
+}
+
+#[test]
+fn cargo_toml_runtime_dependencies_do_not_include_swc_ecma_crates() {
+    let manifest_path = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let source = fs::read_to_string(&manifest_path)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", manifest_path.display()));
+
+    let mut in_dependencies = false;
+
+    for line in source.lines() {
+        let trimmed = line.trim();
+
+        if trimmed.starts_with('[') {
+            in_dependencies = trimmed == "[dependencies]";
+            continue;
+        }
+
+        if in_dependencies && trimmed.contains("swc_ecma_") {
+            panic!(
+                "runtime dependencies in {} must not include swc_ecma_*: {trimmed}",
+                manifest_path.display()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add new `swc_es_codegen` crate for `swc_es_ast` with canonical JS/JSX/TS program emission
- provide pretty/minify output modes via `Config { minify: bool }`, `Emitter`, `WriteJs`, and `BasicJsWriter`
- implement exhaustive emitter modules (`stmt/expr/module_decl/class/jsx/typescript/pat/decl`) with precedence-based parenthesization and minify-safe token spacing
- add fixture/idempotence tests, dependency-boundary tests (no runtime `swc_ecma_*`), and parse+codegen throughput benchmark

## Verification
- cargo test -p swc_es_codegen
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings
