### PR TITLE
fix(cli): skip mkdir when --out-file targets the current directory

### DIFF
--- a/crates/swc_cli_impl/src/commands/compile.rs
+++ b/crates/swc_cli_impl/src/commands/compile.rs
@@ -241,7 +241,7 @@ fn emit_output(
             .parent()
             .expect("Parent should be available");
 
-        if !output_dir.is_dir() {
+        if !output_dir.as_os_str().is_empty() && !output_dir.is_dir() {
             fs::create_dir_all(output_dir)?;
         }
 
@@ -474,11 +474,12 @@ impl CompileOptions {
                 )
                 .collect();
 
-            fs::create_dir_all(
-                single_out_file
-                    .parent()
-                    .expect("Parent should be available"),
-            )?;
+            let parent = single_out_file
+                .parent()
+                .expect("Parent should be available");
+            if !parent.as_os_str().is_empty() {
+                fs::create_dir_all(parent)?;
+            }
             let mut buf = File::create(single_out_file)?;
             let mut buf_srcmap = None;
             let mut buf_dts = None;

--- a/crates/swc_cli_impl/tests/issues.rs
+++ b/crates/swc_cli_impl/tests/issues.rs
@@ -435,6 +435,34 @@ fn root_mode_upward_optional_finds_parent_config() -> Result<()> {
     Ok(())
 }
 
+/// `--out-file file.min.js` (no directory component) should not fail with
+/// EEXIST when trying to mkdir the current directory.
+#[test]
+fn issue_11717_out_file_same_directory() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    fs::write(
+        sandbox.path().join("file.js"),
+        "const x = 1;\nconsole.log(x);\n",
+    )?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--out-file")
+        .arg("file.min.js")
+        .arg("file.js");
+
+    cmd.assert().success();
+
+    let output = fs::read_to_string(sandbox.path().join("file.min.js"))?;
+    assert!(
+        output.contains("console.log"),
+        "Output file should contain compiled code. Got: {output}"
+    );
+
+    Ok(())
+}
+
 /// ln -s $a $b
 fn symlink(a: &Path, b: &Path) {
     #[cfg(unix)]


### PR DESCRIPTION
When `--out-file file.min.js` is used without a directory component, `Path::parent()` returns an empty string. Calling `create_dir_all("")` fails on Windows with EEXIST. Skip the directory creation when the parent path is empty.

Closes #11717

Generated with [Claude Code](https://claude.ai/code)