### PR TITLE
feat(es_ast): add standalone swc_es_codegen canonical emitter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6943,6 +6943,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_es_codegen"
+version = "0.1.0"
+dependencies = [
+ "codspeed-criterion-compat",
+ "ryu-js",
+ "swc_atoms",
+ "swc_common",
+ "swc_es_ast",
+ "swc_es_parser",
+ "swc_malloc",
+ "testing",
+ "walkdir",
+]
+
+[[package]]
 name = "swc_es_parser"
 version = "0.1.0"
 dependencies = [

--- a/crates/swc_es_codegen/Cargo.toml
+++ b/crates/swc_es_codegen/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
+description   = "High-performance ECMAScript code generator for swc_es_ast"
+documentation = "https://rustdoc.swc.rs/swc_es_codegen/"
+edition       = { workspace = true }
+include       = ["Cargo.toml", "README.md", "src/**/*.rs", "tests/**/*.rs", "benches/**/*.rs"]
+license       = { workspace = true }
+name          = "swc_es_codegen"
+repository    = { workspace = true }
+version       = "0.1.0"
+
+[lib]
+bench = false
+
+[features]
+default = []
+
+[dependencies]
+ryu-js     = { workspace = true }
+swc_atoms  = { version = "9.0.0", path = "../swc_atoms" }
+swc_es_ast = { version = "0.1.0", path = "../swc_es_ast" }
+
+[dev-dependencies]
+codspeed-criterion-compat = { workspace = true }
+swc_common = { version = "19.0.0", path = "../swc_common" }
+swc_es_parser = { version = "0.1.0", path = "../swc_es_parser" }
+testing = { version = "20.0.0", path = "../testing" }
+walkdir = { workspace = true }
+
+swc_malloc = { version = "1.2.5", path = "../swc_malloc" }
+
+[[bench]]
+harness = false
+name    = "emit"

--- a/crates/swc_es_codegen/Cargo.toml
+++ b/crates/swc_es_codegen/Cargo.toml
@@ -32,3 +32,7 @@ swc_malloc = { version = "1.2.5", path = "../swc_malloc" }
 [[bench]]
 harness = false
 name    = "emit"
+
+[[bench]]
+harness = false
+name    = "with_parse"

--- a/crates/swc_es_codegen/README.md
+++ b/crates/swc_es_codegen/README.md
@@ -1,0 +1,43 @@
+# swc_es_codegen
+
+`swc_es_codegen` is a standalone code generator for `swc_es_ast`.
+
+## Goals
+
+- Emit JavaScript/TypeScript/JSX from arena-backed `swc_es_ast` nodes.
+- Keep runtime and source-level independence from `swc_ecma_*` crates.
+- Provide a fast canonical output mode with predictable formatting.
+
+## API
+
+```rust
+use swc_es_codegen::emit_program;
+
+let code = emit_program(&parsed.store, parsed.program)?;
+```
+
+The crate currently exposes one output format:
+
+- `OutputFormat::Canonical`
+
+## Output policy
+
+- v1 only emits canonical code (no pretty/minify split).
+- v1 does not emit source maps or preserve original token raw text.
+- Output is regenerated from AST structure.
+
+## Benchmarks
+
+Run:
+
+```bash
+cargo bench -p swc_es_codegen
+```
+
+## Tests
+
+Run:
+
+```bash
+cargo test -p swc_es_codegen
+```

--- a/crates/swc_es_codegen/benches/emit.rs
+++ b/crates/swc_es_codegen/benches/emit.rs
@@ -1,0 +1,56 @@
+extern crate swc_malloc;
+
+use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
+use swc_common::{comments::SingleThreadedComments, FileName};
+use swc_es_codegen::emit_program;
+use swc_es_parser::{parse_file_as_program, EsSyntax, Syntax, TsSyntax};
+
+fn bench_emit_source(b: &mut Bencher, syntax: Syntax, src: &'static str) {
+    let _ = testing::run_test(false, |cm, _| {
+        let fm = cm.new_source_file(FileName::Anon.into(), src);
+        let comments = SingleThreadedComments::default();
+        let mut recovered = Vec::new();
+        let parsed = parse_file_as_program(&fm, syntax, Some(&comments), &mut recovered)
+            .expect("fixture should parse for benchmark");
+        assert!(recovered.is_empty(), "benchmark fixture should be clean");
+
+        b.iter(|| {
+            let output = emit_program(&parsed.store, parsed.program)
+                .expect("emit should succeed for benchmark fixture");
+            std::hint::black_box(output);
+        });
+
+        Ok(())
+    });
+}
+
+fn bench_emit(c: &mut Criterion) {
+    c.bench_function("es_codegen/emit/js", |b| {
+        bench_emit_source(
+            b,
+            Syntax::Es(EsSyntax {
+                jsx: true,
+                decorators: true,
+                import_attributes: true,
+                explicit_resource_management: true,
+                ..Default::default()
+            }),
+            include_str!("../tests/fixture/bench/input.js"),
+        )
+    });
+
+    c.bench_function("es_codegen/emit/ts", |b| {
+        bench_emit_source(
+            b,
+            Syntax::Typescript(TsSyntax {
+                tsx: true,
+                decorators: true,
+                ..Default::default()
+            }),
+            include_str!("../tests/fixture/bench/input.tsx"),
+        )
+    });
+}
+
+criterion_group!(benches, bench_emit);
+criterion_main!(benches);

--- a/crates/swc_es_codegen/benches/with_parse.rs
+++ b/crates/swc_es_codegen/benches/with_parse.rs
@@ -1,0 +1,61 @@
+extern crate swc_malloc;
+
+use codspeed_criterion_compat::{black_box, criterion_group, criterion_main, Bencher, Criterion};
+use swc_common::{comments::SingleThreadedComments, FileName};
+use swc_es_codegen::emit_program;
+use swc_es_parser::{parse_file_as_program, EsSyntax, Syntax, TsSyntax};
+
+fn bench_with_parse(b: &mut Bencher, syntax: Syntax, source: &'static str) {
+    let _ = testing::run_test(false, |cm, _| {
+        let fm = cm.new_source_file(FileName::Anon.into(), source);
+
+        b.iter(|| {
+            let comments = SingleThreadedComments::default();
+            let mut recovered = Vec::new();
+            let parsed = parse_file_as_program(&fm, syntax, Some(&comments), &mut recovered)
+                .expect("fixture should parse for benchmark");
+            assert!(recovered.is_empty(), "benchmark fixture should be clean");
+
+            let output = emit_program(&parsed.store, parsed.program)
+                .expect("emit should succeed for benchmark fixture");
+            black_box(output);
+        });
+
+        Ok(())
+    });
+}
+
+fn bench_cases(c: &mut Criterion) {
+    let js_syntax = Syntax::Es(EsSyntax {
+        jsx: true,
+        decorators: true,
+        import_attributes: true,
+        explicit_resource_management: true,
+        ..Default::default()
+    });
+
+    let tsx_syntax = Syntax::Typescript(TsSyntax {
+        tsx: true,
+        decorators: true,
+        ..Default::default()
+    });
+
+    c.bench_function("es/codegen/with-parser/js-canonical", |b| {
+        bench_with_parse(
+            b,
+            js_syntax,
+            include_str!("../tests/fixture/bench/input.js"),
+        )
+    });
+
+    c.bench_function("es/codegen/with-parser/tsx-canonical", |b| {
+        bench_with_parse(
+            b,
+            tsx_syntax,
+            include_str!("../tests/fixture/bench/input.tsx"),
+        )
+    });
+}
+
+criterion_group!(benches, bench_cases);
+criterion_main!(benches);

--- a/crates/swc_es_codegen/benches/with_parse.rs
+++ b/crates/swc_es_codegen/benches/with_parse.rs
@@ -44,7 +44,7 @@ fn bench_cases(c: &mut Criterion) {
         bench_with_parse(
             b,
             js_syntax,
-            include_str!("../tests/fixture/bench/input.js"),
+            include_str!("../../swc_ecma_parser/benches/files/angular-1.2.5.js"),
         )
     });
 
@@ -52,7 +52,7 @@ fn bench_cases(c: &mut Criterion) {
         bench_with_parse(
             b,
             tsx_syntax,
-            include_str!("../tests/fixture/bench/input.tsx"),
+            include_str!("../../swc_ecma_parser/benches/files/cal.com.tsx"),
         )
     });
 }

