### PR TITLE
test(es/parser): expand flow strip fixture coverage

### DIFF
--- a/crates/swc_ecma_parser/tests/flow-errors/class-variance-method/basic.js
+++ b/crates/swc_ecma_parser/tests/flow-errors/class-variance-method/basic.js
@@ -1,0 +1,9 @@
+class C {
+  +m(): number {
+    return 1;
+  }
+
+  -n(): number {
+    return 2;
+  }
+}

--- a/crates/swc_ecma_parser/tests/flow-errors/class-variance-method/basic.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/flow-errors/class-variance-method/basic.js.swc-stderr
@@ -1,0 +1,14 @@
+  x Modifiers cannot appear here
+   ,-[$DIR/tests/flow-errors/class-variance-method/basic.js:2:1]
+ 1 | class C {
+ 2 |   +m(): number {
+   :   ^
+ 3 |     return 1;
+   `----
+  x Modifiers cannot appear here
+   ,-[$DIR/tests/flow-errors/class-variance-method/basic.js:6:1]
+ 5 | 
+ 6 |   -n(): number {
+   :   ^
+ 7 |     return 2;
+   `----

--- a/crates/swc_ecma_parser/tests/flow-errors/require-directive/with-noflow.js
+++ b/crates/swc_ecma_parser/tests/flow-errors/require-directive/with-noflow.js
@@ -1,0 +1,2 @@
+/* @noflow */
+const value: number = 1;

--- a/crates/swc_ecma_parser/tests/flow-errors/require-directive/with-noflow.js.swc-stderr
+++ b/crates/swc_ecma_parser/tests/flow-errors/require-directive/with-noflow.js.swc-stderr
@@ -1,0 +1,12 @@
+  x 'const' declarations must be initialized
+   ,-[$DIR/tests/flow-errors/require-directive/with-noflow.js:2:1]
+ 1 | /* @noflow */
+ 2 | const value: number = 1;
+   :       ^^^^^
+   `----
+  x Expected a semicolon
+   ,-[$DIR/tests/flow-errors/require-directive/with-noflow.js:2:1]
+ 1 | /* @noflow */
+ 2 | const value: number = 1;
+   :            ^
+   `----

--- a/crates/swc_ecma_parser/tests/flow/declare-export-default-named/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/declare-export-default-named/basic.js
@@ -1,0 +1,5 @@
+declare export default function Foo(x: number): void;
+declare export default async function Bar(x: number): Promise<void>;
+declare export default class Baz {
+  x: number;
+}

--- a/crates/swc_ecma_parser/tests/flow/declare-export-default-named/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/declare-export-default-named/basic.js.json
@@ -1,0 +1,251 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 173
+  },
+  "body": [
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 33,
+          "end": 36
+        },
+        "ctxt": 0,
+        "value": "Foo",
+        "optional": false
+      },
+      "declare": true,
+      "params": [
+        {
+          "type": "Parameter",
+          "span": {
+            "start": 37,
+            "end": 46
+          },
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
+            "span": {
+              "start": 37,
+              "end": 38
+            },
+            "ctxt": 0,
+            "value": "x",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 38,
+                "end": 46
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 40,
+                  "end": 46
+                },
+                "kind": "number"
+              }
+            }
+          }
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 1,
+        "end": 54
+      },
+      "ctxt": 0,
+      "body": null,
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 47,
+          "end": 53
+        },
+        "typeAnnotation": {
+          "type": "TsKeywordType",
+          "span": {
+            "start": 49,
+            "end": 53
+          },
+          "kind": "void"
+        }
+      }
+    },
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 93,
+          "end": 96
+        },
+        "ctxt": 0,
+        "value": "Bar",
+        "optional": false
+      },
+      "declare": true,
+      "params": [
+        {
+          "type": "Parameter",
+          "span": {
+            "start": 97,
+            "end": 106
+          },
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
+            "span": {
+              "start": 97,
+              "end": 98
+            },
+            "ctxt": 0,
+            "value": "x",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 98,
+                "end": 106
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 100,
+                  "end": 106
+                },
+                "kind": "number"
+              }
+            }
+          }
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 55,
+        "end": 123
+      },
+      "ctxt": 0,
+      "body": null,
+      "generator": false,
+      "async": true,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 107,
+          "end": 122
+        },
+        "typeAnnotation": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 109,
+            "end": 122
+          },
+          "typeName": {
+            "type": "Identifier",
+            "span": {
+              "start": 109,
+              "end": 116
+            },
+            "ctxt": 0,
+            "value": "Promise",
+            "optional": false
+          },
+          "typeParams": {
+            "type": "TsTypeParameterInstantiation",
+            "span": {
+              "start": 116,
+              "end": 122
+            },
+            "params": [
+              {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 117,
+                  "end": 121
+                },
+                "kind": "void"
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 153,
+          "end": 156
+        },
+        "ctxt": 0,
+        "value": "Baz",
+        "optional": false
+      },
+      "declare": true,
+      "span": {
+        "start": 124,
+        "end": 173
+      },
+      "ctxt": 0,
+      "decorators": [],
+      "body": [
+        {
+          "type": "ClassProperty",
+          "span": {
+            "start": 161,
+            "end": 171
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 161,
+              "end": 162
+            },
+            "value": "x"
+          },
+          "value": null,
+          "typeAnnotation": {
+            "type": "TsTypeAnnotation",
+            "span": {
+              "start": 162,
+              "end": 170
+            },
+            "typeAnnotation": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 164,
+                "end": 170
+              },
+              "kind": "number"
+            }
+          },
+          "isStatic": false,
+          "decorators": [],
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false,
+          "readonly": false,
+          "declare": false,
+          "definite": false
+        }
+      ],
+      "superClass": null,
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/declare-export-types/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/declare-export-types/basic.js
@@ -1,0 +1,5 @@
+declare export type Foo = string;
+declare export interface IFoo {
+  x: number;
+}
+declare export opaque type UserId: string;

