### PR TITLE
perf(ts/fast-strip): avoid token capture in default transform path

### DIFF
--- a/crates/swc_ts_fast_strip/src/lib.rs
+++ b/crates/swc_ts_fast_strip/src/lib.rs
@@ -233,6 +233,12 @@ pub fn operate(
     input: String,
     options: Options,
 ) -> Result<TransformOutput, TsError> {
+    let deprecated_ts_module_as_error = options.deprecated_ts_module_as_error.unwrap_or_default();
+    // Token capture is only needed for strip-only and deprecated `module`
+    // diagnostics.
+    let should_capture_tokens =
+        matches!(&options.mode, Mode::StripOnly) || deprecated_ts_module_as_error;
+
     let filename = options
         .filename
         .map_or(FileName::Anon, |f| FileName::Real(f.into()));
@@ -245,21 +251,37 @@ pub fn operate(
 
     let comments = SingleThreadedComments::default();
 
-    let lexer = Capturing::new(Lexer::new(
-        syntax,
-        target,
-        StringInput::from(&*fm),
-        Some(&comments),
-    ));
-    let mut parser = Parser::new_from(lexer);
+    let (program, errors, mut tokens) = if should_capture_tokens {
+        let lexer = Capturing::new(Lexer::new(
+            syntax,
+            target,
+            StringInput::from(&*fm),
+            Some(&comments),
+        ));
+        let mut parser = Parser::new_from(lexer);
 
-    let program = match options.module {
-        Some(true) => parser.parse_module().map(Program::Module),
-        Some(false) => parser.parse_script().map(Program::Script),
-        None => parser.parse_program(),
+        let program = match options.module {
+            Some(true) => parser.parse_module().map(Program::Module),
+            Some(false) => parser.parse_script().map(Program::Script),
+            None => parser.parse_program(),
+        };
+        let errors = parser.take_errors();
+        let tokens = parser.input_mut().iter_mut().take();
+
+        (program, errors, tokens)
+    } else {
+        let lexer = Lexer::new(syntax, target, StringInput::from(&*fm), Some(&comments));
+        let mut parser = Parser::new_from(lexer);
+
+        let program = match options.module {
+            Some(true) => parser.parse_module().map(Program::Module),
+            Some(false) => parser.parse_script().map(Program::Script),
+            None => parser.parse_program(),
+        };
+        let errors = parser.take_errors();
+
+        (program, errors, Vec::new())
     };
-    let errors = parser.take_errors();
-    let mut tokens = parser.input_mut().iter_mut().take();
 
     let mut program = match program {
         Ok(program) => program,
@@ -293,10 +315,6 @@ pub fn operate(
             code: ErrorCode::InvalidSyntax,
         });
     }
-
-    drop(parser);
-
-    let deprecated_ts_module_as_error = options.deprecated_ts_module_as_error.unwrap_or_default();
 
     match options.mode {
         Mode::StripOnly => {

--- a/crates/swc_ts_fast_strip/tests/fixture.rs
+++ b/crates/swc_ts_fast_strip/tests/fixture.rs
@@ -113,6 +113,28 @@ fn error(input: PathBuf) {
     .unwrap();
 }
 
+#[testing::fixture("tests/fixture/test-1.ts")]
+fn transform_without_deprecated_ts_module_as_error(input: PathBuf) {
+    let input_code = std::fs::read_to_string(&input).unwrap();
+    let output_file = input.with_extension("transform.js");
+
+    testing::run_test(false, |cm, handler| {
+        let mut options = opts(Mode::Transform);
+        options.deprecated_ts_module_as_error = None;
+
+        let code = operate(&cm, handler, input_code, options)
+            .expect("should not return Err()")
+            .code;
+
+        NormalizedOutput::new_raw(code)
+            .compare_to_file(output_file)
+            .unwrap();
+
+        Ok(())
+    })
+    .expect("should not fail");
+}
+
 fn opts(mode: Mode) -> Options {
     Options {
         module: None,


### PR DESCRIPTION
## Summary
- conditionally disable parser token capturing in `swc_ts_fast_strip::operate` for the default transform hot path
- keep token capture enabled for strip-only mode and `deprecated_ts_module_as_error` diagnostics
- add fixture coverage for transform mode with `deprecated_ts_module_as_error = None`

## Why
`operate` previously always used `Capturing<Lexer<_>>` and always materialized captured tokens, even when transform mode never consumed them. This removes avoidable allocation and token-buffer traffic in the common transform path.

Fixes #11655

## Verification
- `git submodule update --init --recursive`
- `cargo test -p swc_ts_fast_strip`
- `cargo test -p swc_ts_fast_strip transform_without_deprecated_ts_module_as_error_tests__fixture__test_1_ts -- --ignored`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`