--- a/crates/swc_es_codegen/src/config.rs
+++ b/crates/swc_es_codegen/src/config.rs
@@ -1,0 +1,22 @@
+/// Output format strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OutputFormat {
+    /// Canonical output with stable token formatting.
+    Canonical,
+}
+
+/// Configuration for emission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CodegenConfig {
+    /// Output format mode.
+    pub format: OutputFormat,
+}
+
+impl Default for CodegenConfig {
+    #[inline]
+    fn default() -> Self {
+        Self {
+            format: OutputFormat::Canonical,
+        }
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/decl.rs
+++ b/crates/swc_es_codegen/src/emitter/decl.rs
@@ -1,0 +1,362 @@
+use swc_es_ast::{
+    ClassDecl, ClassMember, Decl, FnDecl, Function, MethodKind, PropName, TsEnumMemberName,
+    TsModuleName, TsNamespaceBody, VarDecl,
+};
+
+use super::{EmitResult, Emitter};
+
+impl Emitter<'_> {
+    pub(super) fn emit_decl_stmt(&mut self, id: swc_es_ast::DeclId) -> EmitResult {
+        let store = self.store;
+        let decl = Self::get_decl(store, id)?;
+        match decl {
+            Decl::Var(var) => self.emit_var_decl(var, true),
+            Decl::Fn(fun) => self.emit_fn_decl(fun),
+            Decl::Class(class_decl) => self.emit_class_decl(class_decl),
+            Decl::TsTypeAlias(alias) => {
+                if alias.declare {
+                    self.out.push_str("declare ");
+                }
+                self.out.push_str("type ");
+                self.write_ident_sym(&alias.ident.sym);
+                self.emit_type_params(&alias.type_params)?;
+                self.out.push_str(" = ");
+                self.emit_ts_type(alias.ty)?;
+                self.out.push_byte(b';');
+                Ok(())
+            }
+            Decl::TsInterface(interface) => {
+                if interface.declare {
+                    self.out.push_str("declare ");
+                }
+                self.out.push_str("interface ");
+                self.write_ident_sym(&interface.ident.sym);
+                self.emit_type_params(&interface.type_params)?;
+                if !interface.extends.is_empty() {
+                    self.out.push_str(" extends ");
+                    for (idx, item) in interface.extends.iter().enumerate() {
+                        if idx != 0 {
+                            self.out.push_byte(b',');
+                        }
+                        self.write_ident_sym(&item.sym);
+                    }
+                }
+                self.out.push_byte(b'{');
+                for member in &interface.body {
+                    self.emit_ts_type_member(member)?;
+                }
+                self.out.push_byte(b'}');
+                Ok(())
+            }
+            Decl::TsEnum(en) => {
+                if en.declare {
+                    self.out.push_str("declare ");
+                }
+                if en.is_const {
+                    self.out.push_str("const ");
+                }
+                self.out.push_str("enum ");
+                self.write_ident_sym(&en.ident.sym);
+                self.out.push_byte(b'{');
+                for (idx, member) in en.members.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    match &member.name {
+                        TsEnumMemberName::Ident(ident) => self.write_ident_sym(&ident.sym),
+                        TsEnumMemberName::Str(lit) => self.out.write_js_string(lit.value.as_ref()),
+                        TsEnumMemberName::Num(lit) => self.out.write_number(lit.value),
+                    }
+                    if let Some(init) = member.init {
+                        self.out.push_byte(b'=');
+                        self.emit_expr(init, 0)?;
+                    }
+                }
+                self.out.push_byte(b'}');
+                Ok(())
+            }
+            Decl::TsModule(module_decl) => {
+                if module_decl.declare {
+                    self.out.push_str("declare ");
+                }
+                if module_decl.global {
+                    self.out.push_str("global ");
+                }
+                if module_decl.namespace {
+                    self.out.push_str("namespace ");
+                } else {
+                    self.out.push_str("module ");
+                }
+                match &module_decl.id {
+                    TsModuleName::Ident(ident) => self.write_ident_sym(&ident.sym),
+                    TsModuleName::Str(lit) => self.out.write_js_string(lit.value.as_ref()),
+                }
+
+                match &module_decl.body {
+                    Some(body) => {
+                        if let (TsModuleName::Ident(root), TsNamespaceBody::Namespace(ns)) =
+                            (&module_decl.id, body)
+                        {
+                            if ns.id.sym == root.sym {
+                                return self.emit_ts_namespace_body(&ns.body);
+                            }
+                        }
+                        self.emit_ts_namespace_body(body)
+                    }
+                    None => {
+                        self.out.push_byte(b';');
+                        Ok(())
+                    }
+                }
+            }
+        }
+    }
+
+    pub(super) fn emit_var_decl(&mut self, var: &VarDecl, trailing_semi: bool) -> EmitResult {
+        if var.declare {
+            self.out.push_str("declare ");
+        }
+        match var.kind {
+            swc_es_ast::VarDeclKind::Var => self.out.push_str("var "),
+            swc_es_ast::VarDeclKind::Let => self.out.push_str("let "),
+            swc_es_ast::VarDeclKind::Const => self.out.push_str("const "),
+            swc_es_ast::VarDeclKind::Using => self.out.push_str("using "),
+            swc_es_ast::VarDeclKind::AwaitUsing => self.out.push_str("await using "),
+        }
+
+        for (idx, declarator) in var.declarators.iter().enumerate() {
+            if idx != 0 {
+                self.out.push_byte(b',');
+            }
+            self.emit_pat(declarator.name)?;
+            if let Some(init) = declarator.init {
+                self.out.push_byte(b'=');
+                self.emit_expr(init, 0)?;
+            }
+        }
+
+        if trailing_semi {
+            self.out.push_byte(b';');
+        }
+
+        Ok(())
+    }
+
+    fn emit_fn_decl(&mut self, fun: &FnDecl) -> EmitResult {
+        if fun.declare {
+            self.out.push_str("declare ");
+        }
+        self.out.push_str("function ");
+        self.write_ident_sym(&fun.ident.sym);
+        self.out.push_byte(b'(');
+        for (idx, param) in fun.params.iter().enumerate() {
+            if idx != 0 {
+                self.out.push_byte(b',');
+            }
+            self.emit_pat(*param)?;
+        }
+        self.out.push_byte(b')');
+        self.emit_block_stmts(&fun.body)
+    }
+
+    fn emit_class_decl(&mut self, class_decl: &ClassDecl) -> EmitResult {
+        self.emit_class_with_name(class_decl.class, Some(&class_decl.ident.sym))
+    }
+
+    pub(super) fn emit_class_with_name(
+        &mut self,
+        class_id: swc_es_ast::ClassId,
+        explicit_name: Option<&swc_atoms::Atom>,
+    ) -> EmitResult {
+        let store = self.store;
+        let class = Self::get_class(store, class_id)?;
+
+        for decorator in &class.decorators {
+            self.out.push_byte(b'@');
+            self.emit_expr(decorator.expr, 0)?;
+            self.out.push_byte(b' ');
+        }
+
+        self.out.push_str("class");
+        if let Some(name) = explicit_name {
+            self.out.push_byte(b' ');
+            self.write_ident_sym(name);
+        } else if let Some(ident) = &class.ident {
+            self.out.push_byte(b' ');
+            self.write_ident_sym(&ident.sym);
+        }
+
+        if let Some(super_class) = class.super_class {
+            self.out.push_str(" extends ");
+            self.emit_expr(super_class, 0)?;
+        }
+
+        self.out.push_byte(b'{');
+        for member_id in &class.body {
+            self.emit_class_member(*member_id)?;
+        }
+        self.out.push_byte(b'}');
+        Ok(())
+    }
+
+    pub(super) fn emit_class_member(&mut self, id: swc_es_ast::ClassMemberId) -> EmitResult {
+        let store = self.store;
+        let member = Self::get_class_member(store, id)?;
+
+        match member {
+            ClassMember::Method(method) => {
+                for decorator in &method.decorators {
+                    self.out.push_byte(b'@');
+                    self.emit_expr(decorator.expr, 0)?;
+                    self.out.push_byte(b' ');
+                }
+                if method.is_static {
+                    self.out.push_str("static ");
+                }
+
+                let function = Self::get_function(store, method.function)?;
+                match method.kind {
+                    MethodKind::Getter => {
+                        self.out.push_str("get ");
+                        self.emit_prop_name(&method.key)?;
+                    }
+                    MethodKind::Setter => {
+                        self.out.push_str("set ");
+                        self.emit_prop_name(&method.key)?;
+                    }
+                    MethodKind::Constructor => {
+                        self.emit_prop_name(&method.key)?;
+                    }
+                    MethodKind::Method => {
+                        if function.is_async {
+                            self.out.push_str("async ");
+                        }
+                        if function.is_generator {
+                            self.out.push_byte(b'*');
+                        }
+                        self.emit_prop_name(&method.key)?;
+                    }
+                }
+                self.emit_function_params(function)?;
+                self.emit_block_stmts(&function.body)
+            }
+            ClassMember::Prop(prop) => {
+                for decorator in &prop.decorators {
+                    self.out.push_byte(b'@');
+                    self.emit_expr(decorator.expr, 0)?;
+                    self.out.push_byte(b' ');
+                }
+                if prop.is_static {
+                    self.out.push_str("static ");
+                }
+                self.emit_prop_name(&prop.key)?;
+                if let Some(value) = prop.value {
+                    self.out.push_byte(b'=');
+                    self.emit_expr(value, 0)?;
+                }
+                self.out.push_byte(b';');
+                Ok(())
+            }
+            ClassMember::StaticBlock(block) => {
+                self.out.push_str("static");
+                self.emit_block_stmts(&block.body)
+            }
+        }
+    }
+
+    fn emit_function_params(&mut self, function: &Function) -> EmitResult {
+        self.out.push_byte(b'(');
+        for (idx, param) in function.params.iter().enumerate() {
+            if idx != 0 {
+                self.out.push_byte(b',');
+            }
+            for decorator in &param.decorators {
+                self.out.push_byte(b'@');
+                self.emit_expr(decorator.expr, 0)?;
+                self.out.push_byte(b' ');
+            }
+            self.emit_pat(param.pat)?;
+        }
+        self.out.push_byte(b')');
+        Ok(())
+    }
+
+    pub(super) fn emit_prop_name(&mut self, prop: &PropName) -> EmitResult {
+        match prop {
+            PropName::Ident(ident) => self.write_ident_sym(&ident.sym),
+            PropName::Private(ident) => self.write_private_ident_sym(&ident.sym),
+            PropName::Str(lit) => self.out.write_js_string(lit.value.as_ref()),
+            PropName::Num(lit) => self.out.write_number(lit.value),
+            PropName::Computed(expr) => {
+                self.out.push_byte(b'[');
+                self.emit_expr(*expr, 0)?;
+                self.out.push_byte(b']');
+            }
+        }
+        Ok(())
+    }
+
+    pub(super) fn emit_type_params(&mut self, params: &[swc_es_ast::Ident]) -> EmitResult {
+        if params.is_empty() {
+            return Ok(());
+        }
+
+        self.out.push_byte(b'<');
+        for (idx, param) in params.iter().enumerate() {
+            if idx != 0 {
+                self.out.push_byte(b',');
+            }
+            self.write_ident_sym(&param.sym);
+        }
+        self.out.push_byte(b'>');
+        Ok(())
+    }
+
+    pub(super) fn emit_decl_for_export_default(&mut self, id: swc_es_ast::DeclId) -> EmitResult {
+        let store = self.store;
+        match Self::get_decl(store, id)? {
+            Decl::Fn(fun) => {
+                self.out.push_str("function ");
+                self.write_ident_sym(&fun.ident.sym);
+                self.out.push_byte(b'(');
+                for (idx, param) in fun.params.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_pat(*param)?;
+                }
+                self.out.push_byte(b')');
+                self.emit_block_stmts(&fun.body)
+            }
+            Decl::Class(class_decl) => {
+                self.emit_class_with_name(class_decl.class, Some(&class_decl.ident.sym))
+            }
+            _ => Err(Self::invalid_ast(
+                "export default declaration must be function or class",
+            )),
+        }
+    }
+
+    fn emit_ts_namespace_body(&mut self, body: &TsNamespaceBody) -> EmitResult {
+        match body {
+            TsNamespaceBody::ModuleBlock(stmts) => self.emit_block_stmts(stmts),
+            TsNamespaceBody::Namespace(ns) => {
+                self.out.push_byte(b'.');
+                self.write_ident_sym(&ns.id.sym);
+                self.emit_ts_namespace_body(&ns.body)
+            }
+        }
+    }
+
+    pub(super) fn emit_module_item_decl(&mut self, decl: swc_es_ast::DeclId) -> EmitResult {
+        let store = self.store;
+        match Self::get_decl(store, decl)? {
+            Decl::Var(var) => self.emit_var_decl(var, true),
+            Decl::Fn(fun) => self.emit_fn_decl(fun),
+            Decl::Class(class_decl) => self.emit_class_decl(class_decl),
+            Decl::TsTypeAlias(_) | Decl::TsInterface(_) | Decl::TsEnum(_) | Decl::TsModule(_) => {
+                self.emit_decl_stmt(decl)
+            }
+        }
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/expr.rs
+++ b/crates/swc_es_codegen/src/emitter/expr.rs
@@ -1,0 +1,490 @@
+use swc_es_ast::{
+    AssignOp, BinaryOp, Expr, ExprOrSpread, Lit, MemberProp, MetaPropKind, PropName, UnaryOp,
+    UpdateOp,
+};
+
+use super::{EmitResult, Emitter};
+
+const PREC_COMMA: u8 = 1;
+const PREC_ASSIGN: u8 = 2;
+const PREC_CONDITIONAL: u8 = 3;
+const PREC_LOGICAL_OR: u8 = 4;
+const PREC_LOGICAL_AND: u8 = 5;
+const PREC_BIT_OR: u8 = 6;
+const PREC_BIT_XOR: u8 = 7;
+const PREC_BIT_AND: u8 = 8;
+const PREC_EQUALITY: u8 = 9;
+const PREC_RELATIONAL: u8 = 10;
+const PREC_SHIFT: u8 = 11;
+const PREC_ADDITIVE: u8 = 12;
+const PREC_MULTIPLICATIVE: u8 = 13;
+const PREC_EXPONENTIAL: u8 = 14;
+const PREC_PREFIX: u8 = 15;
+const PREC_POSTFIX: u8 = 16;
+const PREC_CALL: u8 = 17;
+const PREC_PRIMARY: u8 = 18;
+
+impl Emitter<'_> {
+    pub(super) fn emit_expr(&mut self, id: swc_es_ast::ExprId, parent_prec: u8) -> EmitResult {
+        let store = self.store;
+        let expr = Self::get_expr(store, id)?;
+        let prec = self.expr_precedence(expr);
+        let needs_paren = prec < parent_prec;
+        if needs_paren {
+            self.out.push_byte(b'(');
+        }
+
+        match expr {
+            Expr::Ident(ident) => self.write_ident_sym(&ident.sym),
+            Expr::Lit(lit) => self.emit_lit(lit),
+            Expr::Function(function) => {
+                self.out.push_str("function");
+                let function = Self::get_function(store, *function)?;
+                if function.is_generator {
+                    self.out.push_byte(b'*');
+                }
+                self.emit_function_expr(function)?;
+            }
+            Expr::Class(class_id) => self.emit_class_with_name(*class_id, None)?,
+            Expr::JSXElement(id) => self.emit_jsx_element(*id)?,
+            Expr::TsAs(as_expr) => {
+                self.emit_expr(as_expr.expr, PREC_RELATIONAL)?;
+                self.out.push_str(" as ");
+                self.emit_ts_type(as_expr.ty)?;
+            }
+            Expr::Array(array) => {
+                self.out.push_byte(b'[');
+                for (idx, elem) in array.elems.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    if let Some(elem) = elem {
+                        self.emit_expr_or_spread(elem)?;
+                    }
+                }
+                self.out.push_byte(b']');
+            }
+            Expr::Object(object) => {
+                self.out.push_byte(b'{');
+                for (idx, prop) in object.props.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+
+                    if let PropName::Ident(ident) = &prop.key {
+                        if ident.sym.as_ref() == "__spread__" {
+                            self.out.push_str("...");
+                            self.emit_expr(prop.value, 0)?;
+                            continue;
+                        }
+                    }
+
+                    let shorthand = match (&prop.key, Self::get_expr(store, prop.value)?) {
+                        (PropName::Ident(key), Expr::Ident(value)) => key.sym == value.sym,
+                        _ => false,
+                    };
+
+                    if shorthand {
+                        if let PropName::Ident(ident) = &prop.key {
+                            self.write_ident_sym(&ident.sym);
+                            continue;
+                        }
+                    }
+
+                    self.emit_prop_name(&prop.key)?;
+                    self.out.push_byte(b':');
+                    self.emit_expr(prop.value, 0)?;
+                }
+                self.out.push_byte(b'}');
+            }
+            Expr::Unary(unary) => {
+                match unary.op {
+                    UnaryOp::Plus => self.out.push_byte(b'+'),
+                    UnaryOp::Minus => self.out.push_byte(b'-'),
+                    UnaryOp::Bang => self.out.push_byte(b'!'),
+                    UnaryOp::Tilde => self.out.push_byte(b'~'),
+                    UnaryOp::TypeOf => self.out.push_str("typeof "),
+                    UnaryOp::Void => self.out.push_str("void "),
+                    UnaryOp::Delete => self.out.push_str("delete "),
+                }
+                self.emit_expr(unary.arg, PREC_PREFIX)?;
+            }
+            Expr::Binary(binary) => {
+                let op_prec = self.binary_precedence(binary.op);
+                let left_prec = if binary.op == BinaryOp::Exp {
+                    op_prec + 1
+                } else {
+                    op_prec
+                };
+                let right_prec = if binary.op == BinaryOp::Exp {
+                    op_prec
+                } else {
+                    op_prec + 1
+                };
+
+                self.emit_expr(binary.left, left_prec)?;
+                self.out.push_str(self.binary_op_text(binary.op));
+                self.emit_expr(binary.right, right_prec)?;
+            }
+            Expr::Assign(assign) => {
+                self.emit_pat(assign.left)?;
+                self.out.push_str(self.assign_op_text(assign.op));
+                self.emit_expr(assign.right, PREC_ASSIGN)?;
+            }
+            Expr::Call(call) => {
+                self.emit_expr(call.callee, PREC_CALL)?;
+                self.out.push_byte(b'(');
+                for (idx, arg) in call.args.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_expr_or_spread(arg)?;
+                }
+                self.out.push_byte(b')');
+            }
+            Expr::Member(member) => {
+                self.emit_expr(member.obj, PREC_CALL)?;
+                match &member.prop {
+                    MemberProp::Ident(ident) => {
+                        self.out.push_byte(b'.');
+                        self.write_ident_sym(&ident.sym);
+                    }
+                    MemberProp::Private(ident) => {
+                        self.out.push_byte(b'.');
+                        self.write_private_ident_sym(&ident.sym);
+                    }
+                    MemberProp::Computed(expr) => {
+                        self.out.push_byte(b'[');
+                        self.emit_expr(*expr, 0)?;
+                        self.out.push_byte(b']');
+                    }
+                }
+            }
+            Expr::Cond(cond) => {
+                self.emit_expr(cond.test, PREC_CONDITIONAL + 1)?;
+                self.out.push_byte(b'?');
+                self.emit_expr(cond.cons, PREC_ASSIGN)?;
+                self.out.push_byte(b':');
+                self.emit_expr(cond.alt, PREC_CONDITIONAL)?;
+            }
+            Expr::Seq(seq) => {
+                for (idx, expr) in seq.exprs.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_expr(*expr, PREC_ASSIGN)?;
+                }
+            }
+            Expr::New(new_expr) => {
+                self.out.push_str("new ");
+                self.emit_expr(new_expr.callee, PREC_CALL)?;
+                self.out.push_byte(b'(');
+                for (idx, arg) in new_expr.args.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_expr_or_spread(arg)?;
+                }
+                self.out.push_byte(b')');
+            }
+            Expr::Update(update) => {
+                if update.prefix {
+                    self.out.push_str(match update.op {
+                        UpdateOp::PlusPlus => "++",
+                        UpdateOp::MinusMinus => "--",
+                    });
+                    self.emit_expr(update.arg, PREC_POSTFIX)?;
+                } else {
+                    self.emit_expr(update.arg, PREC_POSTFIX)?;
+                    self.out.push_str(match update.op {
+                        UpdateOp::PlusPlus => "++",
+                        UpdateOp::MinusMinus => "--",
+                    });
+                }
+            }
+            Expr::Await(await_expr) => {
+                self.out.push_str("await ");
+                self.emit_expr(await_expr.arg, PREC_PREFIX)?;
+            }
+            Expr::Arrow(arrow) => {
+                if arrow.is_async {
+                    self.out.push_str("async ");
+                }
+                self.out.push_byte(b'(');
+                for (idx, param) in arrow.params.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_pat(*param)?;
+                }
+                self.out.push_str(")=>");
+                match &arrow.body {
+                    swc_es_ast::ArrowBody::Expr(expr) => self.emit_expr(*expr, PREC_ASSIGN)?,
+                    swc_es_ast::ArrowBody::Block(stmts) => self.emit_block_stmts(stmts)?,
+                }
+            }
+            Expr::Template(template) => self.emit_template_expr(template)?,
+            Expr::Yield(yield_expr) => {
+                self.out.push_str("yield");
+                if yield_expr.delegate {
+                    self.out.push_byte(b'*');
+                }
+                if let Some(arg) = yield_expr.arg {
+                    self.out.push_byte(b' ');
+                    self.emit_expr(arg, PREC_ASSIGN)?;
+                }
+            }
+            Expr::TaggedTemplate(tagged) => {
+                self.emit_expr(tagged.tag, PREC_CALL)?;
+                self.emit_template_expr(&tagged.template)?;
+            }
+            Expr::MetaProp(meta_prop) => {
+                self.out.push_str(match meta_prop.kind {
+                    MetaPropKind::NewTarget => "new.target",
+                    MetaPropKind::ImportMeta => "import.meta",
+                });
+            }
+            Expr::OptChain(chain) => {
+                self.emit_opt_chain_base(chain.base)?;
+            }
+            Expr::Paren(paren) => {
+                self.out.push_byte(b'(');
+                self.emit_expr(paren.expr, 0)?;
+                self.out.push_byte(b')');
+            }
+        }
+
+        if needs_paren {
+            self.out.push_byte(b')');
+        }
+
+        Ok(())
+    }
+
+    fn emit_function_expr(&mut self, function: &swc_es_ast::Function) -> EmitResult {
+        self.out.push_byte(b'(');
+        for (idx, param) in function.params.iter().enumerate() {
+            if idx != 0 {
+                self.out.push_byte(b',');
+            }
+            for decorator in &param.decorators {
+                self.out.push_byte(b'@');
+                self.emit_expr(decorator.expr, 0)?;
+                self.out.push_byte(b' ');
+            }
+            self.emit_pat(param.pat)?;
+        }
+        self.out.push_byte(b')');
+        self.emit_block_stmts(&function.body)
+    }
+
+    fn emit_template_expr(&mut self, template: &swc_es_ast::TemplateExpr) -> EmitResult {
+        if template.quasis.is_empty() {
+            if template.exprs.is_empty() {
+                self.out.push_str("``");
+                return Ok(());
+            }
+
+            return Err(Self::invalid_ast(
+                "template with expressions must have at least one quasi",
+            ));
+        }
+
+        if template.quasis.len() != template.exprs.len() + 1 {
+            return Err(Self::invalid_ast(
+                "template quasis length must equal expressions length + 1",
+            ));
+        }
+
+        self.out.push_byte(b'`');
+        for idx in 0..template.exprs.len() {
+            self.out
+                .write_template_chunk(template.quasis[idx].value.as_ref());
+            self.out.push_str("${");
+            self.emit_expr(template.exprs[idx], 0)?;
+            self.out.push_byte(b'}');
+        }
+        self.out
+            .write_template_chunk(template.quasis[template.exprs.len()].value.as_ref());
+        self.out.push_byte(b'`');
+        Ok(())
+    }
+
+    fn emit_opt_chain_base(&mut self, base: swc_es_ast::ExprId) -> EmitResult {
+        let store = self.store;
+        match Self::get_expr(store, base)? {
+            Expr::Member(member) => {
+                self.emit_expr(member.obj, PREC_CALL)?;
+                match &member.prop {
+                    MemberProp::Ident(ident) => {
+                        self.out.push_str("?.");
+                        self.write_ident_sym(&ident.sym);
+                    }
+                    MemberProp::Private(ident) => {
+                        self.out.push_str("?.");
+                        self.write_private_ident_sym(&ident.sym);
+                    }
+                    MemberProp::Computed(expr) => {
+                        self.out.push_str("?.[");
+                        self.emit_expr(*expr, 0)?;
+                        self.out.push_byte(b']');
+                    }
+                }
+                Ok(())
+            }
+            Expr::Call(call) => {
+                self.emit_expr(call.callee, PREC_CALL)?;
+                self.out.push_str("?.(");
+                for (idx, arg) in call.args.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_expr_or_spread(arg)?;
+                }
+                self.out.push_byte(b')');
+                Ok(())
+            }
+            _ => Err(Self::invalid_ast(
+                "optional chain base must be call or member expression",
+            )),
+        }
+    }
+
+    fn emit_expr_or_spread(&mut self, node: &ExprOrSpread) -> EmitResult {
+        if node.spread {
+            self.out.push_str("...");
+        }
+        self.emit_expr(node.expr, 0)
+    }
+
+    fn emit_lit(&mut self, lit: &Lit) {
+        match lit {
+            Lit::Str(lit) => self.out.write_js_string(lit.value.as_ref()),
+            Lit::Bool(lit) => {
+                if lit.value {
+                    self.out.push_str("true");
+                } else {
+                    self.out.push_str("false");
+                }
+            }
+            Lit::Null(_) => self.out.push_str("null"),
+            Lit::Num(lit) => self.out.write_number(lit.value),
+            Lit::BigInt(lit) => {
+                self.out.push_str(lit.value.as_ref());
+                self.out.push_byte(b'n');
+            }
+            Lit::Regex(lit) => {
+                self.out.push_byte(b'/');
+                self.out.push_str(lit.exp.as_ref());
+                self.out.push_byte(b'/');
+                self.out.push_str(lit.flags.as_ref());
+            }
+        }
+    }
+
+    fn expr_precedence(&self, expr: &Expr) -> u8 {
+        match expr {
+            Expr::Seq(_) => PREC_COMMA,
+            Expr::Assign(_) | Expr::Arrow(_) | Expr::Yield(_) => PREC_ASSIGN,
+            Expr::Cond(_) => PREC_CONDITIONAL,
+            Expr::TsAs(_) => PREC_RELATIONAL,
+            Expr::Binary(binary) => self.binary_precedence(binary.op),
+            Expr::Unary(_) | Expr::Await(_) => PREC_PREFIX,
+            Expr::Update(_) => PREC_POSTFIX,
+            Expr::Call(_)
+            | Expr::Member(_)
+            | Expr::New(_)
+            | Expr::TaggedTemplate(_)
+            | Expr::OptChain(_) => PREC_CALL,
+            Expr::Ident(_)
+            | Expr::Lit(_)
+            | Expr::Function(_)
+            | Expr::Class(_)
+            | Expr::JSXElement(_)
+            | Expr::Array(_)
+            | Expr::Object(_)
+            | Expr::Template(_)
+            | Expr::MetaProp(_)
+            | Expr::Paren(_) => PREC_PRIMARY,
+        }
+    }
+
+    fn binary_precedence(&self, op: BinaryOp) -> u8 {
+        match op {
+            BinaryOp::LogicalOr => PREC_LOGICAL_OR,
+            BinaryOp::NullishCoalescing => PREC_LOGICAL_OR,
+            BinaryOp::LogicalAnd => PREC_LOGICAL_AND,
+            BinaryOp::BitOr => PREC_BIT_OR,
+            BinaryOp::BitXor => PREC_BIT_XOR,
+            BinaryOp::BitAnd => PREC_BIT_AND,
+            BinaryOp::EqEq | BinaryOp::EqEqEq | BinaryOp::NotEq | BinaryOp::NotEqEq => {
+                PREC_EQUALITY
+            }
+            BinaryOp::Lt
+            | BinaryOp::LtEq
+            | BinaryOp::Gt
+            | BinaryOp::GtEq
+            | BinaryOp::In
+            | BinaryOp::InstanceOf => PREC_RELATIONAL,
+            BinaryOp::LShift | BinaryOp::RShift | BinaryOp::ZeroFillRShift => PREC_SHIFT,
+            BinaryOp::Add | BinaryOp::Sub => PREC_ADDITIVE,
+            BinaryOp::Mul | BinaryOp::Div | BinaryOp::Mod => PREC_MULTIPLICATIVE,
+            BinaryOp::Exp => PREC_EXPONENTIAL,
+        }
+    }
+
+    fn binary_op_text(&self, op: BinaryOp) -> &'static str {
+        match op {
+            BinaryOp::Add => "+",
+            BinaryOp::Sub => "-",
+            BinaryOp::Mul => "*",
+            BinaryOp::Div => "/",
+            BinaryOp::Mod => "%",
+            BinaryOp::EqEq => "==",
+            BinaryOp::EqEqEq => "===",
+            BinaryOp::NotEq => "!=",
+            BinaryOp::NotEqEq => "!==",
+            BinaryOp::Lt => "<",
+            BinaryOp::LtEq => "<=",
+            BinaryOp::Gt => ">",
+            BinaryOp::GtEq => ">=",
+            BinaryOp::LShift => "<<",
+            BinaryOp::RShift => ">>",
+            BinaryOp::ZeroFillRShift => ">>>",
+            BinaryOp::LogicalAnd => "&&",
+            BinaryOp::LogicalOr => "||",
+            BinaryOp::BitOr => "|",
+            BinaryOp::BitXor => "^",
+            BinaryOp::BitAnd => "&",
+            BinaryOp::In => " in ",
+            BinaryOp::InstanceOf => " instanceof ",
+            BinaryOp::Exp => "**",
+            BinaryOp::NullishCoalescing => "??",
+        }
+    }
+
+    fn assign_op_text(&self, op: AssignOp) -> &'static str {
+        match op {
+            AssignOp::Assign => "=",
+            AssignOp::AddAssign => "+=",
+            AssignOp::SubAssign => "-=",
+            AssignOp::MulAssign => "*=",
+            AssignOp::DivAssign => "/=",
+            AssignOp::ModAssign => "%=",
+            AssignOp::LShiftAssign => "<<=",
+            AssignOp::RShiftAssign => ">>=",
+            AssignOp::ZeroFillRShiftAssign => ">>>=",
+            AssignOp::BitOrAssign => "|=",
+            AssignOp::BitXorAssign => "^=",
+            AssignOp::BitAndAssign => "&=",
+            AssignOp::ExpAssign => "**=",
+            AssignOp::AndAssign => "&&=",
+            AssignOp::OrAssign => "||=",
+            AssignOp::NullishAssign => "??=",
+        }
+    }
+
+    pub(super) fn expr_stmt_needs_paren(&self, expr: &Expr) -> bool {
+        matches!(expr, Expr::Object(_) | Expr::Function(_) | Expr::Class(_))
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/jsx.rs
+++ b/crates/swc_es_codegen/src/emitter/jsx.rs
@@ -1,0 +1,76 @@
+use swc_es_ast::{Expr, JSXElementChild, JSXElementName, Lit};
+
+use super::{EmitResult, Emitter};
+
+impl Emitter<'_> {
+    pub(super) fn emit_jsx_element(&mut self, id: swc_es_ast::JSXElementId) -> EmitResult {
+        let store = self.store;
+        let element = Self::get_jsx_element(store, id)?;
+
+        self.out.push_byte(b'<');
+        self.emit_jsx_name(&element.opening.name);
+
+        for attr in &element.opening.attrs {
+            if attr.name.as_ref() == "..." {
+                self.out.push_byte(b' ');
+                self.out.push_byte(b'{');
+                self.out.push_str("...");
+                if let Some(value) = attr.value {
+                    self.emit_expr(value, 0)?;
+                }
+                self.out.push_byte(b'}');
+                continue;
+            }
+
+            self.out.push_byte(b' ');
+            self.out.push_str(attr.name.as_ref());
+
+            if let Some(value) = attr.value {
+                self.out.push_byte(b'=');
+                if let Expr::Lit(Lit::Str(lit)) = Self::get_expr(store, value)? {
+                    self.out.write_js_string(lit.value.as_ref());
+                } else {
+                    self.out.push_byte(b'{');
+                    self.emit_expr(value, 0)?;
+                    self.out.push_byte(b'}');
+                }
+            }
+        }
+
+        if element.opening.self_closing {
+            self.out.push_str("/>");
+            return Ok(());
+        }
+
+        self.out.push_byte(b'>');
+
+        for child in &element.children {
+            match child {
+                JSXElementChild::Element(id) => self.emit_jsx_element(*id)?,
+                JSXElementChild::Text(text) => self.out.push_str(text.as_ref()),
+                JSXElementChild::Expr(expr) => {
+                    self.out.push_byte(b'{');
+                    self.emit_expr(*expr, 0)?;
+                    self.out.push_byte(b'}');
+                }
+            }
+        }
+
+        let closing = element
+            .closing
+            .as_ref()
+            .ok_or_else(|| Self::invalid_ast("non-self-closing jsx element must have closing"))?;
+
+        self.out.push_str("</");
+        self.emit_jsx_name(closing);
+        self.out.push_byte(b'>');
+        Ok(())
+    }
+
+    fn emit_jsx_name(&mut self, name: &JSXElementName) {
+        match name {
+            JSXElementName::Ident(ident) => self.write_ident_sym(&ident.sym),
+            JSXElementName::Qualified(name) => self.out.push_str(name.as_ref()),
+        }
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/mod.rs
+++ b/crates/swc_es_codegen/src/emitter/mod.rs
@@ -1,0 +1,174 @@
+use swc_atoms::Atom;
+use swc_es_ast::{
+    AstStore, Class, ClassId, ClassMember, ClassMemberId, Decl, DeclId, Expr, ExprId, Function,
+    FunctionId, JSXElement, JSXElementId, ModuleDecl, ModuleDeclId, Pat, PatId, Program, ProgramId,
+    Stmt, StmtId, TsType, TsTypeId,
+};
+
+use crate::{
+    writer::{is_ascii_ident_name, Writer},
+    CodegenConfig, CodegenError, NodeKind, OutputFormat,
+};
+
+mod decl;
+mod expr;
+mod jsx;
+mod module_decl;
+mod pat;
+mod stmt;
+mod typescript;
+
+pub(crate) struct Emitter<'a> {
+    store: &'a AstStore,
+    cfg: CodegenConfig,
+    out: Writer,
+}
+
+type EmitResult = Result<(), CodegenError>;
+
+impl<'a> Emitter<'a> {
+    #[inline]
+    pub fn new(store: &'a AstStore, cfg: CodegenConfig) -> Self {
+        Self {
+            store,
+            cfg,
+            out: Writer::new(),
+        }
+    }
+
+    pub fn emit_program(mut self, program_id: ProgramId) -> Result<String, CodegenError> {
+        match self.cfg.format {
+            OutputFormat::Canonical => {
+                self.emit_program_node(program_id)?;
+                self.out.into_string()
+            }
+        }
+    }
+
+    fn emit_program_node(&mut self, id: ProgramId) -> EmitResult {
+        let store = self.store;
+        let body = {
+            let program = Self::get_program(store, id)?;
+            program.body.clone()
+        };
+
+        for stmt_id in body {
+            self.emit_stmt(stmt_id)?;
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn get_program(store: &AstStore, id: ProgramId) -> Result<&Program, CodegenError> {
+        store
+            .program(id)
+            .ok_or_else(|| Self::missing(NodeKind::Program, id.as_raw()))
+    }
+
+    #[inline]
+    fn get_stmt(store: &AstStore, id: StmtId) -> Result<&Stmt, CodegenError> {
+        store
+            .stmt(id)
+            .ok_or_else(|| Self::missing(NodeKind::Stmt, id.as_raw()))
+    }
+
+    #[inline]
+    fn get_decl(store: &AstStore, id: DeclId) -> Result<&Decl, CodegenError> {
+        store
+            .decl(id)
+            .ok_or_else(|| Self::missing(NodeKind::Decl, id.as_raw()))
+    }
+
+    #[inline]
+    fn get_pat(store: &AstStore, id: PatId) -> Result<&Pat, CodegenError> {
+        store
+            .pat(id)
+            .ok_or_else(|| Self::missing(NodeKind::Pat, id.as_raw()))
+    }
+
+    #[inline]
+    fn get_expr(store: &AstStore, id: ExprId) -> Result<&Expr, CodegenError> {
+        store
+            .expr(id)
+            .ok_or_else(|| Self::missing(NodeKind::Expr, id.as_raw()))
+    }
+
+    #[inline]
+    fn get_module_decl(store: &AstStore, id: ModuleDeclId) -> Result<&ModuleDecl, CodegenError> {
+        store
+            .module_decl(id)
+            .ok_or_else(|| Self::missing(NodeKind::ModuleDecl, id.as_raw()))
+    }
+
+    #[inline]
+    fn get_class(store: &AstStore, id: ClassId) -> Result<&Class, CodegenError> {
+        store
+            .class(id)
+            .ok_or_else(|| Self::missing(NodeKind::Class, id.as_raw()))
+    }
+
+    #[inline]
+    fn get_class_member(store: &AstStore, id: ClassMemberId) -> Result<&ClassMember, CodegenError> {
+        store
+            .class_member(id)
+            .ok_or_else(|| Self::missing(NodeKind::ClassMember, id.as_raw()))
+    }
+
+    #[inline]
+    fn get_function(store: &AstStore, id: FunctionId) -> Result<&Function, CodegenError> {
+        store
+            .function(id)
+            .ok_or_else(|| Self::missing(NodeKind::Function, id.as_raw()))
+    }
+
+    #[inline]
+    fn get_jsx_element(store: &AstStore, id: JSXElementId) -> Result<&JSXElement, CodegenError> {
+        store
+            .jsx_element(id)
+            .ok_or_else(|| Self::missing(NodeKind::JSXElement, id.as_raw()))
+    }
+
+    #[inline]
+    fn get_ts_type(store: &AstStore, id: TsTypeId) -> Result<&TsType, CodegenError> {
+        store
+            .ts_type(id)
+            .ok_or_else(|| Self::missing(NodeKind::TsType, id.as_raw()))
+    }
+
+    #[cold]
+    fn missing(kind: NodeKind, raw_id: u64) -> CodegenError {
+        CodegenError::MissingNode { kind, raw_id }
+    }
+
+    #[cold]
+    fn invalid_ast(context: &'static str) -> CodegenError {
+        CodegenError::invalid_ast(context)
+    }
+
+    #[inline]
+    fn write_ident_sym(&mut self, sym: &Atom) {
+        self.out.push_str(sym.as_ref());
+    }
+
+    #[inline]
+    fn write_private_ident_sym(&mut self, sym: &Atom) {
+        let text = sym.as_ref();
+        if text.starts_with('#') {
+            self.out.push_str(text);
+            return;
+        }
+
+        self.out.push_byte(b'#');
+        self.out.push_str(text);
+    }
+
+    #[inline]
+    fn write_module_name(&mut self, sym: &Atom) {
+        let text = sym.as_ref();
+        if is_ascii_ident_name(text) {
+            self.out.push_str(text);
+        } else {
+            self.out.write_js_string(text);
+        }
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/module_decl.rs
+++ b/crates/swc_es_codegen/src/emitter/module_decl.rs
@@ -1,0 +1,161 @@
+use swc_es_ast::{ImportAttributeName, ImportSpecifier, ModuleDecl};
+
+use super::{EmitResult, Emitter};
+
+impl Emitter<'_> {
+    pub(super) fn emit_module_decl_stmt(&mut self, id: swc_es_ast::ModuleDeclId) -> EmitResult {
+        let store = self.store;
+        match Self::get_module_decl(store, id)? {
+            ModuleDecl::Import(import) => {
+                self.out.push_str("import");
+
+                if import.specifiers.is_empty() {
+                    self.out.push_byte(b' ');
+                    self.out.write_js_string(import.src.value.as_ref());
+                } else {
+                    self.out.push_byte(b' ');
+
+                    let mut default_spec = None;
+                    let mut namespace_spec = None;
+                    let mut named_specs = Vec::new();
+
+                    for spec in &import.specifiers {
+                        match spec {
+                            ImportSpecifier::Default(spec) => default_spec = Some(spec),
+                            ImportSpecifier::Namespace(spec) => namespace_spec = Some(spec),
+                            ImportSpecifier::Named(spec) => named_specs.push(spec),
+                        }
+                    }
+
+                    let mut wrote_any = false;
+                    if let Some(default_spec) = default_spec {
+                        wrote_any = true;
+                        self.write_ident_sym(&default_spec.local.sym);
+                    }
+
+                    if let Some(namespace_spec) = namespace_spec {
+                        if wrote_any {
+                            self.out.push_byte(b',');
+                        }
+                        wrote_any = true;
+                        self.out.push_str("* as ");
+                        self.write_ident_sym(&namespace_spec.local.sym);
+                    }
+
+                    if !named_specs.is_empty() {
+                        if wrote_any {
+                            self.out.push_byte(b',');
+                        }
+                        self.out.push_byte(b'{');
+                        for (idx, spec) in named_specs.iter().enumerate() {
+                            if idx != 0 {
+                                self.out.push_byte(b',');
+                            }
+                            if let Some(imported) = &spec.imported {
+                                self.write_module_name(&imported.sym);
+                                if imported.sym != spec.local.sym {
+                                    self.out.push_str(" as ");
+                                    self.write_ident_sym(&spec.local.sym);
+                                }
+                            } else {
+                                self.write_ident_sym(&spec.local.sym);
+                            }
+                        }
+                        self.out.push_byte(b'}');
+                    }
+
+                    self.out.push_str(" from ");
+                    self.out.write_js_string(import.src.value.as_ref());
+                }
+
+                self.emit_import_attributes(&import.with)?;
+                self.out.push_byte(b';');
+                Ok(())
+            }
+            ModuleDecl::ExportNamed(export_named) => {
+                if let Some(decl) = export_named.decl {
+                    if !export_named.specifiers.is_empty() || export_named.src.is_some() {
+                        return Err(Self::invalid_ast(
+                            "export named declaration cannot combine decl with specifiers/src",
+                        ));
+                    }
+                    self.out.push_str("export ");
+                    return self.emit_module_item_decl(decl);
+                }
+
+                self.out.push_str("export{");
+                for (idx, spec) in export_named.specifiers.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+
+                    self.write_module_name(&spec.local.sym);
+                    if let Some(exported) = &spec.exported {
+                        if exported.sym != spec.local.sym {
+                            self.out.push_str(" as ");
+                            self.write_module_name(&exported.sym);
+                        }
+                    }
+                }
+                self.out.push_byte(b'}');
+
+                if let Some(src) = &export_named.src {
+                    self.out.push_str(" from ");
+                    self.out.write_js_string(src.value.as_ref());
+                }
+                self.emit_import_attributes(&export_named.with)?;
+                self.out.push_byte(b';');
+                Ok(())
+            }
+            ModuleDecl::ExportDefaultExpr(expr) => {
+                self.out.push_str("export default ");
+                self.emit_expr(expr.expr, 0)?;
+                self.out.push_byte(b';');
+                Ok(())
+            }
+            ModuleDecl::ExportDefaultDecl(decl) => {
+                self.out.push_str("export default ");
+                self.emit_decl_for_export_default(decl.decl)
+            }
+            ModuleDecl::ExportAll(export_all) => {
+                self.out.push_str("export *");
+                if let Some(exported) = &export_all.exported {
+                    self.out.push_str(" as ");
+                    self.write_module_name(&exported.sym);
+                }
+                self.out.push_str(" from ");
+                self.out.write_js_string(export_all.src.value.as_ref());
+                self.emit_import_attributes(&export_all.with)?;
+                self.out.push_byte(b';');
+                Ok(())
+            }
+            ModuleDecl::ExportDecl(export_decl) => {
+                self.out.push_str("export ");
+                self.emit_module_item_decl(export_decl.decl)
+            }
+        }
+    }
+
+    fn emit_import_attributes(&mut self, attrs: &[swc_es_ast::ImportAttribute]) -> EmitResult {
+        if attrs.is_empty() {
+            return Ok(());
+        }
+
+        self.out.push_str(" with {");
+        for (idx, attr) in attrs.iter().enumerate() {
+            if idx != 0 {
+                self.out.push_byte(b',');
+            }
+            match &attr.key {
+                ImportAttributeName::Ident(ident) => self.write_module_name(&ident.sym),
+                ImportAttributeName::Str(str_lit) => {
+                    self.out.write_js_string(str_lit.value.as_ref())
+                }
+            }
+            self.out.push_byte(b':');
+            self.out.write_js_string(attr.value.value.as_ref());
+        }
+        self.out.push_byte(b'}');
+        Ok(())
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/pat.rs
+++ b/crates/swc_es_codegen/src/emitter/pat.rs
@@ -1,0 +1,66 @@
+use swc_es_ast::{ObjectPatProp, Pat};
+
+use super::{EmitResult, Emitter};
+
+impl Emitter<'_> {
+    pub(super) fn emit_pat(&mut self, id: swc_es_ast::PatId) -> EmitResult {
+        let store = self.store;
+        match Self::get_pat(store, id)? {
+            Pat::Ident(ident) => {
+                self.write_ident_sym(&ident.sym);
+                Ok(())
+            }
+            Pat::Expr(expr) => self.emit_expr(*expr, 0),
+            Pat::Array(array) => {
+                self.out.push_byte(b'[');
+                for (idx, elem) in array.elems.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    if let Some(elem) = elem {
+                        self.emit_pat(*elem)?;
+                    }
+                }
+                self.out.push_byte(b']');
+                Ok(())
+            }
+            Pat::Object(object) => {
+                self.out.push_byte(b'{');
+                for (idx, prop) in object.props.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    match prop {
+                        ObjectPatProp::KeyValue(prop) => {
+                            self.emit_prop_name(&prop.key)?;
+                            self.out.push_byte(b':');
+                            self.emit_pat(prop.value)?;
+                        }
+                        ObjectPatProp::Assign(prop) => {
+                            self.write_ident_sym(&prop.key.sym);
+                            if let Some(value) = prop.value {
+                                self.out.push_byte(b'=');
+                                self.emit_expr(value, 0)?;
+                            }
+                        }
+                        ObjectPatProp::Rest(rest) => {
+                            self.out.push_str("...");
+                            self.emit_pat(rest.arg)?;
+                        }
+                    }
+                }
+                self.out.push_byte(b'}');
+                Ok(())
+            }
+            Pat::Rest(rest) => {
+                self.out.push_str("...");
+                self.emit_pat(rest.arg)
+            }
+            Pat::Assign(assign) => {
+                self.emit_pat(assign.left)?;
+                self.out.push_byte(b'=');
+                self.emit_expr(assign.right, 0)
+            }
+        }
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/stmt.rs
+++ b/crates/swc_es_codegen/src/emitter/stmt.rs
@@ -1,0 +1,220 @@
+use swc_es_ast::{Decl, ForBinding, ForHead, ForInit, Stmt};
+
+use super::{EmitResult, Emitter};
+
+impl Emitter<'_> {
+    pub(super) fn emit_stmt(&mut self, id: swc_es_ast::StmtId) -> EmitResult {
+        let store = self.store;
+        let node = Self::get_stmt(store, id)?;
+
+        match node {
+            Stmt::Empty(_) => self.out.push_byte(b';'),
+            Stmt::Block(block) => self.emit_block_stmts(&block.stmts)?,
+            Stmt::Expr(stmt) => {
+                self.emit_expr_stmt(stmt.expr)?;
+                self.out.push_byte(b';');
+            }
+            Stmt::Return(stmt) => {
+                self.out.push_str("return");
+                if let Some(arg) = stmt.arg {
+                    self.out.push_byte(b' ');
+                    self.emit_expr(arg, 0)?;
+                }
+                self.out.push_byte(b';');
+            }
+            Stmt::If(stmt) => {
+                self.out.push_str("if(");
+                self.emit_expr(stmt.test, 0)?;
+                self.out.push_byte(b')');
+
+                let force_brace = stmt.alt.is_some() && self.if_stmt_needs_brace(stmt.cons)?;
+                if force_brace {
+                    self.out.push_byte(b'{');
+                    self.emit_stmt(stmt.cons)?;
+                    self.out.push_byte(b'}');
+                } else {
+                    self.emit_stmt(stmt.cons)?;
+                }
+
+                if let Some(alt) = stmt.alt {
+                    self.out.push_str("else");
+                    self.emit_stmt(alt)?;
+                }
+            }
+            Stmt::While(stmt) => {
+                self.out.push_str("while(");
+                self.emit_expr(stmt.test, 0)?;
+                self.out.push_byte(b')');
+                self.emit_stmt(stmt.body)?;
+            }
+            Stmt::For(stmt) => {
+                match &stmt.head {
+                    ForHead::Classic(head) => {
+                        self.out.push_str("for(");
+                        if let Some(init) = &head.init {
+                            match init {
+                                ForInit::Decl(id) => self.emit_decl_in_for_head(*id)?,
+                                ForInit::Expr(id) => self.emit_expr(*id, 0)?,
+                            }
+                        }
+                        self.out.push_byte(b';');
+                        if let Some(test) = head.test {
+                            self.emit_expr(test, 0)?;
+                        }
+                        self.out.push_byte(b';');
+                        if let Some(update) = head.update {
+                            self.emit_expr(update, 0)?;
+                        }
+                        self.out.push_byte(b')');
+                    }
+                    ForHead::In(head) => {
+                        self.out.push_str("for(");
+                        self.emit_for_binding(&head.left)?;
+                        self.out.push_str(" in ");
+                        self.emit_expr(head.right, 0)?;
+                        self.out.push_byte(b')');
+                    }
+                    ForHead::Of(head) => {
+                        if head.is_await {
+                            self.out.push_str("for await(");
+                        } else {
+                            self.out.push_str("for(");
+                        }
+                        self.emit_for_binding(&head.left)?;
+                        self.out.push_str(" of ");
+                        self.emit_expr(head.right, 0)?;
+                        self.out.push_byte(b')');
+                    }
+                }
+
+                self.emit_stmt(stmt.body)?;
+            }
+            Stmt::DoWhile(stmt) => {
+                self.out.push_str("do");
+                self.emit_stmt(stmt.body)?;
+                self.out.push_str("while(");
+                self.emit_expr(stmt.test, 0)?;
+                self.out.push_str(");");
+            }
+            Stmt::Switch(stmt) => {
+                self.out.push_str("switch(");
+                self.emit_expr(stmt.discriminant, 0)?;
+                self.out.push_str("){");
+                for case in &stmt.cases {
+                    match case.test {
+                        Some(test) => {
+                            self.out.push_str("case ");
+                            self.emit_expr(test, 0)?;
+                            self.out.push_byte(b':');
+                        }
+                        None => self.out.push_str("default:"),
+                    }
+                    for cons in &case.cons {
+                        self.emit_stmt(*cons)?;
+                    }
+                }
+                self.out.push_byte(b'}');
+            }
+            Stmt::Try(stmt) => {
+                self.out.push_str("try");
+                self.emit_stmt(stmt.block)?;
+                if let Some(handler) = &stmt.handler {
+                    self.out.push_str("catch");
+                    if let Some(param) = handler.param {
+                        self.out.push_byte(b'(');
+                        self.emit_pat(param)?;
+                        self.out.push_byte(b')');
+                    }
+                    self.emit_stmt(handler.body)?;
+                }
+                if let Some(finalizer) = stmt.finalizer {
+                    self.out.push_str("finally");
+                    self.emit_stmt(finalizer)?;
+                }
+            }
+            Stmt::Throw(stmt) => {
+                self.out.push_str("throw ");
+                self.emit_expr(stmt.arg, 0)?;
+                self.out.push_byte(b';');
+            }
+            Stmt::With(stmt) => {
+                self.out.push_str("with(");
+                self.emit_expr(stmt.obj, 0)?;
+                self.out.push_byte(b')');
+                self.emit_stmt(stmt.body)?;
+            }
+            Stmt::Break(stmt) => {
+                self.out.push_str("break");
+                if let Some(label) = &stmt.label {
+                    self.out.push_byte(b' ');
+                    self.write_ident_sym(&label.sym);
+                }
+                self.out.push_byte(b';');
+            }
+            Stmt::Continue(stmt) => {
+                self.out.push_str("continue");
+                if let Some(label) = &stmt.label {
+                    self.out.push_byte(b' ');
+                    self.write_ident_sym(&label.sym);
+                }
+                self.out.push_byte(b';');
+            }
+            Stmt::Debugger(_) => self.out.push_str("debugger;"),
+            Stmt::Labeled(stmt) => {
+                self.write_ident_sym(&stmt.label.sym);
+                self.out.push_byte(b':');
+                self.emit_stmt(stmt.body)?;
+            }
+            Stmt::Decl(id) => self.emit_decl_stmt(*id)?,
+            Stmt::ModuleDecl(id) => self.emit_module_decl_stmt(*id)?,
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn emit_block_stmts(&mut self, stmts: &[swc_es_ast::StmtId]) -> EmitResult {
+        self.out.push_byte(b'{');
+        for stmt in stmts {
+            self.emit_stmt(*stmt)?;
+        }
+        self.out.push_byte(b'}');
+        Ok(())
+    }
+
+    fn emit_expr_stmt(&mut self, expr: swc_es_ast::ExprId) -> EmitResult {
+        let store = self.store;
+        let expr_node = Self::get_expr(store, expr)?;
+        let needs_paren = self.expr_stmt_needs_paren(expr_node);
+        if needs_paren {
+            self.out.push_byte(b'(');
+        }
+        self.emit_expr(expr, 0)?;
+        if needs_paren {
+            self.out.push_byte(b')');
+        }
+        Ok(())
+    }
+
+    fn emit_decl_in_for_head(&mut self, id: swc_es_ast::DeclId) -> EmitResult {
+        let store = self.store;
+        match Self::get_decl(store, id)? {
+            Decl::Var(var) => self.emit_var_decl(var, false),
+            _ => Err(Self::invalid_ast(
+                "for head declaration must be a variable declaration",
+            )),
+        }
+    }
+
+    fn emit_for_binding(&mut self, binding: &ForBinding) -> EmitResult {
+        match binding {
+            ForBinding::Decl(id) => self.emit_decl_in_for_head(*id),
+            ForBinding::Pat(id) => self.emit_pat(*id),
+            ForBinding::Expr(id) => self.emit_expr(*id, 0),
+        }
+    }
+
+    fn if_stmt_needs_brace(&self, cons: swc_es_ast::StmtId) -> Result<bool, crate::CodegenError> {
+        let store = self.store;
+        Ok(matches!(Self::get_stmt(store, cons)?, Stmt::If(if_stmt) if if_stmt.alt.is_none()))
+    }
+}

--- a/crates/swc_es_codegen/src/emitter/typescript.rs
+++ b/crates/swc_es_codegen/src/emitter/typescript.rs
@@ -1,0 +1,369 @@
+use swc_es_ast::{TsKeywordType, TsType, TsTypeMemberKind, TsTypeOperatorOp};
+
+use super::{EmitResult, Emitter};
+
+impl Emitter<'_> {
+    pub(super) fn emit_ts_type(&mut self, id: swc_es_ast::TsTypeId) -> EmitResult {
+        self.emit_ts_type_inner(id, false)
+    }
+
+    fn emit_ts_type_inner(&mut self, id: swc_es_ast::TsTypeId, in_array_elem: bool) -> EmitResult {
+        let store = self.store;
+        let ty = Self::get_ts_type(store, id)?;
+
+        match ty {
+            TsType::Keyword(keyword) => {
+                self.out.push_str(match keyword {
+                    TsKeywordType::Any => "any",
+                    TsKeywordType::Unknown => "unknown",
+                    TsKeywordType::Never => "never",
+                    TsKeywordType::Void => "void",
+                    TsKeywordType::String => "string",
+                    TsKeywordType::Number => "number",
+                    TsKeywordType::Boolean => "boolean",
+                    TsKeywordType::Symbol => "symbol",
+                    TsKeywordType::Object => "object",
+                    TsKeywordType::BigInt => "bigint",
+                    TsKeywordType::Undefined => "undefined",
+                    TsKeywordType::Intrinsic => "intrinsic",
+                });
+                Ok(())
+            }
+            TsType::TypeRef(type_ref) => {
+                self.write_ident_sym(&type_ref.name.sym);
+                if !type_ref.type_args.is_empty() {
+                    self.out.push_byte(b'<');
+                    for (idx, arg) in type_ref.type_args.iter().enumerate() {
+                        if idx != 0 {
+                            self.out.push_byte(b',');
+                        }
+                        self.emit_ts_type(*arg)?;
+                    }
+                    self.out.push_byte(b'>');
+                }
+                Ok(())
+            }
+            TsType::Lit(lit) => {
+                match lit {
+                    swc_es_ast::TsLitType::Str(v) => self.out.write_js_string(v.value.as_ref()),
+                    swc_es_ast::TsLitType::Num(v) => self.out.write_number(v.value),
+                    swc_es_ast::TsLitType::Bool(v) => {
+                        if v.value {
+                            self.out.push_str("true");
+                        } else {
+                            self.out.push_str("false");
+                        }
+                    }
+                }
+                Ok(())
+            }
+            TsType::Array(array) => {
+                let inner = Self::get_ts_type(store, array.elem_type)?;
+                let needs_paren = matches!(
+                    inner,
+                    TsType::Union(_)
+                        | TsType::Intersection(_)
+                        | TsType::Conditional(_)
+                        | TsType::Fn(_)
+                        | TsType::Mapped(_)
+                );
+                if needs_paren {
+                    self.out.push_byte(b'(');
+                }
+                self.emit_ts_type_inner(array.elem_type, true)?;
+                if needs_paren {
+                    self.out.push_byte(b')');
+                }
+                self.out.push_str("[]");
+                Ok(())
+            }
+            TsType::Tuple(tuple) => {
+                self.out.push_byte(b'[');
+                for (idx, elem) in tuple.elem_types.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_ts_type(*elem)?;
+                }
+                self.out.push_byte(b']');
+                Ok(())
+            }
+            TsType::Union(union) => {
+                if in_array_elem {
+                    self.out.push_byte(b'(');
+                }
+                for (idx, item) in union.types.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b'|');
+                    }
+                    self.emit_ts_type(*item)?;
+                }
+                if in_array_elem {
+                    self.out.push_byte(b')');
+                }
+                Ok(())
+            }
+            TsType::Intersection(intersection) => {
+                if in_array_elem {
+                    self.out.push_byte(b'(');
+                }
+                for (idx, item) in intersection.types.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b'&');
+                    }
+                    self.emit_ts_type(*item)?;
+                }
+                if in_array_elem {
+                    self.out.push_byte(b')');
+                }
+                Ok(())
+            }
+            TsType::Parenthesized(parenthesized) => {
+                self.out.push_byte(b'(');
+                self.emit_ts_type(parenthesized.ty)?;
+                self.out.push_byte(b')');
+                Ok(())
+            }
+            TsType::TypeLit(type_lit) => {
+                self.out.push_byte(b'{');
+                for member in &type_lit.members {
+                    self.emit_ts_type_member(member)?;
+                }
+                self.out.push_byte(b'}');
+                Ok(())
+            }
+            TsType::Fn(fn_type) => {
+                self.out.push_byte(b'(');
+                for (idx, param) in fn_type.params.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_ts_fn_param(param)?;
+                }
+                self.out.push_str(")=>");
+                self.emit_ts_type(fn_type.return_type)
+            }
+            TsType::Conditional(conditional) => {
+                self.emit_ts_type(conditional.check_type)?;
+                self.out.push_str(" extends ");
+                self.emit_ts_type(conditional.extends_type)?;
+                self.out.push_byte(b'?');
+                self.emit_ts_type(conditional.true_type)?;
+                self.out.push_byte(b':');
+                self.emit_ts_type(conditional.false_type)
+            }
+            TsType::IndexedAccess(indexed) => {
+                self.emit_ts_type(indexed.obj_type)?;
+                self.out.push_byte(b'[');
+                self.emit_ts_type(indexed.index_type)?;
+                self.out.push_byte(b']');
+                Ok(())
+            }
+            TsType::TypeOperator(operator) => {
+                self.out.push_str(match operator.op {
+                    TsTypeOperatorOp::KeyOf => "keyof ",
+                    TsTypeOperatorOp::ReadOnly => "readonly ",
+                    TsTypeOperatorOp::Unique => "unique ",
+                });
+                self.emit_ts_type(operator.ty)
+            }
+            TsType::Infer(infer) => {
+                self.out.push_str("infer ");
+                self.write_ident_sym(&infer.type_param.sym);
+                Ok(())
+            }
+            TsType::Import(import) => {
+                self.out.push_str("import(");
+                self.out.write_js_string(import.arg.value.as_ref());
+                self.out.push_byte(b')');
+                if let Some(qualifier) = &import.qualifier {
+                    self.out.push_byte(b'.');
+                    self.write_ident_sym(&qualifier.sym);
+                }
+                if !import.type_args.is_empty() {
+                    self.out.push_byte(b'<');
+                    for (idx, arg) in import.type_args.iter().enumerate() {
+                        if idx != 0 {
+                            self.out.push_byte(b',');
+                        }
+                        self.emit_ts_type(*arg)?;
+                    }
+                    self.out.push_byte(b'>');
+                }
+                Ok(())
+            }
+            TsType::TypeQuery(query) => {
+                self.out.push_str("typeof ");
+                self.write_ident_sym(&query.expr_name.sym);
+                if !query.type_args.is_empty() {
+                    self.out.push_byte(b'<');
+                    for (idx, arg) in query.type_args.iter().enumerate() {
+                        if idx != 0 {
+                            self.out.push_byte(b',');
+                        }
+                        self.emit_ts_type(*arg)?;
+                    }
+                    self.out.push_byte(b'>');
+                }
+                Ok(())
+            }
+            TsType::Mapped(mapped) => {
+                self.out.push_byte(b'{');
+                if let Some(readonly) = mapped.readonly {
+                    if readonly {
+                        self.out.push_str("+readonly ");
+                    } else {
+                        self.out.push_str("-readonly ");
+                    }
+                }
+                self.out.push_byte(b'[');
+                self.write_ident_sym(&mapped.type_param.sym);
+                self.out.push_str(" in ");
+                self.emit_ts_type(mapped.constraint)?;
+                self.out.push_byte(b']');
+                if let Some(optional) = mapped.optional {
+                    if optional {
+                        self.out.push_str("+?");
+                    } else {
+                        self.out.push_str("-?");
+                    }
+                }
+                if let Some(ty) = mapped.ty {
+                    self.out.push_byte(b':');
+                    self.emit_ts_type(ty)?;
+                }
+                self.out.push_byte(b'}');
+                Ok(())
+            }
+        }
+    }
+
+    pub(super) fn emit_ts_type_member(&mut self, member: &swc_es_ast::TsTypeMember) -> EmitResult {
+        match member.kind {
+            TsTypeMemberKind::Property => {
+                if member.readonly {
+                    self.out.push_str("readonly ");
+                }
+                if let Some(name) = &member.name {
+                    self.emit_prop_name(name)?;
+                }
+                if member.optional {
+                    self.out.push_byte(b'?');
+                }
+                if let Some(ty) = member.ty {
+                    self.out.push_byte(b':');
+                    self.emit_ts_type(ty)?;
+                }
+                self.out.push_byte(b';');
+            }
+            TsTypeMemberKind::Method => {
+                if member.readonly {
+                    self.out.push_str("readonly ");
+                }
+                if let Some(name) = &member.name {
+                    self.emit_prop_name(name)?;
+                }
+                if member.optional {
+                    self.out.push_byte(b'?');
+                }
+                self.out.push_byte(b'(');
+                for (idx, param) in member.params.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_ts_fn_param(param)?;
+                }
+                self.out.push_byte(b')');
+                if let Some(ty) = member.ty {
+                    self.out.push_byte(b':');
+                    self.emit_ts_type(ty)?;
+                }
+                self.out.push_byte(b';');
+            }
+            TsTypeMemberKind::Call => {
+                self.out.push_byte(b'(');
+                for (idx, param) in member.params.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_ts_fn_param(param)?;
+                }
+                self.out.push_byte(b')');
+                if let Some(ty) = member.ty {
+                    self.out.push_byte(b':');
+                    self.emit_ts_type(ty)?;
+                }
+                self.out.push_byte(b';');
+            }
+            TsTypeMemberKind::Construct => {
+                self.out.push_str("new(");
+                for (idx, param) in member.params.iter().enumerate() {
+                    if idx != 0 {
+                        self.out.push_byte(b',');
+                    }
+                    self.emit_ts_fn_param(param)?;
+                }
+                self.out.push_byte(b')');
+                if let Some(ty) = member.ty {
+                    self.out.push_byte(b':');
+                    self.emit_ts_type(ty)?;
+                }
+                self.out.push_byte(b';');
+            }
+            TsTypeMemberKind::Index => {
+                if member.readonly {
+                    self.out.push_str("readonly ");
+                }
+                self.out.push_byte(b'[');
+                if let Some(param) = member.params.first() {
+                    if param.is_rest {
+                        self.out.push_str("...");
+                    }
+                    if let Some(name) = &param.name {
+                        self.write_ident_sym(&name.sym);
+                    } else {
+                        self.out.push_byte(b'_');
+                    }
+                    if param.optional {
+                        self.out.push_byte(b'?');
+                    }
+                    if let Some(ty) = param.ty {
+                        self.out.push_byte(b':');
+                        self.emit_ts_type(ty)?;
+                    }
+                }
+                self.out.push_byte(b']');
+                if let Some(ty) = member.ty {
+                    self.out.push_byte(b':');
+                    self.emit_ts_type(ty)?;
+                }
+                self.out.push_byte(b';');
+            }
+        }
+
+        Ok(())
+    }
+
+    fn emit_ts_fn_param(&mut self, param: &swc_es_ast::TsFnParam) -> EmitResult {
+        if param.is_rest {
+            self.out.push_str("...");
+        }
+
+        match (&param.name, param.ty) {
+            (Some(name), ty) => {
+                self.write_ident_sym(&name.sym);
+                if param.optional {
+                    self.out.push_byte(b'?');
+                }
+                if let Some(ty) = ty {
+                    self.out.push_byte(b':');
+                    self.emit_ts_type(ty)?;
+                }
+            }
+            (None, Some(ty)) => self.emit_ts_type(ty)?,
+            (None, None) => self.out.push_byte(b'_'),
+        }
+
+        Ok(())
+    }
+}

