### PR TITLE
fix(html/codegen): keep </p> for span-parent paragraphs

### DIFF
--- a/.changeset/neat-worms-vanish.md
+++ b/.changeset/neat-worms-vanish.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_html_codegen: patch
+---
+
+fix(html): keep </p> for span-parent paragraphs

--- a/crates/swc_html_codegen/src/lib.rs
+++ b/crates/swc_html_codegen/src/lib.rs
@@ -512,6 +512,8 @@ where
                                 tag_name,
                                 ..
                             }) if is_html_tag_name(*namespace, tag_name)
+                                // Keep </p> under span to preserve parser stability for invalid
+                                // markup such as `<span><p>...` (#11748).
                                 && !matches!(
                                     &**tag_name,
                                     "a" | "audio"
@@ -524,6 +526,7 @@ where
                                         | "strike"
                                         | "map"
                                         | "noscript"
+                                        | "span"
                                         | "video"
                                         | "kbd"
                                         | "rbc"

--- a/crates/swc_html_codegen/tests/fixture/issue-11748/input.html
+++ b/crates/swc_html_codegen/tests/fixture/issue-11748/input.html
@@ -1,0 +1,1 @@
+<span><p>TEXT</p></span>

--- a/crates/swc_html_codegen/tests/fixture/issue-11748/output.html
+++ b/crates/swc_html_codegen/tests/fixture/issue-11748/output.html
@@ -1,0 +1,3 @@
+<html>
+<head></head><body><span><p>TEXT</p></span>
+</body></html>

--- a/crates/swc_html_codegen/tests/fixture/issue-11748/output.min.html
+++ b/crates/swc_html_codegen/tests/fixture/issue-11748/output.min.html
@@ -1,0 +1,1 @@
+<span><p>TEXT</p></span>

--- a/crates/swc_html_minifier/tests/recovery/element/issue-11748/input.html
+++ b/crates/swc_html_minifier/tests/recovery/element/issue-11748/input.html
@@ -1,0 +1,1 @@
+<span><p>TEXT</p></span>

--- a/crates/swc_html_minifier/tests/recovery/element/issue-11748/output.min.html
+++ b/crates/swc_html_minifier/tests/recovery/element/issue-11748/output.min.html
@@ -1,0 +1,1 @@
+<span><p>TEXT</p></span>


### PR DESCRIPTION
## Summary
- avoid omitting `</p>` when the parent is `<span>` during HTML tag omission
- add regression fixture for `swc_html_codegen` (`issue-11748`)
- add recovery fixture for `swc_html_minifier` (`issue-11748`)

## Verification
- `cargo test -p swc_html_codegen --test fixture -- --ignored issue_11748`
- `cargo test -p swc_html_minifier --test fixture -- --ignored issue_11748`
- `cargo test -p swc_html_codegen`
- `cargo test -p swc_html_minifier`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

Closes #11748
