### PR TITLE
feat(react-compiler): improve Stage A diagnostic parity and validation aggregation

### DIFF
--- a/crates/swc_ecma_react_compiler/src/entrypoint/imports.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/imports.rs
@@ -68,10 +68,10 @@ pub fn validate_restricted_imports(
         {
             let mut detail = CompilerErrorDetail::error(
                 ErrorCategory::Todo,
-                "Bailing out due to blocklisted import",
+                "Todo: Bailing out due to blocklisted import",
             );
             detail.description = Some(format!(
-                "Import from module {}",
+                "Import from module {}.",
                 import_decl.src.value.to_string_lossy()
             ));
             detail.loc = Some(import_decl.span);

--- a/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/program.rs
@@ -242,10 +242,19 @@ pub fn compile_fn(
     let mut normalized = function.clone();
     normalize_function_params_for_lowering(&mut normalized);
     let mut hir = crate::hir::lower(&normalized, id, fn_type)?;
+    let mut validation_errors = CompilerError::new();
+    let mut collect_validation_error = |result: Result<(), CompilerError>| {
+        if let Err(err) = result {
+            validation_errors.extend(err);
+        }
+    };
 
     optimization::prune_maybe_throws(&mut hir);
-    validation::validate_context_variable_lvalues(&hir)?;
-    validation::validate_use_memo(&hir, opts.environment.validate_no_void_use_memo)?;
+    collect_validation_error(validation::validate_context_variable_lvalues(&hir));
+    collect_validation_error(validation::validate_use_memo(
+        &hir,
+        opts.environment.validate_no_void_use_memo,
+    ));
     inference::drop_manual_memoization(&mut hir);
     inference::inline_immediately_invoked_function_expressions(&mut hir);
 
@@ -256,13 +265,13 @@ pub fn compile_fn(
     inference::infer_types(&mut hir);
 
     if opts.environment.validate_hooks_usage {
-        validation::validate_hooks_usage(&hir)?;
+        collect_validation_error(validation::validate_hooks_usage(&hir));
     }
     if opts.environment.validate_no_impure_functions_in_render {
-        validation::validate_no_impure_functions_in_render(&hir)?;
+        collect_validation_error(validation::validate_no_impure_functions_in_render(&hir));
     }
     if opts.environment.validate_no_capitalized_calls.is_some() {
-        validation::validate_no_capitalized_calls(&hir)?;
+        collect_validation_error(validation::validate_no_capitalized_calls(&hir));
     }
 
     optimization::optimize_props_method_calls(&mut hir);
@@ -279,16 +288,20 @@ pub fn compile_fn(
     inference::infer_mutation_aliasing_ranges(&mut hir);
     // Upstream runs this validation unconditionally and reserves
     // `assert_valid_mutable_ranges` for additional internal checks.
-    validation::validate_locals_not_reassigned_after_render(&hir)?;
+    collect_validation_error(validation::validate_locals_not_reassigned_after_render(
+        &hir,
+    ));
 
     if opts.environment.validate_ref_access_during_render {
-        validation::validate_no_ref_access_in_render(&hir)?;
+        collect_validation_error(validation::validate_no_ref_access_in_render(&hir));
     }
     if opts.environment.validate_no_set_state_in_render {
-        validation::validate_no_set_state_in_render(&hir)?;
+        collect_validation_error(validation::validate_no_set_state_in_render(&hir));
     }
     if opts.environment.validate_no_derived_computations_in_effects {
-        validation::validate_no_derived_computations_in_effects(&hir)?;
+        collect_validation_error(validation::validate_no_derived_computations_in_effects(
+            &hir,
+        ));
     }
     if opts.environment.validate_no_set_state_in_effects && output_mode == CompilerOutputMode::Lint
     {
@@ -303,7 +316,9 @@ pub fn compile_fn(
         .environment
         .validate_no_freezing_known_mutable_functions
     {
-        validation::validate_no_freezing_known_mutable_functions(&hir)?;
+        collect_validation_error(validation::validate_no_freezing_known_mutable_functions(
+            &hir,
+        ));
     }
 
     inference::infer_reactive_places(&mut hir);
@@ -316,12 +331,12 @@ pub fn compile_fn(
             .validate_exhaustive_effect_dependencies
             .is_enabled()
     {
-        validation::validate_exhaustive_dependencies(
+        collect_validation_error(validation::validate_exhaustive_dependencies(
             &hir,
             opts.environment
                 .validate_exhaustive_memoization_dependencies,
             opts.environment.validate_exhaustive_effect_dependencies,
-        )?;
+        ));
     }
     ssa::rewrite_instruction_kinds_based_on_reassignment(&mut hir);
 
@@ -345,16 +360,19 @@ pub fn compile_fn(
             .environment
             .validate_preserve_existing_memoization_guarantees
     {
-        validation::validate_preserved_manual_memoization(&hir)?;
+        collect_validation_error(validation::validate_preserved_manual_memoization(&hir));
     }
     if opts.environment.validate_static_components && output_mode == CompilerOutputMode::Lint {
         let _ = validation::validate_static_components(&hir);
     }
     if opts.environment.validate_source_locations {
-        validation::validate_source_locations(&hir)?;
+        collect_validation_error(validation::validate_source_locations(&hir));
     }
     if opts.environment.throw_unknown_exception_testonly {
         panic!("unexpected error");
+    }
+    if validation_errors.has_any_errors() {
+        return Err(validation_errors);
     }
 
     Ok(reactive_scopes::codegen_function(reactive))

--- a/crates/swc_ecma_react_compiler/src/entrypoint/suppression.rs
+++ b/crates/swc_ecma_react_compiler/src/entrypoint/suppression.rs
@@ -160,13 +160,13 @@ pub fn suppressions_to_compiler_error(suppression_ranges: &[SuppressionRange]) -
     for suppression in suppression_ranges {
         let (reason, suggestion) = match suppression.source {
             SuppressionSource::Eslint => (
-                "React Compiler skipped optimizing this function because one or more React ESLint \
-                 rules were disabled",
+                "React Compiler has skipped optimizing this component because one or more React \
+                 ESLint rules were disabled",
                 "Remove the ESLint suppression and address the React error",
             ),
             SuppressionSource::Flow => (
-                "React Compiler skipped optimizing this function because one or more React rule \
-                 violations were reported by Flow",
+                "React Compiler has skipped optimizing this component because one or more React \
+                 rule violations were reported by Flow",
                 "Remove the Flow suppression and address the React error",
             ),
         };

--- a/crates/swc_ecma_react_compiler/src/options.rs
+++ b/crates/swc_ecma_react_compiler/src/options.rs
@@ -243,7 +243,8 @@ impl Default for EnvironmentConfig {
             enable_custom_type_definition_for_reanimated: false,
             enable_treat_ref_like_identifiers_as_refs: true,
             enable_treat_set_identifiers_as_state_setters: false,
-            validate_no_void_use_memo: true,
+            // Upstream defaults this check to off unless explicitly enabled.
+            validate_no_void_use_memo: false,
             custom_macros: None,
             enable_forest: false,
             enable_reset_cache_on_source_file_changes: None,

--- a/crates/swc_ecma_react_compiler/src/validation/validate_context_variable_lvalues.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/validate_context_variable_lvalues.rs
@@ -1,5 +1,6 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
+use swc_common::Spanned;
 use swc_ecma_ast::{
     op, AssignExpr, AssignTarget, Callee, Expr, MemberExpr, MemberProp, Pat, Stmt, UpdateExpr,
 };
@@ -8,6 +9,7 @@ use swc_ecma_visit::{Visit, VisitWith};
 use crate::{
     error::{CompilerError, CompilerErrorDetail, ErrorCategory},
     hir::HirFunction,
+    utils::is_hook_name,
 };
 
 const GLOBAL_REASSIGN_REASON: &str =
@@ -17,6 +19,13 @@ const FROZEN_JSX_DESCRIPTION: &str = "Modifying a value used previously in JSX i
                                       Consider moving the modification before the JSX.";
 const FROZEN_PROP_DESCRIPTION: &str = "Modifying component props or hook arguments is not \
                                        allowed. Consider using a local variable instead.";
+const HOOK_RETURN_MUTATION_DESCRIPTION: &str = "Modifying a value returned from a hook is not \
+                                                allowed. Consider moving the modification into \
+                                                the hook where the value is constructed.";
+const GLOBAL_MUTATION_DESCRIPTION: &str = "Modifying a variable defined outside a component or \
+                                           hook is not allowed. Consider using an effect.";
+const TODO_UPDATE_GLOBAL_REASON: &str =
+    "Todo: (BuildHIR::lowerExpression) Support UpdateExpression where argument is a global";
 
 pub fn validate_context_variable_lvalues(hir: &HirFunction) -> Result<(), CompilerError> {
     let Some(body) = hir.function.body.as_ref() else {
@@ -27,9 +36,13 @@ pub fn validate_context_variable_lvalues(hir: &HirFunction) -> Result<(), Compil
     for param in &hir.function.params {
         collect_pat_bindings(&param.pat, &mut params);
     }
+    let param_aliases = collect_param_aliases(body, &params);
+    params.extend(param_aliases);
 
     let mut locals = params.clone();
     collect_block_bindings(body, &mut locals);
+    let top_level_function_bindings = collect_top_level_function_bindings(body);
+    let hook_return_bindings = collect_hook_return_bindings(body);
 
     let mut frozen_from_jsx = HashSet::<String>::new();
     let mut errors = Vec::<CompilerErrorDetail>::new();
@@ -42,7 +55,19 @@ pub fn validate_context_variable_lvalues(hir: &HirFunction) -> Result<(), Compil
             if params.contains(mutation.target.as_str()) {
                 errors.push(modification_error(
                     mutation.span,
+                    mutation.target.as_str(),
                     Some(FROZEN_PROP_DESCRIPTION),
+                ));
+                continue;
+            }
+
+            if hook_return_bindings.contains(mutation.target.as_str())
+                && mutation.kind == MutationKind::Property
+            {
+                errors.push(modification_error(
+                    mutation.span,
+                    mutation.target.as_str(),
+                    Some(HOOK_RETURN_MUTATION_DESCRIPTION),
                 ));
                 continue;
             }
@@ -50,20 +75,67 @@ pub fn validate_context_variable_lvalues(hir: &HirFunction) -> Result<(), Compil
             if frozen_from_jsx.contains(mutation.target.as_str()) {
                 errors.push(modification_error(
                     mutation.span,
+                    mutation.target.as_str(),
                     Some(FROZEN_JSX_DESCRIPTION),
                 ));
                 continue;
             }
 
             if !locals.contains(mutation.target.as_str()) && !is_known_global(&mutation.target) {
-                errors.push(global_reassign_error(mutation.span));
+                match mutation.kind {
+                    MutationKind::Direct => errors.push(global_reassign_error(mutation.span)),
+                    MutationKind::Property => errors.push(modification_error(
+                        mutation.span,
+                        mutation.target.as_str(),
+                        Some(GLOBAL_MUTATION_DESCRIPTION),
+                    )),
+                    MutationKind::GlobalUpdate => {
+                        errors.push(global_update_todo_error(mutation.span))
+                    }
+                }
             }
         }
 
         let mut jsx_refs = HashSet::<String>::new();
         collect_jsx_refs(stmt, &mut jsx_refs);
         frozen_from_jsx.extend(jsx_refs);
+
+        let mut render_invoked_names = HashSet::<String>::new();
+        collect_render_invoked_function_names(stmt, &mut render_invoked_names);
+        for name in render_invoked_names {
+            let Some(function_like) = top_level_function_bindings.get(name.as_str()) else {
+                continue;
+            };
+            let mut fn_mutations = Vec::<Mutation>::new();
+            collect_function_like_mutations(function_like, &mut fn_mutations);
+            for mutation in fn_mutations {
+                if params.contains(mutation.target.as_str()) {
+                    errors.push(modification_error(
+                        mutation.span,
+                        mutation.target.as_str(),
+                        Some(FROZEN_PROP_DESCRIPTION),
+                    ));
+                    continue;
+                }
+                if !locals.contains(mutation.target.as_str()) && !is_known_global(&mutation.target)
+                {
+                    match mutation.kind {
+                        MutationKind::Direct => errors.push(global_reassign_error(mutation.span)),
+                        MutationKind::Property => errors.push(modification_error(
+                            mutation.span,
+                            mutation.target.as_str(),
+                            Some(GLOBAL_MUTATION_DESCRIPTION),
+                        )),
+                        MutationKind::GlobalUpdate => {
+                            errors.push(global_update_todo_error(mutation.span))
+                        }
+                    }
+                }
+            }
+        }
     }
+
+    collect_effect_callback_param_mutation_errors(body, &params, &mut errors);
 
     if errors.is_empty() {
         Ok(())
@@ -76,6 +148,14 @@ pub fn validate_context_variable_lvalues(hir: &HirFunction) -> Result<(), Compil
 struct Mutation {
     target: String,
     span: swc_common::Span,
+    kind: MutationKind,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MutationKind {
+    Direct,
+    Property,
+    GlobalUpdate,
 }
 
 fn global_reassign_error(span: swc_common::Span) -> CompilerErrorDetail {
@@ -85,10 +165,25 @@ fn global_reassign_error(span: swc_common::Span) -> CompilerErrorDetail {
     detail
 }
 
-fn modification_error(span: swc_common::Span, description: Option<&str>) -> CompilerErrorDetail {
+fn global_update_todo_error(span: swc_common::Span) -> CompilerErrorDetail {
+    let mut detail = CompilerErrorDetail::error(ErrorCategory::Todo, TODO_UPDATE_GLOBAL_REASON);
+    detail.loc = Some(span);
+    detail
+}
+
+fn modification_error(
+    span: swc_common::Span,
+    target: &str,
+    description: Option<&str>,
+) -> CompilerErrorDetail {
     let mut detail = CompilerErrorDetail::error(ErrorCategory::Immutability, FROZEN_VALUE_REASON);
     detail.description = description.map(str::to_string);
     detail.loc = Some(span);
+    if is_ref_like_name(target) {
+        detail.suggestions = Some(vec!["If this value is a Ref (value returned by \
+                                        `useRef()`), rename the variable to end in \"Ref\"."
+            .to_string()]);
+    }
     detail
 }
 
@@ -165,10 +260,11 @@ fn collect_stmt_mutations(stmt: &Stmt, out: &mut Vec<Mutation>) {
     }
 
     impl Finder<'_> {
-        fn push(&mut self, target: &str, span: swc_common::Span) {
+        fn push(&mut self, target: &str, span: swc_common::Span, kind: MutationKind) {
             self.out.push(Mutation {
                 target: target.to_string(),
                 span,
+                kind,
             });
         }
     }
@@ -188,11 +284,11 @@ fn collect_stmt_mutations(stmt: &Stmt, out: &mut Vec<Mutation>) {
             match &assign.left {
                 AssignTarget::Simple(simple) => match simple {
                     swc_ecma_ast::SimpleAssignTarget::Ident(binding) => {
-                        self.push(binding.id.sym.as_ref(), assign.span);
+                        self.push(binding.id.sym.as_ref(), assign.span, MutationKind::Direct);
                     }
                     swc_ecma_ast::SimpleAssignTarget::Member(member) => {
                         if let Some(name) = member_root_ident(member) {
-                            self.push(name, assign.span);
+                            self.push(name, assign.span, MutationKind::Property);
                         }
                     }
                     _ => {}
@@ -207,11 +303,11 @@ fn collect_stmt_mutations(stmt: &Stmt, out: &mut Vec<Mutation>) {
         fn visit_update_expr(&mut self, update: &UpdateExpr) {
             match &*update.arg {
                 Expr::Ident(ident) => {
-                    self.push(ident.sym.as_ref(), update.span);
+                    self.push(ident.sym.as_ref(), update.span, MutationKind::GlobalUpdate);
                 }
                 Expr::Member(member) => {
                     if let Some(name) = member_root_ident(member) {
-                        self.push(name, update.span);
+                        self.push(name, update.span, MutationKind::Property);
                     }
                 }
                 _ => {}
@@ -223,7 +319,7 @@ fn collect_stmt_mutations(stmt: &Stmt, out: &mut Vec<Mutation>) {
             if unary.op == op!("delete") {
                 if let Expr::Member(member) = &*unary.arg {
                     if let Some(name) = member_root_ident(member) {
-                        self.push(name, unary.span);
+                        self.push(name, unary.span, MutationKind::Property);
                     }
                 }
             }
@@ -232,7 +328,7 @@ fn collect_stmt_mutations(stmt: &Stmt, out: &mut Vec<Mutation>) {
 
         fn visit_call_expr(&mut self, call: &swc_ecma_ast::CallExpr) {
             if let Some(name) = mutating_method_target(call) {
-                self.push(name, call.span);
+                self.push(name, call.span, MutationKind::Property);
             }
             call.visit_children_with(self);
         }
@@ -259,6 +355,7 @@ fn collect_assign_pat_targets(
                         out.push(Mutation {
                             target: assign.key.id.sym.to_string(),
                             span,
+                            kind: MutationKind::Direct,
                         });
                     }
                     swc_ecma_ast::ObjectPatProp::KeyValue(key_value) => {
@@ -279,6 +376,7 @@ fn collect_mutation_targets_from_pat(pat: &Pat, out: &mut Vec<Mutation>, span: s
         Pat::Ident(binding) => out.push(Mutation {
             target: binding.id.sym.to_string(),
             span,
+            kind: MutationKind::Direct,
         }),
         Pat::Array(array) => {
             for elem in array.elems.iter().flatten() {
@@ -291,6 +389,7 @@ fn collect_mutation_targets_from_pat(pat: &Pat, out: &mut Vec<Mutation>, span: s
                     swc_ecma_ast::ObjectPatProp::Assign(assign) => out.push(Mutation {
                         target: assign.key.id.sym.to_string(),
                         span,
+                        kind: MutationKind::Direct,
                     }),
                     swc_ecma_ast::ObjectPatProp::KeyValue(key_value) => {
                         collect_mutation_targets_from_pat(&key_value.value, out, span);
@@ -307,12 +406,14 @@ fn collect_mutation_targets_from_pat(pat: &Pat, out: &mut Vec<Mutation>, span: s
             Expr::Ident(ident) => out.push(Mutation {
                 target: ident.sym.to_string(),
                 span,
+                kind: MutationKind::Direct,
             }),
             Expr::Member(member) => {
                 if let Some(name) = member_root_ident(member) {
                     out.push(Mutation {
                         target: name.to_string(),
                         span,
+                        kind: MutationKind::Property,
                     });
                 }
             }
@@ -449,4 +550,302 @@ fn is_known_global(name: &str) -> bool {
             | "Infinity"
             | "undefined"
     )
+}
+
+#[derive(Debug, Clone)]
+enum FunctionLike {
+    Function(swc_ecma_ast::Function),
+    Arrow(swc_ecma_ast::ArrowExpr),
+}
+
+fn collect_top_level_function_bindings(
+    body: &swc_ecma_ast::BlockStmt,
+) -> HashMap<String, FunctionLike> {
+    let mut out = HashMap::<String, FunctionLike>::new();
+
+    for stmt in &body.stmts {
+        let Stmt::Decl(swc_ecma_ast::Decl::Var(var_decl)) = stmt else {
+            continue;
+        };
+
+        for decl in &var_decl.decls {
+            let Pat::Ident(binding) = &decl.name else {
+                continue;
+            };
+            let Some(init) = &decl.init else {
+                continue;
+            };
+            match &**init {
+                Expr::Fn(fn_expr) => {
+                    out.insert(
+                        binding.id.sym.to_string(),
+                        FunctionLike::Function(*fn_expr.function.clone()),
+                    );
+                }
+                Expr::Arrow(arrow) => {
+                    out.insert(
+                        binding.id.sym.to_string(),
+                        FunctionLike::Arrow(arrow.clone()),
+                    );
+                }
+                _ => {}
+            }
+        }
+    }
+
+    out
+}
+
+fn collect_hook_return_bindings(body: &swc_ecma_ast::BlockStmt) -> HashSet<String> {
+    let mut out = HashSet::<String>::new();
+
+    for stmt in &body.stmts {
+        let Stmt::Decl(swc_ecma_ast::Decl::Var(var_decl)) = stmt else {
+            continue;
+        };
+
+        for decl in &var_decl.decls {
+            let Pat::Ident(binding) = &decl.name else {
+                continue;
+            };
+            let Some(init) = &decl.init else {
+                continue;
+            };
+            let Expr::Call(call) = &**init else {
+                continue;
+            };
+            let Callee::Expr(callee) = &call.callee else {
+                continue;
+            };
+
+            let hook_name = match &**callee {
+                Expr::Ident(ident) => Some(ident.sym.as_ref()),
+                Expr::Member(member) => match &member.prop {
+                    MemberProp::Ident(prop) => Some(prop.sym.as_ref()),
+                    _ => None,
+                },
+                _ => None,
+            };
+
+            if hook_name.is_some_and(|name| is_hook_name(name) && name != "useRef") {
+                out.insert(binding.id.sym.to_string());
+            }
+        }
+    }
+
+    out
+}
+
+fn collect_param_aliases(
+    body: &swc_ecma_ast::BlockStmt,
+    params: &HashSet<String>,
+) -> HashSet<String> {
+    let mut out = HashSet::<String>::new();
+
+    for stmt in &body.stmts {
+        let Stmt::Decl(swc_ecma_ast::Decl::Var(var_decl)) = stmt else {
+            continue;
+        };
+        if !matches!(var_decl.kind, swc_ecma_ast::VarDeclKind::Const) {
+            continue;
+        }
+        for decl in &var_decl.decls {
+            let Some(init) = &decl.init else {
+                continue;
+            };
+            if !init_aliases_param(init, params) {
+                continue;
+            }
+            collect_pat_bindings(&decl.name, &mut out);
+        }
+    }
+
+    out
+}
+
+fn init_aliases_param(init: &Expr, params: &HashSet<String>) -> bool {
+    match init {
+        Expr::Ident(ident) => params.contains(ident.sym.as_ref()),
+        Expr::Cond(cond) => match &*cond.alt {
+            Expr::Ident(ident) => params.contains(ident.sym.as_ref()),
+            _ => false,
+        },
+        _ => false,
+    }
+}
+
+fn collect_function_like_mutations(function_like: &FunctionLike, out: &mut Vec<Mutation>) {
+    match function_like {
+        FunctionLike::Function(function) => {
+            let Some(body) = function.body.as_ref() else {
+                return;
+            };
+            for stmt in &body.stmts {
+                collect_stmt_mutations(stmt, out);
+            }
+        }
+        FunctionLike::Arrow(arrow) => match &*arrow.body {
+            swc_ecma_ast::BlockStmtOrExpr::BlockStmt(body) => {
+                for stmt in &body.stmts {
+                    collect_stmt_mutations(stmt, out);
+                }
+            }
+            swc_ecma_ast::BlockStmtOrExpr::Expr(expr) => {
+                let stmt = Stmt::Expr(swc_ecma_ast::ExprStmt {
+                    span: expr.span(),
+                    expr: expr.clone(),
+                });
+                collect_stmt_mutations(&stmt, out);
+            }
+        },
+    }
+}
+
+fn collect_render_invoked_function_names(stmt: &Stmt, out: &mut HashSet<String>) {
+    struct Finder<'a> {
+        out: &'a mut HashSet<String>,
+        jsx_attr_depth: usize,
+        jsx_child_expr_depth: usize,
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_function(&mut self, _: &swc_ecma_ast::Function) {}
+
+        fn visit_arrow_expr(&mut self, _: &swc_ecma_ast::ArrowExpr) {}
+
+        fn visit_jsx_opening_element(&mut self, opening: &swc_ecma_ast::JSXOpeningElement) {
+            if let swc_ecma_ast::JSXElementName::Ident(ident) = &opening.name {
+                self.out.insert(ident.sym.to_string());
+            }
+            opening.visit_children_with(self);
+        }
+
+        fn visit_jsx_attr(&mut self, attr: &swc_ecma_ast::JSXAttr) {
+            self.jsx_attr_depth += 1;
+            attr.visit_children_with(self);
+            self.jsx_attr_depth -= 1;
+        }
+
+        fn visit_jsx_expr_container(&mut self, expr: &swc_ecma_ast::JSXExprContainer) {
+            if self.jsx_attr_depth == 0 {
+                self.jsx_child_expr_depth += 1;
+                expr.visit_children_with(self);
+                self.jsx_child_expr_depth -= 1;
+                return;
+            }
+            expr.visit_children_with(self);
+        }
+
+        fn visit_ident(&mut self, ident: &swc_ecma_ast::Ident) {
+            if self.jsx_child_expr_depth > 0 {
+                self.out.insert(ident.sym.to_string());
+            }
+        }
+
+        fn visit_member_expr(&mut self, member: &MemberExpr) {
+            if self.jsx_child_expr_depth > 0 {
+                if let Some(root) = member_root_ident(member) {
+                    self.out.insert(root.to_string());
+                }
+            }
+            member.visit_children_with(self);
+        }
+    }
+
+    stmt.visit_with(&mut Finder {
+        out,
+        jsx_attr_depth: 0,
+        jsx_child_expr_depth: 0,
+    });
+}
+
+fn collect_effect_callback_param_mutation_errors(
+    body: &swc_ecma_ast::BlockStmt,
+    params: &HashSet<String>,
+    errors: &mut Vec<CompilerErrorDetail>,
+) {
+    struct Finder<'a> {
+        params: &'a HashSet<String>,
+        errors: &'a mut Vec<CompilerErrorDetail>,
+    }
+
+    impl Finder<'_> {
+        fn inspect_effect_callback_arg(&mut self, arg: &Expr) {
+            let mut mutations = Vec::<Mutation>::new();
+            match arg {
+                Expr::Fn(fn_expr) => {
+                    if let Some(body) = fn_expr.function.body.as_ref() {
+                        for stmt in &body.stmts {
+                            collect_stmt_mutations(stmt, &mut mutations);
+                        }
+                    }
+                }
+                Expr::Arrow(arrow) => match &*arrow.body {
+                    swc_ecma_ast::BlockStmtOrExpr::BlockStmt(body) => {
+                        for stmt in &body.stmts {
+                            collect_stmt_mutations(stmt, &mut mutations);
+                        }
+                    }
+                    swc_ecma_ast::BlockStmtOrExpr::Expr(expr) => {
+                        let stmt = Stmt::Expr(swc_ecma_ast::ExprStmt {
+                            span: expr.span(),
+                            expr: expr.clone(),
+                        });
+                        collect_stmt_mutations(&stmt, &mut mutations);
+                    }
+                },
+                _ => return,
+            }
+
+            for mutation in mutations {
+                if self.params.contains(mutation.target.as_str()) {
+                    self.errors.push(modification_error(
+                        mutation.span,
+                        mutation.target.as_str(),
+                        Some(FROZEN_PROP_DESCRIPTION),
+                    ));
+                }
+            }
+        }
+    }
+
+    impl Visit for Finder<'_> {
+        fn visit_call_expr(&mut self, call: &swc_ecma_ast::CallExpr) {
+            let Callee::Expr(callee) = &call.callee else {
+                call.visit_children_with(self);
+                return;
+            };
+            let effect_like = match &**callee {
+                Expr::Ident(ident) => matches!(
+                    ident.sym.as_ref(),
+                    "useEffect" | "useLayoutEffect" | "useInsertionEffect"
+                ),
+                Expr::Member(member) => match &member.prop {
+                    MemberProp::Ident(ident) => matches!(
+                        ident.sym.as_ref(),
+                        "useEffect" | "useLayoutEffect" | "useInsertionEffect"
+                    ),
+                    _ => false,
+                },
+                _ => false,
+            };
+
+            if effect_like {
+                if let Some(first) = call.args.first() {
+                    if first.spread.is_none() {
+                        self.inspect_effect_callback_arg(&first.expr);
+                    }
+                }
+            }
+
+            call.visit_children_with(self);
+        }
+    }
+
+    body.visit_with(&mut Finder { params, errors });
+}
+
+fn is_ref_like_name(name: &str) -> bool {
+    let lower = name.to_ascii_lowercase();
+    lower == "ref" || lower.ends_with("ref")
 }

--- a/crates/swc_ecma_react_compiler/src/validation/validate_exhaustive_dependencies.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/validate_exhaustive_dependencies.rs
@@ -65,6 +65,10 @@ pub fn validate_exhaustive_dependencies(
 
             let inferred = collect_callback_dependencies(&callback_expr, self.outer_bindings);
             let inferred = dedup_dependencies(inferred);
+            let inferred = inferred
+                .into_iter()
+                .filter(|dep| !dep.path.iter().any(|segment| segment == "current"))
+                .collect::<Vec<_>>();
             let manual = dedup_dependencies(manual);
 
             let mut missing = Vec::new();

--- a/crates/swc_ecma_react_compiler/src/validation/validate_use_memo.rs
+++ b/crates/swc_ecma_react_compiler/src/validation/validate_use_memo.rs
@@ -366,9 +366,14 @@ fn assigns_outer_context(function_like: &FunctionLike, parent_bindings: &HashSet
                 body.visit_with(&mut finder);
             }
         }
-        FunctionLike::Arrow(arrow) => {
-            arrow.visit_with(&mut finder);
-        }
+        FunctionLike::Arrow(arrow) => match &*arrow.body {
+            swc_ecma_ast::BlockStmtOrExpr::BlockStmt(block) => {
+                block.visit_with(&mut finder);
+            }
+            swc_ecma_ast::BlockStmtOrExpr::Expr(expr) => {
+                expr.visit_with(&mut finder);
+            }
+        },
     }
     finder.assigns_outer
 }

--- a/crates/swc_ecma_react_compiler/tests/fixture.rs
+++ b/crates/swc_ecma_react_compiler/tests/fixture.rs
@@ -569,10 +569,23 @@ fn normalize_js_like(value: &str) -> String {
 }
 
 fn expected_error_reasons(expected: &str) -> Vec<String> {
+    const PREFIXES: &[&str] = &["Error: ", "Todo: ", "Invariant: ", "Compilation Skipped: "];
+
     expected
         .lines()
-        .filter_map(|line| line.trim().strip_prefix("Error: "))
-        .map(|reason| reason.trim().to_string())
+        .filter_map(|line| {
+            let trimmed = line.trim();
+            for prefix in PREFIXES {
+                if let Some(reason) = trimmed.strip_prefix(prefix) {
+                    let reason = reason.trim();
+                    if *prefix == "Error: " {
+                        return Some(reason.to_string());
+                    }
+                    return Some(format!("{prefix}{reason}"));
+                }
+            }
+            None
+        })
         .collect()
 }
 


### PR DESCRIPTION
## Summary
- improve Stage A diagnostic parity for `swc_ecma_react_compiler` fixtures
- align several diagnostic reason/description strings with upstream fixture expectations
- aggregate validation diagnostics in `compile_fn` so multiple validator errors can be reported together
- refine context-variable mutation validation (global/property/update handling and hook-return mutation behavior)
- fix useMemo outer-reassignment detection for arrow callbacks
- expand fixture error matching to handle non-`Error:` prefixes (`Todo`, `Invariant`, `Compilation Skipped`)

## Key Files
- `crates/swc_ecma_react_compiler/src/entrypoint/program.rs`
- `crates/swc_ecma_react_compiler/src/entrypoint/imports.rs`
- `crates/swc_ecma_react_compiler/src/options.rs`
- `crates/swc_ecma_react_compiler/src/validation/validate_context_variable_lvalues.rs`
- `crates/swc_ecma_react_compiler/src/validation/validate_use_memo.rs`
- `crates/swc_ecma_react_compiler/src/validation/validate_exhaustive_dependencies.rs`
- `crates/swc_ecma_react_compiler/tests/fixture.rs`

## Verification
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_react_compiler --test fixture fixture_cases_local`
- `cargo test -p swc_ecma_react_compiler --test fixture fixture_cases_upstream_phase1`
- `cargo test -p swc_ecma_react_compiler` (expected upstream fixture suite still failing while parity work continues)

## Notes
- This is an incremental parity step; full upstream strict parity (`1718/1718`) is not achieved in this PR.
