### PR TITLE
fix(flow-strip): normalize module await bindings for Hermes parity

### DIFF
--- a/.changeset/smooth-swans-look.md
+++ b/.changeset/smooth-swans-look.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_transforms_typescript: major
+---
+
+fix(flow-strip): normalize module await bindings for Hermes parity

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -892,6 +892,7 @@ impl Options {
                         verbatim_module_syntax,
                         native_class_properties,
                         ts_enum_is_mutable,
+                        flow_syntax: syntax.flow(),
                         ..Default::default()
                     };
 

--- a/crates/swc_ecma_parser/tests/flow-hermes/known-fail-strip.txt
+++ b/crates/swc_ecma_parser/tests/flow-hermes/known-fail-strip.txt
@@ -1,2 +1,0 @@
-async_await/migrated_0020.js
-async_await/migrated_0024.js

--- a/crates/swc_ecma_transforms/tests/deno.rs
+++ b/crates/swc_ecma_transforms/tests/deno.rs
@@ -42,6 +42,7 @@ fn run_test(input: PathBuf) {
                         import_export_assign_config:
                             typescript::TsImportExportAssignConfig::Preserve,
                         ts_enum_is_mutable: true,
+                        ..Default::default()
                     },
                     unresolved_mark,
                     top_level_mark,

--- a/crates/swc_ecma_transforms_typescript/src/config.rs
+++ b/crates/swc_ecma_transforms_typescript/src/config.rs
@@ -34,6 +34,12 @@ pub struct Config {
     /// Defaults to false.
     #[serde(default)]
     pub ts_enum_is_mutable: bool,
+
+    /// Internal-only hint from the caller that this strip pass is processing
+    /// Flow syntax. Flow-only post-processing must stay disabled for TS/JS to
+    /// avoid extra overhead on the common path.
+    #[serde(skip)]
+    pub flow_syntax: bool,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -7,12 +7,15 @@ use swc_common::{
     DUMMY_SP,
 };
 use swc_ecma_ast::*;
+use swc_ecma_transforms_base::rename::rename;
 use swc_ecma_utils::{
     alias_ident_for, constructor::inject_after_super, ident::IdentLike, is_literal, member_expr,
     private_ident, quote_ident, quote_str, stack_size::maybe_grow_default, ExprFactory, QueryRef,
     RefRewriter, StmtLikeInjector,
 };
-use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
+use swc_ecma_visit::{
+    noop_visit_mut_type, visit_mut_pass, Visit, VisitMut, VisitMutWith, VisitWith,
+};
 
 use crate::{
     config::TsImportExportAssignConfig,
@@ -153,6 +156,8 @@ impl VisitMut for Transform {
                 .into(),
             )
         }
+
+        self.normalize_module_await_bindings(node);
     }
 
     fn visit_mut_module_items(&mut self, node: &mut Vec<ModuleItem>) {
@@ -832,6 +837,115 @@ impl Transform {
             }
             decl => FoldedDecl::Decl(decl),
         }
