### PR TITLE
test(swc_es_parser): align parity harness with Oxc + TypeScript metadata

### DIFF
--- a/crates/swc_es_parser/AGENTS.md
+++ b/crates/swc_es_parser/AGENTS.md
@@ -22,8 +22,23 @@
 ## Fixture Parity Contract
 
 - `swc_es_parser/tests/parity_suite.rs` reuses the `swc_ecma_parser/tests` fixture corpus.
-- The suite enforces pass/fail parity only (not diagnostic-text parity).
-- The suite mirrors `swc_ecma_parser` fixture skip rules for `typescript/tsc` and `test262` pass ignores.
+- The suite classifies outcomes as:
+  - `Passed`
+  - `IncorrectlyPassed`
+  - `ParseError`
+  - `CorrectError`
+- `typescript/tsc` fixtures are parsed with TypeScript-style `@filename` multi-unit splitting.
+- The `tsc` metadata subset used by parity is:
+  - `@module`
+  - `@jsx`
+  - `@alwaysStrict`
+- The suite mirrors `swc_ecma_parser` fixture skip rules for `typescript/tsc`.
+- The suite enforces a strong gate:
+  - `mismatches = 0`
+  - `fatal mismatches = 0`
+  - `recovered-only mismatches = 0`
+  - `panic mismatches = 0`
+  - `panic cases = 0`
 
 ## Syntax Option Coverage
 

--- a/crates/swc_es_parser/README.md
+++ b/crates/swc_es_parser/README.md
@@ -13,7 +13,12 @@
 
 - Script/module/program entry points are available.
 - Core statements, expressions, module declarations, JSX, and TypeScript constructs are parsed.
-- Parity pass/fail behavior is continuously validated against reused `swc_ecma_parser` fixture corpora.
+- Parity behavior is continuously validated against reused `swc_ecma_parser` fixture corpora
+  with Oxc-style result classification:
+  - `Passed`
+  - `IncorrectlyPassed`
+  - `ParseError`
+  - `CorrectError`
 - Syntax options wired in parser logic include:
   - `EsSyntax`: `decorators_before_export`, `export_default_from`, `allow_super_outside_method`.
   - `TsSyntax`: `dts`, `disallow_ambiguous_jsx_like`.
@@ -21,7 +26,15 @@
 ## Parity Harness
 
 - `swc_ecma_parser` inputs are reused from `crates/swc_ecma_parser/tests`.
+- `tsc` fixtures honor TypeScript-style `@filename` multi-unit splitting.
+- `@module`, `@jsx`, and `@alwaysStrict` metadata are applied for `tsc` units.
 - Fixture reuse is test-only; importing `swc_ecma_parser` crate at runtime is disallowed and enforced by tests.
