### PR TITLE
feat(react-compiler): advance SWC upstream fixture parity

### DIFF
--- a/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
@@ -128,6 +128,11 @@ pub fn compile_program(
     let forget_use_render_counter_local =
         pick_unique_external_local_name(program, "useRenderCounter");
     let fixture_fn_type_hints = collect_fixture_entrypoint_type_hints(program);
+    let fixture_entrypoint_fn_names = collect_fixture_entrypoint_fn_names(program);
+    let expect_nothing_compiled = pass
+        .code
+        .as_deref()
+        .is_some_and(|code| code.contains("@expectNothingCompiled"));
     let mut compiler = ProgramCompiler {
         opts: &pass.opts,
         output_mode,
@@ -138,6 +143,8 @@ pub fn compile_program(
         consumed_next_line_suppressions: HashSet::new(),
         report,
         fixture_fn_type_hints,
+        fixture_entrypoint_fn_names,
+        expect_nothing_compiled,
         queued_outlined: Vec::new(),
         used_external_imports: Vec::new(),
         forget_should_instrument_local,
@@ -222,12 +229,15 @@ pub fn compile_fn(
     output_mode: CompilerOutputMode,
     opts: &ParsedPluginOptions,
 ) -> Result<CodegenFunction, CompilerError> {
-    let mut hir = crate::hir::lower(function, id, fn_type)?;
+    let mut normalized = function.clone();
+    normalize_function_params_for_lowering(&mut normalized);
+    let mut hir = crate::hir::lower(&normalized, id, fn_type)?;
 
     optimization::prune_maybe_throws(&mut hir);
     validation::validate_context_variable_lvalues(&hir)?;
     validation::validate_use_memo(&hir)?;
     inference::inline_immediately_invoked_function_expressions(&mut hir);
+    inference::drop_manual_memoization(&mut hir);
 
     ssa::enter_ssa(&mut hir);
     ssa::eliminate_redundant_phi(&mut hir);
@@ -315,6 +325,218 @@ pub fn compile_fn(
     }
 
     Ok(reactive_scopes::codegen_function(reactive))
+}
+
+fn collect_pattern_bindings_for_param_lowering(pat: &Pat, out: &mut HashSet<String>) {
+    match pat {
+        Pat::Ident(binding) => {
+            out.insert(binding.id.sym.to_string());
+        }
+        Pat::Array(array) => {
+            for elem in array.elems.iter().flatten() {
+                collect_pattern_bindings_for_param_lowering(elem, out);
+            }
+        }
+        Pat::Object(object) => {
+            for prop in &object.props {
+                match prop {
+                    swc_ecma_ast::ObjectPatProp::Assign(assign) => {
+                        out.insert(assign.key.sym.to_string());
+                    }
+                    swc_ecma_ast::ObjectPatProp::KeyValue(key_value) => {
+                        collect_pattern_bindings_for_param_lowering(&key_value.value, out);
+                    }
+                    swc_ecma_ast::ObjectPatProp::Rest(rest) => {
+                        collect_pattern_bindings_for_param_lowering(&rest.arg, out);
+                    }
+                }
+            }
+        }
+        Pat::Assign(assign) => {
+            collect_pattern_bindings_for_param_lowering(&assign.left, out);
+        }
+        Pat::Rest(rest) => {
+            collect_pattern_bindings_for_param_lowering(&rest.arg, out);
+        }
+        Pat::Expr(_) | Pat::Invalid(_) => {}
+    }
+}
+
+fn fresh_param_temp_ident(next_index: &mut u32, used: &mut HashSet<String>) -> Ident {
+    loop {
+        let candidate = format!("t{}", *next_index);
+        *next_index += 1;
+        if used.insert(candidate.clone()) {
+            return Ident::new_no_ctxt(candidate.into(), DUMMY_SP);
+        }
+    }
+}
+
+fn collect_stmt_bindings_including_nested(stmt: &Stmt, out: &mut HashSet<String>) {
+    struct Collector<'a> {
+        out: &'a mut HashSet<String>,
+    }
+
+    impl Visit for Collector<'_> {
+        fn visit_var_declarator(&mut self, decl: &swc_ecma_ast::VarDeclarator) {
+            collect_pattern_bindings_for_param_lowering(&decl.name, self.out);
+            decl.visit_children_with(self);
+        }
+
+        fn visit_fn_decl(&mut self, decl: &FnDecl) {
+            self.out.insert(decl.ident.sym.to_string());
+            decl.visit_children_with(self);
+        }
+
+        fn visit_class_decl(&mut self, decl: &swc_ecma_ast::ClassDecl) {
+            self.out.insert(decl.ident.sym.to_string());
+            decl.visit_children_with(self);
+        }
+    }
+
+    stmt.visit_with(&mut Collector { out });
+}
+
+fn normalize_function_params_for_lowering(function: &mut Function) {
+    let Some(body) = function.body.as_mut() else {
+        return;
+    };
+
+    let mut used = HashSet::new();
+    for param in &function.params {
+        collect_pattern_bindings_for_param_lowering(&param.pat, &mut used);
+    }
+    for stmt in &body.stmts {
+        collect_stmt_bindings_including_nested(stmt, &mut used);
+    }
+
+    let mut next_temp = 0u32;
+    let mut prologue = Vec::new();
+    for param in &mut function.params {
+        match &mut param.pat {
+            Pat::Ident(_) => {}
+            Pat::Assign(assign_pat) => {
+                let left_pat = (*assign_pat.left).clone();
+                let default_expr = assign_pat.right.clone();
+                let temp_ident = fresh_param_temp_ident(&mut next_temp, &mut used);
+                param.pat = Pat::Ident(BindingIdent {
+                    id: temp_ident.clone(),
+                    type_ann: None,
+                });
+                prologue.push(Stmt::Decl(Decl::Var(Box::new(swc_ecma_ast::VarDecl {
+                    span: DUMMY_SP,
+                    ctxt: Default::default(),
+                    kind: swc_ecma_ast::VarDeclKind::Const,
+                    declare: false,
+                    decls: vec![swc_ecma_ast::VarDeclarator {
+                        span: DUMMY_SP,
+                        name: left_pat,
+                        init: Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                            span: DUMMY_SP,
+                            test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                                span: DUMMY_SP,
+                                op: op!("==="),
+                                left: Box::new(Expr::Ident(temp_ident.clone())),
+                                right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                    "undefined".into(),
+                                    DUMMY_SP,
+                                ))),
+                            })),
+                            cons: default_expr,
+                            alt: Box::new(Expr::Ident(temp_ident)),
+                        }))),
+                        definite: false,
+                    }],
+                }))));
+            }
+            _ => {
+                let original_pat = param.pat.clone();
+                let temp_ident = fresh_param_temp_ident(&mut next_temp, &mut used);
+                param.pat = Pat::Ident(BindingIdent {
+                    id: temp_ident.clone(),
+                    type_ann: None,
+                });
+
+                if let Pat::Array(array_pat) = &original_pat {
+                    let non_hole_pats = array_pat.elems.iter().flatten().collect::<Vec<_>>();
+                    if non_hole_pats.len() == 1 {
+                        if let Pat::Assign(assign_pat) = non_hole_pats[0] {
+                            if let Pat::Ident(binding) = &*assign_pat.left {
+                                let value_temp = fresh_param_temp_ident(&mut next_temp, &mut used);
+                                prologue.push(Stmt::Decl(Decl::Var(Box::new(swc_ecma_ast::VarDecl {
+                                    span: DUMMY_SP,
+                                    ctxt: Default::default(),
+                                    kind: swc_ecma_ast::VarDeclKind::Const,
+                                    declare: false,
+                                    decls: vec![swc_ecma_ast::VarDeclarator {
+                                        span: DUMMY_SP,
+                                        name: Pat::Array(swc_ecma_ast::ArrayPat {
+                                            span: array_pat.span,
+                                            elems: vec![Some(Pat::Ident(BindingIdent {
+                                                id: value_temp.clone(),
+                                                type_ann: None,
+                                            }))],
+                                            optional: false,
+                                            type_ann: None,
+                                        }),
+                                        init: Some(Box::new(Expr::Ident(temp_ident))),
+                                        definite: false,
+                                    }],
+                                }))));
+                                prologue.push(Stmt::Decl(Decl::Var(Box::new(swc_ecma_ast::VarDecl {
+                                    span: DUMMY_SP,
+                                    ctxt: Default::default(),
+                                    kind: swc_ecma_ast::VarDeclKind::Const,
+                                    declare: false,
+                                    decls: vec![swc_ecma_ast::VarDeclarator {
+                                        span: DUMMY_SP,
+                                        name: Pat::Ident(BindingIdent {
+                                            id: binding.id.clone(),
+                                            type_ann: binding.type_ann.clone(),
+                                        }),
+                                        init: Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                                            span: DUMMY_SP,
+                                            test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                                                span: DUMMY_SP,
+                                                op: op!("==="),
+                                                left: Box::new(Expr::Ident(value_temp.clone())),
+                                                right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                                    "undefined".into(),
+                                                    DUMMY_SP,
+                                                ))),
+                                            })),
+                                            cons: assign_pat.right.clone(),
+                                            alt: Box::new(Expr::Ident(value_temp)),
+                                        }))),
+                                        definite: false,
+                                    }],
+                                }))));
+                                continue;
+                            }
+                        }
+                    }
+                }
+
+                prologue.push(Stmt::Decl(Decl::Var(Box::new(swc_ecma_ast::VarDecl {
+                    span: DUMMY_SP,
+                    ctxt: Default::default(),
+                    kind: swc_ecma_ast::VarDeclKind::Const,
+                    declare: false,
+                    decls: vec![swc_ecma_ast::VarDeclarator {
+                        span: DUMMY_SP,
+                        name: original_pat,
+                        init: Some(Box::new(Expr::Ident(temp_ident))),
+                        definite: false,
+                    }],
+                }))));
+            }
+        }
+    }
+
+    if !prologue.is_empty() {
+        prologue.extend(std::mem::take(&mut body.stmts));
+        body.stmts = prologue;
+    }
 }
 
 /// Returns the runtime import module used by compiler output.
@@ -428,13 +650,21 @@ struct ProgramCompiler<'a> {
     program_suppressions: Vec<suppression::SuppressionRange>,
     consumed_next_line_suppressions: HashSet<usize>,
     report: CompileReport,
-    fixture_fn_type_hints: HashMap<String, ReactFunctionType>,
+    fixture_fn_type_hints: HashMap<String, FixtureFnTypeHint>,
+    fixture_entrypoint_fn_names: HashSet<String>,
+    expect_nothing_compiled: bool,
     queued_outlined: Vec<QueuedOutlinedFunction>,
     used_external_imports: Vec<UsedExternalImport>,
     forget_should_instrument_local: Atom,
     forget_use_render_counter_local: Atom,
     filename: Option<String>,
     fatal_error: Option<CompilerError>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FixtureFnTypeHint {
+    Kind(ReactFunctionType),
+    NotReact,
 }
 
 #[derive(Clone)]
@@ -444,7 +674,20 @@ struct QueuedOutlinedFunction {
 }
 
 impl ProgramCompiler<'_> {
-    fn fixture_fn_type_hint(&self, name: Option<&Ident>) -> Option<ReactFunctionType> {
+    fn allow_infer_return_fallback_for(&self, name: Option<&Ident>) -> bool {
+        if self.expect_nothing_compiled {
+            return false;
+        }
+        if self.fixture_entrypoint_fn_names.is_empty() {
+            return true;
+        }
+        let Some(name) = name else {
+            return false;
+        };
+        self.fixture_entrypoint_fn_names.contains(name.sym.as_ref())
+    }
+
+    fn fixture_fn_type_hint(&self, name: Option<&Ident>) -> Option<FixtureFnTypeHint> {
         let name = name?;
         self.fixture_fn_type_hints.get(name.sym.as_ref()).copied()
     }
@@ -577,7 +820,8 @@ impl ProgramCompiler<'_> {
         is_declaration: bool,
         is_top_level: bool,
         fn_loc: Span,
-        fn_type_hint: Option<ReactFunctionType>,
+        fn_type_hint: Option<FixtureFnTypeHint>,
+        is_forward_ref_or_memo_callback: bool,
     ) {
         if self.fatal_error.is_some() || function.body.is_none() {
             return;
@@ -624,9 +868,16 @@ impl ProgramCompiler<'_> {
             .iter()
             .map(|param| param.pat.clone())
             .collect::<Vec<_>>();
-        let inferred_type = fn_type_hint.or_else(|| {
-            name.and_then(|ident| infer_function_type(ident.sym.as_ref(), &function_params, body))
-        });
+        let inferred_type = match fn_type_hint {
+            Some(FixtureFnTypeHint::NotReact) => return,
+            Some(FixtureFnTypeHint::Kind(kind)) => Some(kind),
+            None => infer_function_type(
+                name.map(|ident| ident.sym.as_ref()),
+                &function_params,
+                body,
+                is_forward_ref_or_memo_callback,
+            ),
+        };
 
         let selected_type = match self.opts.compilation_mode {
             CompilationMode::Annotation => {
@@ -636,8 +887,11 @@ impl ProgramCompiler<'_> {
                     None
                 }
             }
-            CompilationMode::Infer => inferred_type.or_else(|| {
-                if is_top_level && has_return_with_value(body) {
+            CompilationMode::Infer => syntax_type.or(inferred_type).or_else(|| {
+                if is_top_level
+                    && self.allow_infer_return_fallback_for(name)
+                    && has_return_with_value(body)
+                {
                     Some(ReactFunctionType::Component)
                 } else {
                     None
@@ -761,7 +1015,8 @@ impl ProgramCompiler<'_> {
         arrow: &mut ArrowExpr,
         is_top_level: bool,
         fn_loc: Span,
-        fn_type_hint: Option<ReactFunctionType>,
+        fn_type_hint: Option<FixtureFnTypeHint>,
+        is_forward_ref_or_memo_callback: bool,
     ) {
         if self.fatal_error.is_some() {
             return;
@@ -807,9 +1062,16 @@ impl ProgramCompiler<'_> {
             }
         };
 
-        let inferred_type = fn_type_hint.or_else(|| {
-            name.and_then(|ident| infer_function_type(ident.sym.as_ref(), &arrow.params, &block))
-        });
+        let inferred_type = match fn_type_hint {
+            Some(FixtureFnTypeHint::NotReact) => return,
+            Some(FixtureFnTypeHint::Kind(kind)) => Some(kind),
+            None => infer_function_type(
+                name.map(|ident| ident.sym.as_ref()),
+                &arrow.params,
+                &block,
+                is_forward_ref_or_memo_callback,
+            ),
+        };
 
         let selected_type = match self.opts.compilation_mode {
             CompilationMode::Annotation => {
@@ -819,13 +1081,19 @@ impl ProgramCompiler<'_> {
                     None
                 }
             }
-            CompilationMode::Infer => inferred_type.or_else(|| {
-                if is_top_level && has_return_with_value(&block) {
-                    Some(ReactFunctionType::Component)
-                } else {
-                    None
-                }
-            }),
+            CompilationMode::Infer => name
+                .and_then(|ident| syntax_function_type(ident.sym.as_ref()))
+                .or(inferred_type)
+                .or_else(|| {
+                    if is_top_level
+                        && self.allow_infer_return_fallback_for(name)
+                        && has_return_with_value(&block)
+                    {
+                        Some(ReactFunctionType::Component)
+                    } else {
+                        None
+                    }
+                }),
             CompilationMode::Syntax => None,
             CompilationMode::All => {
                 if is_top_level {
@@ -1007,6 +1275,7 @@ impl VisitMut for ProgramCompiler<'_> {
             is_top_level,
             decl.ident.span,
             self.fixture_fn_type_hint(Some(&decl.ident)),
+            false,
         );
 
         self.function_depth += 1;
@@ -1038,6 +1307,7 @@ impl VisitMut for ProgramCompiler<'_> {
                         is_top_level,
                         fn_span,
                         self.fixture_fn_type_hint(compile_name),
+                        false,
                     );
 
                     self.function_depth += 1;
@@ -1052,6 +1322,7 @@ impl VisitMut for ProgramCompiler<'_> {
                         is_top_level,
                         arrow.span,
                         self.fixture_fn_type_hint(name.as_ref()),
+                        false,
                     );
 
                     self.function_depth += 1;
@@ -1090,6 +1361,7 @@ impl VisitMut for ProgramCompiler<'_> {
                     is_top_level,
                     fn_span,
                     self.fixture_fn_type_hint(compile_name),
+                    false,
                 );
 
                 self.function_depth += 1;
@@ -1103,6 +1375,7 @@ impl VisitMut for ProgramCompiler<'_> {
                     is_top_level,
                     arrow.span,
                     self.fixture_fn_type_hint(name.as_ref()),
+                    false,
                 );
 
                 self.function_depth += 1;
@@ -1131,17 +1404,12 @@ impl VisitMut for ProgramCompiler<'_> {
                             false,
                             is_top_level,
                             fn_span,
-                            Some(ReactFunctionType::Component),
+                            self.fixture_fn_type_hint(fn_expr.ident.as_ref()),
+                            true,
                         );
                     }
                     Expr::Arrow(arrow) => {
-                        self.compile_arrow(
-                            None,
-                            arrow,
-                            is_top_level,
-                            arrow.span,
-                            Some(ReactFunctionType::Component),
-                        );
+                        self.compile_arrow(None, arrow, is_top_level, arrow.span, None, true);
                     }
                     _ => {}
                 }
@@ -1161,6 +1429,7 @@ impl VisitMut for ProgramCompiler<'_> {
                 is_top_level,
                 decl.span,
                 self.fixture_fn_type_hint(fn_expr.ident.as_ref()),
+                false,
             );
 
             self.function_depth += 1;
@@ -1184,6 +1453,7 @@ impl VisitMut for ProgramCompiler<'_> {
                     is_top_level,
                     expr.span,
                     self.fixture_fn_type_hint(fn_expr.ident.as_ref()),
+                    false,
                 );
 
                 self.function_depth += 1;
@@ -1191,7 +1461,7 @@ impl VisitMut for ProgramCompiler<'_> {
                 self.function_depth -= 1;
             }
             Expr::Arrow(arrow) => {
-                self.compile_arrow(None, arrow, is_top_level, expr.span, None);
+                self.compile_arrow(None, arrow, is_top_level, expr.span, None, false);
 
                 self.function_depth += 1;
                 arrow.body.visit_mut_with(self);
@@ -1328,6 +1598,10 @@ fn find_top_level_item_index_by_name(module: &swc_ecma_ast::Module, name: &str) 
     })
 }
 
