### PR TITLE
fix(cli): honor externalHelpers=false in rust binary

### DIFF
--- a/.changeset/grumpy-badgers-itch.md
+++ b/.changeset/grumpy-badgers-itch.md
@@ -1,0 +1,5 @@
+---
+swc_cli_impl: patch
+---
+
+fix(cli): honor externalHelpers=false in rust binary

--- a/crates/swc_cli_impl/Cargo.toml
+++ b/crates/swc_cli_impl/Cargo.toml
@@ -43,6 +43,7 @@ swc_core = { version = "58.0.4", features = [
   "common_concurrent",
   "base_concurrent",
   "base_module",
+  "ecma_helpers_inline",
 ], path = "../swc_core" }
 
 [dev-dependencies]

--- a/crates/swc_cli_impl/tests/issues.rs
+++ b/crates/swc_cli_impl/tests/issues.rs
@@ -158,6 +158,54 @@ fn issue_9559() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn issue_11643_external_helpers_false_respected() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    fs::write(
+        sandbox.path().join(".swcrc"),
+        r#"{
+            "jsc": {
+                "externalHelpers": false
+            },
+            "module": {
+                "type": "commonjs"
+            }
+        }"#,
+    )?;
+    fs::write(
+        sandbox.path().join("index.ts"),
+        r#"export * from "./my-file";"#,
+    )?;
+    fs::write(sandbox.path().join("my-file.ts"), "export const foo = 1;")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--config-file")
+        .arg(".swcrc")
+        .arg("--out-file")
+        .arg("index.js")
+        .arg("index.ts");
+
+    cmd.assert().success();
+
+    let output = fs::read_to_string(sandbox.path().join("index.js"))?;
+    assert!(
+        !output.contains("@swc/helpers"),
+        "Expected no external helper imports/requires when externalHelpers is false. Got: {output}",
+    );
+    assert!(
+        output.contains("function _export_star("),
+        "Expected inline _export_star helper when externalHelpers is false. Got: {output}",
+    );
+    assert!(
+        output.contains("_export_star(require(\"./my-file\"), exports);"),
+        "Expected re-export call to use inline helper. Got: {output}",
+    );
+
+    Ok(())
+}
+
 /// Tests that `--root-mode upward` finds a `.swcrc` in a parent directory.
 #[test]
 fn root_mode_upward_finds_parent_config() -> Result<()> {


### PR DESCRIPTION
## Summary
- Enable inline helper support in the Rust CLI build by adding `swc_core/ecma_helpers_inline` to `swc_cli_impl`.
- Fix behavior where `jsc.externalHelpers: false` was ignored and `@swc/helpers` was still emitted.
- Add a regression test for issue #11643.

## Changes
- `crates/swc_cli_impl/Cargo.toml`
  - Add `ecma_helpers_inline` to the `swc_core` feature list.
- `crates/swc_cli_impl/tests/issues.rs`
  - Add `issue_11643_external_helpers_false_respected`.
  - Verify output does not reference `@swc/helpers`.
  - Verify inline `_export_star` helper is emitted.

## Verification
- `git submodule update --init --recursive`
- `cargo test -p swc_cli_impl issue_11643`
- `cargo test -p swc_cli_impl`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

Closes #11643