+    }
+
+    fn normalize_module_await_bindings(&mut self, module: &mut Module) {
+        let mut collector = AwaitBindingCollector::default();
+        module.visit_with(&mut collector);
+
+        if collector.await_binding_ids.is_empty() {
+            return;
+        }
+
+        let mut used_syms = collector.used_syms;
+        let mut rename_map = FxHashMap::default();
+        let mut suffix = 0usize;
+
+        for id in collector.await_binding_ids {
+            let next_sym = loop {
+                let candidate: Atom = if suffix == 0 {
+                    "_await".into()
+                } else {
+                    format!("_await{suffix}").into()
+                };
+                suffix += 1;
+
+                if used_syms.insert(candidate.clone()) {
+                    break candidate;
+                }
+            };
+
+            rename_map.insert(id, next_sym);
+        }
+
+        if !rename_map.is_empty() {
+            module.visit_mut_with(&mut rename(&rename_map));
+        }
+    }
+}
+
+#[derive(Default)]
+struct AwaitBindingCollector {
+    used_syms: FxHashSet<Atom>,
+    seen_await_bindings: FxHashSet<Id>,
+    await_binding_ids: Vec<Id>,
+}
+
+impl AwaitBindingCollector {
+    fn record_binding_ident(&mut self, ident: &Ident) {
+        if ident.sym != "await" {
+            return;
+        }
+
+        let id = ident.to_id();
+        if self.seen_await_bindings.insert(id.clone()) {
+            self.await_binding_ids.push(id);
+        }
+    }
+}
+
+impl Visit for AwaitBindingCollector {
+    fn visit_binding_ident(&mut self, node: &BindingIdent) {
+        self.record_binding_ident(&node.id);
+        node.visit_children_with(self);
+    }
+
+    fn visit_class_decl(&mut self, node: &ClassDecl) {
+        self.record_binding_ident(&node.ident);
+        node.visit_children_with(self);
+    }
+
+    fn visit_class_expr(&mut self, node: &ClassExpr) {
+        if let Some(ident) = &node.ident {
+            self.record_binding_ident(ident);
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_fn_decl(&mut self, node: &FnDecl) {
+        self.record_binding_ident(&node.ident);
+        node.visit_children_with(self);
+    }
+
+    fn visit_fn_expr(&mut self, node: &FnExpr) {
+        if let Some(ident) = &node.ident {
+            self.record_binding_ident(ident);
+        }
+        node.visit_children_with(self);
+    }
+
+    fn visit_ident(&mut self, node: &Ident) {
+        self.used_syms.insert(node.sym.clone());
+    }
+
+    fn visit_import_default_specifier(&mut self, node: &ImportDefaultSpecifier) {
+        self.record_binding_ident(&node.local);
+        node.visit_children_with(self);
+    }
+
+    fn visit_import_named_specifier(&mut self, node: &ImportNamedSpecifier) {
+        self.record_binding_ident(&node.local);
+        node.visit_children_with(self);
+    }
+
+    fn visit_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier) {
+        self.record_binding_ident(&node.local);
+        node.visit_children_with(self);
+    }
+
+    fn visit_ts_import_equals_decl(&mut self, node: &TsImportEqualsDecl) {
+        self.record_binding_ident(&node.id);
+        node.visit_children_with(self);
     }
 }
 

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -60,6 +60,7 @@ pub(crate) struct Transform {
     ts_enum_is_mutable: bool,
     verbatim_module_syntax: bool,
     native_class_properties: bool,
+    flow_syntax: bool,
 
     semantic: SemanticInfo,
 
@@ -88,6 +89,7 @@ pub fn transform(
     ts_enum_is_mutable: bool,
     verbatim_module_syntax: bool,
     native_class_properties: bool,
+    flow_syntax: bool,
 ) -> impl Pass {
     visit_mut_pass(Transform {
         unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
@@ -98,6 +100,7 @@ pub fn transform(
         ts_enum_is_mutable,
         verbatim_module_syntax,
         native_class_properties,
+        flow_syntax,
         ..Default::default()
     })
 }
@@ -157,7 +160,9 @@ impl VisitMut for Transform {
             )
         }
 
-        self.normalize_module_await_bindings(node);
+        if self.flow_syntax {
+            self.normalize_module_await_bindings(node);
+        }
     }
 
     fn visit_mut_module_items(&mut self, node: &mut Vec<ModuleItem>) {

--- a/crates/swc_ecma_transforms_typescript/src/typescript.rs
+++ b/crates/swc_ecma_transforms_typescript/src/typescript.rs
@@ -53,6 +53,7 @@ impl Pass for TypeScript {
             self.config.ts_enum_is_mutable,
             self.config.verbatim_module_syntax,
             self.config.native_class_properties,
+            self.config.flow_syntax,
         ));
 
         if let Some(span) = was_module {


### PR DESCRIPTION
## Summary
- Normalize module-level `await` bindings after TS/Flow strip in `swc_ecma_transforms_typescript`.
- Apply renaming via `swc_ecma_transforms_base::rename::rename` with collision-safe names (`_await`, `_await1`, ...).
- Preserve exported API names (e.g. `await`) through export-specifier rewriting behavior in the renamer.
- Remove stale entries from `crates/swc_ecma_parser/tests/flow-hermes/known-fail-strip.txt`.

## Why
`flow_strip_hermes` had 2 remaining failures where stripped output still emitted invalid module identifiers:
- `async_await/migrated_0020.js`
- `async_await/migrated_0024.js`

This change makes strip output reparsable as ES while keeping external export names stable.

## Testing
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_parser --test flow_hermes --features flow -- --nocapture`
- `cargo test -p swc --test flow_strip_hermes --features flow -- --nocapture`
- `cargo test -p swc_ecma_parser --features flow`
- `cargo test -p swc_ecma_transforms_typescript --test strip -- --skip issue_960_2`

Note:
- `cargo test -p swc_ecma_transforms_typescript` includes an environment-dependent failure (`issue_960_2`) when `mocha` is unavailable.