--- a/crates/swc_es_codegen/src/error.rs
+++ b/crates/swc_es_codegen/src/error.rs
@@ -1,0 +1,68 @@
+use std::{error::Error, fmt};
+
+/// AST node category used in codegen errors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum NodeKind {
+    /// Program root node.
+    Program,
+    /// Statement node.
+    Stmt,
+    /// Declaration node.
+    Decl,
+    /// Pattern node.
+    Pat,
+    /// Expression node.
+    Expr,
+    /// Module declaration node.
+    ModuleDecl,
+    /// Class node.
+    Class,
+    /// Class member node.
+    ClassMember,
+    /// Function node.
+    Function,
+    /// JSX element node.
+    JSXElement,
+    /// TypeScript type node.
+    TsType,
+}
+
+/// Code generation error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CodegenError {
+    /// A typed id referenced a missing node in the AST store.
+    MissingNode {
+        /// Missing node kind.
+        kind: NodeKind,
+        /// Raw id value.
+        raw_id: u64,
+    },
+    /// AST shape was internally inconsistent for emission.
+    InvalidAst {
+        /// Additional context.
+        context: String,
+    },
+}
+
+impl CodegenError {
+    /// Creates an invalid-AST error.
+    #[inline]
+    pub fn invalid_ast(context: impl Into<String>) -> Self {
+        Self::InvalidAst {
+            context: context.into(),
+        }
+    }
+}
+
+impl fmt::Display for CodegenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::MissingNode { kind, raw_id } => {
+                write!(f, "missing {kind:?} node for raw id {raw_id}")
+            }
+            Self::InvalidAst { context } => write!(f, "invalid ast: {context}"),
+        }
+    }
+}
+
+impl Error for CodegenError {}

