### PR TITLE
fix(es/types): add new options types

### DIFF
--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -295,6 +295,10 @@ export interface TerserCompressOptions {
 
     unsafe_undefined?: boolean;
 
+    unsafe_hoist_static_method_alias?: boolean;
+
+    unsafe_hoist_global_objects_alias?: boolean;
+
     unused?: boolean;
 
     const_to_let?: boolean;


### PR DESCRIPTION
**Description:**

#11493 lands `unsafe_hoist_static_method_alias` and `unsafe_hoist_global_objects_alias` options, but `@swc/types` is not updated.

The PR fixes that.

**BREAKING CHANGE:**

N/A

**Related issue (if exists):**

#9741
#11493