### PR TITLE
perf(es/transformer): remove O(n^2) statement mutation hotspots

### DIFF
--- a/crates/swc_ecma_transformer/src/common/statement_injector.rs
+++ b/crates/swc_ecma_transformer/src/common/statement_injector.rs
@@ -113,88 +113,235 @@ impl VisitMutHook<TraverseCtx> for StmtInjector {
 
     fn exit_module_items(&mut self, node: &mut Vec<ModuleItem>, ctx: &mut TraverseCtx) {
         // First pass: collect all (index, adjacent_stmts) pairs while addresses are
-        // valid
+        // valid.
         let mut insertions = Vec::new();
+        let mut insertion_count = 0;
         for (i, item) in node.iter().enumerate() {
             // Only process ModuleItem::Stmt variants
             if let ModuleItem::Stmt(stmt) = item {
                 let address = stmt as *const Stmt;
                 if let Some(adjacent_stmts) = ctx.statement_injector.take_stmts(address) {
+                    insertion_count += adjacent_stmts.len();
                     insertions.push((i, adjacent_stmts));
                 }
             }
         }
 
-        // Second pass: process in reverse order to avoid index invalidation
-        for (i, adjacent_stmts) in insertions.into_iter().rev() {
-            let mut before_stmts = Vec::new();
-            let mut after_stmts = Vec::new();
-
-            // Separate statements by direction
-            for adjacent in adjacent_stmts {
-                match adjacent.direction {
-                    Direction::Before => before_stmts.push(adjacent.stmt),
-                    Direction::After => after_stmts.push(adjacent.stmt),
-                }
-            }
-
-            // Insert statements after (insert first since we're going backwards)
-            if !after_stmts.is_empty() {
-                // Insert all after statements at position i + 1
-                for (offset, stmt) in after_stmts.into_iter().enumerate() {
-                    node.insert(i + 1 + offset, ModuleItem::Stmt(stmt));
-                }
-            }
-
-            // Insert statements before
-            if !before_stmts.is_empty() {
-                // Insert all before statements at position i
-                for (offset, stmt) in before_stmts.into_iter().enumerate() {
-                    node.insert(i + offset, ModuleItem::Stmt(stmt));
-                }
-            }
+        if insertions.is_empty() {
+            return;
         }
+
+        let mut next_insertion = insertions.into_iter().peekable();
+        let original = node.take();
+        let mut rewritten = Vec::with_capacity(original.len() + insertion_count);
+
+        for (i, item) in original.into_iter().enumerate() {
+            let mut after = Vec::new();
+
+            if matches!(
+                next_insertion.peek(),
+                Some(&(insertion_idx, _)) if insertion_idx == i
+            ) {
+                let (_, adjacent_stmts) = next_insertion.next().unwrap();
+
+                for adjacent in adjacent_stmts {
+                    match adjacent.direction {
+                        Direction::Before => rewritten.push(ModuleItem::Stmt(adjacent.stmt)),
+                        Direction::After => after.push(ModuleItem::Stmt(adjacent.stmt)),
+                    }
+                }
+            }
+
+            rewritten.push(item);
+            rewritten.extend(after);
+        }
+
+        *node = rewritten;
     }
 
     fn exit_stmts(&mut self, stmts: &mut Vec<Stmt>, ctx: &mut TraverseCtx) {
         // First pass: collect all (index, adjacent_stmts) pairs while addresses are
-        // valid
+        // valid.
         let mut insertions = Vec::new();
+        let mut insertion_count = 0;
         for (i, stmt) in stmts.iter().enumerate() {
             let address = stmt as *const Stmt;
             if let Some(adjacent_stmts) = ctx.statement_injector.take_stmts(address) {
+                insertion_count += adjacent_stmts.len();
                 insertions.push((i, adjacent_stmts));
             }
         }
 
-        // Second pass: process in reverse order to avoid index invalidation
-        for (i, adjacent_stmts) in insertions.into_iter().rev() {
-            let mut before_stmts = Vec::new();
-            let mut after_stmts = Vec::new();
-
-            // Separate statements by direction
-            for adjacent in adjacent_stmts {
-                match adjacent.direction {
-                    Direction::Before => before_stmts.push(adjacent.stmt),
-                    Direction::After => after_stmts.push(adjacent.stmt),
-                }
-            }
-
-            // Insert statements after (insert first since we're going backwards)
-            if !after_stmts.is_empty() {
-                // Insert all after statements at position i + 1
-                for (offset, stmt) in after_stmts.into_iter().enumerate() {
-                    stmts.insert(i + 1 + offset, stmt);
-                }
-            }
-
-            // Insert statements before
-            if !before_stmts.is_empty() {
-                // Insert all before statements at position i
-                for (offset, stmt) in before_stmts.into_iter().enumerate() {
-                    stmts.insert(i + offset, stmt);
-                }
-            }
+        if insertions.is_empty() {
+            return;
         }
+
+        let mut next_insertion = insertions.into_iter().peekable();
+        let original = stmts.take();
+        let mut rewritten = Vec::with_capacity(original.len() + insertion_count);
+
+        for (i, stmt) in original.into_iter().enumerate() {
+            let mut after = Vec::new();
+
+            if matches!(
+                next_insertion.peek(),
+                Some(&(insertion_idx, _)) if insertion_idx == i
+            ) {
+                let (_, adjacent_stmts) = next_insertion.next().unwrap();
+
+                for adjacent in adjacent_stmts {
+                    match adjacent.direction {
+                        Direction::Before => rewritten.push(adjacent.stmt),
+                        Direction::After => after.push(adjacent.stmt),
+                    }
+                }
+            }
+
+            rewritten.push(stmt);
+            rewritten.extend(after);
+        }
+
+        *stmts = rewritten;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn labeled_stmt(label: &str) -> Stmt {
+        Stmt::Expr(ExprStmt {
+            span: DUMMY_SP,
+            expr: Box::new(Expr::Lit(Lit::Str(Str {
+                span: DUMMY_SP,
+                value: label.into(),
+                raw: None,
+            }))),
+        })
+    }
+
+    fn stmt_label(stmt: &Stmt) -> String {
+        let Stmt::Expr(ExprStmt { expr, .. }) = stmt else {
+            panic!("expected expression statement")
+        };
+        let Expr::Lit(Lit::Str(Str { value, .. })) = &**expr else {
+            panic!("expected string literal expression")
+        };
+
+        value.to_string_lossy().into_owned()
+    }
+
+    fn empty_named_export() -> ModuleItem {
+        ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
+            span: DUMMY_SP,
+            specifiers: Vec::new(),
+            src: None,
+            type_only: false,
+            with: None,
+        }))
+    }
+
+    #[test]
+    fn exit_stmts_keeps_before_and_after_order_for_one_target() {
+        let mut stmts = vec![labeled_stmt("base")];
+        let target = &stmts[0] as *const Stmt;
+
+        let mut ctx = TraverseCtx::default();
+        ctx.statement_injector
+            .insert_before(target, labeled_stmt("before_1"));
+        ctx.statement_injector
+            .insert_before(target, labeled_stmt("before_2"));
+        ctx.statement_injector
+            .insert_after(target, labeled_stmt("after_1"));
+        ctx.statement_injector
+            .insert_after(target, labeled_stmt("after_2"));
+
+        StmtInjector::default().exit_stmts(&mut stmts, &mut ctx);
+
+        let labels = stmts.iter().map(stmt_label).collect::<Vec<_>>();
+        assert_eq!(
+            labels,
+            vec![
+                "before_1".to_string(),
+                "before_2".to_string(),
+                "base".to_string(),
+                "after_1".to_string(),
+                "after_2".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn exit_stmts_keeps_order_for_multiple_targets() {
+        let mut stmts = vec![labeled_stmt("s0"), labeled_stmt("s1"), labeled_stmt("s2")];
+
+        let s0 = &stmts[0] as *const Stmt;
+        let s1 = &stmts[1] as *const Stmt;
+        let s2 = &stmts[2] as *const Stmt;
+
+        let mut ctx = TraverseCtx::default();
+        ctx.statement_injector.insert_after(s0, labeled_stmt("a0"));
+        ctx.statement_injector.insert_before(s1, labeled_stmt("b1"));
+        ctx.statement_injector.insert_after(s2, labeled_stmt("a2"));
+
+        StmtInjector::default().exit_stmts(&mut stmts, &mut ctx);
+
+        let labels = stmts.iter().map(stmt_label).collect::<Vec<_>>();
+        assert_eq!(
+            labels,
+            vec![
+                "s0".to_string(),
+                "a0".to_string(),
+                "b1".to_string(),
+                "s1".to_string(),
+                "s2".to_string(),
+                "a2".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn exit_module_items_only_targets_statement_entries() {
+        let mut items = vec![
+            empty_named_export(),
+            ModuleItem::Stmt(labeled_stmt("s0")),
+            empty_named_export(),
+            ModuleItem::Stmt(labeled_stmt("s1")),
+        ];
+
+        let s0 = match &items[1] {
+            ModuleItem::Stmt(stmt) => stmt as *const Stmt,
+            _ => unreachable!(),
+        };
+        let s1 = match &items[3] {
+            ModuleItem::Stmt(stmt) => stmt as *const Stmt,
+            _ => unreachable!(),
+        };
+
+        let mut ctx = TraverseCtx::default();
+        ctx.statement_injector.insert_after(s0, labeled_stmt("a0"));
+        ctx.statement_injector.insert_before(s1, labeled_stmt("b1"));
+
+        StmtInjector::default().exit_module_items(&mut items, &mut ctx);
+
+        let labels = items
+            .iter()
+            .map(|item| match item {
+                ModuleItem::Stmt(stmt) => stmt_label(stmt),
+                _ => "module".to_string(),
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            labels,
+            vec![
+                "module".to_string(),
+                "s0".to_string(),
+                "a0".to_string(),
+                "module".to_string(),
+                "b1".to_string(),
+                "s1".to_string(),
+            ]
+        );
     }
 }

--- a/crates/swc_ecma_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transformer/src/es2018/object_rest_spread.rs
@@ -275,9 +275,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
             }
 
             let stmts = collector.into_stmts();
-            for stmt in stmts.into_iter().rev() {
-                body.stmts.insert(0, stmt);
-            }
+            prepend_stmts_to_front(&mut body.stmts, stmts);
         }
     }
 
@@ -305,9 +303,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
                 // Insert into body
                 match &mut *arrow.body {
                     BlockStmtOrExpr::BlockStmt(block) => {
-                        for stmt in stmts.into_iter().rev() {
-                            block.stmts.insert(0, stmt);
-                        }
+                        prepend_stmts_to_front(&mut block.stmts, stmts);
                     }
                     BlockStmtOrExpr::Expr(expr) => {
                         let mut body_stmts = stmts;
@@ -353,9 +349,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
             }
 
             let stmts = collector.into_stmts();
-            for stmt in stmts.into_iter().rev() {
-                body.stmts.insert(0, stmt);
-            }
+            prepend_stmts_to_front(&mut body.stmts, stmts);
         }
     }
 
@@ -382,9 +376,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
                         }
 
                         let stmts = collector.into_stmts();
-                        for stmt in stmts.into_iter().rev() {
-                            body.stmts.insert(0, stmt);
-                        }
+                        prepend_stmts_to_front(&mut body.stmts, stmts);
                     }
                 }
                 ClassMember::PrivateMethod(method) => {
@@ -406,9 +398,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
                         }
 
                         let stmts = collector.into_stmts();
