### PR TITLE
feat(es/parser): finish flow strip support for core syntax gaps

### DIFF
--- a/crates/swc/tests/fixture/flow-strip/input/index.js
+++ b/crates/swc/tests/fixture/flow-strip/input/index.js
@@ -1,5 +1,19 @@
 import type { Foo } from "./foo";
 opaque type ID = string;
 type Box = {| +a: number, ...Other |};
+declare module.exports: { value: number };
+declare export default number;
+
+class C {
+  +x: number;
+  -y: string;
+}
+
+function hasValue(x: mixed): boolean %checks(x != null) {
+  return x != null;
+}
+
 const value: ID = (foo: any);
 export const out = value;
+export const ok = hasValue(value);
+export const CRef = C;

--- a/crates/swc/tests/fixture/flow-strip/output/index.js
+++ b/crates/swc/tests/fixture/flow-strip/output/index.js
@@ -1,2 +1,15 @@
+import { _ as _class_call_check } from "@swc/helpers/_/_class_call_check";
+import { _ as _define_property } from "@swc/helpers/_/_define_property";
+var C = function C() {
+    "use strict";
+    _class_call_check(this, C);
+    _define_property(this, "x", void 0);
+    _define_property(this, "y", void 0);
+};
+function hasValue(x) {
+    return x != null;
+}
 var value = foo;
 export var out = value;
+export var ok = hasValue(value);
+export var CRef = C;

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -212,6 +212,28 @@ impl<I: Tokens> Parser<I> {
         }
     }
 