--- a/crates/swc_ecma_parser/tests/flow/declare-export-types/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/declare-export-types/basic.js.json
@@ -1,0 +1,128 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 124
+  },
+  "body": [
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 1,
+        "end": 34
+      },
+      "declare": true,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 21,
+          "end": 24
+        },
+        "ctxt": 0,
+        "value": "Foo",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsKeywordType",
+        "span": {
+          "start": 27,
+          "end": 33
+        },
+        "kind": "string"
+      }
+    },
+    {
+      "type": "TsInterfaceDeclaration",
+      "span": {
+        "start": 35,
+        "end": 81
+      },
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 60,
+          "end": 64
+        },
+        "ctxt": 0,
+        "value": "IFoo",
+        "optional": false
+      },
+      "declare": true,
+      "typeParams": null,
+      "extends": [],
+      "body": {
+        "type": "TsInterfaceBody",
+        "span": {
+          "start": 65,
+          "end": 81
+        },
+        "body": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 69,
+              "end": 79
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 69,
+                "end": 70
+              },
+              "ctxt": 0,
+              "value": "x",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 70,
+                "end": 78
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 72,
+                  "end": 78
+                },
+                "kind": "number"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 82,
+        "end": 124
+      },
+      "declare": true,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 109,
+          "end": 115
+        },
+        "ctxt": 0,
+        "value": "UserId",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsKeywordType",
+        "span": {
+          "start": 82,
+          "end": 123
+        },
+        "kind": "any"
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/import-typeof-namespace/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/import-typeof-namespace/basic.js
@@ -1,0 +1,2 @@
+import typeof * as NS from "ns";
+export const ready = 1;

