### PR TITLE
perf(swc_ecma_transforms_typescript): reduce repeated passes and enum clone churn

### DIFF
--- a/crates/swc_ecma_transforms_typescript/benches/assets/EnumHeavy.ts
+++ b/crates/swc_ecma_transforms_typescript/benches/assets/EnumHeavy.ts
@@ -1,0 +1,60 @@
+const runtime = Math.random() > 0.5 ? 1 : 2;
+
+enum OtherEnum {
+  Start = 100,
+  End = Start + 1,
+}
+
+enum PerfEnum {
+  A0 = 0,
+  A1 = A0 + 1,
+  A2 = A1 + 1,
+  A3 = A2 + 1,
+  A4 = A3 + 1,
+  A5 = A4 + 1,
+  A6 = A5 + 1,
+  A7 = A6 + 1,
+  A8 = A7 + 1,
+  A9 = A8 + 1,
+  A10 = A9 + 1,
+  A11 = A10 + 1,
+  A12 = A11 + 1,
+  A13 = A12 + 1,
+  A14 = A13 + 1,
+  A15 = A14 + 1,
+  A16 = A15 + 1,
+  A17 = A16 + 1,
+  A18 = A17 + 1,
+  A19 = A18 + 1,
+  A20 = A19 + 1,
+  A21 = A20 + 1,
+  A22 = A21 + 1,
+  A23 = A22 + 1,
+  A24 = A23 + 1,
+  A25 = A24 + 1,
+  A26 = A25 + 1,
+  A27 = A26 + 1,
+  A28 = A27 + 1,
+  A29 = A28 + 1,
+  A30 = A29 + 1,
+  B0 = A30 * 2,
+  B1 = B0 | A8,
+  B2 = B1 & 63,
+  B3 = B2 ^ 7,
+  B4 = B3 << 1,
+  B5 = B4 >> 1,
+  B6 = B5 >>> 1,
+  T0 = `perf-${A30}`,
+  T1 = `${T0}-tail`,
+  R0 = A30 + runtime,
+  R1 = R0 + 1,
+  O0 = OtherEnum.Start,
+  O1 = O0 + 2,
+}
+
+export const sink =
+  PerfEnum.A30 +
+  PerfEnum.B6 +
+  PerfEnum.O1 +
+  OtherEnum.End +
+  runtime;

--- a/crates/swc_ecma_transforms_typescript/benches/assets/ModuleStripHeavy.ts
+++ b/crates/swc_ecma_transforms_typescript/benches/assets/ModuleStripHeavy.ts
@@ -1,0 +1,28 @@
+import { type T0, type T1, v0, v1, type T2, v2 } from "pkg-a";
+import { type U0, u0, type U1, u1, type U2 } from "pkg-b";
+import { type V0, type V1, v3, v4 } from "pkg-c";
+import { type W0, type W1, type W2, w0 } from "pkg-d";
+import { type X0, x0 } from "pkg-e";
+import type { OnlyType0, OnlyType1, OnlyType2 } from "pkg-types";
+
+export type PublicShape = T0 | U0 | V0 | W0 | X0 | OnlyType0;
+
+type LocalShape = T1 & U1 & V1 & W1 & OnlyType1;
+
+interface RuntimeShape extends LocalShape {
+  name: string;
+  count: number;
+}
+
+const runtimeValue: RuntimeShape = {
+  name: "bench",
+  count: v0 + v1 + v2 + u0 + u1 + v3 + v4 + w0 + x0,
+};
+
+const values = [v0, v1, v2, u0, u1, v3, v4, w0, x0];
+
+export const kept = values.reduce((sum, value) => sum + value, 0) + runtimeValue.count;
+
+export { v0, v1, u0, u1, v3, v4, w0, x0 };
+
+export type { T2, U2, W2, OnlyType2 };

--- a/crates/swc_ecma_transforms_typescript/benches/compat.rs
+++ b/crates/swc_ecma_transforms_typescript/benches/compat.rs
@@ -6,10 +6,12 @@ use swc_ecma_transforms_base::{helpers, resolver};
 use swc_ecma_transforms_typescript::strip;
 use swc_ecma_visit::{fold_pass, Fold};
 
-static SOURCE: &str = include_str!("assets/AjaxObservable.ts");
+static SOURCE_COMMON: &str = include_str!("assets/AjaxObservable.ts");
+static SOURCE_ENUM_HEAVY: &str = include_str!("assets/EnumHeavy.ts");
+static SOURCE_MODULE_STRIP: &str = include_str!("assets/ModuleStripHeavy.ts");
 