+fn is_fixture_entrypoint_name(name: &str) -> bool {
+    matches!(name, "FIXTURE_ENTRYPOINT" | "TODO_FIXTURE_ENTRYPOINT")
+}
+
 fn is_fixture_entrypoint_export(item: &ModuleItem) -> bool {
     let ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) = item else {
         return false;
@@ -1338,12 +1612,12 @@ fn is_fixture_entrypoint_export(item: &ModuleItem) -> bool {
     var_decl.decls.iter().any(|declarator| {
         matches!(
             &declarator.name,
-            Pat::Ident(BindingIdent { id, .. }) if id.sym == "FIXTURE_ENTRYPOINT"
+            Pat::Ident(BindingIdent { id, .. }) if is_fixture_entrypoint_name(id.sym.as_ref())
         )
     })
 }
 
-fn collect_fixture_entrypoint_type_hints(program: &Program) -> HashMap<String, ReactFunctionType> {
+fn collect_fixture_entrypoint_type_hints(program: &Program) -> HashMap<String, FixtureFnTypeHint> {
     let Program::Module(module) = program else {
         return HashMap::new();
     };
@@ -1360,7 +1634,7 @@ fn collect_fixture_entrypoint_type_hints(program: &Program) -> HashMap<String, R
             let Pat::Ident(BindingIdent { id, .. }) = &decl.name else {
                 continue;
             };
-            if id.sym != "FIXTURE_ENTRYPOINT" {
+            if !is_fixture_entrypoint_name(id.sym.as_ref()) {
                 continue;
             }
             let Some(init) = &decl.init else {
@@ -1372,7 +1646,8 @@ fn collect_fixture_entrypoint_type_hints(program: &Program) -> HashMap<String, R
 
             let mut fn_name = None;
             let mut fn_type = None;
-            let mut saw_is_component = false;
+            let mut saw_react_kind_hint = false;
+            let mut explicit_not_react = false;
             for prop in &object.props {
                 let PropOrSpread::Prop(prop) = prop else {
                     continue;
@@ -1392,7 +1667,7 @@ fn collect_fixture_entrypoint_type_hints(program: &Program) -> HashMap<String, R
                         }
                     }
                     "isComponent" => {
-                        saw_is_component = true;
+                        saw_react_kind_hint = true;
                         match &*key_value.value {
                             Expr::Lit(Lit::Bool(bool_lit)) => {
                                 if bool_lit.value {
@@ -1408,9 +1683,12 @@ fn collect_fixture_entrypoint_type_hints(program: &Program) -> HashMap<String, R
                         }
                     }
                     "isHook" => {
+                        saw_react_kind_hint = true;
                         if let Expr::Lit(Lit::Bool(bool_lit)) = &*key_value.value {
                             if bool_lit.value {
                                 fn_type = Some(ReactFunctionType::Hook);
+                            } else {
+                                explicit_not_react = true;
                             }
                         }
                     }
@@ -1419,13 +1697,18 @@ fn collect_fixture_entrypoint_type_hints(program: &Program) -> HashMap<String, R
             }
 
             if let Some(fn_name) = fn_name {
-                if let Some(kind) = fn_type {
-                    hints.insert(fn_name, kind);
-                } else if !saw_is_component {
+                if explicit_not_react {
+                    hints.insert(fn_name, FixtureFnTypeHint::NotReact);
+                } else if let Some(kind) = fn_type {
+                    hints.insert(fn_name, FixtureFnTypeHint::Kind(kind));
+                } else if !saw_react_kind_hint {
                     if is_hook_name(fn_name.as_str()) {
-                        hints.insert(fn_name, ReactFunctionType::Hook);
+                        hints.insert(fn_name, FixtureFnTypeHint::Kind(ReactFunctionType::Hook));
                     } else if is_component_name(fn_name.as_str()) {
-                        hints.insert(fn_name, ReactFunctionType::Component);
+                        hints.insert(
+                            fn_name,
+                            FixtureFnTypeHint::Kind(ReactFunctionType::Component),
+                        );
                     }
                 }
             }
@@ -1433,6 +1716,59 @@ fn collect_fixture_entrypoint_type_hints(program: &Program) -> HashMap<String, R
     }
 
     hints
+}
+
+fn collect_fixture_entrypoint_fn_names(program: &Program) -> HashSet<String> {
+    let Program::Module(module) = program else {
+        return HashSet::new();
+    };
+
+    let mut names = HashSet::new();
+
+    for item in &module.body {
+        let ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(export_decl)) = item else {
+            continue;
+        };
+        let Decl::Var(var_decl) = &export_decl.decl else {
+            continue;
+        };
+        for decl in &var_decl.decls {
+            let Pat::Ident(BindingIdent { id, .. }) = &decl.name else {
+                continue;
+            };
+            if !is_fixture_entrypoint_name(id.sym.as_ref()) {
+                continue;
+            }
+            let Some(init) = &decl.init else {
+                continue;
+            };
+            let Expr::Object(object) = &**init else {
+                continue;
+            };
+
+            for prop in &object.props {
+                let PropOrSpread::Prop(prop) = prop else {
+                    continue;
+                };
+                let Prop::KeyValue(key_value) = &**prop else {
+                    continue;
+                };
+                let key_name = match &key_value.key {
+                    PropName::Ident(ident) => ident.sym.to_string(),
+                    PropName::Str(value) => value.value.to_string_lossy().into_owned(),
+                    _ => continue,
+                };
+                if key_name != "fn" {
+                    continue;
+                }
+                if let Expr::Ident(ident) = &*key_value.value {
+                    names.insert(ident.sym.to_string());
+                }
+            }
+        }
+    }
+
+    names
 }
 
 fn collect_top_level_names(program: &Program) -> HashSet<String> {
@@ -1508,6 +1844,8 @@ fn apply_codegen_to_function(function: &mut Function, codegen: &CodegenFunction)
     if let Some(original_body) = original_body.as_ref() {
         preserve_leading_directives(original_body, &mut next_body);
     }
+    normalize_compound_assignments_in_block(&mut next_body);
+    normalize_block_labels(&mut next_body);
     function.body = Some(next_body);
     function.is_async = codegen.is_async;
     function.is_generator = codegen.is_generator;
@@ -1527,6 +1865,8 @@ fn apply_codegen_to_arrow(arrow: &mut ArrowExpr, codegen: &CodegenFunction) {
     if let Some(original_block) = original_block.as_ref() {
         preserve_leading_directives(original_block, &mut next_body);
     }
+    normalize_compound_assignments_in_block(&mut next_body);
+    normalize_block_labels(&mut next_body);
     arrow.body = Box::new(BlockStmtOrExpr::BlockStmt(next_body));
     arrow.is_async = codegen.is_async;
     arrow.is_generator = codegen.is_generator;
@@ -1556,6 +1896,8 @@ fn apply_gated_codegen_to_function(
     if let Some(original_body) = original_function.body.as_ref() {
         preserve_leading_directives(original_body, &mut compiled_body);
     }
+    normalize_compound_assignments_in_block(&mut compiled_body);
+    normalize_block_labels(&mut compiled_body);
     function.body = Some(build_gated_body(
         compiled_body,
         original_function.body.clone().unwrap_or_default(),
@@ -1578,6 +1920,8 @@ fn apply_gated_codegen_to_arrow(
     arrow.params = codegen.params.clone();
     let mut compiled_body = codegen.body.clone();
     preserve_leading_directives(original_block, &mut compiled_body);
+    normalize_compound_assignments_in_block(&mut compiled_body);
+    normalize_block_labels(&mut compiled_body);
     arrow.body = Box::new(BlockStmtOrExpr::BlockStmt(build_gated_body(
         compiled_body,
         original_block.clone(),
@@ -1671,11 +2015,16 @@ impl VisitMut for TypeStripper {
 }
 
 fn normalize_static_string_members_in_block(block: &mut BlockStmt) {
-    struct Normalizer;
+    struct Normalizer {
+        in_delete_operand: bool,
+    }
 
     impl VisitMut for Normalizer {
         fn visit_mut_member_expr(&mut self, member: &mut swc_ecma_ast::MemberExpr) {
             member.visit_mut_children_with(self);
+            if self.in_delete_operand {
+                return;
+            }
 
             let swc_ecma_ast::MemberProp::Computed(computed) = &member.prop else {
                 return;
@@ -1691,10 +2040,118 @@ fn normalize_static_string_members_in_block(block: &mut BlockStmt) {
                 );
             }
         }
+
+        fn visit_mut_unary_expr(&mut self, unary: &mut swc_ecma_ast::UnaryExpr) {
+            let prev = self.in_delete_operand;
+            if matches!(unary.op, swc_ecma_ast::UnaryOp::Delete) {
+                self.in_delete_operand = true;
+            }
+            unary.visit_mut_children_with(self);
+            self.in_delete_operand = prev;
+        }
     }
 
-    let mut normalizer = Normalizer;
+    let mut normalizer = Normalizer {
+        in_delete_operand: false,
+    };
     block.visit_mut_with(&mut normalizer);
+}
+
+fn normalize_block_labels(block: &mut BlockStmt) {
+    struct LabelNormalizer {
+        map: HashMap<String, String>,
+        next_index: usize,
+    }
+
+    impl VisitMut for LabelNormalizer {
+        fn visit_mut_labeled_stmt(&mut self, labeled: &mut swc_ecma_ast::LabeledStmt) {
+            let old = labeled.label.sym.to_string();
+            let new = self
+                .map
+                .entry(old)
+                .or_insert_with(|| {
+                    let name = format!("bb{}", self.next_index);
+                    self.next_index += 1;
+                    name
+                })
+                .clone();
+            labeled.label.sym = new.into();
+            labeled.visit_mut_children_with(self);
+        }
+
+        fn visit_mut_break_stmt(&mut self, break_stmt: &mut swc_ecma_ast::BreakStmt) {
+            if let Some(label) = &mut break_stmt.label {
+                if let Some(mapped) = self.map.get(label.sym.as_ref()) {
+                    label.sym = mapped.clone().into();
+                }
+            }
+        }
+    }
+
+    let mut normalizer = LabelNormalizer {
+        map: HashMap::new(),
+        next_index: 0,
+    };
+    block.visit_mut_with(&mut normalizer);
+}
+
+fn normalize_compound_assignments_in_block(block: &mut BlockStmt) {
+    struct Normalizer;
+
+    impl VisitMut for Normalizer {
+        fn visit_mut_assign_expr(&mut self, assign: &mut AssignExpr) {
+            assign.visit_mut_children_with(self);
+
+            let binary_op = match assign.op {
+                swc_ecma_ast::AssignOp::AddAssign => Some(op!(bin, "+")),
+                swc_ecma_ast::AssignOp::SubAssign => Some(op!(bin, "-")),
+                swc_ecma_ast::AssignOp::MulAssign => Some(op!("*")),
+                swc_ecma_ast::AssignOp::DivAssign => Some(op!("/")),
+                swc_ecma_ast::AssignOp::ModAssign => Some(op!("%")),
+                swc_ecma_ast::AssignOp::LShiftAssign => Some(op!("<<")),
+                swc_ecma_ast::AssignOp::RShiftAssign => Some(op!(">>")),
+                swc_ecma_ast::AssignOp::ZeroFillRShiftAssign => Some(op!(">>>")),
+                swc_ecma_ast::AssignOp::BitOrAssign => Some(op!("|")),
+                swc_ecma_ast::AssignOp::BitXorAssign => Some(op!("^")),
+                swc_ecma_ast::AssignOp::BitAndAssign => Some(op!("&")),
+                swc_ecma_ast::AssignOp::ExpAssign => Some(op!("**")),
+                _ => None,
+            };
+            let Some(binary_op) = binary_op else {
+                return;
+            };
+
+            let left_expr = if let Some(binding) = assign.left.as_ident() {
+                Box::new(Expr::Ident(binding.id.clone()))
+            } else if let Some(swc_ecma_ast::SimpleAssignTarget::Member(member)) =
+                assign.left.as_simple()
+            {
+                Box::new(Expr::Member(member.clone()))
+            } else {
+                return;
+            };
+
+            let mut right_expr = assign.right.clone();
+            if matches!(
+                unwrap_transparent_expr(&right_expr),
+                Expr::Assign(_) | Expr::Seq(_) | Expr::Cond(_)
+            ) {
+                right_expr = Box::new(Expr::Paren(swc_ecma_ast::ParenExpr {
+                    span: DUMMY_SP,
+                    expr: right_expr,
+                }));
+            }
+            assign.op = op!("=");
+            assign.right = Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                span: DUMMY_SP,
+                op: binary_op,
+                left: left_expr,
+                right: right_expr,
+            }));
+        }
+    }
+
+    block.visit_mut_with(&mut Normalizer);
 }
 
 fn build_gated_body(
@@ -1733,17 +2190,37 @@ fn syntax_function_type(name: &str) -> Option<ReactFunctionType> {
     }
 }
 
-fn infer_function_type(name: &str, params: &[Pat], body: &BlockStmt) -> Option<ReactFunctionType> {
-    if is_hook_name(name) {
-        let _ = body;
-        return Some(ReactFunctionType::Hook);
+fn infer_function_type(
+    name: Option<&str>,
+    params: &[Pat],
+    body: &BlockStmt,
+    is_forward_ref_or_memo_callback: bool,
+) -> Option<ReactFunctionType> {
+    let calls_hooks_or_creates_jsx = calls_hooks_or_creates_jsx(body);
+
+    if let Some(name) = name {
+        if is_component_name(name) {
+            let is_component = calls_hooks_or_creates_jsx
+                && is_valid_component_params(params)
+                && !returns_non_node(body);
+            return if is_component {
+                Some(ReactFunctionType::Component)
+            } else {
+                None
+            };
+        }
+
+        if is_hook_name(name) {
+            return if calls_hooks_or_creates_jsx {
+                Some(ReactFunctionType::Hook)
+            } else {
+                None
+            };
+        }
     }
 
-    if is_component_name(name) {
-        if is_valid_component_params(params) {
-            return Some(ReactFunctionType::Component);
-        }
-        return None;
+    if is_forward_ref_or_memo_callback && calls_hooks_or_creates_jsx {
+        return Some(ReactFunctionType::Component);
     }
 
     None
@@ -1772,12 +2249,145 @@ fn has_return_with_value(body: &BlockStmt) -> bool {
             if return_stmt.arg.is_some() {
                 self.found = true;
             }
+            return_stmt.visit_children_with(self);
         }
     }
 
     let mut finder = Finder::default();
     body.visit_with(&mut finder);
     finder.found
+}
+
+fn calls_hooks_or_creates_jsx(body: &BlockStmt) -> bool {
+    #[derive(Default)]
+    struct Finder {
+        invokes_hooks: bool,
+        creates_jsx: bool,
+    }
+
+    impl Visit for Finder {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_fn_decl(&mut self, _: &FnDecl) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_call_expr(&mut self, call: &swc_ecma_ast::CallExpr) {
+            if let Callee::Expr(callee_expr) = &call.callee {
+                if is_hook_expr(callee_expr) {
+                    self.invokes_hooks = true;
+                }
+            }
+            call.visit_children_with(self);
+        }
+
+        fn visit_jsx_element(&mut self, jsx: &swc_ecma_ast::JSXElement) {
+            self.creates_jsx = true;
+            jsx.visit_children_with(self);
+        }
+
+        fn visit_jsx_fragment(&mut self, jsx: &swc_ecma_ast::JSXFragment) {
+            self.creates_jsx = true;
+            jsx.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder::default();
+    body.visit_with(&mut finder);
+    finder.invokes_hooks || finder.creates_jsx
+}
+
+fn returns_non_node(body: &BlockStmt) -> bool {
+    #[derive(Default)]
+    struct Finder {
+        returns_non_node: bool,
+    }
+
+    impl Visit for Finder {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_fn_decl(&mut self, _: &FnDecl) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_method_prop(&mut self, _: &swc_ecma_ast::MethodProp) {
+            // Skip object methods.
+        }
+
+        fn visit_return_stmt(&mut self, return_stmt: &swc_ecma_ast::ReturnStmt) {
+            self.returns_non_node = is_non_node(return_stmt.arg.as_deref());
+            return_stmt.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder::default();
+    body.visit_with(&mut finder);
+    finder.returns_non_node
+}
+
+fn is_non_node(expr: Option<&Expr>) -> bool {
+    let Some(expr) = expr else {
+        return true;
+    };
+
+    match unwrap_transparent_expr(expr) {
+        Expr::Object(_)
+        | Expr::Arrow(_)
+        | Expr::Fn(_)
+        | Expr::Class(_)
+        | Expr::New(_)
+        | Expr::Lit(Lit::BigInt(_)) => true,
+        _ => false,
+    }
+}
+
+fn is_hook_expr(expr: &Expr) -> bool {
+    let expr = unwrap_transparent_expr(expr);
+
+    if let Expr::Ident(ident) = expr {
+        return is_hook_name(ident.sym.as_ref());
+    }
+
+    let Expr::Member(member) = expr else {
+        return false;
+    };
+    let swc_ecma_ast::MemberProp::Ident(property) = &member.prop else {
+        return false;
+    };
+    if !is_hook_name(property.sym.as_ref()) {
+        return false;
+    }
+    let Expr::Ident(object) = unwrap_transparent_expr(member.obj.as_ref()) else {
+        return false;
+    };
+
+    matches!(object.sym.chars().next(), Some(c) if c.is_ascii_uppercase())
+}
+
+fn unwrap_transparent_expr(mut expr: &Expr) -> &Expr {
+    loop {
+        match expr {
+            Expr::Paren(paren) => expr = &paren.expr,
+            Expr::TsAs(ts_as) => expr = &ts_as.expr,
+            Expr::TsTypeAssertion(type_assertion) => expr = &type_assertion.expr,
+            Expr::TsNonNull(ts_non_null) => expr = &ts_non_null.expr,
+            Expr::TsSatisfies(ts_satisfies) => expr = &ts_satisfies.expr,
+            Expr::TsInstantiation(ts_instantiation) => expr = &ts_instantiation.expr,
+            _ => return expr,
+        }
+    }
 }
 
 fn is_valid_component_params(params: &[Pat]) -> bool {
@@ -2189,5 +2799,31 @@ mod tests {
             get_react_compiler_runtime_module(&CompilerReactTarget::React17),
             "react-compiler-runtime"
         );
+    }
+
+    #[test]
+    fn normalizes_labels_for_fixture_entrypoint_component() {
+        let mut program = parse_program(
+            "function foo(a, b, c) {\n  label: if (a) {\n    while (b) {\n      if (c) {\n        \
+             break label;\n      }\n    }\n  }\n  return c;\n}\nexport const FIXTURE_ENTRYPOINT \
+             = { fn: foo, params: ['TodoAdd'], isComponent: 'TodoAdd' };\n",
+        );
+
+        let report = compile_program(
+            &mut program,
+            &CompilerPass {
+                opts: crate::options::default_options(),
+                filename: Some("src/fixture.js".into()),
+                comments: Vec::new(),
+                code: None,
+            },
+        )
+        .unwrap();
+        let output = print_program(&program);
+
+        assert!(report.compiled_functions >= 1, "report: {report:?}");
+        assert!(report.diagnostics.is_empty(), "report: {report:?}");
+        assert!(output.contains("bb0: if (a)"), "{output}");
+        assert!(output.contains("break bb0"), "{output}");
     }
 }

--- a/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
@@ -463,54 +463,66 @@ fn normalize_function_params_for_lowering(function: &mut Function) {
                         if let Pat::Assign(assign_pat) = non_hole_pats[0] {
                             if let Pat::Ident(binding) = &*assign_pat.left {
                                 let value_temp = fresh_param_temp_ident(&mut next_temp, &mut used);
-                                prologue.push(Stmt::Decl(Decl::Var(Box::new(swc_ecma_ast::VarDecl {
-                                    span: DUMMY_SP,
-                                    ctxt: Default::default(),
-                                    kind: swc_ecma_ast::VarDeclKind::Const,
-                                    declare: false,
-                                    decls: vec![swc_ecma_ast::VarDeclarator {
+                                prologue.push(Stmt::Decl(Decl::Var(Box::new(
+                                    swc_ecma_ast::VarDecl {
                                         span: DUMMY_SP,
-                                        name: Pat::Array(swc_ecma_ast::ArrayPat {
-                                            span: array_pat.span,
-                                            elems: vec![Some(Pat::Ident(BindingIdent {
-                                                id: value_temp.clone(),
-                                                type_ann: None,
-                                            }))],
-                                            optional: false,
-                                            type_ann: None,
-                                        }),
-                                        init: Some(Box::new(Expr::Ident(temp_ident))),
-                                        definite: false,
-                                    }],
-                                }))));
-                                prologue.push(Stmt::Decl(Decl::Var(Box::new(swc_ecma_ast::VarDecl {
-                                    span: DUMMY_SP,
-                                    ctxt: Default::default(),
-                                    kind: swc_ecma_ast::VarDeclKind::Const,
-                                    declare: false,
-                                    decls: vec![swc_ecma_ast::VarDeclarator {
-                                        span: DUMMY_SP,
-                                        name: Pat::Ident(BindingIdent {
-                                            id: binding.id.clone(),
-                                            type_ann: binding.type_ann.clone(),
-                                        }),
-                                        init: Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                                        ctxt: Default::default(),
+                                        kind: swc_ecma_ast::VarDeclKind::Const,
+                                        declare: false,
+                                        decls: vec![swc_ecma_ast::VarDeclarator {
                                             span: DUMMY_SP,
-                                            test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
-                                                span: DUMMY_SP,
-                                                op: op!("==="),
-                                                left: Box::new(Expr::Ident(value_temp.clone())),
-                                                right: Box::new(Expr::Ident(Ident::new_no_ctxt(
-                                                    "undefined".into(),
-                                                    DUMMY_SP,
-                                                ))),
-                                            })),
-                                            cons: assign_pat.right.clone(),
-                                            alt: Box::new(Expr::Ident(value_temp)),
-                                        }))),
-                                        definite: false,
-                                    }],
-                                }))));
+                                            name: Pat::Array(swc_ecma_ast::ArrayPat {
+                                                span: array_pat.span,
+                                                elems: vec![Some(Pat::Ident(BindingIdent {
+                                                    id: value_temp.clone(),
+                                                    type_ann: None,
+                                                }))],
+                                                optional: false,
+                                                type_ann: None,
+                                            }),
+                                            init: Some(Box::new(Expr::Ident(temp_ident))),
+                                            definite: false,
+                                        }],
+                                    },
+                                ))));
+                                prologue.push(Stmt::Decl(Decl::Var(Box::new(
+                                    swc_ecma_ast::VarDecl {
+                                        span: DUMMY_SP,
+                                        ctxt: Default::default(),
+                                        kind: swc_ecma_ast::VarDeclKind::Const,
+                                        declare: false,
+                                        decls: vec![swc_ecma_ast::VarDeclarator {
+                                            span: DUMMY_SP,
+                                            name: Pat::Ident(BindingIdent {
+                                                id: binding.id.clone(),
+                                                type_ann: binding.type_ann.clone(),
+                                            }),
+                                            init: Some(Box::new(Expr::Cond(
+                                                swc_ecma_ast::CondExpr {
+                                                    span: DUMMY_SP,
+                                                    test: Box::new(Expr::Bin(
+                                                        swc_ecma_ast::BinExpr {
+                                                            span: DUMMY_SP,
+                                                            op: op!("==="),
+                                                            left: Box::new(Expr::Ident(
+                                                                value_temp.clone(),
+                                                            )),
+                                                            right: Box::new(Expr::Ident(
+                                                                Ident::new_no_ctxt(
+                                                                    "undefined".into(),
+                                                                    DUMMY_SP,
+                                                                ),
+                                                            )),
+                                                        },
+                                                    )),
+                                                    cons: assign_pat.right.clone(),
+                                                    alt: Box::new(Expr::Ident(value_temp)),
+                                                },
+                                            ))),
+                                            definite: false,
+                                        }],
+                                    },
+                                ))));
                                 continue;
                             }
                         }
@@ -813,6 +825,7 @@ impl ProgramCompiler<'_> {
         matched
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn compile_named_function(
         &mut self,
         name: Option<&Ident>,
@@ -2342,15 +2355,15 @@ fn is_non_node(expr: Option<&Expr>) -> bool {
         return true;
     };
 
-    match unwrap_transparent_expr(expr) {
+    matches!(
+        unwrap_transparent_expr(expr),
         Expr::Object(_)
-        | Expr::Arrow(_)
-        | Expr::Fn(_)
-        | Expr::Class(_)
-        | Expr::New(_)
-        | Expr::Lit(Lit::BigInt(_)) => true,
-        _ => false,
-    }
+            | Expr::Arrow(_)
+            | Expr::Fn(_)
+            | Expr::Class(_)
+            | Expr::New(_)
+            | Expr::Lit(Lit::BigInt(_))
+    )
 }
 
 fn is_hook_expr(expr: &Expr) -> bool {
@@ -2805,8 +2818,8 @@ mod tests {
     fn normalizes_labels_for_fixture_entrypoint_component() {
         let mut program = parse_program(
             "function foo(a, b, c) {\n  label: if (a) {\n    while (b) {\n      if (c) {\n        \
-             break label;\n      }\n    }\n  }\n  return c;\n}\nexport const FIXTURE_ENTRYPOINT \
-             = { fn: foo, params: ['TodoAdd'], isComponent: 'TodoAdd' };\n",
+             break label;\n      }\n    }\n  }\n  return c;\n}\nexport const FIXTURE_ENTRYPOINT = \
+             { fn: foo, params: ['TodoAdd'], isComponent: 'TodoAdd' };\n",
         );
 
         let report = compile_program(

--- a/crates/swc_ecma_react_compiler/src/inference/drop_manual_memoization.rs
+++ b/crates/swc_ecma_react_compiler/src/inference/drop_manual_memoization.rs
@@ -1,6 +1,209 @@
+use swc_ecma_ast::{BlockStmt, Callee, Expr, Lit, MemberExpr, MemberProp};
+use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
+
 use crate::hir::HirFunction;
 
-/// Drops manual memoization hints before inference when configured.
-pub fn drop_manual_memoization(_hir: &mut HirFunction) {
-    // Kept intentionally conservative for the current Rust parity stage.
+/// Drops manual memoization wrappers when they are a direct `useMemo` call with
+/// a pure dependency array and a callback that is equivalent to an expression.
+pub fn drop_manual_memoization(hir: &mut HirFunction) {
+    let Some(body) = hir.function.body.as_mut() else {
+        return;
+    };
+
+    struct Rewriter;
+
+    impl VisitMut for Rewriter {
+        fn visit_mut_expr(&mut self, expr: &mut Expr) {
+            expr.visit_mut_children_with(self);
+
+            let Expr::Call(call) = expr else {
+                return;
+            };
+            if !is_use_memo_callee(&call.callee) {
+                return;
+            }
+            if call.args.len() < 2 {
+                return;
+            }
+
+            let deps = &call.args[1];
+            if deps.spread.is_some() || !is_pure_dependency_array(&deps.expr) {
+                return;
+            }
+
+            let callback = &call.args[0];
+            if callback.spread.is_some() {
+                return;
+            }
+            let Some(inlined) = extract_callback_expr(&callback.expr) else {
+                return;
+            };
+            if is_self_identity_memo(&inlined, &deps.expr) {
+                return;
+            }
+            if contains_allocating_literal(&inlined) {
+                return;
+            }
+
+            *expr = *inlined;
+        }
+    }
+
+    body.visit_mut_with(&mut Rewriter);
+}
+
+fn is_use_memo_callee(callee: &Callee) -> bool {
+    let Callee::Expr(callee_expr) = callee else {
+        return false;
+    };
+    match &**callee_expr {
+        Expr::Ident(ident) => ident.sym == "useMemo",
+        Expr::Member(member) => is_react_use_memo_member(member),
+        _ => false,
+    }
+}
+
+fn is_react_use_memo_member(member: &MemberExpr) -> bool {
+    let Expr::Ident(object) = &*member.obj else {
+        return false;
+    };
+    if object.sym != "React" {
+        return false;
+    }
+    match &member.prop {
+        MemberProp::Ident(prop) => prop.sym == "useMemo",
+        MemberProp::Computed(computed) => match &*computed.expr {
+            Expr::Lit(Lit::Str(value)) => value.value == *"useMemo",
+            _ => false,
+        },
+        MemberProp::PrivateName(_) => false,
+    }
+}
+
+fn is_pure_dependency_array(expr: &Expr) -> bool {
+    let Expr::Array(array) = expr else {
+        return false;
+    };
+    array.elems.iter().all(|element| {
+        let Some(element) = element else {
+            return true;
+        };
+        if element.spread.is_some() {
+            return false;
+        }
+        matches!(
+            &*element.expr,
+            Expr::Ident(_)
+                | Expr::Member(_)
+                | Expr::Lit(_)
+                | Expr::This(_)
+                | Expr::Unary(_)
+                | Expr::Bin(_)
+                | Expr::Cond(_)
+        )
+    })
+}
+
+fn extract_callback_expr(expr: &Expr) -> Option<Box<Expr>> {
+    match expr {
+        Expr::Arrow(arrow) => {
+            if !arrow.params.is_empty() {
+                return None;
+            }
+            match &*arrow.body {
+                swc_ecma_ast::BlockStmtOrExpr::Expr(value) => Some(value.clone()),
+                swc_ecma_ast::BlockStmtOrExpr::BlockStmt(block) => {
+                    extract_single_return_expr(block)
+                }
+            }
+        }
+        Expr::Fn(function_expr) => {
+            if !function_expr.function.params.is_empty() {
+                return None;
+            }
+            let body = function_expr.function.body.as_ref()?;
+            extract_single_return_expr(body)
+        }
+        _ => None,
+    }
+}
+
+fn extract_single_return_expr(block: &BlockStmt) -> Option<Box<Expr>> {
+    let mut non_empty = block
+        .stmts
+        .iter()
+        .filter(|stmt| !matches!(stmt, swc_ecma_ast::Stmt::Empty(_)));
+    let stmt = non_empty.next()?;
+    if non_empty.next().is_some() {
+        return None;
+    }
+    let swc_ecma_ast::Stmt::Return(return_stmt) = stmt else {
+        return None;
+    };
+    return_stmt.arg.clone()
+}
+
+fn contains_allocating_literal(expr: &Expr) -> bool {
+    struct Finder {
+        found: bool,
+    }
+
+    impl Visit for Finder {
+        fn visit_arrow_expr(&mut self, _: &swc_ecma_ast::ArrowExpr) {
+            self.found = true;
+        }
+
+        fn visit_fn_expr(&mut self, _: &swc_ecma_ast::FnExpr) {
+            self.found = true;
+        }
+
+        fn visit_object_lit(&mut self, _: &swc_ecma_ast::ObjectLit) {
+            self.found = true;
+        }
+
+        fn visit_array_lit(&mut self, _: &swc_ecma_ast::ArrayLit) {
+            self.found = true;
+        }
+
+        fn visit_new_expr(&mut self, _: &swc_ecma_ast::NewExpr) {
+            self.found = true;
+        }
+
+        fn visit_jsx_element(&mut self, _: &swc_ecma_ast::JSXElement) {
+            self.found = true;
+        }
+
+        fn visit_jsx_fragment(&mut self, _: &swc_ecma_ast::JSXFragment) {
+            self.found = true;
+        }
+
+        fn visit_class_expr(&mut self, _: &swc_ecma_ast::ClassExpr) {
+            self.found = true;
+        }
+
+        fn visit_expr(&mut self, expr: &Expr) {
+            if self.found {
+                return;
+            }
+            expr.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder { found: false };
+    expr.visit_with(&mut finder);
+    finder.found
+}
+
+fn is_self_identity_memo(inlined: &Expr, deps_expr: &Expr) -> bool {
+    let Expr::Ident(inlined_ident) = inlined else {
+        return false;
+    };
+    let Expr::Array(deps_array) = deps_expr else {
+        return false;
+    };
+    let [Some(dep)] = deps_array.elems.as_slice() else {
+        return false;
+    };
+    dep.spread.is_none()
+        && matches!(&*dep.expr, Expr::Ident(dep_ident) if dep_ident.sym == inlined_ident.sym)
 }

--- a/crates/swc_ecma_react_compiler/src/optimization/constant_propagation.rs
+++ b/crates/swc_ecma_react_compiler/src/optimization/constant_propagation.rs
@@ -261,10 +261,42 @@ fn propagate_while_stmt(
     while_stmt: &mut swc_ecma_ast::WhileStmt,
     env: &HashMap<String, ConstValue>,
 ) {
-    fold_constants_in_expr(&mut while_stmt.test, env);
-    if let Some(value) = eval_expr(&while_stmt.test, env) {
+    let mut loop_env = env.clone();
+    let mut assigned_in_body = HashSet::new();
+    collect_ident_assignments_in_stmt(&while_stmt.body, &mut assigned_in_body);
+    for name in assigned_in_body {
+        loop_env.remove(name.as_str());
+    }
+
+    fold_constants_in_expr(&mut while_stmt.test, &loop_env);
+    if let Some(value) = eval_expr(&while_stmt.test, &loop_env) {
         while_stmt.test = value.to_expr();
     }
+}
+
+fn collect_ident_assignments_in_stmt(stmt: &Stmt, out: &mut HashSet<String>) {
+    struct Finder<'a> {
+        out: &'a mut HashSet<String>,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_assign_expr(&mut self, assign: &AssignExpr) {
+            if let Some(name) = assign_target_ident_name(&assign.left) {
+                self.out.insert(name);
+            }
+            assign.visit_children_with(self);
+        }
+
+        fn visit_update_expr(&mut self, update: &UpdateExpr) {
+            if let Expr::Ident(ident) = &*update.arg {
+                self.out.insert(ident.sym.to_string());
+            }
+            update.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder { out };
+    stmt.visit_with(&mut finder);
 }
 
 fn can_unwrap_constant_folded_if_block(block: &swc_ecma_ast::BlockStmt) -> bool {

--- a/crates/swc_ecma_react_compiler/src/optimization/dead_code_elimination.rs
+++ b/crates/swc_ecma_react_compiler/src/optimization/dead_code_elimination.rs
@@ -1,7 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use swc_ecma_ast::{
-    op, AssignExpr, AssignTarget, Decl, Expr, Pat, SimpleAssignTarget, Stmt, VarDecl, VarDeclKind,
+    op, AssignExpr, AssignTarget, Decl, Expr, Lit, Pat, SimpleAssignTarget, Stmt, VarDecl,
+    VarDeclKind,
 };
 use swc_ecma_visit::{Visit, VisitWith};
 
@@ -13,6 +14,7 @@ pub fn dead_code_elimination(hir: &mut HirFunction) {
     let Some(body) = hir.function.body.as_mut() else {
         return;
     };
+    let originally_declared = collect_declared_bindings_in_stmts(&body.stmts);
 
     let function_captures = collect_function_like_captures(&body.stmts);
     let mut original = Vec::new();
@@ -29,6 +31,20 @@ pub fn dead_code_elimination(hir: &mut HirFunction) {
 
     kept_rev.reverse();
     body.stmts = kept_rev;
+
+    let mut read_bindings = collect_read_bindings(&body.stmts);
+    let mut written_bindings = collect_assigned_bindings_in_stmts(&body.stmts);
+    prune_dead_writes_with_known_reads(&mut body.stmts, &read_bindings, &written_bindings);
+    // Re-run once after statement pruning so declaration retention can reflect
+    // writes that survived the first pass.
+    read_bindings = collect_read_bindings(&body.stmts);
+    written_bindings = collect_assigned_bindings_in_stmts(&body.stmts);
+    prune_dead_writes_with_known_reads(&mut body.stmts, &read_bindings, &written_bindings);
+    ensure_uninitialized_declarations_for_assigned_reads(
+        &mut body.stmts,
+        &read_bindings,
+        &originally_declared,
+    );
 }
 
 fn keep_statement(
@@ -252,9 +268,9 @@ fn expr_is_pure(expr: &Expr) -> bool {
             expr_is_pure(&cond.test) && expr_is_pure(&cond.cons) && expr_is_pure(&cond.alt)
         }
         Expr::Seq(seq) => seq.exprs.iter().all(|expr| expr_is_pure(expr)),
+        Expr::Call(_) => false,
         // Conservative fallback for expressions with potential side-effects.
-        Expr::Call(_)
-        | Expr::New(_)
+        Expr::New(_)
         | Expr::Update(_)
         | Expr::Assign(_)
         | Expr::Await(_)
@@ -272,4 +288,367 @@ fn expr_is_pure(expr: &Expr) -> bool {
         | Expr::JSXElement(_)
         | Expr::JSXFragment(_) => false,
     }
+}
+
+fn collect_read_bindings(stmts: &[Stmt]) -> HashSet<String> {
+    struct Collector {
+        reads: HashSet<String>,
+        in_lhs: bool,
+        in_pat: bool,
+    }
+
+    impl Visit for Collector {
+        fn visit_ident(&mut self, ident: &swc_ecma_ast::Ident) {
+            if self.in_lhs || self.in_pat {
+                return;
+            }
+            self.reads.insert(ident.sym.to_string());
+        }
+
+        fn visit_var_declarator(&mut self, decl: &swc_ecma_ast::VarDeclarator) {
+            let prev_pat = self.in_pat;
+            self.in_pat = true;
+            decl.name.visit_with(self);
+            self.in_pat = prev_pat;
+
+            if let Some(init) = &decl.init {
+                init.visit_with(self);
+            }
+        }
+
+        fn visit_assign_expr(&mut self, assign: &AssignExpr) {
+            if assign.left.as_ident().is_some() {
+                let prev_lhs = self.in_lhs;
+                self.in_lhs = true;
+                assign.left.visit_with(self);
+                self.in_lhs = prev_lhs;
+            } else {
+                assign.left.visit_with(self);
+            }
+            assign.right.visit_with(self);
+        }
+
+        fn visit_update_expr(&mut self, update: &swc_ecma_ast::UpdateExpr) {
+            if matches!(&*update.arg, Expr::Ident(_)) {
+                let prev_lhs = self.in_lhs;
+                self.in_lhs = true;
+                update.arg.visit_with(self);
+                self.in_lhs = prev_lhs;
+            } else {
+                update.arg.visit_with(self);
+            }
+        }
+    }
+
+    let mut collector = Collector {
+        reads: HashSet::new(),
+        in_lhs: false,
+        in_pat: false,
+    };
+    for stmt in stmts {
+        stmt.visit_with(&mut collector);
+    }
+    collector.reads
+}
+
+fn prune_dead_writes_with_known_reads(
+    stmts: &mut Vec<Stmt>,
+    reads: &HashSet<String>,
+    written: &HashSet<String>,
+) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Decl(Decl::Var(var_decl)) => {
+                rewrite_var_decl_dropping_dead_writes(var_decl, reads, written, &mut rewritten);
+            }
+            Stmt::Expr(expr_stmt) => match &mut *expr_stmt.expr {
+                Expr::Assign(assign) => {
+                    let Some(name) = assign_target_ident_name(&assign.left) else {
+                        rewritten.push(stmt);
+                        continue;
+                    };
+                    if reads.contains(&name) {
+                        rewritten.push(stmt);
+                        continue;
+                    }
+
+                    let rhs = assign.right.clone();
+                    if !expr_is_pure(&rhs) {
+                        rewritten.push(Stmt::Expr(swc_ecma_ast::ExprStmt {
+                            span: expr_stmt.span,
+                            expr: rhs,
+                        }));
+                    }
+                }
+                Expr::Update(update) => {
+                    let Expr::Ident(ident) = &*update.arg else {
+                        rewritten.push(stmt);
+                        continue;
+                    };
+                    if reads.contains(ident.sym.as_ref()) {
+                        rewritten.push(stmt);
+                    }
+                }
+                _ => rewritten.push(stmt),
+            },
+            Stmt::Block(block) => {
+                prune_dead_writes_with_known_reads(&mut block.stmts, reads, written);
+                rewritten.push(stmt);
+            }
+            Stmt::If(if_stmt) => {
+                prune_dead_writes_in_nested_stmt(&mut if_stmt.cons, reads, written);
+                if let Some(alt) = &mut if_stmt.alt {
+                    prune_dead_writes_in_nested_stmt(alt, reads, written);
+                }
+                rewritten.push(stmt);
+            }
+            Stmt::While(while_stmt) => {
+                prune_dead_writes_in_nested_stmt(&mut while_stmt.body, reads, written);
+                rewritten.push(stmt);
+            }
+            Stmt::DoWhile(do_while_stmt) => {
+                prune_dead_writes_in_nested_stmt(&mut do_while_stmt.body, reads, written);
+                rewritten.push(stmt);
+            }
+            Stmt::For(for_stmt) => {
+                prune_dead_writes_in_nested_stmt(&mut for_stmt.body, reads, written);
+                rewritten.push(stmt);
+            }
+            Stmt::ForIn(for_in_stmt) => {
+                prune_dead_writes_in_nested_stmt(&mut for_in_stmt.body, reads, written);
+                rewritten.push(stmt);
+            }
+            Stmt::ForOf(for_of_stmt) => {
+                prune_dead_writes_in_nested_stmt(&mut for_of_stmt.body, reads, written);
+                rewritten.push(stmt);
+            }
+            _ => rewritten.push(stmt),
+        }
+    }
+
+    *stmts = rewritten;
+}
+
+fn rewrite_var_decl_dropping_dead_writes(
+    var_decl: &mut Box<VarDecl>,
+    reads: &HashSet<String>,
+    written: &HashSet<String>,
+    out: &mut Vec<Stmt>,
+) {
+    let mut kept_decls = Vec::with_capacity(var_decl.decls.len());
+
+    for decl in &var_decl.decls {
+        let Some(name) = pat_ident_name(&decl.name) else {
+            kept_decls.push(decl.clone());
+            continue;
+        };
+
+        if reads.contains(&name) {
+            kept_decls.push(decl.clone());
+            continue;
+        }
+        if written.contains(&name) {
+            kept_decls.push(decl.clone());
+            continue;
+        }
+
+        if let Some(init) = &decl.init {
+            if expr_is_outlineable_hook_call(init) {
+                kept_decls.push(decl.clone());
+                continue;
+            }
+            if !expr_is_pure(init) {
+                out.push(Stmt::Expr(swc_ecma_ast::ExprStmt {
+                    span: decl.span,
+                    expr: init.clone(),
+                }));
+            }
+        }
+    }
+
+    if kept_decls.is_empty() {
+        return;
+    }
+
+    let mut kept = (**var_decl).clone();
+    kept.decls = kept_decls;
+    out.push(Stmt::Decl(Decl::Var(Box::new(kept))));
+}
+
+fn expr_is_outlineable_hook_call(expr: &Expr) -> bool {
+    let Expr::Call(call) = expr else {
+        return false;
+    };
+
+    let swc_ecma_ast::Callee::Expr(callee_expr) = &call.callee else {
+        return false;
+    };
+    match &**callee_expr {
+        Expr::Ident(callee) => matches!(callee.sym.as_ref(), "useCallback" | "useMemo"),
+        Expr::Member(member) => {
+            matches!(&*member.obj, Expr::Ident(object) if object.sym == "React")
+                && matches!(
+                    &member.prop,
+                    swc_ecma_ast::MemberProp::Ident(property)
+                        if matches!(property.sym.as_ref(), "useCallback" | "useMemo")
+                )
+        }
+        _ => false,
+    }
+}
+
+fn prune_dead_writes_in_nested_stmt(
+    stmt: &mut Box<Stmt>,
+    reads: &HashSet<String>,
+    written: &HashSet<String>,
+) {
+    match &mut **stmt {
+        Stmt::Block(block) => prune_dead_writes_with_known_reads(&mut block.stmts, reads, written),
+        Stmt::If(if_stmt) => {
+            prune_dead_writes_in_nested_stmt(&mut if_stmt.cons, reads, written);
+            if let Some(alt) = &mut if_stmt.alt {
+                prune_dead_writes_in_nested_stmt(alt, reads, written);
+            }
+        }
+        Stmt::While(while_stmt) => {
+            prune_dead_writes_in_nested_stmt(&mut while_stmt.body, reads, written)
+        }
+        Stmt::DoWhile(do_while_stmt) => {
+            prune_dead_writes_in_nested_stmt(&mut do_while_stmt.body, reads, written)
+        }
+        Stmt::For(for_stmt) => prune_dead_writes_in_nested_stmt(&mut for_stmt.body, reads, written),
+        Stmt::ForIn(for_in_stmt) => {
+            prune_dead_writes_in_nested_stmt(&mut for_in_stmt.body, reads, written)
+        }
+        Stmt::ForOf(for_of_stmt) => {
+            prune_dead_writes_in_nested_stmt(&mut for_of_stmt.body, reads, written)
+        }
+        _ => {}
+    }
+}
+
+fn collect_assigned_bindings_in_stmts(stmts: &[Stmt]) -> HashSet<String> {
+    let mut assigned = HashSet::new();
+    for stmt in stmts {
+        collect_assigned_bindings(stmt, &mut assigned);
+    }
+    assigned
+}
+
+fn ensure_uninitialized_declarations_for_assigned_reads(
+    stmts: &mut Vec<Stmt>,
+    reads: &HashSet<String>,
+    originally_declared: &HashSet<String>,
+) {
+    let mut declared = HashSet::new();
+    let mut assigned = HashSet::new();
+
+    for stmt in stmts.iter() {
+        collect_declared_bindings(stmt, &mut declared);
+        collect_assigned_bindings(stmt, &mut assigned);
+    }
+
+    let mut missing = assigned
+        .into_iter()
+        .filter(|name| {
+            reads.contains(name) && !declared.contains(name) && originally_declared.contains(name)
+        })
+        .collect::<Vec<_>>();
+    if missing.is_empty() {
+        return;
+    }
+    missing.sort();
+
+    let mut decls = missing
+        .into_iter()
+        .map(|name| swc_ecma_ast::VarDeclarator {
+            span: swc_common::DUMMY_SP,
+            name: Pat::Ident(swc_ecma_ast::BindingIdent {
+                id: swc_ecma_ast::Ident::new_no_ctxt(name.into(), swc_common::DUMMY_SP),
+                type_ann: None,
+            }),
+            init: None,
+            definite: false,
+        })
+        .collect::<Vec<_>>();
+    if decls.is_empty() {
+        return;
+    }
+
+    let insert_index = stmts
+        .iter()
+        .take_while(|stmt| matches!(stmt, Stmt::Expr(expr_stmt) if matches!(&*expr_stmt.expr, Expr::Lit(Lit::Str(_)))))
+        .count();
+    stmts.insert(
+        insert_index,
+        Stmt::Decl(Decl::Var(Box::new(VarDecl {
+            span: swc_common::DUMMY_SP,
+            ctxt: Default::default(),
+            kind: VarDeclKind::Let,
+            declare: false,
+            decls: std::mem::take(&mut decls),
+        }))),
+    );
+}
+
+fn collect_declared_bindings_in_stmts(stmts: &[Stmt]) -> HashSet<String> {
+    let mut declared = HashSet::new();
+    for stmt in stmts {
+        collect_declared_bindings(stmt, &mut declared);
+    }
+    declared
+}
+
+fn collect_declared_bindings(stmt: &Stmt, out: &mut HashSet<String>) {
+    struct Collector<'a> {
+        out: &'a mut HashSet<String>,
+    }
+
+    impl Visit for Collector<'_> {
+        fn visit_var_declarator(&mut self, decl: &swc_ecma_ast::VarDeclarator) {
+            if let Some(name) = pat_ident_name(&decl.name) {
+                self.out.insert(name);
+            }
+            decl.visit_children_with(self);
+        }
+
+        fn visit_fn_decl(&mut self, decl: &swc_ecma_ast::FnDecl) {
+            self.out.insert(decl.ident.sym.to_string());
+            decl.visit_children_with(self);
+        }
+
+        fn visit_class_decl(&mut self, decl: &swc_ecma_ast::ClassDecl) {
+            self.out.insert(decl.ident.sym.to_string());
+            decl.visit_children_with(self);
+        }
+    }
+
+    stmt.visit_with(&mut Collector { out });
+}
+
+fn collect_assigned_bindings(stmt: &Stmt, out: &mut HashSet<String>) {
+    struct Collector<'a> {
+        out: &'a mut HashSet<String>,
+    }
+
+    impl Visit for Collector<'_> {
+        fn visit_assign_expr(&mut self, assign: &AssignExpr) {
+            if let Some(name) = assign_target_ident_name(&assign.left) {
+                self.out.insert(name);
+            }
+            assign.visit_children_with(self);
+        }
+
+        fn visit_update_expr(&mut self, update: &swc_ecma_ast::UpdateExpr) {
+            if let Expr::Ident(ident) = &*update.arg {
+                self.out.insert(ident.sym.to_string());
+            }
+            update.visit_children_with(self);
+        }
+    }
+
+    stmt.visit_with(&mut Collector { out });
 }

--- a/crates/swc_ecma_react_compiler/src/reactive_scopes/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/reactive_scopes/mod.rs
@@ -4,8 +4,8 @@ use swc_common::DUMMY_SP;
 use swc_ecma_ast::{
     op, ArrowExpr, AssignExpr, AssignTarget, BindingIdent, BlockStmt, CallExpr, Callee,
     ComputedPropName, Decl, Expr, ExprOrSpread, ExprStmt, Function, Ident, IfStmt, KeyValueProp,
-    LabeledStmt, Lit, MemberExpr, MemberProp, Number, ObjectPatProp, OptChainBase, OptChainExpr, Pat, Prop,
-    PropName, PropOrSpread, Stmt, SwitchStmt, VarDecl, VarDeclKind, VarDeclarator,
+    LabeledStmt, Lit, MemberExpr, MemberProp, Number, ObjectPatProp, OptChainBase, OptChainExpr,
+    Pat, Prop, PropName, PropOrSpread, Stmt, SwitchStmt, VarDecl, VarDeclKind, VarDeclarator,
 };
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
 
@@ -2104,7 +2104,10 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
             break;
         }
         if is_default_param_conditional_expr(init.as_ref())
-            && binding_only_used_in_terminal_return(&stmts[prefix_index + 1..], binding.sym.as_ref())
+            && binding_only_used_in_terminal_return(
+                &stmts[prefix_index + 1..],
+                binding.sym.as_ref(),
+            )
             && !default_param_conditional_allocates_identity(init.as_ref())
         {
             break;
@@ -2461,11 +2464,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
         };
         let use_binding_as_temp = force_memoize_reassigned_jsx_tag_ident_init
             || (!reassigned_after
-                && next_stmt_destructures_from_binding(
-                    &stmts,
-                    prefix_index,
-                    binding.sym.as_ref(),
-                ));
+                && next_stmt_destructures_from_binding(&stmts, prefix_index, binding.sym.as_ref()));
         let temp = if use_binding_as_temp {
             binding.clone()
         } else {
@@ -2929,10 +2928,9 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                         && prelude_blocks == 0
                         && !prelude_contains_if_with_else(&prelude_stmts)
                     {
-                        if let Some(prelude_result_binding) = infer_prelude_result_binding(
-                            &prelude_stmts,
-                            &compute_stmts,
-                        ) {
+                        if let Some(prelude_result_binding) =
+                            infer_prelude_result_binding(&prelude_stmts, &compute_stmts)
+                        {
                             let mut prelude_local_bindings = HashSet::new();
                             for stmt in &prelude_stmts {
                                 collect_stmt_bindings_including_nested_blocks(
@@ -3659,11 +3657,7 @@ fn body_contains_destructuring_default_alloc_literal(body: &BlockStmt) -> bool {
             Pat::Assign(assign_pat) => {
                 is_static_alloc_literal_expr(&assign_pat.right) || pat_has_default(&assign_pat.left)
             }
-            Pat::Array(array_pat) => array_pat
-                .elems
-                .iter()
-                .flatten()
-                .any(pat_has_default),
+            Pat::Array(array_pat) => array_pat.elems.iter().flatten().any(pat_has_default),
             Pat::Object(object_pat) => object_pat.props.iter().any(|prop| match prop {
                 ObjectPatProp::Assign(assign_prop) => assign_prop
                     .value
@@ -3679,9 +3673,10 @@ fn body_contains_destructuring_default_alloc_literal(body: &BlockStmt) -> bool {
 
     fn stmt_has_default(stmt: &Stmt) -> bool {
         match stmt {
-            Stmt::Decl(Decl::Var(var_decl)) => {
-                var_decl.decls.iter().any(|decl| pat_has_default(&decl.name))
-            }
+            Stmt::Decl(Decl::Var(var_decl)) => var_decl
+                .decls
+                .iter()
+                .any(|decl| pat_has_default(&decl.name)),
             Stmt::Block(block) => block.stmts.iter().any(stmt_has_default),
             Stmt::Labeled(labeled) => stmt_has_default(&labeled.body),
             Stmt::If(if_stmt) => {
@@ -3705,22 +3700,29 @@ fn body_contains_destructuring_default_alloc_literal(body: &BlockStmt) -> bool {
             }
             Stmt::For(for_stmt) => {
                 for_stmt.init.as_ref().is_some_and(|init| match init {
-                    swc_ecma_ast::VarDeclOrExpr::VarDecl(var_decl) => {
-                        var_decl.decls.iter().any(|decl| pat_has_default(&decl.name))
-                    }
+                    swc_ecma_ast::VarDeclOrExpr::VarDecl(var_decl) => var_decl
+                        .decls
+                        .iter()
+                        .any(|decl| pat_has_default(&decl.name)),
                     swc_ecma_ast::VarDeclOrExpr::Expr(_) => false,
                 }) || stmt_has_default(&for_stmt.body)
             }
             Stmt::ForIn(for_in_stmt) => match &for_in_stmt.left {
                 swc_ecma_ast::ForHead::VarDecl(var_decl) => {
-                    var_decl.decls.iter().any(|decl| pat_has_default(&decl.name))
+                    var_decl
+                        .decls
+                        .iter()
+                        .any(|decl| pat_has_default(&decl.name))
                         || stmt_has_default(&for_in_stmt.body)
                 }
                 _ => stmt_has_default(&for_in_stmt.body),
             },
             Stmt::ForOf(for_of_stmt) => match &for_of_stmt.left {
                 swc_ecma_ast::ForHead::VarDecl(var_decl) => {
-                    var_decl.decls.iter().any(|decl| pat_has_default(&decl.name))
+                    var_decl
+                        .decls
+                        .iter()
+                        .any(|decl| pat_has_default(&decl.name))
                         || stmt_has_default(&for_of_stmt.body)
                 }
                 _ => stmt_has_default(&for_of_stmt.body),
@@ -5364,7 +5366,9 @@ fn prune_trivial_do_while_break_stmts(stmts: &mut Vec<Stmt>) {
         matches!(stmt, Stmt::Break(break_stmt) if break_stmt.label.is_none())
     }
 
-    fn extract_unconditional_do_while_prefix(do_while_stmt: &swc_ecma_ast::DoWhileStmt) -> Option<Vec<Stmt>> {
+    fn extract_unconditional_do_while_prefix(
+        do_while_stmt: &swc_ecma_ast::DoWhileStmt,
+    ) -> Option<Vec<Stmt>> {
         let Stmt::Block(block) = &*do_while_stmt.body else {
             return stmt_is_unlabeled_break(&do_while_stmt.body).then(Vec::new);
         };
@@ -5375,15 +5379,14 @@ fn prune_trivial_do_while_break_stmts(stmts: &mut Vec<Stmt>) {
             .enumerate()
             .filter_map(|(idx, stmt)| (!matches!(stmt, Stmt::Empty(_))).then_some(idx))
             .collect::<Vec<_>>();
-        let Some(&last_non_empty_idx) = non_empty_indices.last() else {
-            return None;
-        };
+        let &last_non_empty_idx = non_empty_indices.last()?;
         if !stmt_is_unlabeled_break(&block.stmts[last_non_empty_idx]) {
             return None;
         }
 
-        // Keep this rewrite conservative: if the do-body has other top-level break/continue
-        // control flow, we skip lowering because it may alter loop semantics.
+        // Keep this rewrite conservative: if the do-body has other top-level
+        // break/continue control flow, we skip lowering because it may alter
+        // loop semantics.
         for &idx in &non_empty_indices[..non_empty_indices.len().saturating_sub(1)] {
             if matches!(block.stmts[idx], Stmt::Break(_) | Stmt::Continue(_)) {
                 return None;
@@ -5457,7 +5460,7 @@ fn prune_trivial_do_while_break_stmts(stmts: &mut Vec<Stmt>) {
     *stmts = pruned;
 }
 
-fn prune_overwritten_branch_and_switch_assignments_in_stmts(stmts: &mut Vec<Stmt>) {
+fn prune_overwritten_branch_and_switch_assignments_in_stmts(stmts: &mut [Stmt]) {
     fn single_non_empty_stmt(stmts: &[Stmt]) -> Option<&Stmt> {
         let mut non_empty = stmts.iter().filter(|stmt| !matches!(stmt, Stmt::Empty(_)));
         let first = non_empty.next()?;
@@ -5580,9 +5583,9 @@ fn prune_overwritten_branch_and_switch_assignments_in_stmts(stmts: &mut Vec<Stmt
 
     fn recurse_stmt(stmt: &mut Stmt) {
         match stmt {
-            Stmt::Block(block) => prune_overwritten_branch_and_switch_assignments_in_stmts(
-                &mut block.stmts,
-            ),
+            Stmt::Block(block) => {
+                prune_overwritten_branch_and_switch_assignments_in_stmts(&mut block.stmts)
+            }
             Stmt::Labeled(labeled) => recurse_stmt(&mut labeled.body),
             Stmt::If(if_stmt) => {
                 recurse_stmt(&mut if_stmt.cons);
@@ -5602,9 +5605,7 @@ fn prune_overwritten_branch_and_switch_assignments_in_stmts(stmts: &mut Vec<Stmt
             Stmt::ForIn(for_in_stmt) => recurse_stmt(&mut for_in_stmt.body),
             Stmt::ForOf(for_of_stmt) => recurse_stmt(&mut for_of_stmt.body),
             Stmt::Try(try_stmt) => {
-                prune_overwritten_branch_and_switch_assignments_in_stmts(
-                    &mut try_stmt.block.stmts,
-                );
+                prune_overwritten_branch_and_switch_assignments_in_stmts(&mut try_stmt.block.stmts);
                 if let Some(handler) = &mut try_stmt.handler {
                     prune_overwritten_branch_and_switch_assignments_in_stmts(
                         &mut handler.body.stmts,
@@ -5861,13 +5862,17 @@ fn pattern_contains_nested_destructuring(pat: &Pat) -> bool {
 fn pattern_is_flat_reassignment(pat: &Pat) -> bool {
     match pat {
         Pat::Ident(_) => true,
-        Pat::Array(array_pat) => array_pat.elems.iter().flatten().all(|element| match element {
-            Pat::Ident(_) => true,
-            Pat::Expr(expr) => matches!(unwrap_transparent_expr(expr), Expr::Ident(_)),
-            Pat::Assign(assign_pat) => matches!(*assign_pat.left, Pat::Ident(_)),
-            Pat::Rest(rest_pat) => matches!(*rest_pat.arg, Pat::Ident(_)),
-            _ => false,
-        }),
+        Pat::Array(array_pat) => array_pat
+            .elems
+            .iter()
+            .flatten()
+            .all(|element| match element {
+                Pat::Ident(_) => true,
+                Pat::Expr(expr) => matches!(unwrap_transparent_expr(expr), Expr::Ident(_)),
+                Pat::Assign(assign_pat) => matches!(*assign_pat.left, Pat::Ident(_)),
+                Pat::Rest(rest_pat) => matches!(*rest_pat.arg, Pat::Ident(_)),
+                _ => false,
+            }),
         Pat::Object(object_pat) => object_pat.props.iter().all(|prop| match prop {
             ObjectPatProp::Assign(_) => true,
             ObjectPatProp::KeyValue(key_value) => match &*key_value.value {
@@ -5894,10 +5899,7 @@ fn lower_nested_destructuring_pattern_from_source(
     if pattern_is_flat_reassignment(&pat) {
         match pat {
             Pat::Ident(binding) => {
-                out.push(assign_stmt(
-                    AssignTarget::from(binding.id),
-                    source_expr,
-                ));
+                out.push(assign_stmt(AssignTarget::from(binding.id), source_expr));
             }
             Pat::Expr(expr) => {
                 let Expr::Ident(binding) = unwrap_transparent_expr(&expr) else {
@@ -6068,7 +6070,7 @@ fn lower_nested_destructuring_pattern_from_source(
                         let key = key_value.key.clone();
                         let original_value = *key_value.value;
                         temp_props.push(ObjectPatProp::KeyValue(swc_ecma_ast::KeyValuePatProp {
-                            key: key,
+                            key,
                             value: Box::new(Pat::Ident(BindingIdent {
                                 id: temp.clone(),
                                 type_ann: None,
@@ -6165,10 +6167,7 @@ fn lower_nested_destructuring_pattern_from_source(
             }
         }
         Pat::Ident(binding) => {
-            out.push(assign_stmt(
-                AssignTarget::from(binding.id),
-                source_expr,
-            ));
+            out.push(assign_stmt(AssignTarget::from(binding.id), source_expr));
         }
         Pat::Expr(_) | Pat::Invalid(_) => {}
     }
@@ -6424,7 +6423,11 @@ fn flatten_destructuring_decl_to_temp_chain(
                 let (rewritten_pat, nested) =
                     flatten_array_pattern_one_level(array_pat, reserved, next_temp);
                 changed |= !nested.is_empty();
-                rewritten.push(make_var_decl(kind, Pat::Array(rewritten_pat), Some(init_expr)));
+                rewritten.push(make_var_decl(
+                    kind,
+                    Pat::Array(rewritten_pat),
+                    Some(init_expr),
+                ));
                 for (nested_pat, temp) in nested {
                     queue.push_back((nested_pat, Box::new(Expr::Ident(temp))));
                 }
@@ -6433,7 +6436,11 @@ fn flatten_destructuring_decl_to_temp_chain(
                 let (rewritten_pat, nested) =
                     flatten_object_pattern_one_level(object_pat, reserved, next_temp);
                 changed |= !nested.is_empty();
-                rewritten.push(make_var_decl(kind, Pat::Object(rewritten_pat), Some(init_expr)));
+                rewritten.push(make_var_decl(
+                    kind,
+                    Pat::Object(rewritten_pat),
+                    Some(init_expr),
+                ));
                 for (nested_pat, temp) in nested {
                     queue.push_back((nested_pat, Box::new(Expr::Ident(temp))));
                 }
@@ -6580,7 +6587,9 @@ fn rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(stmts: &m
     for mut stmt in original {
         match &mut stmt {
             Stmt::Block(block) => {
-                rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(&mut block.stmts);
+                rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(
+                    &mut block.stmts,
+                );
             }
             Stmt::Labeled(labeled) => {
                 if let Stmt::Block(block) = &mut *labeled.body {
@@ -6825,10 +6834,7 @@ fn rewrite_const_object_pattern_default_decls_to_temp_chain(
                                     DUMMY_SP,
                                 ))),
                             })),
-                            cons: assign_prop
-                                .value
-                                .clone()
-                                .expect("guarded by is_some"),
+                            cons: assign_prop.value.clone().expect("guarded by is_some"),
                             alt: Box::new(Expr::Ident(temp)),
                         }))),
                     ));
@@ -7040,97 +7046,91 @@ fn rewrite_let_array_pattern_decls_to_assignment_stmts(
         }
 
         match (var_decl.kind, non_hole_pats[0]) {
-            (VarDeclKind::Const, Pat::Assign(assign_pat)) => {
-                match &*assign_pat.left {
-                    Pat::Ident(binding) => {
-                        let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
-                        rewritten.push(make_var_decl(
-                            VarDeclKind::Const,
-                            Pat::Array(swc_ecma_ast::ArrayPat {
-                                span: array_pat.span,
-                                elems: vec![Some(Pat::Ident(BindingIdent {
-                                    id: temp.clone(),
-                                    type_ann: None,
-                                }))],
-                                optional: false,
+            (VarDeclKind::Const, Pat::Assign(assign_pat)) => match &*assign_pat.left {
+                Pat::Ident(binding) => {
+                    let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+                    rewritten.push(make_var_decl(
+                        VarDeclKind::Const,
+                        Pat::Array(swc_ecma_ast::ArrayPat {
+                            span: array_pat.span,
+                            elems: vec![Some(Pat::Ident(BindingIdent {
+                                id: temp.clone(),
                                 type_ann: None,
-                            }),
-                            Some(init.clone()),
-                        ));
-                        rewritten.push(make_var_decl(
-                            VarDeclKind::Const,
-                            Pat::Ident(BindingIdent {
-                                id: binding.id.clone(),
-                                type_ann: None,
-                            }),
-                            Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                            }))],
+                            optional: false,
+                            type_ann: None,
+                        }),
+                        Some(init.clone()),
+                    ));
+                    rewritten.push(make_var_decl(
+                        VarDeclKind::Const,
+                        Pat::Ident(BindingIdent {
+                            id: binding.id.clone(),
+                            type_ann: None,
+                        }),
+                        Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                            span: DUMMY_SP,
+                            test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
                                 span: DUMMY_SP,
-                                test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
-                                    span: DUMMY_SP,
-                                    op: op!("==="),
-                                    left: Box::new(Expr::Ident(temp.clone())),
-                                    right: Box::new(Expr::Ident(Ident::new_no_ctxt(
-                                        "undefined".into(),
-                                        DUMMY_SP,
-                                    ))),
-                                })),
-                                cons: parenthesize_conditional_expr(
-                                    assign_pat.right.clone(),
-                                ),
-                                alt: Box::new(Expr::Ident(temp)),
-                            }))),
-                        ));
-                    }
-                    Pat::Array(_) | Pat::Object(_) => {
-                        let input_temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
-                        let value_temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
-                        rewritten.push(make_var_decl(
-                            VarDeclKind::Const,
-                            Pat::Array(swc_ecma_ast::ArrayPat {
-                                span: array_pat.span,
-                                elems: vec![Some(Pat::Ident(BindingIdent {
-                                    id: input_temp.clone(),
-                                    type_ann: None,
-                                }))],
-                                optional: false,
-                                type_ann: None,
-                            }),
-                            Some(init.clone()),
-                        ));
-                        rewritten.push(make_var_decl(
-                            VarDeclKind::Let,
-                            Pat::Ident(BindingIdent {
-                                id: value_temp.clone(),
-                                type_ann: None,
-                            }),
-                            Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
-                                span: DUMMY_SP,
-                                test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
-                                    span: DUMMY_SP,
-                                    op: op!("==="),
-                                    left: Box::new(Expr::Ident(input_temp.clone())),
-                                    right: Box::new(Expr::Ident(Ident::new_no_ctxt(
-                                        "undefined".into(),
-                                        DUMMY_SP,
-                                    ))),
-                                })),
-                                cons: parenthesize_conditional_expr(
-                                    assign_pat.right.clone(),
-                                ),
-                                alt: Box::new(Expr::Ident(input_temp)),
-                            }))),
-                        ));
-                        rewritten.push(make_var_decl(
-                            VarDeclKind::Const,
-                            (*assign_pat.left).clone(),
-                            Some(Box::new(Expr::Ident(value_temp))),
-                        ));
-                    }
-                    _ => {
-                        rewritten.push(stmt);
-                    }
+                                op: op!("==="),
+                                left: Box::new(Expr::Ident(temp.clone())),
+                                right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                    "undefined".into(),
+                                    DUMMY_SP,
+                                ))),
+                            })),
+                            cons: parenthesize_conditional_expr(assign_pat.right.clone()),
+                            alt: Box::new(Expr::Ident(temp)),
+                        }))),
+                    ));
                 }
-            }
+                Pat::Array(_) | Pat::Object(_) => {
+                    let input_temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+                    let value_temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+                    rewritten.push(make_var_decl(
+                        VarDeclKind::Const,
+                        Pat::Array(swc_ecma_ast::ArrayPat {
+                            span: array_pat.span,
+                            elems: vec![Some(Pat::Ident(BindingIdent {
+                                id: input_temp.clone(),
+                                type_ann: None,
+                            }))],
+                            optional: false,
+                            type_ann: None,
+                        }),
+                        Some(init.clone()),
+                    ));
+                    rewritten.push(make_var_decl(
+                        VarDeclKind::Let,
+                        Pat::Ident(BindingIdent {
+                            id: value_temp.clone(),
+                            type_ann: None,
+                        }),
+                        Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                            span: DUMMY_SP,
+                            test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                                span: DUMMY_SP,
+                                op: op!("==="),
+                                left: Box::new(Expr::Ident(input_temp.clone())),
+                                right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                    "undefined".into(),
+                                    DUMMY_SP,
+                                ))),
+                            })),
+                            cons: parenthesize_conditional_expr(assign_pat.right.clone()),
+                            alt: Box::new(Expr::Ident(input_temp)),
+                        }))),
+                    ));
+                    rewritten.push(make_var_decl(
+                        VarDeclKind::Const,
+                        (*assign_pat.left).clone(),
+                        Some(Box::new(Expr::Ident(value_temp))),
+                    ));
+                }
+                _ => {
+                    rewritten.push(stmt);
+                }
+            },
             (VarDeclKind::Let, Pat::Ident(binding)) => {
                 let Ok(target) = AssignTarget::try_from(pat.clone()) else {
                     rewritten.push(stmt);
@@ -7184,11 +7184,13 @@ fn rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
 
     for mut stmt in original {
         match &mut stmt {
-            Stmt::Block(block) => rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
-                &mut block.stmts,
-                reserved,
-                next_temp,
-            ),
+            Stmt::Block(block) => {
+                rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+                    &mut block.stmts,
+                    reserved,
+                    next_temp,
+                )
+            }
             Stmt::Labeled(labeled) => {
                 if let Stmt::Block(block) = &mut *labeled.body {
                     rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
@@ -7402,13 +7404,15 @@ fn normalize_array_pattern_assignments_in_stmts(
                     ObjectPatProp::Assign(assign_prop) if assign_prop.value.is_none() => {
                         let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
                         original_binding = Some(assign_prop.key.id.clone());
-                        rewritten_props.push(ObjectPatProp::KeyValue(swc_ecma_ast::KeyValuePatProp {
-                            key: PropName::Ident(assign_prop.key.id.clone().into()),
-                            value: Box::new(Pat::Ident(BindingIdent {
-                                id: temp.clone(),
-                                type_ann: None,
-                            })),
-                        }));
+                        rewritten_props.push(ObjectPatProp::KeyValue(
+                            swc_ecma_ast::KeyValuePatProp {
+                                key: PropName::Ident(assign_prop.key.id.clone().into()),
+                                value: Box::new(Pat::Ident(BindingIdent {
+                                    id: temp.clone(),
+                                    type_ann: None,
+                                })),
+                            },
+                        ));
                     }
                     ObjectPatProp::KeyValue(key_value)
                         if matches!(*key_value.value, Pat::Ident(_)) =>
@@ -7425,13 +7429,15 @@ fn normalize_array_pattern_assignments_in_stmts(
                         }
                         let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
                         original_binding = Some(binding.id.clone());
-                        rewritten_props.push(ObjectPatProp::KeyValue(swc_ecma_ast::KeyValuePatProp {
-                            key: key_value.key,
-                            value: Box::new(Pat::Ident(BindingIdent {
-                                id: temp.clone(),
-                                type_ann: None,
-                            })),
-                        }));
+                        rewritten_props.push(ObjectPatProp::KeyValue(
+                            swc_ecma_ast::KeyValuePatProp {
+                                key: key_value.key,
+                                value: Box::new(Pat::Ident(BindingIdent {
+                                    id: temp.clone(),
+                                    type_ann: None,
+                                })),
+                            },
+                        ));
                     }
                     _ => {
                         can_rewrite = false;
@@ -8487,7 +8493,9 @@ fn collect_member_object_dependencies_from_expr(
         }
 
         fn visit_member_expr(&mut self, member: &MemberExpr) {
-            if let Some(dep) = member_object_dependency(member, self.known_bindings, self.local_bindings) {
+            if let Some(dep) =
+                member_object_dependency(member, self.known_bindings, self.local_bindings)
+            {
                 maybe_push_dependency(&mut self.deps, &mut self.seen, dep);
             }
 
@@ -8627,16 +8635,18 @@ fn rewrite_top_level_rest_pattern_assignments_in_prelude_to_memo_blocks(
                         let pat = Pat::from(assign_pat.clone());
                         if pattern_has_top_level_rest(&pat) {
                             let mut cache_binding_names =
-                                collect_assigned_bindings_in_order_from_stmts(std::slice::from_ref(
-                                    stmt,
-                                ));
+                                collect_assigned_bindings_in_order_from_stmts(
+                                    std::slice::from_ref(stmt),
+                                );
                             if !cache_binding_names.is_empty() {
                                 cache_binding_names =
                                     reorder_cache_binding_names_for_pattern_assignment(
                                         cache_binding_names,
                                     );
-                                cache_binding_names =
-                                    reorder_array_rest_temp_binding_first(cache_binding_names, &pat);
+                                cache_binding_names = reorder_array_rest_temp_binding_first(
+                                    cache_binding_names,
+                                    &pat,
+                                );
                                 if cache_binding_names.len() >= 2 {
                                     let mut dep_local_bindings = local_bindings.clone();
                                     for binding in &cache_binding_names {
@@ -8817,9 +8827,10 @@ fn try_build_pattern_assignment_prelude_memo_fallback(
             }
 
             let used_in_compute = binding_referenced_in_stmts(compute_stmts, name.as_str());
-            let keep_outer_init = decl.init.as_ref().is_some_and(|init| {
-                used_in_compute && !is_static_alloc_literal_expr(init)
-            });
+            let keep_outer_init = decl
+                .init
+                .as_ref()
+                .is_some_and(|init| used_in_compute && !is_static_alloc_literal_expr(init));
             let outer_init = if keep_outer_init {
                 decl.init.clone()
             } else {
@@ -8861,7 +8872,8 @@ fn try_build_pattern_assignment_prelude_memo_fallback(
 
     let mut prelude_deps =
         collect_dependencies_from_stmts(&prelude_compute, known_bindings, &local_bindings);
-    for dep in collect_called_local_function_capture_dependencies(&prelude_compute, known_bindings) {
+    for dep in collect_called_local_function_capture_dependencies(&prelude_compute, known_bindings)
+    {
         if !prelude_deps.iter().any(|existing| existing.key == dep.key) {
             prelude_deps.push(dep);
         }
@@ -9338,8 +9350,10 @@ fn lower_object_pattern_default_decl_with_memoization(
             .is_some_and(|default_expr| is_static_alloc_literal_expr(default_expr))
         {
             let value_temp = fresh_temp_ident(next_temp, reserved);
-            let mut nested_compute =
-                vec![assign_stmt(AssignTarget::from(value_temp.clone()), assign_expr)];
+            let mut nested_compute = vec![assign_stmt(
+                AssignTarget::from(value_temp.clone()),
+                assign_expr,
+            )];
             strip_runtime_call_type_args_in_stmts(&mut nested_compute);
 
             let nested_deps = vec![ReactiveDependency {
@@ -9458,7 +9472,10 @@ fn inject_nested_call_memoization_into_stmts(
                 mark_stmt_bindings_unstable(&stmt, &mut nested_known_bindings);
                 continue;
             };
-            if matches!(unwrap_transparent_expr(init_expr), Expr::Arrow(_) | Expr::Fn(_)) {
+            if matches!(
+                unwrap_transparent_expr(init_expr),
+                Expr::Arrow(_) | Expr::Fn(_)
+            ) {
                 let nested_deps =
                     collect_function_capture_dependencies(init_expr, &nested_known_bindings);
                 let has_length_dep = nested_deps.iter().any(|dep| dep.key.ends_with(".length"));
@@ -12910,22 +12927,20 @@ fn prelude_contains_control_flow_stmt(stmts: &[Stmt]) -> bool {
         matches!(
             stmt,
             Stmt::If(if_stmt) if if_stmt.alt.is_none()
-        ) || matches!(
-            stmt,
-                | Stmt::Switch(_)
-                | Stmt::Try(_)
-                | Stmt::For(_)
-                | Stmt::ForIn(_)
-                | Stmt::ForOf(_)
-                | Stmt::While(_)
-                | Stmt::DoWhile(_)
-                | Stmt::Labeled(_)
-        )
+        ) || matches!(stmt, |Stmt::Switch(_)| Stmt::Try(_)
+            | Stmt::For(_)
+            | Stmt::ForIn(_)
+            | Stmt::ForOf(_)
+            | Stmt::While(_)
+            | Stmt::DoWhile(_)
+            | Stmt::Labeled(_))
     })
 }
 
 fn prelude_contains_if_with_else(stmts: &[Stmt]) -> bool {
-    stmts.iter().any(|stmt| matches!(stmt, Stmt::If(if_stmt) if if_stmt.alt.is_some()))
+    stmts
+        .iter()
+        .any(|stmt| matches!(stmt, Stmt::If(if_stmt) if if_stmt.alt.is_some()))
 }
 
 fn split_direct_call_prelude_from_compute_stmts(
@@ -12956,11 +12971,15 @@ fn split_direct_call_prelude_from_compute_stmts(
         temp_name,
         &prelude_bindings,
     );
-    let has_local_member_mutation_prelude =
-        contains_mutating_member_call_on_local_binding(&compute_stmts[..split_index], &prelude_bindings);
+    let has_local_member_mutation_prelude = contains_mutating_member_call_on_local_binding(
+        &compute_stmts[..split_index],
+        &prelude_bindings,
+    );
     let has_local_direct_call_prelude = contains_local_direct_call(&compute_stmts[..split_index]);
-    let has_local_conditional_test_prelude =
-        prelude_has_conditional_test_on_local_binding(&compute_stmts[..split_index], &prelude_bindings);
+    let has_local_conditional_test_prelude = prelude_has_conditional_test_on_local_binding(
+        &compute_stmts[..split_index],
+        &prelude_bindings,
+    );
     if has_local_member_mutation_prelude && has_local_conditional_test_prelude {
         return Vec::new();
     }
@@ -13089,7 +13108,10 @@ fn build_memoized_block_multi_values(
     let value_slot_start = slot_start + deps.len() as u32;
     for (index, binding) in value_bindings.iter().enumerate() {
         compute_stmts.push(assign_stmt(
-            AssignTarget::from(make_cache_member(cache_ident, value_slot_start + index as u32)),
+            AssignTarget::from(make_cache_member(
+                cache_ident,
+                value_slot_start + index as u32,
+            )),
             Box::new(Expr::Ident(binding.clone())),
         ));
     }
@@ -13520,9 +13542,11 @@ fn stmt_is_trailing_post_compute_side_effect(stmt: &Stmt, result_name: &str) -> 
         ),
         Stmt::If(if_stmt) => {
             stmt_is_trailing_post_compute_side_effect(&if_stmt.cons, result_name)
-                && if_stmt.alt.as_deref().is_none_or(|alt| {
-                    stmt_is_trailing_post_compute_side_effect(alt, result_name)
-                })
+                && if_stmt
+                    .alt
+                    .as_deref()
+                    .map(|alt| stmt_is_trailing_post_compute_side_effect(alt, result_name))
+                    .unwrap_or(true)
         }
         Stmt::Block(block) => {
             !block.stmts.is_empty()
@@ -17714,14 +17738,11 @@ fn extract_iife_return_expr(expr: &Expr) -> Option<Box<Expr>> {
             Stmt::Decl(Decl::Var(var_decl))
                 if matches!(var_decl.kind, VarDeclKind::Const | VarDeclKind::Let) =>
             {
-                var_decl
-                    .decls
-                    .iter()
-                    .all(|decl| {
-                        decl.init
-                            .as_ref()
-                            .map_or(true, |init| !expr_has_observable_side_effect(init))
-                    })
+                var_decl.decls.iter().all(|decl| {
+                    decl.init
+                        .as_ref()
+                        .map_or(true, |init| !expr_has_observable_side_effect(init))
+                })
             }
             Stmt::Empty(_) => true,
             _ => false,
@@ -17747,7 +17768,10 @@ fn extract_iife_return_expr(expr: &Expr) -> Option<Box<Expr>> {
             return true;
         }
 
-        if matches!(unwrap_transparent_expr(ret_expr), Expr::Arrow(_) | Expr::Fn(_)) {
+        if matches!(
+            unwrap_transparent_expr(ret_expr),
+            Expr::Arrow(_) | Expr::Fn(_)
+        ) {
             !function_expr_may_capture_outer_bindings(ret_expr, &prelude_bindings)
         } else {
             !expr_references_bindings(ret_expr, &prelude_bindings)
@@ -18269,10 +18293,12 @@ fn should_skip_result_tail_pattern_assignment_outer_memoization(
         return false;
     };
 
-    let consequent_assigns = contains_direct_assignment_to_binding(
-        std::slice::from_ref(if_stmt.cons.as_ref()),
-        name,
-    ) || contains_pattern_assignment_to_binding(std::slice::from_ref(if_stmt.cons.as_ref()), name);
+    let consequent_assigns =
+        contains_direct_assignment_to_binding(std::slice::from_ref(if_stmt.cons.as_ref()), name)
+            || contains_pattern_assignment_to_binding(
+                std::slice::from_ref(if_stmt.cons.as_ref()),
+                name,
+            );
     let alternate_assigns = contains_direct_assignment_to_binding(std::slice::from_ref(alt), name)
         || contains_pattern_assignment_to_binding(std::slice::from_ref(alt), name);
 

--- a/crates/swc_ecma_react_compiler/src/reactive_scopes/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/reactive_scopes/mod.rs
@@ -516,6 +516,47 @@ fn outline_non_capturing_inline_functions_in_stmt(
                 self.outlined,
             );
         }
+
+        fn visit_mut_assign_pat(&mut self, assign_pat: &mut swc_ecma_ast::AssignPat) {
+            assign_pat.visit_mut_children_with(self);
+            try_outline_non_capturing_function_expr(
+                &mut assign_pat.right,
+                self.outer_bindings,
+                self.used_names,
+                self.outlined,
+            );
+        }
+
+        fn visit_mut_array_lit(&mut self, array: &mut swc_ecma_ast::ArrayLit) {
+            array.visit_mut_children_with(self);
+            for elem in array.elems.iter_mut().flatten() {
+                if elem.spread.is_some() {
+                    continue;
+                }
+                try_outline_non_capturing_function_expr(
+                    &mut elem.expr,
+                    self.outer_bindings,
+                    self.used_names,
+                    self.outlined,
+                );
+            }
+        }
+
+        fn visit_mut_cond_expr(&mut self, cond: &mut swc_ecma_ast::CondExpr) {
+            cond.visit_mut_children_with(self);
+            try_outline_non_capturing_function_expr(
+                &mut cond.cons,
+                self.outer_bindings,
+                self.used_names,
+                self.outlined,
+            );
+            try_outline_non_capturing_function_expr(
+                &mut cond.alt,
+                self.outer_bindings,
+                self.used_names,
+                self.outlined,
+            );
+        }
     }
 
     let mut outliner = Outliner {
@@ -607,7 +648,7 @@ fn outline_non_capturing_call_args(
     used_names: &mut HashSet<String>,
     outlined: &mut Vec<OutlinedFunction>,
 ) {
-    if call_has_hook_callee(call) {
+    if call_has_hook_callee(call) && !call_is_outlineable_hook_call(call) {
         return;
     }
 
@@ -621,6 +662,25 @@ fn outline_non_capturing_call_args(
             used_names,
             outlined,
         );
+    }
+}
+
+fn call_is_outlineable_hook_call(call: &CallExpr) -> bool {
+    let Callee::Expr(callee_expr) = &call.callee else {
+        return false;
+    };
+
+    match unwrap_transparent_expr(callee_expr) {
+        Expr::Ident(callee) => matches!(callee.sym.as_ref(), "useCallback"),
+        Expr::Member(member) => {
+            matches!(&*member.obj, Expr::Ident(object) if object.sym == "React")
+                && matches!(
+                    &member.prop,
+                    MemberProp::Ident(property)
+                        if matches!(property.sym.as_ref(), "useCallback")
+                )
+        }
+        _ => false,
     }
 }
 
@@ -703,6 +763,54 @@ fn rename_ident_in_block(body: &mut BlockStmt, from: &str, to: &str) {
     body.visit_mut_with(&mut renamer);
 }
 
+fn rename_ident_in_nested_functions_without_param_shadow(
+    body: &mut BlockStmt,
+    from: &str,
+    to: &str,
+) {
+    struct Renamer<'a> {
+        from: &'a str,
+        to: &'a str,
+    }
+
+    impl VisitMut for Renamer<'_> {
+        fn visit_mut_function(&mut self, function: &mut Function) {
+            let mut param_bindings = HashSet::new();
+            for param in &function.params {
+                collect_pattern_bindings(&param.pat, &mut param_bindings);
+            }
+            if param_bindings.contains(self.from) {
+                return;
+            }
+            if let Some(body) = &mut function.body {
+                body.visit_mut_children_with(self);
+            }
+        }
+
+        fn visit_mut_arrow_expr(&mut self, arrow: &mut ArrowExpr) {
+            let mut param_bindings = HashSet::new();
+            for pat in &arrow.params {
+                collect_pattern_bindings(pat, &mut param_bindings);
+            }
+            if param_bindings.contains(self.from) {
+                return;
+            }
+            arrow.visit_mut_children_with(self);
+        }
+
+        fn visit_mut_ident(&mut self, ident: &mut Ident) {
+            if ident.sym == self.from {
+                ident.sym = self.to.into();
+            }
+        }
+    }
+
+    let mut renamer = Renamer { from, to };
+    for stmt in &mut body.stmts {
+        stmt.visit_mut_with(&mut renamer);
+    }
+}
+
 fn preserve_shorthand_property_keys_for_rename_in_block(
     body: &mut BlockStmt,
     from: &str,
@@ -754,6 +862,7 @@ fn normalize_duplicate_id_bindings_in_nested_functions(
         inside_call_arg: bool,
         seen_first_id_binding: bool,
         next_id_suffix: u32,
+        next_param_temp: u32,
     }
 
     impl Renamer {
@@ -852,27 +961,109 @@ fn normalize_duplicate_id_bindings_in_nested_functions(
             for scope in &self.scope_bindings {
                 taken.extend(scope.iter().cloned());
             }
+            let mut param_prologue = Vec::new();
             for param in &mut arrow.params {
-                let Pat::Ident(binding) = param else {
-                    continue;
-                };
-                if !taken.contains(binding.id.sym.as_ref()) {
-                    continue;
-                }
-                let original = binding.id.sym.to_string();
-                let suffix_entry = self.next_suffix.entry(original.clone()).or_insert(0);
-                let replacement = loop {
-                    let candidate = format!("{original}_{}", *suffix_entry);
-                    *suffix_entry += 1;
-                    if !taken.contains(candidate.as_str()) {
-                        break candidate;
+                match param {
+                    Pat::Ident(binding) => {
+                        if !taken.contains(binding.id.sym.as_ref()) {
+                            continue;
+                        }
+                        let original = binding.id.sym.to_string();
+                        let suffix_entry = self.next_suffix.entry(original.clone()).or_insert(0);
+                        let replacement = loop {
+                            let candidate = format!("{original}_{}", *suffix_entry);
+                            *suffix_entry += 1;
+                            if !taken.contains(candidate.as_str()) {
+                                break candidate;
+                            }
+                        };
+                        binding.id.sym = replacement.clone().into();
+                        rename_ident_in_block(block, original.as_str(), replacement.as_str());
+                        rename_ident_in_nested_functions_without_param_shadow(
+                            block,
+                            original.as_str(),
+                            replacement.as_str(),
+                        );
+                        taken.insert(replacement);
                     }
-                };
-                binding.id.sym = replacement.clone().into();
-                rename_ident_in_block(block, original.as_str(), replacement.as_str());
-                taken.insert(replacement);
+                    Pat::Assign(assign_pat) => {
+                        let Pat::Ident(binding) = &mut *assign_pat.left else {
+                            continue;
+                        };
+
+                        let original = binding.id.sym.to_string();
+                        let binding_name = if taken.contains(original.as_str()) {
+                            let suffix_entry =
+                                self.next_suffix.entry(original.clone()).or_insert(0);
+                            loop {
+                                let candidate = format!("{original}_{}", *suffix_entry);
+                                *suffix_entry += 1;
+                                if !taken.contains(candidate.as_str()) {
+                                    break candidate;
+                                }
+                            }
+                        } else {
+                            original.clone()
+                        };
+
+                        if binding_name != original {
+                            binding.id.sym = binding_name.clone().into();
+                            rename_ident_in_block(block, original.as_str(), binding_name.as_str());
+                            rename_ident_in_nested_functions_without_param_shadow(
+                                block,
+                                original.as_str(),
+                                binding_name.as_str(),
+                            );
+                        }
+
+                        let temp_name = loop {
+                            let candidate = format!("t{}", self.next_param_temp);
+                            self.next_param_temp += 1;
+                            if !taken.contains(candidate.as_str()) {
+                                break candidate;
+                            }
+                        };
+                        let temp_ident = Ident::new_no_ctxt(temp_name.clone().into(), DUMMY_SP);
+                        let default_expr = assign_pat.right.clone();
+                        *param = Pat::Ident(BindingIdent {
+                            id: temp_ident.clone(),
+                            type_ann: None,
+                        });
+
+                        param_prologue.push(make_var_decl(
+                            VarDeclKind::Const,
+                            Pat::Ident(BindingIdent {
+                                id: Ident::new_no_ctxt(binding_name.clone().into(), DUMMY_SP),
+                                type_ann: None,
+                            }),
+                            Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                                span: DUMMY_SP,
+                                test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                                    span: DUMMY_SP,
+                                    op: op!("==="),
+                                    left: Box::new(Expr::Ident(temp_ident.clone())),
+                                    right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                        "undefined".into(),
+                                        DUMMY_SP,
+                                    ))),
+                                })),
+                                cons: default_expr,
+                                alt: Box::new(Expr::Ident(temp_ident.clone())),
+                            }))),
+                        ));
+
+                        taken.insert(temp_name);
+                        taken.insert(binding_name);
+                    }
+                    _ => {}
+                }
             }
             self.rename_conflicting_bindings_in_block(block);
+            if !param_prologue.is_empty() {
+                let mut rewritten = param_prologue;
+                rewritten.extend(std::mem::take(&mut block.stmts));
+                block.stmts = rewritten;
+            }
 
             let mut local_bindings = HashSet::new();
             for param in &arrow.params {
@@ -902,27 +1093,109 @@ fn normalize_duplicate_id_bindings_in_nested_functions(
             for scope in &self.scope_bindings {
                 taken.extend(scope.iter().cloned());
             }
+            let mut param_prologue = Vec::new();
             for param in &mut function.params {
-                let Pat::Ident(binding) = &mut param.pat else {
-                    continue;
-                };
-                if !taken.contains(binding.id.sym.as_ref()) {
-                    continue;
-                }
-                let original = binding.id.sym.to_string();
-                let suffix_entry = self.next_suffix.entry(original.clone()).or_insert(0);
-                let replacement = loop {
-                    let candidate = format!("{original}_{}", *suffix_entry);
-                    *suffix_entry += 1;
-                    if !taken.contains(candidate.as_str()) {
-                        break candidate;
+                match &mut param.pat {
+                    Pat::Ident(binding) => {
+                        if !taken.contains(binding.id.sym.as_ref()) {
+                            continue;
+                        }
+                        let original = binding.id.sym.to_string();
+                        let suffix_entry = self.next_suffix.entry(original.clone()).or_insert(0);
+                        let replacement = loop {
+                            let candidate = format!("{original}_{}", *suffix_entry);
+                            *suffix_entry += 1;
+                            if !taken.contains(candidate.as_str()) {
+                                break candidate;
+                            }
+                        };
+                        binding.id.sym = replacement.clone().into();
+                        rename_ident_in_block(body, original.as_str(), replacement.as_str());
+                        rename_ident_in_nested_functions_without_param_shadow(
+                            body,
+                            original.as_str(),
+                            replacement.as_str(),
+                        );
+                        taken.insert(replacement);
                     }
-                };
-                binding.id.sym = replacement.clone().into();
-                rename_ident_in_block(body, original.as_str(), replacement.as_str());
-                taken.insert(replacement);
+                    Pat::Assign(assign_pat) => {
+                        let Pat::Ident(binding) = &mut *assign_pat.left else {
+                            continue;
+                        };
+
+                        let original = binding.id.sym.to_string();
+                        let binding_name = if taken.contains(original.as_str()) {
+                            let suffix_entry =
+                                self.next_suffix.entry(original.clone()).or_insert(0);
+                            loop {
+                                let candidate = format!("{original}_{}", *suffix_entry);
+                                *suffix_entry += 1;
+                                if !taken.contains(candidate.as_str()) {
+                                    break candidate;
+                                }
+                            }
+                        } else {
+                            original.clone()
+                        };
+
+                        if binding_name != original {
+                            binding.id.sym = binding_name.clone().into();
+                            rename_ident_in_block(body, original.as_str(), binding_name.as_str());
+                            rename_ident_in_nested_functions_without_param_shadow(
+                                body,
+                                original.as_str(),
+                                binding_name.as_str(),
+                            );
+                        }
+
+                        let temp_name = loop {
+                            let candidate = format!("t{}", self.next_param_temp);
+                            self.next_param_temp += 1;
+                            if !taken.contains(candidate.as_str()) {
+                                break candidate;
+                            }
+                        };
+                        let temp_ident = Ident::new_no_ctxt(temp_name.clone().into(), DUMMY_SP);
+                        let default_expr = assign_pat.right.clone();
+                        param.pat = Pat::Ident(BindingIdent {
+                            id: temp_ident.clone(),
+                            type_ann: None,
+                        });
+
+                        param_prologue.push(make_var_decl(
+                            VarDeclKind::Const,
+                            Pat::Ident(BindingIdent {
+                                id: Ident::new_no_ctxt(binding_name.clone().into(), DUMMY_SP),
+                                type_ann: None,
+                            }),
+                            Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                                span: DUMMY_SP,
+                                test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                                    span: DUMMY_SP,
+                                    op: op!("==="),
+                                    left: Box::new(Expr::Ident(temp_ident.clone())),
+                                    right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                        "undefined".into(),
+                                        DUMMY_SP,
+                                    ))),
+                                })),
+                                cons: default_expr,
+                                alt: Box::new(Expr::Ident(temp_ident.clone())),
+                            }))),
+                        ));
+
+                        taken.insert(temp_name);
+                        taken.insert(binding_name);
+                    }
+                    _ => {}
+                }
             }
             self.rename_conflicting_bindings_in_block(body);
+            if !param_prologue.is_empty() {
+                let mut rewritten = param_prologue;
+                rewritten.extend(std::mem::take(&mut body.stmts));
+                body.stmts = rewritten;
+            }
 
             let mut local_bindings = HashSet::new();
             for param in &function.params {
@@ -945,6 +1218,7 @@ fn normalize_duplicate_id_bindings_in_nested_functions(
         inside_call_arg: false,
         seen_first_id_binding: false,
         next_id_suffix: 0,
+        next_param_temp: 1,
     };
     for stmt in stmts {
         stmt.visit_mut_with(&mut renamer);
@@ -1306,6 +1580,14 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
     if reactive.body.stmts.is_empty() {
         return (0, 0, 0, 0, 0);
     }
+    if contains_object_pattern_assignment_with_reassigned_binding(&reactive.body.stmts) {
+        split_multi_var_decls_in_stmts(&mut reactive.body.stmts);
+        return (0, 0, 0, 0, 0);
+    }
+    let has_identity_sensitive_work = body_contains_identity_sensitive_work(&reactive.body);
+    if reactive.fn_type == ReactFunctionType::Component && !has_identity_sensitive_work {
+        return (0, 0, 0, 0, 0);
+    }
 
     let mut reserved = HashSet::new();
     for pat in &reactive.params {
@@ -1360,6 +1642,8 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
     rewrite_use_callback_decls_to_use_memo(&mut stmts);
     normalize_switch_case_blocks_in_stmts(&mut stmts);
     normalize_update_expressions_in_stmts(&mut stmts);
+    rewrite_let_array_pattern_decls_to_assignment_stmts(&mut stmts, &mut reserved);
+    normalize_reactive_labels(&mut stmts);
     let mut top_level_bindings = HashSet::new();
     for pat in &reactive.params {
         collect_pattern_bindings(pat, &mut top_level_bindings);
@@ -1789,6 +2073,11 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
         {
             break;
         }
+        if is_default_param_conditional_expr(init.as_ref())
+            && binding_only_used_in_terminal_return(&stmts[prefix_index + 1..], binding.sym.as_ref())
+        {
+            break;
+        }
         if should_passthrough_pure_initializer(init.as_ref())
             && !force_memoize_reassigned_jsx_tag_ident_init
         {
@@ -1852,6 +2141,11 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
         }
         let mut mutated_after =
             binding_mutated_via_member_call_after(&stmts[prefix_index + 1..], binding.sym.as_ref());
+        let mut member_assignment_after = matches!(&*init, Expr::Array(_) | Expr::Object(_))
+            && binding_mutated_via_member_assignment_after(
+                &stmts[prefix_index + 1..],
+                binding.sym.as_ref(),
+            );
         let mut alias_mutated_after = matches!(&*init, Expr::Array(_) | Expr::Object(_))
             && binding_maybe_mutated_via_alias_after(
                 &stmts[prefix_index + 1..],
@@ -1890,6 +2184,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
             );
         if first_following_block_shadows_binding(&stmts[prefix_index + 1..], binding.sym.as_ref()) {
             mutated_after = false;
+            member_assignment_after = false;
             alias_mutated_after = false;
             direct_call_arg_mutated_after = false;
             iife_mutated_after = false;
@@ -1899,6 +2194,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
             iterator_spread_after = false;
         }
         if (mutated_after
+            || member_assignment_after
             || alias_mutated_after
             || direct_call_arg_mutated_after
             || iife_mutated_after
@@ -1908,7 +2204,11 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
             || iterator_spread_after)
             && !reassigned_after
         {
-            if mutated_after || direct_call_arg_mutated_after || iife_mutated_after {
+            if mutated_after
+                || member_assignment_after
+                || direct_call_arg_mutated_after
+                || iife_mutated_after
+            {
                 if let Some((next_binding, next_init)) = stmts
                     .get(prefix_index + 1)
                     .and_then(extract_memoizable_single_decl)
@@ -1991,6 +2291,9 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                 ) && !binding_mutated_via_member_call_after(
                     &stmts[prefix_index + 2..],
                     binding.sym.as_ref(),
+                ) && !binding_mutated_via_member_assignment_after(
+                    &stmts[prefix_index + 2..],
+                    binding.sym.as_ref(),
                 ) && !binding_passed_to_potentially_mutating_call_after(
                     &stmts[prefix_index + 2..],
                     binding.sym.as_ref(),
@@ -2063,7 +2366,12 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
             break;
         }
         let direct_call_in_rest = contains_direct_call(&stmts[prefix_index + 1..]);
-        if (!matches!(&*init, Expr::Array(_)) && direct_call_in_rest)
+        let frozen_via_create_element = matches!(&*init, Expr::Object(_))
+            && binding_frozen_via_create_element_after(
+                &stmts[prefix_index + 1..],
+                binding.sym.as_ref(),
+            );
+        if (!matches!(&*init, Expr::Array(_)) && direct_call_in_rest && !frozen_via_create_element)
             || contains_complex_assignment(&stmts[prefix_index + 1..])
         {
             break;
@@ -2360,6 +2668,10 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                                 result_ident.sym.as_ref(),
                             )
                             && !binding_declared_in_stmts(&tail, result_ident.sym.as_ref())
+                            && !binding_captured_by_called_local_function_after(
+                                &tail,
+                                result_ident.sym.as_ref(),
+                            )
                     });
 
                 prune_empty_stmts(&mut tail);
@@ -2430,8 +2742,17 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                                     ident.sym.as_ref(),
                                 )
                         });
+                    let force_temp_for_post_compute_alias =
+                        result_ident.as_ref().is_some_and(|ident| {
+                            has_create_element_result_assignment_with_post_calls(
+                                &tail,
+                                ident.sym.as_ref(),
+                            )
+                        });
+                    let rewrite_result_assignments_to_temp =
+                        force_distinct_temp_for_result || force_temp_for_post_compute_alias;
                     let mut temp = if result_ident.as_ref().is_some_and(|ident| {
-                        force_distinct_temp_for_result
+                        rewrite_result_assignments_to_temp
                             || binding_declared_in_stmts(&tail, ident.sym.as_ref())
                     }) {
                         fresh_temp_ident(&mut next_temp, &mut reserved)
@@ -2444,7 +2765,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                         && !binding_declared_in_stmts(&tail, temp.sym.as_ref());
 
                     let mut compute_stmts = tail;
-                    if force_distinct_temp_for_result {
+                    if rewrite_result_assignments_to_temp {
                         if let Some(result_ident) = &result_ident {
                             rewrite_assignment_target_in_stmts(
                                 &mut compute_stmts,
@@ -2453,7 +2774,12 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                             );
                         }
                     }
-                    let should_assign_result = if force_distinct_temp_for_result {
+                    normalize_array_pattern_assignments_in_stmts(
+                        &mut compute_stmts,
+                        &mut reserved,
+                        &mut next_temp,
+                    );
+                    let should_assign_result = if rewrite_result_assignments_to_temp {
                         !contains_direct_assignment_to_binding(&compute_stmts, temp.sym.as_ref())
                     } else {
                         !matches!(&*return_expr, Expr::Ident(ident) if ident.sym == temp.sym)
@@ -2480,6 +2806,10 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                     strip_runtime_call_type_args_in_stmts(&mut compute_stmts);
                     prune_unused_pure_var_decls(&mut compute_stmts);
                     prune_unused_function_like_decl_stmts(&mut compute_stmts);
+                    let mut post_compute_stmts = extract_trailing_post_compute_side_effect_stmts(
+                        &mut compute_stmts,
+                        temp.sym.as_ref(),
+                    );
 
                     let mut prelude_stmts = if contains_return_stmt_in_stmts(&compute_stmts) {
                         Vec::new()
@@ -2499,8 +2829,10 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                         next_temp -= 1;
                         deferred_outer_temp_name = Some(temp.sym.to_string());
                     }
-                    let (prelude_slots, prelude_blocks, prelude_values) =
-                        if prelude_stmts.is_empty() {
+                    let skip_nested_prelude_injection =
+                        prelude_stmts.iter().any(stmt_declares_non_ident_pattern);
+                    let (mut prelude_slots, mut prelude_blocks, mut prelude_values) =
+                        if prelude_stmts.is_empty() || skip_nested_prelude_injection {
                             (0, 0, 0)
                         } else {
                             inject_nested_call_memoization_into_stmts(
@@ -2513,6 +2845,69 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                                 true,
                             )
                         };
+                    if !prelude_stmts.is_empty() && prelude_blocks == 0 {
+                        if let Some(prelude_result_binding) = infer_prelude_result_binding(
+                            &prelude_stmts,
+                            &compute_stmts,
+                        ) {
+                            let mut prelude_local_bindings = HashSet::new();
+                            for stmt in &prelude_stmts {
+                                collect_stmt_bindings_including_nested_blocks(
+                                    stmt,
+                                    &mut prelude_local_bindings,
+                                );
+                            }
+                            let mut prelude_deps = collect_dependencies_from_stmts(
+                                &prelude_stmts,
+                                &known_bindings,
+                                &prelude_local_bindings,
+                            );
+                            let prelude_called_fn_deps =
+                                collect_called_local_function_capture_dependencies(
+                                    &prelude_stmts,
+                                    &known_bindings,
+                                );
+                            for dep in prelude_called_fn_deps {
+                                if !prelude_deps.iter().any(|existing| existing.key == dep.key) {
+                                    prelude_deps.push(dep);
+                                }
+                            }
+                            let prelude_inline_fn_capture_deps =
+                                collect_stmt_function_capture_dependencies(
+                                    &prelude_stmts,
+                                    &known_bindings,
+                                );
+                            for dep in prelude_inline_fn_capture_deps {
+                                if !prelude_deps.iter().any(|existing| existing.key == dep.key) {
+                                    prelude_deps.push(dep);
+                                }
+                            }
+                            prelude_deps = reduce_dependencies(prelude_deps);
+                            prelude_deps.retain(|dep| {
+                                dep.key != prelude_result_binding.sym.as_ref()
+                                    && !dep
+                                        .key
+                                        .starts_with(&format!("{}.", prelude_result_binding.sym))
+                                    && !dep
+                                        .key
+                                        .starts_with(&format!("{}[", prelude_result_binding.sym))
+                            });
+                            prelude_deps = reduce_nested_member_dependencies(prelude_deps);
+                            if !prelude_deps.is_empty() {
+                                prelude_stmts = build_memoized_block(
+                                    &cache_ident,
+                                    next_slot,
+                                    &prelude_deps,
+                                    &prelude_result_binding,
+                                    std::mem::take(&mut prelude_stmts),
+                                    false,
+                                );
+                                prelude_slots = prelude_deps.len() as u32 + 1;
+                                prelude_blocks = 1;
+                                prelude_values = 1;
+                            }
+                        }
+                    }
                     if let Some(old_temp_name) = deferred_outer_temp_name {
                         let replacement_temp = fresh_temp_ident(&mut next_temp, &mut reserved);
                         rewrite_assignment_target_in_stmts(
@@ -2752,6 +3147,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                                 }),
                                 Some(Box::new(Expr::Ident(temp.clone()))),
                             ));
+                            transformed.extend(std::mem::take(&mut post_compute_stmts));
                             transformed.push(Stmt::Return(swc_ecma_ast::ReturnStmt {
                                 span: DUMMY_SP,
                                 arg: Some(wrap_with_ts_const_assertion(
@@ -2770,6 +3166,25 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                                     AssignTarget::from(result_ident.clone()),
                                     Box::new(Expr::Ident(temp.clone())),
                                 ));
+                                transformed.extend(std::mem::take(&mut post_compute_stmts));
+                                transformed.push(Stmt::Return(swc_ecma_ast::ReturnStmt {
+                                    span: DUMMY_SP,
+                                    arg: Some(wrap_with_ts_const_assertion(
+                                        Expr::Ident(result_ident.clone()),
+                                        return_as_const,
+                                    )),
+                                }));
+                            } else if result_ident.sym != temp.sym && !post_compute_stmts.is_empty()
+                            {
+                                transformed.push(make_var_decl(
+                                    VarDeclKind::Const,
+                                    Pat::Ident(BindingIdent {
+                                        id: result_ident.clone(),
+                                        type_ann: None,
+                                    }),
+                                    Some(Box::new(Expr::Ident(temp.clone()))),
+                                ));
+                                transformed.extend(std::mem::take(&mut post_compute_stmts));
                                 transformed.push(Stmt::Return(swc_ecma_ast::ReturnStmt {
                                     span: DUMMY_SP,
                                     arg: Some(wrap_with_ts_const_assertion(
@@ -2778,6 +3193,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                                     )),
                                 }));
                             } else {
+                                transformed.extend(std::mem::take(&mut post_compute_stmts));
                                 transformed.push(Stmt::Return(swc_ecma_ast::ReturnStmt {
                                     span: DUMMY_SP,
                                     arg: Some(wrap_with_ts_const_assertion(
@@ -2787,6 +3203,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                                 }));
                             }
                         } else {
+                            transformed.extend(std::mem::take(&mut post_compute_stmts));
                             transformed.push(Stmt::Return(swc_ecma_ast::ReturnStmt {
                                 span: DUMMY_SP,
                                 arg: Some(wrap_with_ts_const_assertion(
@@ -3065,6 +3482,149 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
     }
 
     (next_slot, memo_blocks, memo_values, 0, 0)
+}
+
+fn body_contains_identity_sensitive_work(body: &BlockStmt) -> bool {
+    #[derive(Default)]
+    struct Finder {
+        found: bool,
+    }
+
+    impl Visit for Finder {
+        fn visit_arrow_expr(&mut self, arrow: &ArrowExpr) {
+            self.found = true;
+            arrow.visit_children_with(self);
+        }
+
+        fn visit_function(&mut self, function: &Function) {
+            self.found = true;
+            function.visit_children_with(self);
+        }
+
+        fn visit_call_expr(&mut self, call: &CallExpr) {
+            self.found = true;
+            call.visit_children_with(self);
+        }
+
+        fn visit_expr(&mut self, expr: &Expr) {
+            if self.found {
+                return;
+            }
+
+            if matches!(
+                expr,
+                Expr::Array(_)
+                    | Expr::Object(_)
+                    | Expr::Class(_)
+                    | Expr::New(_)
+                    | Expr::JSXElement(_)
+                    | Expr::JSXFragment(_)
+            ) {
+                self.found = true;
+                return;
+            }
+
+            expr.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder::default();
+    body.visit_with(&mut finder);
+    finder.found
+}
+
+fn contains_object_pattern_assignment_with_reassigned_binding(stmts: &[Stmt]) -> bool {
+    for (index, stmt) in stmts.iter().enumerate() {
+        let Stmt::Expr(expr_stmt) = stmt else {
+            continue;
+        };
+        let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) else {
+            continue;
+        };
+        if assign.op != op!("=") {
+            continue;
+        }
+        let AssignTarget::Pat(assign_pat) = &assign.left else {
+            continue;
+        };
+        let Pat::Object(object_pat) = Pat::from(assign_pat.clone()) else {
+            continue;
+        };
+        let binding_names = collect_pattern_binding_names(&Pat::Object(object_pat));
+        if binding_names.is_empty() {
+            continue;
+        }
+        if binding_names
+            .iter()
+            .any(|name| binding_reassigned_after(&stmts[index + 1..], name.as_str()))
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn split_multi_var_decls_in_stmts(stmts: &mut Vec<Stmt>) {
+    let mut out = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => split_multi_var_decls_in_stmts(&mut block.stmts),
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    split_multi_var_decls_in_stmts(&mut block.stmts);
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    split_multi_var_decls_in_stmts(&mut block.stmts);
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        split_multi_var_decls_in_stmts(&mut block.stmts);
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                split_multi_var_decls_in_stmts(&mut try_stmt.block.stmts);
+                if let Some(handler) = &mut try_stmt.handler {
+                    split_multi_var_decls_in_stmts(&mut handler.body.stmts);
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    split_multi_var_decls_in_stmts(&mut finalizer.stmts);
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    split_multi_var_decls_in_stmts(&mut case.cons);
+                }
+            }
+            _ => {}
+        }
+
+        let Stmt::Decl(Decl::Var(var_decl)) = &stmt else {
+            out.push(stmt);
+            continue;
+        };
+        if var_decl.decls.len() <= 1 {
+            out.push(stmt);
+            continue;
+        }
+
+        for decl in &var_decl.decls {
+            out.push(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+                span: var_decl.span,
+                ctxt: var_decl.ctxt,
+                kind: var_decl.kind,
+                declare: var_decl.declare,
+                decls: vec![decl.clone()],
+            }))));
+        }
+    }
+
+    *stmts = out;
 }
 
 fn extract_memoizable_single_decl(stmt: &Stmt) -> Option<(Ident, Box<Expr>)> {
@@ -3437,7 +3997,17 @@ fn promote_var_decl_to_const_when_immutable(var_decl: &mut VarDecl, remaining: &
         decl.init.is_some()
             && collect_pattern_binding_names(&decl.name)
                 .into_iter()
-                .all(|name| !binding_reassigned_after(remaining, name.as_str()))
+                .all(|name| {
+                    !binding_reassigned_after(remaining, name.as_str())
+                        && !binding_captured_by_called_local_function_after(
+                            remaining,
+                            name.as_str(),
+                        )
+                        && !binding_captured_by_function_passed_to_call_after(
+                            remaining,
+                            name.as_str(),
+                        )
+                })
     });
     if immutable {
         var_decl.kind = VarDeclKind::Const;
@@ -3839,6 +4409,39 @@ fn rewrite_non_ident_params(
         match param {
             Pat::Ident(binding) => {
                 known_bindings.insert(binding.id.sym.to_string(), false);
+            }
+            Pat::Assign(assign_pat) => {
+                let left_pat = (*assign_pat.left).clone();
+                let default_expr = assign_pat.right.clone();
+                for binding in collect_pattern_binding_names(&left_pat) {
+                    known_bindings.insert(binding, false);
+                }
+
+                let temp = fresh_temp_ident(next_temp, used);
+                known_bindings.insert(temp.sym.to_string(), false);
+                *param = Pat::Ident(BindingIdent {
+                    id: temp.clone(),
+                    type_ann: None,
+                });
+
+                prologue.push(make_var_decl(
+                    VarDeclKind::Const,
+                    left_pat,
+                    Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                        span: DUMMY_SP,
+                        test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                            span: DUMMY_SP,
+                            op: op!("==="),
+                            left: Box::new(Expr::Ident(temp.clone())),
+                            right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                "undefined".into(),
+                                DUMMY_SP,
+                            ))),
+                        })),
+                        cons: default_expr,
+                        alt: Box::new(Expr::Ident(temp)),
+                    }))),
+                ));
             }
             _ => {
                 let original = param.clone();
@@ -4451,6 +5054,385 @@ fn rewrite_terminal_self_assignment_to_pattern_write(stmts: &mut Vec<Stmt>, bind
     }
 
     false
+}
+
+fn rewrite_let_array_pattern_decls_to_assignment_stmts(
+    stmts: &mut Vec<Stmt>,
+    reserved: &mut HashSet<String>,
+) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+    let mut scope_bindings = HashSet::new();
+    for stmt in &original {
+        collect_stmt_bindings_including_nested_blocks(stmt, &mut scope_bindings);
+    }
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => {
+                rewrite_let_array_pattern_decls_to_assignment_stmts(&mut block.stmts, reserved);
+            }
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    rewrite_let_array_pattern_decls_to_assignment_stmts(&mut block.stmts, reserved);
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    rewrite_let_array_pattern_decls_to_assignment_stmts(&mut block.stmts, reserved);
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        rewrite_let_array_pattern_decls_to_assignment_stmts(
+                            &mut block.stmts,
+                            reserved,
+                        );
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                rewrite_let_array_pattern_decls_to_assignment_stmts(
+                    &mut try_stmt.block.stmts,
+                    reserved,
+                );
+                if let Some(handler) = &mut try_stmt.handler {
+                    rewrite_let_array_pattern_decls_to_assignment_stmts(
+                        &mut handler.body.stmts,
+                        reserved,
+                    );
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    rewrite_let_array_pattern_decls_to_assignment_stmts(
+                        &mut finalizer.stmts,
+                        reserved,
+                    );
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    rewrite_let_array_pattern_decls_to_assignment_stmts(&mut case.cons, reserved);
+                }
+            }
+            _ => {}
+        }
+
+        let Stmt::Decl(Decl::Var(var_decl)) = &stmt else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if !matches!(var_decl.kind, VarDeclKind::Let | VarDeclKind::Const) {
+            rewritten.push(stmt);
+            continue;
+        }
+        let [decl] = var_decl.decls.as_slice() else {
+            rewritten.push(stmt);
+            continue;
+        };
+        let Some(init) = &decl.init else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if let Expr::Call(call) = unwrap_transparent_expr(init) {
+            if call_is_state_tuple_hook(call) {
+                rewritten.push(stmt);
+                continue;
+            }
+        }
+
+        let mut pat = decl.name.clone();
+        normalize_array_pattern_holes(&mut pat);
+        let Pat::Array(array_pat) = &pat else {
+            rewritten.push(stmt);
+            continue;
+        };
+
+        let non_hole_pats = array_pat.elems.iter().flatten().collect::<Vec<_>>();
+        if non_hole_pats.len() != 1 {
+            rewritten.push(stmt);
+            continue;
+        }
+
+        match (var_decl.kind, non_hole_pats[0]) {
+            (VarDeclKind::Const, Pat::Assign(assign_pat)) => {
+                let Pat::Ident(binding) = &*assign_pat.left else {
+                    rewritten.push(stmt);
+                    continue;
+                };
+                let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+                rewritten.push(make_var_decl(
+                    VarDeclKind::Const,
+                    Pat::Array(swc_ecma_ast::ArrayPat {
+                        span: array_pat.span,
+                        elems: vec![Some(Pat::Ident(BindingIdent {
+                            id: temp.clone(),
+                            type_ann: None,
+                        }))],
+                        optional: false,
+                        type_ann: None,
+                    }),
+                    Some(init.clone()),
+                ));
+                rewritten.push(make_var_decl(
+                    VarDeclKind::Const,
+                    Pat::Ident(BindingIdent {
+                        id: binding.id.clone(),
+                        type_ann: None,
+                    }),
+                    Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                        span: DUMMY_SP,
+                        test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                            span: DUMMY_SP,
+                            op: op!("==="),
+                            left: Box::new(Expr::Ident(temp.clone())),
+                            right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                "undefined".into(),
+                                DUMMY_SP,
+                            ))),
+                        })),
+                        cons: assign_pat.right.clone(),
+                        alt: Box::new(Expr::Ident(temp)),
+                    }))),
+                ));
+            }
+            (VarDeclKind::Let, Pat::Ident(binding)) => {
+                let Ok(target) = AssignTarget::try_from(pat.clone()) else {
+                    rewritten.push(stmt);
+                    continue;
+                };
+                rewritten.push(make_var_decl(
+                    VarDeclKind::Let,
+                    Pat::Ident(BindingIdent {
+                        id: binding.id.clone(),
+                        type_ann: None,
+                    }),
+                    None,
+                ));
+                rewritten.push(assign_stmt(target, init.clone()));
+            }
+            (VarDeclKind::Let, Pat::Assign(assign_pat)) => {
+                let Pat::Ident(binding) = &*assign_pat.left else {
+                    rewritten.push(stmt);
+                    continue;
+                };
+                let Ok(target) = AssignTarget::try_from(pat.clone()) else {
+                    rewritten.push(stmt);
+                    continue;
+                };
+                rewritten.push(make_var_decl(
+                    VarDeclKind::Let,
+                    Pat::Ident(BindingIdent {
+                        id: binding.id.clone(),
+                        type_ann: None,
+                    }),
+                    None,
+                ));
+                rewritten.push(assign_stmt(target, init.clone()));
+            }
+            _ => {
+                rewritten.push(stmt);
+            }
+        }
+    }
+
+    *stmts = rewritten;
+}
+
+fn normalize_array_pattern_assignments_in_stmts(
+    stmts: &mut Vec<Stmt>,
+    reserved: &mut HashSet<String>,
+    _next_temp: &mut u32,
+) {
+    let mut normalized = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+    let mut scope_bindings = HashSet::new();
+    for stmt in &original {
+        collect_stmt_bindings_including_nested_blocks(stmt, &mut scope_bindings);
+    }
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => {
+                normalize_array_pattern_assignments_in_stmts(
+                    &mut block.stmts,
+                    reserved,
+                    _next_temp,
+                );
+            }
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    normalize_array_pattern_assignments_in_stmts(
+                        &mut block.stmts,
+                        reserved,
+                        _next_temp,
+                    );
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    normalize_array_pattern_assignments_in_stmts(
+                        &mut block.stmts,
+                        reserved,
+                        _next_temp,
+                    );
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        normalize_array_pattern_assignments_in_stmts(
+                            &mut block.stmts,
+                            reserved,
+                            _next_temp,
+                        );
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                normalize_array_pattern_assignments_in_stmts(
+                    &mut try_stmt.block.stmts,
+                    reserved,
+                    _next_temp,
+                );
+                if let Some(handler) = &mut try_stmt.handler {
+                    normalize_array_pattern_assignments_in_stmts(
+                        &mut handler.body.stmts,
+                        reserved,
+                        _next_temp,
+                    );
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    normalize_array_pattern_assignments_in_stmts(
+                        &mut finalizer.stmts,
+                        reserved,
+                        _next_temp,
+                    );
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    normalize_array_pattern_assignments_in_stmts(
+                        &mut case.cons,
+                        reserved,
+                        _next_temp,
+                    );
+                }
+            }
+            _ => {}
+        }
+
+        let Stmt::Expr(expr_stmt) = &stmt else {
+            normalized.push(stmt);
+            continue;
+        };
+        let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) else {
+            normalized.push(stmt);
+            continue;
+        };
+        if assign.op != op!("=") {
+            normalized.push(stmt);
+            continue;
+        }
+        let AssignTarget::Pat(assign_pat) = &assign.left else {
+            normalized.push(stmt);
+            continue;
+        };
+        let mut pat = Pat::from(assign_pat.clone());
+        normalize_array_pattern_holes(&mut pat);
+        let Pat::Array(array_pat) = pat else {
+            normalized.push(stmt);
+            continue;
+        };
+        let swc_ecma_ast::ArrayPat {
+            span,
+            elems,
+            optional,
+            ..
+        } = array_pat;
+
+        let mut temp_elems = Vec::with_capacity(elems.len());
+        let mut rewritten_assignments = Vec::new();
+        let mut can_rewrite = true;
+
+        for element in elems {
+            let Some(inner) = element else {
+                temp_elems.push(None);
+                continue;
+            };
+
+            let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+            temp_elems.push(Some(Pat::Ident(BindingIdent {
+                id: temp.clone(),
+                type_ann: None,
+            })));
+            match inner {
+                Pat::Ident(binding) => {
+                    rewritten_assignments.push(assign_stmt(
+                        AssignTarget::from(binding.id.clone()),
+                        Box::new(Expr::Ident(temp)),
+                    ));
+                }
+                Pat::Assign(assign_pat) => {
+                    let Pat::Ident(binding) = &*assign_pat.left else {
+                        can_rewrite = false;
+                        break;
+                    };
+                    rewritten_assignments.push(assign_stmt(
+                        AssignTarget::from(binding.id.clone()),
+                        Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                            span: DUMMY_SP,
+                            test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                                span: DUMMY_SP,
+                                op: op!("==="),
+                                left: Box::new(Expr::Ident(temp.clone())),
+                                right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                    "undefined".into(),
+                                    DUMMY_SP,
+                                ))),
+                            })),
+                            cons: assign_pat.right.clone(),
+                            alt: Box::new(Expr::Ident(temp)),
+                        })),
+                    ));
+                }
+                _ => {
+                    can_rewrite = false;
+                    break;
+                }
+            }
+        }
+
+        if !can_rewrite {
+            normalized.push(stmt);
+            continue;
+        }
+
+        normalized.push(make_var_decl(
+            VarDeclKind::Const,
+            Pat::Array(swc_ecma_ast::ArrayPat {
+                span,
+                elems: temp_elems,
+                optional,
+                type_ann: None,
+            }),
+            Some(assign.right.clone()),
+        ));
+        normalized.extend(rewritten_assignments);
+    }
+
+    *stmts = normalized;
+}
+
+fn fresh_lowest_scoped_temp_ident(
+    scope_bindings: &mut HashSet<String>,
+    reserved: &mut HashSet<String>,
+) -> Ident {
+    let mut index = 0u32;
+    loop {
+        let candidate = format!("t{index}");
+        index += 1;
+        if scope_bindings.insert(candidate.clone()) {
+            reserved.insert(candidate.clone());
+            return Ident::new_no_ctxt(candidate.into(), DUMMY_SP);
+        }
+    }
 }
 
 fn normalize_array_pattern_holes(pat: &mut Pat) {
@@ -5295,6 +6277,26 @@ fn reduce_dependencies(deps: Vec<ReactiveDependency>) -> Vec<ReactiveDependency>
     reduced
 }
 