-                        for stmt in stmts.into_iter().rev() {
-                            body.stmts.insert(0, stmt);
-                        }
+                        prepend_stmts_to_front(&mut body.stmts, stmts);
                     }
                 }
                 _ => {}
@@ -441,7 +431,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
         }
         .into();
 
-        clause.body.stmts.insert(0, stmt);
+        prepend_stmts_to_front(&mut clause.body.stmts, vec![stmt]);
     }
 
     // Object Rest: Transform for-in statement
@@ -455,86 +445,55 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
     }
 
     fn exit_module_items(&mut self, items: &mut Vec<ModuleItem>, _: &mut TraverseCtx) {
-        // Only process export var declarations that need transformation
-        let mut i = 0;
-        while i < items.len() {
-            let needs_transform = matches!(
-                &items[i],
+        let original = items.take();
+        let mut rewritten = Vec::with_capacity(original.len() + self.export_idents.len());
+
+        for item in original {
+            match item {
                 ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                    decl: Decl::Var(_),
-                    ..
-                }))
-            );
+                    span,
+                    decl: Decl::Var(var_decl),
+                })) => {
+                    let var_decl_ptr = &*var_decl as *const VarDecl;
 
-            if !needs_transform {
-                i += 1;
-                continue;
+                    if let Some(exported_names) = self.export_idents.remove(&var_decl_ptr) {
+                        rewritten.push(ModuleItem::Stmt((*var_decl).into()));
+
+                        if !exported_names.is_empty() {
+                            rewritten.push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(
+                                NamedExport {
+                                    span,
+                                    specifiers: exported_names
+                                        .into_iter()
+                                        .map(|id| {
+                                            ExportSpecifier::Named(ExportNamedSpecifier {
+                                                span: DUMMY_SP,
+                                                orig: ModuleExportName::Ident(id),
+                                                exported: None,
+                                                is_type_only: false,
+                                            })
+                                        })
+                                        .collect(),
+                                    src: None,
+                                    type_only: false,
+                                    with: None,
+                                },
+                            )));
+                        }
+                    } else {
+                        rewritten.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(
+                            ExportDecl {
+                                span,
+                                decl: Decl::Var(var_decl),
+                            },
+                        )));
+                    }
+                }
+                _ => rewritten.push(item),
             }
