### PR TITLE
feat(react-compiler): tighten core validation parity for upstream fixtures

### DIFF
--- a/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
@@ -277,9 +277,9 @@ pub fn compile_fn(
     optimization::prune_maybe_throws(&mut hir);
 
     inference::infer_mutation_aliasing_ranges(&mut hir);
-    if opts.environment.assert_valid_mutable_ranges {
-        validation::validate_locals_not_reassigned_after_render(&hir)?;
-    }
+    // Upstream runs this validation unconditionally and reserves
+    // `assert_valid_mutable_ranges` for additional internal checks.
+    validation::validate_locals_not_reassigned_after_render(&hir)?;
 
     if opts.environment.validate_ref_access_during_render {
         validation::validate_no_ref_access_in_render(&hir)?;

--- a/crates/swc_ecma_react_compiler/src/validation/validate_context_variable_lvalues.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/validate_context_variable_lvalues.rs
@@ -1,5 +1,452 @@
-use crate::{error::CompilerError, hir::HirFunction};
+use std::collections::HashSet;
 
-pub fn validate_context_variable_lvalues(_hir: &HirFunction) -> Result<(), CompilerError> {
-    Ok(())
+use swc_ecma_ast::{
+    op, AssignExpr, AssignTarget, Callee, Expr, MemberExpr, MemberProp, Pat, Stmt, UpdateExpr,
+};
+use swc_ecma_visit::{Visit, VisitWith};
+
+use crate::{
+    error::{CompilerError, CompilerErrorDetail, ErrorCategory},
+    hir::HirFunction,
+};
+
+const GLOBAL_REASSIGN_REASON: &str =
+    "Cannot reassign variables declared outside of the component/hook";
+const FROZEN_VALUE_REASON: &str = "This value cannot be modified";
+const FROZEN_JSX_DESCRIPTION: &str = "Modifying a value used previously in JSX is not allowed. \
+                                      Consider moving the modification before the JSX.";
+const FROZEN_PROP_DESCRIPTION: &str = "Modifying component props or hook arguments is not \
+                                       allowed. Consider using a local variable instead.";
+
+pub fn validate_context_variable_lvalues(hir: &HirFunction) -> Result<(), CompilerError> {
+    let Some(body) = hir.function.body.as_ref() else {
+        return Ok(());
+    };
+
+    let mut params = HashSet::<String>::new();
+    for param in &hir.function.params {
+        collect_pat_bindings(&param.pat, &mut params);
+    }
+
+    let mut locals = params.clone();
+    collect_block_bindings(body, &mut locals);
+
+    let mut frozen_from_jsx = HashSet::<String>::new();
+    let mut errors = Vec::<CompilerErrorDetail>::new();
+
+    for stmt in &body.stmts {
+        let mut mutations = Vec::<Mutation>::new();
+        collect_stmt_mutations(stmt, &mut mutations);
+
+        for mutation in &mutations {
+            if params.contains(mutation.target.as_str()) {
+                errors.push(modification_error(
+                    mutation.span,
+                    Some(FROZEN_PROP_DESCRIPTION),
+                ));
+                continue;
+            }
+
+            if frozen_from_jsx.contains(mutation.target.as_str()) {
+                errors.push(modification_error(
+                    mutation.span,
+                    Some(FROZEN_JSX_DESCRIPTION),
+                ));
+                continue;
+            }
+
+            if !locals.contains(mutation.target.as_str()) && !is_known_global(&mutation.target) {
+                errors.push(global_reassign_error(mutation.span));
+            }
+        }
+
+        let mut jsx_refs = HashSet::<String>::new();
+        collect_jsx_refs(stmt, &mut jsx_refs);
+        frozen_from_jsx.extend(jsx_refs);
+    }
+
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(CompilerError { details: errors })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct Mutation {
+    target: String,
+    span: swc_common::Span,
+}
+
+fn global_reassign_error(span: swc_common::Span) -> CompilerErrorDetail {
+    let mut detail =
+        CompilerErrorDetail::error(ErrorCategory::Immutability, GLOBAL_REASSIGN_REASON);
+    detail.loc = Some(span);
+    detail
+}
+
+fn modification_error(span: swc_common::Span, description: Option<&str>) -> CompilerErrorDetail {
+    let mut detail = CompilerErrorDetail::error(ErrorCategory::Immutability, FROZEN_VALUE_REASON);
+    detail.description = description.map(str::to_string);
+    detail.loc = Some(span);
+    detail
+}
+
+fn collect_pat_bindings(pat: &Pat, out: &mut HashSet<String>) {
+    match pat {
+        Pat::Ident(binding) => {
+            out.insert(binding.id.sym.to_string());
+        }
+        Pat::Array(array) => {
+            for elem in array.elems.iter().flatten() {
+                collect_pat_bindings(elem, out);
+            }
+        }
+        Pat::Object(object) => {
+            for prop in &object.props {
+                match prop {
+                    swc_ecma_ast::ObjectPatProp::Assign(assign) => {
+                        out.insert(assign.key.id.sym.to_string());
+                    }
+                    swc_ecma_ast::ObjectPatProp::KeyValue(key_value) => {
+                        collect_pat_bindings(&key_value.value, out);
+                    }
+                    swc_ecma_ast::ObjectPatProp::Rest(rest) => {
+                        collect_pat_bindings(&rest.arg, out);
+                    }
+                }
+            }
+        }
+        Pat::Assign(assign) => collect_pat_bindings(&assign.left, out),
+        Pat::Rest(rest) => collect_pat_bindings(&rest.arg, out),
+        Pat::Expr(_) | Pat::Invalid(_) => {}
+    }
+}
+
+fn collect_block_bindings(block: &swc_ecma_ast::BlockStmt, out: &mut HashSet<String>) {
+    struct Finder<'a> {
+        out: &'a mut HashSet<String>,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_function(&mut self, _: &swc_ecma_ast::Function) {
+            // Function-local mutability should not be affected by declarations
+            // inside nested functions.
+        }
+
+        fn visit_arrow_expr(&mut self, _: &swc_ecma_ast::ArrowExpr) {
+            // Function-local mutability should not be affected by declarations
+            // inside nested functions.
+        }
+
+        fn visit_var_declarator(&mut self, decl: &swc_ecma_ast::VarDeclarator) {
+            collect_pat_bindings(&decl.name, self.out);
+            decl.visit_children_with(self);
+        }
+
+        fn visit_fn_decl(&mut self, decl: &swc_ecma_ast::FnDecl) {
+            self.out.insert(decl.ident.sym.to_string());
+            // No recursion needed: nested declaration body is skipped by
+            // `visit_function`.
+        }
+
+        fn visit_class_decl(&mut self, decl: &swc_ecma_ast::ClassDecl) {
+            self.out.insert(decl.ident.sym.to_string());
+            decl.visit_children_with(self);
+        }
+    }
+
+    block.visit_with(&mut Finder { out });
+}
+
+fn collect_stmt_mutations(stmt: &Stmt, out: &mut Vec<Mutation>) {
+    struct Finder<'a> {
+        out: &'a mut Vec<Mutation>,
+    }
+
+    impl Finder<'_> {
+        fn push(&mut self, target: &str, span: swc_common::Span) {
+            self.out.push(Mutation {
+                target: target.to_string(),
+                span,
+            });
+        }
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_function(&mut self, _: &swc_ecma_ast::Function) {
+            // Skip nested functions. Mutations inside callbacks may or may not
+            // execute during render; this pass only validates direct render
+            // statements conservatively.
+        }
+
+        fn visit_arrow_expr(&mut self, _: &swc_ecma_ast::ArrowExpr) {
+            // Skip nested arrows for the same reason as above.
+        }
+
+        fn visit_assign_expr(&mut self, assign: &AssignExpr) {
+            match &assign.left {
+                AssignTarget::Simple(simple) => match simple {
+                    swc_ecma_ast::SimpleAssignTarget::Ident(binding) => {
+                        self.push(binding.id.sym.as_ref(), assign.span);
+                    }
+                    swc_ecma_ast::SimpleAssignTarget::Member(member) => {
+                        if let Some(name) = member_root_ident(member) {
+                            self.push(name, assign.span);
+                        }
+                    }
+                    _ => {}
+                },
+                AssignTarget::Pat(pat) => {
+                    collect_assign_pat_targets(pat, self.out, assign.span);
+                }
+            }
+            assign.visit_children_with(self);
+        }
+
+        fn visit_update_expr(&mut self, update: &UpdateExpr) {
+            match &*update.arg {
+                Expr::Ident(ident) => {
+                    self.push(ident.sym.as_ref(), update.span);
+                }
+                Expr::Member(member) => {
+                    if let Some(name) = member_root_ident(member) {
+                        self.push(name, update.span);
+                    }
+                }
+                _ => {}
+            }
+            update.visit_children_with(self);
+        }
+
+        fn visit_unary_expr(&mut self, unary: &swc_ecma_ast::UnaryExpr) {
+            if unary.op == op!("delete") {
+                if let Expr::Member(member) = &*unary.arg {
+                    if let Some(name) = member_root_ident(member) {
+                        self.push(name, unary.span);
+                    }
+                }
+            }
+            unary.visit_children_with(self);
+        }
+
+        fn visit_call_expr(&mut self, call: &swc_ecma_ast::CallExpr) {
+            if let Some(name) = mutating_method_target(call) {
+                self.push(name, call.span);
+            }
+            call.visit_children_with(self);
+        }
+    }
+
+    stmt.visit_with(&mut Finder { out });
+}
+
+fn collect_assign_pat_targets(
+    pat: &swc_ecma_ast::AssignTargetPat,
+    out: &mut Vec<Mutation>,
+    span: swc_common::Span,
+) {
+    match pat {
+        swc_ecma_ast::AssignTargetPat::Array(array) => {
+            for elem in array.elems.iter().flatten() {
+                collect_mutation_targets_from_pat(elem, out, span);
+            }
+        }
+        swc_ecma_ast::AssignTargetPat::Object(object) => {
+            for prop in &object.props {
+                match prop {
+                    swc_ecma_ast::ObjectPatProp::Assign(assign) => {
+                        out.push(Mutation {
+                            target: assign.key.id.sym.to_string(),
+                            span,
+                        });
+                    }
+                    swc_ecma_ast::ObjectPatProp::KeyValue(key_value) => {
+                        collect_mutation_targets_from_pat(&key_value.value, out, span);
+                    }
+                    swc_ecma_ast::ObjectPatProp::Rest(rest) => {
+                        collect_mutation_targets_from_pat(&rest.arg, out, span);
+                    }
+                }
+            }
+        }
+        swc_ecma_ast::AssignTargetPat::Invalid(_) => {}
+    }
+}
+
+fn collect_mutation_targets_from_pat(pat: &Pat, out: &mut Vec<Mutation>, span: swc_common::Span) {
+    match pat {
+        Pat::Ident(binding) => out.push(Mutation {
+            target: binding.id.sym.to_string(),
+            span,
+        }),
+        Pat::Array(array) => {
+            for elem in array.elems.iter().flatten() {
+                collect_mutation_targets_from_pat(elem, out, span);
+            }
+        }
+        Pat::Object(object) => {
+            for prop in &object.props {
+                match prop {
+                    swc_ecma_ast::ObjectPatProp::Assign(assign) => out.push(Mutation {
+                        target: assign.key.id.sym.to_string(),
+                        span,
+                    }),
+                    swc_ecma_ast::ObjectPatProp::KeyValue(key_value) => {
+                        collect_mutation_targets_from_pat(&key_value.value, out, span);
+                    }
+                    swc_ecma_ast::ObjectPatProp::Rest(rest) => {
+                        collect_mutation_targets_from_pat(&rest.arg, out, span);
+                    }
+                }
+            }
+        }
+        Pat::Assign(assign) => collect_mutation_targets_from_pat(&assign.left, out, span),
+        Pat::Rest(rest) => collect_mutation_targets_from_pat(&rest.arg, out, span),
+        Pat::Expr(expr) => match &**expr {
+            Expr::Ident(ident) => out.push(Mutation {
+                target: ident.sym.to_string(),
+                span,
+            }),
+            Expr::Member(member) => {
+                if let Some(name) = member_root_ident(member) {
+                    out.push(Mutation {
+                        target: name.to_string(),
+                        span,
+                    });
+                }
+            }
+            _ => {}
+        },
+        Pat::Invalid(_) => {}
+    }
+}
+
+fn member_root_ident(member: &MemberExpr) -> Option<&str> {
+    match &*member.obj {
+        Expr::Ident(ident) => Some(ident.sym.as_ref()),
+        Expr::Member(inner) => member_root_ident(inner),
+        _ => None,
+    }
+}
+
+fn mutating_method_target(call: &swc_ecma_ast::CallExpr) -> Option<&str> {
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    let Expr::Member(member) = &**callee else {
+        return None;
+    };
+    let method = match &member.prop {
+        MemberProp::Ident(ident) => ident.sym.as_ref(),
+        MemberProp::Computed(computed) => match &*computed.expr {
+            Expr::Lit(swc_ecma_ast::Lit::Str(value)) => value.value.as_str()?,
+            _ => return None,
+        },
+        MemberProp::PrivateName(_) => return None,
+    };
+
+    if !matches!(
+        method,
+        "add"
+            | "clear"
+            | "copyWithin"
+            | "delete"
+            | "fill"
+            | "pop"
+            | "push"
+            | "reverse"
+            | "set"
+            | "shift"
+            | "sort"
+            | "splice"
+            | "unshift"
+    ) {
+        return None;
+    }
+
+    member_root_ident(member)
+}
+
+fn collect_jsx_refs(stmt: &Stmt, out: &mut HashSet<String>) {
+    struct Finder<'a> {
+        out: &'a mut HashSet<String>,
+        in_jsx: bool,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_function(&mut self, _: &swc_ecma_ast::Function) {}
+
+        fn visit_arrow_expr(&mut self, _: &swc_ecma_ast::ArrowExpr) {}
+
+        fn visit_jsx_element(&mut self, element: &swc_ecma_ast::JSXElement) {
+            let prev = self.in_jsx;
+            self.in_jsx = true;
+            element.visit_children_with(self);
+            self.in_jsx = prev;
+        }
+
+        fn visit_jsx_fragment(&mut self, fragment: &swc_ecma_ast::JSXFragment) {
+            let prev = self.in_jsx;
+            self.in_jsx = true;
+            fragment.visit_children_with(self);
+            self.in_jsx = prev;
+        }
+
+        fn visit_expr(&mut self, expr: &Expr) {
+            if self.in_jsx {
+                match expr {
+                    Expr::Ident(ident) => {
+                        self.out.insert(ident.sym.to_string());
+                    }
+                    Expr::Member(member) => {
+                        if let Some(name) = member_root_ident(member) {
+                            self.out.insert(name.to_string());
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            expr.visit_children_with(self);
+        }
+    }
+
+    stmt.visit_with(&mut Finder { out, in_jsx: false });
+}
+
+fn is_known_global(name: &str) -> bool {
+    matches!(
+        name,
+        "globalThis"
+            | "global"
+            | "window"
+            | "document"
+            | "console"
+            | "Math"
+            | "Date"
+            | "JSON"
+            | "Number"
+            | "String"
+            | "Boolean"
+            | "Object"
+            | "Array"
+            | "Map"
+            | "Set"
+            | "WeakMap"
+            | "WeakSet"
+            | "Promise"
+            | "Symbol"
+            | "Intl"
+            | "Reflect"
+            | "Proxy"
+            | "RegExp"
+            | "Error"
+            | "TypeError"
+            | "RangeError"
+            | "URL"
+            | "URLSearchParams"
+            | "NaN"
+            | "Infinity"
+            | "undefined"
+    )
 }

--- a/crates/swc_ecma_react_compiler/src/validation/validate_hooks_usage.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/validate_hooks_usage.rs
@@ -2,7 +2,8 @@ use std::collections::HashSet;
 
 use swc_common::Spanned;
 use swc_ecma_ast::{
-    CallExpr, Callee, CondExpr, Expr, MemberExpr, MemberProp, Pat, Stmt, VarDeclarator,
+    AssignExpr, AssignTarget, CallExpr, Callee, CondExpr, Expr, MemberExpr, MemberProp,
+    OptChainBase, OptChainExpr, Pat, Stmt, VarDeclarator,
 };
 use swc_ecma_visit::{Visit, VisitWith};
 
@@ -15,6 +16,7 @@ use crate::{
 const HOOK_REFERENCE_REASON: &str = "Hooks may not be referenced as normal values, they must be called. See https://react.dev/reference/rules/react-calls-components-and-hooks#never-pass-around-hooks-as-regular-values";
 const HOOK_CONDITIONAL_REASON: &str = "Hooks must always be called in a consistent order, and may not be called conditionally. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)";
 const HOOK_NESTED_REASON: &str = "Hooks must be called at the top level in the body of a function component or custom hook, and may not be called within function expressions. See the Rules of Hooks (https://react.dev/warnings/invalid-hook-call-warning)";
+const HOOK_DYNAMIC_REASON: &str = "Hooks must be the same function on every render, but this value may change over time to a different function. See https://react.dev/reference/rules/react-calls-components-and-hooks#dont-dynamically-use-hooks";
 
 pub fn validate_hooks_usage(hir: &HirFunction) -> Result<(), CompilerError> {
     let Some(body) = hir.function.body.as_ref() else {
@@ -44,6 +46,28 @@ pub fn validate_hooks_usage(hir: &HirFunction) -> Result<(), CompilerError> {
             match expr {
                 Expr::Ident(ident) => is_hook_name(ident.sym.as_ref()),
                 Expr::Member(member) => hook_like_member(member),
+                Expr::OptChain(chain) => match &*chain.base {
+                    OptChainBase::Call(call) => Finder::hook_like_expr(&call.callee),
+                    OptChainBase::Member(member) => hook_like_member(member),
+                },
+                _ => false,
+            }
+        }
+
+        fn is_dynamic_local_hook_call(callee: &Expr, local_bindings: &HashSet<String>) -> bool {
+            match callee {
+                Expr::Ident(ident) => local_bindings.contains(ident.sym.as_ref()),
+                Expr::Member(member) => {
+                    root_member_ident(member).is_some_and(|name| local_bindings.contains(name))
+                }
+                Expr::OptChain(chain) => match &*chain.base {
+                    OptChainBase::Call(call) => {
+                        Finder::is_dynamic_local_hook_call(&call.callee, local_bindings)
+                    }
+                    OptChainBase::Member(member) => {
+                        root_member_ident(member).is_some_and(|name| local_bindings.contains(name))
+                    }
+                },
                 _ => false,
             }
         }
@@ -101,23 +125,14 @@ pub fn validate_hooks_usage(hir: &HirFunction) -> Result<(), CompilerError> {
         fn visit_call_expr(&mut self, call: &CallExpr) {
             if let Callee::Expr(callee) = &call.callee {
                 if Finder::hook_like_expr(callee) {
-                    let is_dynamic_local_hook_call = match &**callee {
-                        Expr::Ident(ident) => self.local_bindings.contains(ident.sym.as_ref()),
-                        Expr::Member(member) => {
-                            if let Expr::Ident(obj) = &*member.obj {
-                                self.local_bindings.contains(obj.sym.as_ref())
-                            } else {
-                                false
-                            }
-                        }
-                        _ => false,
-                    };
+                    let is_dynamic_local_hook_call =
+                        Finder::is_dynamic_local_hook_call(callee, &self.local_bindings);
                     if self.nested_function_depth > 0 {
                         self.push(call.span, HOOK_NESTED_REASON);
                     } else if self.conditional_depth > 0 {
                         self.push(call.span, HOOK_CONDITIONAL_REASON);
                     } else if is_dynamic_local_hook_call {
-                        self.push(call.span, HOOK_REFERENCE_REASON);
+                        self.push(call.span, HOOK_DYNAMIC_REASON);
                     }
                 } else if let Expr::Ident(ident) = &**callee {
                     if self.hook_aliases.contains(ident.sym.as_ref()) {
@@ -138,6 +153,30 @@ pub fn validate_hooks_usage(hir: &HirFunction) -> Result<(), CompilerError> {
             self.in_direct_callee = prev;
         }
 
+        fn visit_opt_chain_expr(&mut self, expr: &OptChainExpr) {
+            if let OptChainBase::Call(call) = &*expr.base {
+                if Finder::hook_like_expr(&call.callee) {
+                    if self.nested_function_depth > 0 {
+                        self.push(expr.span, HOOK_NESTED_REASON);
+                    } else {
+                        // Optional calls execute conditionally by definition.
+                        self.push(expr.span, HOOK_CONDITIONAL_REASON);
+                    }
+                }
+
+                for arg in &call.args {
+                    arg.visit_with(self);
+                }
+                let prev = self.in_direct_callee;
+                self.in_direct_callee = true;
+                call.callee.visit_with(self);
+                self.in_direct_callee = prev;
+                return;
+            }
+
+            expr.visit_children_with(self);
+        }
+
         fn visit_var_declarator(&mut self, declarator: &VarDeclarator) {
             if self.nested_function_depth == 0 {
                 if let Pat::Ident(binding) = &declarator.name {
@@ -150,6 +189,24 @@ pub fn validate_hooks_usage(hir: &HirFunction) -> Result<(), CompilerError> {
                 }
             }
             declarator.visit_children_with(self);
+        }
+
+        fn visit_assign_expr(&mut self, assign: &AssignExpr) {
+            if self.nested_function_depth == 0 {
+                if let AssignTarget::Simple(swc_ecma_ast::SimpleAssignTarget::Ident(binding)) =
+                    &assign.left
+                {
+                    if contains_hook_reference(
+                        &assign.right,
+                        &self.hook_aliases,
+                        &self.local_bindings,
+                    ) {
+                        self.hook_aliases.insert(binding.id.sym.to_string());
+                        self.push(assign.span, HOOK_REFERENCE_REASON);
+                    }
+                }
+            }
+            assign.visit_children_with(self);
         }
 
         fn visit_member_expr(&mut self, member: &MemberExpr) {
@@ -201,6 +258,22 @@ fn hook_like_member(member: &MemberExpr) -> bool {
             matches!(&*computed.expr, Expr::Ident(ident) if is_hook_name(ident.sym.as_ref()))
         }
         MemberProp::PrivateName(_) => false,
+    }
+}
+
+fn root_member_ident(member: &MemberExpr) -> Option<&str> {
+    match &*member.obj {
+        Expr::Ident(ident) => Some(ident.sym.as_ref()),
+        Expr::Member(inner) => root_member_ident(inner),
+        Expr::OptChain(chain) => match &*chain.base {
+            OptChainBase::Member(base_member) => root_member_ident(base_member),
+            OptChainBase::Call(call) => match &*call.callee {
+                Expr::Member(base_member) => root_member_ident(base_member),
+                Expr::Ident(ident) => Some(ident.sym.as_ref()),
+                _ => None,
+            },
+        },
+        _ => None,
     }
 }
 

--- a/crates/swc_ecma_react_compiler/src/validation/validate_locals_not_reassigned_after_render.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/validate_locals_not_reassigned_after_render.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use swc_ecma_ast::{AssignExpr, AssignTarget, Expr, Pat, Stmt, UpdateExpr};
+use swc_ecma_ast::{AssignExpr, AssignTarget, Expr, Pat, UpdateExpr};
 use swc_ecma_visit::{Visit, VisitWith};
 
 use crate::{
@@ -17,14 +17,12 @@ pub fn validate_locals_not_reassigned_after_render(hir: &HirFunction) -> Result<
     for param in &hir.function.params {
         collect_pat_bindings(&param.pat, &mut locals);
     }
-    for stmt in &body.stmts {
-        collect_stmt_bindings(stmt, &mut locals);
-    }
+    collect_block_bindings(body, &mut locals);
 
     #[derive(Default)]
     struct Finder {
         locals: HashSet<String>,
-        nested_depth: usize,
+        nested_async_depth: usize,
         errors: Vec<CompilerErrorDetail>,
     }
 
@@ -32,11 +30,11 @@ pub fn validate_locals_not_reassigned_after_render(hir: &HirFunction) -> Result<
         fn push_reassign(&mut self, span: swc_common::Span, name: &str) {
             let mut detail = CompilerErrorDetail::error(
                 ErrorCategory::Immutability,
-                "Cannot reassign variable after render completes",
+                "Cannot reassign variable in async function",
             );
             detail.description = Some(format!(
-                "Reassigning `{name}` after render has completed can cause inconsistent behavior \
-                 on subsequent renders. Consider using state instead."
+                "Reassigning a variable in an async function can cause inconsistent behavior on \
+                 subsequent renders. Consider using state instead. Cannot reassign `{name}`."
             ));
             detail.loc = Some(span);
             self.errors.push(detail);
@@ -45,19 +43,27 @@ pub fn validate_locals_not_reassigned_after_render(hir: &HirFunction) -> Result<
 
     impl Visit for Finder {
         fn visit_function(&mut self, function: &swc_ecma_ast::Function) {
-            self.nested_depth += 1;
+            if function.is_async {
+                self.nested_async_depth += 1;
+            }
             function.visit_children_with(self);
-            self.nested_depth -= 1;
+            if function.is_async {
+                self.nested_async_depth -= 1;
+            }
         }
 
         fn visit_arrow_expr(&mut self, arrow: &swc_ecma_ast::ArrowExpr) {
-            self.nested_depth += 1;
+            if arrow.is_async {
+                self.nested_async_depth += 1;
+            }
             arrow.visit_children_with(self);
-            self.nested_depth -= 1;
+            if arrow.is_async {
+                self.nested_async_depth -= 1;
+            }
         }
 
         fn visit_assign_expr(&mut self, assign: &AssignExpr) {
-            if self.nested_depth > 0 {
+            if self.nested_async_depth > 0 {
                 if let AssignTarget::Simple(swc_ecma_ast::SimpleAssignTarget::Ident(binding)) =
                     &assign.left
                 {
@@ -71,7 +77,7 @@ pub fn validate_locals_not_reassigned_after_render(hir: &HirFunction) -> Result<
         }
 
         fn visit_update_expr(&mut self, update: &UpdateExpr) {
-            if self.nested_depth > 0 {
+            if self.nested_async_depth > 0 {
                 if let Expr::Ident(ident) = &*update.arg {
                     let name = ident.sym.as_ref();
                     if self.locals.contains(name) {
@@ -129,16 +135,29 @@ fn collect_pat_bindings(pat: &Pat, out: &mut HashSet<String>) {
     }
 }
 
-fn collect_stmt_bindings(stmt: &Stmt, out: &mut HashSet<String>) {
-    match stmt {
-        Stmt::Decl(swc_ecma_ast::Decl::Var(var_decl)) => {
-            for decl in &var_decl.decls {
-                collect_pat_bindings(&decl.name, out);
-            }
-        }
-        Stmt::Decl(swc_ecma_ast::Decl::Fn(fn_decl)) => {
-            out.insert(fn_decl.ident.sym.to_string());
-        }
-        _ => {}
+fn collect_block_bindings(block: &swc_ecma_ast::BlockStmt, out: &mut HashSet<String>) {
+    struct Finder<'a> {
+        out: &'a mut HashSet<String>,
     }
+
+    impl Visit for Finder<'_> {
+        fn visit_function(&mut self, _: &swc_ecma_ast::Function) {
+            // Do not include bindings from nested functions.
+        }
+
+        fn visit_arrow_expr(&mut self, _: &swc_ecma_ast::ArrowExpr) {
+            // Do not include bindings from nested functions.
+        }
+
+        fn visit_var_declarator(&mut self, decl: &swc_ecma_ast::VarDeclarator) {
+            collect_pat_bindings(&decl.name, self.out);
+            decl.visit_children_with(self);
+        }
+
+        fn visit_fn_decl(&mut self, decl: &swc_ecma_ast::FnDecl) {
+            self.out.insert(decl.ident.sym.to_string());
+        }
+    }
+
+    block.visit_with(&mut Finder { out });
 }

--- a/crates/swc_ecma_react_compiler/src/validation/validate_no_capitalized_calls.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/validate_no_capitalized_calls.rs
@@ -1,5 +1,78 @@
-use crate::{error::CompilerError, hir::HirFunction};
+use swc_ecma_ast::{CallExpr, Callee, Expr, MemberProp};
+use swc_ecma_visit::{Visit, VisitWith};
 
-pub fn validate_no_capitalized_calls(_hir: &HirFunction) -> Result<(), CompilerError> {
-    Ok(())
+use crate::{
+    error::{CompilerError, CompilerErrorDetail, ErrorCategory},
+    hir::HirFunction,
+};
+
+const CAPITALIZED_CALL_REASON: &str =
+    "Capitalized functions are reserved for components, which must be invoked with JSX. If this \
+     is a component, render it with JSX. Otherwise, ensure that it has no hook calls and rename \
+     it to begin with a lowercase letter. Alternatively, if you know for a fact that this \
+     function is not a component, you can allowlist it via the compiler config";
+
+pub fn validate_no_capitalized_calls(hir: &HirFunction) -> Result<(), CompilerError> {
+    let Some(body) = hir.function.body.as_ref() else {
+        return Ok(());
+    };
+
+    #[derive(Default)]
+    struct Finder {
+        errors: Vec<CompilerErrorDetail>,
+    }
+
+    impl Finder {
+        fn push(&mut self, span: swc_common::Span) {
+            let mut detail = CompilerErrorDetail::error(
+                ErrorCategory::CapitalizedCalls,
+                CAPITALIZED_CALL_REASON,
+            );
+            detail.loc = Some(span);
+            self.errors.push(detail);
+        }
+    }
+
+    impl Visit for Finder {
+        fn visit_call_expr(&mut self, call: &CallExpr) {
+            let should_report = match &call.callee {
+                Callee::Expr(expr) => match &**expr {
+                    Expr::Ident(ident) => ident
+                        .sym
+                        .as_ref()
+                        .chars()
+                        .next()
+                        .is_some_and(|ch| ch.is_ascii_uppercase()),
+                    Expr::Member(member) => match &member.prop {
+                        MemberProp::Ident(prop) => prop
+                            .sym
+                            .as_ref()
+                            .chars()
+                            .next()
+                            .is_some_and(|ch| ch.is_ascii_uppercase()),
+                        MemberProp::Computed(_) | MemberProp::PrivateName(_) => false,
+                    },
+                    _ => false,
+                },
+                Callee::Import(_) | Callee::Super(_) => false,
+            };
+
+            if should_report {
+                self.push(call.span);
+            }
+
+            call.visit_children_with(self);
+        }
+    }
+
+    let mut finder = Finder::default();
+    body.visit_with(&mut finder);
+
+    if finder.errors.is_empty() {
+        Ok(())
+    } else {
+        Err(CompilerError {
+            details: finder.errors,
+        })
+    }
 }


### PR DESCRIPTION
## Summary

This PR continues the React Compiler SWC core-only parity work in `crates/swc_ecma_react_compiler`.

### What changed

- Aligned `compile_fn` pipeline ordering with upstream behavior in [`program.rs`](crates/swc_ecma_react_compiler/src/entrypoint/program.rs):
  - Run `validate_locals_not_reassigned_after_render` unconditionally after `infer_mutation_aliasing_ranges`.
- Replaced no-op validator with implementation:
  - `validate_no_capitalized_calls`
- Added a conservative but working implementation for:
  - `validate_context_variable_lvalues`
- Reduced false positives and improved message parity in:
  - `validate_locals_not_reassigned_after_render`
  - (focuses on async reassignment path in this round)
- Improved hooks validation behavior:
  - dynamic-hook call diagnostics
  - optional-call handling
  - assignment-based hook alias tracking

## Fixture metrics

Using:

```bash
REACT_COMPILER_FIXTURE_CONTINUE_ON_FAIL=1 REACT_COMPILER_FIXTURE_ALLOW_FAILURE=1 cargo test -p swc_ecma_react_compiler fixture_cases_upstream -- --nocapture
```

- Prior baseline (from previous parity round):
  - `mismatch=844`
  - `missing_diag=192`
  - `missing_fragment=34`
- Current (this branch):
  - `mismatch=842`
  - `missing_diag=167`
  - `missing_fragment=31`
  - total failed fixtures: `1040`

Top mismatch clusters currently remain:

- `propagate-scope-deps-hir-fork/* = 47`
- `preserve-memo-validation/* = 40`
- `ssa-* (top-level) = 35`

## Verification

- `git submodule update --init --recursive`
- `cargo check -p swc_ecma_react_compiler`
- `cargo test -p swc_ecma_react_compiler fixture_cases_local -- --nocapture`
- `cargo test -p swc_ecma_react_compiler fixture_cases_upstream_phase1 -- --nocapture`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

Notes:

- `cargo test -p swc_ecma_react_compiler` still fails on expected upstream mismatch fixtures (non-continue mode).
