### PR TITLE
feat(bindings): enable flow strip support in @swc/core

### DIFF
--- a/bindings/binding_core_node/Cargo.toml
+++ b/bindings/binding_core_node/Cargo.toml
@@ -61,6 +61,7 @@ swc_core = { path = "../../crates/swc_core", features = [
   "ecma_visit",
   "base_node",
   "base_concurrent",
+  "base_flow",
   "base_module",
 ] }
 swc_malloc = { path = "../../crates/swc_malloc" }

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -61,6 +61,8 @@ allocator_node = ["swc_malloc"]
 # it is named as 'base' instead.
 base            = ["__base"]
 base_concurrent = ["__base", "swc/concurrent"]
+# Enable flow parser support for compiler APIs exposed via `base`.
+base_flow = ["__base", "swc/flow"]
 # Enable module transforms (CommonJS, AMD, UMD, SystemJS).
 # Bundlers typically don't need this as they handle module transforms themselves.
 base_module = ["__base", "swc/module"]


### PR DESCRIPTION
## Summary
- add a `base_flow` feature in `swc_core` to forward `swc/flow`
- enable `base_flow` from `binding_core_node` so `@swc/core` native bindings build with Flow parser support

## Testing
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings
- cargo test -p swc_core
- cargo test -p binding_core_node
- (cd packages/core && yarn build:dev && yarn test)