-
-            // Extract the export declaration
-            let ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                span,
-                decl: Decl::Var(var_decl),
-            })) = items.remove(i)
-            else {
-                unreachable!()
-            };
-
-            // Get the original identifiers collected before transformation
-            let var_decl_ptr = &*var_decl as *const VarDecl;
-            let exported_names = self.export_idents.remove(&var_decl_ptr);
-
-            // Note: The var_decl has already been transformed by exit_var_decl
-            // Check if transformation happened
-            let transformation_occurred = exported_names.is_some();
-
-            if !transformation_occurred {
-                // No transformation, restore the export declaration
-                items.insert(
-                    i,
-                    ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
-                        span,
-                        decl: Decl::Var(var_decl),
-                    })),
-                );
-                i += 1;
-                continue;
-            }
-
-            // Use the original identifiers collected before transformation
-            let exported_names = exported_names.unwrap();
-
-            // Insert var declaration as a statement
-            let var_stmt: Stmt = (*var_decl).into();
-            items.insert(i, ModuleItem::Stmt(var_stmt));
-
-            // Insert named export
-            if !exported_names.is_empty() {
-                items.insert(
-                    i + 1,
-                    ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
-                        span,
-                        specifiers: exported_names
-                            .into_iter()
-                            .map(|id| {
-                                ExportSpecifier::Named(ExportNamedSpecifier {
-                                    span: DUMMY_SP,
-                                    orig: ModuleExportName::Ident(id),
-                                    exported: None,
-                                    is_type_only: false,
-                                })
-                            })
-                            .collect(),
-                        src: None,
-                        type_only: false,
-                        with: None,
-                    })),
-                );
-                i += 1; // Skip the export we just inserted
-            }
-
-            i += 1;
         }
