### PR TITLE
fix(core): honor cwd in .swcrc lookup for relative filenames

### DIFF
--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1025,9 +1025,7 @@ pub struct CallerOptions {
 
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 fn default_cwd() -> PathBuf {
-    static CWD: Lazy<PathBuf> = Lazy::new(|| ::std::env::current_dir().unwrap());
-
-    CWD.clone()
+    ::std::env::current_dir().unwrap()
 }
 
 /// `.swcrc` file

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -126,7 +126,6 @@ use common::{
     errors::HANDLER,
 };
 use jsonc_parser::{parse_to_serde_value, ParseOptions};
-use once_cell::sync::Lazy;
 use serde_json::error::Category;
 use swc_common::{
     comments::Comments, errors::Handler, sync::Lrc, FileName, Mark, SourceFile, SourceMap, Spanned,
@@ -469,37 +468,32 @@ impl Compiler {
 
     #[tracing::instrument(skip_all)]
     pub fn read_config(&self, opts: &Options, name: &FileName) -> Result<Option<Config>, Error> {
-        static CUR_DIR: Lazy<PathBuf> = Lazy::new(|| {
-            if cfg!(target_arch = "wasm32") {
-                PathBuf::new()
-            } else {
-                ::std::env::current_dir().unwrap()
-            }
-        });
-
         self.run(|| -> Result<_, Error> {
             let Options {
                 ref root,
+                ref cwd,
                 root_mode,
                 swcrc,
                 config_file,
                 ..
             } = opts;
 
-            let root = root.as_ref().unwrap_or(&CUR_DIR);
+            let root = root.as_ref().unwrap_or(cwd);
 
             let swcrc_path = match config_file {
                 Some(ConfigFile::Str(s)) => Some(PathBuf::from(s.clone())),
                 _ => {
                     if *swcrc {
                         if let FileName::Real(ref path) = name {
-                            // Canonicalize relative paths for proper parent traversal
-                            let abs_path = if path.is_relative() {
-                                root.join(path).canonicalize().ok()
+                            // Use the original path for parent traversal if canonicalization fails.
+                            let path_to_search = if path.is_relative() {
+                                root.join(path)
                             } else {
-                                path.canonicalize().ok()
+                                path.to_path_buf()
                             };
-                            let found = abs_path.and_then(|p| find_swcrc(&p, root, *root_mode));
+                            let path_to_search =
+                                path_to_search.canonicalize().unwrap_or(path_to_search);
+                            let found = find_swcrc(&path_to_search, root, *root_mode);
 
                             // "upward" mode requires a .swcrc to be found
                             if found.is_none() && *root_mode == RootMode::Upward {

--- a/packages/core/__tests__/transform/issue_11680_test.mjs
+++ b/packages/core/__tests__/transform/issue_11680_test.mjs
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import swc from "../..";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const fixtureDir = path.join(__dirname, "..", "..", "tests", "issue-11680");
+const fixtureEntry = path.join(fixtureDir, "src", "index.tsx");
+const source = fs.readFileSync(fixtureEntry, "utf8");
+
+function createOptions() {
+    return {
+        filename: path.join("src", "index.tsx"),
+        cwd: fixtureDir,
+        jsc: {
+            parser: {
+                syntax: "typescript",
+                tsx: true,
+            },
+        },
+    };
+}
+
+it("should resolve .swcrc using cwd for relative filenames", () => {
+    const { code } = swc.transformSync(source, createOptions());
+
+    expect(code).toContain("react/jsx-runtime");
+});
+
+it("should match explicit configFile output for the same relative input", () => {
+    const automatic = swc.transformSync(source, createOptions());
+    const explicit = swc.transformSync(source, {
+        ...createOptions(),
+        configFile: path.join(fixtureDir, ".swcrc"),
+    });
+
+    expect(automatic.code).toBe(explicit.code);
+});

--- a/packages/core/tests/issue-11680/.swcrc
+++ b/packages/core/tests/issue-11680/.swcrc
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://swc.rs/schema.json",
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "transform": {
+            "react": {
+                "runtime": "automatic"
+            }
+        }
+    },
+    "module": {
+        "type": "es6"
+    }
+}

--- a/packages/core/tests/issue-11680/src/index.tsx
+++ b/packages/core/tests/issue-11680/src/index.tsx
@@ -1,0 +1,1 @@
+export const App = () => <div>Hello</div>;


### PR DESCRIPTION
## Summary

This fixes `.swcrc` auto-discovery for programmatic transforms that pass a **relative** `filename` plus `cwd` (the pattern observed in loader/integration paths where explicit `configFile` was a workaround).

### What changed

- `Compiler::read_config` now resolves default lookup root as:
  - `opts.root` if provided
  - otherwise `opts.cwd`
- `.swcrc` lookup no longer gives up when `canonicalize()` fails; it falls back to the original path and continues upward search.
- `default_cwd()` no longer uses a process-global cached value, so deserialization reflects the current directory at call time.
- Added regression coverage in `packages/core` for:
  - `transformSync(source, { filename: relative, cwd })` loading `.swcrc`
  - output equivalence with explicit `configFile`

## Files

- `crates/swc/src/lib.rs`
- `crates/swc/src/config/mod.rs`
- `packages/core/__tests__/transform/issue_11680_test.mjs`
- `packages/core/tests/issue-11680/.swcrc`
- `packages/core/tests/issue-11680/src/index.tsx`

## Verification

- `git submodule update --init --recursive`
- `cd packages/core && yarn test __tests__/transform/issue_11680_test.mjs`
- `cd packages/core && yarn test`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc`
- `cd packages/core && yarn build:dev && yarn test`
