### PR TITLE
fix(ci): install zig for core ppc64le/s390x nightly cross builds

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -261,8 +261,9 @@ jobs:
         with:
           targets: ${{ matrix.settings.target }}
           toolchain: ${{ steps.toolchain.outputs.version }}
+      # `yarn napi build ... -x` invokes `cargo-zigbuild`, which requires zig on the runner.
       - uses: mlugg/setup-zig@v2
-        if: ${{ matrix.settings.target == 'armv7-unknown-linux-gnueabihf' }}
+        if: ${{ matrix.settings.target == 'armv7-unknown-linux-gnueabihf' || matrix.settings.target == 'powerpc64le-unknown-linux-gnu' || matrix.settings.target == 's390x-unknown-linux-gnu' }}
         with:
           version: 0.15.1
       - name: Cache cargo registry


### PR DESCRIPTION
## Summary

This fixes nightly @swc/core cross-build failures for:

- powerpc64le-unknown-linux-gnu
- s390x-unknown-linux-gnu

Both jobs failed with:

- Error: Failed to find zig
- cannot find binary path

from `yarn napi build ... -x` (cargo zigbuild path).

## Root Cause

`mlugg/setup-zig@v2` in `publish-npm-package.yml` was only enabled for armv7-unknown-linux-gnueabihf, while powerpc64le and s390x also use the same napi `-x` path and require Zig on the runner.

## Changes

- Expand Zig setup condition to include:
  - armv7-unknown-linux-gnueabihf
  - powerpc64le-unknown-linux-gnu
  - s390x-unknown-linux-gnu
- Keep Zig version unchanged (0.15.1)
- Add a short comment explaining why Zig is needed for this path

## Validation

- git submodule update --init --recursive
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings

## Related CI logs

- https://github.com/swc-project/swc/actions/runs/23397731811/job/68063935265#step:16:213
- https://github.com/swc-project/swc/actions/runs/23397731811/job/68063935252