-fn module(cm: Lrc<SourceMap>) -> Program {
-    let fm = cm.new_source_file(FileName::Anon.into(), SOURCE);
+fn module(cm: Lrc<SourceMap>, source: &str) -> Program {
+    let fm = cm.new_source_file(FileName::Anon.into(), source.to_string());
     let lexer = Lexer::new(
         Syntax::Typescript(Default::default()),
         Default::default(),
@@ -30,7 +32,7 @@ where
     V: Pass,
 {
     let _ = ::testing::run_test(false, |cm, _| {
-        let module = module(cm);
+        let module = module(cm, SOURCE_COMMON);
         let unresolved_mark = Mark::fresh(Mark::root());
         let top_level_mark = Mark::fresh(Mark::root());
         let module = module
@@ -58,6 +60,14 @@ fn baseline_group(c: &mut Criterion) {
         common_reserved_word,
     );
     c.bench_function("es/transform/baseline/common_typescript", common_typescript);
+    c.bench_function(
+        "es/transform/baseline/common_typescript_enum_heavy",
+        common_typescript_enum_heavy,
+    );
+    c.bench_function(
+        "es/transform/baseline/common_typescript_module_strip",
+        common_typescript_module_strip,
+    );
 }
 
 fn base(b: &mut Bencher) {
@@ -73,7 +83,49 @@ fn base(b: &mut Bencher) {
 
 fn common_typescript(b: &mut Bencher) {
     let _ = ::testing::run_test(false, |cm, _| {
-        let module = module(cm);
+        let module = module(cm, SOURCE_COMMON);
+        let unresolved_mark = Mark::fresh(Mark::root());
+        let top_level_mark = Mark::fresh(Mark::root());
+        let module = module
+            .apply(resolver(unresolved_mark, top_level_mark, true))
+            .apply(strip(unresolved_mark, top_level_mark));
+
+        b.iter(|| {
+            let module = module.clone();
+
+            helpers::HELPERS.set(&Default::default(), || {
+                black_box(module.apply(strip(unresolved_mark, top_level_mark)));
+            });
+        });
+
+        Ok(())
+    });
+}
+
+fn common_typescript_enum_heavy(b: &mut Bencher) {
+    let _ = ::testing::run_test(false, |cm, _| {
+        let module = module(cm, SOURCE_ENUM_HEAVY);
+        let unresolved_mark = Mark::fresh(Mark::root());
+        let top_level_mark = Mark::fresh(Mark::root());
+        let module = module
+            .apply(resolver(unresolved_mark, top_level_mark, true))
+            .apply(strip(unresolved_mark, top_level_mark));
+
+        b.iter(|| {
+            let module = module.clone();
+
+            helpers::HELPERS.set(&Default::default(), || {
+                black_box(module.apply(strip(unresolved_mark, top_level_mark)));
+            });
+        });
+
+        Ok(())
+    });
+}
+
+fn common_typescript_module_strip(b: &mut Bencher) {
+    let _ = ::testing::run_test(false, |cm, _| {
+        let module = module(cm, SOURCE_MODULE_STRIP);
         let unresolved_mark = Mark::fresh(Mark::root());
         let top_level_mark = Mark::fresh(Mark::root());
         let module = module

--- a/crates/swc_ecma_transforms_typescript/src/semantic.rs
+++ b/crates/swc_ecma_transforms_typescript/src/semantic.rs
@@ -1,7 +1,7 @@
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_common::{Mark, Span, SyntaxContext};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{find_pat_ids, stack_size::maybe_grow_default};
+use swc_ecma_utils::{for_each_binding_ident, stack_size::maybe_grow_default};
 use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::{
@@ -207,12 +207,14 @@ impl SemanticAnalyzer {
     fn collect_decl(&mut self, decl: &Decl) {
         match decl {
             Decl::Var(var_decl) => {
-                let ids: Vec<Id> = find_pat_ids(&var_decl.decls);
-                self.info.id_value.extend(ids);
+                for_each_binding_ident(&var_decl.decls, |ident| {
+                    self.info.id_value.insert(ident.to_id());
+                });
             }
             Decl::Using(using_decl) => {
-                let ids: Vec<Id> = find_pat_ids(&using_decl.decls);
-                self.info.id_value.extend(ids);
+                for_each_binding_ident(&using_decl.decls, |ident| {
+                    self.info.id_value.insert(ident.to_id());
+                });
             }
             Decl::Fn(fn_decl) => {
                 self.info.id_value.insert(fn_decl.ident.to_id());
@@ -250,7 +252,7 @@ impl SemanticAnalyzer {
     }
 
     fn transform_ts_enum_member(
-        member: TsEnumMember,
+        member: &TsEnumMember,
         enum_id: &Id,
         default_init: &TsEnumRecordValue,
         record: &TsEnumRecord,
@@ -258,6 +260,7 @@ impl SemanticAnalyzer {
     ) -> TsEnumRecordValue {
         member
             .init
+            .clone()
             .map(|expr| {
                 EnumValueComputer {
                     enum_id,
@@ -389,11 +392,12 @@ impl Visit for SemanticAnalyzer {
 
         match &node.decl {
             Decl::Var(var_decl) => {
-                let ids: Vec<Id> = find_pat_ids(&var_decl.decls);
-                self.info.exported_binding.extend(
-                    ids.into_iter()
-                        .zip(std::iter::repeat(self.namespace_id.clone())),
-                );
+                let namespace_id = self.namespace_id.clone();
+                for_each_binding_ident(&var_decl.decls, |ident| {
+                    self.info
+                        .exported_binding
+                        .insert(ident.to_id(), namespace_id.clone());
+                });
             }
             Decl::TsEnum(ts_enum_decl) => {
                 self.info
@@ -536,16 +540,17 @@ impl Visit for SemanticAnalyzer {
             ..
         } = node;
 
+        let enum_id = id.to_id();
         if *is_const {
-            self.info.const_enum.insert(id.to_id());
+            self.info.const_enum.insert(enum_id.clone());
         }
 
         let mut default_init = 0.0.into();
 
         for member in members {
             let value = Self::transform_ts_enum_member(
-                member.clone(),
-                &id.to_id(),
+                member,
+                &enum_id,
                 &default_init,
                 &self.info.enum_record,
                 self.unresolved_ctxt,
@@ -555,7 +560,7 @@ impl Visit for SemanticAnalyzer {
 
             let member_name = enum_member_id_atom(&member.id);
             let key = TsEnumRecordKey {
-                enum_id: id.to_id(),
+                enum_id: enum_id.clone(),
                 member_name,
             };
 

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -157,8 +157,11 @@ impl VisitMut for Transform {
 
     fn visit_mut_module_items(&mut self, node: &mut Vec<ModuleItem>) {
         let var_list = self.var_list.take();
-        node.retain(|item| should_retain_module_item(item, self.in_namespace));
         node.retain_mut(|item| {
+            if !should_retain_module_item(item, self.in_namespace) {
+                return false;
+            }
+
             let is_empty = item.as_stmt().map(Stmt::is_empty).unwrap_or(false);
             item.visit_mut_with(self);
             // Remove those folded into Empty
@@ -294,10 +297,11 @@ impl VisitMut for Transform {
     fn visit_mut_stmts(&mut self, node: &mut Vec<Stmt>) {
         let var_list = self.var_list.take();
         node.retain_mut(|stmt| {
-            let is_empty = stmt.is_empty();
+            let can_keep_empty = stmt.is_empty();
             stmt.visit_mut_with(self);
-            // Remove those folded into Empty
-            is_empty || !stmt.is_empty()
+            // Keep original empties, but remove newly folded empties and dummy empties.
+            (can_keep_empty || !stmt.is_empty())
+                && !matches!(stmt, Stmt::Empty(empty_stmt) if empty_stmt.span.is_dummy())
         });
         let var_list = mem::replace(&mut self.var_list, var_list);
         if !var_list.is_empty() {
@@ -310,8 +314,6 @@ impl VisitMut for Transform {
                 .into(),
             )
         }
-
-        node.retain(|stmt| !matches!(stmt, Stmt::Empty(empty_stmt) if empty_stmt.span.is_dummy()));
     }
 
     fn visit_mut_ts_namespace_decl(&mut self, node: &mut TsNamespaceDecl) {
@@ -961,7 +963,6 @@ impl Transform {
 
         let stmts = member_list
             .into_iter()
-            .filter(|item| !ts_enum_safe_remove || !item.is_const())
             .map(|item| item.build_assign(&id.to_id()));
 
         let namespace_export = self.namespace_id.is_some() && is_export;

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -186,9 +186,9 @@ impl EnumValueComputer<'_> {
     }
 
     fn compute_bin(&self, expr: BinExpr) -> TsEnumRecordValue {
-        let origin_expr = expr.clone();
+        let mut origin_expr = expr;
         if !matches!(
-            expr.op,
+            origin_expr.op,
             op!(bin, "+")
                 | op!(bin, "-")
                 | op!("*")
@@ -205,10 +205,10 @@ impl EnumValueComputer<'_> {
             return TsEnumRecordValue::Opaque(origin_expr.into());
         }
 
-        let left = self.compute_rec(expr.left);
-        let right = self.compute_rec(expr.right);
+        let left = self.compute_rec(origin_expr.left.clone());
+        let right = self.compute_rec(origin_expr.right.clone());
 
-        match (left, right, expr.op) {
+        match (left, right, origin_expr.op) {
             (TsEnumRecordValue::Number(left), TsEnumRecordValue::Number(right), op) => {
                 let value = match op {
                     op!(bin, "+") => left + right,
@@ -242,8 +242,6 @@ impl EnumValueComputer<'_> {
                 TsEnumRecordValue::String(format!("{left}{right}").into())
             }
             (left, right, _) => {
-                let mut origin_expr = origin_expr;
-
                 if left.is_const() {
                     origin_expr.left = Box::new(left.into());
                 }
@@ -258,60 +256,107 @@ impl EnumValueComputer<'_> {
     }
 
     fn compute_member(&self, expr: MemberExpr) -> TsEnumRecordValue {
-        if matches!(expr.prop, MemberProp::PrivateName(..)) {
-            return TsEnumRecordValue::Opaque(expr.into());
+        let MemberExpr { span, obj, prop } = expr;
+        if matches!(prop, MemberProp::PrivateName(..)) {
+            return TsEnumRecordValue::Opaque(MemberExpr { span, obj, prop }.into());
         }
 
-        let opaque_expr = TsEnumRecordValue::Opaque(expr.clone().into());
-
-        let member_name = match expr.prop {
-            MemberProp::Ident(ident) => ident.sym,
+        let member_name = match &prop {
+            MemberProp::Ident(ident) => ident.sym.clone(),
             MemberProp::Computed(ComputedPropName { expr, .. }) => {
-                let Expr::Lit(Lit::Str(s)) = *expr else {
-                    return opaque_expr;
+                let Expr::Lit(Lit::Str(s)) = &**expr else {
+                    return TsEnumRecordValue::Opaque(MemberExpr { span, obj, prop }.into());
                 };
 
                 atom_from_wtf8_atom(&s.value)
             }
-            _ => return opaque_expr,
+            _ => return TsEnumRecordValue::Opaque(MemberExpr { span, obj, prop }.into()),
         };
 
-        let Expr::Ident(ident) = *expr.obj else {
-            return opaque_expr;
+        let ident = match *obj {
+            Expr::Ident(ident) => ident,
+            expr => {
+                return TsEnumRecordValue::Opaque(
+                    MemberExpr {
+                        span,
+                        obj: Box::new(expr),
+                        prop,
+                    }
+                    .into(),
+                );
+            }
         };
 
-        self.record
+        if let Some(value) = self
+            .record
             .get(&TsEnumRecordKey {
                 enum_id: ident.to_id(),
                 member_name,
             })
             .cloned()
             .filter(TsEnumRecordValue::has_value)
-            .unwrap_or(opaque_expr)
+        {
+            value
+        } else {
+            TsEnumRecordValue::Opaque(
+                MemberExpr {
+                    span,
+                    obj: Box::new(ident.into()),
+                    prop,
+                }
+                .into(),
+            )
+        }
     }
 
     fn compute_tpl(&self, expr: Tpl) -> TsEnumRecordValue {
-        let opaque_expr = TsEnumRecordValue::Opaque(expr.clone().into());
+        let Tpl {
+            span,
+            exprs,
+            quasis,
+        } = expr;
 
-        let Tpl { exprs, quasis, .. } = expr;
-
-        let mut quasis_iter = quasis.into_iter();
-
-        let Some(mut string) = quasis_iter.next().map(|q| q.raw.to_string()) else {
-            return opaque_expr;
+        let Some(mut string) = quasis.first().map(|q| q.raw.to_string()) else {
+            return TsEnumRecordValue::Opaque(
+                Tpl {
+                    span,
+                    exprs,
+                    quasis,
+                }
+                .into(),
+            );
         };
 
-        for (q, expr) in quasis_iter.zip(exprs) {
-            let expr = self.compute_rec(expr);
+        for idx in 0..exprs.len() {
+            let Some(quasi) = quasis.get(idx + 1) else {
+                return TsEnumRecordValue::Opaque(
+                    Tpl {
+                        span,
+                        exprs,
+                        quasis,
+                    }
+                    .into(),
+                );
+            };
+            let expr = self.compute_rec(exprs[idx].clone());
 
             let expr = match expr {
                 TsEnumRecordValue::String(s) => s.to_string(),
                 TsEnumRecordValue::Number(n) => n.to_js_string(),
-                _ => return opaque_expr,
+                _ => {
+                    return TsEnumRecordValue::Opaque(
+                        Tpl {
+                            span,
+                            exprs,
+                            quasis,
+                        }
+                        .into(),
+                    )
+                }
             };
 
             string.push_str(&expr);
-            string.push_str(&q.raw);
+            string.push_str(&quasi.raw);
         }
 
         TsEnumRecordValue::String(string.into())

--- a/crates/swc_ecma_transforms_typescript/src/typescript.rs
+++ b/crates/swc_ecma_transforms_typescript/src/typescript.rs
@@ -1,8 +1,11 @@
 use std::mem;
 
+use bytes_str::BytesStr;
 use rustc_hash::FxHashSet;
 use swc_atoms::atom;
-use swc_common::{comments::Comments, sync::Lrc, util::take::Take, Mark, SourceMap, Span, Spanned};
+use swc_common::{
+    comments::Comments, sync::Lrc, util::take::Take, Mark, SourceMap, Span, Spanned, SyntaxContext,
+};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_react::{parse_expr_for_jsx, JsxDirectives};
 use swc_ecma_visit::{visit_mut_pass, VisitMut, VisitMutWith};
@@ -169,6 +172,19 @@ where
     unresolved_mark: Mark,
 }
 
+impl<C> TypeScriptReact<C>
+where
+    C: Comments,
+{
+    #[inline]
+    fn react_id_for_pragma(&self) -> Id {
+        (
+            atom!("React"),
+            SyntaxContext::empty().apply_mark(self.top_level_mark),
+        )
+    }
+}
+
 impl<C> VisitMut for TypeScriptReact<C>
 where
     C: Comments,
@@ -179,28 +195,33 @@ where
         // But in `verbatim_module_syntax` mode, we do not remove any unused imports.
         // So we do not need to collect usage info.
         if !self.config.verbatim_module_syntax {
-            let pragma = parse_expr_for_jsx(
-                &self.cm,
-                "pragma",
-                self.tsx_config
-                    .pragma
-                    .clone()
-                    .unwrap_or_else(|| static_str!("React.createElement")),
-                self.top_level_mark,
-            );
+            let default_pragma: BytesStr = static_str!("React.createElement");
+            let default_pragma_frag: BytesStr = static_str!("React.Fragment");
 
-            let pragma_frag = parse_expr_for_jsx(
-                &self.cm,
-                "pragma",
-                self.tsx_config
-                    .pragma_frag
-                    .clone()
-                    .unwrap_or_else(|| static_str!("React.Fragment")),
-                self.top_level_mark,
-            );
+            let pragma = self
+                .tsx_config
+                .pragma
+                .clone()
+                .unwrap_or_else(|| default_pragma.clone());
+            let pragma_id = if pragma == default_pragma {
+                self.react_id_for_pragma()
+            } else {
+                let pragma = parse_expr_for_jsx(&self.cm, "pragma", pragma, self.top_level_mark);
+                id_for_jsx(&pragma).unwrap()
+            };
 
-            let pragma_id = id_for_jsx(&pragma).unwrap();
-            let pragma_frag_id = id_for_jsx(&pragma_frag).unwrap();
+            let pragma_frag = self
+                .tsx_config
+                .pragma_frag
+                .clone()
+                .unwrap_or_else(|| default_pragma_frag.clone());
+            let pragma_frag_id = if pragma_frag == default_pragma_frag {
+                self.react_id_for_pragma()
+            } else {
+                let pragma_frag =
+                    parse_expr_for_jsx(&self.cm, "pragma", pragma_frag, self.top_level_mark);
+                id_for_jsx(&pragma_frag).unwrap()
+            };
 
             self.id_usage.insert(pragma_id);
             self.id_usage.insert(pragma_frag_id);

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11653/enum-fallback/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11653/enum-fallback/input.ts
@@ -1,0 +1,17 @@
+const runtime = Math.random() > 0.5 ? 10 : 20;
+
+enum Other {
+  Base = 5,
+}
+
+enum Value {
+  A = 1,
+  B = A + 2,
+  C = B * 3,
+  D = `${C}`,
+  E = C + runtime,
+  F = Other.Base + B,
+  G = E + F,
+}
+
+console.log(Value.A, Value.B, Value.C, Value.D, Value.E, Value.F, Value.G);

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11653/enum-fallback/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11653/enum-fallback/output.js
@@ -1,0 +1,16 @@
+const runtime = Math.random() > 0.5 ? 10 : 20;
+var Other = /*#__PURE__*/ function(Other) {
+    Other[Other["Base"] = 5] = "Base";
+    return Other;
+}(Other || {});
+var Value = function(Value) {
+    Value[Value["A"] = 1] = "A";
+    Value[Value["B"] = 3] = "B";
+    Value[Value["C"] = 9] = "C";
+    Value["D"] = "9";
+    Value[Value["E"] = 9 + runtime] = "E";
+    Value[Value["F"] = 8] = "F";
+    Value[Value["G"] = Value.E + 8] = "G";
+    return Value;
+}(Value || {});
+console.log(1, 3, 9, "9", Value.E, 8, Value.G);

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11653/module-strip/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11653/module-strip/input.ts
@@ -1,0 +1,11 @@
+import { type TypeA, type TypeB, valueA, valueB } from "lib-a";
+import { type TypeC, valueC } from "lib-b";
+import type { TypeOnly } from "lib-c";
+
+type Local = TypeA | TypeB | TypeC | TypeOnly;
+
+export type Public = Local;
+
+const sum = valueA + valueB + valueC;
+
+export { valueA, valueC, sum };

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11653/module-strip/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11653/module-strip/output.js
@@ -1,0 +1,4 @@
+import { valueA, valueB } from "lib-a";
+import { valueC } from "lib-b";
+const sum = valueA + valueB + valueC;
+export { valueA, valueC, sum };


### PR DESCRIPTION
## Summary

This PR addresses all optimization items tracked in #11653 for `swc_ecma_transforms_typescript`.

### Implemented optimizations

- Fuse redundant top-level filtering passes in TypeScript transform module/stmt traversal.
- Remove duplicate enum member filtering before assignment generation.
- Avoid cloning entire `TsEnumMember` during semantic enum analysis.
- Make enum fallback opaque construction lazy in `EnumValueComputer` (`bin` / `member` / `tpl`).
- Fast-path default TSX pragma usage (`React.createElement` / `React.Fragment`) to avoid repeated parse overhead.
- Replace temporary `Vec<Id>` collection from `find_pat_ids` with streaming insertion via `for_each_binding_ident`.
- Add targeted perf benchmark inputs for enum-heavy and module-strip-heavy workloads.

## Additional coverage

- Added fixture coverage under:
  - `crates/swc_ecma_transforms_typescript/tests/fixture/issue-11653/enum-fallback`
  - `crates/swc_ecma_transforms_typescript/tests/fixture/issue-11653/module-strip`

## Bench updates

Added benchmark cases in `crates/swc_ecma_transforms_typescript/benches/compat.rs`:

- `es/transform/baseline/common_typescript_enum_heavy`
- `es/transform/baseline/common_typescript_module_strip`

Sample local run (`cargo bench -p swc_ecma_transforms_typescript --bench compat -- common_typescript`):

- `common_typescript`: `25.437 µs .. 28.219 µs`
- `common_typescript_enum_heavy`: `10.550 µs .. 12.778 µs`
- `common_typescript_module_strip`: `2.3388 µs .. 2.4550 µs`

## Verification

- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_transforms_typescript`
- `cargo test -p swc_ecma_transforms_typescript`
- `cargo test -p swc_ecma_transforms_typescript --test strip ts_enum`
- `cargo test -p swc_ecma_transforms_typescript --test strip imports_not_used_as_values_jsx_prag`
- `cargo test -p swc_ecma_transforms_typescript --test strip exec_tests__fixture__issue_11653 -- --ignored`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

Note: the full `cargo test -p swc_ecma_transforms_typescript` run still hits existing env-dependent `mocha` absence in `issue_960_2`.

Closes #11653.
