### PR TITLE
perf(swc_ecma_transforms_module): avoid export sort key clones

### DIFF
--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -24,8 +24,8 @@ use crate::{
     path::Resolver,
     top_level_this::top_level_this,
     util::{
-        define_es_module, emit_export_stmts, local_name_for_src, use_strict, ImportInterop,
-        VecStmtLike,
+        define_es_module, emit_export_stmts, local_name_for_src, sort_export_obj_prop_list,
+        use_strict, ImportInterop, VecStmtLike,
     },
     SpanCtx,
 };
@@ -491,7 +491,7 @@ where
         let mut export_stmts = Default::default();
 
         if !export_obj_prop_list.is_empty() && !is_export_assign {
-            export_obj_prop_list.sort_by_cached_key(|(key, ..)| key.clone());
+            sort_export_obj_prop_list(&mut export_obj_prop_list);
 
             let exports = self.exports();
 

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -20,8 +20,8 @@ use crate::{
     path::Resolver,
     top_level_this::top_level_this,
     util::{
-        define_es_module, emit_export_stmts, local_name_for_src, prop_name, use_strict,
-        ImportInterop, VecStmtLike,
+        define_es_module, emit_export_stmts, local_name_for_src, prop_name,
+        sort_export_obj_prop_list, use_strict, ImportInterop, VecStmtLike,
     },
 };
 
@@ -400,7 +400,7 @@ impl Cjs {
         let mut export_stmts: Vec<Stmt> = Default::default();
 
         if !export_obj_prop_list.is_empty() && !is_export_assign {
-            export_obj_prop_list.sort_by_cached_key(|(key, ..)| key.clone());
+            sort_export_obj_prop_list(&mut export_obj_prop_list);
 
             let exports = self.exports();
 

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -19,8 +19,8 @@ use crate::{
     path::Resolver,
     top_level_this::top_level_this,
     util::{
-        define_es_module, emit_export_stmts, local_name_for_src, use_strict, ImportInterop,
-        VecStmtLike,
+        define_es_module, emit_export_stmts, local_name_for_src, sort_export_obj_prop_list,
+        use_strict, ImportInterop, VecStmtLike,
     },
     SpanCtx,
 };
@@ -261,7 +261,7 @@ impl Umd {
         let mut export_stmts = Default::default();
 
         if !export_obj_prop_list.is_empty() && !is_export_assign {
-            export_obj_prop_list.sort_by_cached_key(|(key, ..)| key.clone());
+            sort_export_obj_prop_list(&mut export_obj_prop_list);
 
             let exports = self.exports();
 

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -332,6 +332,13 @@ pub(crate) fn esm_export() -> Function {
     }
 }
 
+/// Sort export properties by key without allocating cached keys or cloning
+/// `Atom`s for each entry.
+#[inline]
+pub(crate) fn sort_export_obj_prop_list(prop_list: &mut [ExportKV]) {
+    prop_list.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+}
+
 pub(crate) fn emit_export_stmts(exports: Ident, mut prop_list: Vec<ExportKV>) -> Vec<Stmt> {
     match prop_list.len() {
         0 | 1 => prop_list

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-11662/input.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-11662/input.js
@@ -1,0 +1,8 @@
+export { zed as m, alpha as z } from "dep-a";
+
+const localC = 3;
+const localA = 1;
+
+export { localC as c, localA as a };
+export { default as b } from "dep-b";
+export * as d from "dep-c";

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-11662/output.amd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-11662/output.amd.js
@@ -1,0 +1,42 @@
+define([
+    "require",
+    "exports",
+    "dep-a",
+    "dep-b",
+    "dep-c"
+], function(require, exports, _depa, _depb, _depc) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    function _export(target, all) {
+        for(var name in all)Object.defineProperty(target, name, {
+            enumerable: true,
+            get: Object.getOwnPropertyDescriptor(all, name).get
+        });
+    }
+    _export(exports, {
+        get a () {
+            return localA;
+        },
+        get b () {
+            return _depb.default;
+        },
+        get c () {
+            return localC;
+        },
+        get d () {
+            return _depc;
+        },
+        get m () {
+            return _depa.zed;
+        },
+        get z () {
+            return _depa.alpha;
+        }
+    });
+    _depb = /*#__PURE__*/ _interop_require_default(_depb);
+    _depc = /*#__PURE__*/ _interop_require_wildcard(_depc);
+    const localC = 3;
+    const localA = 1;
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-11662/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-11662/output.cjs
@@ -1,0 +1,35 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+function _export(target, all) {
+    for(var name in all)Object.defineProperty(target, name, {
+        enumerable: true,
+        get: Object.getOwnPropertyDescriptor(all, name).get
+    });
+}
+_export(exports, {
+    get a () {
+        return localA;
+    },
+    get b () {
+        return _depb.default;
+    },
+    get c () {
+        return localC;
+    },
+    get d () {
+        return _depc;
+    },
+    get m () {
+        return _depa.zed;
+    },
+    get z () {
+        return _depa.alpha;
+    }
+});
+const _depa = require("dep-a");
+const _depb = /*#__PURE__*/ _interop_require_default(require("dep-b"));
+const _depc = /*#__PURE__*/ _interop_require_wildcard(require("dep-c"));
+const localC = 3;
+const localA = 1;

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-11662/output.umd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-11662/output.umd.js
@@ -1,0 +1,45 @@
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("dep-a"), require("dep-b"), require("dep-c"));
+    else if (typeof define === "function" && define.amd) define([
+        "exports",
+        "dep-a",
+        "dep-b",
+        "dep-c"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.input = {}, global.depA, global.depB, global.depC);
+})(this, function(exports, _depa, _depb, _depc) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    function _export(target, all) {
+        for(var name in all)Object.defineProperty(target, name, {
+            enumerable: true,
+            get: Object.getOwnPropertyDescriptor(all, name).get
+        });
+    }
+    _export(exports, {
+        get a () {
+            return localA;
+        },
+        get b () {
+            return _depb.default;
+        },
+        get c () {
+            return localC;
+        },
+        get d () {
+            return _depc;
+        },
+        get m () {
+            return _depa.zed;
+        },
+        get z () {
+            return _depa.alpha;
+        }
+    });
+    _depb = /*#__PURE__*/ _interop_require_default(_depb);
+    _depc = /*#__PURE__*/ _interop_require_wildcard(_depc);
+    const localC = 3;
+    const localA = 1;
+});


### PR DESCRIPTION
## Summary
- add a shared helper to sort export object properties via comparator without cloning keys
- replace `sort_by_cached_key(|(key, ..)| key.clone())` in `common_js`, `amd`, and `umd` with the shared helper
- add fixture coverage at `tests/fixture/common/issue-11662` (input + cjs/amd/umd outputs)

## Why
- `sort_by_cached_key` + `key.clone()` allocates cached keys and clones `Atom` values unnecessarily
- `sort_unstable_by` keeps deterministic key ordering while avoiding extra allocation/cloning work

## Testing
- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_transforms_module`
- `cargo test -p swc_ecma_transforms_module`
- `UPDATE=1 cargo test -p swc_ecma_transforms_module --test common_js esm_to_cjs_tests__fixture__common__issue_11662__input_js -- --ignored --exact`
- `UPDATE=1 cargo test -p swc_ecma_transforms_module --test amd esm_to_amd_tests__fixture__common__issue_11662__input_js -- --ignored --exact`
- `UPDATE=1 cargo test -p swc_ecma_transforms_module --test umd esm_to_umd_tests__fixture__common__issue_11662__input_js -- --ignored --exact`
- `cargo test -p swc_ecma_transforms_module --test common_js esm_to_cjs_tests__fixture__common__issue_11662__input_js -- --ignored --exact`
- `cargo test -p swc_ecma_transforms_module --test amd esm_to_amd_tests__fixture__common__issue_11662__input_js -- --ignored --exact`
- `cargo test -p swc_ecma_transforms_module --test umd esm_to_umd_tests__fixture__common__issue_11662__input_js -- --ignored --exact`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

Closes #11662