--- a/crates/swc_es_codegen/src/lib.rs
+++ b/crates/swc_es_codegen/src/lib.rs
@@ -1,0 +1,33 @@
+//! High-performance code generator for `swc_es_ast`.
+
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![deny(clippy::all)]
+#![deny(missing_docs)]
+
+use swc_es_ast::{AstStore, ProgramId};
+
+pub use crate::{
+    config::{CodegenConfig, OutputFormat},
+    error::{CodegenError, NodeKind},
+};
+
+mod config;
+mod emitter;
+mod error;
+mod writer;
+
+/// Emits a program in canonical format.
+#[inline]
+pub fn emit_program(store: &AstStore, program: ProgramId) -> Result<String, CodegenError> {
+    emit_program_with_config(store, program, CodegenConfig::default())
+}
+
+/// Emits a program with explicit codegen configuration.
+#[inline]
+pub fn emit_program_with_config(
+    store: &AstStore,
+    program: ProgramId,
+    config: CodegenConfig,
+) -> Result<String, CodegenError> {
+    emitter::Emitter::new(store, config).emit_program(program)
+}

--- a/crates/swc_es_codegen/src/writer.rs
+++ b/crates/swc_es_codegen/src/writer.rs
@@ -1,0 +1,151 @@
+use ryu_js::Buffer;
+
+use crate::CodegenError;
+
+#[derive(Default)]
+pub(crate) struct Writer {
+    buf: Vec<u8>,
+}
+
+impl Writer {
+    #[inline]
+    pub fn new() -> Self {
+        Self {
+            buf: Vec::with_capacity(16 * 1024),
+        }
+    }
+
+    #[inline]
+    pub fn into_string(self) -> Result<String, CodegenError> {
+        String::from_utf8(self.buf)
+            .map_err(|_| CodegenError::invalid_ast("codegen produced non-utf8 output"))
+    }
+
+    #[inline]
+    pub fn push_byte(&mut self, b: u8) {
+        self.buf.push(b);
+    }
+
+    #[inline]
+    pub fn push_char(&mut self, ch: char) {
+        let mut scratch = [0; 4];
+        let encoded = ch.encode_utf8(&mut scratch);
+        self.buf.extend_from_slice(encoded.as_bytes());
+    }
+
+    #[inline]
+    pub fn push_str(&mut self, s: &str) {
+        self.buf.extend_from_slice(s.as_bytes());
+    }
+
+    #[inline]
+    pub fn write_number(&mut self, value: f64) {
+        if value.is_nan() {
+            self.push_str("NaN");
+            return;
+        }
+        if value.is_infinite() {
+            if value.is_sign_negative() {
+                self.push_str("-Infinity");
+            } else {
+                self.push_str("Infinity");
+            }
+            return;
+        }
+
+        let mut buf = Buffer::new();
+        self.push_str(buf.format(value));
+    }
+
+    pub fn write_js_string(&mut self, value: &str) {
+        self.push_byte(b'"');
+        for ch in value.chars() {
+            match ch {
+                '\\' => self.push_str("\\\\"),
+                '"' => self.push_str("\\\""),
+                '\n' => self.push_str("\\n"),
+                '\r' => self.push_str("\\r"),
+                '\t' => self.push_str("\\t"),
+                '\u{08}' => self.push_str("\\b"),
+                '\u{0c}' => self.push_str("\\f"),
+                '\u{2028}' => self.push_str("\\u2028"),
+                '\u{2029}' => self.push_str("\\u2029"),
+                _ if ch.is_control() => self.write_hex_escape(ch as u32),
+                _ => self.push_char(ch),
+            }
+        }
+        self.push_byte(b'"');
+    }
+
+    pub fn write_template_chunk(&mut self, value: &str) {
+        let mut chars = value.chars().peekable();
+        while let Some(ch) = chars.next() {
+            match ch {
+                '\\' => self.push_str("\\\\"),
+                '`' => self.push_str("\\`"),
+                '$' => {
+                    if chars.peek() == Some(&'{') {
+                        self.push_str("\\$");
+                    } else {
+                        self.push_char('$');
+                    }
+                }
+                '\u{2028}' => self.push_str("\\u2028"),
+                '\u{2029}' => self.push_str("\\u2029"),
+                _ => self.push_char(ch),
+            }
+        }
+    }
+
+    fn write_hex_escape(&mut self, value: u32) {
+        self.push_str("\\u");
+        if value <= 0xffff {
+            self.write_hex_fixed(value, 4);
+            return;
+        }
+
+        self.push_byte(b'{');
+        self.write_hex_compact(value);
+        self.push_byte(b'}');
+    }
+
+    fn write_hex_fixed(&mut self, value: u32, width: usize) {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        for i in (0..width).rev() {
+            let shift = i * 4;
+            let nibble = ((value >> shift) & 0x0f) as usize;
+            self.push_byte(HEX[nibble]);
+        }
+    }
+
+    fn write_hex_compact(&mut self, mut value: u32) {
+        const HEX: &[u8; 16] = b"0123456789abcdef";
+        let mut scratch = [0u8; 8];
+        let mut i = scratch.len();
+
+        loop {
+            i -= 1;
+            scratch[i] = HEX[(value & 0x0f) as usize];
+            value >>= 4;
+            if value == 0 {
+                break;
+            }
+        }
+
+        self.buf.extend_from_slice(&scratch[i..]);
+    }
+}
+
+#[inline]
+pub(crate) fn is_ascii_ident_name(sym: &str) -> bool {
+    let mut chars = sym.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+
+    if !(first == '$' || first == '_' || first.is_ascii_alphabetic()) {
+        return false;
+    }
+
+    chars.all(|ch| ch == '$' || ch == '_' || ch.is_ascii_alphanumeric())
+}