+
+        *items = rewritten;
     }
 }
 
@@ -573,7 +532,7 @@ impl ObjectRestSpreadPass {
                 .into();
 
                 match &mut **body {
-                    Stmt::Block(block) => block.stmts.insert(0, stmt),
+                    Stmt::Block(block) => prepend_stmts_to_front(&mut block.stmts, vec![stmt]),
                     _ => {
                         *body = Box::new(
                             BlockStmt {
@@ -611,7 +570,9 @@ impl ObjectRestSpreadPass {
                 .into_stmt();
 
                 match &mut **body {
-                    Stmt::Block(block) => block.stmts.insert(0, assign_stmt),
+                    Stmt::Block(block) => {
+                        prepend_stmts_to_front(&mut block.stmts, vec![assign_stmt])
+                    }
                     _ => {
                         *body = Box::new(
                             BlockStmt {
@@ -626,6 +587,18 @@ impl ObjectRestSpreadPass {
             _ => {}
         }
     }
+}
+
+fn prepend_stmts_to_front(stmts: &mut Vec<Stmt>, mut prepended: Vec<Stmt>) {
+    if prepended.is_empty() {
+        return;
+    }
+
+    let mut original = mem::take(stmts);
+    let mut merged = Vec::with_capacity(prepended.len() + original.len());
+    merged.append(&mut prepended);
+    merged.append(&mut original);
+    *stmts = merged;
 }
 
 // ========================================

--- a/crates/swc_ecma_transformer/src/es2022/private_property_in_object.rs
+++ b/crates/swc_ecma_transformer/src/es2022/private_property_in_object.rs
@@ -129,10 +129,10 @@ struct ClassData {
     privates: FxHashSet<Atom>,
 
     /// Name of private methods.
-    methods: Vec<Atom>,
+    methods: FxHashSet<Atom>,
 
     /// Name of private statics.
-    statics: Vec<Atom>,
+    statics: FxHashSet<Atom>,
 
     constructor_exprs: Vec<Expr>,
 
@@ -165,17 +165,17 @@ impl PrivatePropertyInObjectPass {
             match m {
                 ClassMember::PrivateMethod(m) => {
                     self.cls.privates.insert(m.key.name.clone());
-                    self.cls.methods.push(m.key.name.clone());
+                    self.cls.methods.insert(m.key.name.clone());
 
                     if m.is_static {
-                        self.cls.statics.push(m.key.name.clone());
+                        self.cls.statics.insert(m.key.name.clone());
                     }
                 }
                 ClassMember::PrivateProp(m) => {
                     self.cls.privates.insert(m.key.name.clone());
 
                     if m.is_static {
-                        self.cls.statics.push(m.key.name.clone());
+                        self.cls.statics.insert(m.key.name.clone());
                     }
                 }
                 _ => {}


### PR DESCRIPTION
## Summary

This PR addresses the highest-impact performance hotspots from #11667 in `swc_ecma_transformer` (`#1`-`#4` scope):

- Remove repeated front `Vec::insert(0, ...)` patterns in object-rest lowering by using one-shot prepend materialization.
- Rewrite object-rest `exit_module_items` export-var rewriting to a single-pass rebuild, avoiding repeated middle `remove/insert` mutations.
- Rework statement injector insertion for both `Vec<Stmt>` and `Vec<ModuleItem>` to rebuild once while preserving insertion order and statement-address targeting semantics.
- Switch private-in-object class membership tracking (`methods`, `statics`) from `Vec<Atom>` to `FxHashSet<Atom>` for faster membership checks in hot paths.

## Testing

- `git submodule update --init --recursive`
- `cargo test -p swc_ecma_transformer`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_transforms_compat` *(fails in this environment because `mocha` is unavailable for existing exec tests)*
- `cargo test -p swc_ecma_transforms_compat --test es2018_object_rest_spread -- --skip exec --skip issue_6029_1 --skip issue_6029_2 --skip issue_4631`

## Notes

- No public API changes.
- Kept scope intentionally limited to findings `#1`-`#4`; follow-up work (`#5`-`#7`) is not included.
