### PR TITLE
fix(es/transforms): avoid rewriting unknown relative extensions

### DIFF
--- a/.changeset/smooth-games-knock.md
+++ b/.changeset/smooth-games-knock.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_module: patch
+---
+
+fix(es/transforms): avoid rewriting unknown relative extensions

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/issue-11644/input/.swcrc
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/issue-11644/input/.swcrc
@@ -1,0 +1,15 @@
+{
+    "module": {
+        "type": "nodenext"
+    },
+    "jsc": {
+        "target": "esnext",
+        "rewriteRelativeImportExtensions": true,
+        "parser": {
+            "syntax": "typescript"
+        },
+        "transform": {
+            "verbatimModuleSyntax": true
+        }
+    }
+}

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/issue-11644/input/main.ts
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/issue-11644/input/main.ts
@@ -1,0 +1,5 @@
+import legacy from "./index.legacy";
+import rewritten from "./index.legacy.ts";
+
+legacy.method();
+rewritten.method();

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/issue-11644/output/main.ts
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/issue-11644/output/main.ts
@@ -1,0 +1,4 @@
+import legacy from "./index.legacy";
+import rewritten from "./index.legacy.js";
+legacy.method();
+rewritten.method();

--- a/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
+++ b/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
@@ -94,11 +94,12 @@ fn get_output_extension(specifier: &Atom) -> Option<Atom> {
     // https://github.com/microsoft/TypeScript/blob/3eb7b6a1794a6d2cde7948a3016c57e628b104b9/src/compiler/emitter.ts#L540
     let ext = path.extension()?.to_str()?;
     let ext = match ext {
+        "js" | "ts" => "js",
         "json" => "json",
         "jsx" | "tsx" => "jsx",
         "mjs" | "mts" => "mjs",
         "cjs" | "cts" => "cjs",
-        _ => "js",
+        _ => return None,
     };
 
     Some(Atom::new(path.with_extension(ext).to_str()?))


### PR DESCRIPTION
## Summary

This PR fixes `jsc.rewriteRelativeImportExtensions` rewriting unknown relative extensions to `.js`.

Previously, specifiers like `./index.legacy` were rewritten to `./index.js` because unknown extensions fell through to a default rewrite. This diverged from TypeScript behavior.

This change makes rewriting extension-aware and only rewrites supported extensions:

- `ts | js -> js`
- `tsx | jsx -> jsx`
- `mts | mjs -> mjs`
- `cts | cjs -> cjs`
- `json -> json`
- unknown extensions -> no rewrite

Also adds fixture coverage for issue `#11644` to assert:

- `import "./index.legacy"` stays unchanged
- `import "./index.legacy.ts"` rewrites to `import "./index.legacy.js"`

Closes #11644.

## Testing

- `git submodule update --init --recursive`
- `cargo test -p swc --test projects ts_id_tests__typescript__rewrite_relative_import_specifier__issue_11644__input -- --exact --ignored --nocapture`
- `cargo test -p swc --test projects rewrite_relative_import_specifier -- --ignored`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_transforms_module`

`cargo test -p swc` was also run; unrelated `tests/source_map` cases failed in this environment because Node module `sourcemap-validator` is missing.