--- a/crates/swc_es_codegen/tests/errors.rs
+++ b/crates/swc_es_codegen/tests/errors.rs
@@ -1,0 +1,56 @@
+use swc_atoms::Atom;
+use swc_common::DUMMY_SP;
+use swc_es_ast::{AstStore, Expr, ExprStmt, Id, Ident, OptChainExpr, Program, ProgramKind, Stmt};
+use swc_es_codegen::{emit_program, CodegenError, NodeKind};
+
+#[test]
+fn returns_missing_node_error_for_invalid_store_reference() {
+    let mut store = AstStore::default();
+    let missing_stmt = Id::<Stmt>::try_from_raw(1).expect("raw id should be constructible");
+
+    let program = store.alloc_program(Program {
+        span: DUMMY_SP,
+        kind: ProgramKind::Script,
+        body: vec![missing_stmt],
+    });
+
+    let err = emit_program(&store, program).expect_err("emission should fail");
+    assert_eq!(
+        err,
+        CodegenError::MissingNode {
+            kind: NodeKind::Stmt,
+            raw_id: 1,
+        }
+    );
+}
+
+#[test]
+fn returns_invalid_ast_error_for_malformed_optional_chain() {
+    let mut store = AstStore::default();
+
+    let base = store.alloc_expr(Expr::Ident(Ident::new(DUMMY_SP, Atom::new("base"))));
+    let malformed = store.alloc_expr(Expr::OptChain(OptChainExpr {
+        span: DUMMY_SP,
+        base,
+    }));
+    let stmt = store.alloc_stmt(Stmt::Expr(ExprStmt {
+        span: DUMMY_SP,
+        expr: malformed,
+    }));
+    let program = store.alloc_program(Program {
+        span: DUMMY_SP,
+        kind: ProgramKind::Script,
+        body: vec![stmt],
+    });
+
+    let err = emit_program(&store, program).expect_err("emission should fail");
+    match err {
+        CodegenError::InvalidAst { context } => {
+            assert!(
+                context.contains("optional chain"),
+                "unexpected invalid-ast context: {context}"
+            );
+        }
+        _ => panic!("expected invalid ast error, got {err:?}"),
+    }
+}