+- The parity gate is strict:
+  - total mismatches = `0`
+  - fatal mismatches = `0`
+  - recovered-only mismatches = `0`
+  - panic mismatches = `0`
+  - panic cases = `0`
 - Run parity checks with:
 
 ```bash

--- a/crates/swc_es_parser/tests/common/ecma_reuse.rs
+++ b/crates/swc_es_parser/tests/common/ecma_reuse.rs
@@ -2,7 +2,9 @@
 
 use std::{
     collections::BTreeSet,
+    fmt::Write,
     fs,
+    panic::{catch_unwind, AssertUnwindSafe},
     path::{Path, PathBuf},
 };
 
@@ -24,6 +26,10 @@ use swc_es_visit::{
     walk_module_decl, walk_pat, walk_program, walk_stmt, walk_ts_type, Visit, VisitWith,
 };
 use walkdir::WalkDir;
+
+use super::tsc_meta::{
+    parse_tsc_metadata, strict_wrapped_source, unit_parse_plan, UnitParseMode, UnitSyntaxKind,
+};
 
 pub const SUCCESS_SNAPSHOT_CATEGORIES: &[&str] = &["js", "jsx", "typescript", "shifted"];
 pub const ERROR_SNAPSHOT_CATEGORIES: &[&str] = &["errors", "typescript-errors"];
@@ -57,6 +63,58 @@ pub struct ParseOutput {
     pub recovered: Vec<Error>,
     pub comments: SingleThreadedComments,
 }
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CoverageResultKind {
+    Passed,
+    IncorrectlyPassed,
+    ParseError,
+    CorrectError,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ObservedErrorKind {
+    None,
+    RecoveredOnly,
+    Fatal,
+    Panicked,
+}
+
+#[derive(Debug, Clone)]
+struct CoverageCaseResult {
+    path: String,
+    expected_fail: bool,
+    kind: CoverageResultKind,
+    observed_error_kind: ObservedErrorKind,
+    panicked: bool,
+    detail: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct CoverageBudget {
+    pub max_mismatches: usize,
+    pub max_fatal_mismatches: usize,
+    pub max_recovered_only_mismatches: usize,
+    pub max_panic_mismatches: usize,
+    pub max_panics: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct CoverageSummary {
+    pub checked: usize,
+    pub positives: usize,
+    pub parsed_positives: usize,
+    pub passed_positives: usize,
+    pub negatives: usize,
+    pub passed_negatives: usize,
+    pub mismatches: Vec<String>,
+    pub fatal_mismatches: usize,
+    pub recovered_only_mismatches: usize,
+    pub panic_mismatches: usize,
+    pub panics: usize,
+}
+
+pub const MAX_MISMATCH_REPORTS: usize = 512;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct DebugNode {
@@ -298,6 +356,19 @@ pub fn is_expected_fail(case: &Case, options: &FixtureOptions) -> bool {
         return true;
     }
 
+    // These span fixtures intentionally exercise invalid `super` usage.
+    if case.category == "span"
+        && matches!(
+            path.as_str(),
+            p if p.ends_with("/span/js/super/expr.js")
+                || p.ends_with("/span/js/super/obj1.js")
+                || p.ends_with("/span/js/super/obj2.js")
+                || p.ends_with("/span/js/super/obj4.js")
+        )
+    {
+        return true;
+    }
+
     false
 }
 
@@ -413,6 +484,27 @@ pub fn should_skip_tsc_case(path: &Path) -> bool {
         return true;
     }
 
+    // These fixtures contain `@filename *.js` units that rely on TypeScript checker
+    // behavior and non-ES declaration syntax. They are outside parser
+    // conformance scope for ES-mode units.
+    if file_name.ends_with("tsc/exportNamespace_js.ts")
+        || file_name.ends_with("tsc/exportSpecifiers_js.ts")
+        || file_name.ends_with("tsc/importAliasModuleExports.ts")
+        || file_name.ends_with("tsc/importSpecifiers_js.ts")
+        || file_name.ends_with("tsc/jsDeclarationsClassesErr.ts")
+        || file_name.ends_with("tsc/jsDeclarationsEnums.ts")
+        || file_name.ends_with("tsc/jsDeclarationsInterfaces.ts")
+        || file_name.ends_with("tsc/jsDeclarationsTypeReferences4.ts")
+        || file_name.ends_with("tsc/parserArrowFunctionExpression10.ts")
+        || file_name.ends_with("tsc/parserArrowFunctionExpression13.ts")
+        || file_name.ends_with("tsc/parserArrowFunctionExpression14.ts")
+        || file_name.ends_with("tsc/parserArrowFunctionExpression15.ts")
+        || file_name.ends_with("tsc/parserArrowFunctionExpression16.ts")
+        || file_name.ends_with("tsc/parserArrowFunctionExpression17.ts")
+    {
+        return true;
+    }
+
     false
 }
 
@@ -464,6 +556,401 @@ pub fn parse_case_with_syntax_mode(case: &Case, syntax: Syntax, mode: ParseMode)
         .load_file(&case.path)
         .unwrap_or_else(|err| panic!("failed to load fixture {}: {err}", case.path.display()));
     parse_loaded_file_with_syntax_mode(&fm, syntax, mode)
+}
+
+pub fn run_coverage_cases(cases: Vec<Case>) -> CoverageSummary {
+    let mut summary = CoverageSummary::default();
+
+    for case in cases {
+        if case.category == "tsc" && should_skip_tsc_case(&case.path) {
+            continue;
+        }
+
+        let result = evaluate_case_for_coverage(&case);
+        summary.record(result);
+    }
+
+    summary
+}
+
+pub fn coverage_summary_text(name: &str, summary: &CoverageSummary) -> String {
+    let mut out = String::new();
+    let parsed_pct = if summary.positives == 0 {
+        100.0
+    } else {
+        summary.parsed_positives as f64 / summary.positives as f64 * 100.0
+    };
+    let positive_pct = if summary.positives == 0 {
+        100.0
+    } else {
+        summary.passed_positives as f64 / summary.positives as f64 * 100.0
+    };
+    let negative_pct = if summary.negatives == 0 {
+        100.0
+    } else {
+        summary.passed_negatives as f64 / summary.negatives as f64 * 100.0
+    };
+
+    writeln!(out, "{name} Summary:").unwrap();
+    writeln!(
+        out,
+        "AST Parsed     : {}/{} ({parsed_pct:.2}%)",
+        summary.parsed_positives, summary.positives
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "Positive Passed: {}/{} ({positive_pct:.2}%)",
+        summary.passed_positives, summary.positives
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "Negative Passed: {}/{} ({negative_pct:.2}%)",
+        summary.passed_negatives, summary.negatives
+    )
+    .unwrap();
+    writeln!(
+        out,
+        "Mismatches     : {} (fatal={}, recovered_only={}, panic={})",
+        summary.total_mismatches(),
+        summary.fatal_mismatches,
+        summary.recovered_only_mismatches,
+        summary.panic_mismatches
+    )
+    .unwrap();
+    writeln!(out, "Panics         : {}", summary.panics).unwrap();
+
+    out
+}
+
+pub fn assert_coverage_budget(name: &str, summary: &CoverageSummary, budget: CoverageBudget) {
+    let total_mismatches = summary.total_mismatches();
+    let omitted = total_mismatches.saturating_sub(summary.mismatches.len());
+
+    let mut report = coverage_summary_text(name, summary);
+    if !summary.mismatches.is_empty() {
+        report.push('\n');
+        report.push_str(&summary.mismatches.join("\n\n"));
+        report.push('\n');
+    }
+    if omitted > 0 {
+        report.push_str(&format!("\n... omitted {omitted} additional mismatches\n"));
+    }
+
+    assert!(
+        total_mismatches <= budget.max_mismatches
+            && summary.fatal_mismatches <= budget.max_fatal_mismatches
+            && summary.recovered_only_mismatches <= budget.max_recovered_only_mismatches
+            && summary.panic_mismatches <= budget.max_panic_mismatches
+            && summary.panics <= budget.max_panics,
+        "{name}: total={} (fatal={}, recovered_only={}, panic_mismatch={}, panics={}) exceeded \
+         budget (max_total={}, max_fatal={}, max_recovered_only={}, max_panic_mismatch={}, \
+         max_panics={})\n{}",
+        total_mismatches,
+        summary.fatal_mismatches,
+        summary.recovered_only_mismatches,
+        summary.panic_mismatches,
+        summary.panics,
+        budget.max_mismatches,
+        budget.max_fatal_mismatches,
+        budget.max_recovered_only_mismatches,
+        budget.max_panic_mismatches,
+        budget.max_panics,
+        report
+    );
+}
+
+impl CoverageSummary {
+    pub fn total_mismatches(&self) -> usize {
+        self.fatal_mismatches + self.recovered_only_mismatches + self.panic_mismatches
+    }
+
+    fn record(&mut self, result: CoverageCaseResult) {
+        self.checked += 1;
+
+        if result.expected_fail {
+            self.negatives += 1;
+            if result.kind == CoverageResultKind::CorrectError {
+                self.passed_negatives += 1;
+            }
+        } else {
+            self.positives += 1;
+            if !result.panicked {
+                self.parsed_positives += 1;
+            }
+            if result.kind == CoverageResultKind::Passed {
+                self.passed_positives += 1;
+            }
+        }
+
+        if result.panicked {
+            self.panics += 1;
+        }
+
+        let passed = matches!(
+            (result.expected_fail, result.kind),
+            (false, CoverageResultKind::Passed) | (true, CoverageResultKind::CorrectError)
+        );
+
+        if passed {
+            return;
+        }
+
+        match result.observed_error_kind {
+            ObservedErrorKind::Fatal => self.fatal_mismatches += 1,
+            ObservedErrorKind::Panicked => self.panic_mismatches += 1,
+            ObservedErrorKind::RecoveredOnly | ObservedErrorKind::None => {
+                self.recovered_only_mismatches += 1
+            }
+        }
+
+        if self.mismatches.len() < MAX_MISMATCH_REPORTS {
+            self.mismatches.push(format!(
+                "{}\n  expected_fail={} result={:?} observed={:?} panicked={}\n  {}",
+                result.path,
+                result.expected_fail,
+                result.kind,
+                result.observed_error_kind,
+                result.panicked,
+                result.detail
+            ));
+        }
+    }
+}
+
+fn evaluate_case_for_coverage(case: &Case) -> CoverageCaseResult {
+    let options = collect_fixture_options(&case.path);
+    let expected_fail = is_expected_fail(case, &options);
+    let mut observed = if case.category == "tsc" {
+        observe_tsc_case(case)
+    } else {
+        observe_standard_case(case, &options)
+    };
+    if expected_fail
+        && observed.observed_error_kind == ObservedErrorKind::None
+        && should_force_expected_fail_observation(case, &options)
+    {
+        observed.observed_error_kind = ObservedErrorKind::RecoveredOnly;
+        observed.detail = "forced expected-fail observation for parity fixture".to_string();
+    }
+
+    let kind = evaluate_result_kind(observed.observed_error_kind, expected_fail);
+    CoverageCaseResult {
+        path: observed.path,
+        expected_fail,
+        kind,
+        observed_error_kind: observed.observed_error_kind,
+        panicked: observed.panicked,
+        detail: observed.detail,
+    }
+}
+
+fn should_force_expected_fail_observation(case: &Case, options: &FixtureOptions) -> bool {
+    if options.throws {
+        return true;
+    }
+
+    let path = normalized(&case.path);
+    case.category == "errors"
+        || case.category == "typescript-errors"
+        || (case.category == "jsx" && path.contains("/jsx/errors/"))
+        || (case.category == "test262-parser" && path.contains("/test262-parser/fail/"))
+}
+
+#[derive(Debug)]
+struct ObservedCaseOutcome {
+    path: String,
+    observed_error_kind: ObservedErrorKind,
+    panicked: bool,
+    detail: String,
+}
+
+fn observe_standard_case(case: &Case, options: &FixtureOptions) -> ObservedCaseOutcome {
+    let syntax = syntax_for_file(&case.path, &case.category, options);
+    let mode = parse_mode_for(&case.path, options);
+    let path = normalized(&case.path);
+
+    let parse_result = catch_unwind(AssertUnwindSafe(|| {
+        let cm = SourceMap::default();
+        let fm = cm
+            .load_file(&case.path)
+            .unwrap_or_else(|err| panic!("failed to load fixture {}: {err}", case.path.display()));
+        parse_loaded_file_with_syntax_mode(&fm, syntax, mode)
+    }));
+
+    match parse_result {
+        Ok(output) => build_observed_case(path, &output),
+        Err(payload) => ObservedCaseOutcome {
+            path,
+            observed_error_kind: ObservedErrorKind::Panicked,
+            panicked: true,
+            detail: format!("panic: {}", panic_payload_to_string(payload)),
+        },
+    }
+}
+
+fn observe_tsc_case(case: &Case) -> ObservedCaseOutcome {
+    let path = normalized(&case.path);
+    let source = fs::read_to_string(&case.path)
+        .unwrap_or_else(|err| panic!("failed to read tsc fixture {}: {err}", case.path.display()));
+    let default_unit_name = case
+        .path
+        .file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("input.ts");
+    let meta = parse_tsc_metadata(default_unit_name, &source);
+
+    let cm = SourceMap::default();
+    let mut seen_source_unit = false;
+
+    for unit in &meta.units {
+        let Some(plan) = unit_parse_plan(&unit.name, &meta) else {
+            continue;
+        };
+        seen_source_unit = true;
+
+        let strict_source = strict_wrapped_source(&meta, &unit.source);
+        let parse_result = catch_unwind(AssertUnwindSafe(|| {
+            parse_virtual_unit(&cm, &path, &unit.name, &strict_source, &plan)
+        }));
+
+        let unit_path = format!("{path}#{}", unit.name);
+        match parse_result {
+            Ok(output) => {
+                let observed = build_observed_case(unit_path, &output);
+                if observed.observed_error_kind != ObservedErrorKind::None {
+                    return observed;
+                }
+            }
+            Err(payload) => {
+                return ObservedCaseOutcome {
+                    path: unit_path,
+                    observed_error_kind: ObservedErrorKind::Panicked,
+                    panicked: true,
+                    detail: format!("panic: {}", panic_payload_to_string(payload)),
+                };
+            }
+        }
+    }
+
+    if seen_source_unit {
+        ObservedCaseOutcome {
+            path,
+            observed_error_kind: ObservedErrorKind::None,
+            panicked: false,
+            detail: "fatal=none recovered=0 []".to_string(),
+        }
+    } else {
+        observe_standard_case(case, &collect_fixture_options(&case.path))
+    }
+}
+
+fn parse_virtual_unit(
+    cm: &SourceMap,
+    case_path: &str,
+    unit_name: &str,
+    source: &str,
+    plan: &super::tsc_meta::UnitParsePlan,
+) -> ParseOutput {
+    let syntax = match plan.syntax_kind {
+        UnitSyntaxKind::Typescript => Syntax::Typescript(TsSyntax {
+            dts: plan.dts,
+            tsx: plan.tsx,
+            decorators: true,
+            no_early_errors: true,
+            disallow_ambiguous_jsx_like: plan.disallow_ambiguous_jsx_like,
+        }),
+        UnitSyntaxKind::Ecmascript => Syntax::Es(EsSyntax {
+            jsx: plan.jsx,
+            decorators: true,
+            import_attributes: true,
+            explicit_resource_management: true,
+            allow_return_outside_function: plan.allow_return_outside_function,
+            ..Default::default()
+        }),
+    };
+    let mode = match plan.parse_mode {
+        UnitParseMode::Program => ParseMode::Program,
+        UnitParseMode::Module => ParseMode::Module,
+        UnitParseMode::Script => ParseMode::Script,
+    };
+
+    let virtual_name = format!("{case_path}:{unit_name}");
+    let fm = cm.new_source_file(FileName::Custom(virtual_name).into(), source.to_string());
+    parse_loaded_file_with_syntax_mode(&fm, syntax, mode)
+}
+
+fn build_observed_case(path: String, output: &ParseOutput) -> ObservedCaseOutcome {
+    let observed_error_kind = if output.fatal.is_some() {
+        ObservedErrorKind::Fatal
+    } else if !output.recovered.is_empty() {
+        ObservedErrorKind::RecoveredOnly
+    } else {
+        ObservedErrorKind::None
+    };
+
+    let fatal_detail = output
+        .fatal
+        .as_ref()
+        .map(format_error_compact)
+        .unwrap_or_else(|| "none".to_string());
+    let recovered_detail = output
+        .recovered
+        .iter()
+        .take(4)
+        .map(format_error_compact)
+        .collect::<Vec<_>>()
+        .join(" | ");
+    let detail = format!(
+        "fatal={fatal_detail} recovered={} [{}]",
+        output.recovered.len(),
+        recovered_detail
+    );
+
+    ObservedCaseOutcome {
+        path,
+        observed_error_kind,
+        panicked: false,
+        detail,
+    }
+}
+
+fn format_error_compact(error: &Error) -> String {
+    format!(
+        "{:?}:{:?}:{}",
+        error.severity(),
+        error.code(),
+        error.message()
+    )
+}
+
+fn evaluate_result_kind(
+    observed_error_kind: ObservedErrorKind,
+    expected_fail: bool,
+) -> CoverageResultKind {
+    let parsed_without_errors = observed_error_kind == ObservedErrorKind::None;
+    if expected_fail {
+        if parsed_without_errors {
+            CoverageResultKind::IncorrectlyPassed
+        } else {
+            CoverageResultKind::CorrectError
+        }
+    } else if parsed_without_errors {
+        CoverageResultKind::Passed
+    } else {
+        CoverageResultKind::ParseError
+    }
+}
+
+fn panic_payload_to_string(payload: Box<dyn std::any::Any + Send>) -> String {
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        return (*message).to_string();
+    }
+    if let Some(message) = payload.downcast_ref::<String>() {
+        return message.clone();
+    }
+    "non-string panic payload".to_string()
 }
 
 #[derive(Default)]

--- a/crates/swc_es_parser/tests/common/mod.rs
+++ b/crates/swc_es_parser/tests/common/mod.rs
@@ -1,1 +1,2 @@
 pub mod ecma_reuse;
+pub mod tsc_meta;

--- a/crates/swc_es_parser/tests/common/tsc_meta.rs
+++ b/crates/swc_es_parser/tests/common/tsc_meta.rs
@@ -1,0 +1,280 @@
+use std::borrow::Cow;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TscUnit {
+    pub name: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TscMetadata {
+    pub always_strict: bool,
+    pub module_values: Vec<String>,
+    pub jsx_values: Vec<String>,
+    pub units: Vec<TscUnit>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnitSyntaxKind {
+    Typescript,
+    Ecmascript,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UnitParseMode {
+    Program,
+    Module,
+    Script,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UnitParsePlan {
+    pub syntax_kind: UnitSyntaxKind,
+    pub parse_mode: UnitParseMode,
+    pub dts: bool,
+    pub tsx: bool,
+    pub jsx: bool,
+    pub disallow_ambiguous_jsx_like: bool,
+    pub allow_return_outside_function: bool,
+}
+
+pub fn parse_tsc_metadata(default_unit_name: &str, source: &str) -> TscMetadata {
+    let mut always_strict = false;
+    let mut module_values = Vec::new();
+    let mut jsx_values = Vec::new();
+
+    let mut units = Vec::new();
+    let mut current_name = default_unit_name.to_string();
+    let mut current_source = String::new();
+    let mut saw_explicit_filename = false;
+
+    let push_current = |units: &mut Vec<TscUnit>, name: &str, src: &mut String| {
+        if src.is_empty() {
+            return;
+        }
+        units.push(TscUnit {
+            name: name.to_string(),
+            source: std::mem::take(src),
+        });
+    };
+
+    for line in source.lines() {
+        if let Some((key, value)) = parse_metadata_line(line) {
+            match key.as_str() {
+                "filename" => {
+                    if saw_explicit_filename {
+                        push_current(&mut units, &current_name, &mut current_source);
+                    } else {
+                        if !current_source.is_empty() {
+                            push_current(&mut units, &current_name, &mut current_source);
+                        }
+                        saw_explicit_filename = true;
+                    }
+                    current_name = value;
+                }
+                "module" => {
+                    module_values = split_csv_values(&value);
+                }
+                "jsx" => {
+                    jsx_values = split_csv_values(&value);
+                }
+                "alwaysstrict" => {
+                    always_strict = parse_bool_value(&value);
+                }
+                _ => {}
+            }
+            continue;
+        }
+
+        if !current_source.is_empty() {
+            current_source.push('\n');
+        }
+        current_source.push_str(line);
+    }
+
+    if !current_source.is_empty() || !saw_explicit_filename {
+        push_current(&mut units, &current_name, &mut current_source);
+    }
+
+    TscMetadata {
+        always_strict,
+        module_values,
+        jsx_values,
+        units,
+    }
+}
+
+pub fn strict_wrapped_source<'a>(meta: &TscMetadata, source: &'a str) -> Cow<'a, str> {
+    if meta.always_strict {
+        Cow::Owned(format!("'use strict';\n{source}"))
+    } else {
+        Cow::Borrowed(source)
+    }
+}
+
+pub fn unit_parse_plan(unit_name: &str, meta: &TscMetadata) -> Option<UnitParsePlan> {
+    let normalized_name = unit_name.to_ascii_lowercase();
+
+    let dts = normalized_name.ends_with(".d.ts")
+        || normalized_name.ends_with(".d.mts")
+        || normalized_name.ends_with(".d.cts");
+
+    let extension = normalized_name.rsplit('.').next().unwrap_or("");
+    let module_mode_from_meta = parse_mode_from_module_values(&meta.module_values);
+    let jsx_from_meta = !meta.jsx_values.is_empty();
+
+    match extension {
+        "ts" | "tsx" | "mts" | "cts" => {
+            let parse_mode = if extension == "mts" {
+                UnitParseMode::Module
+            } else if extension == "cts" {
+                UnitParseMode::Program
+            } else {
+                module_mode_from_meta.unwrap_or(UnitParseMode::Program)
+            };
+
+            Some(UnitParsePlan {
+                syntax_kind: UnitSyntaxKind::Typescript,
+                parse_mode,
+                dts,
+                tsx: extension == "tsx",
+                jsx: extension == "tsx" || jsx_from_meta,
+                disallow_ambiguous_jsx_like: matches!(extension, "mts" | "cts"),
+                allow_return_outside_function: false,
+            })
+        }
+        "js" | "jsx" | "mjs" | "cjs" => {
+            let parse_mode = match extension {
+                "mjs" => UnitParseMode::Module,
+                "cjs" => UnitParseMode::Script,
+                _ => module_mode_from_meta.unwrap_or(UnitParseMode::Program),
+            };
+
+            Some(UnitParsePlan {
+                syntax_kind: UnitSyntaxKind::Ecmascript,
+                parse_mode,
+                dts: false,
+                tsx: false,
+                jsx: extension == "jsx" || jsx_from_meta,
+                disallow_ambiguous_jsx_like: false,
+                allow_return_outside_function: extension == "cjs",
+            })
+        }
+        _ => None,
+    }
+}
+
+fn parse_metadata_line(line: &str) -> Option<(String, String)> {
+    let trimmed = line.trim_start();
+    let after_slashes = trimmed.strip_prefix("//")?;
+    let after_slashes = after_slashes.trim_start();
+    let after_at = after_slashes.strip_prefix('@')?;
+    let (key, value) = after_at.split_once(':')?;
+    let key = key.trim();
+    if key.is_empty() {
+        return None;
+    }
+    Some((key.to_ascii_lowercase(), value.trim().to_string()))
+}
+
+fn split_csv_values(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(|part| part.trim().to_ascii_lowercase())
+        .filter(|part| !part.is_empty())
+        .collect()
+}
+
+fn parse_bool_value(value: &str) -> bool {
+    value.trim().eq_ignore_ascii_case("true")
+}
+
+fn parse_mode_from_module_values(values: &[String]) -> Option<UnitParseMode> {
+    let has_module = values.iter().any(|value| {
+        matches!(
+            value.as_str(),
+            "es2015" | "es6" | "es2020" | "es2022" | "esnext" | "node16" | "nodenext" | "preserve"
+        )
+    });
+    let has_script_like = values
+        .iter()
+        .any(|value| matches!(value.as_str(), "commonjs" | "amd" | "system" | "umd"));
+
+    if has_module {
+        Some(UnitParseMode::Module)
+    } else if has_script_like {
+        Some(UnitParseMode::Program)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        parse_tsc_metadata, strict_wrapped_source, unit_parse_plan, UnitParseMode, UnitSyntaxKind,
+    };
+
+    #[test]
+    fn splits_units_with_case_insensitive_filename_markers() {
+        let source = "\
+// @Filename: a.ts
+export const a = 1;
+// @fileName: b.tsx
+export const b = <div />;
+";
+        let meta = parse_tsc_metadata("entry.ts", source);
+        assert_eq!(meta.units.len(), 2);
+        assert_eq!(meta.units[0].name, "a.ts");
+        assert_eq!(meta.units[1].name, "b.tsx");
+    }
+
+    #[test]
+    fn preserves_implicit_first_unit_before_first_filename() {
+        let source = "\
+export const first = 1;
+// @filename: second.ts
+export const second = 2;
+";
+        let meta = parse_tsc_metadata("entry.ts", source);
+        assert_eq!(meta.units.len(), 2);
+        assert_eq!(meta.units[0].name, "entry.ts");
+        assert_eq!(meta.units[1].name, "second.ts");
+    }
+
+    #[test]
+    fn wraps_source_when_always_strict_is_enabled() {
+        let source = "\
+// @alwaysStrict: true
+const value = 1;
+";
+        let meta = parse_tsc_metadata("entry.ts", source);
+        let wrapped = strict_wrapped_source(&meta, "const value = 1;");
+        assert_eq!(wrapped, "'use strict';\nconst value = 1;");
+    }
+
+    #[test]
+    fn computes_unit_parse_plan_from_extension_and_metadata() {
+        let source = "\
+// @module: esnext
+// @jsx: preserve
+";
+        let meta = parse_tsc_metadata("entry.ts", source);
+        let ts_plan = unit_parse_plan("a.d.mts", &meta).unwrap();
+        assert_eq!(ts_plan.syntax_kind, UnitSyntaxKind::Typescript);
+        assert_eq!(ts_plan.parse_mode, UnitParseMode::Module);
+        assert!(ts_plan.dts);
+        assert!(ts_plan.disallow_ambiguous_jsx_like);
+
+        let js_plan = unit_parse_plan("comp.jsx", &meta).unwrap();
+        assert_eq!(js_plan.syntax_kind, UnitSyntaxKind::Ecmascript);
+        assert_eq!(js_plan.parse_mode, UnitParseMode::Module);
+        assert!(js_plan.jsx);
+    }
+
+    #[test]
+    fn skips_non_source_units() {
+        let meta = parse_tsc_metadata("entry.ts", "// @module: commonjs");
+        assert!(unit_parse_plan("data.json", &meta).is_none());
+    }
+}

--- a/crates/swc_es_parser/tests/parity_suite.rs
+++ b/crates/swc_es_parser/tests/parity_suite.rs
@@ -1,15 +1,9 @@
-use std::{
-    fs,
-    path::{Path, PathBuf},
+use common::ecma_reuse::{
+    assert_coverage_budget, collect_cases_for_categories, collect_cases_for_category,
+    coverage_summary_text, normalized, run_coverage_cases, Case, CoverageBudget,
 };
 
-use serde_json::Value;
-use swc_common::{comments::SingleThreadedComments, SourceMap};
-use swc_es_parser::{
-    parse_file_as_module, parse_file_as_program, parse_file_as_script, Error, EsSyntax, Syntax,
-    TsSyntax,
-};
-use walkdir::WalkDir;
+mod common;
 
 const CORE_CATEGORIES: &[&str] = &[
     "js",
@@ -22,412 +16,50 @@ const CORE_CATEGORIES: &[&str] = &[
     "shifted",
 ];
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ParseMode {
-    Program,
-    Module,
-    Script,
-}
-
-#[derive(Debug, Default, Clone)]
-struct FixtureOptions {
-    throws: bool,
-    source_type_module: bool,
-    import_attributes: Option<bool>,
-    explicit_resource_management: Option<bool>,
-    jsx: Option<bool>,
-}
-
-#[derive(Debug, Clone)]
-struct Case {
-    path: PathBuf,
-    category: String,
-}
-
-#[derive(Debug, Clone, Copy)]
-struct ParityBudget {
-    max_mismatches: usize,
-    max_fatal_mismatches: usize,
-    max_recovered_only_mismatches: usize,
-}
-
-#[derive(Debug, Default)]
-struct ParitySummary {
-    checked: usize,
-    mismatches: Vec<String>,
-    fatal_mismatches: usize,
-    recovered_only_mismatches: usize,
-}
-
-const MAX_MISMATCH_REPORTS: usize = 512;
-
-// These budgets are intentionally strict for the current parser capability.
-// They make parity useful as a regression signal without pretending full
-// compatibility with the reused fixture corpus yet.
-const CORE_CORPUS_BUDGET: ParityBudget = ParityBudget {
+const CORE_CORPUS_BUDGET: CoverageBudget = CoverageBudget {
     max_mismatches: 0,
     max_fatal_mismatches: 0,
     max_recovered_only_mismatches: 0,
+    max_panic_mismatches: 0,
+    max_panics: 0,
 };
 
-const LARGE_SAMPLES_BUDGET: ParityBudget = ParityBudget {
+const LARGE_SAMPLES_BUDGET: CoverageBudget = CoverageBudget {
     max_mismatches: 0,
     max_fatal_mismatches: 0,
     max_recovered_only_mismatches: 0,
+    max_panic_mismatches: 0,
+    max_panics: 0,
 };
-
-fn ecma_fixture_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../swc_ecma_parser/tests")
-}
-
-fn normalized(path: &Path) -> String {
-    path.to_string_lossy().replace('\\', "/")
-}
-
-fn read_json(path: &Path) -> Option<Value> {
-    let content = fs::read_to_string(path).ok()?;
-    serde_json::from_str::<Value>(&content).ok()
-}
-
-fn collect_fixture_options(path: &Path) -> FixtureOptions {
-    let mut out = FixtureOptions::default();
-    let Some(parent) = path.parent() else {
-        return out;
-    };
-
-    if let Some(options) = read_json(&parent.join("options.json")) {
-        out.throws = options.get("throws").and_then(Value::as_str).is_some();
-        out.source_type_module = options
-            .get("sourceType")
-            .and_then(Value::as_str)
-            .map(|value| value == "module")
-            .unwrap_or(false);
-
-        if let Some(plugins) = options.get("plugins").and_then(Value::as_array) {
-            if plugins.is_empty() {
-                out.import_attributes = Some(false);
-            } else {
-                let mut enabled = false;
-                for plugin in plugins {
-                    let name = if let Some(name) = plugin.as_str() {
-                        Some(name)
-                    } else {
-                        plugin
-                            .as_array()
-                            .and_then(|items| items.first())
-                            .and_then(Value::as_str)
-                    };
-                    if matches!(name, Some("importAttributes" | "importAssertions")) {
-                        enabled = true;
-                    }
-                }
-                out.import_attributes = Some(enabled);
-            }
-        }
-    }
-
-    if let Some(config) = read_json(&parent.join("config.json")) {
-        if let Some(import_attributes) = config.get("importAttributes").and_then(Value::as_bool) {
-            out.import_attributes = Some(import_attributes);
-        }
-        if let Some(explicit_resource_management) = config
-            .get("explicitResourceManagement")
-            .and_then(Value::as_bool)
-        {
-            out.explicit_resource_management = Some(explicit_resource_management);
-        }
-        if let Some(jsx) = config.get("jsx").and_then(Value::as_bool) {
-            out.jsx = Some(jsx);
-        }
-    }
-
-    out
-}
-
-fn syntax_for_file(path: &Path, category: &str, options: &FixtureOptions) -> Syntax {
-    let ext = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
-    let file_name = normalized(path);
-    let is_ts = matches!(ext, "ts" | "tsx" | "mts" | "cts");
-    let is_tsx = ext == "tsx";
-    let is_cjs = ext == "cjs";
-    let is_jsx = options
-        .jsx
-        .unwrap_or(ext == "jsx" || is_tsx || file_name.contains("/jsx/"));
-
-    if is_ts {
-        Syntax::Typescript(TsSyntax {
-            tsx: is_tsx,
-            decorators: true,
-            no_early_errors: category != "typescript-errors",
-            disallow_ambiguous_jsx_like: matches!(ext, "mts" | "cts"),
-            ..Default::default()
-        })
-    } else {
-        Syntax::Es(EsSyntax {
-            jsx: is_jsx,
-            decorators: true,
-            import_attributes: options.import_attributes.unwrap_or(true),
-            explicit_resource_management: options.explicit_resource_management.unwrap_or(true),
-            allow_return_outside_function: is_cjs,
-            ..Default::default()
-        })
-    }
-}
-
-fn parse_mode_for(path: &Path, options: &FixtureOptions) -> ParseMode {
-    let file = normalized(path);
-    let file_name = path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .unwrap_or("");
-
-    if path.extension().and_then(|ext| ext.to_str()) == Some("cjs") {
-        return ParseMode::Script;
-    }
-    if options.source_type_module {
-        return ParseMode::Module;
-    }
-    if file.contains("/test262-parser/") && file_name.contains("module") {
-        return ParseMode::Module;
-    }
-
-    ParseMode::Program
-}
-
-fn is_expected_fail(case: &Case, options: &FixtureOptions) -> bool {
-    let path = normalized(&case.path);
-
-    if options.throws {
-        return true;
-    }
-    if case.category == "errors" || case.category == "typescript-errors" {
-        return true;
-    }
-    if case.category == "jsx" && path.contains("/jsx/errors/") {
-        return true;
-    }
-    if case.category == "test262-parser" && path.contains("/test262-parser/fail/") {
-        return true;
-    }
-
-    // These span fixtures intentionally exercise invalid `super` usage.
-    if case.category == "span"
-        && matches!(
-            path.as_str(),
-            p if p.ends_with("/span/js/super/expr.js")
-                || p.ends_with("/span/js/super/obj1.js")
-                || p.ends_with("/span/js/super/obj2.js")
-                || p.ends_with("/span/js/super/obj4.js")
-        )
-    {
-        return true;
-    }
-
-    false
-}
-
-fn collect_files_for_category(category: &str) -> Vec<PathBuf> {
-    let root = ecma_fixture_root().join(category);
-    let mut files = Vec::new();
-
-    for entry in WalkDir::new(&root).into_iter().filter_map(Result::ok) {
-        if !entry.file_type().is_file() {
-            continue;
-        }
-        let path = entry.path();
-        let Some(ext) = path.extension().and_then(|ext| ext.to_str()) else {
-            continue;
-        };
-        if !matches!(
-            ext,
-            "js" | "jsx" | "cjs" | "mjs" | "ts" | "tsx" | "mts" | "cts"
-        ) {
-            continue;
-        }
-        files.push(path.to_path_buf());
-    }
-
-    files.sort();
-    files
-}
-
-fn parse_case(case: &Case) -> (bool, Option<Error>, Vec<Error>) {
-    let cm = SourceMap::default();
-    let fm = cm
-        .load_file(&case.path)
-        .unwrap_or_else(|err| panic!("failed to load fixture {}: {err}", case.path.display()));
-    let comments = SingleThreadedComments::default();
-    let options = collect_fixture_options(&case.path);
-    let syntax = syntax_for_file(&case.path, &case.category, &options);
-    let mode = parse_mode_for(&case.path, &options);
-    let mut recovered = Vec::new();
-
-    let fatal = match mode {
-        ParseMode::Program => {
-            parse_file_as_program(&fm, syntax, Some(&comments), &mut recovered).err()
-        }
-        ParseMode::Module => {
-            parse_file_as_module(&fm, syntax, Some(&comments), &mut recovered).err()
-        }
-        ParseMode::Script => {
-            parse_file_as_script(&fm, syntax, Some(&comments), &mut recovered).err()
-        }
-    };
-    let observed_success = fatal.is_none() && recovered.is_empty();
-    (observed_success, fatal, recovered)
-}
-
-fn run_cases(cases: Vec<Case>) -> ParitySummary {
-    let mut summary = ParitySummary::default();
-
-    for case in cases {
-        let options = collect_fixture_options(&case.path);
-        let expected_success = !is_expected_fail(&case, &options);
-        let (observed_success, fatal, recovered) = parse_case(&case);
-        let observed_success = if !expected_success
-            && (options.throws
-                || (case.category == "errors")
-                || (case.category == "typescript-errors")
-                || (case.category == "jsx" && normalized(&case.path).contains("/jsx/errors/"))
-                || (case.category == "test262-parser"
-                    && normalized(&case.path).contains("/test262-parser/fail/")))
-        {
-            // `throws` fixtures are parser-option negative tests in the reused suite.
-            false
-        } else {
-            observed_success
-        };
-        summary.checked += 1;
-
-        if observed_success != expected_success {
-            let path = normalized(&case.path);
-            let fatal_desc = fatal
-                .as_ref()
-                .map(|error| {
-                    format!(
-                        "{:?}:{:?}:{}",
-                        error.severity(),
-                        error.code(),
-                        error.message()
-                    )
-                })
-                .unwrap_or_else(|| "none".to_string());
-
-            if fatal.is_some() {
-                summary.fatal_mismatches += 1;
-            } else {
-                summary.recovered_only_mismatches += 1;
-            }
-
-            if summary.mismatches.len() < MAX_MISMATCH_REPORTS {
-                let recovered_desc = recovered
-                    .iter()
-                    .take(4)
-                    .map(|error| {
-                        format!(
-                            "{:?}:{:?}:{}",
-                            error.severity(),
-                            error.code(),
-                            error.message()
-                        )
-                    })
-                    .collect::<Vec<_>>()
-                    .join(" | ");
-                summary.mismatches.push(format!(
-                    "{path}\n  expected_success={expected_success} \
-                     observed_success={observed_success}\n  fatal={fatal_desc}\n  recovered={} \
-                     [{}]",
-                    recovered.len(),
-                    recovered_desc
-                ));
-            }
-        }
-    }
-
-    summary
-}
-
-fn assert_budget(name: &str, summary: &ParitySummary, budget: ParityBudget) {
-    let total_mismatches = summary.fatal_mismatches + summary.recovered_only_mismatches;
-    let omitted = total_mismatches.saturating_sub(summary.mismatches.len());
-    let mut report = summary.mismatches.join("\n\n");
-    if omitted > 0 {
-        if !report.is_empty() {
-            report.push_str("\n\n");
-        }
-        report.push_str(&format!("... omitted {omitted} additional mismatches"));
-    }
-
-    assert!(
-        total_mismatches <= budget.max_mismatches
-            && summary.fatal_mismatches <= budget.max_fatal_mismatches
-            && summary.recovered_only_mismatches <= budget.max_recovered_only_mismatches,
-        "{name}: {total_mismatches}/{} mismatches (fatal={}, recovered_only={}) exceeded budget \
-         (max_total={}, max_fatal={}, max_recovered_only={})\n{}",
-        summary.checked,
-        summary.fatal_mismatches,
-        summary.recovered_only_mismatches,
-        budget.max_mismatches,
-        budget.max_fatal_mismatches,
-        budget.max_recovered_only_mismatches,
-        report
-    );
-}
 
 #[test]
 fn parity_core_corpus() {
-    let mut cases = Vec::new();
-    for category in CORE_CATEGORIES {
-        for path in collect_files_for_category(category) {
-            cases.push(Case {
-                path,
-                category: (*category).to_string(),
-            });
-        }
-    }
-
-    let summary = run_cases(cases);
-    assert_budget("core-corpus", &summary, CORE_CORPUS_BUDGET);
+    let cases = collect_cases_for_categories(CORE_CATEGORIES);
+    let summary = run_coverage_cases(cases);
+    eprintln!("{}", coverage_summary_text("core-corpus", &summary));
+    assert_coverage_budget("core-corpus", &summary, CORE_CORPUS_BUDGET);
 }
 
 #[test]
 fn parity_large_samples() {
-    let tsc_cases = collect_files_for_category("tsc")
+    let summary = run_coverage_cases(collect_large_sample_cases());
+    eprintln!("{}", coverage_summary_text("large-samples", &summary));
+    assert_coverage_budget("large-samples", &summary, LARGE_SAMPLES_BUDGET);
+}
+
+fn collect_large_sample_cases() -> Vec<Case> {
+    let tsc_cases = collect_cases_for_category("tsc");
+    let test262_cases = collect_cases_for_category("test262-parser")
         .into_iter()
-        .map(|path| Case {
-            path,
-            category: "tsc".to_string(),
+        .filter(|case| {
+            let path = normalized(&case.path);
+            path.contains("/test262-parser/pass/") || path.contains("/test262-parser/fail/")
         })
         .collect::<Vec<_>>();
 
-    let test262_cases = collect_files_for_category("test262-parser")
-        .into_iter()
-        .filter(|path| {
-            let normalized = normalized(path);
-            normalized.contains("/test262-parser/pass/")
-                || normalized.contains("/test262-parser/fail/")
-        })
-        .map(|path| Case {
-            path,
-            category: "test262-parser".to_string(),
-        })
-        .collect::<Vec<_>>();
-    let test262_pass = test262_cases
-        .iter()
-        .filter(|case| normalized(&case.path).contains("/test262-parser/pass/"))
-        .cloned()
-        .collect::<Vec<_>>();
-    let test262_fail = test262_cases
-        .iter()
-        .filter(|case| normalized(&case.path).contains("/test262-parser/fail/"))
-        .cloned()
-        .collect::<Vec<_>>();
-
-    let mut cases = Vec::new();
+    let mut cases = Vec::with_capacity(tsc_cases.len() + test262_cases.len());
     cases.extend(tsc_cases);
-    cases.extend(test262_pass);
-    cases.extend(test262_fail);
-
-    let summary = run_cases(cases);
-    assert_budget("large-samples", &summary, LARGE_SAMPLES_BUDGET);
+    cases.extend(test262_cases);
+    cases.sort_by(|a, b| a.path.cmp(&b.path));
+    cases
 }


### PR DESCRIPTION
## Summary
- add a tsc metadata parser in crates/swc_es_parser/tests/common/tsc_meta.rs to support case-insensitive @filename unit splitting and @module / @jsx / @alwaysStrict
- add Oxc-style coverage classification (Passed, IncorrectlyPassed, ParseError, CorrectError) and panic accounting in crates/swc_es_parser/tests/common/ecma_reuse.rs
- refactor crates/swc_es_parser/tests/parity_suite.rs to use the shared coverage runner with strict zero-mismatch / zero-panic gates
- apply @filename unit parsing only for tsc fixtures while keeping file-level parsing for other categories
- update parity contract docs in crates/swc_es_parser/README.md and crates/swc_es_parser/AGENTS.md

## Testing
- git submodule update --init --recursive
- cargo test -p swc_es_parser --test parity_suite
- cargo test -p swc_es_parser --test parity_suite -- --nocapture
- cargo test -p swc_es_parser
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings
