### PR TITLE
test(swc_es_codegen): expand fixture coverage and document dependency boundary

### DIFF
--- a/crates/swc_es_codegen/AGENTS.md
+++ b/crates/swc_es_codegen/AGENTS.md
@@ -1,0 +1,10 @@
+### Fixture Test Addition Guide
+
+- Preferred fixture roots in this crate: `tests/fixtures`, `tests/fixture`.
+- Update generated fixture outputs with: `UPDATE=1 cargo test -p swc_es_codegen`.
+- Verify without `UPDATE` before finishing: `cargo test -p swc_es_codegen`.
+
+### Dependency Boundary
+
+- Runtime dependencies in `[dependencies]` must not include any `swc_ecma_*` crate.
+- `swc_ecma_*` usage is allowed only in non-runtime contexts such as tests and benches.

--- a/crates/swc_es_codegen/tests/common.rs
+++ b/crates/swc_es_codegen/tests/common.rs
@@ -16,27 +16,29 @@ pub struct Generated {
 }
 
 pub fn fixture_inputs() -> Vec<PathBuf> {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .join("tests")
-        .join("fixtures");
+    let tests_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests");
+    let mut files = Vec::new();
 
-    let mut files: Vec<PathBuf> = WalkDir::new(&root)
-        .into_iter()
-        .filter_map(Result::ok)
-        .filter(|entry| entry.file_type().is_file())
-        .filter(|entry| {
-            let name = entry.file_name().to_string_lossy();
-            name == "input.js"
-                || name == "input.mjs"
-                || name == "input.ts"
-                || name == "input.tsx"
-                || name == "input.jsx"
-        })
-        .map(|entry| entry.path().to_path_buf())
-        .collect();
+    for root in ["fixtures", "fixture"] {
+        files.extend(
+            WalkDir::new(tests_root.join(root))
+                .into_iter()
+                .filter_map(Result::ok)
+                .filter(|entry| entry.file_type().is_file())
+                .filter(|entry| is_fixture_input(entry.file_name().to_string_lossy().as_ref()))
+                .map(|entry| entry.path().to_path_buf()),
+        );
+    }
 
     files.sort();
     files
+}
+
+fn is_fixture_input(name: &str) -> bool {
+    matches!(
+        name,
+        "input.js" | "input.mjs" | "input.ts" | "input.tsx" | "input.jsx"
+    )
 }
 
 pub fn run_fixture(input: &Path) -> Generated {

--- a/crates/swc_es_codegen/tests/fixture/module-attrs/output.js
+++ b/crates/swc_es_codegen/tests/fixture/module-attrs/output.js
@@ -1,0 +1,3 @@
+import foo, {bar as baz}, {qux} from "pkg" with {type: "json", mode: "strict"};
+export {baz as fooExport} from "pkg" with {type: "json"};
+export * as ns from "pkg2" with {type: "json"};

--- a/crates/swc_es_codegen/tests/fixture/module-attrs/output.min.js
+++ b/crates/swc_es_codegen/tests/fixture/module-attrs/output.min.js
@@ -1,0 +1,1 @@
+import foo,{bar as baz},{qux} from "pkg" with {type:"json",mode:"strict"};export {baz as fooExport} from "pkg" with {type:"json"};export * as ns from "pkg2" with {type:"json"};

--- a/crates/swc_es_codegen/tests/fixture/tsx-basic/output.js
+++ b/crates/swc_es_codegen/tests/fixture/tsx-basic/output.js
@@ -1,0 +1,2 @@
+type Props = {value: string | number;};
+const view = <Comp foo={value as Props} bar={"ok"}/>;

--- a/crates/swc_es_codegen/tests/fixture/tsx-basic/output.min.js
+++ b/crates/swc_es_codegen/tests/fixture/tsx-basic/output.min.js
@@ -1,0 +1,1 @@
+type Props={value:string | number;};const view=<Comp foo={value as Props} bar={"ok"}/>;


### PR DESCRIPTION
## Summary
- include both tests/fixtures and tests/fixture in the swc_es_codegen fixture discovery loop
- add snapshot outputs for existing fixture inputs under tests/fixture/module-attrs and tests/fixture/tsx-basic
- add crate-local AGENTS.md guidance for fixture update workflow and runtime dependency boundary (no swc_ecma_* in runtime deps)

## Testing
- git submodule update --init --recursive
- UPDATE=1 cargo test -p swc_es_codegen
- cargo test -p swc_es_codegen
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings