### PR TITLE
fix(es/decorators): scope 2023-11 implicit-global rewrite to decorator-lifted exprs

### DIFF
--- a/.changeset/rude-candles-shout.md
+++ b/.changeset/rude-candles-shout.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_proposal: patch
+---
+
+fix(decorators): scope 2023-11 implicit-global rewrite to decorator-lifted exprs

--- a/crates/swc/tests/fixture/issues-11xxx/11742/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-11xxx/11742/input/.swcrc
@@ -1,0 +1,13 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "typescript",
+      "decorators": true
+    },
+    "transform": {
+      "legacyDecorator": false,
+      "decoratorVersion": "2023-11"
+    }
+  },
+  "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-11xxx/11742/input/1.ts
+++ b/crates/swc/tests/fixture/issues-11xxx/11742/input/1.ts
@@ -1,0 +1,1 @@
+__webpack_nonce__ = "CSP_NONCE_PLACEHOLDER";

--- a/crates/swc/tests/fixture/issues-11xxx/11742/output/1.ts
+++ b/crates/swc/tests/fixture/issues-11xxx/11742/output/1.ts
@@ -1,0 +1,1 @@
+__webpack_nonce__ = "CSP_NONCE_PLACEHOLDER";

--- a/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
@@ -149,6 +149,37 @@ impl Visit for CurrentClassNameFinder {
     }
 }
 
+#[derive(Default)]
+struct DecoratorPresenceFinder {
+    found: bool,
+}
+
+impl Visit for DecoratorPresenceFinder {
+    noop_visit_type!();
+
+    fn visit_decorator(&mut self, _: &Decorator) {
+        self.found = true;
+    }
+
+    fn visit_module_items(&mut self, items: &[ModuleItem]) {
+        for item in items {
+            if self.found {
+                break;
+            }
+            item.visit_with(self);
+        }
+    }
+
+    fn visit_stmts(&mut self, stmts: &[Stmt]) {
+        for stmt in stmts {
+            if self.found {
+                break;
+            }
+            stmt.visit_with(self);
+        }
+    }
+}
+
 struct ImplicitGlobalUsageRewriter<'a> {
     implicit_globals: &'a mut FxHashSet<Atom>,
 }