+fn reduce_nested_member_dependencies(deps: Vec<ReactiveDependency>) -> Vec<ReactiveDependency> {
+    let mut reduced = Vec::with_capacity(deps.len());
+    for (idx, dep) in deps.iter().enumerate() {
+        let subsumed = deps.iter().enumerate().any(|(other_idx, other)| {
+            if idx == other_idx {
+                return false;
+            }
+            dep.key.starts_with(&other.key)
+                && dep.key.len() > other.key.len()
+                && matches!(dep.key.as_bytes().get(other.key.len()), Some(b'.' | b'['))
+        });
+        if !subsumed {
+            reduced.push(dep.clone());
+        }
+    }
+
+    reduced.sort_by(|left, right| left.key.cmp(&right.key));
+    reduced
+}
+
 #[allow(clippy::too_many_arguments)]
 fn maybe_split_static_array_elements_initializer(
     init_expr: &mut Box<Expr>,
@@ -6053,6 +7055,57 @@ fn inject_nested_call_memoization_into_stmts(
             mark_stmt_bindings_unstable(&rewritten_stmt, &mut nested_known_bindings);
             continue;
         }
+        if !callee_is_local_binding
+            && !callee_is_iife_function
+            && is_react_create_element_call(call)
+        {
+            let mut changed = false;
+            for arg in &mut call.args {
+                if arg.spread.is_some() {
+                    continue;
+                }
+                if !matches!(
+                    unwrap_transparent_expr(&arg.expr),
+                    Expr::Array(_) | Expr::Object(_)
+                ) {
+                    continue;
+                }
+
+                let arg_expr = arg.expr.clone();
+                let local_bindings = HashSet::new();
+                let nested_deps = collect_dependencies_from_expr(
+                    &arg_expr,
+                    &nested_known_bindings,
+                    &local_bindings,
+                );
+                let arg_temp = fresh_temp_ident(next_temp, reserved);
+                let mut nested_compute =
+                    vec![assign_stmt(AssignTarget::from(arg_temp.clone()), arg_expr)];
+                strip_runtime_call_type_args_in_stmts(&mut nested_compute);
+
+                out.extend(build_memoized_block(
+                    cache_ident,
+                    cursor,
+                    &nested_deps,
+                    &arg_temp,
+                    nested_compute,
+                    true,
+                ));
+                cursor += nested_deps.len() as u32 + 1;
+                added_blocks += 1;
+                added_values += 1;
+                nested_known_bindings.insert(arg_temp.sym.to_string(), false);
+
+                arg.expr = Box::new(Expr::Ident(arg_temp));
+                changed = true;
+            }
+
+            if changed {
+                out.push(rewritten_stmt.clone());
+                mark_stmt_bindings_unstable(&rewritten_stmt, &mut nested_known_bindings);
+                continue;
+            }
+        }
         if !callee_is_local_binding {
             let [arg] = call.args.as_slice() else {
                 out.push(stmt.clone());
@@ -6621,6 +7674,10 @@ fn promote_immutable_lets_to_const_with_reassigned(
         fn visit_assign_expr(&mut self, assign: &AssignExpr) {
             if let Some(binding) = assign.left.as_ident() {
                 self.names.insert(binding.id.sym.to_string());
+            } else if let AssignTarget::Pat(assign_pat) = &assign.left {
+                for binding in collect_pattern_binding_names(&Pat::from(assign_pat.clone())) {
+                    self.names.insert(binding);
+                }
             }
             assign.visit_children_with(self);
         }
@@ -7058,6 +8115,18 @@ fn binding_mutated_via_member_assignment_after(stmts: &[Stmt], name: &str) -> bo
             }
             update.visit_children_with(self);
         }
+
+        fn visit_unary_expr(&mut self, unary: &swc_ecma_ast::UnaryExpr) {
+            if matches!(unary.op, swc_ecma_ast::UnaryOp::Delete) {
+                if let Expr::Member(member) = unwrap_transparent_expr(&unary.arg) {
+                    if member_root_is_binding(member, self.name) {
+                        self.found = true;
+                        return;
+                    }
+                }
+            }
+            unary.visit_children_with(self);
+        }
     }
 
     let mut finder = Finder { name, found: false };
@@ -7092,9 +8161,33 @@ fn binding_maybe_mutated_via_alias_after(stmts: &[Stmt], name: &str) -> bool {
 
 fn binding_passed_to_potentially_mutating_call_after(stmts: &[Stmt], name: &str) -> bool {
     let aliases = HashSet::from([name.to_string()]);
+    let mut frozen_by_create_element = false;
+
+    for stmt in stmts {
+        let freezes_alias = stmt_freezes_alias_via_create_element(stmt, &aliases);
+        let mutates_via_call = stmt_calls_identifier_with_alias_argument(stmt, &aliases);
+
+        if freezes_alias {
+            frozen_by_create_element = true;
+            continue;
+        }
+
+        if mutates_via_call {
+            if frozen_by_create_element {
+                continue;
+            }
+            return true;
+        }
+    }
+
+    false
+}
+
+fn binding_frozen_via_create_element_after(stmts: &[Stmt], name: &str) -> bool {
+    let aliases = HashSet::from([name.to_string()]);
     stmts
         .iter()
-        .any(|stmt| stmt_calls_identifier_with_alias_argument(stmt, &aliases))
+        .any(|stmt| stmt_freezes_alias_via_create_element(stmt, &aliases))
 }
 
 fn binding_captured_by_called_local_function_after(stmts: &[Stmt], name: &str) -> bool {
@@ -8163,6 +9256,68 @@ fn stmt_calls_identifier_with_alias_argument(stmt: &Stmt, aliases: &HashSet<Stri
     finder.found
 }
 
+fn stmt_freezes_alias_via_create_element(stmt: &Stmt, aliases: &HashSet<String>) -> bool {
+    struct Finder<'a> {
+        aliases: &'a HashSet<String>,
+        found: bool,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_call_expr(&mut self, call: &CallExpr) {
+            if call_freezes_alias_via_create_element(call, self.aliases) {
+                self.found = true;
+                return;
+            }
+            call.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder {
+        aliases,
+        found: false,
+    };
+    stmt.visit_with(&mut finder);
+    finder.found
+}
+
+fn call_freezes_alias_via_create_element(call: &CallExpr, aliases: &HashSet<String>) -> bool {
+    if !is_react_create_element_call(call) {
+        return false;
+    }
+
+    let Some(props_arg) = call.args.get(1) else {
+        return false;
+    };
+    if props_arg.spread.is_some() {
+        return false;
+    }
+
+    expr_is_alias(props_arg.expr.as_ref(), aliases)
+}
+
+fn is_react_create_element_call(call: &CallExpr) -> bool {
+    let Callee::Expr(callee_expr) = &call.callee else {
+        return false;
+    };
+
+    match unwrap_transparent_expr(callee_expr) {
+        Expr::Ident(ident) => ident.sym == "createElement",
+        Expr::Member(member) => {
+            matches!(&*member.obj, Expr::Ident(object) if object.sym == "React")
+                && matches!(&member.prop, MemberProp::Ident(property) if property.sym == "createElement")
+        }
+        _ => false,
+    }
+}
+
 fn stmt_calls_mutating_member_on_alias(stmt: &Stmt, aliases: &HashSet<String>) -> bool {
     struct Finder<'a> {
         aliases: &'a HashSet<String>,
@@ -8723,6 +9878,93 @@ fn contains_direct_call(stmts: &[Stmt]) -> bool {
     false
 }
 
+fn contains_local_direct_call(stmts: &[Stmt]) -> bool {
+    struct Finder<'a> {
+        local_bindings: &'a HashSet<String>,
+        found: bool,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_call_expr(&mut self, call: &CallExpr) {
+            if let Callee::Expr(expr) = &call.callee {
+                if let Expr::Ident(callee) = &**expr {
+                    if self.local_bindings.contains(callee.sym.as_ref()) {
+                        self.found = true;
+                        return;
+                    }
+                }
+            }
+
+            call.visit_children_with(self);
+        }
+    }
+
+    let mut local_bindings = HashSet::new();
+    for stmt in stmts {
+        collect_stmt_bindings(stmt, &mut local_bindings);
+    }
+
+    let mut finder = Finder {
+        local_bindings: &local_bindings,
+        found: false,
+    };
+    for stmt in stmts {
+        stmt.visit_with(&mut finder);
+        if finder.found {
+            return true;
+        }
+    }
+    false
+}
+
+fn has_create_element_result_assignment_with_post_calls(stmts: &[Stmt], name: &str) -> bool {
+    let assignment_index = stmts.iter().position(|stmt| {
+        let Stmt::Expr(expr_stmt) = stmt else {
+            return false;
+        };
+        let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) else {
+            return false;
+        };
+        if assign.op != op!("=") {
+            return false;
+        }
+        let Some(target) = assign.left.as_ident() else {
+            return false;
+        };
+        if target.id.sym != name {
+            return false;
+        }
+        let Expr::Call(call) = unwrap_transparent_expr(&assign.right) else {
+            return false;
+        };
+
+        is_react_create_element_call(call)
+    });
+
+    let Some(assignment_index) = assignment_index else {
+        return false;
+    };
+
+    stmts[assignment_index + 1..].iter().any(|stmt| {
+        let Stmt::Expr(expr_stmt) = stmt else {
+            return false;
+        };
+        !matches!(unwrap_transparent_expr(&expr_stmt.expr), Expr::Assign(_))
+            && matches!(
+                unwrap_transparent_expr(&expr_stmt.expr),
+                Expr::Call(_) | Expr::OptChain(_)
+            )
+    })
+}
+
 fn split_direct_call_prelude_from_compute_stmts(
     compute_stmts: &mut Vec<Stmt>,
     temp_name: &str,
@@ -8732,52 +9974,64 @@ fn split_direct_call_prelude_from_compute_stmts(
         return Vec::new();
     }
 
-    let last_index = compute_stmts.len() - 1;
+    let Some(split_index) = compute_stmts
+        .iter()
+        .rposition(|stmt| stmt_assigns_binding(stmt, temp_name))
+    else {
+        return Vec::new();
+    };
+    if split_index == 0 {
+        return Vec::new();
+    }
+
     let mut prelude_bindings = HashSet::new();
-    for stmt in &compute_stmts[..last_index] {
+    for stmt in &compute_stmts[..split_index] {
         collect_stmt_bindings(stmt, &mut prelude_bindings);
     }
     let force_split_for_prelude_call_arg = stmt_assigns_nonlocal_call_with_prelude_arg(
-        &compute_stmts[last_index],
+        &compute_stmts[split_index],
         temp_name,
         &prelude_bindings,
     );
-    if !contains_direct_call(&compute_stmts[..last_index]) {
+    let has_local_member_mutation_prelude =
+        contains_mutating_member_call_on_local_binding(&compute_stmts[..split_index], &prelude_bindings);
+    let has_local_direct_call_prelude = contains_local_direct_call(&compute_stmts[..split_index]);
+    let has_local_conditional_test_prelude =
+        prelude_has_conditional_test_on_local_binding(&compute_stmts[..split_index], &prelude_bindings);
+    if has_local_member_mutation_prelude && has_local_conditional_test_prelude {
         return Vec::new();
     }
-    if !force_split_for_prelude_call_arg
-        && !contains_non_allowlisted_direct_call(&compute_stmts[..last_index])
+    if !contains_direct_call(&compute_stmts[..split_index])
+        && !has_local_direct_call_prelude
+        && !has_local_member_mutation_prelude
     {
         return Vec::new();
     }
-    if contains_allowlisted_mutating_direct_call(&compute_stmts[..last_index]) {
+    if contains_allowlisted_mutating_direct_call(&compute_stmts[..split_index]) {
         return Vec::new();
     }
     if !force_split_for_prelude_call_arg
-        && prelude_passes_local_binding_to_call(&compute_stmts[..last_index], &prelude_bindings)
+        && prelude_passes_local_binding_to_call(&compute_stmts[..split_index], &prelude_bindings)
     {
         return Vec::new();
     }
     if prelude_var_call_initializer_uses_prelude_binding(
-        &compute_stmts[..last_index],
+        &compute_stmts[..split_index],
         &prelude_bindings,
     ) {
         return Vec::new();
     }
-    if prelude_declares_local_function_capturing_local_binding(&compute_stmts[..last_index]) {
+    if prelude_declares_local_function_capturing_local_binding(&compute_stmts[..split_index]) {
         return Vec::new();
     }
-    if stmt_rhs_uses_binding_as_call_callee(&compute_stmts[last_index], &prelude_bindings) {
+    if stmt_rhs_uses_binding_as_call_callee(&compute_stmts[split_index], &prelude_bindings) {
         return Vec::new();
     }
     let prelude_references_known_bindings =
-        stmts_reference_known_bindings(&compute_stmts[..last_index], known_bindings);
+        stmts_reference_known_bindings(&compute_stmts[..split_index], known_bindings);
     let prelude_has_memoizable_call_binding =
-        prelude_contains_memoizable_call_binding(&compute_stmts[..last_index], &prelude_bindings);
+        prelude_contains_memoizable_call_binding(&compute_stmts[..split_index], &prelude_bindings);
     if !prelude_references_known_bindings && !prelude_has_memoizable_call_binding {
-        return Vec::new();
-    }
-    if !stmt_assigns_binding(&compute_stmts[last_index], temp_name) {
         return Vec::new();
     }
     let mut split_local_bindings = HashSet::new();
@@ -8789,16 +10043,302 @@ fn split_direct_call_prelude_from_compute_stmts(
     {
         return Vec::new();
     }
-    if let Some(source_name) = stmt_assigned_identifier_rhs(&compute_stmts[last_index], temp_name) {
-        if prelude_mutates_result_source(&compute_stmts[..last_index], &source_name) {
+    if let Some(rhs_expr) = stmt_assigned_rhs(&compute_stmts[split_index], temp_name) {
+        if !matches!(unwrap_transparent_expr(rhs_expr), Expr::Ident(_)) {
+            let rhs_referenced_bindings = collect_ident_references_in_expr(rhs_expr);
+            if rhs_referenced_bindings.iter().any(|name| {
+                prelude_bindings.contains(name)
+                    && prelude_mutates_binding_for_non_ident_rhs_split_guard(
+                        &compute_stmts[..split_index],
+                        name,
+                    )
+            }) {
+                return Vec::new();
+            }
+        }
+    }
+    if let Some(source_name) = stmt_assigned_identifier_rhs(&compute_stmts[split_index], temp_name)
+    {
+        let source_declared_in_prelude =
+            binding_declared_in_stmts(&compute_stmts[..split_index], source_name.as_str());
+        if !source_declared_in_prelude
+            && prelude_mutates_result_source(&compute_stmts[..split_index], &source_name)
+        {
             return Vec::new();
         }
     }
 
-    let trailing = compute_stmts.split_off(last_index);
+    let trailing = compute_stmts.split_off(split_index);
     let prelude = std::mem::take(compute_stmts);
     *compute_stmts = trailing;
     prelude
+}
+
+fn stmt_assigned_rhs<'a>(stmt: &'a Stmt, target_name: &str) -> Option<&'a Expr> {
+    match stmt {
+        Stmt::Expr(expr_stmt) => {
+            let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) else {
+                return None;
+            };
+            let target = assign.left.as_ident()?;
+            if target.id.sym != target_name {
+                return None;
+            }
+            Some(&assign.right)
+        }
+        Stmt::Decl(Decl::Var(var_decl)) => {
+            let [decl] = var_decl.decls.as_slice() else {
+                return None;
+            };
+            let Pat::Ident(binding) = &decl.name else {
+                return None;
+            };
+            if binding.id.sym != target_name {
+                return None;
+            }
+            decl.init.as_deref()
+        }
+        _ => None,
+    }
+}
+
+fn collect_ident_references_in_expr(expr: &Expr) -> HashSet<String> {
+    #[derive(Default)]
+    struct Collector {
+        names: HashSet<String>,
+    }
+
+    impl Visit for Collector {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_ident(&mut self, ident: &Ident) {
+            self.names.insert(ident.sym.to_string());
+        }
+    }
+
+    let mut collector = Collector::default();
+    expr.visit_with(&mut collector);
+    collector.names
+}
+
+fn extract_trailing_post_compute_side_effect_stmts(
+    compute_stmts: &mut Vec<Stmt>,
+    result_name: &str,
+) -> Vec<Stmt> {
+    if contains_return_stmt_in_stmts(compute_stmts) {
+        return Vec::new();
+    }
+
+    let Some(last_assignment_index) = compute_stmts
+        .iter()
+        .rposition(|stmt| stmt_assigns_binding(stmt, result_name))
+    else {
+        return Vec::new();
+    };
+
+    let mut post_assignment_bindings = HashSet::new();
+    for stmt in &compute_stmts[last_assignment_index + 1..] {
+        collect_stmt_bindings_including_nested_blocks(stmt, &mut post_assignment_bindings);
+    }
+
+    let mut suffix_start = compute_stmts.len();
+    while suffix_start > last_assignment_index + 1 {
+        let idx = suffix_start - 1;
+        if stmt_is_trailing_post_compute_side_effect(&compute_stmts[idx], result_name)
+            && !stmt_references_bindings(&compute_stmts[idx], &post_assignment_bindings)
+        {
+            suffix_start -= 1;
+        } else {
+            break;
+        }
+    }
+
+    if suffix_start == compute_stmts.len() {
+        return Vec::new();
+    }
+
+    compute_stmts.split_off(suffix_start)
+}
+
+fn stmt_references_bindings(stmt: &Stmt, bindings: &HashSet<String>) -> bool {
+    if bindings.is_empty() {
+        return false;
+    }
+
+    struct Finder<'a> {
+        bindings: &'a HashSet<String>,
+        found: bool,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_ident(&mut self, ident: &Ident) {
+            if self.bindings.contains(ident.sym.as_ref()) {
+                self.found = true;
+            }
+        }
+    }
+
+    let mut finder = Finder {
+        bindings,
+        found: false,
+    };
+    stmt.visit_with(&mut finder);
+    finder.found
+}
+
+fn infer_prelude_result_binding(prelude_stmts: &[Stmt], compute_stmts: &[Stmt]) -> Option<Ident> {
+    let mut assigned = HashSet::new();
+    collect_assigned_bindings_in_stmts(prelude_stmts, &mut assigned);
+    if assigned.is_empty() {
+        return None;
+    }
+
+    let mut declared = HashSet::new();
+    for stmt in prelude_stmts {
+        collect_stmt_bindings_including_nested_blocks(stmt, &mut declared);
+    }
+
+    let mut used_in_compute = assigned
+        .into_iter()
+        .filter(|name| !declared.contains(name))
+        .filter(|name| {
+            compute_stmts
+                .iter()
+                .any(|stmt| count_binding_references_in_stmt(stmt, name.as_str()) > 0)
+        })
+        .collect::<Vec<_>>();
+
+    if used_in_compute.len() != 1 {
+        return None;
+    }
+
+    Some(Ident::new_no_ctxt(
+        used_in_compute.swap_remove(0).into(),
+        DUMMY_SP,
+    ))
+}
+
+fn collect_assigned_bindings_in_stmts(stmts: &[Stmt], out: &mut HashSet<String>) {
+    for stmt in stmts {
+        collect_assigned_bindings_in_stmt(stmt, out);
+    }
+}
+
+fn collect_assigned_bindings_in_stmt(stmt: &Stmt, out: &mut HashSet<String>) {
+    match stmt {
+        Stmt::Expr(expr_stmt) => {
+            out.extend(collect_assigned_bindings_in_expr(&expr_stmt.expr));
+        }
+        Stmt::Decl(Decl::Var(var_decl)) => {
+            for decl in &var_decl.decls {
+                if decl.init.is_some() {
+                    out.extend(collect_pattern_binding_names(&decl.name));
+                }
+            }
+        }
+        Stmt::Block(block) => {
+            collect_assigned_bindings_in_stmts(&block.stmts, out);
+        }
+        Stmt::Labeled(labeled) => {
+            collect_assigned_bindings_in_stmt(&labeled.body, out);
+        }
+        Stmt::If(if_stmt) => {
+            collect_assigned_bindings_in_stmt(&if_stmt.cons, out);
+            if let Some(alt) = &if_stmt.alt {
+                collect_assigned_bindings_in_stmt(alt, out);
+            }
+        }
+        Stmt::While(while_stmt) => {
+            collect_assigned_bindings_in_stmt(&while_stmt.body, out);
+        }
+        Stmt::DoWhile(do_while_stmt) => {
+            collect_assigned_bindings_in_stmt(&do_while_stmt.body, out);
+        }
+        Stmt::For(for_stmt) => {
+            if let Some(init) = &for_stmt.init {
+                match init {
+                    swc_ecma_ast::VarDeclOrExpr::VarDecl(var_decl) => {
+                        for decl in &var_decl.decls {
+                            if decl.init.is_some() {
+                                out.extend(collect_pattern_binding_names(&decl.name));
+                            }
+                        }
+                    }
+                    swc_ecma_ast::VarDeclOrExpr::Expr(expr) => {
+                        out.extend(collect_assigned_bindings_in_expr(expr));
+                    }
+                }
+            }
+            collect_assigned_bindings_in_stmt(&for_stmt.body, out);
+        }
+        Stmt::ForIn(for_in_stmt) => {
+            if let swc_ecma_ast::ForHead::VarDecl(var_decl) = &for_in_stmt.left {
+                for decl in &var_decl.decls {
+                    out.extend(collect_pattern_binding_names(&decl.name));
+                }
+            }
+            collect_assigned_bindings_in_stmt(&for_in_stmt.body, out);
+        }
+        Stmt::ForOf(for_of_stmt) => {
+            if let swc_ecma_ast::ForHead::VarDecl(var_decl) = &for_of_stmt.left {
+                for decl in &var_decl.decls {
+                    out.extend(collect_pattern_binding_names(&decl.name));
+                }
+            }
+            collect_assigned_bindings_in_stmt(&for_of_stmt.body, out);
+        }
+        Stmt::Switch(switch_stmt) => {
+            for case in &switch_stmt.cases {
+                collect_assigned_bindings_in_stmts(&case.cons, out);
+            }
+        }
+        Stmt::Try(try_stmt) => {
+            collect_assigned_bindings_in_stmts(&try_stmt.block.stmts, out);
+            if let Some(handler) = &try_stmt.handler {
+                collect_assigned_bindings_in_stmts(&handler.body.stmts, out);
+            }
+            if let Some(finalizer) = &try_stmt.finalizer {
+                collect_assigned_bindings_in_stmts(&finalizer.stmts, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn stmt_is_trailing_post_compute_side_effect(stmt: &Stmt, result_name: &str) -> bool {
+    if count_binding_references_in_stmt(stmt, result_name) > 0 {
+        return false;
+    }
+
+    match stmt {
+        Stmt::Expr(expr_stmt) => matches!(
+            unwrap_transparent_expr(&expr_stmt.expr),
+            Expr::Call(_) | Expr::OptChain(_)
+        ),
+        Stmt::If(if_stmt) => {
+            stmt_is_trailing_post_compute_side_effect(&if_stmt.cons, result_name)
+                && if_stmt.alt.as_deref().is_none_or(|alt| {
+                    stmt_is_trailing_post_compute_side_effect(alt, result_name)
+                })
+        }
+        Stmt::Block(block) => {
+            !block.stmts.is_empty()
+                && block
+                    .stmts
+                    .iter()
+                    .all(|nested| stmt_is_trailing_post_compute_side_effect(nested, result_name))
+        }
+        Stmt::Labeled(labeled) => {
+            stmt_is_trailing_post_compute_side_effect(&labeled.body, result_name)
+        }
+        _ => false,
+    }
 }
 
 fn prelude_contains_memoizable_call_binding(
@@ -8906,6 +10446,17 @@ fn stmt_declares_const_ident_alias(stmt: &Stmt) -> bool {
     })
 }
 
+fn stmt_declares_non_ident_pattern(stmt: &Stmt) -> bool {
+    let Stmt::Decl(Decl::Var(var_decl)) = stmt else {
+        return false;
+    };
+
+    var_decl
+        .decls
+        .iter()
+        .any(|decl| !matches!(decl.name, Pat::Ident(_)))
+}
+
 fn prelude_passes_local_binding_to_call(stmts: &[Stmt], local_bindings: &HashSet<String>) -> bool {
     if local_bindings.is_empty() {
         return false;
@@ -9005,12 +10556,100 @@ fn prelude_declares_local_function_capturing_local_binding(stmts: &[Stmt]) -> bo
                 continue;
             }
             if function_expr_may_capture_outer_bindings(init, &local_bindings) {
-                return true;
+                let Pat::Ident(binding) = &decl.name else {
+                    return true;
+                };
+                if !binding_only_called_directly_in_stmts(stmts, binding.id.sym.as_ref()) {
+                    return true;
+                }
             }
         }
     }
 
     false
+}
+
+fn binding_only_called_directly_in_stmts(stmts: &[Stmt], name: &str) -> bool {
+    #[derive(Default)]
+    struct Finder<'a> {
+        name: &'a str,
+        called: bool,
+        invalid: bool,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_var_decl(&mut self, var_decl: &VarDecl) {
+            for decl in &var_decl.decls {
+                if let Some(init) = &decl.init {
+                    init.visit_with(self);
+                }
+            }
+        }
+
+        fn visit_call_expr(&mut self, call: &CallExpr) {
+            if let Callee::Expr(callee_expr) = &call.callee {
+                if let Expr::Ident(callee) = unwrap_transparent_expr(callee_expr) {
+                    if callee.sym == self.name {
+                        self.called = true;
+                        for arg in &call.args {
+                            arg.visit_with(self);
+                            if self.invalid {
+                                return;
+                            }
+                        }
+                        return;
+                    }
+                }
+            }
+
+            call.visit_children_with(self);
+        }
+
+        fn visit_opt_call(&mut self, call: &swc_ecma_ast::OptCall) {
+            if let Expr::Ident(callee) = unwrap_transparent_expr(&call.callee) {
+                if callee.sym == self.name {
+                    self.called = true;
+                    for arg in &call.args {
+                        arg.visit_with(self);
+                        if self.invalid {
+                            return;
+                        }
+                    }
+                    return;
+                }
+            }
+
+            call.visit_children_with(self);
+        }
+
+        fn visit_ident(&mut self, ident: &Ident) {
+            if ident.sym == self.name {
+                self.invalid = true;
+            }
+        }
+    }
+
+    let mut finder = Finder {
+        name,
+        called: false,
+        invalid: false,
+    };
+    for stmt in stmts {
+        stmt.visit_with(&mut finder);
+        if finder.invalid {
+            return false;
+        }
+    }
+
+    finder.called
 }
 
 fn extract_post_memo_switch_stmts(
@@ -9497,63 +11136,12 @@ fn prelude_mutates_result_source(stmts: &[Stmt], source_name: &str) -> bool {
         || binding_maybe_mutated_in_called_iife_after(stmts, source_name)
 }
 
-fn contains_non_allowlisted_direct_call(stmts: &[Stmt]) -> bool {
-    let mut local_bindings = HashSet::new();
-    for stmt in stmts {
-        collect_stmt_bindings(stmt, &mut local_bindings);
-    }
-
-    struct Finder<'a> {
-        local_bindings: &'a HashSet<String>,
-        found: bool,
-    }
-
-    impl Visit for Finder<'_> {
-        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
-            // Skip nested functions.
-        }
-
-        fn visit_function(&mut self, _: &Function) {
-            // Skip nested functions.
-        }
-
-        fn visit_call_expr(&mut self, call: &CallExpr) {
-            if let Callee::Expr(expr) = &call.callee {
-                if let Expr::Ident(callee) = &**expr {
-                    if is_hook_name(callee.sym.as_ref())
-                        || matches!(callee.sym.as_ref(), "String" | "Number" | "Boolean")
-                        || self.local_bindings.contains(callee.sym.as_ref())
-                    {
-                        call.visit_children_with(self);
-                        return;
-                    }
-
-                    let allowlisted = matches!(
-                        callee.sym.as_ref(),
-                        "mutate" | "setProperty" | "setPropertyByKey"
-                    );
-                    if !allowlisted {
-                        self.found = true;
-                        return;
-                    }
-                }
-            }
-            call.visit_children_with(self);
-        }
-    }
-
-    let mut finder = Finder {
-        local_bindings: &local_bindings,
-        found: false,
-    };
-    for stmt in stmts {
-        stmt.visit_with(&mut finder);
-        if finder.found {
-            return true;
-        }
-    }
-
-    false
+fn prelude_mutates_binding_for_non_ident_rhs_split_guard(stmts: &[Stmt], name: &str) -> bool {
+    has_assignment_to_binding(stmts, name)
+        || binding_mutated_via_member_call_after(stmts, name)
+        || binding_mutated_via_member_assignment_after(stmts, name)
+        || binding_captured_by_called_local_function_after(stmts, name)
+        || binding_maybe_mutated_in_called_iife_after(stmts, name)
 }
 
 fn contains_allowlisted_mutating_direct_call(stmts: &[Stmt]) -> bool {
@@ -9574,6 +11162,176 @@ fn contains_allowlisted_mutating_direct_call(stmts: &[Stmt]) -> bool {
             callee.sym.as_ref(),
             "mutate" | "setProperty" | "setPropertyByKey"
         ) {
+            return true;
+        }
+    }
+    false
+}
+
+fn contains_mutating_member_call_on_local_binding(
+    stmts: &[Stmt],
+    local_bindings: &HashSet<String>,
+) -> bool {
+    struct Finder<'a> {
+        local_bindings: &'a HashSet<String>,
+        found: bool,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_call_expr(&mut self, call: &CallExpr) {
+            let Callee::Expr(callee_expr) = &call.callee else {
+                call.visit_children_with(self);
+                return;
+            };
+            let Expr::Member(member) = unwrap_transparent_expr(callee_expr) else {
+                call.visit_children_with(self);
+                return;
+            };
+            let Expr::Ident(object) = unwrap_transparent_expr(&member.obj) else {
+                call.visit_children_with(self);
+                return;
+            };
+            if self.local_bindings.contains(object.sym.as_ref())
+                && call_mutates_binding(call, object.sym.as_ref())
+            {
+                self.found = true;
+                return;
+            }
+
+            call.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder {
+        local_bindings,
+        found: false,
+    };
+    for stmt in stmts {
+        stmt.visit_with(&mut finder);
+        if finder.found {
+            return true;
+        }
+    }
+    false
+}
+
+fn prelude_has_conditional_test_on_local_binding(
+    stmts: &[Stmt],
+    local_bindings: &HashSet<String>,
+) -> bool {
+    struct Finder<'a> {
+        local_bindings: &'a HashSet<String>,
+        found: bool,
+        in_test: bool,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_if_stmt(&mut self, if_stmt: &IfStmt) {
+            let prev_in_test = self.in_test;
+            self.in_test = true;
+            if_stmt.test.visit_with(self);
+            self.in_test = prev_in_test;
+            if self.found {
+                return;
+            }
+            if_stmt.cons.visit_with(self);
+            if self.found {
+                return;
+            }
+            if let Some(alt) = &if_stmt.alt {
+                alt.visit_with(self);
+            }
+        }
+
+        fn visit_for_stmt(&mut self, for_stmt: &swc_ecma_ast::ForStmt) {
+            if let Some(test) = &for_stmt.test {
+                let prev_in_test = self.in_test;
+                self.in_test = true;
+                test.visit_with(self);
+                self.in_test = prev_in_test;
+                if self.found {
+                    return;
+                }
+            }
+            for_stmt.init.visit_with(self);
+            if self.found {
+                return;
+            }
+            for_stmt.update.visit_with(self);
+            if self.found {
+                return;
+            }
+            for_stmt.body.visit_with(self);
+        }
+
+        fn visit_while_stmt(&mut self, while_stmt: &swc_ecma_ast::WhileStmt) {
+            let prev_in_test = self.in_test;
+            self.in_test = true;
+            while_stmt.test.visit_with(self);
+            self.in_test = prev_in_test;
+            if self.found {
+                return;
+            }
+            while_stmt.body.visit_with(self);
+        }
+
+        fn visit_do_while_stmt(&mut self, do_while_stmt: &swc_ecma_ast::DoWhileStmt) {
+            do_while_stmt.body.visit_with(self);
+            if self.found {
+                return;
+            }
+            let prev_in_test = self.in_test;
+            self.in_test = true;
+            do_while_stmt.test.visit_with(self);
+            self.in_test = prev_in_test;
+        }
+
+        fn visit_cond_expr(&mut self, cond_expr: &swc_ecma_ast::CondExpr) {
+            let prev_in_test = self.in_test;
+            self.in_test = true;
+            cond_expr.test.visit_with(self);
+            self.in_test = prev_in_test;
+            if self.found {
+                return;
+            }
+            cond_expr.cons.visit_with(self);
+            if self.found {
+                return;
+            }
+            cond_expr.alt.visit_with(self);
+        }
+
+        fn visit_ident(&mut self, ident: &Ident) {
+            if self.in_test && self.local_bindings.contains(ident.sym.as_ref()) {
+                self.found = true;
+            }
+        }
+    }
+
+    let mut finder = Finder {
+        local_bindings,
+        found: false,
+        in_test: false,
+    };
+    for stmt in stmts {
+        stmt.visit_with(&mut finder);
+        if finder.found {
             return true;
         }
     }
@@ -10680,7 +12438,6 @@ fn rewrite_result_binding_to_assignment(stmts: &mut [Stmt], name: &str) -> bool 
         *stmt = assign_stmt(AssignTarget::from(binding.id.clone()), init.clone());
         return true;
     }
-
     false
 }
 
@@ -11164,6 +12921,39 @@ fn should_passthrough_pure_initializer(expr: &Expr) -> bool {
     )
 }
 
+fn is_default_param_conditional_expr(expr: &Expr) -> bool {
+    fn is_undefined(expr: &Expr) -> bool {
+        matches!(unwrap_transparent_expr(expr), Expr::Ident(ident) if ident.sym == "undefined")
+    }
+
+    let Expr::Cond(cond) = unwrap_transparent_expr(expr) else {
+        return false;
+    };
+    let Expr::Bin(test) = unwrap_transparent_expr(&cond.test) else {
+        return false;
+    };
+    if test.op != op!("===") {
+        return false;
+    }
+
+    let param_ident = match (
+        unwrap_transparent_expr(&test.left),
+        unwrap_transparent_expr(&test.right),
+    ) {
+        (Expr::Ident(left), right) if is_undefined(right) => Some(left.sym.to_string()),
+        (left, Expr::Ident(right)) if is_undefined(left) => Some(right.sym.to_string()),
+        _ => None,
+    };
+    let Some(param_ident) = param_ident else {
+        return false;
+    };
+
+    matches!(
+        unwrap_transparent_expr(&cond.alt),
+        Expr::Ident(alt_ident) if alt_ident.sym == param_ident
+    )
+}
+
 fn append_for_update_assignment_result_in_stmts(stmts: &mut Vec<Stmt>) {
     struct Rewriter;
 
@@ -11263,11 +13053,16 @@ fn extract_const_decl_initializer(stmts: &mut Vec<Stmt>, name: &str) -> Option<B
 }
 
 fn normalize_static_string_members_in_stmts(stmts: &mut [Stmt]) {
-    struct Normalizer;
+    struct Normalizer {
+        in_delete_operand: bool,
+    }
 
     impl VisitMut for Normalizer {
         fn visit_mut_member_expr(&mut self, member: &mut MemberExpr) {
             member.visit_mut_children_with(self);
+            if self.in_delete_operand {
+                return;
+            }
 
             let MemberProp::Computed(computed) = &member.prop else {
                 return;
@@ -11283,9 +13078,20 @@ fn normalize_static_string_members_in_stmts(stmts: &mut [Stmt]) {
                 );
             }
         }
+
+        fn visit_mut_unary_expr(&mut self, unary: &mut swc_ecma_ast::UnaryExpr) {
+            let prev = self.in_delete_operand;
+            if matches!(unary.op, swc_ecma_ast::UnaryOp::Delete) {
+                self.in_delete_operand = true;
+            }
+            unary.visit_mut_children_with(self);
+            self.in_delete_operand = prev;
+        }
     }
 
-    let mut normalizer = Normalizer;
+    let mut normalizer = Normalizer {
+        in_delete_operand: false,
+    };
     for stmt in stmts {
         stmt.visit_mut_with(&mut normalizer);
     }
@@ -12690,14 +14496,64 @@ fn strip_runtime_call_type_args_in_stmts(stmts: &mut [Stmt]) {
 }
 
 fn extract_iife_return_expr(expr: &Expr) -> Option<Box<Expr>> {
+    fn stmt_is_drop_pure_iife_prelude(stmt: &Stmt) -> bool {
+        match stmt {
+            Stmt::Decl(Decl::Var(var_decl))
+                if matches!(var_decl.kind, VarDeclKind::Const | VarDeclKind::Let) =>
+            {
+                var_decl
+                    .decls
+                    .iter()
+                    .all(|decl| {
+                        decl.init
+                            .as_ref()
+                            .map_or(true, |init| !expr_has_observable_side_effect(init))
+                    })
+            }
+            Stmt::Empty(_) => true,
+            _ => false,
+        }
+    }
+
+    fn can_drop_iife_prelude_stmts(preceding: &[Stmt], ret_expr: &Expr) -> bool {
+        if preceding.is_empty() {
+            return true;
+        }
+        if preceding
+            .iter()
+            .any(|stmt| !stmt_is_drop_pure_iife_prelude(stmt))
+        {
+            return false;
+        }
+
+        let mut prelude_bindings = HashSet::new();
+        for stmt in preceding {
+            collect_stmt_bindings(stmt, &mut prelude_bindings);
+        }
+        if prelude_bindings.is_empty() {
+            return true;
+        }
+
+        if matches!(unwrap_transparent_expr(ret_expr), Expr::Arrow(_) | Expr::Fn(_)) {
+            !function_expr_may_capture_outer_bindings(ret_expr, &prelude_bindings)
+        } else {
+            !expr_references_bindings(ret_expr, &prelude_bindings)
+        }
+    }
+
     match expr {
         Expr::Paren(paren) => extract_iife_return_expr(&paren.expr),
         Expr::Arrow(arrow) if !arrow.is_async && !arrow.is_generator && arrow.params.is_empty() => {
             match &*arrow.body {
                 swc_ecma_ast::BlockStmtOrExpr::Expr(value_expr) => Some(value_expr.clone()),
                 swc_ecma_ast::BlockStmtOrExpr::BlockStmt(block) => {
-                    if let [Stmt::Return(return_stmt)] = block.stmts.as_slice() {
-                        return_stmt.arg.clone()
+                    let (last, preceding) = block.stmts.split_last()?;
+                    let Stmt::Return(return_stmt) = last else {
+                        return None;
+                    };
+                    let ret_expr = return_stmt.arg.clone()?;
+                    if can_drop_iife_prelude_stmts(preceding, ret_expr.as_ref()) {
+                        Some(ret_expr)
                     } else {
                         None
                     }
@@ -12710,8 +14566,13 @@ fn extract_iife_return_expr(expr: &Expr) -> Option<Box<Expr>> {
                 && fn_expr.function.params.is_empty() =>
         {
             let body = fn_expr.function.body.as_ref()?;
-            if let [Stmt::Return(return_stmt)] = body.stmts.as_slice() {
-                return_stmt.arg.clone()
+            let (last, preceding) = body.stmts.split_last()?;
+            let Stmt::Return(return_stmt) = last else {
+                return None;
+            };
+            let ret_expr = return_stmt.arg.clone()?;
+            if can_drop_iife_prelude_stmts(preceding, ret_expr.as_ref()) {
+                Some(ret_expr)
             } else {
                 None
             }

--- a/crates/swc_ecma_react_compiler/src/reactive_scopes/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/reactive_scopes/mod.rs
@@ -1,10 +1,10 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use swc_common::DUMMY_SP;
 use swc_ecma_ast::{
     op, ArrowExpr, AssignExpr, AssignTarget, BindingIdent, BlockStmt, CallExpr, Callee,
     ComputedPropName, Decl, Expr, ExprOrSpread, ExprStmt, Function, Ident, IfStmt, KeyValueProp,
-    LabeledStmt, Lit, MemberExpr, MemberProp, Number, OptChainBase, OptChainExpr, Pat, Prop,
+    LabeledStmt, Lit, MemberExpr, MemberProp, Number, ObjectPatProp, OptChainBase, OptChainExpr, Pat, Prop,
     PropName, PropOrSpread, Stmt, SwitchStmt, VarDecl, VarDeclKind, VarDeclarator,
 };
 use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
@@ -1585,7 +1585,13 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
         return (0, 0, 0, 0, 0);
     }
     let has_identity_sensitive_work = body_contains_identity_sensitive_work(&reactive.body);
-    if reactive.fn_type == ReactFunctionType::Component && !has_identity_sensitive_work {
+    let has_destructuring_default_alloc =
+        body_contains_destructuring_default_alloc_literal(&reactive.body);
+    if reactive.fn_type == ReactFunctionType::Component
+        && !has_identity_sensitive_work
+        && !has_destructuring_default_alloc
+    {
+        normalize_non_ident_params_without_memoization(reactive);
         return (0, 0, 0, 0, 0);
     }
 
@@ -1606,6 +1612,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
         &mut known_bindings,
     );
     strip_runtime_call_type_args_in_stmts(&mut param_prologue);
+    rewrite_let_array_pattern_decls_to_assignment_stmts(&mut param_prologue, &mut reserved);
     let mut declared_bindings = HashSet::new();
     for stmt in &reactive.body.stmts {
         collect_stmt_bindings(stmt, &mut declared_bindings);
@@ -1642,7 +1649,19 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
     rewrite_use_callback_decls_to_use_memo(&mut stmts);
     normalize_switch_case_blocks_in_stmts(&mut stmts);
     normalize_update_expressions_in_stmts(&mut stmts);
+    prune_trivial_do_while_break_stmts(&mut stmts);
+    flatten_nested_destructuring_assignments_in_stmts(&mut stmts, &mut reserved, &mut next_temp);
+    collapse_single_object_temp_destructure_assign_pairs(&mut stmts);
+    flatten_nested_destructuring_decls_to_temp_chain(&mut stmts, &mut reserved, &mut next_temp);
+    rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+        &mut stmts,
+        &mut reserved,
+        &mut next_temp,
+    );
+    rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(&mut stmts);
+    rewrite_let_object_pattern_decls_to_assignment_stmts(&mut stmts);
     rewrite_let_array_pattern_decls_to_assignment_stmts(&mut stmts, &mut reserved);
+    split_multi_var_decls_without_initializers_in_stmts(&mut stmts);
     normalize_reactive_labels(&mut stmts);
     let mut top_level_bindings = HashSet::new();
     for pat in &reactive.params {
@@ -1759,9 +1778,20 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                 for decl in &var_decl.decls {
                     let stable_setters = state_tuple_setter_bindings(decl);
                     let stable_ref_object = ref_object_binding_from_hook(decl);
+                    let stable_destructure_source = var_decl.kind == VarDeclKind::Const
+                        && decl.init.as_deref().is_some_and(|init| {
+                            let Expr::Ident(source) = unwrap_transparent_expr(init) else {
+                                return false;
+                            };
+                            known_bindings
+                                .get(source.sym.as_ref())
+                                .copied()
+                                .unwrap_or(false)
+                        });
                     for name in collect_pattern_binding_names(&decl.name) {
                         if stable_setters.contains(&name)
                             || stable_ref_object.as_deref() == Some(&name)
+                            || stable_destructure_source
                         {
                             known_bindings.insert(name.clone(), true);
                         } else {
@@ -2075,6 +2105,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
         }
         if is_default_param_conditional_expr(init.as_ref())
             && binding_only_used_in_terminal_return(&stmts[prefix_index + 1..], binding.sym.as_ref())
+            && !default_param_conditional_allocates_identity(init.as_ref())
         {
             break;
         }
@@ -2106,7 +2137,20 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
             && terminal_return_is_array_literal(&stmts[prefix_index + 1..])
             && !expr_is_mutating_member_call(&init)
         {
-            break;
+            let local_bindings = HashSet::new();
+            let init_deps = collect_dependencies_from_expr(&init, &known_bindings, &local_bindings);
+            let direct_identifier_call = matches!(
+                unwrap_transparent_expr(init.as_ref()),
+                Expr::Call(call)
+                    if matches!(
+                        &call.callee,
+                        Callee::Expr(callee_expr)
+                            if matches!(unwrap_transparent_expr(callee_expr), Expr::Ident(_))
+                    )
+            );
+            if !direct_identifier_call || init_deps.is_empty() {
+                break;
+            }
         }
         if let Expr::Call(call) = &*init {
             if call
@@ -2415,7 +2459,14 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
             let local = HashSet::new();
             collect_dependencies_from_expr(&init, &known_bindings, &local)
         };
-        let temp = if force_memoize_reassigned_jsx_tag_ident_init {
+        let use_binding_as_temp = force_memoize_reassigned_jsx_tag_ident_init
+            || (!reassigned_after
+                && next_stmt_destructures_from_binding(
+                    &stmts,
+                    prefix_index,
+                    binding.sym.as_ref(),
+                ));
+        let temp = if use_binding_as_temp {
             binding.clone()
         } else {
             fresh_temp_ident(&mut next_temp, &mut reserved)
@@ -2440,7 +2491,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
             std::mem::take(&mut compute_stmts),
             true,
         ));
-        if !force_memoize_reassigned_jsx_tag_ident_init {
+        if !use_binding_as_temp {
             transformed.push(make_var_decl(
                 if reassigned_after {
                     VarDeclKind::Let
@@ -2655,6 +2706,19 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                                 result_ident.sym.as_ref(),
                             )
                     });
+                let skip_tail_result_pattern_assignment_outer_memoization =
+                    result_ident.as_ref().is_some_and(|result_ident| {
+                        const_result_alias.is_none()
+                            && !return_as_const
+                            && matches!(
+                                &*return_expr,
+                                Expr::Ident(return_ident) if return_ident.sym == result_ident.sym
+                            )
+                            && should_skip_result_tail_pattern_assignment_outer_memoization(
+                                &tail,
+                                result_ident.sym.as_ref(),
+                            )
+                    });
                 let skip_tail_result_passthrough =
                     result_ident.as_ref().is_some_and(|result_ident| {
                         const_result_alias.is_none()
@@ -2696,6 +2760,7 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
 
                 if skip_tail_result_block_memoization
                     || skip_tail_result_outer_memoization
+                    || skip_tail_result_pattern_assignment_outer_memoization
                     || skip_tail_result_passthrough
                 {
                     let result_ident = result_ident
@@ -2846,6 +2911,24 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                             )
                         };
                     if !prelude_stmts.is_empty() && prelude_blocks == 0 {
+                        if let Some((rewritten_prelude, slots, blocks, values)) =
+                            rewrite_top_level_rest_pattern_assignments_in_prelude_to_memo_blocks(
+                                &prelude_stmts,
+                                &known_bindings,
+                                &cache_ident,
+                                next_slot,
+                            )
+                        {
+                            prelude_stmts = rewritten_prelude;
+                            prelude_slots = slots;
+                            prelude_blocks = blocks;
+                            prelude_values = values;
+                        }
+                    }
+                    if !prelude_stmts.is_empty()
+                        && prelude_blocks == 0
+                        && !prelude_contains_if_with_else(&prelude_stmts)
+                    {
                         if let Some(prelude_result_binding) = infer_prelude_result_binding(
                             &prelude_stmts,
                             &compute_stmts,
@@ -2906,6 +2989,22 @@ fn memoize_reactive_function(reactive: &mut ReactiveFunction) -> (u32, u32, u32,
                                 prelude_blocks = 1;
                                 prelude_values = 1;
                             }
+                        }
+                    }
+                    if !prelude_stmts.is_empty() && prelude_blocks == 0 {
+                        if let Some((rewritten_prelude, slots, values)) =
+                            try_build_pattern_assignment_prelude_memo_fallback(
+                                &prelude_stmts,
+                                &compute_stmts,
+                                &known_bindings,
+                                &cache_ident,
+                                next_slot,
+                            )
+                        {
+                            prelude_stmts = rewritten_prelude;
+                            prelude_slots = slots;
+                            prelude_blocks = 1;
+                            prelude_values = values;
                         }
                     }
                     if let Some(old_temp_name) = deferred_outer_temp_name {
@@ -3526,11 +3625,113 @@ fn body_contains_identity_sensitive_work(body: &BlockStmt) -> bool {
 
             expr.visit_children_with(self);
         }
+
+        fn visit_assign_pat(&mut self, assign_pat: &swc_ecma_ast::AssignPat) {
+            if self.found {
+                return;
+            }
+
+            if matches!(
+                unwrap_transparent_expr(&assign_pat.right),
+                Expr::Array(_)
+                    | Expr::Object(_)
+                    | Expr::Class(_)
+                    | Expr::New(_)
+                    | Expr::JSXElement(_)
+                    | Expr::JSXFragment(_)
+            ) {
+                self.found = true;
+                return;
+            }
+
+            assign_pat.visit_children_with(self);
+        }
     }
 
     let mut finder = Finder::default();
     body.visit_with(&mut finder);
     finder.found
+}
+
+fn body_contains_destructuring_default_alloc_literal(body: &BlockStmt) -> bool {
+    fn pat_has_default(pat: &Pat) -> bool {
+        match pat {
+            Pat::Assign(assign_pat) => {
+                is_static_alloc_literal_expr(&assign_pat.right) || pat_has_default(&assign_pat.left)
+            }
+            Pat::Array(array_pat) => array_pat
+                .elems
+                .iter()
+                .flatten()
+                .any(pat_has_default),
+            Pat::Object(object_pat) => object_pat.props.iter().any(|prop| match prop {
+                ObjectPatProp::Assign(assign_prop) => assign_prop
+                    .value
+                    .as_ref()
+                    .is_some_and(|value| is_static_alloc_literal_expr(value)),
+                ObjectPatProp::KeyValue(key_value) => pat_has_default(&key_value.value),
+                ObjectPatProp::Rest(rest) => pat_has_default(&rest.arg),
+            }),
+            Pat::Rest(rest_pat) => pat_has_default(&rest_pat.arg),
+            Pat::Ident(_) | Pat::Expr(_) | Pat::Invalid(_) => false,
+        }
+    }
+
+    fn stmt_has_default(stmt: &Stmt) -> bool {
+        match stmt {
+            Stmt::Decl(Decl::Var(var_decl)) => {
+                var_decl.decls.iter().any(|decl| pat_has_default(&decl.name))
+            }
+            Stmt::Block(block) => block.stmts.iter().any(stmt_has_default),
+            Stmt::Labeled(labeled) => stmt_has_default(&labeled.body),
+            Stmt::If(if_stmt) => {
+                stmt_has_default(&if_stmt.cons)
+                    || if_stmt.alt.as_deref().is_some_and(stmt_has_default)
+            }
+            Stmt::Switch(switch_stmt) => switch_stmt
+                .cases
+                .iter()
+                .any(|case| case.cons.iter().any(stmt_has_default)),
+            Stmt::Try(try_stmt) => {
+                try_stmt.block.stmts.iter().any(stmt_has_default)
+                    || try_stmt
+                        .handler
+                        .as_ref()
+                        .is_some_and(|handler| handler.body.stmts.iter().any(stmt_has_default))
+                    || try_stmt
+                        .finalizer
+                        .as_ref()
+                        .is_some_and(|finalizer| finalizer.stmts.iter().any(stmt_has_default))
+            }
+            Stmt::For(for_stmt) => {
+                for_stmt.init.as_ref().is_some_and(|init| match init {
+                    swc_ecma_ast::VarDeclOrExpr::VarDecl(var_decl) => {
+                        var_decl.decls.iter().any(|decl| pat_has_default(&decl.name))
+                    }
+                    swc_ecma_ast::VarDeclOrExpr::Expr(_) => false,
+                }) || stmt_has_default(&for_stmt.body)
+            }
+            Stmt::ForIn(for_in_stmt) => match &for_in_stmt.left {
+                swc_ecma_ast::ForHead::VarDecl(var_decl) => {
+                    var_decl.decls.iter().any(|decl| pat_has_default(&decl.name))
+                        || stmt_has_default(&for_in_stmt.body)
+                }
+                _ => stmt_has_default(&for_in_stmt.body),
+            },
+            Stmt::ForOf(for_of_stmt) => match &for_of_stmt.left {
+                swc_ecma_ast::ForHead::VarDecl(var_decl) => {
+                    var_decl.decls.iter().any(|decl| pat_has_default(&decl.name))
+                        || stmt_has_default(&for_of_stmt.body)
+                }
+                _ => stmt_has_default(&for_of_stmt.body),
+            },
+            Stmt::While(while_stmt) => stmt_has_default(&while_stmt.body),
+            Stmt::DoWhile(do_while_stmt) => stmt_has_default(&do_while_stmt.body),
+            _ => false,
+        }
+    }
+
+    body.stmts.iter().any(stmt_has_default)
 }
 
 fn contains_object_pattern_assignment_with_reassigned_binding(stmts: &[Stmt]) -> bool {
@@ -3609,6 +3810,70 @@ fn split_multi_var_decls_in_stmts(stmts: &mut Vec<Stmt>) {
             continue;
         };
         if var_decl.decls.len() <= 1 {
+            out.push(stmt);
+            continue;
+        }
+
+        for decl in &var_decl.decls {
+            out.push(Stmt::Decl(Decl::Var(Box::new(VarDecl {
+                span: var_decl.span,
+                ctxt: var_decl.ctxt,
+                kind: var_decl.kind,
+                declare: var_decl.declare,
+                decls: vec![decl.clone()],
+            }))));
+        }
+    }
+
+    *stmts = out;
+}
+
+fn split_multi_var_decls_without_initializers_in_stmts(stmts: &mut Vec<Stmt>) {
+    let mut out = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => {
+                split_multi_var_decls_without_initializers_in_stmts(&mut block.stmts);
+            }
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    split_multi_var_decls_without_initializers_in_stmts(&mut block.stmts);
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    split_multi_var_decls_without_initializers_in_stmts(&mut block.stmts);
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        split_multi_var_decls_without_initializers_in_stmts(&mut block.stmts);
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                split_multi_var_decls_without_initializers_in_stmts(&mut try_stmt.block.stmts);
+                if let Some(handler) = &mut try_stmt.handler {
+                    split_multi_var_decls_without_initializers_in_stmts(&mut handler.body.stmts);
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    split_multi_var_decls_without_initializers_in_stmts(&mut finalizer.stmts);
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    split_multi_var_decls_without_initializers_in_stmts(&mut case.cons);
+                }
+            }
+            _ => {}
+        }
+
+        let Stmt::Decl(Decl::Var(var_decl)) = &stmt else {
+            out.push(stmt);
+            continue;
+        };
+        if var_decl.decls.len() <= 1 || !var_decl.decls.iter().all(|decl| decl.init.is_none()) {
             out.push(stmt);
             continue;
         }
@@ -4352,6 +4617,28 @@ fn next_stmt_iife_may_mutate_binding(stmts: &[Stmt], index: usize, binding: &str
     iife_call_may_mutate_binding(call, binding)
 }
 
+fn next_stmt_destructures_from_binding(stmts: &[Stmt], index: usize, binding: &str) -> bool {
+    let Some(next_stmt) = stmts.get(index + 1) else {
+        return false;
+    };
+    let Stmt::Decl(Decl::Var(var_decl)) = next_stmt else {
+        return false;
+    };
+    let [decl] = var_decl.decls.as_slice() else {
+        return false;
+    };
+    if matches!(decl.name, Pat::Ident(_)) {
+        return false;
+    }
+    let Some(init) = &decl.init else {
+        return false;
+    };
+    matches!(
+        unwrap_transparent_expr(init),
+        Expr::Ident(source) if source.sym == binding
+    )
+}
+
 fn first_following_block_shadows_binding(stmts: &[Stmt], binding: &str) -> bool {
     let Some(Stmt::Block(block)) = stmts.first() else {
         return false;
@@ -4395,6 +4682,50 @@ fn maybe_extract_single_call_arg_to_temp(
     ));
     arg.expr = Box::new(Expr::Ident(arg_temp.clone()));
     known_bindings.insert(arg_temp.sym.to_string(), false);
+}
+
+fn normalize_non_ident_params_without_memoization(reactive: &mut ReactiveFunction) {
+    let mut reserved = HashSet::new();
+    for pat in &reactive.params {
+        collect_pattern_bindings(pat, &mut reserved);
+    }
+    for stmt in &reactive.body.stmts {
+        collect_stmt_bindings(stmt, &mut reserved);
+    }
+
+    let mut known_bindings = HashMap::<String, bool>::new();
+    let mut next_temp = 0u32;
+    let mut param_prologue = rewrite_non_ident_params(
+        &mut reactive.params,
+        &mut reserved,
+        &mut next_temp,
+        &mut known_bindings,
+    );
+    strip_runtime_call_type_args_in_stmts(&mut param_prologue);
+    rewrite_let_array_pattern_decls_to_assignment_stmts(&mut param_prologue, &mut reserved);
+    rewrite_const_object_pattern_default_decls_to_temp_chain(&mut param_prologue, &mut reserved);
+
+    let mut stmts = std::mem::take(&mut reactive.body.stmts);
+    rewrite_let_array_pattern_decls_to_assignment_stmts(&mut stmts, &mut reserved);
+    rewrite_const_object_pattern_default_decls_to_temp_chain(&mut stmts, &mut reserved);
+    prune_overwritten_branch_and_switch_assignments_in_stmts(&mut stmts);
+    normalize_switch_case_blocks_in_stmts(&mut stmts);
+    prune_trivial_do_while_break_stmts(&mut stmts);
+    normalize_reactive_labels(&mut stmts);
+    if param_prologue.is_empty() {
+        reactive.body.stmts = stmts;
+        return;
+    }
+
+    let directive_end = stmts
+        .iter()
+        .take_while(|stmt| directive_from_stmt(stmt).is_some())
+        .count();
+    let mut transformed = Vec::new();
+    transformed.extend(stmts.drain(..directive_end));
+    transformed.extend(param_prologue);
+    transformed.extend(stmts);
+    reactive.body.stmts = transformed;
 }
 
 fn rewrite_non_ident_params(
@@ -4455,6 +4786,55 @@ fn rewrite_non_ident_params(
                     id: temp.clone(),
                     type_ann: None,
                 });
+
+                if let Pat::Array(array_pat) = &original {
+                    let non_hole_pats = array_pat.elems.iter().flatten().collect::<Vec<_>>();
+                    if non_hole_pats.len() == 1 {
+                        if let Pat::Assign(assign_pat) = non_hole_pats[0] {
+                            if let Pat::Ident(binding) = &*assign_pat.left {
+                                let value_temp = fresh_temp_ident(next_temp, used);
+                                known_bindings.insert(value_temp.sym.to_string(), false);
+                                prologue.push(make_var_decl(
+                                    VarDeclKind::Const,
+                                    Pat::Array(swc_ecma_ast::ArrayPat {
+                                        span: array_pat.span,
+                                        elems: vec![Some(Pat::Ident(BindingIdent {
+                                            id: value_temp.clone(),
+                                            type_ann: None,
+                                        }))],
+                                        optional: false,
+                                        type_ann: None,
+                                    }),
+                                    Some(Box::new(Expr::Ident(temp))),
+                                ));
+                                prologue.push(make_var_decl(
+                                    VarDeclKind::Const,
+                                    Pat::Ident(BindingIdent {
+                                        id: binding.id.clone(),
+                                        type_ann: binding.type_ann.clone(),
+                                    }),
+                                    Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                                        span: DUMMY_SP,
+                                        test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                                            span: DUMMY_SP,
+                                            op: op!("==="),
+                                            left: Box::new(Expr::Ident(value_temp.clone())),
+                                            right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                                "undefined".into(),
+                                                DUMMY_SP,
+                                            ))),
+                                        })),
+                                        cons: parenthesize_conditional_expr(
+                                            assign_pat.right.clone(),
+                                        ),
+                                        alt: Box::new(Expr::Ident(value_temp)),
+                                    }))),
+                                ));
+                                continue;
+                            }
+                        }
+                    }
+                }
 
                 prologue.push(make_var_decl(
                     VarDeclKind::Const,
@@ -4979,6 +5359,280 @@ fn collect_dependencies_from_manual_memo_dep_array(
     Some(deps)
 }
 
+fn prune_trivial_do_while_break_stmts(stmts: &mut Vec<Stmt>) {
+    fn stmt_is_unlabeled_break(stmt: &Stmt) -> bool {
+        matches!(stmt, Stmt::Break(break_stmt) if break_stmt.label.is_none())
+    }
+
+    fn extract_unconditional_do_while_prefix(do_while_stmt: &swc_ecma_ast::DoWhileStmt) -> Option<Vec<Stmt>> {
+        let Stmt::Block(block) = &*do_while_stmt.body else {
+            return stmt_is_unlabeled_break(&do_while_stmt.body).then(Vec::new);
+        };
+
+        let non_empty_indices = block
+            .stmts
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, stmt)| (!matches!(stmt, Stmt::Empty(_))).then_some(idx))
+            .collect::<Vec<_>>();
+        let Some(&last_non_empty_idx) = non_empty_indices.last() else {
+            return None;
+        };
+        if !stmt_is_unlabeled_break(&block.stmts[last_non_empty_idx]) {
+            return None;
+        }
+
+        // Keep this rewrite conservative: if the do-body has other top-level break/continue
+        // control flow, we skip lowering because it may alter loop semantics.
+        for &idx in &non_empty_indices[..non_empty_indices.len().saturating_sub(1)] {
+            if matches!(block.stmts[idx], Stmt::Break(_) | Stmt::Continue(_)) {
+                return None;
+            }
+        }
+
+        let mut prefix = Vec::with_capacity(non_empty_indices.len().saturating_sub(1));
+        for (idx, stmt) in block.stmts.iter().enumerate() {
+            if idx == last_non_empty_idx || matches!(stmt, Stmt::Empty(_)) {
+                continue;
+            }
+            prefix.push(stmt.clone());
+        }
+
+        Some(prefix)
+    }
+
+    let mut pruned = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => prune_trivial_do_while_break_stmts(&mut block.stmts),
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    prune_trivial_do_while_break_stmts(&mut block.stmts);
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    prune_trivial_do_while_break_stmts(&mut block.stmts);
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        prune_trivial_do_while_break_stmts(&mut block.stmts);
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                prune_trivial_do_while_break_stmts(&mut try_stmt.block.stmts);
+                if let Some(handler) = &mut try_stmt.handler {
+                    prune_trivial_do_while_break_stmts(&mut handler.body.stmts);
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    prune_trivial_do_while_break_stmts(&mut finalizer.stmts);
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    prune_trivial_do_while_break_stmts(&mut case.cons);
+                }
+            }
+            Stmt::DoWhile(do_while_stmt) => {
+                if let Stmt::Block(block) = &mut *do_while_stmt.body {
+                    prune_trivial_do_while_break_stmts(&mut block.stmts);
+                }
+            }
+            _ => {}
+        }
+
+        if let Stmt::DoWhile(do_while_stmt) = &stmt {
+            if let Some(prefix) = extract_unconditional_do_while_prefix(do_while_stmt) {
+                pruned.extend(prefix);
+                continue;
+            }
+        }
+
+        pruned.push(stmt);
+    }
+
+    *stmts = pruned;
+}
+
+fn prune_overwritten_branch_and_switch_assignments_in_stmts(stmts: &mut Vec<Stmt>) {
+    fn single_non_empty_stmt(stmts: &[Stmt]) -> Option<&Stmt> {
+        let mut non_empty = stmts.iter().filter(|stmt| !matches!(stmt, Stmt::Empty(_)));
+        let first = non_empty.next()?;
+        if non_empty.next().is_some() {
+            return None;
+        }
+        Some(first)
+    }
+
+    fn simple_assignment_target_and_purity(stmt: &Stmt) -> Option<(String, bool)> {
+        let stmt = match stmt {
+            Stmt::Block(block) => single_non_empty_stmt(&block.stmts)?,
+            other => other,
+        };
+
+        let Stmt::Expr(expr_stmt) = stmt else {
+            return None;
+        };
+        let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) else {
+            return None;
+        };
+        if assign.op != op!("=") {
+            return None;
+        }
+        let target = assign.left.as_ident()?;
+        Some((
+            target.id.sym.to_string(),
+            !expr_has_observable_side_effect(&assign.right),
+        ))
+    }
+
+    fn clear_simple_pure_assignment_stmt_if_matches(stmt: &mut Box<Stmt>, target: &str) -> bool {
+        let Some((name, is_pure)) = simple_assignment_target_and_purity(stmt) else {
+            return false;
+        };
+        if name != target || !is_pure {
+            return false;
+        }
+
+        match &mut **stmt {
+            Stmt::Block(block) => {
+                block.stmts.clear();
+            }
+            _ => {
+                *stmt = Box::new(Stmt::Block(BlockStmt {
+                    span: DUMMY_SP,
+                    ctxt: Default::default(),
+                    stmts: Vec::new(),
+                }));
+            }
+        }
+        true
+    }
+
+    fn case_falls_through(case: &swc_ecma_ast::SwitchCase) -> bool {
+        fn stmt_terminates_case(stmt: &Stmt) -> bool {
+            match stmt {
+                Stmt::Break(_) | Stmt::Continue(_) | Stmt::Return(_) | Stmt::Throw(_) => true,
+                Stmt::Block(block) => block
+                    .stmts
+                    .iter()
+                    .rev()
+                    .find(|stmt| !matches!(stmt, Stmt::Empty(_)))
+                    .is_some_and(stmt_terminates_case),
+                _ => false,
+            }
+        }
+
+        case.cons
+            .iter()
+            .rev()
+            .find(|stmt| !matches!(stmt, Stmt::Empty(_)))
+            .map(|stmt| !stmt_terminates_case(stmt))
+            .unwrap_or(true)
+    }
+
+    fn case_single_pure_assignment_target(case: &swc_ecma_ast::SwitchCase) -> Option<String> {
+        let stmt = single_non_empty_stmt(&case.cons)?;
+        let (target, is_pure) = simple_assignment_target_and_purity(stmt)?;
+        is_pure.then_some(target)
+    }
+
+    fn case_starts_with_assignment_to_target(
+        case: &swc_ecma_ast::SwitchCase,
+        target: &str,
+    ) -> bool {
+        let Some(first) = case
+            .cons
+            .iter()
+            .find(|stmt| !matches!(stmt, Stmt::Empty(_)))
+        else {
+            return false;
+        };
+        let Some((name, _)) = simple_assignment_target_and_purity(first) else {
+            return false;
+        };
+        name == target
+    }
+
+    fn prune_switch_case_fallthrough_overwritten_assignments(
+        switch_stmt: &mut swc_ecma_ast::SwitchStmt,
+    ) {
+        let mut index = 0usize;
+        while index + 1 < switch_stmt.cases.len() {
+            let Some(target) = case_single_pure_assignment_target(&switch_stmt.cases[index]) else {
+                index += 1;
+                continue;
+            };
+            if !case_falls_through(&switch_stmt.cases[index])
+                || !case_starts_with_assignment_to_target(&switch_stmt.cases[index + 1], &target)
+            {
+                index += 1;
+                continue;
+            }
+
+            switch_stmt.cases[index].cons.clear();
+            index += 1;
+        }
+    }
+
+    fn recurse_stmt(stmt: &mut Stmt) {
+        match stmt {
+            Stmt::Block(block) => prune_overwritten_branch_and_switch_assignments_in_stmts(
+                &mut block.stmts,
+            ),
+            Stmt::Labeled(labeled) => recurse_stmt(&mut labeled.body),
+            Stmt::If(if_stmt) => {
+                recurse_stmt(&mut if_stmt.cons);
+                if let Some(alt) = &mut if_stmt.alt {
+                    recurse_stmt(alt);
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    prune_overwritten_branch_and_switch_assignments_in_stmts(&mut case.cons);
+                }
+                prune_switch_case_fallthrough_overwritten_assignments(switch_stmt);
+            }
+            Stmt::While(while_stmt) => recurse_stmt(&mut while_stmt.body),
+            Stmt::DoWhile(do_while_stmt) => recurse_stmt(&mut do_while_stmt.body),
+            Stmt::For(for_stmt) => recurse_stmt(&mut for_stmt.body),
+            Stmt::ForIn(for_in_stmt) => recurse_stmt(&mut for_in_stmt.body),
+            Stmt::ForOf(for_of_stmt) => recurse_stmt(&mut for_of_stmt.body),
+            Stmt::Try(try_stmt) => {
+                prune_overwritten_branch_and_switch_assignments_in_stmts(
+                    &mut try_stmt.block.stmts,
+                );
+                if let Some(handler) = &mut try_stmt.handler {
+                    prune_overwritten_branch_and_switch_assignments_in_stmts(
+                        &mut handler.body.stmts,
+                    );
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    prune_overwritten_branch_and_switch_assignments_in_stmts(&mut finalizer.stmts);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    for stmt in stmts.iter_mut() {
+        recurse_stmt(stmt);
+    }
+
+    for index in 0..stmts.len().saturating_sub(1) {
+        let Some((next_target, _)) = simple_assignment_target_and_purity(&stmts[index + 1]) else {
+            continue;
+        };
+        let Stmt::If(if_stmt) = &mut stmts[index] else {
+            continue;
+        };
+        clear_simple_pure_assignment_stmt_if_matches(&mut if_stmt.cons, &next_target);
+    }
+}
+
 fn rewrite_assignment_target_in_stmts(stmts: &mut [Stmt], from: &str, to: &str) {
     struct Rewriter<'a> {
         from: &'a str,
@@ -5054,6 +5708,1239 @@ fn rewrite_terminal_self_assignment_to_pattern_write(stmts: &mut Vec<Stmt>, bind
     }
 
     false
+}
+
+fn flatten_nested_destructuring_assignments_in_stmts(
+    stmts: &mut Vec<Stmt>,
+    reserved: &mut HashSet<String>,
+    next_temp: &mut u32,
+) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => flatten_nested_destructuring_assignments_in_stmts(
+                &mut block.stmts,
+                reserved,
+                next_temp,
+            ),
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    flatten_nested_destructuring_assignments_in_stmts(
+                        &mut block.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    flatten_nested_destructuring_assignments_in_stmts(
+                        &mut block.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        flatten_nested_destructuring_assignments_in_stmts(
+                            &mut block.stmts,
+                            reserved,
+                            next_temp,
+                        );
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                flatten_nested_destructuring_assignments_in_stmts(
+                    &mut try_stmt.block.stmts,
+                    reserved,
+                    next_temp,
+                );
+                if let Some(handler) = &mut try_stmt.handler {
+                    flatten_nested_destructuring_assignments_in_stmts(
+                        &mut handler.body.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    flatten_nested_destructuring_assignments_in_stmts(
+                        &mut finalizer.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    flatten_nested_destructuring_assignments_in_stmts(
+                        &mut case.cons,
+                        reserved,
+                        next_temp,
+                    );
+                }
+            }
+            _ => {}
+        }
+
+        let Some(lowered) = lower_nested_destructuring_assignment_stmt(&stmt, reserved, next_temp)
+        else {
+            rewritten.push(stmt);
+            continue;
+        };
+        rewritten.extend(lowered);
+    }
+
+    *stmts = rewritten;
+}
+
+fn lower_nested_destructuring_assignment_stmt(
+    stmt: &Stmt,
+    reserved: &mut HashSet<String>,
+    next_temp: &mut u32,
+) -> Option<Vec<Stmt>> {
+    let Stmt::Expr(expr_stmt) = stmt else {
+        return None;
+    };
+    let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) else {
+        return None;
+    };
+    if assign.op != op!("=") {
+        return None;
+    }
+    let AssignTarget::Pat(assign_pat) = &assign.left else {
+        return None;
+    };
+    let pat = Pat::from(assign_pat.clone());
+    if !pattern_contains_nested_destructuring(&pat) {
+        return None;
+    }
+
+    let mut lowered = Vec::new();
+    lower_nested_destructuring_pattern_from_source(
+        pat,
+        assign.right.clone(),
+        reserved,
+        next_temp,
+        &mut lowered,
+    );
+    Some(lowered)
+}
+
+fn pattern_contains_nested_destructuring(pat: &Pat) -> bool {
+    match pat {
+        Pat::Array(array_pat) => array_pat.elems.iter().flatten().any(|element| {
+            matches!(element, Pat::Array(_) | Pat::Object(_))
+                || pattern_contains_nested_destructuring(element)
+        }),
+        Pat::Object(object_pat) => object_pat.props.iter().any(|prop| match prop {
+            ObjectPatProp::Assign(_) => false,
+            ObjectPatProp::KeyValue(key_value) => {
+                matches!(*key_value.value, Pat::Array(_) | Pat::Object(_))
+                    || pattern_contains_nested_destructuring(&key_value.value)
+            }
+            ObjectPatProp::Rest(rest) => {
+                matches!(*rest.arg, Pat::Array(_) | Pat::Object(_))
+                    || pattern_contains_nested_destructuring(&rest.arg)
+            }
+        }),
+        Pat::Assign(assign_pat) => {
+            matches!(*assign_pat.left, Pat::Array(_) | Pat::Object(_))
+                || pattern_contains_nested_destructuring(&assign_pat.left)
+        }
+        Pat::Rest(rest_pat) => {
+            matches!(*rest_pat.arg, Pat::Array(_) | Pat::Object(_))
+                || pattern_contains_nested_destructuring(&rest_pat.arg)
+        }
+        Pat::Ident(_) | Pat::Expr(_) | Pat::Invalid(_) => false,
+    }
+}
+
+fn pattern_is_flat_reassignment(pat: &Pat) -> bool {
+    match pat {
+        Pat::Ident(_) => true,
+        Pat::Array(array_pat) => array_pat.elems.iter().flatten().all(|element| match element {
+            Pat::Ident(_) => true,
+            Pat::Expr(expr) => matches!(unwrap_transparent_expr(expr), Expr::Ident(_)),
+            Pat::Assign(assign_pat) => matches!(*assign_pat.left, Pat::Ident(_)),
+            Pat::Rest(rest_pat) => matches!(*rest_pat.arg, Pat::Ident(_)),
+            _ => false,
+        }),
+        Pat::Object(object_pat) => object_pat.props.iter().all(|prop| match prop {
+            ObjectPatProp::Assign(_) => true,
+            ObjectPatProp::KeyValue(key_value) => match &*key_value.value {
+                Pat::Ident(_) => true,
+                Pat::Expr(expr) => matches!(unwrap_transparent_expr(expr), Expr::Ident(_)),
+                Pat::Assign(assign_pat) => matches!(*assign_pat.left, Pat::Ident(_)),
+                _ => false,
+            },
+            ObjectPatProp::Rest(rest) => matches!(*rest.arg, Pat::Ident(_)),
+        }),
+        Pat::Assign(assign_pat) => matches!(*assign_pat.left, Pat::Ident(_)),
+        Pat::Rest(rest_pat) => matches!(*rest_pat.arg, Pat::Ident(_)),
+        Pat::Expr(_) | Pat::Invalid(_) => false,
+    }
+}
+
+fn lower_nested_destructuring_pattern_from_source(
+    pat: Pat,
+    source_expr: Box<Expr>,
+    reserved: &mut HashSet<String>,
+    next_temp: &mut u32,
+    out: &mut Vec<Stmt>,
+) {
+    if pattern_is_flat_reassignment(&pat) {
+        match pat {
+            Pat::Ident(binding) => {
+                out.push(assign_stmt(
+                    AssignTarget::from(binding.id),
+                    source_expr,
+                ));
+            }
+            Pat::Expr(expr) => {
+                let Expr::Ident(binding) = unwrap_transparent_expr(&expr) else {
+                    return;
+                };
+                out.push(assign_stmt(
+                    AssignTarget::from(binding.clone()),
+                    source_expr,
+                ));
+            }
+            Pat::Assign(assign_pat) => {
+                let Pat::Ident(binding) = &*assign_pat.left else {
+                    return;
+                };
+                out.push(assign_stmt(
+                    AssignTarget::from(binding.id.clone()),
+                    Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                        span: DUMMY_SP,
+                        test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                            span: DUMMY_SP,
+                            op: op!("==="),
+                            left: source_expr,
+                            right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                "undefined".into(),
+                                DUMMY_SP,
+                            ))),
+                        })),
+                        cons: parenthesize_conditional_expr(assign_pat.right.clone()),
+                        alt: Box::new(Expr::Ident(binding.id.clone())),
+                    })),
+                ));
+            }
+            other => {
+                if let Ok(target) = AssignTarget::try_from(other) {
+                    out.push(assign_stmt(target, source_expr));
+                }
+            }
+        }
+        return;
+    }
+
+    match pat {
+        Pat::Assign(assign_pat) => {
+            let value_temp = fresh_temp_ident(next_temp, reserved);
+            let source_for_alt = source_expr.clone();
+            out.push(make_var_decl(
+                VarDeclKind::Const,
+                Pat::Ident(BindingIdent {
+                    id: value_temp.clone(),
+                    type_ann: None,
+                }),
+                Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                    span: DUMMY_SP,
+                    test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                        span: DUMMY_SP,
+                        op: op!("==="),
+                        left: source_expr,
+                        right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                            "undefined".into(),
+                            DUMMY_SP,
+                        ))),
+                    })),
+                    cons: parenthesize_conditional_expr(assign_pat.right.clone()),
+                    alt: source_for_alt,
+                }))),
+            ));
+            lower_nested_destructuring_pattern_from_source(
+                *assign_pat.left,
+                Box::new(Expr::Ident(value_temp)),
+                reserved,
+                next_temp,
+                out,
+            );
+        }
+        Pat::Rest(rest_pat) => {
+            lower_nested_destructuring_pattern_from_source(
+                *rest_pat.arg,
+                source_expr,
+                reserved,
+                next_temp,
+                out,
+            );
+        }
+        Pat::Array(array_pat) => {
+            let mut temp_elems = Vec::with_capacity(array_pat.elems.len());
+            let mut actions = Vec::<(Pat, Ident)>::new();
+            for element in array_pat.elems {
+                let Some(element) = element else {
+                    temp_elems.push(None);
+                    continue;
+                };
+                let temp = fresh_temp_ident(next_temp, reserved);
+                match element {
+                    Pat::Rest(rest_pat) => {
+                        temp_elems.push(Some(Pat::Rest(swc_ecma_ast::RestPat {
+                            span: rest_pat.span,
+                            dot3_token: rest_pat.dot3_token,
+                            type_ann: rest_pat.type_ann,
+                            arg: Box::new(Pat::Ident(BindingIdent {
+                                id: temp.clone(),
+                                type_ann: None,
+                            })),
+                        })));
+                        actions.push((*rest_pat.arg, temp));
+                    }
+                    other => {
+                        temp_elems.push(Some(Pat::Ident(BindingIdent {
+                            id: temp.clone(),
+                            type_ann: None,
+                        })));
+                        actions.push((other, temp));
+                    }
+                }
+            }
+            out.push(make_var_decl(
+                VarDeclKind::Const,
+                Pat::Array(swc_ecma_ast::ArrayPat {
+                    span: array_pat.span,
+                    elems: temp_elems,
+                    optional: array_pat.optional,
+                    type_ann: array_pat.type_ann,
+                }),
+                Some(source_expr),
+            ));
+            for (action_pat, temp_ident) in actions {
+                lower_nested_destructuring_pattern_from_source(
+                    action_pat,
+                    Box::new(Expr::Ident(temp_ident)),
+                    reserved,
+                    next_temp,
+                    out,
+                );
+            }
+        }
+        Pat::Object(object_pat) => {
+            let mut temp_props = Vec::with_capacity(object_pat.props.len());
+            let mut actions = Vec::<(Pat, Ident)>::new();
+            for prop in object_pat.props {
+                match prop {
+                    ObjectPatProp::Assign(assign_prop) => {
+                        let temp = fresh_temp_ident(next_temp, reserved);
+                        temp_props.push(ObjectPatProp::KeyValue(swc_ecma_ast::KeyValuePatProp {
+                            key: PropName::Ident(assign_prop.key.id.clone().into()),
+                            value: Box::new(Pat::Ident(BindingIdent {
+                                id: temp.clone(),
+                                type_ann: None,
+                            })),
+                        }));
+                        let action_pat = if let Some(default_expr) = assign_prop.value {
+                            Pat::Assign(swc_ecma_ast::AssignPat {
+                                span: assign_prop.span,
+                                left: Box::new(Pat::Ident(BindingIdent {
+                                    id: assign_prop.key.id,
+                                    type_ann: None,
+                                })),
+                                right: default_expr,
+                            })
+                        } else {
+                            Pat::Ident(BindingIdent {
+                                id: assign_prop.key.id,
+                                type_ann: None,
+                            })
+                        };
+                        actions.push((action_pat, temp));
+                    }
+                    ObjectPatProp::KeyValue(key_value) => {
+                        let temp = fresh_temp_ident(next_temp, reserved);
+                        let key = key_value.key.clone();
+                        let original_value = *key_value.value;
+                        temp_props.push(ObjectPatProp::KeyValue(swc_ecma_ast::KeyValuePatProp {
+                            key: key,
+                            value: Box::new(Pat::Ident(BindingIdent {
+                                id: temp.clone(),
+                                type_ann: None,
+                            })),
+                        }));
+                        let action_pat = match &original_value {
+                            Pat::Ident(binding) => {
+                                let key_mismatches_binding = match &key_value.key {
+                                    PropName::Ident(prop_ident) => prop_ident.sym != binding.id.sym,
+                                    _ => true,
+                                };
+                                if key_mismatches_binding {
+                                    Pat::Object(swc_ecma_ast::ObjectPat {
+                                        span: DUMMY_SP,
+                                        props: vec![ObjectPatProp::KeyValue(
+                                            swc_ecma_ast::KeyValuePatProp {
+                                                key: key_value.key,
+                                                value: Box::new(Pat::Ident(binding.clone())),
+                                            },
+                                        )],
+                                        optional: false,
+                                        type_ann: None,
+                                    })
+                                } else {
+                                    original_value
+                                }
+                            }
+                            Pat::Expr(expr) => {
+                                if let Expr::Ident(binding) = unwrap_transparent_expr(expr) {
+                                    let key_mismatches_binding = match &key_value.key {
+                                        PropName::Ident(prop_ident) => {
+                                            prop_ident.sym != binding.sym
+                                        }
+                                        _ => true,
+                                    };
+                                    if key_mismatches_binding {
+                                        Pat::Object(swc_ecma_ast::ObjectPat {
+                                            span: DUMMY_SP,
+                                            props: vec![ObjectPatProp::KeyValue(
+                                                swc_ecma_ast::KeyValuePatProp {
+                                                    key: key_value.key,
+                                                    value: Box::new(Pat::Expr(Box::new(
+                                                        Expr::Ident(binding.clone()),
+                                                    ))),
+                                                },
+                                            )],
+                                            optional: false,
+                                            type_ann: None,
+                                        })
+                                    } else {
+                                        original_value
+                                    }
+                                } else {
+                                    original_value
+                                }
+                            }
+                            _ => original_value,
+                        };
+                        actions.push((action_pat, temp));
+                    }
+                    ObjectPatProp::Rest(rest_prop) => {
+                        let temp = fresh_temp_ident(next_temp, reserved);
+                        temp_props.push(ObjectPatProp::Rest(swc_ecma_ast::RestPat {
+                            span: rest_prop.span,
+                            dot3_token: rest_prop.dot3_token,
+                            type_ann: rest_prop.type_ann,
+                            arg: Box::new(Pat::Ident(BindingIdent {
+                                id: temp.clone(),
+                                type_ann: None,
+                            })),
+                        }));
+                        actions.push((*rest_prop.arg, temp));
+                    }
+                }
+            }
+            out.push(make_var_decl(
+                VarDeclKind::Const,
+                Pat::Object(swc_ecma_ast::ObjectPat {
+                    span: object_pat.span,
+                    props: temp_props,
+                    optional: object_pat.optional,
+                    type_ann: object_pat.type_ann,
+                }),
+                Some(source_expr),
+            ));
+            for (action_pat, temp_ident) in actions {
+                lower_nested_destructuring_pattern_from_source(
+                    action_pat,
+                    Box::new(Expr::Ident(temp_ident)),
+                    reserved,
+                    next_temp,
+                    out,
+                );
+            }
+        }
+        Pat::Ident(binding) => {
+            out.push(assign_stmt(
+                AssignTarget::from(binding.id),
+                source_expr,
+            ));
+        }
+        Pat::Expr(_) | Pat::Invalid(_) => {}
+    }
+}
+
+fn collapse_single_object_temp_destructure_assign_pairs(stmts: &mut Vec<Stmt>) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    let mut index = 0usize;
+
+    while index < stmts.len() {
+        if let Some(replacement) =
+            build_collapsed_object_temp_destructure_assign(stmts.get(index), stmts.get(index + 1))
+        {
+            rewritten.push(replacement);
+            index += 2;
+            continue;
+        }
+
+        let mut stmt = stmts[index].clone();
+        match &mut stmt {
+            Stmt::Block(block) => {
+                collapse_single_object_temp_destructure_assign_pairs(&mut block.stmts);
+            }
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    collapse_single_object_temp_destructure_assign_pairs(&mut block.stmts);
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    collapse_single_object_temp_destructure_assign_pairs(&mut block.stmts);
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        collapse_single_object_temp_destructure_assign_pairs(&mut block.stmts);
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                collapse_single_object_temp_destructure_assign_pairs(&mut try_stmt.block.stmts);
+                if let Some(handler) = &mut try_stmt.handler {
+                    collapse_single_object_temp_destructure_assign_pairs(&mut handler.body.stmts);
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    collapse_single_object_temp_destructure_assign_pairs(&mut finalizer.stmts);
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    collapse_single_object_temp_destructure_assign_pairs(&mut case.cons);
+                }
+            }
+            _ => {}
+        }
+
+        rewritten.push(stmt);
+        index += 1;
+    }
+
+    *stmts = rewritten;
+}
+
+fn build_collapsed_object_temp_destructure_assign(
+    first: Option<&Stmt>,
+    second: Option<&Stmt>,
+) -> Option<Stmt> {
+    let first = first?;
+    let second = second?;
+
+    let Stmt::Decl(Decl::Var(var_decl)) = first else {
+        return None;
+    };
+    if var_decl.kind != VarDeclKind::Const {
+        return None;
+    }
+    let [decl] = var_decl.decls.as_slice() else {
+        return None;
+    };
+    let Pat::Object(object_pat) = &decl.name else {
+        return None;
+    };
+    let [ObjectPatProp::KeyValue(key_value)] = object_pat.props.as_slice() else {
+        return None;
+    };
+    let Pat::Ident(temp_binding) = &*key_value.value else {
+        return None;
+    };
+    let source_expr = decl.init.clone()?;
+
+    let Stmt::Expr(expr_stmt) = second else {
+        return None;
+    };
+    let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) else {
+        return None;
+    };
+    if assign.op != op!("=") {
+        return None;
+    }
+    let target_ident = assign.left.as_ident()?;
+    let Expr::Ident(source_ident) = unwrap_transparent_expr(&assign.right) else {
+        return None;
+    };
+    if source_ident.sym != temp_binding.id.sym {
+        return None;
+    }
+
+    let collapsed_pat = Pat::Object(swc_ecma_ast::ObjectPat {
+        span: object_pat.span,
+        props: vec![ObjectPatProp::KeyValue(swc_ecma_ast::KeyValuePatProp {
+            key: key_value.key.clone(),
+            value: Box::new(Pat::Ident(BindingIdent {
+                id: target_ident.id.clone(),
+                type_ann: None,
+            })),
+        })],
+        optional: object_pat.optional,
+        type_ann: object_pat.type_ann.clone(),
+    });
+    let target = AssignTarget::try_from(collapsed_pat).ok()?;
+    Some(assign_stmt(target, source_expr))
+}
+
+fn flatten_nested_destructuring_decls_to_temp_chain(
+    stmts: &mut Vec<Stmt>,
+    reserved: &mut HashSet<String>,
+    next_temp: &mut u32,
+) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => {
+                flatten_nested_destructuring_decls_to_temp_chain(
+                    &mut block.stmts,
+                    reserved,
+                    next_temp,
+                );
+            }
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    flatten_nested_destructuring_decls_to_temp_chain(
+                        &mut block.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    flatten_nested_destructuring_decls_to_temp_chain(
+                        &mut block.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        flatten_nested_destructuring_decls_to_temp_chain(
+                            &mut block.stmts,
+                            reserved,
+                            next_temp,
+                        );
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                flatten_nested_destructuring_decls_to_temp_chain(
+                    &mut try_stmt.block.stmts,
+                    reserved,
+                    next_temp,
+                );
+                if let Some(handler) = &mut try_stmt.handler {
+                    flatten_nested_destructuring_decls_to_temp_chain(
+                        &mut handler.body.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    flatten_nested_destructuring_decls_to_temp_chain(
+                        &mut finalizer.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    flatten_nested_destructuring_decls_to_temp_chain(
+                        &mut case.cons,
+                        reserved,
+                        next_temp,
+                    );
+                }
+            }
+            _ => {}
+        }
+
+        let Stmt::Decl(Decl::Var(var_decl)) = &stmt else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if !matches!(var_decl.kind, VarDeclKind::Let | VarDeclKind::Const) {
+            rewritten.push(stmt);
+            continue;
+        }
+        let [decl] = var_decl.decls.as_slice() else {
+            rewritten.push(stmt);
+            continue;
+        };
+        let Some(init) = &decl.init else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if !matches!(decl.name, Pat::Array(_) | Pat::Object(_)) {
+            rewritten.push(stmt);
+            continue;
+        }
+
+        let Some(flattened) = flatten_destructuring_decl_to_temp_chain(
+            var_decl.kind,
+            decl.name.clone(),
+            init.clone(),
+            reserved,
+            next_temp,
+        ) else {
+            rewritten.push(stmt);
+            continue;
+        };
+        rewritten.extend(flattened);
+    }
+
+    *stmts = rewritten;
+}
+
+fn flatten_destructuring_decl_to_temp_chain(
+    kind: VarDeclKind,
+    pattern: Pat,
+    init: Box<Expr>,
+    reserved: &mut HashSet<String>,
+    next_temp: &mut u32,
+) -> Option<Vec<Stmt>> {
+    let mut queue = VecDeque::new();
+    queue.push_back((pattern, init));
+
+    let mut rewritten = Vec::new();
+    let mut changed = false;
+
+    while let Some((pat, init_expr)) = queue.pop_front() {
+        match pat {
+            Pat::Array(array_pat) => {
+                let (rewritten_pat, nested) =
+                    flatten_array_pattern_one_level(array_pat, reserved, next_temp);
+                changed |= !nested.is_empty();
+                rewritten.push(make_var_decl(kind, Pat::Array(rewritten_pat), Some(init_expr)));
+                for (nested_pat, temp) in nested {
+                    queue.push_back((nested_pat, Box::new(Expr::Ident(temp))));
+                }
+            }
+            Pat::Object(object_pat) => {
+                let (rewritten_pat, nested) =
+                    flatten_object_pattern_one_level(object_pat, reserved, next_temp);
+                changed |= !nested.is_empty();
+                rewritten.push(make_var_decl(kind, Pat::Object(rewritten_pat), Some(init_expr)));
+                for (nested_pat, temp) in nested {
+                    queue.push_back((nested_pat, Box::new(Expr::Ident(temp))));
+                }
+            }
+            Pat::Assign(assign_pat)
+                if matches!(*assign_pat.left, Pat::Array(_) | Pat::Object(_)) =>
+            {
+                changed = true;
+                let value_temp = fresh_temp_ident(next_temp, reserved);
+                let source_for_alt = init_expr.clone();
+                rewritten.push(make_var_decl(
+                    kind,
+                    Pat::Ident(BindingIdent {
+                        id: value_temp.clone(),
+                        type_ann: None,
+                    }),
+                    Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                        span: DUMMY_SP,
+                        test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                            span: DUMMY_SP,
+                            op: op!("==="),
+                            left: init_expr,
+                            right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                "undefined".into(),
+                                DUMMY_SP,
+                            ))),
+                        })),
+                        cons: parenthesize_conditional_expr(assign_pat.right.clone()),
+                        alt: source_for_alt,
+                    }))),
+                ));
+                queue.push_back((*assign_pat.left, Box::new(Expr::Ident(value_temp))));
+            }
+            _ => {
+                rewritten.push(make_var_decl(kind, pat, Some(init_expr)));
+            }
+        }
+    }
+
+    changed.then_some(rewritten)
+}
+
+fn flatten_array_pattern_one_level(
+    mut array_pat: swc_ecma_ast::ArrayPat,
+    reserved: &mut HashSet<String>,
+    next_temp: &mut u32,
+) -> (swc_ecma_ast::ArrayPat, Vec<(Pat, Ident)>) {
+    let mut nested = Vec::new();
+    let mut rewritten_elems = Vec::with_capacity(array_pat.elems.len());
+
+    for element in array_pat.elems {
+        let Some(element) = element else {
+            rewritten_elems.push(None);
+            continue;
+        };
+
+        match element {
+            Pat::Array(_) | Pat::Object(_) => {
+                let temp = fresh_temp_ident(next_temp, reserved);
+                nested.push((element, temp.clone()));
+                rewritten_elems.push(Some(Pat::Ident(BindingIdent {
+                    id: temp,
+                    type_ann: None,
+                })));
+            }
+            Pat::Rest(mut rest_pat) if matches!(*rest_pat.arg, Pat::Array(_) | Pat::Object(_)) => {
+                let nested_pat = *rest_pat.arg;
+                let temp = fresh_temp_ident(next_temp, reserved);
+                rest_pat.arg = Box::new(Pat::Ident(BindingIdent {
+                    id: temp.clone(),
+                    type_ann: None,
+                }));
+                nested.push((nested_pat, temp));
+                rewritten_elems.push(Some(Pat::Rest(rest_pat)));
+            }
+            _ => rewritten_elems.push(Some(element)),
+        }
+    }
+
+    array_pat.elems = rewritten_elems;
+    (array_pat, nested)
+}
+
+fn flatten_object_pattern_one_level(
+    mut object_pat: swc_ecma_ast::ObjectPat,
+    reserved: &mut HashSet<String>,
+    next_temp: &mut u32,
+) -> (swc_ecma_ast::ObjectPat, Vec<(Pat, Ident)>) {
+    let mut nested = Vec::new();
+    let mut rewritten_props = Vec::with_capacity(object_pat.props.len());
+
+    for prop in object_pat.props {
+        match prop {
+            ObjectPatProp::KeyValue(mut key_value) => match *key_value.value {
+                Pat::Array(_) | Pat::Object(_) => {
+                    let nested_pat = *key_value.value;
+                    let temp = fresh_temp_ident(next_temp, reserved);
+                    key_value.value = Box::new(Pat::Ident(BindingIdent {
+                        id: temp.clone(),
+                        type_ann: None,
+                    }));
+                    nested.push((nested_pat, temp));
+                    rewritten_props.push(ObjectPatProp::KeyValue(key_value));
+                }
+                Pat::Assign(assign_pat)
+                    if matches!(*assign_pat.left, Pat::Array(_) | Pat::Object(_)) =>
+                {
+                    let nested_pat = Pat::Assign(assign_pat);
+                    let temp = fresh_temp_ident(next_temp, reserved);
+                    key_value.value = Box::new(Pat::Ident(BindingIdent {
+                        id: temp.clone(),
+                        type_ann: None,
+                    }));
+                    nested.push((nested_pat, temp));
+                    rewritten_props.push(ObjectPatProp::KeyValue(key_value));
+                }
+                _ => rewritten_props.push(ObjectPatProp::KeyValue(key_value)),
+            },
+            ObjectPatProp::Rest(mut rest) => match *rest.arg {
+                Pat::Array(_) | Pat::Object(_) => {
+                    let nested_pat = *rest.arg;
+                    let temp = fresh_temp_ident(next_temp, reserved);
+                    rest.arg = Box::new(Pat::Ident(BindingIdent {
+                        id: temp.clone(),
+                        type_ann: None,
+                    }));
+                    nested.push((nested_pat, temp));
+                    rewritten_props.push(ObjectPatProp::Rest(rest));
+                }
+                _ => rewritten_props.push(ObjectPatProp::Rest(rest)),
+            },
+            other => rewritten_props.push(other),
+        }
+    }
+
+    object_pat.props = rewritten_props;
+    (object_pat, nested)
+}
+
+fn rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(stmts: &mut Vec<Stmt>) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => {
+                rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(&mut block.stmts);
+            }
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(
+                        &mut block.stmts,
+                    );
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(
+                        &mut block.stmts,
+                    );
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(
+                            &mut block.stmts,
+                        );
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(
+                    &mut try_stmt.block.stmts,
+                );
+                if let Some(handler) = &mut try_stmt.handler {
+                    rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(
+                        &mut handler.body.stmts,
+                    );
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(
+                        &mut finalizer.stmts,
+                    );
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    rewrite_destructuring_decls_with_top_level_rest_to_assignment_stmts(
+                        &mut case.cons,
+                    );
+                }
+            }
+            _ => {}
+        }
+
+        let Stmt::Decl(Decl::Var(var_decl)) = &stmt else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if !matches!(var_decl.kind, VarDeclKind::Let | VarDeclKind::Const) {
+            rewritten.push(stmt);
+            continue;
+        }
+        let [decl] = var_decl.decls.as_slice() else {
+            rewritten.push(stmt);
+            continue;
+        };
+        let Some(init) = &decl.init else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if !pattern_has_top_level_rest(&decl.name) {
+            rewritten.push(stmt);
+            continue;
+        }
+        let Ok(target) = AssignTarget::try_from(decl.name.clone()) else {
+            rewritten.push(stmt);
+            continue;
+        };
+
+        let mut seen = HashSet::new();
+        let binding_names = collect_pattern_binding_names_in_order(&decl.name)
+            .into_iter()
+            .filter(|name| seen.insert(name.clone()))
+            .collect::<Vec<_>>();
+        let binding_names = reorder_array_rest_temp_binding_first(
+            reorder_cache_binding_names_for_pattern_assignment(binding_names),
+            &decl.name,
+        );
+        if binding_names.is_empty() {
+            rewritten.push(stmt);
+            continue;
+        }
+
+        for binding in binding_names {
+            rewritten.push(make_var_decl(
+                VarDeclKind::Let,
+                Pat::Ident(BindingIdent {
+                    id: Ident::new_no_ctxt(binding.into(), DUMMY_SP),
+                    type_ann: None,
+                }),
+                None,
+            ));
+        }
+        rewritten.push(assign_stmt(target, init.clone()));
+    }
+
+    *stmts = rewritten;
+}
+
+fn pattern_has_top_level_rest(pat: &Pat) -> bool {
+    match pat {
+        Pat::Array(array) => array
+            .elems
+            .iter()
+            .flatten()
+            .any(|element| matches!(element, Pat::Rest(_))),
+        Pat::Object(object) => object
+            .props
+            .iter()
+            .any(|prop| matches!(prop, ObjectPatProp::Rest(_))),
+        _ => false,
+    }
+}
+
+fn rewrite_const_object_pattern_default_decls_to_temp_chain(
+    stmts: &mut Vec<Stmt>,
+    reserved: &mut HashSet<String>,
+) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+    let mut scope_bindings = HashSet::new();
+    for stmt in &original {
+        collect_stmt_bindings_including_nested_blocks(stmt, &mut scope_bindings);
+    }
+    scope_bindings.extend(reserved.iter().cloned());
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => {
+                rewrite_const_object_pattern_default_decls_to_temp_chain(
+                    &mut block.stmts,
+                    reserved,
+                );
+            }
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    rewrite_const_object_pattern_default_decls_to_temp_chain(
+                        &mut block.stmts,
+                        reserved,
+                    );
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    rewrite_const_object_pattern_default_decls_to_temp_chain(
+                        &mut block.stmts,
+                        reserved,
+                    );
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        rewrite_const_object_pattern_default_decls_to_temp_chain(
+                            &mut block.stmts,
+                            reserved,
+                        );
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                rewrite_const_object_pattern_default_decls_to_temp_chain(
+                    &mut try_stmt.block.stmts,
+                    reserved,
+                );
+                if let Some(handler) = &mut try_stmt.handler {
+                    rewrite_const_object_pattern_default_decls_to_temp_chain(
+                        &mut handler.body.stmts,
+                        reserved,
+                    );
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    rewrite_const_object_pattern_default_decls_to_temp_chain(
+                        &mut finalizer.stmts,
+                        reserved,
+                    );
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    rewrite_const_object_pattern_default_decls_to_temp_chain(
+                        &mut case.cons,
+                        reserved,
+                    );
+                }
+            }
+            _ => {}
+        }
+
+        let Stmt::Decl(Decl::Var(var_decl)) = &stmt else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if !matches!(var_decl.kind, VarDeclKind::Const | VarDeclKind::Let) {
+            rewritten.push(stmt);
+            continue;
+        }
+        let [decl] = var_decl.decls.as_slice() else {
+            rewritten.push(stmt);
+            continue;
+        };
+        let Pat::Object(object_pat) = &decl.name else {
+            rewritten.push(stmt);
+            continue;
+        };
+        let Some(init) = &decl.init else {
+            rewritten.push(stmt);
+            continue;
+        };
+
+        let mut rewritten_props = Vec::with_capacity(object_pat.props.len());
+        let mut follow_up = Vec::new();
+        let mut changed = false;
+
+        for prop in &object_pat.props {
+            match prop {
+                ObjectPatProp::Assign(assign_prop) if assign_prop.value.is_some() => {
+                    changed = true;
+                    let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+                    rewritten_props.push(ObjectPatProp::KeyValue(swc_ecma_ast::KeyValuePatProp {
+                        key: PropName::Ident(assign_prop.key.id.clone().into()),
+                        value: Box::new(Pat::Ident(BindingIdent {
+                            id: temp.clone(),
+                            type_ann: None,
+                        })),
+                    }));
+                    follow_up.push(make_var_decl(
+                        var_decl.kind,
+                        Pat::Ident(BindingIdent {
+                            id: assign_prop.key.id.clone(),
+                            type_ann: None,
+                        }),
+                        Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                            span: DUMMY_SP,
+                            test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                                span: DUMMY_SP,
+                                op: op!("==="),
+                                left: Box::new(Expr::Ident(temp.clone())),
+                                right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                    "undefined".into(),
+                                    DUMMY_SP,
+                                ))),
+                            })),
+                            cons: assign_prop
+                                .value
+                                .clone()
+                                .expect("guarded by is_some"),
+                            alt: Box::new(Expr::Ident(temp)),
+                        }))),
+                    ));
+                }
+                other => rewritten_props.push(other.clone()),
+            }
+        }
+
+        if !changed {
+            rewritten.push(stmt);
+            continue;
+        }
+
+        rewritten.push(make_var_decl(
+            var_decl.kind,
+            Pat::Object(swc_ecma_ast::ObjectPat {
+                span: object_pat.span,
+                props: rewritten_props,
+                optional: object_pat.optional,
+                type_ann: object_pat.type_ann.clone(),
+            }),
+            Some(init.clone()),
+        ));
+        rewritten.extend(follow_up);
+    }
+
+    *stmts = rewritten;
+}
+
+fn rewrite_let_object_pattern_decls_to_assignment_stmts(stmts: &mut Vec<Stmt>) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => {
+                rewrite_let_object_pattern_decls_to_assignment_stmts(&mut block.stmts);
+            }
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    rewrite_let_object_pattern_decls_to_assignment_stmts(&mut block.stmts);
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    rewrite_let_object_pattern_decls_to_assignment_stmts(&mut block.stmts);
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        rewrite_let_object_pattern_decls_to_assignment_stmts(&mut block.stmts);
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                rewrite_let_object_pattern_decls_to_assignment_stmts(&mut try_stmt.block.stmts);
+                if let Some(handler) = &mut try_stmt.handler {
+                    rewrite_let_object_pattern_decls_to_assignment_stmts(&mut handler.body.stmts);
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    rewrite_let_object_pattern_decls_to_assignment_stmts(&mut finalizer.stmts);
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    rewrite_let_object_pattern_decls_to_assignment_stmts(&mut case.cons);
+                }
+            }
+            _ => {}
+        }
+
+        let Stmt::Decl(Decl::Var(var_decl)) = &stmt else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if var_decl.kind != VarDeclKind::Let {
+            rewritten.push(stmt);
+            continue;
+        }
+        let [decl] = var_decl.decls.as_slice() else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if !matches!(decl.name, Pat::Object(_)) {
+            rewritten.push(stmt);
+            continue;
+        }
+        let Some(init) = &decl.init else {
+            rewritten.push(stmt);
+            continue;
+        };
+        let binding_names = collect_pattern_binding_names_in_order(&decl.name);
+        let [binding] = binding_names.as_slice() else {
+            rewritten.push(stmt);
+            continue;
+        };
+        let Ok(target) = AssignTarget::try_from(decl.name.clone()) else {
+            rewritten.push(stmt);
+            continue;
+        };
+
+        rewritten.push(make_var_decl(
+            VarDeclKind::Let,
+            Pat::Ident(BindingIdent {
+                id: Ident::new_no_ctxt(binding.clone().into(), DUMMY_SP),
+                type_ann: None,
+            }),
+            None,
+        ));
+        rewritten.push(assign_stmt(target, init.clone()));
+    }
+
+    *stmts = rewritten;
 }
 
 fn rewrite_let_array_pattern_decls_to_assignment_stmts(
@@ -5154,45 +7041,95 @@ fn rewrite_let_array_pattern_decls_to_assignment_stmts(
 
         match (var_decl.kind, non_hole_pats[0]) {
             (VarDeclKind::Const, Pat::Assign(assign_pat)) => {
-                let Pat::Ident(binding) = &*assign_pat.left else {
-                    rewritten.push(stmt);
-                    continue;
-                };
-                let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
-                rewritten.push(make_var_decl(
-                    VarDeclKind::Const,
-                    Pat::Array(swc_ecma_ast::ArrayPat {
-                        span: array_pat.span,
-                        elems: vec![Some(Pat::Ident(BindingIdent {
-                            id: temp.clone(),
-                            type_ann: None,
-                        }))],
-                        optional: false,
-                        type_ann: None,
-                    }),
-                    Some(init.clone()),
-                ));
-                rewritten.push(make_var_decl(
-                    VarDeclKind::Const,
-                    Pat::Ident(BindingIdent {
-                        id: binding.id.clone(),
-                        type_ann: None,
-                    }),
-                    Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
-                        span: DUMMY_SP,
-                        test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
-                            span: DUMMY_SP,
-                            op: op!("==="),
-                            left: Box::new(Expr::Ident(temp.clone())),
-                            right: Box::new(Expr::Ident(Ident::new_no_ctxt(
-                                "undefined".into(),
-                                DUMMY_SP,
-                            ))),
-                        })),
-                        cons: assign_pat.right.clone(),
-                        alt: Box::new(Expr::Ident(temp)),
-                    }))),
-                ));
+                match &*assign_pat.left {
+                    Pat::Ident(binding) => {
+                        let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+                        rewritten.push(make_var_decl(
+                            VarDeclKind::Const,
+                            Pat::Array(swc_ecma_ast::ArrayPat {
+                                span: array_pat.span,
+                                elems: vec![Some(Pat::Ident(BindingIdent {
+                                    id: temp.clone(),
+                                    type_ann: None,
+                                }))],
+                                optional: false,
+                                type_ann: None,
+                            }),
+                            Some(init.clone()),
+                        ));
+                        rewritten.push(make_var_decl(
+                            VarDeclKind::Const,
+                            Pat::Ident(BindingIdent {
+                                id: binding.id.clone(),
+                                type_ann: None,
+                            }),
+                            Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                                span: DUMMY_SP,
+                                test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                                    span: DUMMY_SP,
+                                    op: op!("==="),
+                                    left: Box::new(Expr::Ident(temp.clone())),
+                                    right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                        "undefined".into(),
+                                        DUMMY_SP,
+                                    ))),
+                                })),
+                                cons: parenthesize_conditional_expr(
+                                    assign_pat.right.clone(),
+                                ),
+                                alt: Box::new(Expr::Ident(temp)),
+                            }))),
+                        ));
+                    }
+                    Pat::Array(_) | Pat::Object(_) => {
+                        let input_temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+                        let value_temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+                        rewritten.push(make_var_decl(
+                            VarDeclKind::Const,
+                            Pat::Array(swc_ecma_ast::ArrayPat {
+                                span: array_pat.span,
+                                elems: vec![Some(Pat::Ident(BindingIdent {
+                                    id: input_temp.clone(),
+                                    type_ann: None,
+                                }))],
+                                optional: false,
+                                type_ann: None,
+                            }),
+                            Some(init.clone()),
+                        ));
+                        rewritten.push(make_var_decl(
+                            VarDeclKind::Let,
+                            Pat::Ident(BindingIdent {
+                                id: value_temp.clone(),
+                                type_ann: None,
+                            }),
+                            Some(Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                                span: DUMMY_SP,
+                                test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                                    span: DUMMY_SP,
+                                    op: op!("==="),
+                                    left: Box::new(Expr::Ident(input_temp.clone())),
+                                    right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                                        "undefined".into(),
+                                        DUMMY_SP,
+                                    ))),
+                                })),
+                                cons: parenthesize_conditional_expr(
+                                    assign_pat.right.clone(),
+                                ),
+                                alt: Box::new(Expr::Ident(input_temp)),
+                            }))),
+                        ));
+                        rewritten.push(make_var_decl(
+                            VarDeclKind::Const,
+                            (*assign_pat.left).clone(),
+                            Some(Box::new(Expr::Ident(value_temp))),
+                        ));
+                    }
+                    _ => {
+                        rewritten.push(stmt);
+                    }
+                }
             }
             (VarDeclKind::Let, Pat::Ident(binding)) => {
                 let Ok(target) = AssignTarget::try_from(pat.clone()) else {
@@ -5232,6 +7169,125 @@ fn rewrite_let_array_pattern_decls_to_assignment_stmts(
                 rewritten.push(stmt);
             }
         }
+    }
+
+    *stmts = rewritten;
+}
+
+fn rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+    stmts: &mut Vec<Stmt>,
+    reserved: &mut HashSet<String>,
+    next_temp: &mut u32,
+) {
+    let mut rewritten = Vec::with_capacity(stmts.len());
+    let original = std::mem::take(stmts);
+
+    for mut stmt in original {
+        match &mut stmt {
+            Stmt::Block(block) => rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+                &mut block.stmts,
+                reserved,
+                next_temp,
+            ),
+            Stmt::Labeled(labeled) => {
+                if let Stmt::Block(block) = &mut *labeled.body {
+                    rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+                        &mut block.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+            }
+            Stmt::If(if_stmt) => {
+                if let Stmt::Block(block) = &mut *if_stmt.cons {
+                    rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+                        &mut block.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+                if let Some(alt) = &mut if_stmt.alt {
+                    if let Stmt::Block(block) = &mut **alt {
+                        rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+                            &mut block.stmts,
+                            reserved,
+                            next_temp,
+                        );
+                    }
+                }
+            }
+            Stmt::Try(try_stmt) => {
+                rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+                    &mut try_stmt.block.stmts,
+                    reserved,
+                    next_temp,
+                );
+                if let Some(handler) = &mut try_stmt.handler {
+                    rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+                        &mut handler.body.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+                if let Some(finalizer) = &mut try_stmt.finalizer {
+                    rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+                        &mut finalizer.stmts,
+                        reserved,
+                        next_temp,
+                    );
+                }
+            }
+            Stmt::Switch(switch_stmt) => {
+                for case in &mut switch_stmt.cases {
+                    rewrite_const_object_pattern_static_literal_decls_to_temp_aliases(
+                        &mut case.cons,
+                        reserved,
+                        next_temp,
+                    );
+                }
+            }
+            _ => {}
+        }
+
+        let Stmt::Decl(Decl::Var(var_decl)) = &stmt else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if var_decl.kind != VarDeclKind::Const {
+            rewritten.push(stmt);
+            continue;
+        }
+        let [decl] = var_decl.decls.as_slice() else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if !matches!(decl.name, Pat::Object(_)) {
+            rewritten.push(stmt);
+            continue;
+        }
+        let Some(init) = &decl.init else {
+            rewritten.push(stmt);
+            continue;
+        };
+        if !is_static_alloc_literal_expr(init) {
+            rewritten.push(stmt);
+            continue;
+        }
+
+        let temp = fresh_temp_ident(next_temp, reserved);
+        rewritten.push(make_var_decl(
+            VarDeclKind::Const,
+            Pat::Ident(BindingIdent {
+                id: temp.clone(),
+                type_ann: None,
+            }),
+            Some(init.clone()),
+        ));
+        rewritten.push(make_var_decl(
+            VarDeclKind::Const,
+            decl.name.clone(),
+            Some(Box::new(Expr::Ident(temp))),
+        ));
     }
 
     *stmts = rewritten;
