### PR TITLE
feat(react-compiler): scaffold SWC port of Babel entrypoint

### DIFF
--- a/.changeset/green-owls-jump.md
+++ b/.changeset/green-owls-jump.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_react_compiler: major
+---
+
+feat(react-compiler): scaffold SWC port of Babel entrypoint

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6516,8 +6516,10 @@ dependencies = [
 name = "swc_ecma_react_compiler"
 version = "14.0.0"
 dependencies = [
+ "swc_atoms",
  "swc_common",
  "swc_ecma_ast",
+ "swc_ecma_codegen",
  "swc_ecma_parser",
  "swc_ecma_visit",
  "testing",

--- a/crates/swc_ecma_react_compiler/Cargo.toml
+++ b/crates/swc_ecma_react_compiler/Cargo.toml
@@ -13,10 +13,12 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
+swc_atoms      = { version = "9.0.0", path = "../swc_atoms" }
 swc_common     = { version = "19.0.0", path = "../swc_common" }
 swc_ecma_ast   = { version = "21.0.0", path = "../swc_ecma_ast" }
 swc_ecma_visit = { version = "21.0.0", path = "../swc_ecma_visit" }
 
 [dev-dependencies]
+swc_ecma_codegen = { version = "24.0.0", path = "../swc_ecma_codegen" }
 swc_ecma_parser = { version = "35.0.0", path = "../swc_ecma_parser" }
 testing         = { version = "20.0.0", path = "../testing" }

--- a/crates/swc_ecma_react_compiler/scripts/sync_fixtures.sh
+++ b/crates/swc_ecma_react_compiler/scripts/sync_fixtures.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MANIFEST="$ROOT_DIR/tests/fixtures/upstream_manifest.txt"
+OUT_DIR="$ROOT_DIR/tests/fixtures/upstream"
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh CLI is required" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+extract_block() {
+  local section="$1"
+  local file="$2"
+  awk -v section="$section" '
+    $0 ~ "^## " section "$" {
+      in_section = 1
+      in_code = 0
+      next
+    }
+    in_section && /^## / {
+      in_section = 0
+      in_code = 0
+    }
+    in_section && /^```/ {
+      if (in_code == 0) {
+        in_code = 1
+        next
+      }
+      exit
+    }
+    in_section && in_code {
+      print
+    }
+  ' "$file"
+}
+
+mkdir -p "$OUT_DIR"
+
+while IFS= read -r raw_name; do
+  name="${raw_name%%#*}"
+  name="$(echo "$name" | xargs)"
+  if [[ -z "$name" ]]; then
+    continue
+  fi
+
+  api_path="repos/facebook/react/contents/compiler/packages/babel-plugin-react-compiler/src/__tests__/fixtures/compiler/${name}.expect.md?ref=main"
+  tmp_file="$(mktemp)"
+
+  gh api "$api_path" | jq -r '.content' | base64 --decode > "$tmp_file"
+
+  fixture_dir="$OUT_DIR/$name"
+  mkdir -p "$fixture_dir"
+
+  extract_block "Input" "$tmp_file" > "$fixture_dir/input.js"
+
+  code_block="$(extract_block "Code" "$tmp_file" || true)"
+  error_block="$(extract_block "Error" "$tmp_file" || true)"
+
+  if [[ -n "$code_block" ]]; then
+    printf '%s\n' "$code_block" > "$fixture_dir/output.js"
+    rm -f "$fixture_dir/error.txt"
+  elif [[ -n "$error_block" ]]; then
+    printf '%s\n' "$error_block" > "$fixture_dir/error.txt"
+    rm -f "$fixture_dir/output.js"
+  else
+    echo "warn: neither Code nor Error section found for $name" >&2
+  fi
+
+  rm -f "$tmp_file"
+  echo "synced: $name"
+done < "$MANIFEST"

--- a/crates/swc_ecma_react_compiler/src/entrypoint/gating.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/gating.rs
@@ -1,0 +1,93 @@
+use swc_atoms::Atom;
+
+use crate::{
+    error::{CompilerError, CompilerErrorDetail, ErrorCategory},
+    options::{DynamicGatingOptions, ExternalFunction, ParsedPluginOptions},
+    utils::is_valid_identifier,
+};
+
+const DYNAMIC_GATING_PREFIX: &str = "use memo if(";
+const DYNAMIC_GATING_SUFFIX: &str = ")";
+
+pub fn find_dynamic_gating(
+    directives: &[String],
+    opts: &ParsedPluginOptions,
+) -> Result<Option<ExternalFunction>, CompilerError> {
+    let Some(dynamic_gating) = &opts.dynamic_gating else {
+        return Ok(None);
+    };
+
+    find_dynamic_gating_with_opts(directives, dynamic_gating)
+}
+
+fn find_dynamic_gating_with_opts(
+    directives: &[String],
+    dynamic_gating: &DynamicGatingOptions,
+) -> Result<Option<ExternalFunction>, CompilerError> {
+    let mut matches = Vec::new();
+
+    for directive in directives {
+        let Some(candidate) = directive
+            .strip_prefix(DYNAMIC_GATING_PREFIX)
+            .and_then(|value| value.strip_suffix(DYNAMIC_GATING_SUFFIX))
+        else {
+            continue;
+        };
+
+        if !is_valid_identifier(candidate) {
+            let mut detail = CompilerErrorDetail::error(
+                ErrorCategory::Gating,
+                "Dynamic gating directive is not a valid JavaScript identifier",
+            );
+            detail.description = Some(format!("Found '{directive}'"));
+            return Err(CompilerError::with_detail(detail));
+        }
+
+        matches.push(candidate.to_string());
+    }
+
+    if matches.len() > 1 {
+        let mut detail = CompilerErrorDetail::error(
+            ErrorCategory::Gating,
+            "Multiple dynamic gating directives found",
+        );
+        detail.description = Some(format!(
+            "Expected a single directive but found [{}]",
+            matches.join(", ")
+        ));
+        return Err(CompilerError::with_detail(detail));
+    }
+
+    let Some(import_specifier_name) = matches.into_iter().next() else {
+        return Ok(None);
+    };
+
+    Ok(Some(ExternalFunction {
+        source: dynamic_gating.source.clone(),
+        import_specifier_name: Atom::from(import_specifier_name),
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_atoms::Atom;
+
+    use super::*;
+
+    #[test]
+    fn parses_dynamic_gating_directive() {
+        let opts = ParsedPluginOptions {
+            dynamic_gating: Some(DynamicGatingOptions {
+                source: Atom::new("my-runtime"),
+            }),
+            ..crate::options::default_options()
+        };
+
+        let gating = find_dynamic_gating(&["use memo if(isEnabled)".into()], &opts)
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(gating.source, Atom::new("my-runtime"));
+        assert_eq!(gating.import_specifier_name, Atom::new("isEnabled"));
+    }
+}

--- a/crates/swc_ecma_react_compiler/src/entrypoint/imports.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/imports.rs
@@ -1,0 +1,213 @@
+use swc_atoms::Atom;
+use swc_common::{Span, DUMMY_SP};
+use swc_ecma_ast::{
+    Decl, Ident, ImportDecl, ImportNamedSpecifier, ImportPhase, ImportSpecifier, Module,
+    ModuleDecl, ModuleExportName, ModuleItem, Program, Str, VarDecl, VarDeclKind, VarDeclarator,
+};
+
+use crate::{
+    error::{CompilerError, CompilerErrorDetail, ErrorCategory},
+    options::ExternalFunction,
+};
+
+pub fn has_memo_cache_function_import(program: &Program, module_name: &str) -> bool {
+    let Program::Module(module) = program else {
+        return false;
+    };
+
+    module.body.iter().any(|item| {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)) = item else {
+            return false;
+        };
+
+        if import_decl.src.value != module_name {
+            return false;
+        }
+
+        import_decl.specifiers.iter().any(|specifier| {
+            let ImportSpecifier::Named(named) = specifier else {
+                return false;
+            };
+
+            match &named.imported {
+                Some(ModuleExportName::Ident(imported)) => imported.sym == "c",
+                Some(ModuleExportName::Str(imported)) => imported.value == "c",
+                None => named.local.sym == "c",
+            }
+        })
+    })
+}
+
+pub fn validate_restricted_imports(
+    program: &Program,
+    restricted: &[Atom],
+) -> Result<(), CompilerError> {
+    if restricted.is_empty() {
+        return Ok(());
+    }
+
+    let Program::Module(module) = program else {
+        return Ok(());
+    };
+
+    let mut err = CompilerError::new();
+
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)) = item else {
+            continue;
+        };
+
+        if restricted
+            .iter()
+            .any(|candidate| import_decl.src.value == candidate.as_ref())
+        {
+            let mut detail = CompilerErrorDetail::error(
+                ErrorCategory::Todo,
+                "Bailing out due to blocklisted import",
+            );
+            detail.description = Some(format!(
+                "Import from module {}",
+                import_decl.src.value.to_string_lossy()
+            ));
+            detail.loc = Some(import_decl.span);
+            err.push(detail);
+        }
+    }
+
+    if err.has_any_errors() {
+        Err(err)
+    } else {
+        Ok(())
+    }
+}
+
+pub fn add_memo_cache_import(program: &mut Program, module_name: &str) -> bool {
+    add_import_specifier(program, module_name, "c", "_c").is_some()
+}
+
+pub fn add_external_import(program: &mut Program, function: &ExternalFunction) -> bool {
+    add_import_specifier(
+        program,
+        function.source.as_ref(),
+        function.import_specifier_name.as_ref(),
+        function.import_specifier_name.as_ref(),
+    )
+    .is_some()
+}
+
+fn add_import_specifier(
+    program: &mut Program,
+    module_name: &str,
+    imported_name: &str,
+    local_hint: &str,
+) -> Option<Ident> {
+    let Program::Module(module) = program else {
+        return None;
+    };
+
+    if let Some(existing_local) = find_existing_named_import(module, module_name, imported_name) {
+        return Some(existing_local);
+    }
+
+    let local = Ident::new_no_ctxt(Atom::new(local_hint), DUMMY_SP);
+
+    let new_specifier = ImportSpecifier::Named(ImportNamedSpecifier {
+        span: DUMMY_SP,
+        local: local.clone(),
+        imported: Some(ModuleExportName::Ident(Ident::new_no_ctxt(
+            Atom::new(imported_name),
+            DUMMY_SP,
+        ))),
+        is_type_only: false,
+    });
+
+    if let Some(import_decl) = find_existing_import_mut(module, module_name) {
+        import_decl.specifiers.push(new_specifier);
+        return Some(local);
+    }
+
+    module.body.insert(
+        0,
+        ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+            span: DUMMY_SP,
+            specifiers: vec![new_specifier],
+            src: Box::new(Str {
+                span: DUMMY_SP,
+                value: Atom::new(module_name).into(),
+                raw: None,
+            }),
+            type_only: false,
+            with: None,
+            phase: ImportPhase::Evaluation,
+        })),
+    );
+
+    Some(local)
+}
+
+fn find_existing_import_mut<'a>(
+    module: &'a mut Module,
+    module_name: &str,
+) -> Option<&'a mut ImportDecl> {
+    for item in &mut module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)) = item else {
+            continue;
+        };
+
+        if import_decl.src.value == module_name {
+            return Some(import_decl);
+        }
+    }
+
+    None
+}
+
+fn find_existing_named_import(
+    module: &Module,
+    module_name: &str,
+    imported_name: &str,
+) -> Option<Ident> {
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::Import(import_decl)) = item else {
+            continue;
+        };
+
+        if import_decl.src.value != module_name {
+            continue;
+        }
+
+        for specifier in &import_decl.specifiers {
+            let ImportSpecifier::Named(named) = specifier else {
+                continue;
+            };
+
+            let imported_matches = match &named.imported {
+                Some(ModuleExportName::Ident(ident_name)) => ident_name.sym == imported_name,
+                Some(ModuleExportName::Str(str_name)) => str_name.value == imported_name,
+                None => named.local.sym == imported_name,
+            };
+
+            if imported_matches {
+                return Some(named.local.clone());
+            }
+        }
+    }
+
+    None
+}
+
+#[allow(dead_code)]
+fn _script_require_stub(_span: Span) -> Decl {
+    Decl::Var(Box::new(VarDecl {
+        span: DUMMY_SP,
+        ctxt: Default::default(),
+        kind: VarDeclKind::Const,
+        declare: false,
+        decls: vec![VarDeclarator {
+            span: DUMMY_SP,
+            name: swc_ecma_ast::Pat::Invalid(swc_ecma_ast::Invalid { span: DUMMY_SP }),
+            init: None,
+            definite: false,
+        }],
+    }))
+}

--- a/crates/swc_ecma_react_compiler/src/entrypoint/imports.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/imports.rs
@@ -20,6 +20,10 @@ pub fn has_memo_cache_function_import(program: &Program, module_name: &str) -> b
             return false;
         };
 
+        if import_decl.type_only {
+            return false;
+        }
+
         if import_decl.src.value != module_name {
             return false;
         }
@@ -28,6 +32,10 @@ pub fn has_memo_cache_function_import(program: &Program, module_name: &str) -> b
             let ImportSpecifier::Named(named) = specifier else {
                 return false;
             };
+
+            if named.is_type_only {
+                return false;
+            }
 
             match &named.imported {
                 Some(ModuleExportName::Ident(imported)) => imported.sym == "c",
@@ -154,7 +162,7 @@ fn find_existing_import_mut<'a>(
             continue;
         };
 
-        if import_decl.src.value == module_name {
+        if import_decl.src.value == module_name && !import_decl.type_only {
             return Some(import_decl);
         }
     }
@@ -175,11 +183,17 @@ fn find_existing_named_import(
         if import_decl.src.value != module_name {
             continue;
         }
+        if import_decl.type_only {
+            continue;
+        }
 
         for specifier in &import_decl.specifiers {
             let ImportSpecifier::Named(named) = specifier else {
                 continue;
             };
+            if named.is_type_only {
+                continue;
+            }
 
             let imported_matches = match &named.imported {
                 Some(ModuleExportName::Ident(ident_name)) => ident_name.sym == imported_name,
@@ -210,4 +224,49 @@ fn _script_require_stub(_span: Span) -> Decl {
             definite: false,
         }],
     }))
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_common::FileName;
+    use swc_ecma_ast::EsVersion;
+    use swc_ecma_parser::{parse_file_as_module, Syntax, TsSyntax};
+
+    use super::*;
+
+    fn parse_module(code: &str) -> Program {
+        let cm = swc_common::sync::Lrc::new(swc_common::SourceMap::default());
+        let fm = cm.new_source_file(
+            FileName::Custom("fixture.ts".into()).into(),
+            code.to_string(),
+        );
+        Program::Module(
+            parse_file_as_module(
+                &fm,
+                Syntax::Typescript(TsSyntax::default()),
+                EsVersion::latest(),
+                None,
+                &mut vec![],
+            )
+            .expect("should parse"),
+        )
+    }
+
+    #[test]
+    fn ignores_type_only_cache_helper_import() {
+        let program = parse_module("import type { c } from \"react/compiler-runtime\";\n");
+        assert!(!has_memo_cache_function_import(
+            &program,
+            "react/compiler-runtime"
+        ));
+    }
+
+    #[test]
+    fn detects_runtime_cache_helper_import() {
+        let program = parse_module("import { c as _c } from \"react/compiler-runtime\";\n");
+        assert!(has_memo_cache_function_import(
+            &program,
+            "react/compiler-runtime"
+        ));
+    }
 }

--- a/crates/swc_ecma_react_compiler/src/entrypoint/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/mod.rs
@@ -1,0 +1,10 @@
+mod gating;
+mod imports;
+mod program;
+mod suppression;
+
+pub use program::{
+    compile_fn, compile_program, find_directive_disabling_memoization,
+    get_react_compiler_runtime_module, try_find_directive_enabling_memoization, CompileReport,
+    CompilerPass,
+};

--- a/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
@@ -119,6 +119,7 @@ pub fn compile_program(
         function_depth: 0,
         class_depth: 0,
         program_suppressions,
+        consumed_next_line_suppressions: HashSet::new(),
         report,
         queued_outlined: Vec::new(),
         used_external_imports: Vec::new(),
@@ -346,6 +347,7 @@ struct ProgramCompiler<'a> {
     function_depth: u32,
     class_depth: u32,
     program_suppressions: Vec<suppression::SuppressionRange>,
+    consumed_next_line_suppressions: HashSet<usize>,
     report: CompileReport,
     queued_outlined: Vec<QueuedOutlinedFunction>,
     used_external_imports: Vec<crate::options::ExternalFunction>,
@@ -358,6 +360,32 @@ struct QueuedOutlinedFunction {
 }
 
 impl ProgramCompiler<'_> {
+    fn suppressions_for_span(&mut self, span: Span) -> Vec<suppression::SuppressionRange> {
+        let mut matched = Vec::new();
+
+        for (index, suppression_range) in self.program_suppressions.iter().enumerate() {
+            let is_next_line = suppression::is_next_line_suppression(suppression_range);
+            if is_next_line && self.consumed_next_line_suppressions.contains(&index) {
+                continue;
+            }
+
+            let hits = suppression::filter_suppressions_that_affect_range(
+                std::slice::from_ref(suppression_range),
+                span,
+            );
+            if hits.is_empty() {
+                continue;
+            }
+
+            matched.push(suppression_range.clone());
+            if is_next_line {
+                self.consumed_next_line_suppressions.insert(index);
+            }
+        }
+
+        matched
+    }
+
     fn compile_named_function(
         &mut self,
         name: Option<&Ident>,
@@ -370,10 +398,7 @@ impl ProgramCompiler<'_> {
             return;
         }
 
-        let suppression_ranges = suppression::filter_suppressions_that_affect_range(
-            &self.program_suppressions,
-            function.span,
-        );
+        let suppression_ranges = self.suppressions_for_span(function.span);
         if !suppression_ranges.is_empty() {
             let err = suppression::suppressions_to_compiler_error(&suppression_ranges);
             self.record_error(err, Some(fn_loc));
@@ -559,10 +584,7 @@ impl ProgramCompiler<'_> {
             }
         };
 
-        let suppression_ranges = suppression::filter_suppressions_that_affect_range(
-            &self.program_suppressions,
-            arrow.span,
-        );
+        let suppression_ranges = self.suppressions_for_span(arrow.span);
         if !suppression_ranges.is_empty() {
             let err = suppression::suppressions_to_compiler_error(&suppression_ranges);
             self.record_error(err, Some(fn_loc));

--- a/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
@@ -1,0 +1,1438 @@
+use std::{any::Any, collections::HashSet, panic::AssertUnwindSafe, time::Instant};
+
+use swc_common::{comments::Comment, Span, DUMMY_SP};
+use swc_ecma_ast::{
+    op, ArrowExpr, AssignExpr, BindingIdent, BlockStmt, BlockStmtOrExpr, Callee, Decl, DefaultDecl,
+    Expr, FnDecl, Function, Ident, ModuleItem, Param, Pat, Program, Stmt,
+};
+use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
+
+use crate::{
+    entrypoint::{gating::find_dynamic_gating, imports, suppression},
+    error::{CompilerError, CompilerErrorDetail, ErrorCategory, ErrorSeverity},
+    inference, optimization,
+    options::{
+        CompilationMode, CompilerOutputMode, CompilerReactTarget, LoggerEvent,
+        PanicThresholdOptions, ParsedPluginOptions,
+    },
+    reactive_scopes::{self, CodegenFunction},
+    ssa, transform,
+    transform::ReactFunctionType,
+    utils::{collect_block_directives, collect_directives, is_component_name, is_hook_name},
+    validation,
+};
+
+const OPT_IN_DIRECTIVES: &[&str] = &["use forget", "use memo"];
+const OPT_OUT_DIRECTIVES: &[&str] = &["use no forget", "use no memo"];
+
+/// Program-level pass context for React Compiler.
+#[derive(Clone)]
+pub struct CompilerPass {
+    pub opts: ParsedPluginOptions,
+    pub filename: Option<String>,
+    pub comments: Vec<Comment>,
+    pub code: Option<String>,
+}
+
+/// Compile summary and emitted diagnostics/events.
+#[derive(Debug, Default, Clone)]
+pub struct CompileReport {
+    pub compiled_functions: usize,
+    pub skipped_functions: usize,
+    pub inserted_imports: usize,
+    pub events: Vec<LoggerEvent>,
+    pub diagnostics: Vec<CompilerErrorDetail>,
+    pub changed: bool,
+}
+
+pub fn compile_program(
+    program: &mut Program,
+    pass: &CompilerPass,
+) -> Result<CompileReport, CompilerError> {
+    let program_start = Instant::now();
+    let mut report = CompileReport::default();
+
+    if let Some(filename) = pass.filename.as_deref() {
+        if !pass.opts.should_include_file(filename) {
+            report.events.push(LoggerEvent::CompileSkip {
+                fn_loc: None,
+                reason: "Skipped because file is excluded by `sources` filters.".into(),
+                loc: None,
+            });
+            return Ok(report);
+        }
+    } else if pass.opts.sources.is_some() {
+        return Err(CompilerError::invalid_config(
+            "Expected a filename but found none.",
+            "When the `sources` option is specified, React Compiler requires filename context.",
+        ));
+    }
+
+    if imports::has_memo_cache_function_import(program, pass.opts.target.runtime_module().as_ref())
+    {
+        report.events.push(LoggerEvent::CompileSkip {
+            fn_loc: None,
+            reason: "Skipped because compiler runtime import already exists in this file."
+                .to_string(),
+            loc: None,
+        });
+        return Ok(report);
+    }
+
+    imports::validate_restricted_imports(
+        program,
+        &pass.opts.environment.validate_blocklisted_imports,
+    )?;
+
+    let suppression_rules = if pass
+        .opts
+        .environment
+        .validate_exhaustive_memoization_dependencies
+        && pass.opts.environment.validate_hooks_usage
+    {
+        None
+    } else {
+        Some(
+            pass.opts
+                .eslint_suppression_rules
+                .clone()
+                .unwrap_or_else(suppression::default_eslint_suppression_rules),
+        )
+    };
+    let program_suppressions = suppression::find_program_suppressions(
+        &pass.comments,
+        suppression_rules.as_deref(),
+        pass.opts.flow_suppressions,
+    );
+
+    let module_scope_opt_out = {
+        let directives = top_level_directives(program);
+        find_directive_disabling_memoization(&directives, &pass.opts.custom_opt_out_directives)
+            .is_some()
+    };
+
+    let output_mode = pass.opts.effective_output_mode();
+    let mut compiler = ProgramCompiler {
+        opts: &pass.opts,
+        output_mode,
+        module_scope_opt_out,
+        function_depth: 0,
+        class_depth: 0,
+        program_suppressions,
+        report,
+        queued_outlined: Vec::new(),
+        used_external_imports: Vec::new(),
+        fatal_error: None,
+    };
+
+    program.visit_mut_with(&mut compiler);
+
+    if let Some(err) = compiler.fatal_error {
+        return Err(err);
+    }
+
+    let mut report = compiler.report;
+    let used_external_imports = compiler.used_external_imports;
+    let mut queued_outlined = compiler.queued_outlined;
+
+    if !module_scope_opt_out
+        && report.compiled_functions > 0
+        && output_mode != CompilerOutputMode::Lint
+    {
+        if imports::add_memo_cache_import(program, pass.opts.target.runtime_module().as_ref()) {
+            report.inserted_imports += 1;
+            report.changed = true;
+        }
+
+        let mut seen = HashSet::new();
+        for external in used_external_imports {
+            let key = (
+                external.source.to_string(),
+                external.import_specifier_name.to_string(),
+            );
+            if !seen.insert(key) {
+                continue;
+            }
+
+            if imports::add_external_import(program, &external) {
+                report.inserted_imports += 1;
+                report.changed = true;
+            }
+        }
+    }
+
+    if !module_scope_opt_out && output_mode != CompilerOutputMode::Lint {
+        let inserted = insert_queued_outlined(program, &mut queued_outlined);
+        if inserted > 0 {
+            report.changed = true;
+        }
+    }
+
+    report.events.push(LoggerEvent::Timing {
+        measurement: format!(
+            "compile_program_ms={:.3}",
+            program_start.elapsed().as_secs_f64() * 1000.0
+        ),
+    });
+
+    if let Some(logger) = pass.opts.logger.as_ref() {
+        for event in &report.events {
+            logger.log_event(pass.filename.as_deref(), event);
+        }
+    }
+
+    Ok(report)
+}
+
+/// Compiles one function through the staged pipeline.
+pub fn compile_fn(
+    function: &Function,
+    id: Option<&Ident>,
+    fn_type: ReactFunctionType,
+    output_mode: CompilerOutputMode,
+    opts: &ParsedPluginOptions,
+) -> Result<CodegenFunction, CompilerError> {
+    let mut hir = crate::hir::lower(function, id, fn_type)?;
+
+    optimization::prune_maybe_throws(&mut hir);
+    validation::validate_context_variable_lvalues(&hir)?;
+    validation::validate_use_memo(&hir)?;
+
+    ssa::enter_ssa(&mut hir);
+    ssa::eliminate_redundant_phi(&mut hir);
+
+    optimization::constant_propagation(&mut hir);
+    inference::infer_types(&mut hir);
+
+    if opts.environment.validate_hooks_usage {
+        validation::validate_hooks_usage(&hir)?;
+    }
+    if opts.environment.validate_no_capitalized_calls {
+        validation::validate_no_capitalized_calls(&hir)?;
+    }
+
+    optimization::optimize_props_method_calls(&mut hir);
+    inference::analyse_functions(&mut hir);
+    inference::infer_mutation_aliasing_effects(&mut hir);
+
+    if output_mode == CompilerOutputMode::Ssr {
+        optimization::optimize_for_ssr(&mut hir);
+    }
+
+    optimization::dead_code_elimination(&mut hir);
+    optimization::prune_maybe_throws(&mut hir);
+
+    inference::infer_mutation_aliasing_ranges(&mut hir);
+    validation::validate_locals_not_reassigned_after_render(&hir)?;
+
+    if opts.environment.validate_ref_access_during_render {
+        validation::validate_no_ref_access_in_render(&hir)?;
+    }
+    if opts.environment.validate_no_set_state_in_render {
+        validation::validate_no_set_state_in_render(&hir)?;
+    }
+    if opts.environment.validate_no_derived_computations_in_effects {
+        validation::validate_no_derived_computations_in_effects(&hir)?;
+    }
+    if opts.environment.validate_no_set_state_in_effects {
+        validation::validate_no_set_state_in_effects(&hir)?;
+    }
+    if opts.environment.validate_no_jsx_in_try_statements {
+        validation::validate_no_jsx_in_try_statement(&hir)?;
+    }
+
+    inference::infer_reactive_places(&mut hir);
+
+    if opts
+        .environment
+        .validate_exhaustive_memoization_dependencies
+        || opts.environment.validate_exhaustive_effect_dependencies
+    {
+        validation::validate_exhaustive_dependencies(&hir)?;
+    }
+
+    if opts.environment.enable_jsx_outlining {
+        optimization::outline_jsx(&mut hir);
+    }
+    if opts.environment.enable_name_anonymous_functions {
+        transform::name_anonymous_functions();
+    }
+    if opts.environment.enable_function_outlining {
+        optimization::outline_functions(&mut hir);
+    }
+
+    let reactive = reactive_scopes::build_reactive_function(&hir);
+
+    if opts
+        .environment
+        .enable_preserve_existing_memoization_guarantees
+        || opts
+            .environment
+            .validate_preserve_existing_memoization_guarantees
+    {
+        validation::validate_preserved_manual_memoization(&hir)?;
+    }
+    if opts.environment.validate_static_components {
+        validation::validate_static_components(&hir)?;
+    }
+    if opts.environment.validate_source_locations {
+        validation::validate_source_locations(&hir)?;
+    }
+
+    Ok(reactive_scopes::codegen_function(reactive))
+}
+
+/// Returns the runtime import module used by compiler output.
+pub fn get_react_compiler_runtime_module(target: &CompilerReactTarget) -> String {
+    target.runtime_module().to_string()
+}
+
+pub fn try_find_directive_enabling_memoization(
+    directives: &[String],
+    opts: &ParsedPluginOptions,
+) -> Result<Option<String>, CompilerError> {
+    if let Some(directive) = directives
+        .iter()
+        .find(|value| OPT_IN_DIRECTIVES.iter().any(|item| item == &value.as_str()))
+    {
+        return Ok(Some(directive.clone()));
+    }
+
+    if find_dynamic_gating(directives, opts)?.is_some() {
+        if let Some(dynamic) = directives
+            .iter()
+            .find(|value| value.starts_with("use memo if("))
+        {
+            return Ok(Some(dynamic.clone()));
+        }
+    }
+
+    Ok(None)
+}
+
+pub fn find_directive_disabling_memoization(
+    directives: &[String],
+    custom_opt_out_directives: &Option<Vec<String>>,
+) -> Option<String> {
+    if let Some(custom) = custom_opt_out_directives {
+        return directives
+            .iter()
+            .find(|value| custom.iter().any(|item| item == *value))
+            .cloned();
+    }
+
+    directives
+        .iter()
+        .find(|value| {
+            OPT_OUT_DIRECTIVES
+                .iter()
+                .any(|item| item == &value.as_str())
+        })
+        .cloned()
+}
+
+fn should_panic(threshold: &PanicThresholdOptions, err: &CompilerError) -> bool {
+    match threshold {
+        PanicThresholdOptions::AllErrors => err.has_any_errors(),
+        PanicThresholdOptions::CriticalErrors => err.has_critical_errors(),
+        PanicThresholdOptions::None => false,
+    }
+}
+
+struct ProgramCompiler<'a> {
+    opts: &'a ParsedPluginOptions,
+    output_mode: CompilerOutputMode,
+    module_scope_opt_out: bool,
+    function_depth: u32,
+    class_depth: u32,
+    program_suppressions: Vec<suppression::SuppressionRange>,
+    report: CompileReport,
+    queued_outlined: Vec<QueuedOutlinedFunction>,
+    used_external_imports: Vec<crate::options::ExternalFunction>,
+    fatal_error: Option<CompilerError>,
+}
+
+#[derive(Clone)]
+struct QueuedOutlinedFunction {
+    function: CodegenFunction,
+}
+
+impl ProgramCompiler<'_> {
+    fn compile_named_function(
+        &mut self,
+        name: Option<&Ident>,
+        function: &mut Function,
+        is_declaration: bool,
+        is_top_level: bool,
+        fn_loc: Span,
+    ) {
+        if self.fatal_error.is_some() || function.body.is_none() {
+            return;
+        }
+
+        let suppression_ranges = suppression::filter_suppressions_that_affect_range(
+            &self.program_suppressions,
+            function.span,
+        );
+        if !suppression_ranges.is_empty() {
+            let err = suppression::suppressions_to_compiler_error(&suppression_ranges);
+            self.record_error(err, Some(fn_loc));
+            return;
+        }
+
+        let directives = collect_block_directives(function.body.as_ref().expect("checked above"));
+
+        let opt_in = match try_find_directive_enabling_memoization(&directives, self.opts) {
+            Ok(value) => value,
+            Err(err) => {
+                self.record_error(err, Some(fn_loc));
+                return;
+            }
+        };
+
+        let opt_out =
+            find_directive_disabling_memoization(&directives, &self.opts.custom_opt_out_directives);
+
+        let dynamic_gating = match find_dynamic_gating(&directives, self.opts) {
+            Ok(value) => value,
+            Err(err) => {
+                self.record_error(err, Some(fn_loc));
+                return;
+            }
+        };
+
+        let syntax_type = if is_declaration {
+            name.and_then(|ident| syntax_function_type(ident.sym.as_ref()))
+        } else {
+            None
+        };
+
+        let inferred_type = name.and_then(|ident| {
+            infer_function_type(
+                ident.sym.as_ref(),
+                function.body.as_ref().expect("checked above"),
+            )
+        });
+
+        let selected_type = match self.opts.compilation_mode {
+            CompilationMode::Annotation => {
+                if opt_in.is_some() {
+                    inferred_type.or(Some(ReactFunctionType::Other))
+                } else {
+                    None
+                }
+            }
+            CompilationMode::Infer => inferred_type,
+            CompilationMode::Syntax => syntax_type,
+            CompilationMode::All => {
+                if is_top_level {
+                    inferred_type.or(Some(ReactFunctionType::Other))
+                } else {
+                    None
+                }
+            }
+        };
+
+        let Some(fn_type) = selected_type else {
+            return;
+        };
+
+        if opt_out.is_some() && !self.opts.ignore_use_no_forget {
+            self.report.skipped_functions += 1;
+            self.report.events.push(LoggerEvent::CompileSkip {
+                fn_loc: Some(fn_loc),
+                reason: format!(
+                    "Skipped due to '{}' directive.",
+                    opt_out.as_deref().unwrap_or("use no memo")
+                ),
+                loc: Some(fn_loc),
+            });
+            return;
+        }
+
+        let compile_start = Instant::now();
+        let compiled = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            compile_fn(function, name, fn_type, self.output_mode, self.opts)
+        }));
+        self.report.events.push(LoggerEvent::Timing {
+            measurement: format!(
+                "compile_function_ms={:.3}",
+                compile_start.elapsed().as_secs_f64() * 1000.0
+            ),
+        });
+        let codegen = match compiled {
+            Ok(Ok(codegen)) => codegen,
+            Ok(Err(err)) => {
+                self.record_error(err, Some(fn_loc));
+                return;
+            }
+            Err(payload) => {
+                let message = panic_payload_to_string(payload);
+                self.report
+                    .events
+                    .push(LoggerEvent::CompileUnexpectedThrow {
+                        fn_loc: Some(fn_loc),
+                        data: message.clone(),
+                    });
+                let mut err = CompilerError::new();
+                let mut detail = CompilerErrorDetail::error(
+                    ErrorCategory::Pipeline,
+                    "React Compiler pipeline unexpectedly panicked",
+                );
+                detail.description = Some(message);
+                detail.loc = Some(fn_loc);
+                err.push(detail);
+                self.record_error(err, Some(fn_loc));
+                return;
+            }
+        };
+
+        self.report.compiled_functions += 1;
+        self.report.events.push(LoggerEvent::CompileSuccess {
+            fn_loc: Some(fn_loc),
+            fn_name: name.map(|ident| ident.sym.to_string()),
+            memo_slots: codegen.memo_slots_used,
+            memo_blocks: codegen.memo_blocks,
+            memo_values: codegen.memo_values,
+            pruned_memo_blocks: codegen.pruned_memo_blocks,
+            pruned_memo_values: codegen.pruned_memo_values,
+        });
+
+        for outlined in &codegen.outlined {
+            self.queued_outlined.push(QueuedOutlinedFunction {
+                function: outlined.function.clone(),
+            });
+        }
+
+        if self.module_scope_opt_out {
+            return;
+        }
+
+        if self.output_mode == CompilerOutputMode::Lint {
+            return;
+        }
+
+        if self.opts.compilation_mode == CompilationMode::Annotation && opt_in.is_none() {
+            return;
+        }
+
+        apply_codegen_to_function(function, &codegen);
+        self.report.changed = true;
+
+        if let Some(gating) = dynamic_gating.or_else(|| self.opts.gating.clone()) {
+            self.used_external_imports.push(gating);
+        }
+    }
+
+    fn compile_arrow(
+        &mut self,
+        name: Option<&Ident>,
+        arrow: &mut ArrowExpr,
+        is_top_level: bool,
+        fn_loc: Span,
+    ) {
+        if self.fatal_error.is_some() {
+            return;
+        }
+
+        let block = match &*arrow.body {
+            BlockStmtOrExpr::BlockStmt(block) => block,
+            BlockStmtOrExpr::Expr(_) => {
+                // We compile concise-body arrows by wrapping into a block.
+                let expr = match *arrow.body.clone() {
+                    BlockStmtOrExpr::Expr(expr) => expr,
+                    BlockStmtOrExpr::BlockStmt(_) => unreachable!(),
+                };
+                arrow.body = Box::new(BlockStmtOrExpr::BlockStmt(BlockStmt {
+                    span: arrow.span,
+                    ctxt: arrow.ctxt,
+                    stmts: vec![swc_ecma_ast::Stmt::Return(swc_ecma_ast::ReturnStmt {
+                        span: arrow.span,
+                        arg: Some(expr),
+                    })],
+                }));
+
+                match &*arrow.body {
+                    BlockStmtOrExpr::BlockStmt(block) => block,
+                    BlockStmtOrExpr::Expr(_) => unreachable!(),
+                }
+            }
+        };
+
+        let suppression_ranges = suppression::filter_suppressions_that_affect_range(
+            &self.program_suppressions,
+            arrow.span,
+        );
+        if !suppression_ranges.is_empty() {
+            let err = suppression::suppressions_to_compiler_error(&suppression_ranges);
+            self.record_error(err, Some(fn_loc));
+            return;
+        }
+
+        let directives = collect_block_directives(block);
+        let opt_in = match try_find_directive_enabling_memoization(&directives, self.opts) {
+            Ok(value) => value,
+            Err(err) => {
+                self.record_error(err, Some(fn_loc));
+                return;
+            }
+        };
+
+        let opt_out =
+            find_directive_disabling_memoization(&directives, &self.opts.custom_opt_out_directives);
+
+        let dynamic_gating = match find_dynamic_gating(&directives, self.opts) {
+            Ok(value) => value,
+            Err(err) => {
+                self.record_error(err, Some(fn_loc));
+                return;
+            }
+        };
+
+        let inferred_type = name.and_then(|ident| infer_function_type(ident.sym.as_ref(), block));
+
+        let selected_type = match self.opts.compilation_mode {
+            CompilationMode::Annotation => {
+                if opt_in.is_some() {
+                    inferred_type.or(Some(ReactFunctionType::Other))
+                } else {
+                    None
+                }
+            }
+            CompilationMode::Infer => inferred_type,
+            CompilationMode::Syntax => None,
+            CompilationMode::All => {
+                if is_top_level {
+                    inferred_type.or(Some(ReactFunctionType::Other))
+                } else {
+                    None
+                }
+            }
+        };
+
+        let Some(fn_type) = selected_type else {
+            return;
+        };
+
+        if opt_out.is_some() && !self.opts.ignore_use_no_forget {
+            self.report.skipped_functions += 1;
+            self.report.events.push(LoggerEvent::CompileSkip {
+                fn_loc: Some(fn_loc),
+                reason: format!(
+                    "Skipped due to '{}' directive.",
+                    opt_out.as_deref().unwrap_or("use no memo")
+                ),
+                loc: Some(fn_loc),
+            });
+            return;
+        }
+
+        let synthetic = Function {
+            params: arrow
+                .params
+                .iter()
+                .cloned()
+                .map(|pat| Param {
+                    span: DUMMY_SP,
+                    decorators: Vec::new(),
+                    pat,
+                })
+                .collect(),
+            decorators: Vec::new(),
+            span: arrow.span,
+            ctxt: arrow.ctxt,
+            body: Some(block.clone()),
+            is_generator: arrow.is_generator,
+            is_async: arrow.is_async,
+            type_params: arrow.type_params.clone(),
+            return_type: arrow.return_type.clone(),
+        };
+
+        let compile_start = Instant::now();
+        let compiled = std::panic::catch_unwind(AssertUnwindSafe(|| {
+            compile_fn(&synthetic, name, fn_type, self.output_mode, self.opts)
+        }));
+        self.report.events.push(LoggerEvent::Timing {
+            measurement: format!(
+                "compile_function_ms={:.3}",
+                compile_start.elapsed().as_secs_f64() * 1000.0
+            ),
+        });
+        let codegen = match compiled {
+            Ok(Ok(codegen)) => codegen,
+            Ok(Err(err)) => {
+                self.record_error(err, Some(fn_loc));
+                return;
+            }
+            Err(payload) => {
+                let message = panic_payload_to_string(payload);
+                self.report
+                    .events
+                    .push(LoggerEvent::CompileUnexpectedThrow {
+                        fn_loc: Some(fn_loc),
+                        data: message.clone(),
+                    });
+                let mut err = CompilerError::new();
+                let mut detail = CompilerErrorDetail::error(
+                    ErrorCategory::Pipeline,
+                    "React Compiler pipeline unexpectedly panicked",
+                );
+                detail.description = Some(message);
+                detail.loc = Some(fn_loc);
+                err.push(detail);
+                self.record_error(err, Some(fn_loc));
+                return;
+            }
+        };
+
+        self.report.compiled_functions += 1;
+        self.report.events.push(LoggerEvent::CompileSuccess {
+            fn_loc: Some(fn_loc),
+            fn_name: name.map(|ident| ident.sym.to_string()),
+            memo_slots: codegen.memo_slots_used,
+            memo_blocks: codegen.memo_blocks,
+            memo_values: codegen.memo_values,
+            pruned_memo_blocks: codegen.pruned_memo_blocks,
+            pruned_memo_values: codegen.pruned_memo_values,
+        });
+
+        for outlined in &codegen.outlined {
+            self.queued_outlined.push(QueuedOutlinedFunction {
+                function: outlined.function.clone(),
+            });
+        }
+
+        if self.module_scope_opt_out {
+            return;
+        }
+
+        if self.output_mode == CompilerOutputMode::Lint {
+            return;
+        }
+
+        if self.opts.compilation_mode == CompilationMode::Annotation && opt_in.is_none() {
+            return;
+        }
+
+        apply_codegen_to_arrow(arrow, &codegen);
+        self.report.changed = true;
+
+        if let Some(gating) = dynamic_gating.or_else(|| self.opts.gating.clone()) {
+            self.used_external_imports.push(gating);
+        }
+    }
+
+    fn record_error(&mut self, err: CompilerError, fn_loc: Option<Span>) {
+        for detail in &err.details {
+            if detail.category == ErrorCategory::Pipeline {
+                self.report.events.push(LoggerEvent::PipelineError {
+                    fn_loc,
+                    data: detail
+                        .description
+                        .clone()
+                        .unwrap_or_else(|| detail.reason.clone()),
+                });
+            }
+
+            if detail.severity == ErrorSeverity::Error {
+                self.report.events.push(LoggerEvent::CompileError {
+                    fn_loc,
+                    detail: detail.reason.clone(),
+                });
+            } else {
+                self.report.events.push(LoggerEvent::CompileDiagnostic {
+                    fn_loc,
+                    detail: detail.reason.clone(),
+                });
+            }
+            self.report.diagnostics.push(detail.clone());
+        }
+
+        if should_panic(&self.opts.panic_threshold, &err) {
+            self.fatal_error = Some(err);
+        }
+    }
+}
+
+impl VisitMut for ProgramCompiler<'_> {
+    fn visit_mut_class(&mut self, class: &mut swc_ecma_ast::Class) {
+        self.class_depth += 1;
+        class.visit_mut_children_with(self);
+        self.class_depth -= 1;
+    }
+
+    fn visit_mut_fn_decl(&mut self, decl: &mut FnDecl) {
+        let is_top_level = self.function_depth == 0 && self.class_depth == 0;
+        self.compile_named_function(
+            Some(&decl.ident),
+            &mut decl.function,
+            true,
+            is_top_level,
+            decl.ident.span,
+        );
+
+        self.function_depth += 1;
+        decl.function.visit_mut_children_with(self);
+        self.function_depth -= 1;
+    }
+
+    fn visit_mut_var_declarator(&mut self, declarator: &mut swc_ecma_ast::VarDeclarator) {
+        let name = match &declarator.name {
+            Pat::Ident(BindingIdent { id, .. }) => Some(id.clone()),
+            _ => None,
+        };
+        let is_top_level = self.function_depth == 0 && self.class_depth == 0;
+
+        if let Some(init) = declarator.init.as_mut() {
+            match &mut **init {
+                Expr::Fn(fn_expr) => {
+                    let compile_name = fn_expr.ident.as_ref().or(name.as_ref());
+                    let fn_span = fn_expr.function.span;
+                    self.compile_named_function(
+                        compile_name,
+                        &mut fn_expr.function,
+                        false,
+                        is_top_level,
+                        fn_span,
+                    );
+
+                    self.function_depth += 1;
+                    fn_expr.function.visit_mut_children_with(self);
+                    self.function_depth -= 1;
+                    return;
+                }
+                Expr::Arrow(arrow) => {
+                    self.compile_arrow(name.as_ref(), arrow, is_top_level, arrow.span);
+
+                    self.function_depth += 1;
+                    arrow.body.visit_mut_with(self);
+                    self.function_depth -= 1;
+                    return;
+                }
+                _ => {}
+            }
+        }
+
+        declarator.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_assign_expr(&mut self, assign: &mut AssignExpr) {
+        let is_top_level = self.function_depth == 0 && self.class_depth == 0;
+        let name = if assign.op == op!("=") {
+            assign.left.as_ident().map(|binding| binding.id.clone())
+        } else {
+            None
+        };
+
+        match &mut *assign.right {
+            Expr::Fn(fn_expr) => {
+                let compile_name = fn_expr.ident.as_ref().or(name.as_ref());
+                let fn_span = fn_expr.function.span;
+                self.compile_named_function(
+                    compile_name,
+                    &mut fn_expr.function,
+                    false,
+                    is_top_level,
+                    fn_span,
+                );
+
+                self.function_depth += 1;
+                fn_expr.function.visit_mut_children_with(self);
+                self.function_depth -= 1;
+            }
+            Expr::Arrow(arrow) => {
+                self.compile_arrow(name.as_ref(), arrow, is_top_level, arrow.span);
+
+                self.function_depth += 1;
+                arrow.body.visit_mut_with(self);
+                self.function_depth -= 1;
+            }
+            _ => assign.visit_mut_children_with(self),
+        }
+    }
+
+    fn visit_mut_export_default_decl(&mut self, decl: &mut swc_ecma_ast::ExportDefaultDecl) {
+        if let DefaultDecl::Fn(fn_expr) = &mut decl.decl {
+            let is_top_level = self.function_depth == 0 && self.class_depth == 0;
+            self.compile_named_function(
+                fn_expr.ident.as_ref(),
+                &mut fn_expr.function,
+                true,
+                is_top_level,
+                decl.span,
+            );
+
+            self.function_depth += 1;
+            fn_expr.function.visit_mut_children_with(self);
+            self.function_depth -= 1;
+            return;
+        }
+
+        decl.visit_mut_children_with(self);
+    }
+
+    fn visit_mut_export_default_expr(&mut self, expr: &mut swc_ecma_ast::ExportDefaultExpr) {
+        let is_top_level = self.function_depth == 0 && self.class_depth == 0;
+
+        match &mut *expr.expr {
+            Expr::Fn(fn_expr) => {
+                self.compile_named_function(
+                    fn_expr.ident.as_ref(),
+                    &mut fn_expr.function,
+                    false,
+                    is_top_level,
+                    expr.span,
+                );
+
+                self.function_depth += 1;
+                fn_expr.function.visit_mut_children_with(self);
+                self.function_depth -= 1;
+            }
+            Expr::Arrow(arrow) => {
+                self.compile_arrow(None, arrow, is_top_level, expr.span);
+
+                self.function_depth += 1;
+                arrow.body.visit_mut_with(self);
+                self.function_depth -= 1;
+            }
+            _ => expr.visit_mut_children_with(self),
+        }
+    }
+}
+
+fn panic_payload_to_string(payload: Box<dyn Any + Send>) -> String {
+    let payload = payload.as_ref();
+    if let Some(message) = payload.downcast_ref::<&str>() {
+        return (*message).to_string();
+    }
+    if let Some(message) = payload.downcast_ref::<String>() {
+        return message.clone();
+    }
+    "React Compiler pipeline panic without message".to_string()
+}
+
+fn insert_queued_outlined(program: &mut Program, queue: &mut Vec<QueuedOutlinedFunction>) -> usize {
+    if queue.is_empty() {
+        return 0;
+    }
+
+    let mut known_names = collect_top_level_names(program);
+    let mut inserted = 0;
+    let queued = std::mem::take(queue);
+
+    for (index, outlined) in queued.into_iter().enumerate() {
+        let mut id = outlined.function.id.unwrap_or_else(|| {
+            Ident::new_no_ctxt(format!("_react_compiler_outlined_{index}").into(), DUMMY_SP)
+        });
+
+        if known_names.contains(id.sym.as_ref()) {
+            let base = id.sym.to_string();
+            let mut counter = 1usize;
+            loop {
+                let candidate = format!("{base}_{counter}");
+                if !known_names.contains(candidate.as_str()) {
+                    id = Ident::new_no_ctxt(candidate.into(), DUMMY_SP);
+                    break;
+                }
+                counter += 1;
+            }
+        }
+
+        known_names.insert(id.sym.to_string());
+
+        let function = Function {
+            params: outlined
+                .function
+                .params
+                .into_iter()
+                .map(|pat| Param {
+                    span: DUMMY_SP,
+                    decorators: Vec::new(),
+                    pat,
+                })
+                .collect(),
+            decorators: Vec::new(),
+            span: DUMMY_SP,
+            ctxt: Default::default(),
+            body: Some(outlined.function.body),
+            is_generator: outlined.function.is_generator,
+            is_async: outlined.function.is_async,
+            type_params: None,
+            return_type: None,
+        };
+        let decl = Stmt::Decl(Decl::Fn(FnDecl {
+            ident: id,
+            declare: false,
+            function: Box::new(function),
+        }));
+
+        match program {
+            Program::Module(module) => {
+                module.body.push(ModuleItem::Stmt(decl));
+            }
+            Program::Script(script) => {
+                script.body.push(decl);
+            }
+        }
+
+        inserted += 1;
+    }
+
+    inserted
+}
+
+fn collect_top_level_names(program: &Program) -> HashSet<String> {
+    fn add_pat_name(names: &mut HashSet<String>, pat: &Pat) {
+        if let Pat::Ident(binding) = pat {
+            names.insert(binding.id.sym.to_string());
+        }
+    }
+
+    let mut names = HashSet::new();
+
+    match program {
+        Program::Module(module) => {
+            for item in &module.body {
+                match item {
+                    ModuleItem::Stmt(Stmt::Decl(decl)) => match decl {
+                        Decl::Fn(fn_decl) => {
+                            names.insert(fn_decl.ident.sym.to_string());
+                        }
+                        Decl::Var(var_decl) => {
+                            for declarator in &var_decl.decls {
+                                add_pat_name(&mut names, &declarator.name);
+                            }
+                        }
+                        Decl::Class(class_decl) => {
+                            names.insert(class_decl.ident.sym.to_string());
+                        }
+                        _ => {}
+                    },
+                    ModuleItem::ModuleDecl(_) => {}
+                    ModuleItem::Stmt(_) => {}
+                }
+            }
+        }
+        Program::Script(script) => {
+            for stmt in &script.body {
+                if let Stmt::Decl(decl) = stmt {
+                    match decl {
+                        Decl::Fn(fn_decl) => {
+                            names.insert(fn_decl.ident.sym.to_string());
+                        }
+                        Decl::Var(var_decl) => {
+                            for declarator in &var_decl.decls {
+                                add_pat_name(&mut names, &declarator.name);
+                            }
+                        }
+                        Decl::Class(class_decl) => {
+                            names.insert(class_decl.ident.sym.to_string());
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+
+    names
+}
+
+fn apply_codegen_to_function(function: &mut Function, codegen: &CodegenFunction) {
+    function.params = codegen
+        .params
+        .iter()
+        .cloned()
+        .map(|pat| Param {
+            span: DUMMY_SP,
+            decorators: Vec::new(),
+            pat,
+        })
+        .collect();
+    function.body = Some(codegen.body.clone());
+    function.is_async = codegen.is_async;
+    function.is_generator = codegen.is_generator;
+}
+
+fn apply_codegen_to_arrow(arrow: &mut ArrowExpr, codegen: &CodegenFunction) {
+    arrow.params = codegen.params.clone();
+    arrow.body = Box::new(BlockStmtOrExpr::BlockStmt(codegen.body.clone()));
+    arrow.is_async = codegen.is_async;
+    arrow.is_generator = codegen.is_generator;
+}
+
+fn syntax_function_type(name: &str) -> Option<ReactFunctionType> {
+    if is_component_name(name) {
+        Some(ReactFunctionType::Component)
+    } else if is_hook_name(name) {
+        Some(ReactFunctionType::Hook)
+    } else {
+        None
+    }
+}
+
+fn infer_function_type(name: &str, body: &BlockStmt) -> Option<ReactFunctionType> {
+    if is_component_name(name) {
+        if calls_hooks_or_creates_jsx(body) {
+            return Some(ReactFunctionType::Component);
+        }
+        return None;
+    }
+
+    if is_hook_name(name) {
+        if calls_hooks_or_creates_jsx(body) {
+            return Some(ReactFunctionType::Hook);
+        }
+        return None;
+    }
+
+    None
+}
+
+fn calls_hooks_or_creates_jsx(body: &BlockStmt) -> bool {
+    #[derive(Default)]
+    struct Finder {
+        found: bool,
+    }
+
+    impl Visit for Finder {
+        fn visit_arrow_expr(&mut self, _node: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_fn_decl(&mut self, _node: &FnDecl) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _node: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_expr(&mut self, expr: &Expr) {
+            if self.found {
+                return;
+            }
+
+            if matches!(
+                expr,
+                Expr::JSXElement(..)
+                    | Expr::JSXFragment(..)
+                    | Expr::JSXMember(..)
+                    | Expr::JSXNamespacedName(..)
+                    | Expr::JSXEmpty(..)
+            ) {
+                self.found = true;
+                return;
+            }
+
+            if let Expr::Call(call) = expr {
+                if is_hook_callee(&call.callee) {
+                    self.found = true;
+                    return;
+                }
+            }
+
+            expr.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder::default();
+    body.visit_with(&mut finder);
+    finder.found
+}
+
+fn is_hook_callee(callee: &Callee) -> bool {
+    let Callee::Expr(expr) = callee else {
+        return false;
+    };
+
+    if let Expr::Ident(ident) = &**expr {
+        return is_hook_name(ident.sym.as_ref());
+    }
+
+    if let Expr::Member(member) = &**expr {
+        let Expr::Ident(object) = &*member.obj else {
+            return false;
+        };
+
+        let property = match &member.prop {
+            swc_ecma_ast::MemberProp::Ident(ident_name) => ident_name,
+            _ => return false,
+        };
+
+        return is_component_name(object.sym.as_ref()) && is_hook_name(property.sym.as_ref());
+    }
+
+    false
+}
+
+fn top_level_directives(program: &Program) -> Vec<String> {
+    match program {
+        Program::Module(module) => {
+            let mut stmts = Vec::new();
+            for item in &module.body {
+                let ModuleItem::Stmt(stmt) = item else {
+                    break;
+                };
+                stmts.push(stmt.clone());
+            }
+            collect_directives(&stmts)
+        }
+        Program::Script(script) => collect_directives(&script.body),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_common::{
+        comments::{Comment, CommentKind},
+        BytePos, FileName, Span,
+    };
+    use swc_ecma_ast::EsVersion;
+    use swc_ecma_codegen::{text_writer::JsWriter, Emitter};
+    use swc_ecma_parser::{parse_file_as_module, Syntax, TsSyntax};
+
+    use super::*;
+
+    fn parse_program(code: &str) -> Program {
+        let cm = swc_common::sync::Lrc::new(swc_common::SourceMap::default());
+        let fm = cm.new_source_file(
+            FileName::Custom("fixture.tsx".into()).into(),
+            code.to_string(),
+        );
+
+        Program::Module(
+            parse_file_as_module(
+                &fm,
+                Syntax::Typescript(TsSyntax {
+                    tsx: true,
+                    ..Default::default()
+                }),
+                EsVersion::latest(),
+                None,
+                &mut vec![],
+            )
+            .unwrap(),
+        )
+    }
+
+    fn print_program(program: &Program) -> String {
+        let cm = swc_common::sync::Lrc::new(swc_common::SourceMap::default());
+        let mut out = Vec::new();
+        {
+            let writer = JsWriter::new(cm.clone(), "\n", &mut out, None);
+            let mut emitter = Emitter {
+                cfg: Default::default(),
+                comments: None,
+                cm,
+                wr: writer,
+            };
+            emitter.emit_program(program).unwrap();
+        }
+        String::from_utf8(out).unwrap()
+    }
+
+    fn line_comment(start: u32, end: u32, text: &str) -> Comment {
+        Comment {
+            kind: CommentKind::Line,
+            span: Span::new(BytePos(start), BytePos(end)),
+            text: text.into(),
+        }
+    }
+
+    #[test]
+    fn inserts_runtime_import_for_compiled_component() {
+        let mut program =
+            parse_program("function Component(props) {\n  return <div>{props.value}</div>;\n}\n");
+
+        let report = compile_program(
+            &mut program,
+            &CompilerPass {
+                opts: crate::options::default_options(),
+                filename: Some("src/Component.tsx".into()),
+                comments: Vec::new(),
+                code: None,
+            },
+        )
+        .unwrap();
+
+        let output = print_program(&program);
+
+        assert!(report.compiled_functions > 0);
+        assert!(output.contains("react/compiler-runtime"));
+    }
+
+    #[test]
+    fn respects_module_opt_out_directive() {
+        let mut program = parse_program(
+            "\"use no memo\";\nfunction Component(props) {\n  return \
+             <div>{props.value}</div>;\n}\n",
+        );
+
+        let report = compile_program(
+            &mut program,
+            &CompilerPass {
+                opts: crate::options::default_options(),
+                filename: Some("src/Component.tsx".into()),
+                comments: Vec::new(),
+                code: None,
+            },
+        )
+        .unwrap();
+
+        let output = print_program(&program);
+        assert!(report.compiled_functions > 0);
+        assert!(!output.contains("react/compiler-runtime"));
+    }
+
+    #[test]
+    fn suppression_comment_only_skips_affected_function() {
+        let mut program = parse_program(
+            "function ComponentA() {\n  return <div>A</div>;\n}\nfunction ComponentB() {\n  \
+             return <div>B</div>;\n}\n",
+        );
+
+        let (first_span, second_span) = match &program {
+            Program::Module(module) => {
+                let first = match &module.body[0] {
+                    ModuleItem::Stmt(Stmt::Decl(Decl::Fn(decl))) => decl.function.span,
+                    _ => panic!("first statement should be a function declaration"),
+                };
+                let second = match &module.body[1] {
+                    ModuleItem::Stmt(Stmt::Decl(Decl::Fn(decl))) => decl.function.span,
+                    _ => panic!("second statement should be a function declaration"),
+                };
+                (first, second)
+            }
+            Program::Script(_) => panic!("expected module"),
+        };
+
+        let report = compile_program(
+            &mut program,
+            &CompilerPass {
+                opts: crate::options::default_options(),
+                filename: Some("src/Component.tsx".into()),
+                comments: vec![line_comment(
+                    first_span.lo.0 + 1,
+                    first_span.lo.0 + 20,
+                    " eslint-disable-next-line react-hooks/rules-of-hooks ",
+                )],
+                code: None,
+            },
+        )
+        .unwrap();
+
+        let output = print_program(&program);
+        assert!(report.compiled_functions >= 1);
+        assert!(!report.diagnostics.is_empty());
+        assert!(report
+            .diagnostics
+            .iter()
+            .any(|detail| detail.category == ErrorCategory::Suppression));
+        assert!(output.contains("react/compiler-runtime"));
+        assert!(second_span.lo > first_span.lo);
+    }
+
+    #[test]
+    fn skips_when_runtime_import_already_exists() {
+        let mut program = parse_program(
+            "import { c as _c } from \"react/compiler-runtime\";\nfunction Component() {\n  \
+             return <div />;\n}\n",
+        );
+
+        let report = compile_program(
+            &mut program,
+            &CompilerPass {
+                opts: crate::options::default_options(),
+                filename: Some("src/Component.tsx".into()),
+                comments: Vec::new(),
+                code: None,
+            },
+        )
+        .unwrap();
+
+        assert_eq!(report.compiled_functions, 0);
+        assert!(report
+            .events
+            .iter()
+            .any(|event| matches!(event, LoggerEvent::CompileSkip { .. })));
+    }
+
+    #[test]
+    fn records_timing_events() {
+        let mut program =
+            parse_program("function Component(props) {\n  return <div>{props.value}</div>;\n}\n");
+
+        let report = compile_program(
+            &mut program,
+            &CompilerPass {
+                opts: crate::options::default_options(),
+                filename: Some("src/Component.tsx".into()),
+                comments: Vec::new(),
+                code: None,
+            },
+        )
+        .unwrap();
+
+        assert!(report
+            .events
+            .iter()
+            .any(|event| matches!(event, LoggerEvent::Timing { .. })));
+    }
+
+    #[test]
+    fn appends_outlined_functions() {
+        let mut program = parse_program("function Component() { return <div />; }\n");
+        let mut queue = vec![QueuedOutlinedFunction {
+            function: CodegenFunction {
+                id: None,
+                params: Vec::new(),
+                body: BlockStmt {
+                    span: DUMMY_SP,
+                    ctxt: Default::default(),
+                    stmts: Vec::new(),
+                },
+                is_async: false,
+                is_generator: false,
+                memo_slots_used: 0,
+                memo_blocks: 0,
+                memo_values: 0,
+                pruned_memo_blocks: 0,
+                pruned_memo_values: 0,
+                outlined: Vec::new(),
+            },
+        }];
+
+        let inserted = insert_queued_outlined(&mut program, &mut queue);
+        let output = print_program(&program);
+
+        assert_eq!(inserted, 1);
+        assert!(queue.is_empty());
+        assert!(output.contains("function _react_compiler_outlined_0()"));
+    }
+
+    #[test]
+    fn parses_opt_in_directive() {
+        let opts = crate::options::default_options();
+        let directives = vec!["use memo".to_string()];
+
+        assert_eq!(
+            try_find_directive_enabling_memoization(&directives, &opts)
+                .unwrap()
+                .as_deref(),
+            Some("use memo")
+        );
+    }
+
+    #[test]
+    fn runtime_module_matches_target() {
+        assert_eq!(
+            get_react_compiler_runtime_module(&CompilerReactTarget::React19),
+            "react/compiler-runtime"
+        );
+        assert_eq!(
+            get_react_compiler_runtime_module(&CompilerReactTarget::React17),
+            "react-compiler-runtime"
+        );
+    }
+}

--- a/crates/swc_ecma_react_compiler/src/entrypoint/suppression.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/suppression.rs
@@ -1,0 +1,229 @@
+use swc_common::{comments::Comment, Span};
+
+use crate::error::{CompilerError, CompilerErrorDetail, ErrorCategory, ErrorSeverity};
+
+const DEFAULT_ESLINT_SUPPRESSIONS: &[&str] =
+    &["react-hooks/exhaustive-deps", "react-hooks/rules-of-hooks"];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SuppressionSource {
+    Eslint,
+    Flow,
+}
+
+#[derive(Debug, Clone)]
+pub struct SuppressionRange {
+    pub disable_comment: Comment,
+    pub enable_comment: Option<Comment>,
+    pub source: SuppressionSource,
+}
+
+pub fn default_eslint_suppression_rules() -> Vec<String> {
+    DEFAULT_ESLINT_SUPPRESSIONS
+        .iter()
+        .map(|value| (*value).to_string())
+        .collect()
+}
+
+pub fn find_program_suppressions(
+    comments: &[Comment],
+    eslint_suppression_rules: Option<&[String]>,
+    flow_suppressions: bool,
+) -> Vec<SuppressionRange> {
+    let rules: Vec<&str> = if let Some(rules) = eslint_suppression_rules {
+        rules.iter().map(String::as_str).collect()
+    } else {
+        DEFAULT_ESLINT_SUPPRESSIONS.to_vec()
+    };
+
+    let mut ranges = Vec::new();
+    let mut open_eslint_disable: Option<Comment> = None;
+
+    for comment in comments {
+        let text = comment.text.as_ref();
+
+        let has_rule = !rules.is_empty() && rules.iter().any(|rule| text.contains(rule));
+        let is_disable_next_line = text.contains("eslint-disable-next-line") && has_rule;
+        if is_disable_next_line {
+            ranges.push(SuppressionRange {
+                disable_comment: comment.clone(),
+                enable_comment: Some(comment.clone()),
+                source: SuppressionSource::Eslint,
+            });
+            continue;
+        }
+
+        let is_flow = flow_suppressions
+            && text.contains("react-rule")
+            && (text.contains("$FlowFixMe")
+                || text.contains("$FlowExpectedError")
+                || text.contains("$FlowIssue"));
+        if is_flow {
+            ranges.push(SuppressionRange {
+                disable_comment: comment.clone(),
+                enable_comment: Some(comment.clone()),
+                source: SuppressionSource::Flow,
+            });
+            continue;
+        }
+
+        let is_disable = text.contains("eslint-disable")
+            && !text.contains("eslint-disable-next-line")
+            && has_rule;
+        if is_disable {
+            open_eslint_disable = Some(comment.clone());
+        }
+
+        let is_enable = text.contains("eslint-enable") && has_rule;
+        if is_enable {
+            if let Some(disable_comment) = open_eslint_disable.take() {
+                ranges.push(SuppressionRange {
+                    disable_comment,
+                    enable_comment: Some(comment.clone()),
+                    source: SuppressionSource::Eslint,
+                });
+            }
+        }
+    }
+
+    if let Some(disable_comment) = open_eslint_disable {
+        ranges.push(SuppressionRange {
+            disable_comment,
+            enable_comment: None,
+            source: SuppressionSource::Eslint,
+        });
+    }
+
+    ranges
+}
+
+pub fn filter_suppressions_that_affect_range(
+    suppression_ranges: &[SuppressionRange],
+    span: Span,
+) -> Vec<SuppressionRange> {
+    let mut suppressions_in_scope = Vec::new();
+
+    for suppression_range in suppression_ranges {
+        let disable_span = suppression_range.disable_comment.span;
+        let enable_span = suppression_range
+            .enable_comment
+            .as_ref()
+            .map(|comment| comment.span);
+
+        let is_within_function = disable_span.lo > span.lo
+            && match enable_span {
+                Some(enable) => enable.hi < span.hi,
+                None => true,
+            };
+
+        let wraps_function = disable_span.lo < span.lo
+            && match enable_span {
+                Some(enable) => enable.hi > span.hi,
+                None => true,
+            };
+
+        if is_within_function || wraps_function {
+            suppressions_in_scope.push(suppression_range.clone());
+        }
+    }
+
+    suppressions_in_scope
+}
+
+pub fn suppressions_to_compiler_error(suppression_ranges: &[SuppressionRange]) -> CompilerError {
+    let mut err = CompilerError::new();
+
+    for suppression in suppression_ranges {
+        let (reason, suggestion) = match suppression.source {
+            SuppressionSource::Eslint => (
+                "React Compiler skipped optimizing this function because one or more React ESLint \
+                 rules were disabled",
+                "Remove the ESLint suppression and address the React error",
+            ),
+            SuppressionSource::Flow => (
+                "React Compiler skipped optimizing this function because one or more React rule \
+                 violations were reported by Flow",
+                "Remove the Flow suppression and address the React error",
+            ),
+        };
+
+        let mut detail = CompilerErrorDetail::error(ErrorCategory::Suppression, reason);
+        detail.severity = ErrorSeverity::Error;
+        detail.description = Some(format!(
+            "Found suppression `{}`",
+            suppression.disable_comment.text.trim()
+        ));
+        detail.loc = Some(suppression.disable_comment.span);
+        detail.suggestions = Some(vec![suggestion.to_string()]);
+        err.push(detail);
+    }
+
+    err
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_common::{
+        comments::{Comment, CommentKind},
+        BytePos, DUMMY_SP,
+    };
+
+    use super::*;
+
+    fn comment(start: u32, end: u32, text: &str) -> Comment {
+        Comment {
+            kind: CommentKind::Line,
+            span: Span::new(BytePos(start), BytePos(end)),
+            text: text.into(),
+        }
+    }
+
+    #[test]
+    fn detects_disable_next_line() {
+        let comments = vec![comment(
+            10,
+            30,
+            " eslint-disable-next-line react-hooks/rules-of-hooks ",
+        )];
+
+        let ranges = find_program_suppressions(&comments, None, true);
+        assert_eq!(ranges.len(), 1);
+        assert_eq!(ranges[0].source, SuppressionSource::Eslint);
+        assert!(ranges[0].enable_comment.is_some());
+    }
+
+    #[test]
+    fn filters_suppressions_in_function_range() {
+        let comments = vec![comment(
+            10,
+            30,
+            " eslint-disable-next-line react-hooks/rules-of-hooks ",
+        )];
+        let ranges = find_program_suppressions(&comments, None, true);
+        let hits =
+            filter_suppressions_that_affect_range(&ranges, Span::new(BytePos(5), BytePos(100)));
+        assert_eq!(hits.len(), 1);
+
+        let misses =
+            filter_suppressions_that_affect_range(&ranges, Span::new(BytePos(40), BytePos(100)));
+        assert_eq!(misses.len(), 0);
+    }
+
+    #[test]
+    fn builds_compiler_error_from_suppressions() {
+        let range = SuppressionRange {
+            disable_comment: comment(
+                10,
+                20,
+                " eslint-disable-next-line react-hooks/rules-of-hooks ",
+            ),
+            enable_comment: None,
+            source: SuppressionSource::Eslint,
+        };
+        let err = suppressions_to_compiler_error(&[range]);
+        assert!(err.has_any_errors());
+        assert_eq!(err.details.len(), 1);
+        assert_eq!(err.details[0].category, ErrorCategory::Suppression);
+        assert_ne!(DUMMY_SP, err.details[0].loc.expect("loc should be set"));
+    }
+}

--- a/crates/swc_ecma_react_compiler/src/entrypoint/suppression.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/suppression.rs
@@ -4,6 +4,7 @@ use crate::error::{CompilerError, CompilerErrorDetail, ErrorCategory, ErrorSever
 
 const DEFAULT_ESLINT_SUPPRESSIONS: &[&str] =
     &["react-hooks/exhaustive-deps", "react-hooks/rules-of-hooks"];
+const NEXT_LINE_SUPPRESSION_MAX_GAP_BYTES: u32 = 256;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum SuppressionSource {
@@ -16,6 +17,25 @@ pub struct SuppressionRange {
     pub disable_comment: Comment,
     pub enable_comment: Option<Comment>,
     pub source: SuppressionSource,
+}
+
+pub fn is_next_line_suppression(range: &SuppressionRange) -> bool {
+    if range.source != SuppressionSource::Eslint {
+        return false;
+    }
+
+    if !range
+        .disable_comment
+        .text
+        .contains("eslint-disable-next-line")
+    {
+        return false;
+    }
+
+    match range.enable_comment.as_ref() {
+        Some(enable) => enable.span == range.disable_comment.span,
+        None => false,
+    }
 }
 
 pub fn default_eslint_suppression_rules() -> Vec<String> {
@@ -122,7 +142,11 @@ pub fn filter_suppressions_that_affect_range(
                 None => true,
             };
 
-        if is_within_function || wraps_function {
+        let is_next_line_suppression = is_next_line_suppression(suppression_range)
+            && disable_span.hi <= span.lo
+            && span.lo.0.saturating_sub(disable_span.hi.0) <= NEXT_LINE_SUPPRESSION_MAX_GAP_BYTES;
+
+        if is_within_function || wraps_function || is_next_line_suppression {
             suppressions_in_scope.push(suppression_range.clone());
         }
     }
@@ -205,8 +229,22 @@ mod tests {
         assert_eq!(hits.len(), 1);
 
         let misses =
-            filter_suppressions_that_affect_range(&ranges, Span::new(BytePos(40), BytePos(100)));
+            filter_suppressions_that_affect_range(&ranges, Span::new(BytePos(400), BytePos(600)));
         assert_eq!(misses.len(), 0);
+    }
+
+    #[test]
+    fn next_line_suppression_affects_following_function() {
+        let comments = vec![comment(
+            10,
+            30,
+            " eslint-disable-next-line react-hooks/rules-of-hooks ",
+        )];
+        let ranges = find_program_suppressions(&comments, None, true);
+        let hits =
+            filter_suppressions_that_affect_range(&ranges, Span::new(BytePos(35), BytePos(200)));
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].source, SuppressionSource::Eslint);
     }
 
     #[test]

--- a/crates/swc_ecma_react_compiler/src/error.rs
+++ b/crates/swc_ecma_react_compiler/src/error.rs
@@ -1,0 +1,127 @@
+use std::{error::Error, fmt};
+
+use swc_common::Span;
+
+/// Error severity compatible with React Compiler diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ErrorSeverity {
+    Error,
+    Warning,
+    Info,
+}
+
+/// Error categories used by the compiler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ErrorCategory {
+    Config,
+    Gating,
+    Invariant,
+    Todo,
+    Suppression,
+    Pipeline,
+    Validation,
+}
+
+/// A diagnostic detail emitted by the compiler.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompilerErrorDetail {
+    pub severity: ErrorSeverity,
+    pub category: ErrorCategory,
+    pub reason: String,
+    pub description: Option<String>,
+    pub loc: Option<Span>,
+    pub suggestions: Option<Vec<String>>,
+}
+
+impl CompilerErrorDetail {
+    pub fn error(category: ErrorCategory, reason: impl Into<String>) -> Self {
+        Self {
+            severity: ErrorSeverity::Error,
+            category,
+            reason: reason.into(),
+            description: None,
+            loc: None,
+            suggestions: None,
+        }
+    }
+}
+
+/// Compiler diagnostic wrapper.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CompilerDiagnostic {
+    pub severity: ErrorSeverity,
+    pub detail: CompilerErrorDetail,
+}
+
+/// Aggregated compiler error.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CompilerError {
+    pub details: Vec<CompilerErrorDetail>,
+}
+
+impl CompilerError {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn with_detail(detail: CompilerErrorDetail) -> Self {
+        Self {
+            details: vec![detail],
+        }
+    }
+
+    pub fn invalid_config(reason: impl Into<String>, description: impl Into<String>) -> Self {
+        let mut detail = CompilerErrorDetail::error(ErrorCategory::Config, reason);
+        detail.description = Some(description.into());
+        Self::with_detail(detail)
+    }
+
+    pub fn invariant(reason: impl Into<String>) -> Self {
+        Self::with_detail(CompilerErrorDetail::error(ErrorCategory::Invariant, reason))
+    }
+
+    pub fn push(&mut self, detail: CompilerErrorDetail) {
+        self.details.push(detail);
+    }
+
+    pub fn extend(&mut self, other: Self) {
+        self.details.extend(other.details);
+    }
+
+    pub fn has_any_errors(&self) -> bool {
+        self.details
+            .iter()
+            .any(|detail| detail.severity == ErrorSeverity::Error)
+    }
+
+    pub fn has_critical_errors(&self) -> bool {
+        self.details.iter().any(|detail| {
+            detail.severity == ErrorSeverity::Error
+                && matches!(
+                    detail.category,
+                    ErrorCategory::Config | ErrorCategory::Invariant
+                )
+        })
+    }
+}
+
+impl fmt::Display for CompilerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.details.is_empty() {
+            return write!(f, "React Compiler failed without diagnostics");
+        }
+
+        writeln!(f, "Found {} errors:", self.details.len())?;
+        for detail in &self.details {
+            writeln!(f)?;
+            writeln!(f, "{:?}: {}", detail.severity, detail.reason)?;
+            if let Some(description) = &detail.description {
+                writeln!(f, "{description}")?;
+            }
+            writeln!(f, "Category: {:?}", detail.category)?;
+        }
+        Ok(())
+    }
+}
+
+impl Error for CompilerError {}

--- a/crates/swc_ecma_react_compiler/src/hir/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/hir/mod.rs
@@ -1,0 +1,24 @@
+use swc_ecma_ast::{Function, Ident};
+
+use crate::{error::CompilerError, transform::ReactFunctionType};
+
+/// Lowered function IR placeholder.
+#[derive(Debug, Clone)]
+pub struct HirFunction {
+    pub fn_type: ReactFunctionType,
+    pub id: Option<Ident>,
+    pub function: Function,
+}
+
+/// Lowers an AST function into HIR.
+pub fn lower(
+    function: &Function,
+    id: Option<&Ident>,
+    fn_type: ReactFunctionType,
+) -> Result<HirFunction, CompilerError> {
+    Ok(HirFunction {
+        fn_type,
+        id: id.cloned(),
+        function: function.clone(),
+    })
+}

--- a/crates/swc_ecma_react_compiler/src/inference/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/inference/mod.rs
@@ -1,0 +1,26 @@
+use crate::hir::HirFunction;
+
+/// Performs type inference.
+pub fn infer_types(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// Performs function-level aliasing and dependency analysis.
+pub fn analyse_functions(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// Infers reactive places used by memoization logic.
+pub fn infer_reactive_places(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// Infers mutable aliasing effects.
+pub fn infer_mutation_aliasing_effects(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// Infers mutable aliasing ranges.
+pub fn infer_mutation_aliasing_ranges(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}

--- a/crates/swc_ecma_react_compiler/src/lib.rs
+++ b/crates/swc_ecma_react_compiler/src/lib.rs
@@ -1,1 +1,59 @@
+#![deny(clippy::all)]
+
+use swc_common::errors::HANDLER;
+use swc_ecma_ast::{Pass, Program};
+use swc_ecma_visit::{visit_mut_pass, VisitMut, VisitMutWith};
+
+pub mod entrypoint;
+pub mod error;
 pub mod fast_check;
+pub mod hir;
+pub mod inference;
+pub mod optimization;
+pub mod options;
+pub mod reactive_scopes;
+pub mod ssa;
+pub mod transform;
+pub mod utils;
+pub mod validation;
+
+pub use crate::{
+    entrypoint::{compile_fn, compile_program, CompileReport, CompilerPass},
+    error::{CompilerDiagnostic, CompilerError, CompilerErrorDetail, ErrorCategory, ErrorSeverity},
+    options::{
+        default_options, parse_plugin_options, CompilationMode, CompilerOutputMode,
+        CompilerReactTarget, DynamicGatingOptions, EnvironmentConfig, ExternalFunction, Logger,
+        LoggerEvent, PanicThresholdOptions, ParsedPluginOptions, PluginOptions,
+    },
+    reactive_scopes::CodegenFunction,
+};
+
+/// Returns a SWC pass wrapper for React Compiler.
+pub fn react_compiler(options: ParsedPluginOptions) -> impl Pass {
+    visit_mut_pass(ReactCompilerVisitor { options })
+}
+
+struct ReactCompilerVisitor {
+    options: ParsedPluginOptions,
+}
+
+impl VisitMut for ReactCompilerVisitor {
+    fn visit_mut_program(&mut self, program: &mut Program) {
+        let pass = CompilerPass {
+            opts: self.options.clone(),
+            filename: None,
+            comments: Vec::new(),
+            code: None,
+        };
+
+        if let Err(err) = compile_program(program, &pass) {
+            if HANDLER.is_set() {
+                HANDLER.with(|handler| {
+                    handler.struct_err(&err.to_string()).emit();
+                });
+            }
+        }
+
+        program.visit_mut_children_with(self);
+    }
+}

--- a/crates/swc_ecma_react_compiler/src/optimization/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/optimization/mod.rs
@@ -1,0 +1,36 @@
+use crate::hir::HirFunction;
+
+/// Prunes known throw-only instructions.
+pub fn prune_maybe_throws(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// Runs constant propagation.
+pub fn constant_propagation(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// Runs dead-code elimination.
+pub fn dead_code_elimination(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// Optimizes props method calls.
+pub fn optimize_props_method_calls(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// SSR-specific optimizations.
+pub fn optimize_for_ssr(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// Placeholder for outlined JSX lowering.
+pub fn outline_jsx(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// Placeholder for outlined function extraction.
+pub fn outline_functions(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}

--- a/crates/swc_ecma_react_compiler/src/options.rs
+++ b/crates/swc_ecma_react_compiler/src/options.rs
@@ -1,0 +1,390 @@
+use std::{borrow::Cow, sync::Arc};
+
+use swc_atoms::Atom;
+use swc_common::Span;
+
+use crate::error::{CompilerError, CompilerErrorDetail, ErrorCategory};
+
+/// Structured compiler event stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LoggerEvent {
+    CompileError {
+        fn_loc: Option<Span>,
+        detail: String,
+    },
+    CompileDiagnostic {
+        fn_loc: Option<Span>,
+        detail: String,
+    },
+    CompileSuccess {
+        fn_loc: Option<Span>,
+        fn_name: Option<String>,
+        memo_slots: u32,
+        memo_blocks: u32,
+        memo_values: u32,
+        pruned_memo_blocks: u32,
+        pruned_memo_values: u32,
+    },
+    CompileSkip {
+        fn_loc: Option<Span>,
+        reason: String,
+        loc: Option<Span>,
+    },
+    CompileUnexpectedThrow {
+        fn_loc: Option<Span>,
+        data: String,
+    },
+    PipelineError {
+        fn_loc: Option<Span>,
+        data: String,
+    },
+    Timing {
+        measurement: String,
+    },
+}
+
+/// Logger hook for compile events.
+pub trait Logger: Send + Sync {
+    fn log_event(&self, filename: Option<&str>, event: &LoggerEvent);
+}
+
+/// Panic threshold for compile failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PanicThresholdOptions {
+    AllErrors,
+    CriticalErrors,
+    None,
+}
+
+impl Default for PanicThresholdOptions {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Function selection strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompilationMode {
+    Infer,
+    Syntax,
+    Annotation,
+    All,
+}
+
+impl Default for CompilationMode {
+    fn default() -> Self {
+        Self::Infer
+    }
+}
+
+/// Output mode of the compiler.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum CompilerOutputMode {
+    Ssr,
+    Client,
+    Lint,
+}
+
+/// Runtime target for emitted compiler runtime API calls.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CompilerReactTarget {
+    React17,
+    React18,
+    React19,
+    DoNotUseMetaInternal { runtime_module: Atom },
+}
+
+impl Default for CompilerReactTarget {
+    fn default() -> Self {
+        Self::React19
+    }
+}
+
+impl CompilerReactTarget {
+    pub fn runtime_module(&self) -> Cow<'_, str> {
+        match self {
+            Self::React19 => Cow::Borrowed("react/compiler-runtime"),
+            Self::React17 | Self::React18 => Cow::Borrowed("react-compiler-runtime"),
+            Self::DoNotUseMetaInternal { runtime_module } => Cow::Borrowed(runtime_module),
+        }
+    }
+}
+
+/// Imported function descriptor.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ExternalFunction {
+    pub source: Atom,
+    pub import_specifier_name: Atom,
+}
+
+/// Dynamic gating options (`use memo if(...)`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DynamicGatingOptions {
+    pub source: Atom,
+}
+
+/// Environment behavior flags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EnvironmentConfig {
+    pub validate_blocklisted_imports: Vec<Atom>,
+    pub validate_hooks_usage: bool,
+    pub validate_no_capitalized_calls: bool,
+    pub validate_ref_access_during_render: bool,
+    pub validate_no_set_state_in_render: bool,
+    pub validate_no_derived_computations_in_effects: bool,
+    pub validate_no_set_state_in_effects: bool,
+    pub validate_no_jsx_in_try_statements: bool,
+    pub validate_exhaustive_memoization_dependencies: bool,
+    pub validate_exhaustive_effect_dependencies: bool,
+    pub validate_preserve_existing_memoization_guarantees: bool,
+    pub enable_preserve_existing_memoization_guarantees: bool,
+    pub validate_static_components: bool,
+    pub validate_source_locations: bool,
+    pub enable_name_anonymous_functions: bool,
+    pub enable_jsx_outlining: bool,
+    pub enable_function_outlining: bool,
+}
+
+impl Default for EnvironmentConfig {
+    fn default() -> Self {
+        Self {
+            validate_blocklisted_imports: Vec::new(),
+            validate_hooks_usage: true,
+            validate_no_capitalized_calls: true,
+            validate_ref_access_during_render: true,
+            validate_no_set_state_in_render: true,
+            validate_no_derived_computations_in_effects: true,
+            validate_no_set_state_in_effects: true,
+            validate_no_jsx_in_try_statements: true,
+            validate_exhaustive_memoization_dependencies: false,
+            validate_exhaustive_effect_dependencies: false,
+            validate_preserve_existing_memoization_guarantees: false,
+            enable_preserve_existing_memoization_guarantees: false,
+            validate_static_components: false,
+            validate_source_locations: false,
+            enable_name_anonymous_functions: true,
+            enable_jsx_outlining: true,
+            enable_function_outlining: true,
+        }
+    }
+}
+
+/// User-facing plugin options.
+#[derive(Default, Clone)]
+pub struct PluginOptions {
+    pub environment: Option<EnvironmentConfig>,
+    pub logger: Option<Arc<dyn Logger>>,
+    pub gating: Option<ExternalFunction>,
+    pub dynamic_gating: Option<DynamicGatingOptions>,
+    pub panic_threshold: Option<PanicThresholdOptions>,
+    pub no_emit: Option<bool>,
+    pub output_mode: Option<CompilerOutputMode>,
+    pub compilation_mode: Option<CompilationMode>,
+    pub eslint_suppression_rules: Option<Vec<String>>,
+    pub flow_suppressions: Option<bool>,
+    pub ignore_use_no_forget: Option<bool>,
+    pub custom_opt_out_directives: Option<Vec<String>>,
+    pub sources: Option<Vec<String>>,
+    pub enable_reanimated_check: Option<bool>,
+    pub target: Option<CompilerReactTarget>,
+}
+
+/// Fully parsed plugin options with defaults applied.
+#[derive(Clone)]
+pub struct ParsedPluginOptions {
+    pub environment: EnvironmentConfig,
+    pub logger: Option<Arc<dyn Logger>>,
+    pub gating: Option<ExternalFunction>,
+    pub dynamic_gating: Option<DynamicGatingOptions>,
+    pub panic_threshold: PanicThresholdOptions,
+    pub no_emit: bool,
+    pub output_mode: Option<CompilerOutputMode>,
+    pub compilation_mode: CompilationMode,
+    pub eslint_suppression_rules: Option<Vec<String>>,
+    pub flow_suppressions: bool,
+    pub ignore_use_no_forget: bool,
+    pub custom_opt_out_directives: Option<Vec<String>>,
+    pub sources: Option<Vec<String>>,
+    pub enable_reanimated_check: bool,
+    pub target: CompilerReactTarget,
+}
+
+impl ParsedPluginOptions {
+    pub fn effective_output_mode(&self) -> CompilerOutputMode {
+        if let Some(mode) = self.output_mode {
+            mode
+        } else if self.no_emit {
+            CompilerOutputMode::Lint
+        } else {
+            CompilerOutputMode::Client
+        }
+    }
+
+    pub fn should_include_file(&self, filename: &str) -> bool {
+        if let Some(sources) = &self.sources {
+            if sources.is_empty() {
+                return true;
+            }
+
+            return sources.iter().any(|prefix| filename.contains(prefix));
+        }
+
+        !filename.contains("node_modules")
+    }
+}
+
+/// Returns default parsed options.
+pub fn default_options() -> ParsedPluginOptions {
+    ParsedPluginOptions {
+        compilation_mode: CompilationMode::Infer,
+        panic_threshold: PanicThresholdOptions::None,
+        environment: EnvironmentConfig::default(),
+        logger: None,
+        gating: None,
+        no_emit: false,
+        output_mode: None,
+        dynamic_gating: None,
+        eslint_suppression_rules: None,
+        flow_suppressions: true,
+        ignore_use_no_forget: false,
+        sources: None,
+        enable_reanimated_check: true,
+        custom_opt_out_directives: None,
+        target: CompilerReactTarget::React19,
+    }
+}
+
+/// Parses options and applies defaults.
+pub fn parse_plugin_options(options: PluginOptions) -> Result<ParsedPluginOptions, CompilerError> {
+    let mut parsed = default_options();
+
+    if let Some(environment) = options.environment {
+        parsed.environment = environment;
+    }
+    if let Some(logger) = options.logger {
+        parsed.logger = Some(logger);
+    }
+    if let Some(gating) = options.gating {
+        if gating.source.is_empty() || gating.import_specifier_name.is_empty() {
+            let mut detail = CompilerErrorDetail::error(
+                ErrorCategory::Config,
+                "Could not parse gating config. Update React Compiler config to fix the error",
+            );
+            detail.description =
+                Some("`gating.source` and `gating.importSpecifierName` are required".into());
+            return Err(CompilerError::with_detail(detail));
+        }
+        parsed.gating = Some(gating);
+    }
+    if let Some(dynamic_gating) = options.dynamic_gating {
+        if dynamic_gating.source.is_empty() {
+            return Err(CompilerError::invalid_config(
+                "Could not parse dynamic gating. Update React Compiler config to fix the error",
+                "`dynamicGating.source` must be a non-empty string",
+            ));
+        }
+        parsed.dynamic_gating = Some(dynamic_gating);
+    }
+    if let Some(panic_threshold) = options.panic_threshold {
+        parsed.panic_threshold = panic_threshold;
+    }
+    if let Some(no_emit) = options.no_emit {
+        parsed.no_emit = no_emit;
+    }
+    if let Some(output_mode) = options.output_mode {
+        parsed.output_mode = Some(output_mode);
+    }
+    if let Some(compilation_mode) = options.compilation_mode {
+        parsed.compilation_mode = compilation_mode;
+    }
+    if let Some(rules) = options.eslint_suppression_rules {
+        parsed.eslint_suppression_rules = Some(rules);
+    }
+    if let Some(flow_suppressions) = options.flow_suppressions {
+        parsed.flow_suppressions = flow_suppressions;
+    }
+    if let Some(ignore_use_no_forget) = options.ignore_use_no_forget {
+        parsed.ignore_use_no_forget = ignore_use_no_forget;
+    }
+    if let Some(custom_opt_out_directives) = options.custom_opt_out_directives {
+        if custom_opt_out_directives
+            .iter()
+            .any(|value| value.is_empty())
+        {
+            return Err(CompilerError::invalid_config(
+                "Could not parse custom opt out directives. Update React Compiler config to fix \
+                 the error",
+                "custom opt-out directives cannot contain empty values",
+            ));
+        }
+        parsed.custom_opt_out_directives = Some(custom_opt_out_directives);
+    }
+    if let Some(sources) = options.sources {
+        if sources.iter().any(|value| value.is_empty()) {
+            return Err(CompilerError::invalid_config(
+                "Expected every source filter to be non-empty",
+                "Remove empty string entries from `sources` option",
+            ));
+        }
+        parsed.sources = Some(sources);
+    }
+    if let Some(enable_reanimated_check) = options.enable_reanimated_check {
+        parsed.enable_reanimated_check = enable_reanimated_check;
+    }
+    if let Some(target) = options.target {
+        parsed.target = target;
+    }
+
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_atoms::Atom;
+
+    use super::*;
+
+    #[test]
+    fn defaults_match_expected() {
+        let options = parse_plugin_options(PluginOptions::default()).unwrap();
+
+        assert_eq!(options.compilation_mode, CompilationMode::Infer);
+        assert_eq!(options.panic_threshold, PanicThresholdOptions::None);
+        assert_eq!(options.target, CompilerReactTarget::React19);
+        assert_eq!(options.effective_output_mode(), CompilerOutputMode::Client);
+        assert!(options.should_include_file("/project/src/app.tsx"));
+        assert!(!options.should_include_file("/project/node_modules/react/index.js"));
+    }
+
+    #[test]
+    fn target_runtime_resolution() {
+        assert_eq!(
+            CompilerReactTarget::React19.runtime_module(),
+            Cow::Borrowed("react/compiler-runtime")
+        );
+        assert_eq!(
+            CompilerReactTarget::React18.runtime_module(),
+            Cow::Borrowed("react-compiler-runtime")
+        );
+        assert_eq!(
+            CompilerReactTarget::DoNotUseMetaInternal {
+                runtime_module: Atom::new("my-runtime"),
+            }
+            .runtime_module(),
+            Cow::Borrowed("my-runtime")
+        );
+    }
+
+    #[test]
+    fn invalid_dynamic_gating_source_errors() {
+        let result = parse_plugin_options(PluginOptions {
+            dynamic_gating: Some(DynamicGatingOptions {
+                source: Atom::new(""),
+            }),
+            ..Default::default()
+        });
+
+        assert!(result.is_err());
+        assert!(result.err().is_some_and(|err| err.has_any_errors()));
+    }
+}

--- a/crates/swc_ecma_react_compiler/src/reactive_scopes/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/reactive_scopes/mod.rs
@@ -1,0 +1,70 @@
+use swc_ecma_ast::{BlockStmt, Function, Ident, Pat};
+
+use crate::{hir::HirFunction, transform::ReactFunctionType};
+
+/// Generated outlined function.
+#[derive(Debug, Clone)]
+pub struct OutlinedFunction {
+    pub function: CodegenFunction,
+    pub kind: Option<ReactFunctionType>,
+}
+
+/// Final codegen payload for one compiled function.
+#[derive(Debug, Clone)]
+pub struct CodegenFunction {
+    pub id: Option<Ident>,
+    pub params: Vec<Pat>,
+    pub body: BlockStmt,
+    pub is_async: bool,
+    pub is_generator: bool,
+    pub memo_slots_used: u32,
+    pub memo_blocks: u32,
+    pub memo_values: u32,
+    pub pruned_memo_blocks: u32,
+    pub pruned_memo_values: u32,
+    pub outlined: Vec<OutlinedFunction>,
+}
+
+/// Reactive function IR placeholder.
+#[derive(Debug, Clone)]
+pub struct ReactiveFunction {
+    pub id: Option<Ident>,
+    pub params: Vec<Pat>,
+    pub body: BlockStmt,
+    pub is_async: bool,
+    pub is_generator: bool,
+}
+
+pub fn build_reactive_function(hir: &HirFunction) -> ReactiveFunction {
+    function_to_reactive(&hir.function, hir.id.clone())
+}
+
+pub fn codegen_function(reactive: ReactiveFunction) -> CodegenFunction {
+    CodegenFunction {
+        id: reactive.id,
+        params: reactive.params,
+        body: reactive.body,
+        is_async: reactive.is_async,
+        is_generator: reactive.is_generator,
+        memo_slots_used: 0,
+        memo_blocks: 0,
+        memo_values: 0,
+        pruned_memo_blocks: 0,
+        pruned_memo_values: 0,
+        outlined: Vec::new(),
+    }
+}
+
+fn function_to_reactive(function: &Function, id: Option<Ident>) -> ReactiveFunction {
+    ReactiveFunction {
+        id,
+        params: function
+            .params
+            .iter()
+            .map(|param| param.pat.clone())
+            .collect(),
+        body: function.body.clone().unwrap_or_default(),
+        is_async: function.is_async,
+        is_generator: function.is_generator,
+    }
+}

--- a/crates/swc_ecma_react_compiler/src/ssa/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/ssa/mod.rs
@@ -1,0 +1,11 @@
+use crate::hir::HirFunction;
+
+/// Converts HIR into SSA form.
+pub fn enter_ssa(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}
+
+/// Removes redundant phi nodes.
+pub fn eliminate_redundant_phi(_hir: &mut HirFunction) {
+    // Intentionally a no-op in the first Rust port stage.
+}

--- a/crates/swc_ecma_react_compiler/src/transform/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/transform/mod.rs
@@ -1,0 +1,12 @@
+/// React function kind used by compile selection and lowering.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReactFunctionType {
+    Component,
+    Hook,
+    Other,
+}
+
+/// Placeholder for upstream anonymous-function naming transform.
+pub fn name_anonymous_functions() {
+    // No-op placeholder for parity with pipeline staging.
+}

--- a/crates/swc_ecma_react_compiler/src/utils/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/utils/mod.rs
@@ -1,0 +1,50 @@
+use swc_ecma_ast::{BlockStmt, Expr, Lit, Stmt};
+
+/// Returns directive values from the top of a statement list.
+pub fn collect_directives(stmts: &[Stmt]) -> Vec<String> {
+    let mut directives = Vec::new();
+
+    for stmt in stmts {
+        let Some(value) = directive_from_stmt(stmt) else {
+            break;
+        };
+        directives.push(value);
+    }
+
+    directives
+}
+
+/// Returns directive values from a block body.
+pub fn collect_block_directives(block: &BlockStmt) -> Vec<String> {
+    collect_directives(&block.stmts)
+}
+
+/// Returns directive value for a single statement.
+pub fn directive_from_stmt(stmt: &Stmt) -> Option<String> {
+    let Stmt::Expr(expr_stmt) = stmt else {
+        return None;
+    };
+    let Expr::Lit(Lit::Str(str_lit)) = &*expr_stmt.expr else {
+        return None;
+    };
+
+    Some(str_lit.value.to_string_lossy().into_owned())
+}
+
+pub fn is_hook_name(name: &str) -> bool {
+    let Some(rest) = name.strip_prefix("use") else {
+        return false;
+    };
+    matches!(
+        rest.chars().next(),
+        Some(c) if c.is_ascii_uppercase() || c.is_ascii_digit()
+    )
+}
+
+pub fn is_component_name(name: &str) -> bool {
+    matches!(name.chars().next(), Some(c) if c.is_ascii_uppercase())
+}
+
+pub fn is_valid_identifier(value: &str) -> bool {
+    swc_ecma_ast::Ident::verify_symbol(value).is_ok()
+}

--- a/crates/swc_ecma_react_compiler/src/validation/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/mod.rs
@@ -1,0 +1,61 @@
+use crate::{error::CompilerError, hir::HirFunction};
+
+pub fn validate_context_variable_lvalues(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_use_memo(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_hooks_usage(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_no_capitalized_calls(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_locals_not_reassigned_after_render(
+    _hir: &HirFunction,
+) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_no_ref_access_in_render(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_no_set_state_in_render(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_no_derived_computations_in_effects(
+    _hir: &HirFunction,
+) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_no_set_state_in_effects(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_no_jsx_in_try_statement(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_exhaustive_dependencies(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_preserved_manual_memoization(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_static_components(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}
+
+pub fn validate_source_locations(_hir: &HirFunction) -> Result<(), CompilerError> {
+    Ok(())
+}

--- a/crates/swc_ecma_react_compiler/tests/fixture.rs
+++ b/crates/swc_ecma_react_compiler/tests/fixture.rs
@@ -1,0 +1,131 @@
+use std::{fs, path::PathBuf};
+
+use swc_common::{sync::Lrc, FileName, SourceMap};
+use swc_ecma_ast::{EsVersion, Program};
+use swc_ecma_codegen::{text_writer::JsWriter, Emitter};
+use swc_ecma_parser::{parse_file_as_module, EsSyntax, Syntax};
+use swc_ecma_react_compiler::{
+    compile_program, default_options, CompilerPass, DynamicGatingOptions,
+};
+
+fn parse(input: &PathBuf) -> Program {
+    let cm = Lrc::new(SourceMap::default());
+    let source = fs::read_to_string(input).unwrap();
+    let fm = cm.new_source_file(FileName::Real(input.clone()).into(), source);
+
+    Program::Module(
+        parse_file_as_module(
+            &fm,
+            Syntax::Es(EsSyntax {
+                jsx: true,
+                ..Default::default()
+            }),
+            EsVersion::latest(),
+            None,
+            &mut vec![],
+        )
+        .unwrap(),
+    )
+}
+
+fn print(program: &Program) -> String {
+    let cm = Lrc::new(SourceMap::default());
+    let mut out = Vec::new();
+    {
+        let wr = JsWriter::new(cm.clone(), "\n", &mut out, None);
+        let mut emitter = Emitter {
+            cfg: Default::default(),
+            comments: None,
+            cm,
+            wr,
+        };
+        emitter.emit_program(program).unwrap();
+    }
+    String::from_utf8(out).unwrap()
+}
+
+fn normalize(value: &str) -> String {
+    value.replace("\r\n", "\n").trim().to_string()
+}
+
+fn run_fixture(input: PathBuf) {
+    let mut program = parse(&input);
+    let expected_output = input.with_file_name("output.js");
+    let expected_error = input.with_file_name("error.txt");
+
+    let mut options = default_options();
+    options.dynamic_gating = Some(DynamicGatingOptions {
+        source: "feature-flags".into(),
+    });
+
+    let result = compile_program(
+        &mut program,
+        &CompilerPass {
+            opts: options,
+            filename: Some(input.to_string_lossy().to_string()),
+            comments: Vec::new(),
+            code: None,
+        },
+    );
+
+    if expected_error.exists() {
+        let expected = fs::read_to_string(expected_error).unwrap();
+
+        match result {
+            Ok(report) => {
+                let joined = report
+                    .diagnostics
+                    .iter()
+                    .map(|detail| detail.reason.clone())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                assert!(
+                    normalize(&joined).contains(&normalize(&expected)),
+                    "expected error fragment not found: {expected}\nactual:\n{joined}"
+                );
+            }
+            Err(err) => {
+                assert!(
+                    normalize(&err.to_string()).contains(&normalize(&expected)),
+                    "expected error fragment not found: {expected}\nactual:\n{err}",
+                );
+            }
+        }
+
+        return;
+    }
+
+    result.unwrap();
+
+    let expected = fs::read_to_string(expected_output).unwrap();
+    let actual = print(&program);
+
+    assert_eq!(normalize(&actual), normalize(&expected));
+}
+
+#[test]
+fn fixture_cases() {
+    let fixture_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures");
+
+    let mut inputs = Vec::new();
+    for entry in fs::read_dir(&fixture_root).unwrap() {
+        let entry = entry.unwrap();
+        if !entry.file_type().unwrap().is_dir() {
+            continue;
+        }
+
+        let input = entry.path().join("input.js");
+        if input.exists() {
+            inputs.push(input);
+        }
+    }
+
+    inputs.sort();
+    assert!(!inputs.is_empty(), "no fixture input.js files were found");
+
+    for input in inputs {
+        run_fixture(input);
+    }
+}

--- a/crates/swc_ecma_react_compiler/tests/fixtures/basic-component/input.js
+++ b/crates/swc_ecma_react_compiler/tests/fixtures/basic-component/input.js
@@ -1,0 +1,3 @@
+function Component(props) {
+  return <div>{props.value}</div>;
+}

--- a/crates/swc_ecma_react_compiler/tests/fixtures/basic-component/output.js
+++ b/crates/swc_ecma_react_compiler/tests/fixtures/basic-component/output.js
@@ -1,0 +1,4 @@
+import { c as _c } from "react/compiler-runtime";
+function Component(props) {
+    return <div>{props.value}</div>;
+}

--- a/crates/swc_ecma_react_compiler/tests/fixtures/dynamic-gating-invalid/error.txt
+++ b/crates/swc_ecma_react_compiler/tests/fixtures/dynamic-gating-invalid/error.txt
@@ -1,0 +1,1 @@
+Dynamic gating directive is not a valid JavaScript identifier

--- a/crates/swc_ecma_react_compiler/tests/fixtures/dynamic-gating-invalid/input.js
+++ b/crates/swc_ecma_react_compiler/tests/fixtures/dynamic-gating-invalid/input.js
@@ -1,0 +1,4 @@
+function Component(props) {
+  "use memo if(invalid-name)";
+  return <div>{props.value}</div>;
+}

--- a/crates/swc_ecma_react_compiler/tests/fixtures/module-opt-out/input.js
+++ b/crates/swc_ecma_react_compiler/tests/fixtures/module-opt-out/input.js
@@ -1,0 +1,5 @@
+"use no memo";
+
+function Component(props) {
+  return <div>{props.value}</div>;
+}

--- a/crates/swc_ecma_react_compiler/tests/fixtures/module-opt-out/output.js
+++ b/crates/swc_ecma_react_compiler/tests/fixtures/module-opt-out/output.js
@@ -1,0 +1,4 @@
+"use no memo";
+function Component(props) {
+    return <div>{props.value}</div>;
+}

--- a/crates/swc_ecma_react_compiler/tests/fixtures/upstream_manifest.txt
+++ b/crates/swc_ecma_react_compiler/tests/fixtures/upstream_manifest.txt
@@ -1,0 +1,5 @@
+# React Compiler upstream fixture names (without extension).
+# Sync script downloads `<name>.expect.md` and creates local fixture directories.
+component
+custom-opt-out-directive
+error.invalid-setState-in-useMemo


### PR DESCRIPTION
## Summary
- add swc_ecma_react_compiler public API surface for options, errors, and entrypoint
- port Program-level compile entrypoint with function selection, directives, suppression handling, runtime and gating imports, and pass adapter
- add pipeline stage modules (hir, ssa, inference, optimization, reactive_scopes, validation, transform, utils) and fixture harness plus upstream sync script
- keep fast_check::is_required behavior compatible

## Tests
- cargo test -p swc_ecma_react_compiler
- cargo clippy -p swc_ecma_react_compiler --all-targets -- -D warnings

## Notes
- workspace-wide cargo fmt --all and cargo clippy --all --all-targets -- -D warnings currently fail due an existing unrelated parse error in crates/swc_es_parser/tests/bench_parser_inputs.rs (unclosed delimiter).