@@ -214,6 +245,18 @@ impl DecoratorPass {
         expr.visit_mut_with(&mut ImplicitGlobalUsageRewriter {
             implicit_globals: &mut self.implicit_globals,
         });
+    }
+
+    fn module_items_have_decorators(&self, items: &[ModuleItem]) -> bool {
+        let mut finder = DecoratorPresenceFinder::default();
+        items.visit_with(&mut finder);
+        finder.found
+    }
+
+    fn stmts_have_decorators(&self, stmts: &[Stmt]) -> bool {
+        let mut finder = DecoratorPresenceFinder::default();
+        stmts.visit_with(&mut finder);
+        finder.found
     }
 
     fn maybe_to_property_key(&self, expr: Expr) -> Expr {
@@ -3192,6 +3235,12 @@ impl VisitMut for DecoratorPass {
     }
 
     fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
+        if self.is_2023_11() && self.module_items_have_decorators(n) {
+            n.visit_mut_with(&mut ImplicitGlobalUsageRewriter {
+                implicit_globals: &mut self.implicit_globals,
+            });
+        }
+
         let extra_vars = self.extra_vars.take();
         let extra_lets = self.extra_lets.take();
         let pre_class_inits = self.pre_class_inits.take();
@@ -3528,6 +3577,12 @@ impl VisitMut for DecoratorPass {
     }
 
     fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
+        if self.is_2023_11() && self.stmts_have_decorators(n) {
+            n.visit_mut_with(&mut ImplicitGlobalUsageRewriter {
+                implicit_globals: &mut self.implicit_globals,
+            });
+        }
+
         let old_state = take(&mut self.state);
         let old_pre_class_inits = self.pre_class_inits.take();
         let old_extra_lets = self.extra_lets.take();

--- a/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
@@ -61,6 +61,11 @@ struct DecoratorPass {
     /// tagged with a child mark for implicit-global rewrite.
     in_implicit_global_rewrite_expr: bool,
 
+    /// Local bindings referenced by decorator expressions.
+    /// Initializers of these bindings are also rewrite-scoped because they can
+    /// be executed by decorator application.
+    decorator_binding_ids_for_implicit_global_rewrite: FxHashSet<Id>,
+
     /// Stack of private names declared by currently visited classes.
     class_private_names: Vec<FxHashSet<Atom>>,
 }
@@ -212,6 +217,52 @@ impl DecoratorPass {
         self.implicit_global_rewrite_marks
             .values()
             .any(|&mark| ident.ctxt.has_mark(mark))
+    }
+
+    fn maybe_rewrite_implicit_globals_in_decorator_binding_var_decl(
+        &mut self,
+        var_decl: &mut VarDecl,
+    ) {
+        for decl in &mut var_decl.decls {
+            let Pat::Ident(name) = &decl.name else {
+                continue;
+            };
+
+            if !self
+                .decorator_binding_ids_for_implicit_global_rewrite
+                .contains(&name.id.to_id())
+            {
+                continue;
+            }
+
+            if let Some(init) = decl.init.as_mut() {
+                self.rewrite_implicit_globals_in_expr(init);
+            }
+        }
+    }
+
+    fn maybe_rewrite_implicit_globals_in_decorator_binding_stmt(&mut self, stmt: &mut Stmt) {
+        if let Stmt::Decl(Decl::Var(var_decl)) = stmt {
+            self.maybe_rewrite_implicit_globals_in_decorator_binding_var_decl(var_decl);
+        }
+    }
+
+    fn maybe_rewrite_implicit_globals_in_decorator_binding_module_item(
+        &mut self,
+        module_item: &mut ModuleItem,
+    ) {
+        match module_item {
+            ModuleItem::Stmt(stmt) => {
+                self.maybe_rewrite_implicit_globals_in_decorator_binding_stmt(stmt);
+            }
+            ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
+                decl: Decl::Var(var_decl),
+                ..
+            })) => {
+                self.maybe_rewrite_implicit_globals_in_decorator_binding_var_decl(var_decl);
+            }
+            _ => {}
+        }
     }
 
     fn maybe_to_property_key(&self, expr: Expr) -> Expr {
@@ -996,6 +1047,13 @@ impl DecoratorPass {
         dec: Box<Expr>,
         allow_class_name_queue: bool,
     ) -> Box<Expr> {
+        if self.is_2023_11() {
+            if let Expr::Ident(ident) = &*dec {
+                self.decorator_binding_ids_for_implicit_global_rewrite
+                    .insert(ident.to_id());
+            }
+        }
+
         let return_directly = dec.is_ident()
             || dec.is_arrow()
             || dec.is_fn_expr()
@@ -2022,6 +2080,13 @@ impl DecoratorPass {
 
     fn process_decorators(&mut self, decorators: &mut [Decorator]) {
         decorators.iter_mut().for_each(|dec| {
+            if self.is_2023_11() {
+                if let Expr::Ident(ident) = &*dec.expr {
+                    self.decorator_binding_ids_for_implicit_global_rewrite
+                        .insert(ident.to_id());
+                }
+            }
+
             self.maybe_alias_current_class_name_expr(&mut dec.expr);
 
             let e = if self.is_2023_11()
@@ -3157,6 +3222,17 @@ impl VisitMut for DecoratorPass {
             return;
         }
 
+        if self.in_implicit_global_rewrite_expr {
+            // Keep rewrite mode side-effect free. We only want mark-gated
+            // implicit-global rewrites, not decorator/class transformations.
+            if e.is_class() {
+                return;
+            }
+
+            maybe_grow_default(|| e.visit_mut_children_with(self));
+            return;
+        }
+
         if let Expr::Class(c) = e {
             if !c.class.decorators.is_empty() {
                 let new = self.handle_class_expr(&mut c.class, c.ident.as_ref());
@@ -3262,6 +3338,10 @@ impl VisitMut for DecoratorPass {
                     .into(),
                 );
             }
+        }
+
+        for module_item in n.iter_mut() {
+            self.maybe_rewrite_implicit_globals_in_decorator_binding_module_item(module_item);
         }
 
         if !self.extra_vars.is_empty() {
@@ -3597,6 +3677,10 @@ impl VisitMut for DecoratorPass {
                     .into(),
                 );
             }
+        }
+
+        for stmt in n.iter_mut() {
+            self.maybe_rewrite_implicit_globals_in_decorator_binding_stmt(stmt);
         }
 
         if !self.extra_vars.is_empty() {

--- a/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
@@ -149,9 +149,71 @@ impl Visit for CurrentClassNameFinder {
     }
 }
 
+struct ImplicitGlobalUsageRewriter<'a> {
+    implicit_globals: &'a mut FxHashSet<Atom>,
+}
+
+impl ImplicitGlobalUsageRewriter<'_> {
+    fn is_unresolved_ident(ident: &Ident) -> bool {
+        matches!(ident.ctxt.as_u32(), 0 | 1)
+    }
+
+    fn global_this_member_expr(sym: Atom, span: Span) -> MemberExpr {
+        MemberExpr {
+            span,
+            obj: Ident::new("globalThis".into(), span, SyntaxContext::empty()).into(),
+            prop: MemberProp::Ident(Ident::new(sym, span, SyntaxContext::empty()).into()),
+        }
+    }
+}
+
+impl VisitMut for ImplicitGlobalUsageRewriter<'_> {
+    noop_visit_mut_type!();
+
+    fn visit_mut_expr(&mut self, e: &mut Expr) {
+        if let Expr::Assign(assign) = e {
+            assign.left.visit_mut_with(self);
+            assign.right.visit_mut_with(self);
+
+            if assign.op == op!("=") {
+                if let AssignTarget::Simple(SimpleAssignTarget::Ident(binding)) = &assign.left {
+                    let id = &binding.id;
+                    if Self::is_unresolved_ident(id) {
+                        self.implicit_globals.insert(id.sym.clone());
+                        assign.left = AssignTarget::Simple(SimpleAssignTarget::Member(
+                            Self::global_this_member_expr(id.sym.clone(), id.span),
+                        ));
+                    }
+                }
+            }
+
+            return;
+        }
+
+        if let Expr::Ident(ident) = e {
+            if Self::is_unresolved_ident(ident) && self.implicit_globals.contains(&ident.sym) {
+                *e = Self::global_this_member_expr(ident.sym.clone(), ident.span).into();
+            }
+            return;
+        }
+
+        maybe_grow_default(|| e.visit_mut_children_with(self));
+    }
+}
+
 impl DecoratorPass {
     fn is_2023_11(&self) -> bool {
         matches!(self.version, DecoratorVersion::V202311)
+    }
+
+    fn rewrite_implicit_globals_in_expr(&mut self, expr: &mut Expr) {
+        if !self.is_2023_11() {
+            return;
+        }
+
+        expr.visit_mut_with(&mut ImplicitGlobalUsageRewriter {
+            implicit_globals: &mut self.implicit_globals,
+        });
     }
 
     fn maybe_to_property_key(&self, expr: Expr) -> Expr {
@@ -419,18 +481,6 @@ impl DecoratorPass {
         replace_ident(expr, class_name.to_id(), alias);
     }
 
-    fn is_unresolved_ident(&self, ident: &Ident) -> bool {
-        matches!(ident.ctxt.as_u32(), 0 | 1)
-    }
-
-    fn global_this_member_expr(&self, sym: Atom, span: Span) -> MemberExpr {
-        MemberExpr {
-            span,
-            obj: Ident::new("globalThis".into(), span, SyntaxContext::empty()).into(),
-            prop: MemberProp::Ident(Ident::new(sym, span, SyntaxContext::empty()).into()),
-        }
-    }
-
     fn memoize_static_closure(
         &mut self,
         hint: &str,
@@ -571,6 +621,9 @@ impl DecoratorPass {
     }
 
     fn preserve_decorator_this_target(&mut self, target: Box<Expr>) -> Box<Expr> {
+        let mut target = target;
+        self.rewrite_implicit_globals_in_expr(&mut target);
+
         if target.is_ident() || target.is_this() {
             return target;
         }
@@ -945,11 +998,15 @@ impl DecoratorPass {
         dec: Box<Expr>,
         allow_class_name_queue: bool,
     ) -> Box<Expr> {
-        if dec.is_ident()
+        let return_directly = dec.is_ident()
             || dec.is_arrow()
             || dec.is_fn_expr()
-            || (!self.is_2023_11() && self.expr_uses_current_class_private_name(&dec))
-        {
+            || (!self.is_2023_11() && self.expr_uses_current_class_private_name(&dec));
+
+        let mut dec = dec;
+        self.rewrite_implicit_globals_in_expr(&mut dec);
+
+        if return_directly {
             return dec;
         }
 
@@ -1224,6 +1281,7 @@ impl DecoratorPass {
 
                 let mut key_expr = self.maybe_to_property_key(prop_name_to_expr_value(name.take()));
                 self.maybe_alias_current_class_name_expr(&mut key_expr);
+                self.rewrite_implicit_globals_in_expr(&mut key_expr);
                 let prefer_class_key = self.should_queue_class_key_init(&key_expr, true);
 
                 self.queue_pre_class_init(
@@ -1321,7 +1379,9 @@ impl DecoratorPass {
     }
 
     fn handle_super_class(&mut self, class: &mut Class) {
-        if let Some(super_class) = class.super_class.take() {
+        if let Some(mut super_class) = class.super_class.take() {
+            self.rewrite_implicit_globals_in_expr(&mut super_class);
+
             let id = alias_ident_for(&super_class, "_super");
             self.extra_vars.push(VarDeclarator {
                 span: DUMMY_SP,
@@ -3059,37 +3119,6 @@ impl VisitMut for DecoratorPass {
     }
 
     fn visit_mut_expr(&mut self, e: &mut Expr) {
-        if let Expr::Assign(assign) = e {
-            assign.left.visit_mut_with(self);
-            assign.right.visit_mut_with(self);
-
-            if self.is_2023_11() && assign.op == op!("=") {
-                if let AssignTarget::Simple(SimpleAssignTarget::Ident(binding)) = &assign.left {
-                    let id = &binding.id;
-                    if self.is_unresolved_ident(id) {
-                        self.implicit_globals.insert(id.sym.clone());
-                        assign.left = AssignTarget::Simple(SimpleAssignTarget::Member(
-                            self.global_this_member_expr(id.sym.clone(), id.span),
-                        ));
-                    }
-                }
-            }
-
-            return;
-        }
-
-        if let Expr::Ident(ident) = e {
-            if self.is_2023_11()
-                && self.is_unresolved_ident(ident)
-                && self.implicit_globals.contains(&ident.sym)
-            {
-                *e = self
-                    .global_this_member_expr(ident.sym.clone(), ident.span)
-                    .into();
-            }
-            return;
-        }
-
         if let Expr::Class(c) = e {
             if !c.class.decorators.is_empty() {
                 let new = self.handle_class_expr(&mut c.class, c.ident.as_ref());

--- a/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
@@ -53,6 +53,14 @@ struct DecoratorPass {
     /// Track them to preserve sloppy-mode behavior expected by Babel fixtures.
     implicit_globals: FxHashSet<Atom>,
 
+    /// Child mark per unresolved outer mark for implicit-global rewrites that
+    /// are scoped to decorator-lifted expressions.
+    implicit_global_rewrite_marks: FxHashMap<Mark, Mark>,
+
+    /// If true, unresolved identifiers visited in the current expression are
+    /// tagged with a child mark for implicit-global rewrite.
+    in_implicit_global_rewrite_expr: bool,
+
     /// Stack of private names declared by currently visited classes.
     class_private_names: Vec<FxHashSet<Atom>>,
 }
@@ -149,89 +157,6 @@ impl Visit for CurrentClassNameFinder {
     }
 }
 
-#[derive(Default)]
-struct DecoratorPresenceFinder {
-    found: bool,
-}
-
-impl Visit for DecoratorPresenceFinder {
-    noop_visit_type!();
-
-    fn visit_decorator(&mut self, _: &Decorator) {
-        self.found = true;
-    }
-
-    fn visit_module_items(&mut self, items: &[ModuleItem]) {
-        for item in items {
-            if self.found {
-                break;
-            }
-            item.visit_with(self);
-        }
-    }
-
-    fn visit_stmts(&mut self, stmts: &[Stmt]) {
-        for stmt in stmts {
-            if self.found {
-                break;
-            }
-            stmt.visit_with(self);
-        }
-    }
-}
-
-struct ImplicitGlobalUsageRewriter<'a> {
-    implicit_globals: &'a mut FxHashSet<Atom>,
-}
-
-impl ImplicitGlobalUsageRewriter<'_> {
-    fn is_unresolved_ident(ident: &Ident) -> bool {
-        matches!(ident.ctxt.as_u32(), 0 | 1)
-    }
-
-    fn global_this_member_expr(sym: Atom, span: Span) -> MemberExpr {
-        MemberExpr {
-            span,
-            obj: Ident::new("globalThis".into(), span, SyntaxContext::empty()).into(),
-            prop: MemberProp::Ident(Ident::new(sym, span, SyntaxContext::empty()).into()),
-        }
-    }
-}
-
-impl VisitMut for ImplicitGlobalUsageRewriter<'_> {
-    noop_visit_mut_type!();
-
-    fn visit_mut_expr(&mut self, e: &mut Expr) {
-        if let Expr::Assign(assign) = e {
-            assign.left.visit_mut_with(self);
-            assign.right.visit_mut_with(self);
-
-            if assign.op == op!("=") {
-                if let AssignTarget::Simple(SimpleAssignTarget::Ident(binding)) = &assign.left {
-                    let id = &binding.id;
-                    if Self::is_unresolved_ident(id) {
-                        self.implicit_globals.insert(id.sym.clone());
-                        assign.left = AssignTarget::Simple(SimpleAssignTarget::Member(
-                            Self::global_this_member_expr(id.sym.clone(), id.span),
-                        ));
-                    }
-                }
-            }
-
-            return;
-        }
-
-        if let Expr::Ident(ident) = e {
-            if Self::is_unresolved_ident(ident) && self.implicit_globals.contains(&ident.sym) {
-                *e = Self::global_this_member_expr(ident.sym.clone(), ident.span).into();
-            }
-            return;
-        }
-
-        maybe_grow_default(|| e.visit_mut_children_with(self));
-    }
-}
-
 impl DecoratorPass {
     fn is_2023_11(&self) -> bool {
         matches!(self.version, DecoratorVersion::V202311)
@@ -242,21 +167,51 @@ impl DecoratorPass {
             return;
         }
 
-        expr.visit_mut_with(&mut ImplicitGlobalUsageRewriter {
-            implicit_globals: &mut self.implicit_globals,
-        });
+        let old = self.in_implicit_global_rewrite_expr;
+        self.in_implicit_global_rewrite_expr = true;
+        expr.visit_mut_with(self);
+        self.in_implicit_global_rewrite_expr = old;
     }
 
-    fn module_items_have_decorators(&self, items: &[ModuleItem]) -> bool {
-        let mut finder = DecoratorPresenceFinder::default();
-        items.visit_with(&mut finder);
-        finder.found
+    fn is_unresolved_ident(&self, ident: &Ident) -> bool {
+        matches!(ident.ctxt.as_u32(), 0 | 1)
     }
 
-    fn stmts_have_decorators(&self, stmts: &[Stmt]) -> bool {
-        let mut finder = DecoratorPresenceFinder::default();
-        stmts.visit_with(&mut finder);
-        finder.found
+    fn global_this_member_expr(&self, sym: Atom, span: Span) -> MemberExpr {
+        MemberExpr {
+            span,
+            obj: Ident::new("globalThis".into(), span, SyntaxContext::empty()).into(),
+            prop: MemberProp::Ident(Ident::new(sym, span, SyntaxContext::empty()).into()),
+        }
+    }
+
+    fn unresolved_outer_mark_for_implicit_global_rewrite(&self, ident: &Ident) -> Option<Mark> {
+        if !self.is_unresolved_ident(ident) {
+            return None;
+        }
+
+        let unresolved_outer_mark = ident.ctxt.outer();
+        (unresolved_outer_mark != Mark::root()).then_some(unresolved_outer_mark)
+    }
+
+    fn mark_ident_for_implicit_global_rewrite(&mut self, ident: &mut Ident) {
+        let Some(unresolved_outer_mark) =
+            self.unresolved_outer_mark_for_implicit_global_rewrite(ident)
+        else {
+            return;
+        };
+
+        let child_mark = self
+            .implicit_global_rewrite_marks
+            .entry(unresolved_outer_mark)
+            .or_insert_with(|| Mark::fresh(unresolved_outer_mark));
+        ident.ctxt = ident.ctxt.apply_mark(*child_mark);
+    }
+
+    fn is_marked_for_implicit_global_rewrite(&self, ident: &Ident) -> bool {
+        self.implicit_global_rewrite_marks
+            .values()
+            .any(|&mark| ident.ctxt.has_mark(mark))
     }
 
     fn maybe_to_property_key(&self, expr: Expr) -> Expr {
@@ -2098,6 +2053,7 @@ impl DecoratorPass {
 
                 let mut key_expr = self.maybe_to_property_key(prop_name_to_expr_value(name.take()));
                 self.maybe_alias_current_class_name_expr(&mut key_expr);
+                self.rewrite_implicit_globals_in_expr(&mut key_expr);
                 let prefer_class_key = self.should_queue_class_key_init(&key_expr, true);
 
                 self.queue_pre_class_init(
@@ -2163,6 +2119,12 @@ impl VisitMut for DecoratorPass {
         self.current_class_name = n.ident.clone();
         n.class.visit_mut_with(self);
         self.current_class_name = old_name;
+    }
+
+    fn visit_mut_ident(&mut self, n: &mut Ident) {
+        if self.in_implicit_global_rewrite_expr {
+            self.mark_ident_for_implicit_global_rewrite(n);
+        }
     }
 
     fn visit_mut_class(&mut self, n: &mut Class) {
@@ -3162,6 +3124,39 @@ impl VisitMut for DecoratorPass {
     }
 
     fn visit_mut_expr(&mut self, e: &mut Expr) {
+        if let Expr::Assign(assign) = e {
+            assign.left.visit_mut_with(self);
+            assign.right.visit_mut_with(self);
+
+            if self.is_2023_11() && assign.op == op!("=") {
+                if let AssignTarget::Simple(SimpleAssignTarget::Ident(binding)) = &assign.left {
+                    let id = &binding.id;
+                    if self.is_marked_for_implicit_global_rewrite(id) {
+                        self.implicit_globals.insert(id.sym.clone());
+                        assign.left = AssignTarget::Simple(SimpleAssignTarget::Member(
+                            self.global_this_member_expr(id.sym.clone(), id.span),
+                        ));
+                    }
+                }
+            }
+
+            return;
+        }
+
+        if let Expr::Ident(ident) = e {
+            self.visit_mut_ident(ident);
+
+            if self.is_2023_11()
+                && self.is_marked_for_implicit_global_rewrite(ident)
+                && self.implicit_globals.contains(&ident.sym)
+            {
+                *e = self
+                    .global_this_member_expr(ident.sym.clone(), ident.span)
+                    .into();
+            }
+            return;
+        }
+
         if let Expr::Class(c) = e {
             if !c.class.decorators.is_empty() {
                 let new = self.handle_class_expr(&mut c.class, c.ident.as_ref());
@@ -3235,12 +3230,6 @@ impl VisitMut for DecoratorPass {
     }
 
     fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
-        if self.is_2023_11() && self.module_items_have_decorators(n) {
-            n.visit_mut_with(&mut ImplicitGlobalUsageRewriter {
-                implicit_globals: &mut self.implicit_globals,
-            });
-        }
-
         let extra_vars = self.extra_vars.take();
         let extra_lets = self.extra_lets.take();
         let pre_class_inits = self.pre_class_inits.take();
@@ -3577,12 +3566,6 @@ impl VisitMut for DecoratorPass {
     }
 
     fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
-        if self.is_2023_11() && self.stmts_have_decorators(n) {
-            n.visit_mut_with(&mut ImplicitGlobalUsageRewriter {
-                implicit_globals: &mut self.implicit_globals,
-            });
-        }
-
         let old_state = take(&mut self.state);
         let old_pre_class_inits = self.pre_class_inits.take();
         let old_extra_lets = self.extra_lets.take();

--- a/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
@@ -265,6 +265,81 @@ impl DecoratorPass {
         }
     }
 
+    fn rewrite_implicit_globals_in_prop_name_expr(&mut self, name: &mut PropName) {
+        if let PropName::Computed(computed) = name {
+            computed.expr.visit_mut_with(self);
+        }
+    }
+
+    fn rewrite_implicit_globals_in_key_expr(&mut self, key: &mut Key) {
+        if let Key::Public(name) = key {
+            self.rewrite_implicit_globals_in_prop_name_expr(name);
+        }
+    }
+
+    fn rewrite_implicit_globals_in_class_member_exprs(&mut self, member: &mut ClassMember) {
+        match member {
+            ClassMember::ClassProp(prop) => {
+                self.rewrite_implicit_globals_in_prop_name_expr(&mut prop.key);
+                for decorator in &mut prop.decorators {
+                    decorator.expr.visit_mut_with(self);
+                }
+                if prop.is_static {
+                    if let Some(value) = &mut prop.value {
+                        value.visit_mut_with(self);
+                    }
+                }
+            }
+            ClassMember::PrivateProp(prop) => {
+                for decorator in &mut prop.decorators {
+                    decorator.expr.visit_mut_with(self);
+                }
+                if prop.is_static {
+                    if let Some(value) = &mut prop.value {
+                        value.visit_mut_with(self);
+                    }
+                }
+            }
+            ClassMember::Method(method) => {
+                self.rewrite_implicit_globals_in_prop_name_expr(&mut method.key);
+                for decorator in &mut method.function.decorators {
+                    decorator.expr.visit_mut_with(self);
+                }
+            }
+            ClassMember::PrivateMethod(method) => {
+                for decorator in &mut method.function.decorators {
+                    decorator.expr.visit_mut_with(self);
+                }
+            }
+            ClassMember::AutoAccessor(accessor) => {
+                self.rewrite_implicit_globals_in_key_expr(&mut accessor.key);
+                for decorator in &mut accessor.decorators {
+                    decorator.expr.visit_mut_with(self);
+                }
+                if accessor.is_static {
+                    if let Some(value) = &mut accessor.value {
+                        value.visit_mut_with(self);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn rewrite_implicit_globals_in_class_expr(&mut self, class_expr: &mut ClassExpr) {
+        for decorator in &mut class_expr.class.decorators {
+            decorator.expr.visit_mut_with(self);
+        }
+
+        if let Some(super_class) = &mut class_expr.class.super_class {
+            super_class.visit_mut_with(self);
+        }
+
+        for member in &mut class_expr.class.body {
+            self.rewrite_implicit_globals_in_class_member_exprs(member);
+        }
+    }
+
     fn maybe_to_property_key(&self, expr: Expr) -> Expr {
         if self.is_2023_11() {
             CallExpr {
@@ -3223,12 +3298,14 @@ impl VisitMut for DecoratorPass {
         }
 
         if self.in_implicit_global_rewrite_expr {
-            // Keep rewrite mode side-effect free. We only want mark-gated
-            // implicit-global rewrites, not decorator/class transformations.
-            if e.is_class() {
+            if let Expr::Class(class_expr) = e {
+                // Traverse class-expression evaluation-time subexpressions
+                // without invoking the main decorator/class transform flow.
+                self.rewrite_implicit_globals_in_class_expr(class_expr);
                 return;
             }
 
+            // Keep rewrite mode traversal local to this expression.
             maybe_grow_default(|| e.visit_mut_children_with(self));
             return;
         }

--- a/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
@@ -8,8 +8,8 @@ use swc_ecma_transforms_base::{helper, helper_expr};
 use swc_ecma_transforms_classes::super_field::SuperFieldAccessFolder;
 use swc_ecma_utils::{
     alias_ident_for, constructor::inject_after_super, default_constructor_with_span,
-    is_maybe_branch_directive, private_ident, prop_name_to_expr_value, quote_ident, replace_ident,
-    stack_size::maybe_grow_default, ExprFactory, IdentRenamer,
+    for_each_binding_ident, is_maybe_branch_directive, private_ident, prop_name_to_expr_value,
+    quote_ident, replace_ident, stack_size::maybe_grow_default, ExprFactory, IdentRenamer,
 };
 use swc_ecma_visit::{
     noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith, VisitWith,
@@ -224,14 +224,17 @@ impl DecoratorPass {
         var_decl: &mut VarDecl,
     ) {
         for decl in &mut var_decl.decls {
-            let Pat::Ident(name) = &decl.name else {
-                continue;
-            };
+            let mut is_decorator_binding = false;
+            for_each_binding_ident(&decl.name, |binding| {
+                if self
+                    .decorator_binding_ids_for_implicit_global_rewrite
+                    .contains(&binding.id.to_id())
+                {
+                    is_decorator_binding = true;
+                }
+            });
 
-            if !self
-                .decorator_binding_ids_for_implicit_global_rewrite
-                .contains(&name.id.to_id())
-            {
+            if !is_decorator_binding {
                 continue;
             }
 

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/decorator-binding-destructuring-init/input.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/decorator-binding-destructuring-init/input.js
@@ -1,0 +1,8 @@
+function init() {}
+
+const { dec } = (x = init(), {
+  dec: init,
+});
+
+@dec
+class C {}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/decorator-binding-destructuring-init/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/decorator-binding-destructuring-init/output.js
@@ -1,0 +1,17 @@
+let _initClass;
+function init() {}
+const { dec } = (globalThis.x = init(), {
+    dec: init
+});
+let _C, _C_member;
+class C {
+    static{
+        ({ c: [_C, _initClass] } = _apply_decs_2311(this, [
+            dec
+        ], []));
+    }
+    static{
+        _initClass();
+        _C_member = _C;
+    }
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/decorator-lifted-unbound-assignment/input.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/decorator-lifted-unbound-assignment/input.js
@@ -1,0 +1,4 @@
+function dec() {}
+
+@(x = dec, x)
+class A {}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/decorator-lifted-unbound-assignment/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/decorator-lifted-unbound-assignment/output.js
@@ -1,0 +1,15 @@
+let _dec, _initClass;
+function dec() {}
+_dec = (globalThis.x = dec, globalThis.x);
+let _A, _A_member;
+class A {
+    static{
+        ({ c: [_A, _initClass] } = _apply_decs_2311(this, [
+            _dec
+        ], []));
+    }
+    static{
+        _initClass();
+        _A_member = _A;
+    }
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/no-decorators-unbound-assignment/input.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/no-decorators-unbound-assignment/input.js
@@ -1,0 +1,1 @@
+__webpack_nonce__ = "CSP_NONCE_PLACEHOLDER";

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/no-decorators-unbound-assignment/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/no-decorators-unbound-assignment/output.js
@@ -1,0 +1,1 @@
+__webpack_nonce__ = "CSP_NONCE_PLACEHOLDER";


### PR DESCRIPTION
## Summary

Fixes #11742.

This change scopes the 2023-11 implicit-global rewrite to only decorator-related lifted/reordered expressions.

- remove the global implicit-global rewrite branch from `DecoratorPass::visit_mut_expr`
- add an expression-local rewriter (`ImplicitGlobalUsageRewriter`) for unresolved assignment/reference rewriting to `globalThis`
- apply the local rewriter only at 2023-11 decorator lifting points (`super` aliasing, decorator expression preservation, computed key pre-init)
- keep 2022-03 behavior unchanged
- add regression fixtures for:
  - decorator proposal fixture (`2023-11-misc/no-decorators-unbound-assignment`)
  - swc projects fixture (`issues-11xxx/11742`)

## Test

- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_transforms_proposal`
- `cargo test -p swc_ecma_transforms_proposal`
- `cargo test -p swc --test projects -- issues-11xxx/11742` (filter matched 0 tests)
- `cargo test -p swc --test projects fixture_tests__fixture__issues_11xxx__11742__input -- --ignored`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
