### PR TITLE
fix(es/parser): close remaining Flow parser gaps for #11729 (phase 2)

### DIFF
--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -79,6 +79,9 @@ impl<I: Tokens> Parser<I> {
         let start = self.cur_pos();
 
         while self.input().is(Token::At) {
+            if self.syntax().flow() && peek!(self).is_some_and(|peek| peek == Token::At) {
+                break;
+            }
             decorators.push(self.parse_decorator()?);
         }
         if decorators.is_empty() {

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -769,6 +769,21 @@ impl<I: Tokens> Parser<I> {
                     value,
                     raw: Some(Atom::new(raw)),
                 })
+            } else if p.syntax().flow()
+                && cur == Token::At
+                && peek!(p).is_some_and(|peek| peek == Token::At)
+            {
+                p.assert_and_bump(Token::At);
+                p.assert_and_bump(Token::At);
+                if !p.input().cur().is_word() {
+                    unexpected!(p, "identifier");
+                }
+                let key = p.input_mut().expect_word_token_and_bump();
+                PropName::Str(Str {
+                    span: p.span(start),
+                    value: format!("@@{key}").into(),
+                    raw: None,
+                })
             } else if cur.is_word() {
                 let w = p.input_mut().expect_word_token_and_bump();
                 PropName::Ident(IdentName::new(w, p.span(start)))

--- a/crates/swc_ecma_parser/src/parser/pat.rs
+++ b/crates/swc_ecma_parser/src/parser/pat.rs
@@ -550,7 +550,7 @@ impl<I: Tokens> Parser<I> {
     /// spec: 'FormalParameter'
     ///
     /// babel: `parseAssignableListItem`
-    fn parse_formal_param_pat(&mut self) -> PResult<Pat> {
+    pub(crate) fn parse_formal_param_pat(&mut self) -> PResult<Pat> {
         let start = self.cur_pos();
 
         let has_modifier = self.eat_any_ts_modifier()?;

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -220,7 +220,7 @@ impl<I: Tokens> Parser<I> {
 
             if allow_rest_type {
                 if let Some(type_ann) = self.try_parse_ts(|p| {
-                    let ty = p.parse_ts_type()?;
+                    let ty = p.in_type(Self::parse_ts_type)?;
                     if p.input().is(Token::Comma) || p.input().is(Token::RParen) {
                         Ok(Some(ty))
                     } else {

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -168,6 +168,13 @@ impl<I: Tokens> Parser<I> {
         })
     }
 
+    fn make_flow_component_rest_fallback_binding(&mut self, span: Span) -> Pat {
+        Pat::Ident(BindingIdent {
+            id: Ident::new_no_ctxt(atom!("component_rest"), span),
+            type_ann: None,
+        })
+    }
+
     fn flow_mark_pat_optional(&mut self, pat: &mut Pat) {
         match pat {
             Pat::Ident(binding) => {
@@ -204,11 +211,39 @@ impl<I: Tokens> Parser<I> {
         &mut self,
         require_type_ann: bool,
         string_key_requires_as: bool,
+        allow_rest_type: bool,
     ) -> PResult<FlowComponentParam> {
         let start = self.cur_pos();
 
         if self.input_mut().eat(Token::DotDotDot) {
             let dot3_token = self.input().prev_span();
+
+            if allow_rest_type {
+                if let Some(type_ann) = self.try_parse_ts(|p| {
+                    let ty = p.parse_ts_type()?;
+                    if p.input().is(Token::Comma) || p.input().is(Token::RParen) {
+                        Ok(Some(ty))
+                    } else {
+                        Ok(None)
+                    }
+                }) {
+                    let type_ann_span = type_ann.span();
+                    return Ok(FlowComponentParam::Rest {
+                        rest: RestPat {
+                            span: self.span(start),
+                            dot3_token,
+                            arg: Box::new(
+                                self.make_flow_component_rest_fallback_binding(self.span(start)),
+                            ),
+                            type_ann: Some(Box::new(TsTypeAnn {
+                                span: type_ann_span,
+                                type_ann,
+                            })),
+                        },
+                    });
+                }
+            }
+
             let mut arg = self.parse_binding_pat_or_ident(false)?;
             if self.input_mut().eat(Token::QuestionMark) {
                 self.flow_mark_pat_optional(&mut arg);
@@ -321,12 +356,17 @@ impl<I: Tokens> Parser<I> {
         &mut self,
         require_type_ann: bool,
         string_key_requires_as: bool,
+        allow_rest_type: bool,
     ) -> PResult<Vec<FlowComponentParam>> {
         expect!(self, Token::LParen);
 
         let mut params = Vec::new();
         while !self.input().is(Token::RParen) {
-            params.push(self.parse_flow_component_param(require_type_ann, string_key_requires_as)?);
+            params.push(self.parse_flow_component_param(
+                require_type_ann,
+                string_key_requires_as,
+                allow_rest_type,
+            )?);
 
             if self.input().is(Token::RParen) {
                 break;
@@ -395,7 +435,7 @@ impl<I: Tokens> Parser<I> {
         let ident = self.parse_binding_ident(false)?.id;
 
         let type_params = self.try_parse_ts_type_params(false, true)?;
-        let component_params = self.parse_flow_component_params(declare, !declare)?;
+        let component_params = self.parse_flow_component_params(declare, !declare, declare)?;
         let params = vec![Param {
             span: self.span(start),
             decorators: Vec::new(),
@@ -457,7 +497,7 @@ impl<I: Tokens> Parser<I> {
 
     fn parse_flow_component_type(&mut self, start: BytePos) -> PResult<TsType> {
         let type_params = self.try_parse_ts_type_params(false, true)?;
-        let component_params = self.parse_flow_component_params(false, false)?;
+        let component_params = self.parse_flow_component_params(false, false, true)?;
 
         if self.input().is(Token::Colon) {
             self.emit_err(self.input().cur_span(), SyntaxError::TS1003);
@@ -2492,14 +2532,11 @@ impl<I: Tokens> Parser<I> {
 
         debug_assert!(self.input().syntax().typescript());
 
-        let params = self.parse_formal_params()?;
-        let mut list = Vec::with_capacity(4);
-
-        for param in params {
-            let item = match param.pat {
+        fn pat_to_ts_fn_param<I: Tokens>(p: &mut Parser<I>, pat: Pat) -> PResult<TsFnParam> {
+            let item = match pat {
                 Pat::Ident(pat) => {
-                    if self.input().syntax().flow() && &*pat.id.sym == "static" {
-                        self.emit_err(
+                    if p.input().syntax().flow() && &*pat.id.sym == "static" {
+                        p.emit_err(
                             pat.span(),
                             SyntaxError::InvalidIdentInStrict(atom!("static")),
                         );
@@ -2511,12 +2548,102 @@ impl<I: Tokens> Parser<I> {
                 Pat::Object(pat) => TsFnParam::Object(pat),
                 Pat::Rest(pat) => TsFnParam::Rest(pat),
                 _ => unexpected!(
-                    self,
+                    p,
                     "an identifier, [ for an array pattern, { for an object patter or ... for a \
                      rest pattern"
                 ),
             };
-            list.push(item);
+
+            Ok(item)
+        }
+
+        if self.input().syntax().flow() && self.ctx().contains(Context::InType) {
+            let mut list = Vec::with_capacity(4);
+            let mut rest_span = Span::default();
+
+            while !self.input().is(Token::RParen) {
+                if !rest_span.is_dummy() {
+                    self.emit_err(rest_span, SyntaxError::TS1014);
+                }
+
+                if let Some(param) =
+                    self.try_parse_ts(|p| p.try_parse_flow_anon_signature_param(list.len()))
+                {
+                    if matches!(param, TsFnParam::Rest(..)) {
+                        rest_span = param.span();
+                    }
+                    list.push(param);
+                } else {
+                    let pat_start = self.cur_pos();
+                    let pat = if self.input_mut().eat(Token::DotDotDot) {
+                        let dot3_token = self.span(pat_start);
+
+                        let mut pat = self.parse_binding_pat_or_ident(false)?;
+
+                        if self.input_mut().eat(Token::Eq) {
+                            let right = self.parse_assignment_expr()?;
+                            self.emit_err(pat.span(), SyntaxError::TS1048);
+                            pat = AssignPat {
+                                span: self.span(pat_start),
+                                left: Box::new(pat),
+                                right,
+                            }
+                            .into();
+                        }
+
+                        let type_ann = if self.input().syntax().typescript()
+                            && self.input().is(Token::Colon)
+                        {
+                            let cur_pos = self.cur_pos();
+                            Some(self.parse_ts_type_ann(/* eat_colon */ true, cur_pos)?)
+                        } else {
+                            None
+                        };
+
+                        let pat: Pat = RestPat {
+                            span: self.span(pat_start),
+                            dot3_token,
+                            arg: Box::new(pat),
+                            type_ann,
+                        }
+                        .into();
+
+                        if self.syntax().typescript() && self.input_mut().eat(Token::QuestionMark) {
+                            self.emit_err(self.input().prev_span(), SyntaxError::TS1047);
+                        }
+
+                        rest_span = pat.span();
+                        pat
+                    } else {
+                        self.parse_formal_param_pat()?
+                    };
+
+                    let is_rest = matches!(pat, Pat::Rest(..));
+                    let item = pat_to_ts_fn_param(self, pat)?;
+                    list.push(item);
+
+                    if is_rest && !self.input().is(Token::RParen) {
+                        rest_span = list.last().expect("rest param").span();
+                    }
+                }
+
+                if !self.input().is(Token::RParen) {
+                    expect!(self, Token::Comma);
+                    if !rest_span.is_dummy() && self.input().is(Token::RParen) {
+                        self.emit_err(self.input().prev_span(), SyntaxError::CommaAfterRestElement);
+                    }
+                }
+            }
+
+            expect!(self, Token::RParen);
+            return Ok(list);
+        }
+
+        let params = self.parse_formal_params()?;
+        let mut list = Vec::with_capacity(4);
+
+        for param in params {
+            list.push(pat_to_ts_fn_param(self, param.pat)?);
         }
         expect!(self, Token::RParen);
         Ok(list)
@@ -3008,6 +3135,88 @@ impl<I: Tokens> Parser<I> {
         }
     }
 
+    fn flow_starts_like_anon_signature_param_type(&mut self) -> bool {
+        let cur = self.input().cur();
+
+        if matches!(
+            cur,
+            Token::LParen
+                | Token::LBrace
+                | Token::LBracket
+                | Token::QuestionMark
+                | Token::Asterisk
+                | Token::Minus
+                | Token::Str
+                | Token::Num
+                | Token::BigInt
+                | Token::True
+                | Token::False
+                | Token::BackQuote
+                | Token::NoSubstitutionTemplateLiteral
+                | Token::TemplateHead
+                | Token::Import
+                | Token::This
+                | Token::TypeOf
+                | Token::Void
+                | Token::Null
+                | Token::Any
+                | Token::Boolean
+                | Token::Bigint
+                | Token::Never
+                | Token::Number
+                | Token::Object
+                | Token::String
+                | Token::Symbol
+                | Token::Unknown
+                | Token::Undefined
+                | Token::Intrinsic
+                | Token::Readonly
+                | Token::Keyof
+                | Token::Unique
+                | Token::Infer
+        ) {
+            return true;
+        }
+
+        if cur == Token::Interface {
+            return peek!(self).is_some_and(|peek| peek == Token::LBrace);
+        }
+
+        cur.is_word() && peek!(self).is_some_and(|peek| peek == Token::Lt || peek == Token::LShift)
+    }
+
+    fn try_parse_flow_anon_signature_param(&mut self, index: usize) -> PResult<Option<TsFnParam>> {
+        if !self.input().syntax().flow() || !self.ctx().contains(Context::InType) {
+            return Ok(None);
+        }
+
+        let start = self.cur_pos();
+        let dot3_token = if self.input_mut().eat(Token::DotDotDot) {
+            Some(self.input().prev_span())
+        } else {
+            None
+        };
+
+        if !self.flow_starts_like_anon_signature_param_type() {
+            return Ok(None);
+        }
+
+        let ty = self.parse_ts_type()?;
+        if matches!(
+            self.input().cur(),
+            Token::Colon | Token::QuestionMark | Token::Eq
+        ) {
+            return Ok(None);
+        }
+        if !(self.input().is(Token::Comma) || self.input().is(Token::RParen)) {
+            return Ok(None);
+        }
+
+        Ok(Some(
+            self.make_flow_anon_fn_param(start, index, dot3_token, ty),
+        ))
+    }
+
     fn try_parse_flow_anon_fn_type(&mut self) -> PResult<Option<TsFnType>> {
         if !self.input().syntax().flow()
             || self.ctx().contains(Context::DisallowFlowAnonFnType)
@@ -3367,7 +3576,28 @@ impl<I: Tokens> Parser<I> {
     ///
     /// Returns `(computed, key)`.
     fn parse_ts_property_name(&mut self) -> PResult<(bool, Box<Expr>)> {
-        let (computed, key) = if self.input_mut().eat(Token::LBracket) {
+        let (computed, key) = if self.input().syntax().flow()
+            && self.input().is(Token::At)
+            && peek!(self).is_some_and(|peek| peek == Token::At)
+        {
+            let start = self.cur_pos();
+            self.assert_and_bump(Token::At);
+            self.assert_and_bump(Token::At);
+
+            if !self.input().cur().is_word() {
+                unexpected!(self, "identifier");
+            }
+            let key = self.input_mut().expect_word_token_and_bump();
+
+            (
+                false,
+                Box::new(Expr::Lit(Lit::Str(Str {
+                    span: self.span(start),
+                    value: format!("@@{key}").into(),
+                    raw: None,
+                }))),
+            )
+        } else if self.input_mut().eat(Token::LBracket) {
             let key = self.parse_assignment_expr()?;
             expect!(self, Token::RBracket);
             (true, key)

--- a/crates/swc_ecma_parser/tests/flow/issue-11729-phase2/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/issue-11729-phase2/basic.js
@@ -1,0 +1,52 @@
+declare export class URLSearchParams {
+  @@iterator(): Iterator<[string, string]>;
+}
+
+type IgnorePattern = string;
+interface ILogBox {
+  ignoreLogs($ReadOnlyArray<IgnorePattern>): void;
+}
+
+type ReactDevToolsAgent = {};
+
+type ReactDevToolsGlobalHook = {
+  on: (eventName: string, (agent: ReactDevToolsAgent) => void) => void,
+  off: (eventName: string, (agent: ReactDevToolsAgent) => void) => void,
+};
+
+type ReactFabricType = {foo: number};
+type ReactNativeType = {bar: string};
+
+type GetMethod = (<MethodName: $Keys<ReactFabricType>>(
+  () => ReactFabricType,
+  MethodName,
+) => ReactFabricType[MethodName]) &
+  (<MethodName: $Keys<ReactNativeType>>(
+    () => ReactNativeType,
+    MethodName,
+  ) => ReactNativeType[MethodName]);
+
+type AnimatedProps<Props: {...}> = Props;
+
+type AnimatedComponentType<
+  Props: {...},
+  +Instance = unknown,
+> = component(ref?: React.RefSetter<Instance>, ...AnimatedProps<Props>);
+
+type GenericProps<T, S> = {
+  t: T,
+  s: S,
+  ...
+};
+
+type SectionListType = component(
+  ref?: React.RefSetter<any>,
+  ...GenericProps<any, string>,
+);
+
+type ActivityType = component(
+  ...{
+    mode: 'visible' | 'hidden',
+    children: React.Node,
+  }
+);

--- a/crates/swc_ecma_parser/tests/flow/issue-11729-phase2/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11729-phase2/basic.js.json
@@ -1,0 +1,2237 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 1173
+  },
+  "body": [
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 22,
+          "end": 37
+        },
+        "ctxt": 0,
+        "value": "URLSearchParams",
+        "optional": false
+      },
+      "declare": true,
+      "span": {
+        "start": 1,
+        "end": 85
+      },
+      "ctxt": 0,
+      "decorators": [],
+      "body": [
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 42,
+            "end": 83
+          },
+          "key": {
+            "type": "StringLiteral",
+            "span": {
+              "start": 42,
+              "end": 52
+            },
+            "value": "@@iterator",
+            "raw": null
+          },
+          "function": {
+            "params": [],
+            "decorators": [],
+            "span": {
+              "start": 42,
+              "end": 83
+            },
+            "ctxt": 0,
+            "body": null,
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 54,
+                "end": 82
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 56,
+                  "end": 82
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 56,
+                    "end": 64
+                  },
+                  "ctxt": 0,
+                  "value": "Iterator",
+                  "optional": false
+                },
+                "typeParams": {
+                  "type": "TsTypeParameterInstantiation",
+                  "span": {
+                    "start": 64,
+                    "end": 82
+                  },
+                  "params": [
+                    {
+                      "type": "TsTupleType",
+                      "span": {
+                        "start": 65,
+                        "end": 81
+                      },
+                      "elemTypes": [
+                        {
+                          "type": "TsTupleElement",
+                          "span": {
+                            "start": 66,
+                            "end": 72
+                          },
+                          "label": null,
+                          "ty": {
+                            "type": "TsKeywordType",
+                            "span": {
+                              "start": 66,
+                              "end": 72
+                            },
+                            "kind": "string"
+                          }
+                        },
+                        {
+                          "type": "TsTupleElement",
+                          "span": {
+                            "start": 74,
+                            "end": 80
+                          },
+                          "label": null,
+                          "ty": {
+                            "type": "TsKeywordType",
+                            "span": {
+                              "start": 74,
+                              "end": 80
+                            },
+                            "kind": "string"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "kind": "method",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false
+        }
+      ],
+      "superClass": null,
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 87,
+        "end": 115
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 92,
+          "end": 105
+        },
+        "ctxt": 0,
+        "value": "IgnorePattern",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsKeywordType",
+        "span": {
+          "start": 108,
+          "end": 114
+        },
+        "kind": "string"
+      }
+    },
+    {
+      "type": "TsInterfaceDeclaration",
+      "span": {
+        "start": 116,
+        "end": 188
+      },
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 126,
+          "end": 133
+        },
+        "ctxt": 0,
+        "value": "ILogBox",
+        "optional": false
+      },
+      "declare": false,
+      "typeParams": null,
+      "extends": [],
+      "body": {
+        "type": "TsInterfaceBody",
+        "span": {
+          "start": 134,
+          "end": 188
+        },
+        "body": [
+          {
+            "type": "TsMethodSignature",
+            "span": {
+              "start": 138,
+              "end": 186
+            },
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 138,
+                "end": 148
+              },
+              "ctxt": 0,
+              "value": "ignoreLogs",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 149,
+                  "end": 149
+                },
+                "ctxt": 0,
+                "value": "__flow_anon_param_0",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 149,
+                    "end": 178
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 149,
+                      "end": 178
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 149,
+                        "end": 163
+                      },
+                      "ctxt": 0,
+                      "value": "$ReadOnlyArray",
+                      "optional": false
+                    },
+                    "typeParams": {
+                      "type": "TsTypeParameterInstantiation",
+                      "span": {
+                        "start": 163,
+                        "end": 178
+                      },
+                      "params": [
+                        {
+                          "type": "TsTypeReference",
+                          "span": {
+                            "start": 164,
+                            "end": 177
+                          },
+                          "typeName": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 164,
+                              "end": 177
+                            },
+                            "ctxt": 0,
+                            "value": "IgnorePattern",
+                            "optional": false
+                          },
+                          "typeParams": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "typeAnn": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 179,
+                "end": 185
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 181,
+                  "end": 185
+                },
+                "kind": "void"
+              }
+            },
+            "typeParams": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 190,
+        "end": 219
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 195,
+          "end": 213
+        },
+        "ctxt": 0,
+        "value": "ReactDevToolsAgent",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 216,
+          "end": 218
+        },
+        "members": []
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 221,
+        "end": 401
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 226,
+          "end": 249
+        },
+        "ctxt": 0,
+        "value": "ReactDevToolsGlobalHook",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 252,
+          "end": 400
+        },
+        "members": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 256,
+              "end": 325
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 256,
+                "end": 258
+              },
+              "ctxt": 0,
+              "value": "on",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 258,
+                "end": 324
+              },
+              "typeAnnotation": {
+                "type": "TsFunctionType",
+                "span": {
+                  "start": 260,
+                  "end": 324
+                },
+                "params": [
+                  {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 261,
+                      "end": 270
+                    },
+                    "ctxt": 0,
+                    "value": "eventName",
+                    "optional": false,
+                    "typeAnnotation": {
+                      "type": "TsTypeAnnotation",
+                      "span": {
+                        "start": 270,
+                        "end": 278
+                      },
+                      "typeAnnotation": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 272,
+                          "end": 278
+                        },
+                        "kind": "string"
+                      }
+                    }
+                  },
+                  {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 280,
+                      "end": 280
+                    },
+                    "ctxt": 0,
+                    "value": "__flow_anon_param_1",
+                    "optional": false,
+                    "typeAnnotation": {
+                      "type": "TsTypeAnnotation",
+                      "span": {
+                        "start": 280,
+                        "end": 315
+                      },
+                      "typeAnnotation": {
+                        "type": "TsFunctionType",
+                        "span": {
+                          "start": 280,
+                          "end": 315
+                        },
+                        "params": [
+                          {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 281,
+                              "end": 286
+                            },
+                            "ctxt": 0,
+                            "value": "agent",
+                            "optional": false,
+                            "typeAnnotation": {
+                              "type": "TsTypeAnnotation",
+                              "span": {
+                                "start": 286,
+                                "end": 306
+                              },
+                              "typeAnnotation": {
+                                "type": "TsTypeReference",
+                                "span": {
+                                  "start": 288,
+                                  "end": 306
+                                },
+                                "typeName": {
+                                  "type": "Identifier",
+                                  "span": {
+                                    "start": 288,
+                                    "end": 306
+                                  },
+                                  "ctxt": 0,
+                                  "value": "ReactDevToolsAgent",
+                                  "optional": false
+                                },
+                                "typeParams": null
+                              }
+                            }
+                          }
+                        ],
+                        "typeParams": null,
+                        "typeAnnotation": {
+                          "type": "TsTypeAnnotation",
+                          "span": {
+                            "start": 308,
+                            "end": 315
+                          },
+                          "typeAnnotation": {
+                            "type": "TsKeywordType",
+                            "span": {
+                              "start": 311,
+                              "end": 315
+                            },
+                            "kind": "void"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "typeParams": null,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 317,
+                    "end": 324
+                  },
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 320,
+                      "end": 324
+                    },
+                    "kind": "void"
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 328,
+              "end": 398
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 328,
+                "end": 331
+              },
+              "ctxt": 0,
+              "value": "off",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 331,
+                "end": 397
+              },
+              "typeAnnotation": {
+                "type": "TsFunctionType",
+                "span": {
+                  "start": 333,
+                  "end": 397
+                },
+                "params": [
+                  {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 334,
+                      "end": 343
+                    },
+                    "ctxt": 0,
+                    "value": "eventName",
+                    "optional": false,
+                    "typeAnnotation": {
+                      "type": "TsTypeAnnotation",
+                      "span": {
+                        "start": 343,
+                        "end": 351
+                      },
+                      "typeAnnotation": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 345,
+                          "end": 351
+                        },
+                        "kind": "string"
+                      }
+                    }
+                  },
+                  {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 353,
+                      "end": 353
+                    },
+                    "ctxt": 0,
+                    "value": "__flow_anon_param_1",
+                    "optional": false,
+                    "typeAnnotation": {
+                      "type": "TsTypeAnnotation",
+                      "span": {
+                        "start": 353,
+                        "end": 388
+                      },
+                      "typeAnnotation": {
+                        "type": "TsFunctionType",
+                        "span": {
+                          "start": 353,
+                          "end": 388
+                        },
+                        "params": [
+                          {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 354,
+                              "end": 359
+                            },
+                            "ctxt": 0,
+                            "value": "agent",
+                            "optional": false,
+                            "typeAnnotation": {
+                              "type": "TsTypeAnnotation",
+                              "span": {
+                                "start": 359,
+                                "end": 379
+                              },
+                              "typeAnnotation": {
+                                "type": "TsTypeReference",
+                                "span": {
+                                  "start": 361,
+                                  "end": 379
+                                },
+                                "typeName": {
+                                  "type": "Identifier",
+                                  "span": {
+                                    "start": 361,
+                                    "end": 379
+                                  },
+                                  "ctxt": 0,
+                                  "value": "ReactDevToolsAgent",
+                                  "optional": false
+                                },
+                                "typeParams": null
+                              }
+                            }
+                          }
+                        ],
+                        "typeParams": null,
+                        "typeAnnotation": {
+                          "type": "TsTypeAnnotation",
+                          "span": {
+                            "start": 381,
+                            "end": 388
+                          },
+                          "typeAnnotation": {
+                            "type": "TsKeywordType",
+                            "span": {
+                              "start": 384,
+                              "end": 388
+                            },
+                            "kind": "void"
+                          }
+                        }
+                      }
+                    }
+                  }
+                ],
+                "typeParams": null,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 390,
+                    "end": 397
+                  },
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 393,
+                      "end": 397
+                    },
+                    "kind": "void"
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 403,
+        "end": 440
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 408,
+          "end": 423
+        },
+        "ctxt": 0,
+        "value": "ReactFabricType",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 426,
+          "end": 439
+        },
+        "members": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 427,
+              "end": 438
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 427,
+                "end": 430
+              },
+              "ctxt": 0,
+              "value": "foo",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 430,
+                "end": 438
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 432,
+                  "end": 438
+                },
+                "kind": "number"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 441,
+        "end": 478
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 446,
+          "end": 461
+        },
+        "ctxt": 0,
+        "value": "ReactNativeType",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 464,
+          "end": 477
+        },
+        "members": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 465,
+              "end": 476
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 465,
+                "end": 468
+              },
+              "ctxt": 0,
+              "value": "bar",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 468,
+                "end": 476
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 470,
+                  "end": 476
+                },
+                "kind": "string"
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 480,
+        "end": 731
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 485,
+          "end": 494
+        },
+        "ctxt": 0,
+        "value": "GetMethod",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsIntersectionType",
+        "span": {
+          "start": 497,
+          "end": 730
+        },
+        "types": [
+          {
+            "type": "TsParenthesizedType",
+            "span": {
+              "start": 497,
+              "end": 608
+            },
+            "typeAnnotation": {
+              "type": "TsFunctionType",
+              "span": {
+                "start": 498,
+                "end": 607
+              },
+              "params": [
+                {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 538,
+                    "end": 538
+                  },
+                  "ctxt": 0,
+                  "value": "__flow_anon_param_0",
+                  "optional": false,
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 538,
+                      "end": 559
+                    },
+                    "typeAnnotation": {
+                      "type": "TsFunctionType",
+                      "span": {
+                        "start": 538,
+                        "end": 559
+                      },
+                      "params": [],
+                      "typeParams": null,
+                      "typeAnnotation": {
+                        "type": "TsTypeAnnotation",
+                        "span": {
+                          "start": 541,
+                          "end": 559
+                        },
+                        "typeAnnotation": {
+                          "type": "TsTypeReference",
+                          "span": {
+                            "start": 544,
+                            "end": 559
+                          },
+                          "typeName": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 544,
+                              "end": 559
+                            },
+                            "ctxt": 0,
+                            "value": "ReactFabricType",
+                            "optional": false
+                          },
+                          "typeParams": null
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 563,
+                    "end": 573
+                  },
+                  "ctxt": 0,
+                  "value": "MethodName",
+                  "optional": false,
+                  "typeAnnotation": null
+                }
+              ],
+              "typeParams": {
+                "type": "TsTypeParameterDeclaration",
+                "span": {
+                  "start": 498,
+                  "end": 534
+                },
+                "parameters": [
+                  {
+                    "type": "TsTypeParameter",
+                    "span": {
+                      "start": 499,
+                      "end": 533
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 499,
+                        "end": 509
+                      },
+                      "ctxt": 0,
+                      "value": "MethodName",
+                      "optional": false
+                    },
+                    "in": false,
+                    "out": false,
+                    "const": false,
+                    "constraint": {
+                      "type": "TsTypeReference",
+                      "span": {
+                        "start": 511,
+                        "end": 533
+                      },
+                      "typeName": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 511,
+                          "end": 516
+                        },
+                        "ctxt": 0,
+                        "value": "$Keys",
+                        "optional": false
+                      },
+                      "typeParams": {
+                        "type": "TsTypeParameterInstantiation",
+                        "span": {
+                          "start": 516,
+                          "end": 533
+                        },
+                        "params": [
+                          {
+                            "type": "TsTypeReference",
+                            "span": {
+                              "start": 517,
+                              "end": 532
+                            },
+                            "typeName": {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 517,
+                                "end": 532
+                              },
+                              "ctxt": 0,
+                              "value": "ReactFabricType",
+                              "optional": false
+                            },
+                            "typeParams": null
+                          }
+                        ]
+                      }
+                    },
+                    "default": null
+                  }
+                ]
+              },
+              "typeAnnotation": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 577,
+                  "end": 607
+                },
+                "typeAnnotation": {
+                  "type": "TsIndexedAccessType",
+                  "span": {
+                    "start": 580,
+                    "end": 607
+                  },
+                  "readonly": false,
+                  "objectType": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 580,
+                      "end": 595
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 580,
+                        "end": 595
+                      },
+                      "ctxt": 0,
+                      "value": "ReactFabricType",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  },
+                  "indexType": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 596,
+                      "end": 606
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 596,
+                        "end": 606
+                      },
+                      "ctxt": 0,
+                      "value": "MethodName",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "TsParenthesizedType",
+            "span": {
+              "start": 613,
+              "end": 730
+            },
+            "typeAnnotation": {
+              "type": "TsFunctionType",
+              "span": {
+                "start": 614,
+                "end": 729
+              },
+              "params": [
+                {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 656,
+                    "end": 656
+                  },
+                  "ctxt": 0,
+                  "value": "__flow_anon_param_0",
+                  "optional": false,
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 656,
+                      "end": 677
+                    },
+                    "typeAnnotation": {
+                      "type": "TsFunctionType",
+                      "span": {
+                        "start": 656,
+                        "end": 677
+                      },
+                      "params": [],
+                      "typeParams": null,
+                      "typeAnnotation": {
+                        "type": "TsTypeAnnotation",
+                        "span": {
+                          "start": 659,
+                          "end": 677
+                        },
+                        "typeAnnotation": {
+                          "type": "TsTypeReference",
+                          "span": {
+                            "start": 662,
+                            "end": 677
+                          },
+                          "typeName": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 662,
+                              "end": 677
+                            },
+                            "ctxt": 0,
+                            "value": "ReactNativeType",
+                            "optional": false
+                          },
+                          "typeParams": null
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 683,
+                    "end": 693
+                  },
+                  "ctxt": 0,
+                  "value": "MethodName",
+                  "optional": false,
+                  "typeAnnotation": null
+                }
+              ],
+              "typeParams": {
+                "type": "TsTypeParameterDeclaration",
+                "span": {
+                  "start": 614,
+                  "end": 650
+                },
+                "parameters": [
+                  {
+                    "type": "TsTypeParameter",
+                    "span": {
+                      "start": 615,
+                      "end": 649
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 615,
+                        "end": 625
+                      },
+                      "ctxt": 0,
+                      "value": "MethodName",
+                      "optional": false
+                    },
+                    "in": false,
+                    "out": false,
+                    "const": false,
+                    "constraint": {
+                      "type": "TsTypeReference",
+                      "span": {
+                        "start": 627,
+                        "end": 649
+                      },
+                      "typeName": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 627,
+                          "end": 632
+                        },
+                        "ctxt": 0,
+                        "value": "$Keys",
+                        "optional": false
+                      },
+                      "typeParams": {
+                        "type": "TsTypeParameterInstantiation",
+                        "span": {
+                          "start": 632,
+                          "end": 649
+                        },
+                        "params": [
+                          {
+                            "type": "TsTypeReference",
+                            "span": {
+                              "start": 633,
+                              "end": 648
+                            },
+                            "typeName": {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 633,
+                                "end": 648
+                              },
+                              "ctxt": 0,
+                              "value": "ReactNativeType",
+                              "optional": false
+                            },
+                            "typeParams": null
+                          }
+                        ]
+                      }
+                    },
+                    "default": null
+                  }
+                ]
+              },
+              "typeAnnotation": {
+                "type": "TsTypeAnnotation",
+                "span": {
+                  "start": 699,
+                  "end": 729
+                },
+                "typeAnnotation": {
+                  "type": "TsIndexedAccessType",
+                  "span": {
+                    "start": 702,
+                    "end": 729
+                  },
+                  "readonly": false,
+                  "objectType": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 702,
+                      "end": 717
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 702,
+                        "end": 717
+                      },
+                      "ctxt": 0,
+                      "value": "ReactNativeType",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  },
+                  "indexType": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 718,
+                      "end": 728
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 718,
+                        "end": 728
+                      },
+                      "ctxt": 0,
+                      "value": "MethodName",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                }
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 733,
+        "end": 774
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 738,
+          "end": 751
+        },
+        "ctxt": 0,
+        "value": "AnimatedProps",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 751,
+          "end": 765
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 752,
+              "end": 764
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 752,
+                "end": 757
+              },
+              "ctxt": 0,
+              "value": "Props",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "const": false,
+            "constraint": {
+              "type": "TsTypeLiteral",
+              "span": {
+                "start": 759,
+                "end": 764
+              },
+              "members": [
+                {
+                  "type": "TsPropertySignature",
+                  "span": {
+                    "start": 760,
+                    "end": 763
+                  },
+                  "readonly": false,
+                  "key": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 760,
+                      "end": 763
+                    },
+                    "ctxt": 0,
+                    "value": "__flow_spread",
+                    "optional": false
+                  },
+                  "computed": false,
+                  "optional": false,
+                  "typeAnnotation": null
+                }
+              ]
+            },
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsTypeReference",
+        "span": {
+          "start": 768,
+          "end": 773
+        },
+        "typeName": {
+          "type": "Identifier",
+          "span": {
+            "start": 768,
+            "end": 773
+          },
+          "ctxt": 0,
+          "value": "Props",
+          "optional": false
+        },
+        "typeParams": null
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 776,
+        "end": 915
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 781,
+          "end": 802
+        },
+        "ctxt": 0,
+        "value": "AnimatedComponentType",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 802,
+          "end": 844
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 806,
+              "end": 818
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 806,
+                "end": 811
+              },
+              "ctxt": 0,
+              "value": "Props",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "const": false,
+            "constraint": {
+              "type": "TsTypeLiteral",
+              "span": {
+                "start": 813,
+                "end": 818
+              },
+              "members": [
+                {
+                  "type": "TsPropertySignature",
+                  "span": {
+                    "start": 814,
+                    "end": 817
+                  },
+                  "readonly": false,
+                  "key": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 814,
+                      "end": 817
+                    },
+                    "ctxt": 0,
+                    "value": "__flow_spread",
+                    "optional": false
+                  },
+                  "computed": false,
+                  "optional": false,
+                  "typeAnnotation": null
+                }
+              ]
+            },
+            "default": null
+          },
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 822,
+              "end": 841
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 823,
+                "end": 831
+              },
+              "ctxt": 0,
+              "value": "Instance",
+              "optional": false
+            },
+            "in": false,
+            "out": true,
+            "const": false,
+            "constraint": null,
+            "default": {
+              "type": "TsKeywordType",
+              "span": {
+                "start": 834,
+                "end": 841
+              },
+              "kind": "unknown"
+            }
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsFunctionType",
+        "span": {
+          "start": 847,
+          "end": 914
+        },
+        "params": [
+          {
+            "type": "ObjectPattern",
+            "span": {
+              "start": 847,
+              "end": 914
+            },
+            "properties": [
+              {
+                "type": "KeyValuePatternProperty",
+                "key": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 857,
+                    "end": 860
+                  },
+                  "value": "ref"
+                },
+                "value": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 857,
+                    "end": 860
+                  },
+                  "ctxt": 0,
+                  "value": "ref",
+                  "optional": true,
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 861,
+                      "end": 888
+                    },
+                    "typeAnnotation": {
+                      "type": "TsTypeReference",
+                      "span": {
+                        "start": 863,
+                        "end": 888
+                      },
+                      "typeName": {
+                        "type": "TsQualifiedName",
+                        "span": {
+                          "start": 863,
+                          "end": 878
+                        },
+                        "left": {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 863,
+                            "end": 868
+                          },
+                          "ctxt": 0,
+                          "value": "React",
+                          "optional": false
+                        },
+                        "right": {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 869,
+                            "end": 878
+                          },
+                          "value": "RefSetter"
+                        }
+                      },
+                      "typeParams": {
+                        "type": "TsTypeParameterInstantiation",
+                        "span": {
+                          "start": 878,
+                          "end": 888
+                        },
+                        "params": [
+                          {
+                            "type": "TsTypeReference",
+                            "span": {
+                              "start": 879,
+                              "end": 887
+                            },
+                            "typeName": {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 879,
+                                "end": 887
+                              },
+                              "ctxt": 0,
+                              "value": "Instance",
+                              "optional": false
+                            },
+                            "typeParams": null
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "RestElement",
+                "span": {
+                  "start": 890,
+                  "end": 913
+                },
+                "rest": {
+                  "start": 890,
+                  "end": 893
+                },
+                "argument": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 890,
+                    "end": 913
+                  },
+                  "ctxt": 0,
+                  "value": "component_rest",
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 893,
+                    "end": 913
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 893,
+                      "end": 913
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 893,
+                        "end": 906
+                      },
+                      "ctxt": 0,
+                      "value": "AnimatedProps",
+                      "optional": false
+                    },
+                    "typeParams": {
+                      "type": "TsTypeParameterInstantiation",
+                      "span": {
+                        "start": 906,
+                        "end": 913
+                      },
+                      "params": [
+                        {
+                          "type": "TsTypeReference",
+                          "span": {
+                            "start": 907,
+                            "end": 912
+                          },
+                          "typeName": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 907,
+                              "end": 912
+                            },
+                            "ctxt": 0,
+                            "value": "Props",
+                            "optional": false
+                          },
+                          "typeParams": null
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "optional": false,
+            "typeAnnotation": null
+          }
+        ],
+        "typeParams": null,
+        "typeAnnotation": {
+          "type": "TsTypeAnnotation",
+          "span": {
+            "start": 847,
+            "end": 914
+          },
+          "typeAnnotation": {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 847,
+              "end": 914
+            },
+            "kind": "any"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 917,
+        "end": 969
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 922,
+          "end": 934
+        },
+        "ctxt": 0,
+        "value": "GenericProps",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 934,
+          "end": 940
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 935,
+              "end": 936
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 935,
+                "end": 936
+              },
+              "ctxt": 0,
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "const": false,
+            "constraint": null,
+            "default": null
+          },
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 938,
+              "end": 939
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 938,
+                "end": 939
+              },
+              "ctxt": 0,
+              "value": "S",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "const": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 943,
+          "end": 968
+        },
+        "members": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 947,
+              "end": 952
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 947,
+                "end": 948
+              },
+              "ctxt": 0,
+              "value": "t",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 948,
+                "end": 951
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 950,
+                  "end": 951
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 950,
+                    "end": 951
+                  },
+                  "ctxt": 0,
+                  "value": "T",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          },
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 955,
+              "end": 960
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 955,
+                "end": 956
+              },
+              "ctxt": 0,
+              "value": "s",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 956,
+                "end": 959
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 958,
+                  "end": 959
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 958,
+                    "end": 959
+                  },
+                  "ctxt": 0,
+                  "value": "S",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          },
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 963,
+              "end": 966
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 963,
+                "end": 966
+              },
+              "ctxt": 0,
+              "value": "__flow_spread",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 971,
+        "end": 1069
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 976,
+          "end": 991
+        },
+        "ctxt": 0,
+        "value": "SectionListType",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsFunctionType",
+        "span": {
+          "start": 994,
+          "end": 1068
+        },
+        "params": [
+          {
+            "type": "ObjectPattern",
+            "span": {
+              "start": 994,
+              "end": 1068
+            },
+            "properties": [
+              {
+                "type": "KeyValuePatternProperty",
+                "key": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 1007,
+                    "end": 1010
+                  },
+                  "value": "ref"
+                },
+                "value": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 1007,
+                    "end": 1010
+                  },
+                  "ctxt": 0,
+                  "value": "ref",
+                  "optional": true,
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 1011,
+                      "end": 1033
+                    },
+                    "typeAnnotation": {
+                      "type": "TsTypeReference",
+                      "span": {
+                        "start": 1013,
+                        "end": 1033
+                      },
+                      "typeName": {
+                        "type": "TsQualifiedName",
+                        "span": {
+                          "start": 1013,
+                          "end": 1028
+                        },
+                        "left": {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 1013,
+                            "end": 1018
+                          },
+                          "ctxt": 0,
+                          "value": "React",
+                          "optional": false
+                        },
+                        "right": {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 1019,
+                            "end": 1028
+                          },
+                          "value": "RefSetter"
+                        }
+                      },
+                      "typeParams": {
+                        "type": "TsTypeParameterInstantiation",
+                        "span": {
+                          "start": 1028,
+                          "end": 1033
+                        },
+                        "params": [
+                          {
+                            "type": "TsKeywordType",
+                            "span": {
+                              "start": 1029,
+                              "end": 1032
+                            },
+                            "kind": "any"
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              },
+              {
+                "type": "RestElement",
+                "span": {
+                  "start": 1037,
+                  "end": 1065
+                },
+                "rest": {
+                  "start": 1037,
+                  "end": 1040
+                },
+                "argument": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 1037,
+                    "end": 1065
+                  },
+                  "ctxt": 0,
+                  "value": "component_rest",
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 1040,
+                    "end": 1065
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 1040,
+                      "end": 1065
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 1040,
+                        "end": 1052
+                      },
+                      "ctxt": 0,
+                      "value": "GenericProps",
+                      "optional": false
+                    },
+                    "typeParams": {
+                      "type": "TsTypeParameterInstantiation",
+                      "span": {
+                        "start": 1052,
+                        "end": 1065
+                      },
+                      "params": [
+                        {
+                          "type": "TsKeywordType",
+                          "span": {
+                            "start": 1053,
+                            "end": 1056
+                          },
+                          "kind": "any"
+                        },
+                        {
+                          "type": "TsKeywordType",
+                          "span": {
+                            "start": 1058,
+                            "end": 1064
+                          },
+                          "kind": "string"
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            ],
+            "optional": false,
+            "typeAnnotation": null
+          }
+        ],
+        "typeParams": null,
+        "typeAnnotation": {
+          "type": "TsTypeAnnotation",
+          "span": {
+            "start": 994,
+            "end": 1068
+          },
+          "typeAnnotation": {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 994,
+              "end": 1068
+            },
+            "kind": "any"
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 1071,
+        "end": 1173
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 1076,
+          "end": 1088
+        },
+        "ctxt": 0,
+        "value": "ActivityType",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsFunctionType",
+        "span": {
+          "start": 1091,
+          "end": 1172
+        },
+        "params": [
+          {
+            "type": "ObjectPattern",
+            "span": {
+              "start": 1091,
+              "end": 1172
+            },
+            "properties": [
+              {
+                "type": "RestElement",
+                "span": {
+                  "start": 1104,
+                  "end": 1170
+                },
+                "rest": {
+                  "start": 1104,
+                  "end": 1107
+                },
+                "argument": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 1104,
+                    "end": 1170
+                  },
+                  "ctxt": 0,
+                  "value": "component_rest",
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 1107,
+                    "end": 1170
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeLiteral",
+                    "span": {
+                      "start": 1107,
+                      "end": 1170
+                    },
+                    "members": [
+                      {
+                        "type": "TsPropertySignature",
+                        "span": {
+                          "start": 1113,
+                          "end": 1140
+                        },
+                        "readonly": false,
+                        "key": {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 1113,
+                            "end": 1117
+                          },
+                          "ctxt": 0,
+                          "value": "mode",
+                          "optional": false
+                        },
+                        "computed": false,
+                        "optional": false,
+                        "typeAnnotation": {
+                          "type": "TsTypeAnnotation",
+                          "span": {
+                            "start": 1117,
+                            "end": 1139
+                          },
+                          "typeAnnotation": {
+                            "type": "TsUnionType",
+                            "span": {
+                              "start": 1119,
+                              "end": 1139
+                            },
+                            "types": [
+                              {
+                                "type": "TsLiteralType",
+                                "span": {
+                                  "start": 1119,
+                                  "end": 1128
+                                },
+                                "literal": {
+                                  "type": "StringLiteral",
+                                  "span": {
+                                    "start": 1119,
+                                    "end": 1128
+                                  },
+                                  "value": "visible",
+                                  "raw": "'visible'"
+                                }
+                              },
+                              {
+                                "type": "TsLiteralType",
+                                "span": {
+                                  "start": 1131,
+                                  "end": 1139
+                                },
+                                "literal": {
+                                  "type": "StringLiteral",
+                                  "span": {
+                                    "start": 1131,
+                                    "end": 1139
+                                  },
+                                  "value": "hidden",
+                                  "raw": "'hidden'"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "type": "TsPropertySignature",
+                        "span": {
+                          "start": 1145,
+                          "end": 1166
+                        },
+                        "readonly": false,
+                        "key": {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 1145,
+                            "end": 1153
+                          },
+                          "ctxt": 0,
+                          "value": "children",
+                          "optional": false
+                        },
+                        "computed": false,
+                        "optional": false,
+                        "typeAnnotation": {
+                          "type": "TsTypeAnnotation",
+                          "span": {
+                            "start": 1153,
+                            "end": 1165
+                          },
+                          "typeAnnotation": {
+                            "type": "TsTypeReference",
+                            "span": {
+                              "start": 1155,
+                              "end": 1165
+                            },
+                            "typeName": {
+                              "type": "TsQualifiedName",
+                              "span": {
+                                "start": 1155,
+                                "end": 1165
+                              },
+                              "left": {
+                                "type": "Identifier",
+                                "span": {
+                                  "start": 1155,
+                                  "end": 1160
+                                },
+                                "ctxt": 0,
+                                "value": "React",
+                                "optional": false
+                              },
+                              "right": {
+                                "type": "Identifier",
+                                "span": {
+                                  "start": 1161,
+                                  "end": 1165
+                                },
+                                "value": "Node"
+                              }
+                            },
+                            "typeParams": null
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            ],
+            "optional": false,
+            "typeAnnotation": null
+          }
+        ],
+        "typeParams": null,
+        "typeAnnotation": {
+          "type": "TsTypeAnnotation",
+          "span": {
+            "start": 1091,
+            "end": 1172
+          },
+          "typeAnnotation": {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 1091,
+              "end": 1172
+            },
+            "kind": "any"
+          }
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/issue-11729-phase2/config.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11729-phase2/config.json
@@ -1,0 +1,3 @@
+{
+  "components": true
+}


### PR DESCRIPTION
## Summary
- close the remaining RN Flow parser gaps tracked by #11729
- in Flow component *type* contexts, accept rest type forms like `...AnimatedProps<Props>`, `...Props<any, T>`, and `...{ ... }`
- preserve non-declare component declaration behavior (`component Foo(...rest) {}`) by keeping named-rest parsing there
- allow anonymous typed params in Flow signature/member contexts (including nested function-type params) while still preferring named-param parsing when `:`, `?`, or `=` markers are present
- prevent decorator parsing from consuming `@@...` in Flow mode and parse `@@ident` keys as string keys (`"@@ident"`)
- add Flow fixtures for phase 2 coverage under `crates/swc_ecma_parser/tests/flow/issue-11729-phase2`

## Testing
- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_parser`
- `cargo test -p swc_ecma_parser`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_parser --features flow --test flow -- --ignored`

---

Closes #11729