### PR TITLE
fix: only rewrite known TS/JS extensions in rewriteRelativeImportExtensions

### DIFF
--- a/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
+++ b/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
@@ -94,11 +94,15 @@ fn get_output_extension(specifier: &Atom) -> Option<Atom> {
     // https://github.com/microsoft/TypeScript/blob/3eb7b6a1794a6d2cde7948a3016c57e628b104b9/src/compiler/emitter.ts#L540
     let ext = path.extension()?.to_str()?;
     let ext = match ext {
+        "ts" => "js",
+        "tsx" => "jsx",
+        "mts" => "mjs",
+        "cts" => "cjs",
+        "jsx" => "jsx",
+        "mjs" => "mjs",
+        "cjs" => "cjs",
         "json" => "json",
-        "jsx" | "tsx" => "jsx",
-        "mjs" | "mts" => "mjs",
-        "cjs" | "cts" => "cjs",
-        _ => "js",
+        _ => return None,
     };
 
     Some(Atom::new(path.with_extension(ext).to_str()?))


### PR DESCRIPTION
## Summary
- `jsc.rewriteRelativeImportExtensions` rewrites arbitrary extensions like `.legacy` to `.js`
- TypeScript only rewrites `.ts`, `.tsx`, `.mts`, `.cts`, `.jsx`, `.mjs`, `.cjs`, and `.json`

## Root Cause
The `get_output_extension` function has a catch-all `_ => "js"` match arm that converts any unrecognized extension to `.js`. TypeScript's implementation only processes known TypeScript/JavaScript extensions and leaves others untouched.

## Fix
Replace the catch-all with explicit matches for each known extension, returning `None` for unrecognized extensions so they are left as-is.

## Testing
- Verified the match arms align with TypeScript's `getOutputExtension` behavior
- Non-TS extensions (e.g. `.legacy`, `.css`, `.wasm`) are now preserved unchanged

Fixes #11644

Made with [Cursor](https://cursor.com)