+    fn try_parse_flow_predicate(&mut self) -> PResult<()> {
+        if !self.input().syntax().flow() || !self.input_mut().eat(Token::Percent) {
+            return Ok(());
+        }
+
+        let is_checks = self.input().cur().is_word()
+            && self.input().cur().take_word(&self.input) == atom!("checks");
+        if !is_checks {
+            unexpected!(self, "checks");
+        }
+        self.bump();
+
+        if self.input_mut().eat(Token::LParen) {
+            if !self.input().is(Token::RParen) {
+                self.allow_in_expr(Self::parse_assignment_expr)?;
+            }
+            expect!(self, Token::RParen);
+        }
+
+        Ok(())
+    }
+
     /// `parse_args` closure should not eat '(' or ')'.
     pub(crate) fn parse_fn_args_body<F>(
         &mut self,
@@ -271,6 +293,8 @@ impl<I: Tokens> Parser<I> {
             } else {
                 None
             };
+
+            p.try_parse_flow_predicate()?;
 
             let body: Option<_> = p.parse_fn_block_body(
                 is_async,
@@ -948,9 +972,24 @@ impl<I: Tokens> Parser<I> {
             }
         }
 
+        let mut flow_variance_span = None;
+        let mut flow_variance_readonly = false;
+        if self.input().syntax().flow() {
+            let variance_start = self.cur_pos();
+            if self.input_mut().eat(Token::Plus) {
+                flow_variance_span = Some(self.span(variance_start));
+                flow_variance_readonly = true;
+            } else if self.input_mut().eat(Token::Minus) {
+                flow_variance_span = Some(self.span(variance_start));
+            }
+        }
+
         if self.input_mut().eat(Token::Asterisk) {
             // generator method
             let key = self.parse_class_prop_name()?;
+            if let Some(variance_span) = flow_variance_span {
+                self.emit_err(variance_span, SyntaxError::TS1184);
+            }
             if readonly.is_some() {
                 self.emit_err(self.span(start), SyntaxError::ReadOnlyMethod);
             }
@@ -998,6 +1037,9 @@ impl<I: Tokens> Parser<I> {
                 self.emit_err(token, SyntaxError::TS1031)
             }
 
+            if let Some(variance_span) = flow_variance_span {
+                self.emit_err(variance_span, SyntaxError::TS1184);
+            }
             if readonly.is_some() {
                 syntax_error!(self, self.span(start), SyntaxError::ReadOnlyMethod);
             }
@@ -1138,7 +1180,7 @@ impl<I: Tokens> Parser<I> {
                 is_static,
                 accessor_token,
                 is_optional,
-                readonly.is_some(),
+                readonly.is_some() || flow_variance_readonly,
                 declare,
                 is_abstract,
                 is_override,
@@ -1148,6 +1190,9 @@ impl<I: Tokens> Parser<I> {
         if key_token == Token::Async && !self.input_mut().had_line_break_before_cur() {
             // handle async foo(){}
 
+            if let Some(variance_span) = flow_variance_span {
+                self.emit_err(variance_span, SyntaxError::TS1184);
+            }
             if self.input().syntax().typescript()
                 && self.parse_ts_modifier(&[Token::Override], false)?.is_some()
             {
@@ -1190,6 +1235,9 @@ impl<I: Tokens> Parser<I> {
 
         if getter_or_setter_ident {
             let key_span = key.span();
+            if let Some(variance_span) = flow_variance_span {
+                self.emit_err(variance_span, SyntaxError::TS1184);
+            }
 
             // handle get foo(){} / set foo(v){}
             let key = self.parse_class_prop_name()?;

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -1724,6 +1724,21 @@ impl<I: Tokens> Parser<I> {
         }))
     }
 
+    fn make_flow_synthetic_type_alias_decl(
+        &mut self,
+        start: BytePos,
+        id: Atom,
+        type_ann: Box<TsType>,
+    ) -> Box<TsTypeAliasDecl> {
+        Box::new(TsTypeAliasDecl {
+            declare: false,
+            span: self.span(start),
+            id: Ident::new_no_ctxt(id, self.span(start)),
+            type_params: None,
+            type_ann,
+        })
+    }
+
     fn parse_flow_opaque_type_alias_decl(
         &mut self,
         start: BytePos,
@@ -2889,6 +2904,84 @@ impl<I: Tokens> Parser<I> {
                     .map(make_decl_declare)
                     .map(Some);
             } else if p.input().syntax().flow() && p.input_mut().eat(Token::Export) {
+                if p.input_mut().eat(Token::Default) {
+                    if p.input().is(Token::Class) {
+                        return p
+                            .parse_class_decl(start, start, decorators.clone(), false)
+                            .map(|decl| match decl {
+                                Decl::Class(c) => ClassDecl {
+                                    declare: true,
+                                    class: Box::new(Class {
+                                        span: Span {
+                                            lo: declare_start,
+                                            ..c.class.span
+                                        },
+                                        ..*c.class
+                                    }),
+                                    ..c
+                                }
+                                .into(),
+                                _ => decl,
+                            })
+                            .map(Some);
+                    }
+
+                    if p.input().is(Token::Async)
+                        && peek!(p).is_some_and(|peek| peek == Token::Function)
+                        && !p.input_mut().has_linebreak_between_cur_and_peeked()
+                    {
+                        return p
+                            .parse_async_fn_decl(decorators.clone())
+                            .map(|decl| match decl {
+                                Decl::Fn(f) => FnDecl {
+                                    declare: true,
+                                    function: Box::new(Function {
+                                        span: Span {
+                                            lo: declare_start,
+                                            ..f.function.span
+                                        },
+                                        ..*f.function
+                                    }),
+                                    ..f
+                                }
+                                .into(),
+                                _ => decl,
+                            })
+                            .map(Some);
+                    }
+
+                    if p.input().is(Token::Function) {
+                        return p
+                            .parse_fn_decl(decorators.clone())
+                            .map(|decl| match decl {
+                                Decl::Fn(f) => FnDecl {
+                                    declare: true,
+                                    function: Box::new(Function {
+                                        span: Span {
+                                            lo: declare_start,
+                                            ..f.function.span
+                                        },
+                                        ..*f.function
+                                    }),
+                                    ..f
+                                }
+                                .into(),
+                                _ => decl,
+                            })
+                            .map(Some);
+                    }
+
+                    let type_ann = p.in_type(Self::parse_ts_type)?;
+                    p.expect_general_semi()?;
+
+                    let decl = Decl::TsTypeAlias(p.make_flow_synthetic_type_alias_decl(
+                        declare_start,
+                        atom!("__flow_default_export"),
+                        type_ann,
+                    ));
+                    return Ok(Some(make_decl_declare(decl)));
+                }
+
                 if p.input().is(Token::Function) {
                     return p
                         .parse_fn_decl(decorators.clone())
@@ -3043,6 +3136,31 @@ impl<I: Tokens> Parser<I> {
             "module" if !self.input().had_line_break_before_cur() => {
                 if next {
                     self.bump();
+                }
+
+                if self.input().syntax().flow()
+                    && self.ctx().contains(Context::InDeclare)
+                    && self.input_mut().eat(Token::Dot)
+                {
+                    let is_exports = self.input().cur().is_word()
+                        && self.input().cur().take_word(&self.input) == atom!("exports");
+
+                    if !is_exports {
+                        unexpected!(self, "exports")
+                    }
+                    self.bump();
+
+                    expect!(self, Token::Colon);
+                    let type_ann = self.in_type(Self::parse_ts_type)?;
+                    self.expect_general_semi()?;
+
+                    return Ok(Some(Decl::TsTypeAlias(
+                        self.make_flow_synthetic_type_alias_decl(
+                            start,
+                            atom!("__flow_module_exports"),
+                            type_ann,
+                        ),
+                    )));
                 }
 
                 let cur = self.input().cur();

--- a/crates/swc_ecma_parser/tests/flow/class-variance/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/class-variance/basic.js
@@ -1,0 +1,5 @@
+class C {
+  +x: number;
+  -y: string;
+  z: boolean;
+}

--- a/crates/swc_ecma_parser/tests/flow/class-variance/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/class-variance/basic.js.json
@@ -1,0 +1,157 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 54
+  },
+  "body": [
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 7,
+          "end": 8
+        },
+        "ctxt": 0,
+        "value": "C",
+        "optional": false
+      },
+      "declare": false,
+      "span": {
+        "start": 1,
+        "end": 54
+      },
+      "ctxt": 0,
+      "decorators": [],
+      "body": [
+        {
+          "type": "ClassProperty",
+          "span": {
+            "start": 13,
+            "end": 24
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 14,
+              "end": 15
+            },
+            "value": "x"
+          },
+          "value": null,
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 15,
+              "end": 23
+            },
+            "typeAnnotation": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 17,
+                "end": 23
+              },
+              "kind": "number"
+            }
+          },
+          "isStatic": false,
+          "decorators": [],
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false,
+          "readonly": true,
+          "declare": false,
+          "definite": false
+        },
+        {
+          "type": "ClassProperty",
+          "span": {
+            "start": 27,
+            "end": 38
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 28,
+              "end": 29
+            },
+            "value": "y"
+          },
+          "value": null,
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 29,
+              "end": 37
+            },
+            "typeAnnotation": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 31,
+                "end": 37
+              },
+              "kind": "string"
+            }
+          },
+          "isStatic": false,
+          "decorators": [],
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false,
+          "readonly": false,
+          "declare": false,
+          "definite": false
+        },
+        {
+          "type": "ClassProperty",
+          "span": {
+            "start": 41,
+            "end": 52
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 41,
+              "end": 42
+            },
+            "value": "z"
+          },
+          "value": null,
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 42,
+              "end": 51
+            },
+            "typeAnnotation": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 44,
+                "end": 51
+              },
+              "kind": "boolean"
+            }
+          },
+          "isStatic": false,
+          "decorators": [],
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false,
+          "readonly": false,
+          "declare": false,
+          "definite": false
+        }
+      ],
+      "superClass": null,
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/declare-export-default/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/declare-export-default/basic.js
@@ -1,0 +1,4 @@
+declare export default class C {
+  x: number;
+}
+declare export default number;