--- a/crates/swc_es_codegen/tests/fixture.rs
+++ b/crates/swc_es_codegen/tests/fixture.rs
@@ -1,0 +1,144 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+use swc_common::{comments::SingleThreadedComments, FileName};
+use swc_es_codegen::emit_program;
+use swc_es_parser::{parse_file_as_program, EsSyntax, Syntax, TsSyntax};
+use testing::NormalizedOutput;
+
+fn syntax_for_path(path: &Path) -> Syntax {
+    match path.extension().and_then(|ext| ext.to_str()) {
+        Some("ts") => Syntax::Typescript(TsSyntax {
+            decorators: true,
+            ..Default::default()
+        }),
+        Some("tsx") => Syntax::Typescript(TsSyntax {
+            tsx: true,
+            decorators: true,
+            ..Default::default()
+        }),
+        Some("jsx") => Syntax::Es(EsSyntax {
+            jsx: true,
+            decorators: true,
+            import_attributes: true,
+            explicit_resource_management: true,
+            ..Default::default()
+        }),
+        _ => Syntax::Es(EsSyntax {
+            jsx: true,
+            decorators: true,
+            import_attributes: true,
+            explicit_resource_management: true,
+            ..Default::default()
+        }),
+    }
+}
+
+fn expected_output_path(input: &Path) -> PathBuf {
+    let ext = input
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("js");
+    input.with_file_name(format!("output.{ext}"))
+}
+
+fn compare_or_update(path: &Path, mut content: String) {
+    if !content.ends_with('\n') {
+        content.push('\n');
+    }
+
+    if std::env::var("UPDATE").is_ok() {
+        fs::write(path, &content)
+            .unwrap_or_else(|err| panic!("failed to update snapshot {}: {err}", path.display()));
+        return;
+    }
+
+    NormalizedOutput::from(content)
+        .compare_to_file(path)
+        .unwrap_or_else(|_| panic!("snapshot mismatch: {}", path.display()));
+}
+
+fn run_fixture(path: PathBuf) {
+    let syntax = syntax_for_path(&path);
+
+    testing::run_test(false, |cm, handler| {
+        let fm = cm
+            .load_file(&path)
+            .unwrap_or_else(|err| panic!("failed to load fixture {}: {err}", path.display()));
+
+        let comments = SingleThreadedComments::default();
+        let mut recovered = Vec::new();
+        let parsed = parse_file_as_program(&fm, syntax, Some(&comments), &mut recovered)
+            .unwrap_or_else(|err| panic!("failed to parse fixture {}: {err:?}", path.display()));
+
+        for error in recovered {
+            error.into_diagnostic(handler).emit();
+        }
+
+        if handler.has_errors() {
+            return Err(());
+        }
+
+        let emitted = emit_program(&parsed.store, parsed.program)
+            .unwrap_or_else(|err| panic!("failed to emit fixture {}: {err}", path.display()));
+
+        let output = expected_output_path(&path);
+        compare_or_update(&output, emitted.clone());
+
+        let roundtrip_fm = cm.new_source_file(
+            FileName::Custom("roundtrip.js".into()).into(),
+            emitted.clone(),
+        );
+        let mut roundtrip_recovered = Vec::new();
+        let roundtrip_parsed = parse_file_as_program(
+            &roundtrip_fm,
+            syntax,
+            Some(&comments),
+            &mut roundtrip_recovered,
+        )
+        .unwrap_or_else(|err| panic!("failed to parse emitted output {}: {err:?}", path.display()));
+
+        for error in roundtrip_recovered {
+            error.into_diagnostic(handler).emit();
+        }
+
+        if handler.has_errors() {
+            return Err(());
+        }
+
+        let emitted_again = emit_program(&roundtrip_parsed.store, roundtrip_parsed.program)
+            .unwrap_or_else(|err| panic!("failed to re-emit fixture {}: {err}", path.display()));
+
+        assert_eq!(
+            emitted,
+            emitted_again,
+            "emit -> parse -> emit should be idempotent for {}",
+            path.display()
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[testing::fixture("tests/fixture/**/input.js")]
+fn fixture_js(path: PathBuf) {
+    run_fixture(path);
+}
+
+#[testing::fixture("tests/fixture/**/input.jsx")]
+fn fixture_jsx(path: PathBuf) {
+    run_fixture(path);
+}
+
+#[testing::fixture("tests/fixture/**/input.ts")]
+fn fixture_ts(path: PathBuf) {
+    run_fixture(path);
+}
+
+#[testing::fixture("tests/fixture/**/input.tsx")]
+fn fixture_tsx(path: PathBuf) {
+    run_fixture(path);
+}

--- a/crates/swc_es_codegen/tests/fixture/basic/input.js
+++ b/crates/swc_es_codegen/tests/fixture/basic/input.js
@@ -1,0 +1,24 @@
+let a = 1 + 2 * 3;
+const b = { x: a, __spread__: rest };
+function f(x, y) {
+  if (x) return y;
+  return 0;
+}
+class C extends B {
+  static m(x) {
+    return x ?? 0;
+  }
+  static {
+    a++;
+  }
+  p = 1;
+}
+for (let i = 0; i < 3; i++) a += i;
+for (const k in obj) break;
+for (const v of arr) a = v;
+switch (a) {
+  case 1:
+    break;
+  default:
+    throw err;
+}

--- a/crates/swc_es_codegen/tests/fixture/basic/output.js
+++ b/crates/swc_es_codegen/tests/fixture/basic/output.js
@@ -1,0 +1,1 @@
+let a=1+2*3;const b={x:a,...rest};function f(x,y){if(x)return y;return 0;}class C extends B{static m(x){return x??0;}static{a++;}p=1;}for(let i=0;i<3;i++)a+=i;for(const k in obj)break;for(const v of arr)a=v;switch(a){case 1:break;default:throw err;}

--- a/crates/swc_es_codegen/tests/fixture/bench/input.js
+++ b/crates/swc_es_codegen/tests/fixture/bench/input.js
@@ -1,0 +1,20 @@
+const table = { __spread__: base, a: 1, b: 2, c: 3 };
+function compute(items) {
+  let total = 0;
+  for (let i = 0; i < items.length; i++) {
+    const item = items[i];
+    if (item && item.enabled) {
+      total += item.value ?? 0;
+    }
+  }
+  return total;
+}
+class Worker {
+  static {
+    init();
+  }
+  run(items) {
+    return compute(items.map((item) => item.value + 1));
+  }
+}
+export { compute, Worker, table };

--- a/crates/swc_es_codegen/tests/fixture/bench/input.tsx
+++ b/crates/swc_es_codegen/tests/fixture/bench/input.tsx
@@ -1,0 +1,11 @@
+type Props = {
+  value: number;
+  render(v: number): string;
+};
+
+function View(props: Props) {
+  return <div className="root">{props.render(props.value)}</div>;
+}
+
+const node = <View value={1} render={(v) => `${v}`} />;
+export { View, node };

--- a/crates/swc_es_codegen/tests/fixture/bench/output.js
+++ b/crates/swc_es_codegen/tests/fixture/bench/output.js
@@ -1,0 +1,1 @@
+const table={...base,a:1,b:2,c:3};function compute(items){let total=0;for(let i=0;i<items.length;i++){const item=items[i];if(item&&item.enabled){total+=item.value??0;}}return total;}class Worker{static{init();}run(items){return compute(items.map((item)=>item.value+1));}}export{compute,Worker,table};

--- a/crates/swc_es_codegen/tests/fixture/bench/output.tsx
+++ b/crates/swc_es_codegen/tests/fixture/bench/output.tsx
@@ -1,0 +1,1 @@
+type Props = {value:number;render(v:number):string;};function View(props){return <div className="root">{props.render(props.value)}</div>;}const node=<View value={1} render={(v)=>`\${v}`}/>;export{View,node};

--- a/crates/swc_es_codegen/tests/fixture/class/input.js
+++ b/crates/swc_es_codegen/tests/fixture/class/input.js
@@ -1,0 +1,19 @@
+@sealed
+class Service extends Base {
+  @readonly
+  prop = 1;
+  #value = 2;
+  @log
+  method(@param arg) {
+    return this.#value + arg;
+  }
+  get value() {
+    return this.#value;
+  }
+  set value(v) {
+    this.#value = v;
+  }
+  static {
+    init();
+  }
+}

--- a/crates/swc_es_codegen/tests/fixture/class/output.js
+++ b/crates/swc_es_codegen/tests/fixture/class/output.js
@@ -1,0 +1,1 @@
+@sealed class Service extends Base{@readonly prop=1;#value=2;@log method(@param arg){return this.#value+arg;}get value(){return this.#value;}set value(v){this.#value=v;}static{init();}}

--- a/crates/swc_es_codegen/tests/fixture/jsx/input.jsx
+++ b/crates/swc_es_codegen/tests/fixture/jsx/input.jsx
@@ -1,0 +1,2 @@
+const el = <App foo="bar" {...props}><Item>{value}</Item>text</App>;
+const selfClosing = <Box data={1} />;

--- a/crates/swc_es_codegen/tests/fixture/jsx/output.jsx
+++ b/crates/swc_es_codegen/tests/fixture/jsx/output.jsx
@@ -1,0 +1,1 @@
+const el=<App foo="bar" {...props}><Item>{value}</Item>text</App>;const selfClosing=<Box data={1}/>;

--- a/crates/swc_es_codegen/tests/fixture/module/input.js
+++ b/crates/swc_es_codegen/tests/fixture/module/input.js
@@ -1,0 +1,7 @@
+import a, { b as c, "d-e" as de } from "m1" with { type: "json" };
+import * as ns from "m2";
+import "m3";
+export { a, c as cc, "d-e" as de } from "m1" with { type: "json" };
+export * as all from "m2";
+export default class Defaulted extends Base {}
+export const value = 1;

--- a/crates/swc_es_codegen/tests/fixture/module/output.js
+++ b/crates/swc_es_codegen/tests/fixture/module/output.js
@@ -1,0 +1,1 @@
+import a,{b as c,"d-e" as de} from "m1" with {type:"json"};import * as ns from "m2";import "m3";export{a,c as cc,"d-e" as de} from "m1" with {type:"json"};export * as all from "m2";export default class Defaulted extends Base{}export const value=1;

--- a/crates/swc_es_codegen/tests/fixture/precedence/input.js
+++ b/crates/swc_es_codegen/tests/fixture/precedence/input.js
@@ -1,0 +1,6 @@
+const v = a + b * c ** d;
+const w = (a ? b : c) + d;
+const x = a = b = c;
+const y = a ** (b ** c);
+const z = (a, b, c);
+foo((a, b), c ? d : e, (f = g));

--- a/crates/swc_es_codegen/tests/fixture/precedence/output.js
+++ b/crates/swc_es_codegen/tests/fixture/precedence/output.js
@@ -1,0 +1,1 @@
+const v=a+b*c**d;const w=(a?b:c)+d;const x=a=b=c;const y=a**(b**c);const z=(a,b,c);foo((a,b),c?d:e,(f=g));

--- a/crates/swc_es_codegen/tests/fixture/typescript/input.ts
+++ b/crates/swc_es_codegen/tests/fixture/typescript/input.ts
@@ -1,0 +1,17 @@
+declare namespace A.B {
+  let n: number;
+}
+type Pair<T> = [T, T];
+interface I<T> extends Base, Extra {
+  readonly x?: T;
+  call(a: T): Pair<T>;
+  [k: string]: T;
+}
+const enum E {
+  A = 1,
+  B = 2,
+}
+type C<T> = T extends string ? number : boolean;
+type R = import("pkg").Type<string[]>;
+type Q = typeof Foo;
+let value: C<string>;

--- a/crates/swc_es_codegen/tests/fixture/typescript/output.ts
+++ b/crates/swc_es_codegen/tests/fixture/typescript/output.ts
@@ -1,0 +1,1 @@
+declare namespace A.B{let n;}type Pair<T> = [T,T];interface I<T> extends Base,Extra{readonly x?:T;call(a:T):Pair<T>;[k:string]:T;}const enum E{A=1,B=2}type C<T> = T extends string?number:boolean;type R = import("pkg").Type<string[]>;type Q = typeof Foo;let value;

--- a/crates/swc_es_codegen/tests/no_ecma_dependency.rs
+++ b/crates/swc_es_codegen/tests/no_ecma_dependency.rs
@@ -1,0 +1,54 @@
+use std::{fs, path::PathBuf};
+
+use walkdir::WalkDir;
+
+fn scan_tree_for_ecma_refs(root: &PathBuf, skip_file_name: Option<&str>) {
+    for entry in WalkDir::new(root).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+
+        let path = entry.path();
+        if path.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        if skip_file_name
+            .is_some_and(|name| path.file_name().and_then(|n| n.to_str()) == Some(name))
+        {
+            continue;
+        }
+
+        let source = fs::read_to_string(path)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", path.display()));
+        assert!(
+            !source.contains("swc_ecma_"),
+            "source file {} must not reference swc_ecma_*",
+            path.display()
+        );
+    }
+}
+
+#[test]
+fn src_does_not_reference_swc_ecma_crates() {
+    let src_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src");
+    scan_tree_for_ecma_refs(&src_root, None);
+}
+
+#[test]
+fn tests_do_not_reference_swc_ecma_crates() {
+    let test_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+    scan_tree_for_ecma_refs(&test_root, Some("no_ecma_dependency.rs"));
+}
+
+#[test]
+fn cargo_manifest_does_not_reference_swc_ecma_crates() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+    let source = fs::read_to_string(&manifest)
+        .unwrap_or_else(|err| panic!("failed to read {}: {err}", manifest.display()));
+
+    assert!(
+        !source.contains("swc_ecma_"),
+        "Cargo.toml must not reference swc_ecma_*: {}",
+        manifest.display()
+    );
+}


### PR DESCRIPTION
## Summary
- add a new standalone crate `swc_es_codegen` for `swc_es_ast`
- implement a fresh canonical emitter without `swc_ecma_*` runtime/source dependency
- expose `emit_program`, `emit_program_with_config`, `CodegenConfig`, `OutputFormat`, and enum-based error model
- add fixture/error/dependency-guard tests and emission benchmark

## Details
- single-pass writer based on `Vec<u8>` with direct token appends
- precedence-based expression emission with minimal required parentheses
- supports JS/TS/JSX nodes in `swc_es_ast`, including parser sentinel restoration (`__spread__`, JSX `...`) and private identifiers
- import/export names are safely emitted as strings when needed

## Verification
- `git submodule update --init --recursive`
- `cargo test -p swc_es_codegen`
- `cargo test -p swc_es_codegen --test fixture -- --ignored`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
