### PR TITLE
feat(es/parser): support Flow declare export default interface strip path

### DIFF
--- a/crates/swc/tests/fixture/flow-strip/input/index.js
+++ b/crates/swc/tests/fixture/flow-strip/input/index.js
@@ -3,6 +3,9 @@ opaque type ID = string;
 type Box = {| +a: number, ...Other |};
 declare module.exports: { value: number };
 declare export default number;
+declare export default interface Foo {
+  x: number;
+}
 declare export { Foo, type Bar as Baz } from "./foo";
 declare export * from "./foo";
 declare export * as ns from "./foo";

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -3060,6 +3060,15 @@ impl<I: Tokens> Parser<I> {
                             .map(Some);
                     }
 
+                    if p.input().is(Token::Interface) {
+                        p.assert_and_bump(Token::Interface);
+                        return p
+                            .parse_ts_interface_decl(declare_start)
+                            .map(Decl::from)
+                            .map(make_decl_declare)
+                            .map(Some);
+                    }
+
                     let type_ann = p.in_type(Self::parse_ts_type)?;
                     p.expect_general_semi()?;
 

--- a/crates/swc_ecma_parser/tests/flow/declare-export-default-interface/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/declare-export-default-interface/basic.js
@@ -1,0 +1,3 @@
+declare export default interface Foo {
+  x: number;
+}

--- a/crates/swc_ecma_parser/tests/flow/declare-export-default-interface/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/declare-export-default-interface/basic.js.json
@@ -1,0 +1,74 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 54
+  },
+  "body": [
+    {
+      "type": "TsInterfaceDeclaration",
+      "span": {
+        "start": 1,
+        "end": 54
+      },
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 34,
+          "end": 37
+        },
+        "ctxt": 0,
+        "value": "Foo",
+        "optional": false
+      },
+      "declare": true,
+      "typeParams": null,
+      "extends": [],
+      "body": {
+        "type": "TsInterfaceBody",
+        "span": {
+          "start": 38,
+          "end": 54
+        },
+        "body": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 42,
+              "end": 52
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 42,
+                "end": 43
+              },
+              "ctxt": 0,
+              "value": "x",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 43,
+                "end": 51
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 45,
+                  "end": 51
+                },
+                "kind": "number"
+              }
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
## Summary

This PR completes the remaining Flow strip parser gap for `declare export default interface ...`.

### What changed
- Added a Flow-specific `declare export default` branch for `interface` in `swc_ecma_parser`.
- Parses `declare export default interface Foo { ... }` as `Decl::TsInterface`, then marks it `declare` via the existing `make_decl_declare` path.
- Kept existing fallback behavior for `declare export default <type>;` unchanged.
- Added a new parser fixture suite:
  - `crates/swc_ecma_parser/tests/flow/declare-export-default-interface/basic.js`
- Extended flow-strip e2e fixture input:
  - `crates/swc/tests/fixture/flow-strip/input/index.js`

## Scope notes
- Intentionally **not** changing behavior for:
  - `declare export default opaque type ...`
  - semicolon-separated declare-export specifier lists like `declare export { Foo; Bar }`

## Testing

- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_parser --test flow --features flow -- --ignored`
- `cargo test -p swc_ecma_parser --test flow --features flow -- --ignored`
- `UPDATE=1 cargo test -p swc --test projects -F flow -- --ignored flow_strip`
- `cargo test -p swc --test projects -F flow -- --ignored flow_strip`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_parser`
- `cargo test -p swc` *(fails in `source_map` tests in this environment due missing Node module `sourcemap-validator`)*
