### PR TITLE
fix: update lz4_flex to resolve RUSTSEC-2026-0041

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,11 +3450,11 @@ dependencies = [
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 dependencies = [
- "twox-hash",
+ "twox-hash 2.1.2",
 ]
 
 [[package]]
@@ -5017,7 +5017,7 @@ checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
 dependencies = [
  "byteorder",
  "derive_more 0.99.18",
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -8114,6 +8114,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typenum"


### PR DESCRIPTION
## Summary
- update `lz4_flex` from `0.11.3` to `0.11.6` in `Cargo.lock`
- resolves `cargo deny` failure from advisory `RUSTSEC-2026-0041` in CI
- add an empty follow-up commit (`chore: trigger CI validation`) as requested

## Context
- failing job: https://github.com/swc-project/swc/actions/runs/23222366993/job/67497601624

## Verification
- `cargo deny check` (with `cargo-deny 0.18.9`)
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
