### PR TITLE
feat(cli): enable Flow strip support in swc_cli_impl

### DIFF
--- a/crates/swc_cli_impl/Cargo.toml
+++ b/crates/swc_cli_impl/Cargo.toml
@@ -42,6 +42,7 @@ swc_core = { version = "58.0.4", features = [
   "trace_macro",
   "common_concurrent",
   "base_concurrent",
+  "base_flow",
   "base_module",
   "ecma_helpers_inline",
 ], path = "../swc_core" }

--- a/crates/swc_cli_impl/tests/issues.rs
+++ b/crates/swc_cli_impl/tests/issues.rs
@@ -206,6 +206,57 @@ fn issue_11643_external_helpers_false_respected() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn issue_flow_strip_enabled_via_parser_syntax_flow() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    fs::write(
+        sandbox.path().join(".swcrc"),
+        r#"{
+            "jsc": {
+                "parser": {
+                    "syntax": "flow"
+                }
+            }
+        }"#,
+    )?;
+    fs::write(
+        sandbox.path().join("input.js"),
+        r#"// @flow
+function add(a: number): number {
+  return a;
+}
+const value: string = "ok";
+"#,
+    )?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--config-file")
+        .arg(".swcrc")
+        .arg("--out-file")
+        .arg("output.js")
+        .arg("input.js");
+
+    cmd.assert().success();
+
+    let output = fs::read_to_string(sandbox.path().join("output.js"))?;
+    assert!(
+        output.contains("function add(a)"),
+        "Expected Flow type annotations to be stripped. Got: {output}"
+    );
+    assert!(
+        !output.contains(": number"),
+        "Flow function type annotation should be stripped. Got: {output}"
+    );
+    assert!(
+        !output.contains(": string"),
+        "Flow variable type annotation should be stripped. Got: {output}"
+    );
+
+    Ok(())
+}
+
 /// Tests that `--root-mode upward` finds a `.swcrc` in a parent directory.
 #[test]
 fn root_mode_upward_finds_parent_config() -> Result<()> {


### PR DESCRIPTION
## Summary
- enable Flow parser support in `swc_cli_impl` by adding `swc_core/base_flow`
- add a CLI integration regression test for `.swcrc` with `jsc.parser.syntax: "flow"`
- verify Flow type annotations are stripped in compile output

## Testing
- git submodule update --init --recursive
- cargo test -p swc_cli_impl
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings
- cargo test -p swc_cli_impl