--- a/crates/swc_ecma_parser/tests/flow/import-typeof-namespace/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/import-typeof-namespace/basic.js.json
@@ -1,0 +1,95 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 57
+  },
+  "body": [
+    {
+      "type": "ImportDeclaration",
+      "span": {
+        "start": 1,
+        "end": 33
+      },
+      "specifiers": [
+        {
+          "type": "ImportNamespaceSpecifier",
+          "span": {
+            "start": 15,
+            "end": 22
+          },
+          "local": {
+            "type": "Identifier",
+            "span": {
+              "start": 20,
+              "end": 22
+            },
+            "ctxt": 0,
+            "value": "NS",
+            "optional": false
+          }
+        }
+      ],
+      "source": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 28,
+          "end": 32
+        },
+        "value": "ns",
+        "raw": "\"ns\""
+      },
+      "typeOnly": true,
+      "with": null,
+      "phase": "evaluation"
+    },
+    {
+      "type": "ExportDeclaration",
+      "span": {
+        "start": 34,
+        "end": 57
+      },
+      "declaration": {
+        "type": "VariableDeclaration",
+        "span": {
+          "start": 41,
+          "end": 57
+        },
+        "ctxt": 0,
+        "kind": "const",
+        "declare": false,
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "span": {
+              "start": 47,
+              "end": 56
+            },
+            "id": {
+              "type": "Identifier",
+              "span": {
+                "start": 47,
+                "end": 52
+              },
+              "ctxt": 0,
+              "value": "ready",
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "init": {
+              "type": "NumericLiteral",
+              "span": {
+                "start": 55,
+                "end": 56
+              },
+              "value": 1.0,
+              "raw": "1"
+            },
+            "definite": false
+          }
+        ]
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/import-typeof-specifiers/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/import-typeof-specifiers/basic.js
@@ -1,0 +1,3 @@
+import { typeof Foo, typeof Bar as Baz } from "foo";
+import { type T, typeof U as V } from "mod";
+export const value = 1;

--- a/crates/swc_ecma_parser/tests/flow/import-typeof-specifiers/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/import-typeof-specifiers/basic.js.json
@@ -1,0 +1,202 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 122
+  },
+  "body": [
+    {
+      "type": "ImportDeclaration",
+      "span": {
+        "start": 1,
+        "end": 53
+      },
+      "specifiers": [
+        {
+          "type": "ImportSpecifier",
+          "span": {
+            "start": 10,
+            "end": 20
+          },
+          "local": {
+            "type": "Identifier",
+            "span": {
+              "start": 17,
+              "end": 20
+            },
+            "ctxt": 0,
+            "value": "Foo",
+            "optional": false
+          },
+          "imported": {
+            "type": "Identifier",
+            "span": {
+              "start": 17,
+              "end": 20
+            },
+            "ctxt": 0,
+            "value": "Foo",
+            "optional": false
+          },
+          "isTypeOnly": true
+        },
+        {
+          "type": "ImportSpecifier",
+          "span": {
+            "start": 22,
+            "end": 39
+          },
+          "local": {
+            "type": "Identifier",
+            "span": {
+              "start": 36,
+              "end": 39
+            },
+            "ctxt": 0,
+            "value": "Baz",
+            "optional": false
+          },
+          "imported": {
+            "type": "Identifier",
+            "span": {
+              "start": 29,
+              "end": 32
+            },
+            "ctxt": 0,
+            "value": "Bar",
+            "optional": false
+          },
+          "isTypeOnly": true
+        }
+      ],
+      "source": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 47,
+          "end": 52
+        },
+        "value": "foo",
+        "raw": "\"foo\""
+      },
+      "typeOnly": false,
+      "with": null,
+      "phase": "evaluation"
+    },
+    {
+      "type": "ImportDeclaration",
+      "span": {
+        "start": 54,
+        "end": 98
+      },
+      "specifiers": [
+        {
+          "type": "ImportSpecifier",
+          "span": {
+            "start": 63,
+            "end": 69
+          },
+          "local": {
+            "type": "Identifier",
+            "span": {
+              "start": 68,
+              "end": 69
+            },
+            "ctxt": 0,
+            "value": "T",
+            "optional": false
+          },
+          "imported": null,
+          "isTypeOnly": true
+        },
+        {
+          "type": "ImportSpecifier",
+          "span": {
+            "start": 71,
+            "end": 84
+          },
+          "local": {
+            "type": "Identifier",
+            "span": {
+              "start": 83,
+              "end": 84
+            },
+            "ctxt": 0,
+            "value": "V",
+            "optional": false
+          },
+          "imported": {
+            "type": "Identifier",
+            "span": {
+              "start": 78,
+              "end": 79
+            },
+            "ctxt": 0,
+            "value": "U",
+            "optional": false
+          },
+          "isTypeOnly": true
+        }
+      ],
+      "source": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 92,
+          "end": 97
+        },
+        "value": "mod",
+        "raw": "\"mod\""
+      },
+      "typeOnly": false,
+      "with": null,
+      "phase": "evaluation"
+    },
+    {
+      "type": "ExportDeclaration",
+      "span": {
+        "start": 99,
+        "end": 122
+      },
+      "declaration": {
+        "type": "VariableDeclaration",
+        "span": {
+          "start": 106,
+          "end": 122
+        },
+        "ctxt": 0,
+        "kind": "const",
+        "declare": false,
+        "declarations": [
+          {
+            "type": "VariableDeclarator",
+            "span": {
+              "start": 112,
+              "end": 121
+            },
+            "id": {
+              "type": "Identifier",
+              "span": {
+                "start": 112,
+                "end": 117
+              },
+              "ctxt": 0,
+              "value": "value",
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "init": {
+              "type": "NumericLiteral",
+              "span": {
+                "start": 120,
+                "end": 121
+              },
+              "value": 1.0,
+              "raw": "1"
+            },
+            "definite": false
+          }
+        ]
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/object-boundary/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/object-boundary/basic.js
@@ -1,0 +1,4 @@
+type Inexact = { a: number, ... };
+type InexactOnlySpread = { ... };
+type Exact = {| a: number, ... |};
+type ExactOnlySpread = {| ... |};

--- a/crates/swc_ecma_parser/tests/flow/object-boundary/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/object-boundary/basic.js.json
@@ -1,0 +1,276 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 138
+  },
+  "body": [
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 1,
+        "end": 35
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 6,
+          "end": 13
+        },
+        "ctxt": 0,
+        "value": "Inexact",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 16,
+          "end": 34
+        },
+        "members": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 18,
+              "end": 28
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 18,
+                "end": 19
+              },
+              "ctxt": 0,
+              "value": "a",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 19,
+                "end": 27
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 21,
+                  "end": 27
+                },
+                "kind": "number"
+              }
+            }
+          },
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 29,
+              "end": 32
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 29,
+                "end": 32
+              },
+              "ctxt": 0,
+              "value": "__flow_spread",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 36,
+        "end": 69
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 41,
+          "end": 58
+        },
+        "ctxt": 0,
+        "value": "InexactOnlySpread",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 61,
+          "end": 68
+        },
+        "members": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 63,
+              "end": 66
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 63,
+                "end": 66
+              },
+              "ctxt": 0,
+              "value": "__flow_spread",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 70,
+        "end": 104
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 75,
+          "end": 80
+        },
+        "ctxt": 0,
+        "value": "Exact",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 83,
+          "end": 103
+        },
+        "members": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 86,
+              "end": 96
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 86,
+                "end": 87
+              },
+              "ctxt": 0,
+              "value": "a",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 87,
+                "end": 95
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 89,
+                  "end": 95
+                },
+                "kind": "number"
+              }
+            }
+          },
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 97,
+              "end": 100
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 97,
+                "end": 100
+              },
+              "ctxt": 0,
+              "value": "__flow_spread",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 105,
+        "end": 138
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 110,
+          "end": 125
+        },
+        "ctxt": 0,
+        "value": "ExactOnlySpread",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 128,
+          "end": 137
+        },
+        "members": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 131,
+              "end": 134
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 131,
+                "end": 134
+              },
+              "ctxt": 0,
+              "value": "__flow_spread",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": null
+          }
+        ]
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/opaque-variants/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/opaque-variants/basic.js
@@ -1,0 +1,3 @@
+opaque type Token;
+opaque type PublicId: string;
+opaque type InternalId: string = string;