@@ -5336,6 +7392,93 @@ fn normalize_array_pattern_assignments_in_stmts(
         };
         let mut pat = Pat::from(assign_pat.clone());
         normalize_array_pattern_holes(&mut pat);
+        if let Pat::Object(object_pat) = pat {
+            let mut can_rewrite = true;
+            let mut original_binding = None::<Ident>;
+            let mut rewritten_props = Vec::with_capacity(object_pat.props.len());
+
+            for prop in object_pat.props {
+                match prop {
+                    ObjectPatProp::Assign(assign_prop) if assign_prop.value.is_none() => {
+                        let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+                        original_binding = Some(assign_prop.key.id.clone());
+                        rewritten_props.push(ObjectPatProp::KeyValue(swc_ecma_ast::KeyValuePatProp {
+                            key: PropName::Ident(assign_prop.key.id.clone().into()),
+                            value: Box::new(Pat::Ident(BindingIdent {
+                                id: temp.clone(),
+                                type_ann: None,
+                            })),
+                        }));
+                    }
+                    ObjectPatProp::KeyValue(key_value)
+                        if matches!(*key_value.value, Pat::Ident(_)) =>
+                    {
+                        let Pat::Ident(binding) = *key_value.value else {
+                            unreachable!("guarded by matches!");
+                        };
+                        if matches!(
+                            &key_value.key,
+                            PropName::Ident(prop_ident) if prop_ident.sym != binding.id.sym
+                        ) {
+                            can_rewrite = false;
+                            break;
+                        }
+                        let temp = fresh_lowest_scoped_temp_ident(&mut scope_bindings, reserved);
+                        original_binding = Some(binding.id.clone());
+                        rewritten_props.push(ObjectPatProp::KeyValue(swc_ecma_ast::KeyValuePatProp {
+                            key: key_value.key,
+                            value: Box::new(Pat::Ident(BindingIdent {
+                                id: temp.clone(),
+                                type_ann: None,
+                            })),
+                        }));
+                    }
+                    _ => {
+                        can_rewrite = false;
+                        break;
+                    }
+                }
+            }
+
+            let Some(original_binding) = original_binding else {
+                normalized.push(stmt);
+                continue;
+            };
+            if !can_rewrite || rewritten_props.len() != 1 {
+                normalized.push(stmt);
+                continue;
+            }
+
+            let temp_name = match &rewritten_props[0] {
+                ObjectPatProp::KeyValue(key_value) => match &*key_value.value {
+                    Pat::Ident(binding) => binding.id.clone(),
+                    _ => {
+                        normalized.push(stmt);
+                        continue;
+                    }
+                },
+                _ => {
+                    normalized.push(stmt);
+                    continue;
+                }
+            };
+
+            normalized.push(make_var_decl(
+                VarDeclKind::Const,
+                Pat::Object(swc_ecma_ast::ObjectPat {
+                    span: object_pat.span,
+                    props: rewritten_props,
+                    optional: object_pat.optional,
+                    type_ann: object_pat.type_ann,
+                }),
+                Some(assign.right.clone()),
+            ));
+            normalized.push(assign_stmt(
+                AssignTarget::from(original_binding),
+                Box::new(Expr::Ident(temp_name)),
+            ));
+            continue;
+        }
         let Pat::Array(array_pat) = pat else {
             normalized.push(stmt);
             continue;
@@ -5346,6 +7489,15 @@ fn normalize_array_pattern_assignments_in_stmts(
             optional,
             ..
         } = array_pat;
+        if elems
+            .iter()
+            .flatten()
+            .all(|element| matches!(element, Pat::Ident(_)))
+            && matches!(unwrap_transparent_expr(&assign.right), Expr::Ident(_))
+        {
+            normalized.push(stmt);
+            continue;
+        }
 
         let mut temp_elems = Vec::with_capacity(elems.len());
         let mut rewritten_assignments = Vec::new();
@@ -5387,7 +7539,7 @@ fn normalize_array_pattern_assignments_in_stmts(
                                     DUMMY_SP,
                                 ))),
                             })),
