### PR TITLE
chore(ci): bump cargo-mono to 0.5.3

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install cargo-mono
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mono@0.5.0
+          tool: cargo-mono@0.5.3
 
       - name: List crates
         id: list-tests

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install cargo-mono
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mono@0.5.0
+          tool: cargo-mono@0.5.3
 
       - name: Update constant of swc_core
         run: npx ts-node .github/bot/src/cargo/update-constants.ts


### PR DESCRIPTION
## Summary
- bump GitHub Actions `cargo-mono` version from `0.5.0` to `0.5.3`
- update both workflow install points (`.github/workflows/CI.yml`, `.github/workflows/publish-crates.yml`)

## Verification
- `rg -n "cargo-mono@" .github/workflows`
- `rg -n "cargo-mono@0.5.0" .github/workflows` (no matches)
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