--- a/crates/swc_ecma_parser/tests/flow/opaque-variants/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/opaque-variants/basic.js.json
@@ -1,0 +1,91 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 90
+  },
+  "body": [
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 1,
+        "end": 19
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 13,
+          "end": 18
+        },
+        "ctxt": 0,
+        "value": "Token",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsKeywordType",
+        "span": {
+          "start": 1,
+          "end": 18
+        },
+        "kind": "any"
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 20,
+        "end": 49
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 32,
+          "end": 40
+        },
+        "ctxt": 0,
+        "value": "PublicId",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsKeywordType",
+        "span": {
+          "start": 20,
+          "end": 48
+        },
+        "kind": "any"
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 50,
+        "end": 90
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 62,
+          "end": 72
+        },
+        "ctxt": 0,
+        "value": "InternalId",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsKeywordType",
+        "span": {
+          "start": 83,
+          "end": 89
+        },
+        "kind": "string"
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/require-directive/with-block-pragma.js
+++ b/crates/swc_ecma_parser/tests/flow/require-directive/with-block-pragma.js
@@ -1,0 +1,3 @@
+/* @flow */
+const value: number = 1;
+export { value };

--- a/crates/swc_ecma_parser/tests/flow/require-directive/with-block-pragma.js.json
+++ b/crates/swc_ecma_parser/tests/flow/require-directive/with-block-pragma.js.json
@@ -1,0 +1,95 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 13,
+    "end": 55
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 13,
+        "end": 37
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 19,
+            "end": 36
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 19,
+              "end": 24
+            },
+            "ctxt": 0,
+            "value": "value",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 24,
+                "end": 32
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 26,
+                  "end": 32
+                },
+                "kind": "number"
+              }
+            }
+          },
+          "init": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 35,
+              "end": 36
+            },
+            "value": 1.0,
+            "raw": "1"
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "ExportNamedDeclaration",
+      "span": {
+        "start": 38,
+        "end": 55
+      },
+      "specifiers": [
+        {
+          "type": "ExportSpecifier",
+          "span": {
+            "start": 47,
+            "end": 52
+          },
+          "orig": {
+            "type": "Identifier",
+            "span": {
+              "start": 47,
+              "end": 52
+            },
+            "ctxt": 0,
+            "value": "value",
+            "optional": false
+          },
+          "exported": null,
+          "isTypeOnly": false
+        }
+      ],
+      "source": null,
+      "typeOnly": false,
+      "with": null
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/require-directive/with-leading-comment-and-block-pragma.js
+++ b/crates/swc_ecma_parser/tests/flow/require-directive/with-leading-comment-and-block-pragma.js
@@ -1,0 +1,4 @@
+/* eslint-disable */
+/* @flow */
+const value: number = 1;
+export { value };