-                            cons: assign_pat.right.clone(),
+                            cons: parenthesize_conditional_expr(assign_pat.right.clone()),
                             alt: Box::new(Expr::Ident(temp)),
                         })),
                     ));
@@ -5623,6 +7775,48 @@ fn collect_dependencies_from_expr(
             member.visit_children_with(self);
         }
 
+        fn visit_do_while_stmt(&mut self, do_while: &swc_ecma_ast::DoWhileStmt) {
+            for dep in collect_loop_test_dependencies_from_expr(
+                &do_while.test,
+                self.known_bindings,
+                self.local_bindings,
+            ) {
+                maybe_push_dependency(&mut self.deps, &mut self.seen, dep);
+            }
+            do_while.body.visit_with(self);
+        }
+
+        fn visit_while_stmt(&mut self, while_stmt: &swc_ecma_ast::WhileStmt) {
+            for dep in collect_loop_test_dependencies_from_expr(
+                &while_stmt.test,
+                self.known_bindings,
+                self.local_bindings,
+            ) {
+                maybe_push_dependency(&mut self.deps, &mut self.seen, dep);
+            }
+            while_stmt.body.visit_with(self);
+        }
+
+        fn visit_for_stmt(&mut self, for_stmt: &swc_ecma_ast::ForStmt) {
+            if let Some(test) = &for_stmt.test {
+                for dep in collect_loop_test_dependencies_from_expr(
+                    test,
+                    self.known_bindings,
+                    self.local_bindings,
+                ) {
+                    maybe_push_dependency(&mut self.deps, &mut self.seen, dep);
+                }
+            }
+
+            if let Some(init) = &for_stmt.init {
+                init.visit_with(self);
+            }
+            if let Some(update) = &for_stmt.update {
+                update.visit_with(self);
+            }
+            for_stmt.body.visit_with(self);
+        }
+
         fn visit_call_expr(&mut self, call: &CallExpr) {
             if let Callee::Expr(callee_expr) = &call.callee {
                 if let Expr::Member(member) = &**callee_expr {
@@ -5762,6 +7956,48 @@ fn collect_dependencies_from_stmts(
             }
 
             member.visit_children_with(self);
+        }
+
+        fn visit_do_while_stmt(&mut self, do_while: &swc_ecma_ast::DoWhileStmt) {
+            for dep in collect_loop_test_dependencies_from_expr(
+                &do_while.test,
+                self.known_bindings,
+                self.local_bindings,
+            ) {
+                maybe_push_dependency(&mut self.deps, &mut self.seen, dep);
+            }
+            do_while.body.visit_with(self);
+        }
+
+        fn visit_while_stmt(&mut self, while_stmt: &swc_ecma_ast::WhileStmt) {
+            for dep in collect_loop_test_dependencies_from_expr(
+                &while_stmt.test,
+                self.known_bindings,
+                self.local_bindings,
+            ) {
+                maybe_push_dependency(&mut self.deps, &mut self.seen, dep);
+            }
+            while_stmt.body.visit_with(self);
+        }
+
+        fn visit_for_stmt(&mut self, for_stmt: &swc_ecma_ast::ForStmt) {
+            if let Some(test) = &for_stmt.test {
+                for dep in collect_loop_test_dependencies_from_expr(
+                    test,
+                    self.known_bindings,
+                    self.local_bindings,
+                ) {
+                    maybe_push_dependency(&mut self.deps, &mut self.seen, dep);
+                }
+            }
+
+            if let Some(init) = &for_stmt.init {
+                init.visit_with(self);
+            }
+            if let Some(update) = &for_stmt.update {
+                update.visit_with(self);
+            }
+            for_stmt.body.visit_with(self);
         }
 
         fn visit_call_expr(&mut self, call: &CallExpr) {
@@ -6229,6 +8465,79 @@ fn member_object_dependency(
     })
 }
 
+fn collect_member_object_dependencies_from_expr(
+    expr: &Expr,
+    known_bindings: &HashMap<String, bool>,
+    local_bindings: &HashSet<String>,
+) -> Vec<ReactiveDependency> {
+    struct Collector<'a> {
+        known_bindings: &'a HashMap<String, bool>,
+        local_bindings: &'a HashSet<String>,
+        seen: HashSet<String>,
+        deps: Vec<ReactiveDependency>,
+    }
+
+    impl Visit for Collector<'_> {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_member_expr(&mut self, member: &MemberExpr) {
+            if let Some(dep) = member_object_dependency(member, self.known_bindings, self.local_bindings) {
+                maybe_push_dependency(&mut self.deps, &mut self.seen, dep);
+            }
+
+            member.visit_children_with(self);
+        }
+    }
+
+    let mut collector = Collector {
+        known_bindings,
+        local_bindings,
+        seen: HashSet::new(),
+        deps: Vec::new(),
+    };
+    expr.visit_with(&mut collector);
+    collector.deps
+}
+
+fn collect_loop_test_dependencies_from_expr(
+    expr: &Expr,
+    known_bindings: &HashMap<String, bool>,
+    local_bindings: &HashSet<String>,
+) -> Vec<ReactiveDependency> {
+    fn is_member_path_of_object(dep_key: &str, object_key: &str) -> bool {
+        dep_key.len() > object_key.len()
+            && dep_key.starts_with(object_key)
+            && dep_key.as_bytes()[object_key.len()] == b'.'
+    }
+
+    let mut deps = collect_dependencies_from_expr(expr, known_bindings, local_bindings);
+    let object_deps =
+        collect_member_object_dependencies_from_expr(expr, known_bindings, local_bindings);
+    if object_deps.is_empty() {
+        return deps;
+    }
+
+    let object_keys: HashSet<String> = object_deps.iter().map(|dep| dep.key.clone()).collect();
+    deps.retain(|dep| {
+        !object_keys
+            .iter()
+            .any(|object_key| is_member_path_of_object(&dep.key, object_key))
+    });
+
+    let mut seen: HashSet<String> = deps.iter().map(|dep| dep.key.clone()).collect();
+    for dep in object_deps {
+        maybe_push_dependency(&mut deps, &mut seen, dep);
+    }
+
+    reduce_dependencies(deps)
+}
+
 fn should_collapse_member_callee_dependency(member: &MemberExpr) -> bool {
     match &member.prop {
         MemberProp::Ident(prop) => matches!(
@@ -6295,6 +8604,295 @@ fn reduce_nested_member_dependencies(deps: Vec<ReactiveDependency>) -> Vec<React
 
     reduced.sort_by(|left, right| left.key.cmp(&right.key));
     reduced
+}
+
+fn rewrite_top_level_rest_pattern_assignments_in_prelude_to_memo_blocks(
+    prelude_stmts: &[Stmt],
+    known_bindings: &HashMap<String, bool>,
+    cache_ident: &Ident,
+    slot_start: u32,
+) -> Option<(Vec<Stmt>, u32, u32, u32)> {
+    let mut rewritten = Vec::with_capacity(prelude_stmts.len());
+    let mut local_bindings = HashSet::new();
+    let mut cursor = slot_start;
+    let mut added_blocks = 0u32;
+    let mut added_values = 0u32;
+
+    for stmt in prelude_stmts {
+        let mut transformed_stmt = false;
+        if let Stmt::Expr(expr_stmt) = stmt {
+            if let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) {
+                if assign.op == op!("=") {
+                    if let AssignTarget::Pat(assign_pat) = &assign.left {
+                        let pat = Pat::from(assign_pat.clone());
+                        if pattern_has_top_level_rest(&pat) {
+                            let mut cache_binding_names =
+                                collect_assigned_bindings_in_order_from_stmts(std::slice::from_ref(
+                                    stmt,
+                                ));
+                            if !cache_binding_names.is_empty() {
+                                cache_binding_names =
+                                    reorder_cache_binding_names_for_pattern_assignment(
+                                        cache_binding_names,
+                                    );
+                                cache_binding_names =
+                                    reorder_array_rest_temp_binding_first(cache_binding_names, &pat);
+                                if cache_binding_names.len() >= 2 {
+                                    let mut dep_local_bindings = local_bindings.clone();
+                                    for binding in &cache_binding_names {
+                                        dep_local_bindings.insert(binding.clone());
+                                    }
+
+                                    let mut deps = collect_dependencies_from_stmts(
+                                        std::slice::from_ref(stmt),
+                                        known_bindings,
+                                        &dep_local_bindings,
+                                    );
+                                    for dep in collect_called_local_function_capture_dependencies(
+                                        std::slice::from_ref(stmt),
+                                        known_bindings,
+                                    ) {
+                                        if !deps.iter().any(|existing| existing.key == dep.key) {
+                                            deps.push(dep);
+                                        }
+                                    }
+                                    for dep in collect_stmt_function_capture_dependencies(
+                                        std::slice::from_ref(stmt),
+                                        known_bindings,
+                                    ) {
+                                        if !deps.iter().any(|existing| existing.key == dep.key) {
+                                            deps.push(dep);
+                                        }
+                                    }
+                                    deps = reduce_dependencies(deps);
+                                    deps = reduce_nested_member_dependencies(deps);
+                                    if deps.is_empty() {
+                                        if let Expr::Ident(rhs_ident) =
+                                            unwrap_transparent_expr(&assign.right)
+                                        {
+                                            let rhs_name = rhs_ident.sym.to_string();
+                                            deps.push(ReactiveDependency {
+                                                key: rhs_name,
+                                                expr: Box::new(Expr::Ident(rhs_ident.clone())),
+                                            });
+                                        }
+                                    }
+                                    if !deps.is_empty() {
+                                        let cache_bindings = cache_binding_names
+                                            .iter()
+                                            .map(|name| {
+                                                Ident::new_no_ctxt(name.clone().into(), DUMMY_SP)
+                                            })
+                                            .collect::<Vec<_>>();
+                                        rewritten.extend(build_memoized_block_multi_values(
+                                            cache_ident,
+                                            cursor,
+                                            &deps,
+                                            &cache_bindings,
+                                            vec![stmt.clone()],
+                                        ));
+                                        cursor += deps.len() as u32 + cache_bindings.len() as u32;
+                                        added_blocks += 1;
+                                        added_values += cache_bindings.len() as u32;
+                                        transformed_stmt = true;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if transformed_stmt {
+            collect_stmt_bindings_including_nested_blocks(stmt, &mut local_bindings);
+            continue;
+        }
+
+        rewritten.push(stmt.clone());
+        collect_stmt_bindings_including_nested_blocks(stmt, &mut local_bindings);
+    }
+
+    if added_blocks == 0 {
+        None
+    } else {
+        Some((rewritten, cursor - slot_start, added_blocks, added_values))
+    }
+}
+
+fn reorder_cache_binding_names_for_pattern_assignment(names: Vec<String>) -> Vec<String> {
+    let mut seen = HashSet::new();
+    let mut ordered = Vec::new();
+    let mut temp_names = Vec::new();
+
+    for name in names {
+        if !seen.insert(name.clone()) {
+            continue;
+        }
+        if parse_temp_name(name.as_str()).is_some() {
+            temp_names.push(name);
+        } else {
+            ordered.push(name);
+        }
+    }
+
+    ordered.extend(temp_names);
+    ordered
+}
+
+fn reorder_array_rest_temp_binding_first(mut names: Vec<String>, pattern: &Pat) -> Vec<String> {
+    let Pat::Array(array_pat) = pattern else {
+        return names;
+    };
+    let rest_ident = array_pat.elems.iter().flatten().find_map(|element| {
+        let Pat::Rest(rest_pat) = element else {
+            return None;
+        };
+        let Pat::Ident(binding) = &*rest_pat.arg else {
+            return None;
+        };
+        parse_temp_name(binding.id.sym.as_ref()).map(|_| binding.id.sym.to_string())
+    });
+    let Some(rest_ident) = rest_ident else {
+        return names;
+    };
+
+    let Some(index) = names.iter().position(|name| name == &rest_ident) else {
+        return names;
+    };
+    if index == 0 {
+        return names;
+    }
+
+    let rest_name = names.remove(index);
+    let mut reordered = vec![rest_name];
+    reordered.extend(names);
+    reordered
+}
+
+fn try_build_pattern_assignment_prelude_memo_fallback(
+    prelude_stmts: &[Stmt],
+    compute_stmts: &[Stmt],
+    known_bindings: &HashMap<String, bool>,
+    cache_ident: &Ident,
+    slot_start: u32,
+) -> Option<(Vec<Stmt>, u32, u32)> {
+    let has_pattern_assignment = stmts_contain_pattern_assignment(prelude_stmts);
+    let allow_without_rest =
+        has_pattern_assignment && prelude_contains_control_flow_stmt(prelude_stmts);
+    if !prelude_has_top_level_rest_pattern_assignment(prelude_stmts) && !allow_without_rest {
+        return None;
+    }
+
+    let mut outer_decls = Vec::new();
+    let mut prelude_compute = Vec::new();
+    let mut declared_bindings = Vec::<String>::new();
+    let mut declared_set = HashSet::<String>::new();
+
+    for stmt in prelude_stmts {
+        let Stmt::Decl(Decl::Var(var_decl)) = stmt else {
+            prelude_compute.push(stmt.clone());
+            continue;
+        };
+        if !matches!(var_decl.kind, VarDeclKind::Let | VarDeclKind::Const) {
+            prelude_compute.push(stmt.clone());
+            continue;
+        }
+        if var_decl
+            .decls
+            .iter()
+            .any(|decl| !matches!(decl.name, Pat::Ident(_)))
+        {
+            prelude_compute.push(stmt.clone());
+            continue;
+        }
+
+        for decl in &var_decl.decls {
+            let Pat::Ident(binding) = &decl.name else {
+                continue;
+            };
+            let name = binding.id.sym.to_string();
+            if declared_set.insert(name.clone()) {
+                declared_bindings.push(name.clone());
+            }
+
+            let used_in_compute = binding_referenced_in_stmts(compute_stmts, name.as_str());
+            let keep_outer_init = decl.init.as_ref().is_some_and(|init| {
+                used_in_compute && !is_static_alloc_literal_expr(init)
+            });
+            let outer_init = if keep_outer_init {
+                decl.init.clone()
+            } else {
+                None
+            };
+
+            outer_decls.push(make_var_decl(
+                VarDeclKind::Let,
+                Pat::Ident(BindingIdent {
+                    id: binding.id.clone(),
+                    type_ann: binding.type_ann.clone(),
+                }),
+                outer_init,
+            ));
+
+            if decl.init.is_some() && !keep_outer_init && used_in_compute {
+                prelude_compute.push(assign_stmt(
+                    AssignTarget::from(binding.id.clone()),
+                    decl.init.clone().expect("checked is_some"),
+                ));
+            }
+        }
+    }
+
+    if outer_decls.is_empty() || prelude_compute.is_empty() {
+        return None;
+    }
+
+    let mut cache_binding_names = collect_assigned_bindings_in_order_from_stmts(&prelude_compute);
+    cache_binding_names.retain(|name| declared_set.contains(name));
+    if cache_binding_names.len() < 2 {
+        return None;
+    }
+
+    let mut local_bindings = declared_set.clone();
+    for stmt in &prelude_compute {
+        collect_stmt_bindings_including_nested_blocks(stmt, &mut local_bindings);
+    }
+
+    let mut prelude_deps =
+        collect_dependencies_from_stmts(&prelude_compute, known_bindings, &local_bindings);
+    for dep in collect_called_local_function_capture_dependencies(&prelude_compute, known_bindings) {
+        if !prelude_deps.iter().any(|existing| existing.key == dep.key) {
+            prelude_deps.push(dep);
+        }
+    }
+    for dep in collect_stmt_function_capture_dependencies(&prelude_compute, known_bindings) {
+        if !prelude_deps.iter().any(|existing| existing.key == dep.key) {
+            prelude_deps.push(dep);
+        }
+    }
+    prelude_deps = reduce_dependencies(prelude_deps);
+    prelude_deps = reduce_nested_member_dependencies(prelude_deps);
+    if prelude_deps.is_empty() {
+        return None;
+    }
+
+    let cache_bindings = cache_binding_names
+        .into_iter()
+        .map(|name| Ident::new_no_ctxt(name.into(), DUMMY_SP))
+        .collect::<Vec<_>>();
+    let mut rewritten = outer_decls;
+    rewritten.extend(build_memoized_block_multi_values(
+        cache_ident,
+        slot_start,
+        &prelude_deps,
+        &cache_bindings,
+        prelude_compute,
+    ));
+    let slots = prelude_deps.len() as u32 + cache_bindings.len() as u32;
+    let values = cache_bindings.len() as u32;
+
+    Some((rewritten, slots, values))
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -6583,6 +9181,218 @@ fn maybe_split_single_element_array_initializer(
     *memo_values += 1;
 }
 
+fn match_pattern_assignment_default_memo_candidate(
+    stmt: &Stmt,
+    previous_stmt: Option<&Stmt>,
+) -> Option<(Ident, Box<Expr>, Ident)> {
+    let Stmt::Expr(expr_stmt) = stmt else {
+        return None;
+    };
+    let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) else {
+        return None;
+    };
+    if assign.op != op!("=") {
+        return None;
+    }
+    if !matches!(assign.left, AssignTarget::Pat(_)) {
+        return None;
+    }
+    let Expr::Ident(rhs_ident) = unwrap_transparent_expr(&assign.right) else {
+        return None;
+    };
+
+    let previous_stmt = previous_stmt?;
+    let Stmt::Decl(Decl::Var(var_decl)) = previous_stmt else {
+        return None;
+    };
+    if var_decl.kind != VarDeclKind::Const {
+        return None;
+    }
+    let [decl] = var_decl.decls.as_slice() else {
+        return None;
+    };
+    let Pat::Ident(binding) = &decl.name else {
+        return None;
+    };
+    if binding.id.sym != rhs_ident.sym {
+        return None;
+    }
+
+    let init_expr = decl.init.clone()?;
+    let Expr::Cond(cond_expr) = unwrap_transparent_expr(&init_expr) else {
+        return None;
+    };
+    let Expr::Bin(test_expr) = unwrap_transparent_expr(&cond_expr.test) else {
+        return None;
+    };
+    if test_expr.op != op!("===") {
+        return None;
+    }
+
+    let dep_ident = match (
+        unwrap_transparent_expr(&test_expr.left),
+        unwrap_transparent_expr(&test_expr.right),
+    ) {
+        (Expr::Ident(left), Expr::Ident(right)) if right.sym == "undefined" => left.clone(),
+        (Expr::Ident(left), Expr::Ident(right)) if left.sym == "undefined" => right.clone(),
+        _ => return None,
+    };
+
+    let Expr::Ident(alt_ident) = unwrap_transparent_expr(&cond_expr.alt) else {
+        return None;
+    };
+    if alt_ident.sym != dep_ident.sym {
+        return None;
+    }
+
+    Some((binding.id.clone(), init_expr, dep_ident))
+}
+
+fn lower_object_pattern_default_decl_with_memoization(
+    var_decl: &VarDecl,
+    cache_ident: &Ident,
+    slot_start: u32,
+    reserved: &mut HashSet<String>,
+    next_temp: &mut u32,
+) -> Option<(Vec<Stmt>, u32, u32, u32)> {
+    #[derive(Clone)]
+    struct AssignDefaultTask {
+        binding: Ident,
+        source_temp: Ident,
+        default_expr: Option<Box<Expr>>,
+    }
+
+    if var_decl.kind != VarDeclKind::Const {
+        return None;
+    }
+    let [decl] = var_decl.decls.as_slice() else {
+        return None;
+    };
+    let Pat::Object(object_pat) = &decl.name else {
+        return None;
+    };
+    let init_expr = decl.init.clone()?;
+
+    let mut rewritten_props = Vec::with_capacity(object_pat.props.len());
+    let mut assign_tasks = Vec::<AssignDefaultTask>::new();
+    let mut changed = false;
+    let mut cursor = slot_start;
+    let mut added_blocks = 0u32;
+    let mut added_values = 0u32;
+
+    for prop in &object_pat.props {
+        match prop {
+            ObjectPatProp::Assign(assign_prop) => {
+                if assign_prop.value.is_none() {
+                    rewritten_props.push(ObjectPatProp::Assign(assign_prop.clone()));
+                    continue;
+                }
+
+                changed = true;
+                let source_temp = fresh_temp_ident(next_temp, reserved);
+                rewritten_props.push(ObjectPatProp::KeyValue(swc_ecma_ast::KeyValuePatProp {
+                    key: PropName::Ident(assign_prop.key.id.clone().into()),
+                    value: Box::new(Pat::Ident(BindingIdent {
+                        id: source_temp.clone(),
+                        type_ann: None,
+                    })),
+                }));
+                assign_tasks.push(AssignDefaultTask {
+                    binding: assign_prop.key.id.clone(),
+                    source_temp,
+                    default_expr: assign_prop.value.clone(),
+                });
+            }
+            other => rewritten_props.push(other.clone()),
+        }
+    }
+
+    if !changed {
+        return None;
+    }
+
+    let mut follow_up_stmts = Vec::with_capacity(assign_tasks.len() * 2);
+    for task in assign_tasks {
+        let assign_expr = if let Some(default_expr) = &task.default_expr {
+            Box::new(Expr::Cond(swc_ecma_ast::CondExpr {
+                span: DUMMY_SP,
+                test: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                    span: DUMMY_SP,
+                    op: op!("==="),
+                    left: Box::new(Expr::Ident(task.source_temp.clone())),
+                    right: Box::new(Expr::Ident(Ident::new_no_ctxt(
+                        "undefined".into(),
+                        DUMMY_SP,
+                    ))),
+                })),
+                cons: default_expr.clone(),
+                alt: Box::new(Expr::Ident(task.source_temp.clone())),
+            }))
+        } else {
+            Box::new(Expr::Ident(task.source_temp.clone()))
+        };
+
+        if task
+            .default_expr
+            .as_ref()
+            .is_some_and(|default_expr| is_static_alloc_literal_expr(default_expr))
+        {
+            let value_temp = fresh_temp_ident(next_temp, reserved);
+            let mut nested_compute =
+                vec![assign_stmt(AssignTarget::from(value_temp.clone()), assign_expr)];
+            strip_runtime_call_type_args_in_stmts(&mut nested_compute);
+
+            let nested_deps = vec![ReactiveDependency {
+                key: task.source_temp.sym.to_string(),
+                expr: Box::new(Expr::Ident(task.source_temp)),
+            }];
+            follow_up_stmts.extend(build_memoized_block(
+                cache_ident,
+                cursor,
+                &nested_deps,
+                &value_temp,
+                nested_compute,
+                true,
+            ));
+            cursor += nested_deps.len() as u32 + 1;
+            added_blocks += 1;
+            added_values += 1;
+
+            follow_up_stmts.push(make_var_decl(
+                VarDeclKind::Const,
+                Pat::Ident(BindingIdent {
+                    id: task.binding,
+                    type_ann: None,
+                }),
+                Some(Box::new(Expr::Ident(value_temp))),
+            ));
+        } else {
+            follow_up_stmts.push(make_var_decl(
+                VarDeclKind::Const,
+                Pat::Ident(BindingIdent {
+                    id: task.binding,
+                    type_ann: None,
+                }),
+                Some(assign_expr),
+            ));
+        }
+    }
+
+    let mut lowered = vec![make_var_decl(
+        var_decl.kind,
+        Pat::Object(swc_ecma_ast::ObjectPat {
+            span: object_pat.span,
+            props: rewritten_props,
+            optional: object_pat.optional,
+            type_ann: object_pat.type_ann.clone(),
+        }),
+        Some(init_expr),
+    )];
+    lowered.extend(follow_up_stmts);
+
+    Some((lowered, cursor - slot_start, added_blocks, added_values))
+}
+
 fn inject_nested_call_memoization_into_stmts(
     stmts: &mut Vec<Stmt>,
     known_bindings: &HashMap<String, bool>,
@@ -6614,6 +9424,25 @@ fn inject_nested_call_memoization_into_stmts(
         let remaining = &original[index + 1..];
 
         if let Stmt::Decl(Decl::Var(var_decl)) = &stmt {
+            if let Some((lowered_stmts, used_slots, nested_blocks, nested_values)) =
+                lower_object_pattern_default_decl_with_memoization(
+                    var_decl,
+                    cache_ident,
+                    cursor,
+                    reserved,
+                    next_temp,
+                )
+            {
+                cursor += used_slots;
+                added_blocks += nested_blocks;
+                added_values += nested_values;
+                for lowered_stmt in lowered_stmts {
+                    out.push(lowered_stmt.clone());
+                    mark_stmt_bindings_unstable(&lowered_stmt, &mut nested_known_bindings);
+                }
+                continue;
+            }
+
             let [decl] = var_decl.decls.as_slice() else {
                 out.push(stmt.clone());
                 mark_stmt_bindings_unstable(&stmt, &mut nested_known_bindings);
@@ -6629,6 +9458,53 @@ fn inject_nested_call_memoization_into_stmts(
                 mark_stmt_bindings_unstable(&stmt, &mut nested_known_bindings);
                 continue;
             };
+            if matches!(unwrap_transparent_expr(init_expr), Expr::Arrow(_) | Expr::Fn(_)) {
+                let nested_deps =
+                    collect_function_capture_dependencies(init_expr, &nested_known_bindings);
+                let has_length_dep = nested_deps.iter().any(|dep| dep.key.ends_with(".length"));
+                let supported_member_deps =
+                    has_length_dep && nested_deps.iter().all(|dep| dep.key.ends_with(".length"));
+                let captures_mutated_dep = nested_deps.iter().any(|dep| {
+                    let base = dep
+                        .key
+                        .split_once('.')
+                        .map(|(base, _)| base)
+                        .unwrap_or(dep.key.as_str());
+                    binding_reassigned_after(remaining, base)
+                        || binding_mutated_via_member_call_after(remaining, base)
+                        || binding_mutated_via_member_assignment_after(remaining, base)
+                        || binding_maybe_mutated_via_alias_after(remaining, base)
+                });
+                if !nested_deps.is_empty() && supported_member_deps && !captures_mutated_dep {
+                    let result_temp = fresh_temp_ident(next_temp, reserved);
+                    let mut nested_compute = vec![assign_stmt(
+                        AssignTarget::from(result_temp.clone()),
+                        init_expr.clone(),
+                    )];
+                    strip_runtime_call_type_args_in_stmts(&mut nested_compute);
+
+                    out.extend(build_memoized_block(
+                        cache_ident,
+                        cursor,
+                        &nested_deps,
+                        &result_temp,
+                        nested_compute,
+                        true,
+                    ));
+                    cursor += nested_deps.len() as u32 + 1;
+                    added_blocks += 1;
+                    added_values += 1;
+
+                    let rewritten_stmt = make_var_decl(
+                        var_decl.kind,
+                        Pat::Ident(binding.clone()),
+                        Some(Box::new(Expr::Ident(result_temp))),
+                    );
+                    out.push(rewritten_stmt.clone());
+                    mark_stmt_bindings_unstable(&rewritten_stmt, &mut nested_known_bindings);
+                    continue;
+                }
+            }
 
             let captured_by_called_local_function =
                 binding_captured_by_called_local_function_after(remaining, binding.id.sym.as_ref());
@@ -6882,6 +9758,39 @@ fn inject_nested_call_memoization_into_stmts(
                     continue;
                 }
             }
+        }
+
+        if let Some((value_binding, default_init_expr, dep_ident)) =
+            match_pattern_assignment_default_memo_candidate(&stmt, out.last())
+        {
+            out.pop();
+
+            let mut nested_compute = vec![assign_stmt(
+                AssignTarget::from(value_binding.clone()),
+                default_init_expr,
+            )];
+            strip_runtime_call_type_args_in_stmts(&mut nested_compute);
+
+            let nested_deps = vec![ReactiveDependency {
+                key: dep_ident.sym.to_string(),
+                expr: Box::new(Expr::Ident(dep_ident)),
+            }];
+            out.extend(build_memoized_block(
+                cache_ident,
+                cursor,
+                &nested_deps,
+                &value_binding,
+                nested_compute,
+                true,
+            ));
+            cursor += nested_deps.len() as u32 + 1;
+            added_blocks += 1;
+            added_values += 1;
+            nested_known_bindings.insert(value_binding.sym.to_string(), false);
+
+            out.push(stmt.clone());
+            mark_stmt_bindings_unstable(&stmt, &mut nested_known_bindings);
+            continue;
         }
 
         let mut rewritten_stmt = stmt.clone();
@@ -9507,6 +12416,19 @@ fn unwrap_transparent_expr(mut expr: &Expr) -> &Expr {
     }
 }
 
+fn parenthesize_conditional_expr(expr: Box<Expr>) -> Box<Expr> {
+    let needs_paren = matches!(unwrap_transparent_expr(&expr), Expr::Cond(_))
+        && !matches!(&*expr, Expr::Paren(_));
+    if needs_paren {
+        Box::new(Expr::Paren(swc_ecma_ast::ParenExpr {
+            span: DUMMY_SP,
+            expr,
+        }))
+    } else {
+        expr
+    }
+}
+
 fn assign_target_is_member_of_binding(target: &AssignTarget, name: &str) -> bool {
     let Some(simple_target) = target.as_simple() else {
         return false;
@@ -9965,6 +12887,47 @@ fn has_create_element_result_assignment_with_post_calls(stmts: &[Stmt], name: &s
     })
 }
 
+fn prelude_has_top_level_rest_pattern_assignment(stmts: &[Stmt]) -> bool {
+    stmts.iter().any(|stmt| {
+        let Stmt::Expr(expr_stmt) = stmt else {
+            return false;
+        };
+        let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) else {
+            return false;
+        };
+        if assign.op != op!("=") {
+            return false;
+        }
+        let AssignTarget::Pat(assign_pat) = &assign.left else {
+            return false;
+        };
+        pattern_has_top_level_rest(&Pat::from(assign_pat.clone()))
+    })
+}
+
+fn prelude_contains_control_flow_stmt(stmts: &[Stmt]) -> bool {
+    stmts.iter().any(|stmt| {
+        matches!(
+            stmt,
+            Stmt::If(if_stmt) if if_stmt.alt.is_none()
+        ) || matches!(
+            stmt,
+                | Stmt::Switch(_)
+                | Stmt::Try(_)
+                | Stmt::For(_)
+                | Stmt::ForIn(_)
+                | Stmt::ForOf(_)
+                | Stmt::While(_)
+                | Stmt::DoWhile(_)
+                | Stmt::Labeled(_)
+        )
+    })
+}
+
+fn prelude_contains_if_with_else(stmts: &[Stmt]) -> bool {
+    stmts.iter().any(|stmt| matches!(stmt, Stmt::If(if_stmt) if if_stmt.alt.is_some()))
+}
+
 fn split_direct_call_prelude_from_compute_stmts(
     compute_stmts: &mut Vec<Stmt>,
     temp_name: &str,
@@ -10004,6 +12967,7 @@ fn split_direct_call_prelude_from_compute_stmts(
     if !contains_direct_call(&compute_stmts[..split_index])
         && !has_local_direct_call_prelude
         && !has_local_member_mutation_prelude
+        && !stmts_contain_pattern_assignment(&compute_stmts[..split_index])
     {
         return Vec::new();
     }
@@ -10074,6 +13038,89 @@ fn split_direct_call_prelude_from_compute_stmts(
     prelude
 }
 
+fn build_memoized_block_multi_values(
+    cache_ident: &Ident,
+    slot_start: u32,
+    deps: &[ReactiveDependency],
+    value_bindings: &[Ident],
+    mut compute_stmts: Vec<Stmt>,
+) -> Vec<Stmt> {
+    if value_bindings.is_empty() {
+        return Vec::new();
+    }
+
+    let test = if deps.is_empty() {
+        Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+            span: DUMMY_SP,
+            op: op!("==="),
+            left: make_cache_index_expr(cache_ident, slot_start),
+            right: memo_cache_sentinel_expr(),
+        }))
+    } else {
+        let mut current = Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+            span: DUMMY_SP,
+            op: op!("!=="),
+            left: make_cache_index_expr(cache_ident, slot_start),
+            right: deps[0].expr.clone(),
+        }));
+        for (index, dep) in deps.iter().enumerate().skip(1) {
+            current = Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                span: DUMMY_SP,
+                op: op!("||"),
+                left: current,
+                right: Box::new(Expr::Bin(swc_ecma_ast::BinExpr {
+                    span: DUMMY_SP,
+                    op: op!("!=="),
+                    left: make_cache_index_expr(cache_ident, slot_start + index as u32),
+                    right: dep.expr.clone(),
+                })),
+            }));
+        }
+        current
+    };
+
+    for (index, dep) in deps.iter().enumerate() {
+        compute_stmts.push(assign_stmt(
+            AssignTarget::from(make_cache_member(cache_ident, slot_start + index as u32)),
+            dep.expr.clone(),
+        ));
+    }
+
+    let value_slot_start = slot_start + deps.len() as u32;
+    for (index, binding) in value_bindings.iter().enumerate() {
+        compute_stmts.push(assign_stmt(
+            AssignTarget::from(make_cache_member(cache_ident, value_slot_start + index as u32)),
+            Box::new(Expr::Ident(binding.clone())),
+        ));
+    }
+
+    let else_stmts = value_bindings
+        .iter()
+        .enumerate()
+        .map(|(index, binding)| {
+            assign_stmt(
+                AssignTarget::from(binding.clone()),
+                make_cache_index_expr(cache_ident, value_slot_start + index as u32),
+            )
+        })
+        .collect::<Vec<_>>();
+
+    vec![Stmt::If(IfStmt {
+        span: DUMMY_SP,
+        test,
+        cons: Box::new(Stmt::Block(BlockStmt {
+            span: DUMMY_SP,
+            ctxt: Default::default(),
+            stmts: compute_stmts,
+        })),
+        alt: Some(Box::new(Stmt::Block(BlockStmt {
+            span: DUMMY_SP,
+            ctxt: Default::default(),
+            stmts: else_stmts,
+        }))),
+    })]
+}
+
 fn stmt_assigned_rhs<'a>(stmt: &'a Stmt, target_name: &str) -> Option<&'a Expr> {
     match stmt {
         Stmt::Expr(expr_stmt) => {
@@ -10125,6 +13172,156 @@ fn collect_ident_references_in_expr(expr: &Expr) -> HashSet<String> {
     let mut collector = Collector::default();
     expr.visit_with(&mut collector);
     collector.names
+}
+
+fn stmts_contain_pattern_assignment(stmts: &[Stmt]) -> bool {
+    struct Finder {
+        found: bool,
+    }
+
+    impl Visit for Finder {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_assign_expr(&mut self, assign: &AssignExpr) {
+            if matches!(assign.left, AssignTarget::Pat(_)) {
+                self.found = true;
+                return;
+            }
+            assign.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder { found: false };
+    for stmt in stmts {
+        stmt.visit_with(&mut finder);
+        if finder.found {
+            return true;
+        }
+    }
+    false
+}
+
+fn collect_assigned_bindings_in_order_from_stmts(stmts: &[Stmt]) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut seen = HashSet::new();
+    for stmt in stmts {
+        collect_assigned_bindings_in_order_from_stmt(stmt, &mut out, &mut seen);
+    }
+    out
+}
+
+fn collect_assigned_bindings_in_order_from_stmt(
+    stmt: &Stmt,
+    out: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+) {
+    match stmt {
+        Stmt::Expr(expr_stmt) => {
+            let Expr::Assign(assign) = unwrap_transparent_expr(&expr_stmt.expr) else {
+                return;
+            };
+            if let Some(ident) = assign.left.as_ident() {
+                let name = ident.id.sym.to_string();
+                if seen.insert(name.clone()) {
+                    out.push(name);
+                }
+                return;
+            }
+            let AssignTarget::Pat(assign_pat) = &assign.left else {
+                return;
+            };
+            let pat = Pat::from(assign_pat.clone());
+            for name in collect_pattern_binding_names_in_order(&pat) {
+                if seen.insert(name.clone()) {
+                    out.push(name);
+                }
+            }
+        }
+        Stmt::Decl(Decl::Var(var_decl)) => {
+            for decl in &var_decl.decls {
+                if decl.init.is_none() {
+                    continue;
+                }
+                for name in collect_pattern_binding_names_in_order(&decl.name) {
+                    if seen.insert(name.clone()) {
+                        out.push(name);
+                    }
+                }
+            }
+        }
+        Stmt::Block(block) => {
+            for nested in &block.stmts {
+                collect_assigned_bindings_in_order_from_stmt(nested, out, seen);
+            }
+        }
+        Stmt::Labeled(labeled) => {
+            collect_assigned_bindings_in_order_from_stmt(&labeled.body, out, seen);
+        }
+        Stmt::If(if_stmt) => {
+            collect_assigned_bindings_in_order_from_stmt(&if_stmt.cons, out, seen);
+            if let Some(alt) = &if_stmt.alt {
+                collect_assigned_bindings_in_order_from_stmt(alt, out, seen);
+            }
+        }
+        Stmt::Switch(switch_stmt) => {
+            for case in &switch_stmt.cases {
+                for cons in &case.cons {
+                    collect_assigned_bindings_in_order_from_stmt(cons, out, seen);
+                }
+            }
+        }
+        Stmt::Try(try_stmt) => {
+            for nested in &try_stmt.block.stmts {
+                collect_assigned_bindings_in_order_from_stmt(nested, out, seen);
+            }
+            if let Some(handler) = &try_stmt.handler {
+                for nested in &handler.body.stmts {
+                    collect_assigned_bindings_in_order_from_stmt(nested, out, seen);
+                }
+            }
+            if let Some(finalizer) = &try_stmt.finalizer {
+                for nested in &finalizer.stmts {
+                    collect_assigned_bindings_in_order_from_stmt(nested, out, seen);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_pattern_binding_names_in_order(pat: &Pat) -> Vec<String> {
+    fn collect(pat: &Pat, out: &mut Vec<String>) {
+        match pat {
+            Pat::Ident(binding) => out.push(binding.id.sym.to_string()),
+            Pat::Array(array) => {
+                for element in array.elems.iter().flatten() {
+                    collect(element, out);
+                }
+            }
+            Pat::Object(object) => {
+                for prop in &object.props {
+                    match prop {
+                        ObjectPatProp::Assign(assign) => out.push(assign.key.id.sym.to_string()),
+                        ObjectPatProp::KeyValue(key_value) => collect(&key_value.value, out),
+                        ObjectPatProp::Rest(rest) => collect(&rest.arg, out),
+                    }
+                }
+            }
+            Pat::Assign(assign) => collect(&assign.left, out),
+            Pat::Rest(rest) => collect(&rest.arg, out),
+            Pat::Invalid(_) | Pat::Expr(_) => {}
+        }
+    }
+
+    let mut out = Vec::new();
+    collect(pat, &mut out);
+    out
 }
 
 fn extract_trailing_post_compute_side_effect_stmts(
@@ -12905,6 +16102,9 @@ fn should_passthrough_pure_initializer(expr: &Expr) -> bool {
     if expr_has_observable_side_effect(expr) {
         return false;
     }
+    if default_param_conditional_allocates_identity(expr) {
+        return false;
+    }
 
     matches!(
         unwrap_transparent_expr(expr),
@@ -12915,6 +16115,22 @@ fn should_passthrough_pure_initializer(expr: &Expr) -> bool {
             | Expr::Cond(_)
             | Expr::Member(_)
             | Expr::Tpl(_)
+    )
+}
+
+fn default_param_conditional_allocates_identity(expr: &Expr) -> bool {
+    let Expr::Cond(cond) = unwrap_transparent_expr(expr) else {
+        return false;
+    };
+
+    matches!(
+        unwrap_transparent_expr(&cond.cons),
+        Expr::Array(_)
+            | Expr::Object(_)
+            | Expr::Class(_)
+            | Expr::New(_)
+            | Expr::JSXElement(_)
+            | Expr::JSXFragment(_)
     )
 }
 
@@ -15042,6 +18258,74 @@ fn should_skip_result_tail_outer_memoization(stmts: &[Stmt], name: &str) -> bool
         && contains_object_assignment_to_binding(stmts, name)
 }
 
+fn should_skip_result_tail_pattern_assignment_outer_memoization(
+    stmts: &[Stmt],
+    name: &str,
+) -> bool {
+    let [Stmt::If(if_stmt)] = stmts else {
+        return false;
+    };
+    let Some(alt) = if_stmt.alt.as_deref() else {
+        return false;
+    };
+
+    let consequent_assigns = contains_direct_assignment_to_binding(
+        std::slice::from_ref(if_stmt.cons.as_ref()),
+        name,
+    ) || contains_pattern_assignment_to_binding(std::slice::from_ref(if_stmt.cons.as_ref()), name);
+    let alternate_assigns = contains_direct_assignment_to_binding(std::slice::from_ref(alt), name)
+        || contains_pattern_assignment_to_binding(std::slice::from_ref(alt), name);
+
+    !contains_return_stmt_in_stmts(stmts)
+        && !contains_direct_call(stmts)
+        && consequent_assigns
+        && alternate_assigns
+        && contains_pattern_assignment_to_binding(stmts, name)
+}
+
+fn contains_pattern_assignment_to_binding(stmts: &[Stmt], name: &str) -> bool {
+    #[derive(Default)]
+    struct Finder<'a> {
+        name: &'a str,
+        found: bool,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_arrow_expr(&mut self, _: &ArrowExpr) {
+            // Skip nested functions.
+        }
+
+        fn visit_function(&mut self, _: &Function) {
+            // Skip nested functions.
+        }
+
+        fn visit_assign_expr(&mut self, assign: &AssignExpr) {
+            let AssignTarget::Pat(assign_pat) = &assign.left else {
+                assign.visit_children_with(self);
+                return;
+            };
+            let pat = Pat::from(assign_pat.clone());
+            if collect_pattern_binding_names(&pat)
+                .iter()
+                .any(|binding| binding == self.name)
+            {
+                self.found = true;
+                return;
+            }
+            assign.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder { name, found: false };
+    for stmt in stmts {
+        stmt.visit_with(&mut finder);
+        if finder.found {
+            return true;
+        }
+    }
+    false
+}
+
 fn contains_object_assignment_to_binding(stmts: &[Stmt], name: &str) -> bool {
     #[derive(Default)]
     struct Finder<'a> {
@@ -15416,14 +18700,27 @@ fn make_var_decl(kind: VarDeclKind, name: Pat, init: Option<Box<Expr>>) -> Stmt 
 }
 
 fn assign_stmt(left: AssignTarget, right: Box<Expr>) -> Stmt {
+    let needs_paren = matches!(
+        &left,
+        AssignTarget::Pat(assign_pat) if matches!(Pat::from(assign_pat.clone()), Pat::Object(_))
+    );
+    let assign = Expr::Assign(AssignExpr {
+        span: DUMMY_SP,
+        op: op!("="),
+        left,
+        right,
+    });
+
     Stmt::Expr(ExprStmt {
         span: DUMMY_SP,
-        expr: Box::new(Expr::Assign(AssignExpr {
-            span: DUMMY_SP,
-            op: op!("="),
-            left,
-            right,
-        })),
+        expr: if needs_paren {
+            Box::new(Expr::Paren(swc_ecma_ast::ParenExpr {
+                span: DUMMY_SP,
+                expr: Box::new(assign),
+            }))
+        } else {
+            Box::new(assign)
+        },
     })
 }
 

--- a/crates/swc_ecma_react_compiler/src/reactive_scopes/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/reactive_scopes/mod.rs
@@ -11137,10 +11137,7 @@ fn prelude_mutates_result_source(stmts: &[Stmt], source_name: &str) -> bool {
 }
 
 fn prelude_mutates_binding_for_non_ident_rhs_split_guard(stmts: &[Stmt], name: &str) -> bool {
-    has_assignment_to_binding(stmts, name)
-        || binding_mutated_via_member_call_after(stmts, name)
-        || binding_mutated_via_member_assignment_after(stmts, name)
-        || binding_captured_by_called_local_function_after(stmts, name)
+    binding_captured_by_called_local_function_after(stmts, name)
         || binding_maybe_mutated_in_called_iife_after(stmts, name)
 }
 

--- a/crates/swc_ecma_react_compiler/tests/fixture.rs
+++ b/crates/swc_ecma_react_compiler/tests/fixture.rs
@@ -55,6 +55,112 @@ fn normalize_flow_component_syntax(source: &str) -> String {
     out
 }
 
+fn normalize_flow_typecast_syntax(source: &str) -> String {
+    let chars = source.char_indices().collect::<Vec<_>>();
+    if chars.is_empty() {
+        return String::new();
+    }
+
+    let mut out = String::with_capacity(source.len());
+    let mut cursor = 0usize;
+
+    while cursor < chars.len() {
+        let (start_idx, ch) = chars[cursor];
+        if ch != '(' {
+            let end_idx = chars
+                .get(cursor + 1)
+                .map(|(idx, _)| *idx)
+                .unwrap_or(source.len());
+            out.push_str(&source[start_idx..end_idx]);
+            cursor += 1;
+            continue;
+        }
+
+        let mut depth = 1usize;
+        let mut end_cursor = cursor + 1;
+        while end_cursor < chars.len() {
+            let (_, ch) = chars[end_cursor];
+            match ch {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => {}
+            }
+            end_cursor += 1;
+        }
+
+        if end_cursor >= chars.len() {
+            // Unbalanced parentheses; copy the current character and continue.
+            let end_idx = chars
+                .get(cursor + 1)
+                .map(|(idx, _)| *idx)
+                .unwrap_or(source.len());
+            out.push_str(&source[start_idx..end_idx]);
+            cursor += 1;
+            continue;
+        }
+
+        let inner_start = chars[cursor + 1].0;
+        let inner_end = chars[end_cursor].0;
+        let inner = &source[inner_start..inner_end];
+
+        let mut paren_depth = 0usize;
+        let mut brace_depth = 0usize;
+        let mut bracket_depth = 0usize;
+        let mut saw_top_level_question = false;
+        let mut top_level_colon_byte = None::<usize>;
+
+        for (offset, ch) in inner.char_indices() {
+            match ch {
+                '(' => paren_depth += 1,
+                ')' => paren_depth = paren_depth.saturating_sub(1),
+                '{' => brace_depth += 1,
+                '}' => brace_depth = brace_depth.saturating_sub(1),
+                '[' => bracket_depth += 1,
+                ']' => bracket_depth = bracket_depth.saturating_sub(1),
+                '?' if paren_depth == 0 && brace_depth == 0 && bracket_depth == 0 => {
+                    saw_top_level_question = true;
+                }
+                ':' if paren_depth == 0 && brace_depth == 0 && bracket_depth == 0 => {
+                    top_level_colon_byte = Some(offset);
+                    break;
+                }
+                _ => {}
+            }
+        }
+
+        let mut rewritten = false;
+        if let Some(colon_offset) = top_level_colon_byte {
+            if !saw_top_level_question {
+                let expr_part = inner[..colon_offset].trim();
+                let type_part = inner[colon_offset + 1..].trim();
+                if !expr_part.is_empty() && !type_part.is_empty() {
+                    out.push('(');
+                    out.push_str(expr_part);
+                    out.push(')');
+                    rewritten = true;
+                }
+            }
+        }
+
+        if !rewritten {
+            let end_byte = chars
+                .get(end_cursor + 1)
+                .map(|(idx, _)| *idx)
+                .unwrap_or(source.len());
+            out.push_str(&source[start_idx..end_byte]);
+        }
+
+        cursor = end_cursor + 1;
+    }
+
+    out
+}
+
 fn collect_flow_component_declaration_names(source: &str) -> HashSet<String> {
     let mut names = HashSet::new();
 
@@ -312,7 +418,7 @@ fn parse(input: &Path, source: &str) -> (Program, Vec<Comment>) {
     );
 
     if parsed_es.is_err() {
-        let normalized = normalize_flow_component_syntax(source);
+        let normalized = normalize_flow_component_syntax(&normalize_flow_typecast_syntax(source));
         if normalized != source {
             let component_names = collect_flow_component_declaration_names(source);
             let (parsed_ts_normalized, ts_comments_normalized) = parse_with_source(


### PR DESCRIPTION
## Summary
- Continue React Compiler SWC parity work against upstream fixture expectations.
- Align infer-mode function selection and fixture-entrypoint handling (including `TODO_FIXTURE_ENTRYPOINT`).
- Implement and wire `drop_manual_memoization` in the compile pipeline with conservative guards.
- Improve reactive-scope parity for loop/dependency handling, do-while lowering, destructuring/default normalization, and CFG peepholes used by upstream fixtures.
- Extend fixture parsing normalization for Flow syntax edge cases.

## Validation
- `git submodule update --init --recursive`
- Targeted upstream fixture manifests for regression checks (multiple focused sets)
- `RUN_UPSTREAM_FIXTURES=1 cargo test -p swc_ecma_react_compiler --test fixture fixture_cases_upstream`

## Current Status
- Draft for incremental parity work.
- Full upstream run is improved but not fully green yet.
- Current first failing fixture during full run:
  - `crates/swc_ecma_react_compiler/tests/fixtures/upstream/dont-merge-if-dep-is-inner-declaration-of-previous-scope/input.js`
