### PR TITLE
feat(react-compiler): M1 memo validators + lint gating alignment

### DIFF
--- a/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
@@ -315,7 +315,12 @@ pub fn compile_fn(
             .validate_exhaustive_effect_dependencies
             .is_enabled()
     {
-        validation::validate_exhaustive_dependencies(&hir)?;
+        validation::validate_exhaustive_dependencies(
+            &hir,
+            opts.environment
+                .validate_exhaustive_memoization_dependencies,
+            opts.environment.validate_exhaustive_effect_dependencies,
+        )?;
     }
     ssa::rewrite_instruction_kinds_based_on_reassignment(&mut hir);
 

--- a/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
@@ -290,14 +290,12 @@ pub fn compile_fn(
     if opts.environment.validate_no_derived_computations_in_effects {
         validation::validate_no_derived_computations_in_effects(&hir)?;
     }
-    if opts.environment.validate_no_set_state_in_effects
-        && output_mode == CompilerOutputMode::Lint
+    if opts.environment.validate_no_set_state_in_effects && output_mode == CompilerOutputMode::Lint
     {
         // Upstream keeps lint progression non-blocking for this validation.
         let _ = validation::validate_no_set_state_in_effects(&hir);
     }
-    if opts.environment.validate_no_jsx_in_try_statements
-        && output_mode == CompilerOutputMode::Lint
+    if opts.environment.validate_no_jsx_in_try_statements && output_mode == CompilerOutputMode::Lint
     {
         let _ = validation::validate_no_jsx_in_try_statement(&hir);
     }

--- a/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
@@ -246,8 +246,8 @@ pub fn compile_fn(
     optimization::prune_maybe_throws(&mut hir);
     validation::validate_context_variable_lvalues(&hir)?;
     validation::validate_use_memo(&hir, opts.environment.validate_no_void_use_memo)?;
-    inference::inline_immediately_invoked_function_expressions(&mut hir);
     inference::drop_manual_memoization(&mut hir);
+    inference::inline_immediately_invoked_function_expressions(&mut hir);
 
     ssa::enter_ssa(&mut hir);
     ssa::eliminate_redundant_phi(&mut hir);
@@ -290,13 +290,16 @@ pub fn compile_fn(
     if opts.environment.validate_no_derived_computations_in_effects {
         validation::validate_no_derived_computations_in_effects(&hir)?;
     }
-    if opts.environment.validate_no_set_state_in_effects {
-        // Upstream fixture behavior keeps lint/codegen progression even when
-        // this validation would otherwise report issues.
+    if opts.environment.validate_no_set_state_in_effects
+        && output_mode == CompilerOutputMode::Lint
+    {
+        // Upstream keeps lint progression non-blocking for this validation.
         let _ = validation::validate_no_set_state_in_effects(&hir);
     }
-    if opts.environment.validate_no_jsx_in_try_statements {
-        validation::validate_no_jsx_in_try_statement(&hir)?;
+    if opts.environment.validate_no_jsx_in_try_statements
+        && output_mode == CompilerOutputMode::Lint
+    {
+        let _ = validation::validate_no_jsx_in_try_statement(&hir);
     }
     if opts
         .environment
@@ -346,8 +349,8 @@ pub fn compile_fn(
     {
         validation::validate_preserved_manual_memoization(&hir)?;
     }
-    if opts.environment.validate_static_components {
-        validation::validate_static_components(&hir)?;
+    if opts.environment.validate_static_components && output_mode == CompilerOutputMode::Lint {
+        let _ = validation::validate_static_components(&hir);
     }
     if opts.environment.validate_source_locations {
         validation::validate_source_locations(&hir)?;

--- a/crates/swc_ecma_react_compiler/src/validation/dependency.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/dependency.rs
@@ -1,0 +1,585 @@
+use std::collections::{HashMap, HashSet};
+
+use swc_common::Span;
+use swc_ecma_ast::{
+    ArrowExpr, BlockStmt, CallExpr, Callee, Expr, ExprOrSpread, Function, MemberExpr, MemberProp,
+    OptChainBase, OptChainExpr, Pat, Stmt, VarDeclarator,
+};
+use swc_ecma_visit::{Visit, VisitWith};
+
+use crate::hir::HirFunction;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum HookCallKind {
+    Memo,
+    Callback,
+    Effect,
+}
+
+#[derive(Debug, Clone)]
+pub enum ManualDeps {
+    Absent,
+    Parsed(Vec<Dependency>),
+    Unsupported,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Dependency {
+    pub root: String,
+    pub path: Vec<String>,
+    pub span: Span,
+}
+
+#[derive(Clone)]
+pub enum FunctionLike {
+    Function(Function),
+    Arrow(ArrowExpr),
+}
+
+impl FunctionLike {
+    pub fn as_expr(&self) -> Expr {
+        match self {
+            Self::Function(function) => Expr::Fn(swc_ecma_ast::FnExpr {
+                ident: None,
+                function: Box::new(function.clone()),
+            }),
+            Self::Arrow(arrow) => Expr::Arrow(arrow.clone()),
+        }
+    }
+}
+
+pub fn format_dependency(dep: &Dependency) -> String {
+    if dep.path.is_empty() {
+        dep.root.clone()
+    } else {
+        format!("{}.{}", dep.root, dep.path.join("."))
+    }
+}
+
+pub fn dependency_prefix_match(prefix: &Dependency, full: &Dependency) -> bool {
+    if prefix.root != full.root {
+        return false;
+    }
+    if prefix.path.len() > full.path.len() {
+        return false;
+    }
+    prefix
+        .path
+        .iter()
+        .zip(full.path.iter())
+        .all(|(lhs, rhs)| lhs == rhs)
+}
+
+pub fn is_probably_stable_dependency(dep: &Dependency, stable_bindings: &HashSet<String>) -> bool {
+    if stable_bindings.contains(dep.root.as_str())
+        && (dep.path.is_empty() || dep.path.iter().any(|segment| segment == "current"))
+    {
+        return true;
+    }
+
+    if dep.path.is_empty() {
+        let root = dep.root.as_str();
+        if root == "dispatch" {
+            return true;
+        }
+        if let Some(stripped) = root.strip_prefix("set") {
+            return stripped
+                .chars()
+                .next()
+                .is_some_and(|ch| ch.is_ascii_uppercase());
+        }
+    }
+
+    false
+}
+
+pub fn collect_stable_hook_bindings(body: &BlockStmt) -> HashSet<String> {
+    let mut stable = HashSet::new();
+
+    for stmt in &body.stmts {
+        let Stmt::Decl(swc_ecma_ast::Decl::Var(var_decl)) = stmt else {
+            continue;
+        };
+
+        for decl in &var_decl.decls {
+            let Some(init) = &decl.init else {
+                continue;
+            };
+            let Expr::Call(call) = &**init else {
+                continue;
+            };
+
+            if is_call_of(call, &["useRef", "useEffectEvent"]) {
+                if let Pat::Ident(binding) = &decl.name {
+                    stable.insert(binding.id.sym.to_string());
+                }
+                continue;
+            }
+
+            if is_call_of(call, &["useState", "useReducer", "useTransition"]) {
+                let Pat::Array(array) = &decl.name else {
+                    continue;
+                };
+                let Some(Some(second)) = array.elems.get(1) else {
+                    continue;
+                };
+                let Pat::Ident(binding) = second else {
+                    continue;
+                };
+                stable.insert(binding.id.sym.to_string());
+            }
+        }
+    }
+
+    stable
+}
+
+pub fn collect_top_level_bindings(hir: &HirFunction) -> HashSet<String> {
+    let mut out = HashSet::new();
+    for param in &hir.function.params {
+        collect_pat_bindings(&param.pat, &mut out);
+    }
+    if let Some(body) = &hir.function.body {
+        for stmt in &body.stmts {
+            collect_stmt_bindings(stmt, &mut out);
+        }
+    }
+    out
+}
+
+pub fn collect_function_like_bindings(body: &BlockStmt) -> HashMap<String, FunctionLike> {
+    let mut out = HashMap::new();
+    for stmt in &body.stmts {
+        let Stmt::Decl(swc_ecma_ast::Decl::Var(var_decl)) = stmt else {
+            continue;
+        };
+
+        for decl in &var_decl.decls {
+            let Pat::Ident(binding) = &decl.name else {
+                continue;
+            };
+            let Some(init) = &decl.init else {
+                continue;
+            };
+
+            match &**init {
+                Expr::Fn(fn_expr) => {
+                    out.insert(
+                        binding.id.sym.to_string(),
+                        FunctionLike::Function(*fn_expr.function.clone()),
+                    );
+                }
+                Expr::Arrow(arrow) => {
+                    out.insert(
+                        binding.id.sym.to_string(),
+                        FunctionLike::Arrow(arrow.clone()),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+    out
+}
+
+pub fn resolve_callback_expr(
+    callback: &Expr,
+    function_like_bindings: &HashMap<String, FunctionLike>,
+) -> Option<Expr> {
+    match callback {
+        Expr::Fn(_) | Expr::Arrow(_) => Some(callback.clone()),
+        Expr::Ident(ident) => function_like_bindings
+            .get(ident.sym.as_ref())
+            .map(FunctionLike::as_expr),
+        _ => None,
+    }
+}
+
+pub fn hook_call_kind(call: &CallExpr) -> Option<HookCallKind> {
+    let Callee::Expr(callee) = &call.callee else {
+        return None;
+    };
+    hook_call_kind_from_expr(callee)
+}
+
+pub fn parse_manual_dependencies(
+    arg: Option<&ExprOrSpread>,
+    outer_bindings: &HashSet<String>,
+) -> ManualDeps {
+    let Some(arg) = arg else {
+        return ManualDeps::Absent;
+    };
+    if arg.spread.is_some() {
+        return ManualDeps::Unsupported;
+    }
+    let Expr::Array(array) = &*arg.expr else {
+        return ManualDeps::Unsupported;
+    };
+    let mut deps = Vec::with_capacity(array.elems.len());
+    for item in &array.elems {
+        let Some(item) = item else {
+            continue;
+        };
+        if item.spread.is_some() {
+            return ManualDeps::Unsupported;
+        }
+        let Some(mut dep) = dependency_from_expr(&item.expr) else {
+            return ManualDeps::Unsupported;
+        };
+        if !outer_bindings.contains(dep.root.as_str()) {
+            // Keep globals stable; they'll be treated as extra if explicitly listed.
+            dep.path.clear();
+        }
+        deps.push(dep);
+    }
+    ManualDeps::Parsed(deps)
+}
+
+pub fn collect_callback_dependencies(
+    callback_expr: &Expr,
+    outer_bindings: &HashSet<String>,
+) -> Vec<Dependency> {
+    let mut local_bindings = HashSet::new();
+    match callback_expr {
+        Expr::Fn(fn_expr) => {
+            for param in &fn_expr.function.params {
+                collect_pat_bindings(&param.pat, &mut local_bindings);
+            }
+            if let Some(body) = &fn_expr.function.body {
+                for stmt in &body.stmts {
+                    collect_stmt_bindings(stmt, &mut local_bindings);
+                }
+            }
+        }
+        Expr::Arrow(arrow) => {
+            for param in &arrow.params {
+                collect_pat_bindings(param, &mut local_bindings);
+            }
+            match &*arrow.body {
+                swc_ecma_ast::BlockStmtOrExpr::BlockStmt(block) => {
+                    for stmt in &block.stmts {
+                        collect_stmt_bindings(stmt, &mut local_bindings);
+                    }
+                }
+                swc_ecma_ast::BlockStmtOrExpr::Expr(_) => {}
+            }
+        }
+        _ => return Vec::new(),
+    }
+
+    struct Collector<'a> {
+        outer_bindings: &'a HashSet<String>,
+        local_bindings: &'a HashSet<String>,
+        deps: Vec<Dependency>,
+    }
+
+    impl Collector<'_> {
+        fn maybe_push(&mut self, dep: Dependency) {
+            if !self.outer_bindings.contains(dep.root.as_str()) {
+                return;
+            }
+            if self.local_bindings.contains(dep.root.as_str()) {
+                return;
+            }
+            if self
+                .deps
+                .iter()
+                .any(|item| item.root == dep.root && item.path == dep.path)
+            {
+                return;
+            }
+            self.deps.push(dep);
+        }
+    }
+
+    impl Visit for Collector<'_> {
+        fn visit_call_expr(&mut self, call: &CallExpr) {
+            if let Callee::Expr(callee) = &call.callee {
+                if let Some((root, span)) = root_dependency_from_call_callee(callee) {
+                    self.maybe_push(Dependency {
+                        root,
+                        path: Vec::new(),
+                        span,
+                    });
+                }
+            }
+
+            for arg in &call.args {
+                arg.visit_with(self);
+            }
+        }
+
+        fn visit_opt_chain_expr(&mut self, chain: &OptChainExpr) {
+            if let OptChainBase::Call(call) = &*chain.base {
+                if let Some((root, span)) = root_dependency_from_call_callee(&call.callee) {
+                    self.maybe_push(Dependency {
+                        root,
+                        path: Vec::new(),
+                        span,
+                    });
+                }
+                for arg in &call.args {
+                    arg.visit_with(self);
+                }
+                return;
+            }
+            chain.visit_children_with(self);
+        }
+
+        fn visit_member_expr(&mut self, member: &MemberExpr) {
+            if let Some(mut dep) = dependency_from_expr(&Expr::Member(member.clone())) {
+                if dep.path.last().is_some_and(|segment| segment == "current") {
+                    dep.path.pop();
+                }
+                self.maybe_push(dep);
+                return;
+            }
+            member.visit_children_with(self);
+        }
+
+        fn visit_ident(&mut self, ident: &swc_ecma_ast::Ident) {
+            self.maybe_push(Dependency {
+                root: ident.sym.to_string(),
+                path: Vec::new(),
+                span: ident.span,
+            });
+        }
+    }
+
+    let mut collector = Collector {
+        outer_bindings,
+        local_bindings: &local_bindings,
+        deps: Vec::new(),
+    };
+    callback_expr.visit_with(&mut collector);
+    collector.deps
+}
+
+fn collect_stmt_bindings(stmt: &Stmt, out: &mut HashSet<String>) {
+    match stmt {
+        Stmt::Decl(decl) => match decl {
+            swc_ecma_ast::Decl::Var(var_decl) => {
+                for decl in &var_decl.decls {
+                    collect_var_declarator_bindings(decl, out);
+                }
+            }
+            swc_ecma_ast::Decl::Fn(fn_decl) => {
+                out.insert(fn_decl.ident.sym.to_string());
+            }
+            swc_ecma_ast::Decl::Class(class_decl) => {
+                out.insert(class_decl.ident.sym.to_string());
+            }
+            _ => {}
+        },
+        Stmt::Block(block) => {
+            for stmt in &block.stmts {
+                collect_stmt_bindings(stmt, out);
+            }
+        }
+        Stmt::If(if_stmt) => {
+            collect_stmt_bindings(&if_stmt.cons, out);
+            if let Some(alt) = &if_stmt.alt {
+                collect_stmt_bindings(alt, out);
+            }
+        }
+        Stmt::For(for_stmt) => {
+            if let Some(init) = &for_stmt.init {
+                match init {
+                    swc_ecma_ast::VarDeclOrExpr::VarDecl(var_decl) => {
+                        for decl in &var_decl.decls {
+                            collect_var_declarator_bindings(decl, out);
+                        }
+                    }
+                    swc_ecma_ast::VarDeclOrExpr::Expr(_) => {}
+                }
+            }
+            collect_stmt_bindings(&for_stmt.body, out);
+        }
+        Stmt::ForIn(for_in_stmt) => {
+            if let swc_ecma_ast::ForHead::VarDecl(var_decl) = &for_in_stmt.left {
+                for decl in &var_decl.decls {
+                    collect_var_declarator_bindings(decl, out);
+                }
+            }
+            collect_stmt_bindings(&for_in_stmt.body, out);
+        }
+        Stmt::ForOf(for_of_stmt) => {
+            if let swc_ecma_ast::ForHead::VarDecl(var_decl) = &for_of_stmt.left {
+                for decl in &var_decl.decls {
+                    collect_var_declarator_bindings(decl, out);
+                }
+            }
+            collect_stmt_bindings(&for_of_stmt.body, out);
+        }
+        Stmt::While(while_stmt) => {
+            collect_stmt_bindings(&while_stmt.body, out);
+        }
+        Stmt::DoWhile(do_while_stmt) => {
+            collect_stmt_bindings(&do_while_stmt.body, out);
+        }
+        Stmt::Switch(switch_stmt) => {
+            for case in &switch_stmt.cases {
+                for stmt in &case.cons {
+                    collect_stmt_bindings(stmt, out);
+                }
+            }
+        }
+        Stmt::Try(try_stmt) => {
+            for stmt in &try_stmt.block.stmts {
+                collect_stmt_bindings(stmt, out);
+            }
+            if let Some(handler) = &try_stmt.handler {
+                if let Some(param) = &handler.param {
+                    collect_pat_bindings(param, out);
+                }
+                for stmt in &handler.body.stmts {
+                    collect_stmt_bindings(stmt, out);
+                }
+            }
+            if let Some(finalizer) = &try_stmt.finalizer {
+                for stmt in &finalizer.stmts {
+                    collect_stmt_bindings(stmt, out);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+fn collect_var_declarator_bindings(decl: &VarDeclarator, out: &mut HashSet<String>) {
+    collect_pat_bindings(&decl.name, out);
+}
+
+fn collect_pat_bindings(pat: &Pat, out: &mut HashSet<String>) {
+    match pat {
+        Pat::Ident(binding) => {
+            out.insert(binding.id.sym.to_string());
+        }
+        Pat::Array(array) => {
+            for element in array.elems.iter().flatten() {
+                collect_pat_bindings(element, out);
+            }
+        }
+        Pat::Object(object) => {
+            for prop in &object.props {
+                match prop {
+                    swc_ecma_ast::ObjectPatProp::Assign(assign) => {
+                        out.insert(assign.key.id.sym.to_string());
+                    }
+                    swc_ecma_ast::ObjectPatProp::KeyValue(key_value) => {
+                        collect_pat_bindings(&key_value.value, out);
+                    }
+                    swc_ecma_ast::ObjectPatProp::Rest(rest) => {
+                        collect_pat_bindings(&rest.arg, out);
+                    }
+                }
+            }
+        }
+        Pat::Assign(assign) => {
+            collect_pat_bindings(&assign.left, out);
+        }
+        Pat::Rest(rest) => {
+            collect_pat_bindings(&rest.arg, out);
+        }
+        Pat::Expr(_) | Pat::Invalid(_) => {}
+    }
+}
+
+fn hook_call_kind_from_expr(callee: &Expr) -> Option<HookCallKind> {
+    match callee {
+        Expr::Ident(ident) => hook_kind_from_name(ident.sym.as_ref()),
+        Expr::Member(member) => member_name(member).and_then(hook_kind_from_name),
+        Expr::OptChain(chain) => match &*chain.base {
+            OptChainBase::Call(call) => hook_call_kind_from_expr(&call.callee),
+            OptChainBase::Member(member) => member_name(member).and_then(hook_kind_from_name),
+        },
+        _ => None,
+    }
+}
+
+fn is_call_of(call: &CallExpr, names: &[&str]) -> bool {
+    let Callee::Expr(callee) = &call.callee else {
+        return false;
+    };
+    let Some(name) = callee_name(callee) else {
+        return false;
+    };
+    names.contains(&name)
+}
+
+fn callee_name(callee: &Expr) -> Option<&str> {
+    match callee {
+        Expr::Ident(ident) => Some(ident.sym.as_ref()),
+        Expr::Member(member) => member_name(member),
+        Expr::OptChain(chain) => match &*chain.base {
+            OptChainBase::Call(call) => callee_name(&call.callee),
+            OptChainBase::Member(member) => member_name(member),
+        },
+        _ => None,
+    }
+}
+
+fn hook_kind_from_name(name: &str) -> Option<HookCallKind> {
+    match name {
+        "useMemo" => Some(HookCallKind::Memo),
+        "useCallback" => Some(HookCallKind::Callback),
+        "useEffect" | "useLayoutEffect" | "useInsertionEffect" => Some(HookCallKind::Effect),
+        _ => None,
+    }
+}
+
+fn root_dependency_from_call_callee(callee: &Expr) -> Option<(String, Span)> {
+    let (root, _, span) = parse_dependency_parts(callee)?;
+    Some((root, span))
+}
+
+fn dependency_from_expr(expr: &Expr) -> Option<Dependency> {
+    let (root, path, span) = parse_dependency_parts(expr)?;
+    Some(Dependency { root, path, span })
+}
+
+fn parse_dependency_parts(expr: &Expr) -> Option<(String, Vec<String>, Span)> {
+    match expr {
+        Expr::Ident(ident) => Some((ident.sym.to_string(), Vec::new(), ident.span)),
+        Expr::Paren(paren) => parse_dependency_parts(&paren.expr),
+        Expr::Member(member) => {
+            let (root, mut path, span) = parse_dependency_parts(&member.obj)?;
+            let segment = member_prop_to_segment(&member.prop)?;
+            path.push(segment);
+            Some((root, path, span))
+        }
+        Expr::OptChain(chain) => match &*chain.base {
+            OptChainBase::Member(member) => parse_dependency_parts(&Expr::Member(member.clone())),
+            OptChainBase::Call(call) => parse_dependency_parts(&call.callee),
+        },
+        _ => None,
+    }
+}
+
+fn member_name(member: &MemberExpr) -> Option<&str> {
+    match &member.prop {
+        MemberProp::Ident(prop) => Some(prop.sym.as_ref()),
+        MemberProp::Computed(computed) => {
+            let Expr::Lit(swc_ecma_ast::Lit::Str(value)) = &*computed.expr else {
+                return None;
+            };
+            value.value.as_str()
+        }
+        MemberProp::PrivateName(_) => None,
+    }
+}
+
+fn member_prop_to_segment(prop: &MemberProp) -> Option<String> {
+    match prop {
+        MemberProp::Ident(ident) => Some(ident.sym.to_string()),
+        MemberProp::Computed(computed) => match &*computed.expr {
+            Expr::Ident(ident) => Some(ident.sym.to_string()),
+            Expr::Lit(swc_ecma_ast::Lit::Str(value)) => {
+                Some(value.value.to_string_lossy().into_owned())
+            }
+            Expr::Lit(swc_ecma_ast::Lit::Num(value)) => Some(value.value.to_string()),
+            _ => None,
+        },
+        MemberProp::PrivateName(_) => None,
+    }
+}

--- a/crates/swc_ecma_react_compiler/src/validation/mod.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/mod.rs
@@ -1,3 +1,4 @@
+mod dependency;
 mod validate_context_variable_lvalues;
 mod validate_exhaustive_dependencies;
 mod validate_hooks_usage;

--- a/crates/swc_ecma_react_compiler/src/validation/validate_exhaustive_dependencies.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/validate_exhaustive_dependencies.rs
@@ -1,5 +1,241 @@
-use crate::{error::CompilerError, hir::HirFunction};
+use super::dependency::{
+    collect_callback_dependencies, collect_function_like_bindings, collect_stable_hook_bindings,
+    collect_top_level_bindings, dependency_prefix_match, format_dependency, hook_call_kind,
+    is_probably_stable_dependency, parse_manual_dependencies, resolve_callback_expr, Dependency,
+    FunctionLike, HookCallKind, ManualDeps,
+};
+use crate::{
+    error::{CompilerError, CompilerErrorDetail, ErrorCategory},
+    hir::HirFunction,
+    options::ExhaustiveEffectDependenciesMode,
+};
 
-pub fn validate_exhaustive_dependencies(_hir: &HirFunction) -> Result<(), CompilerError> {
-    Ok(())
+pub fn validate_exhaustive_dependencies(
+    hir: &HirFunction,
+    validate_exhaustive_memoization_dependencies: bool,
+    validate_exhaustive_effect_dependencies: ExhaustiveEffectDependenciesMode,
+) -> Result<(), CompilerError> {
+    let Some(body) = hir.function.body.as_ref() else {
+        return Ok(());
+    };
+
+    let outer_bindings = collect_top_level_bindings(hir);
+    let function_like_bindings = collect_function_like_bindings(body);
+    let stable_bindings = collect_stable_hook_bindings(body);
+    let mut details = Vec::<CompilerErrorDetail>::new();
+
+    struct Visitor<'a> {
+        outer_bindings: &'a std::collections::HashSet<String>,
+        function_like_bindings: &'a std::collections::HashMap<String, FunctionLike>,
+        stable_bindings: &'a std::collections::HashSet<String>,
+        validate_memo: bool,
+        validate_effect_mode: ExhaustiveEffectDependenciesMode,
+        details: &'a mut Vec<CompilerErrorDetail>,
+    }
+
+    impl Visitor<'_> {
+        fn validate_call(&mut self, call: &swc_ecma_ast::CallExpr) {
+            let Some(kind) = hook_call_kind(call) else {
+                return;
+            };
+            match kind {
+                HookCallKind::Memo | HookCallKind::Callback if !self.validate_memo => return,
+                HookCallKind::Effect if !self.validate_effect_mode.is_enabled() => return,
+                _ => {}
+            }
+
+            let Some(callback_arg) = call.args.first() else {
+                return;
+            };
+            if callback_arg.spread.is_some() {
+                return;
+            }
+            let Some(callback_expr) =
+                resolve_callback_expr(&callback_arg.expr, self.function_like_bindings)
+            else {
+                return;
+            };
+
+            let manual = parse_manual_dependencies(call.args.get(1), self.outer_bindings);
+            let ManualDeps::Parsed(manual) = manual else {
+                // No deps list or unsupported deps expression; upstream treats many of these
+                // cases in other validators. Keep exhaustive-deps conservative here.
+                return;
+            };
+
+            let inferred = collect_callback_dependencies(&callback_expr, self.outer_bindings);
+            let inferred = dedup_dependencies(inferred);
+            let manual = dedup_dependencies(manual);
+
+            let mut missing = Vec::new();
+            for inferred_dep in &inferred {
+                if is_probably_stable_dependency(inferred_dep, self.stable_bindings) {
+                    continue;
+                }
+                let matched = manual
+                    .iter()
+                    .any(|manual_dep| dependency_prefix_match(manual_dep, inferred_dep));
+                if !matched {
+                    missing.push(inferred_dep.clone());
+                }
+            }
+
+            let mut extra = Vec::new();
+            for manual_dep in &manual {
+                let matched = inferred
+                    .iter()
+                    .any(|inferred_dep| dependency_prefix_match(manual_dep, inferred_dep));
+                if !matched {
+                    extra.push(manual_dep.clone());
+                }
+            }
+
+            if matches!(kind, HookCallKind::Effect) {
+                match self.validate_effect_mode {
+                    ExhaustiveEffectDependenciesMode::MissingOnly => extra.clear(),
+                    ExhaustiveEffectDependenciesMode::ExtraOnly => missing.clear(),
+                    ExhaustiveEffectDependenciesMode::All
+                    | ExhaustiveEffectDependenciesMode::Off => {}
+                }
+            }
+
+            if missing.is_empty() && extra.is_empty() {
+                return;
+            }
+
+            let (category, reason, description) = report_strings(kind, &missing, &extra);
+
+            let mut detail = CompilerErrorDetail::error(category, reason);
+            let mut description_lines = vec![description.to_string()];
+            if !missing.is_empty() {
+                description_lines.push(format!(
+                    "Missing dependencies: [{}]",
+                    missing
+                        .iter()
+                        .map(format_dependency)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            if !extra.is_empty() {
+                description_lines.push(format!(
+                    "Extra dependencies: [{}]",
+                    extra
+                        .iter()
+                        .map(format_dependency)
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                ));
+            }
+            description_lines.push(format!(
+                "Inferred dependencies: `[{}]`",
+                inferred
+                    .iter()
+                    .map(format_dependency)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+            detail.description = Some(description_lines.join("\n"));
+            detail.loc = Some(call.span);
+            self.details.push(detail);
+        }
+    }
+
+    impl swc_ecma_visit::Visit for Visitor<'_> {
+        fn visit_call_expr(&mut self, call: &swc_ecma_ast::CallExpr) {
+            self.validate_call(call);
+            call.visit_children_with(self);
+        }
+    }
+
+    use swc_ecma_visit::VisitWith;
+    let mut visitor = Visitor {
+        outer_bindings: &outer_bindings,
+        function_like_bindings: &function_like_bindings,
+        stable_bindings: &stable_bindings,
+        validate_memo: validate_exhaustive_memoization_dependencies,
+        validate_effect_mode: validate_exhaustive_effect_dependencies,
+        details: &mut details,
+    };
+    body.visit_with(&mut visitor);
+
+    if details.is_empty() {
+        Ok(())
+    } else {
+        Err(CompilerError { details })
+    }
+}
+
+fn dedup_dependencies(deps: Vec<Dependency>) -> Vec<Dependency> {
+    let mut out = Vec::new();
+    for dep in deps {
+        if out
+            .iter()
+            .any(|item: &Dependency| item.root == dep.root && item.path == dep.path)
+        {
+            continue;
+        }
+        out.push(dep);
+    }
+    out
+}
+
+fn report_strings(
+    kind: HookCallKind,
+    missing: &[Dependency],
+    extra: &[Dependency],
+) -> (ErrorCategory, &'static str, &'static str) {
+    match kind {
+        HookCallKind::Memo | HookCallKind::Callback => {
+            let reason = if !missing.is_empty() && !extra.is_empty() {
+                "Found missing/extra memoization dependencies"
+            } else if !missing.is_empty() {
+                "Found missing memoization dependencies"
+            } else {
+                "Found extra memoization dependencies"
+            };
+
+            let description = if !missing.is_empty() && !extra.is_empty() {
+                "Missing dependencies can cause a value to update less often than it should, \
+                 resulting in stale UI. Extra dependencies can cause a value to update more often \
+                 than it should, resulting in performance problems such as excessive renders or \
+                 effects firing too often."
+            } else if !missing.is_empty() {
+                "Missing dependencies can cause a value to update less often than it should, \
+                 resulting in stale UI."
+            } else {
+                "Extra dependencies can cause a value to update more often than it should, \
+                 resulting in performance problems such as excessive renders or effects firing too \
+                 often."
+            };
+
+            (ErrorCategory::MemoDependencies, reason, description)
+        }
+        HookCallKind::Effect => {
+            let reason = if !missing.is_empty() && !extra.is_empty() {
+                "Found missing/extra effect dependencies"
+            } else if !missing.is_empty() {
+                "Found missing effect dependencies"
+            } else {
+                "Found extra effect dependencies"
+            };
+
+            let description = if !missing.is_empty() && !extra.is_empty() {
+                "Missing dependencies can cause an effect to fire less often than it should. Extra \
+                 dependencies can cause an effect to fire more often than it should, resulting in \
+                 performance problems such as excessive renders and side effects."
+            } else if !missing.is_empty() {
+                "Missing dependencies can cause an effect to fire less often than it should."
+            } else {
+                "Extra dependencies can cause an effect to fire more often than it should, \
+                 resulting in performance problems such as excessive renders and side effects."
+            };
+
+            (
+                ErrorCategory::EffectExhaustiveDependencies,
+                reason,
+                description,
+            )
+        }
+    }
 }

--- a/crates/swc_ecma_react_compiler/src/validation/validate_preserved_manual_memoization.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/validate_preserved_manual_memoization.rs
@@ -1,5 +1,140 @@
-use crate::{error::CompilerError, hir::HirFunction};
+use super::dependency::{
+    collect_callback_dependencies, collect_function_like_bindings, collect_top_level_bindings,
+    dependency_prefix_match, format_dependency, hook_call_kind, parse_manual_dependencies,
+    resolve_callback_expr, Dependency, FunctionLike, HookCallKind, ManualDeps,
+};
+use crate::{
+    error::{CompilerError, CompilerErrorDetail, ErrorCategory},
+    hir::HirFunction,
+};
 
-pub fn validate_preserved_manual_memoization(_hir: &HirFunction) -> Result<(), CompilerError> {
-    Ok(())
+pub fn validate_preserved_manual_memoization(hir: &HirFunction) -> Result<(), CompilerError> {
+    let Some(body) = hir.function.body.as_ref() else {
+        return Ok(());
+    };
+
+    let outer_bindings = collect_top_level_bindings(hir);
+    let function_like_bindings = collect_function_like_bindings(body);
+
+    let mut details = Vec::<CompilerErrorDetail>::new();
+
+    struct Visitor<'a> {
+        outer_bindings: &'a std::collections::HashSet<String>,
+        function_like_bindings: &'a std::collections::HashMap<String, FunctionLike>,
+        details: &'a mut Vec<CompilerErrorDetail>,
+    }
+
+    impl Visitor<'_> {
+        fn validate_manual_memo(&mut self, call: &swc_ecma_ast::CallExpr) {
+            let Some(kind) = hook_call_kind(call) else {
+                return;
+            };
+            if !matches!(kind, HookCallKind::Memo | HookCallKind::Callback) {
+                return;
+            }
+
+            let Some(callback_arg) = call.args.first() else {
+                return;
+            };
+            if callback_arg.spread.is_some() {
+                return;
+            }
+            let Some(callback_expr) =
+                resolve_callback_expr(&callback_arg.expr, self.function_like_bindings)
+            else {
+                return;
+            };
+
+            let inferred = collect_callback_dependencies(&callback_expr, self.outer_bindings);
+            if inferred.is_empty() {
+                return;
+            }
+
+            let ManualDeps::Parsed(manual_deps) =
+                parse_manual_dependencies(call.args.get(1), self.outer_bindings)
+            else {
+                return;
+            };
+
+            // Empty deps arrays are intentionally handled conservatively here:
+            // without the upstream reactive-scope sidecar we cannot reliably
+            // distinguish truly invalid preservation from safe rewrites.
+            if manual_deps.is_empty() {
+                return;
+            }
+
+            if let Some(missing) = inferred.iter().find(|inferred_dep| {
+                !manual_deps
+                    .iter()
+                    .any(|manual_dep| dependency_prefix_match(manual_dep, inferred_dep))
+            }) {
+                self.push_mismatch_error(call.span, missing, &manual_deps);
+            }
+        }
+
+        fn push_mismatch_error(
+            &mut self,
+            span: swc_common::Span,
+            inferred_dep: &Dependency,
+            manual_deps: &[Dependency],
+        ) {
+            let manual_list = if manual_deps.is_empty() {
+                String::new()
+            } else {
+                manual_deps
+                    .iter()
+                    .map(format_dependency)
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            };
+
+            let mismatch_kind = if manual_deps.iter().any(|manual_dep| {
+                manual_dep.root == inferred_dep.root
+                    && dependency_prefix_match(inferred_dep, manual_dep)
+                    && inferred_dep.path.len() < manual_dep.path.len()
+            }) {
+                " Inferred less specific property than source."
+            } else {
+                " Inferred different dependency than source."
+            };
+
+            let mut detail = CompilerErrorDetail::error(
+                ErrorCategory::PreserveManualMemo,
+                "Compilation Skipped: Existing memoization could not be preserved",
+            );
+            detail.description = Some(format!(
+                "React Compiler has skipped optimizing this component because the existing manual \
+                 memoization could not be preserved. The inferred dependencies did not match the \
+                 manually specified dependencies, which could cause the value to change more or \
+                 less frequently than expected. The inferred dependency was `{}`, but the source \
+                 dependencies were [{}].{}",
+                format_dependency(inferred_dep),
+                manual_list,
+                mismatch_kind
+            ));
+            detail.loc = Some(span);
+            self.details.push(detail);
+        }
+    }
+
+    impl swc_ecma_visit::Visit for Visitor<'_> {
+        fn visit_call_expr(&mut self, call: &swc_ecma_ast::CallExpr) {
+            self.validate_manual_memo(call);
+            call.visit_children_with(self);
+        }
+    }
+
+    use swc_ecma_visit::VisitWith;
+    let mut visitor = Visitor {
+        outer_bindings: &outer_bindings,
+        function_like_bindings: &function_like_bindings,
+        details: &mut details,
+    };
+    body.visit_with(&mut visitor);
+
+    if details.is_empty() {
+        Ok(())
+    } else {
+        Err(CompilerError { details })
+    }
 }


### PR DESCRIPTION
## Summary
This PR implements the M1 slice of the React Compiler SWC port finalization plan:
- implement non-placeholder validation for manual memo preservation and exhaustive deps
- add shared dependency analysis helpers
- align a subset of pipeline ordering/gating with upstream (`Pipeline.ts`) semantics

## Changes
- Added dependency analysis side helpers in `validation/dependency.rs`
  - hook kind detection (`useMemo`/`useCallback`/effect hooks)
  - callback dependency collection
  - manual deps parsing and prefix matching
  - stable hook binding inference (`useRef`, state/reducer/transition setters)
- Implemented `validate_preserved_manual_memoization`
  - emits `PreserveManualMemo` diagnostics for inferred-vs-source dep mismatch
  - currently conservative for empty deps arrays to avoid false-positive bailouts without upstream reactive sidecar
- Implemented `validate_exhaustive_dependencies`
  - supports memo + effect modes (`all`, `missing-only`, `extra-only`)
  - emits `MemoDependencies` / `EffectExhaustiveDependencies`
- Pipeline integration updates in `entrypoint/program.rs`
  - wired exhaustive deps validator with env flags
  - reordered `drop_manual_memoization` before `inline_immediately_invoked_function_expressions`
  - lint-only non-blocking gating for:
    - `validate_no_set_state_in_effects`
    - `validate_no_jsx_in_try_statement`
    - `validate_static_components`
- Registered new module in `validation/mod.rs`

## Verification
Ran:
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_react_compiler fixture_cases_local -- --nocapture`
- `cargo test -p swc_ecma_react_compiler fixture_cases_upstream_phase1 -- --nocapture`
- `REACT_COMPILER_FIXTURE_CONTINUE_ON_FAIL=1 cargo test -p swc_ecma_react_compiler fixture_cases_upstream -- --nocapture`
- `cargo test -p swc_ecma_react_compiler`

Current fixture snapshot (continue-on-fail):
- `1022/1718 failed`
- `output_mismatch: 835`
- `missing_error: 150`
- `error_fragment_mismatch: 37`

Baseline from plan text:
- `1029/1718 failed`
- `output_mismatch: 835`
- `missing_error: 163`
- `error_fragment_mismatch: 31`

## Notes
- `fixture_cases_upstream` is still red; this PR intentionally focuses on M1 and initial pipeline parity pieces.
- Remaining work is primarily M2+ clusters (reactive-scope dependency propagation / reduce-reactive-deps / new-mutability and other placeholder passes).