--- a/crates/swc_ecma_parser/tests/flow/require-directive/with-leading-comment-and-block-pragma.js.json
+++ b/crates/swc_ecma_parser/tests/flow/require-directive/with-leading-comment-and-block-pragma.js.json
@@ -1,0 +1,95 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 34,
+    "end": 76
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 34,
+        "end": 58
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 40,
+            "end": 57
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 40,
+              "end": 45
+            },
+            "ctxt": 0,
+            "value": "value",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 45,
+                "end": 53
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 47,
+                  "end": 53
+                },
+                "kind": "number"
+              }
+            }
+          },
+          "init": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 56,
+              "end": 57
+            },
+            "value": 1.0,
+            "raw": "1"
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "ExportNamedDeclaration",
+      "span": {
+        "start": 59,
+        "end": 76
+      },
+      "specifiers": [
+        {
+          "type": "ExportSpecifier",
+          "span": {
+            "start": 68,
+            "end": 73
+          },
+          "orig": {
+            "type": "Identifier",
+            "span": {
+              "start": 68,
+              "end": 73
+            },
+            "ctxt": 0,
+            "value": "value",
+            "optional": false
+          },
+          "exported": null,
+          "isTypeOnly": false
+        }
+      ],
+      "source": null,
+      "typeOnly": false,
+      "with": null
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
## Summary
- expand Flow parser fixture coverage for strip-focused high-signal syntax boundaries
- add success fixtures for declare export type/interface/opaque type, named declare export default forms, opaque variants, import typeof forms, object boundary forms, and block-comment pragma variants
- add error fixtures for @noflow directive behavior and Flow variance misuse on methods

## Notes
- no parser/runtime code changes were required; new coverage passes with existing implementation

## Verification
- git submodule update --init --recursive
- UPDATE=1 cargo test -p swc_ecma_parser --test flow --features flow -- --ignored --nocapture
- cargo test -p swc_ecma_parser --test flow --features flow -- --ignored --nocapture
- cargo test -p swc --test flow_strip_correctness --features flow -- --ignored --nocapture
- cargo test -p swc --test projects flow_strip -- --ignored --nocapture
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings
- cargo test -p swc_ecma_parser