### PR TITLE
docs(es): add AGENTS two-pass rules for es crates

### DIFF
--- a/crates/swc_es_minifier/AGENTS.md
+++ b/crates/swc_es_minifier/AGENTS.md
@@ -1,0 +1,8 @@
+### Instructions
+
+- This crate must operate in exactly two passes.
+- Pass 1 is the analysis pass. It must collect data only and must not transform the AST.
+- Pass 2 is the transform pass. It must apply transformations using data from pass 1.
+- Do not add a third pass, and do not merge analysis and transformation into a single pass.
+- Never add dependencies on any `swc_ecma_*` crate.
+

--- a/crates/swc_es_transforms/AGENTS.md
+++ b/crates/swc_es_transforms/AGENTS.md
@@ -1,0 +1,8 @@
+### Instructions
+
+- This crate must operate in exactly two passes.
+- Pass 1 is the analysis pass. It must collect data only and must not transform the AST.
+- Pass 2 is the transform pass. It must apply transformations using data from pass 1.
+- Do not add a third pass, and do not merge analysis and transformation into a single pass.
+- Never add dependencies on any `swc_ecma_*` crate.
+


### PR DESCRIPTION
## Summary
- add AGENTS.md to crates/swc_es_transforms
- add AGENTS.md to crates/swc_es_minifier
- document strict 2-pass rule (analysis pass, then transform pass)
- document prohibition on dependencies to any swc_ecma_* crates

## Testing
- not run (docs-only change)