--- a/crates/swc_ecma_parser/tests/flow/declare-export-default/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/declare-export-default/basic.js.json
@@ -1,0 +1,104 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 79
+  },
+  "body": [
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 30,
+          "end": 31
+        },
+        "ctxt": 0,
+        "value": "C",
+        "optional": false
+      },
+      "declare": true,
+      "span": {
+        "start": 1,
+        "end": 48
+      },
+      "ctxt": 0,
+      "decorators": [],
+      "body": [
+        {
+          "type": "ClassProperty",
+          "span": {
+            "start": 36,
+            "end": 46
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 36,
+              "end": 37
+            },
+            "value": "x"
+          },
+          "value": null,
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 37,
+              "end": 45
+            },
+            "typeAnnotation": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 39,
+                "end": 45
+              },
+              "kind": "number"
+            }
+          },
+          "isStatic": false,
+          "decorators": [],
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false,
+          "readonly": false,
+          "declare": false,
+          "definite": false
+        }
+      ],
+      "superClass": null,
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 49,
+        "end": 79
+      },
+      "declare": true,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 49,
+          "end": 79
+        },
+        "ctxt": 0,
+        "value": "__flow_default_export",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsKeywordType",
+        "span": {
+          "start": 72,
+          "end": 78
+        },
+        "kind": "number"
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/module-exports/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/module-exports/basic.js
@@ -1,0 +1,1 @@
+declare module.exports: { value: number };

--- a/crates/swc_ecma_parser/tests/flow/module-exports/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/module-exports/basic.js.json
@@ -1,0 +1,73 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 43
+  },
+  "body": [
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 1,
+        "end": 43
+      },
+      "declare": true,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 1,
+          "end": 43
+        },
+        "ctxt": 0,
+        "value": "__flow_module_exports",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 25,
+          "end": 42
+        },
+        "members": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 27,
+              "end": 40
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 27,
+                "end": 32
+              },
+              "ctxt": 0,
+              "value": "value",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 32,
+                "end": 40
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 34,
+                  "end": 40
+                },
+                "kind": "number"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/predicate/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/predicate/basic.js
@@ -1,0 +1,7 @@
+function isString(x: mixed): boolean %checks {
+  return typeof x === "string";
+}
+
+function hasValue(x: mixed): boolean %checks(x != null) {
+  return x != null;
+}

--- a/crates/swc_ecma_parser/tests/flow/predicate/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/predicate/basic.js.json
@@ -1,0 +1,270 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 162
+  },
+  "body": [
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 10,
+          "end": 18
+        },
+        "ctxt": 0,
+        "value": "isString",
+        "optional": false
+      },
+      "declare": false,
+      "params": [
+        {
+          "type": "Parameter",
+          "span": {
+            "start": 19,
+            "end": 27
+          },
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
+            "span": {
+              "start": 19,
+              "end": 20
+            },
+            "ctxt": 0,
+            "value": "x",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 20,
+                "end": 27
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 22,
+                  "end": 27
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 22,
+                    "end": 27
+                  },
+                  "ctxt": 0,
+                  "value": "mixed",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          }
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 1,
+        "end": 81
+      },
+      "ctxt": 0,
+      "body": {
+        "type": "BlockStatement",
+        "span": {
+          "start": 46,
+          "end": 81
+        },
+        "ctxt": 0,
+        "stmts": [
+          {
+            "type": "ReturnStatement",
+            "span": {
+              "start": 50,
+              "end": 79
+            },
+            "argument": {
+              "type": "BinaryExpression",
+              "span": {
+                "start": 57,
+                "end": 78
+              },
+              "operator": "===",
+              "left": {
+                "type": "UnaryExpression",
+                "span": {
+                  "start": 57,
+                  "end": 65
+                },
+                "operator": "typeof",
+                "argument": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 64,
+                    "end": 65
+                  },
+                  "ctxt": 0,
+                  "value": "x",
+                  "optional": false
+                }
+              },
+              "right": {
+                "type": "StringLiteral",
+                "span": {
+                  "start": 70,
+                  "end": 78
+                },
+                "value": "string",
+                "raw": "\"string\""
+              }
+            }
+          }
+        ]
+      },
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 28,
+          "end": 37
+        },
+        "typeAnnotation": {
+          "type": "TsKeywordType",
+          "span": {
+            "start": 30,
+            "end": 37
+          },
+          "kind": "boolean"
+        }
+      }
+    },
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 92,
+          "end": 100
+        },
+        "ctxt": 0,
+        "value": "hasValue",
+        "optional": false
+      },
+      "declare": false,
+      "params": [
+        {
+          "type": "Parameter",
+          "span": {
+            "start": 101,
+            "end": 109
+          },
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
+            "span": {
+              "start": 101,
+              "end": 102
+            },
+            "ctxt": 0,
+            "value": "x",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 102,
+                "end": 109
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 104,
+                  "end": 109
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 104,
+                    "end": 109
+                  },
+                  "ctxt": 0,
+                  "value": "mixed",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          }
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 83,
+        "end": 162
+      },
+      "ctxt": 0,
+      "body": {
+        "type": "BlockStatement",
+        "span": {
+          "start": 139,
+          "end": 162
+        },
+        "ctxt": 0,
+        "stmts": [
+          {
+            "type": "ReturnStatement",
+            "span": {
+              "start": 143,
+              "end": 160
+            },
+            "argument": {
+              "type": "BinaryExpression",
+              "span": {
+                "start": 150,
+                "end": 159
+              },
+              "operator": "!=",
+              "left": {
+                "type": "Identifier",
+                "span": {
+                  "start": 150,
+                  "end": 151
+                },
+                "ctxt": 0,
+                "value": "x",
+                "optional": false
+              },
+              "right": {
+                "type": "NullLiteral",
+                "span": {
+                  "start": 155,
+                  "end": 159
+                }
+              }
+            }
+          }
+        ]
+      },
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 110,
+          "end": 119
+        },
+        "typeAnnotation": {
+          "type": "TsKeywordType",
+          "span": {
+            "start": 112,
+            "end": 119
+          },
+          "kind": "boolean"
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
## Summary

This PR completes Flow stripping coverage in `swc_ecma_parser` for four syntax gaps by normalizing Flow-only forms into existing TS-compatible parser paths, so downstream strip behavior removes them consistently.

## What changed

- `declare module.exports: T;`
  - Added Flow-mode handling in `parse_ts_decl` (`module` branch).
  - Normalized to synthetic `TsTypeAliasDecl` with id `__flow_module_exports`.

- `declare export default ...`
  - Added dedicated default handling in Flow `export` declare branch.
  - Supports:
    - `declare export default class ...`
    - `declare export default function ...`
    - `declare export default <Type>;` (normalized via synthetic alias `__flow_default_export`)

- Flow predicate `%checks` / `%checks(expr)`
  - Added consume-only parsing after return type and before function body.
  - No AST node introduced (strip-friendly behavior).

- Class field variance `+x` / `-y`
  - Added Flow variance token consumption before class field names.
  - `+` maps to readonly semantics on fields.
  - `-` maps to writable semantics.
  - Variance in method contexts emits error and continues.

## Tests

Added parser fixtures:

- `crates/swc_ecma_parser/tests/flow/class-variance/basic.js`
- `crates/swc_ecma_parser/tests/flow/declare-export-default/basic.js`
- `crates/swc_ecma_parser/tests/flow/module-exports/basic.js`
- `crates/swc_ecma_parser/tests/flow/predicate/basic.js`

Expanded flow-strip e2e fixture:

- `crates/swc/tests/fixture/flow-strip/input/index.js`
- `crates/swc/tests/fixture/flow-strip/output/index.js`

Validation run:

- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_parser --test flow --features flow -- --ignored`
- `cargo test -p swc_ecma_parser --test flow --features flow -- --ignored`
- `UPDATE=1 cargo test -p swc --test projects -F flow -- --ignored flow_strip`
- `cargo test -p swc --test projects -F flow -- --ignored flow_strip`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_parser`
