### PR TITLE
fix(es/regexp): preserve source for wrapped named groups

### DIFF
--- a/.changeset/stale-kings-grow.md
+++ b/.changeset/stale-kings-grow.md
@@ -1,0 +1,7 @@
+---
+swc_ecma_transformer: patch
+swc_ecma_transforms_base: patch
+swc_core: patch
+---
+
+fix(es/regexp): preserve source for wrapped named groups

--- a/crates/swc/tests/exec/issues-11xxx/11754/exec.js
+++ b/crates/swc/tests/exec/issues-11xxx/11754/exec.js
@@ -1,0 +1,31 @@
+const SIMPLE_REGEX = /^(?<greeting>hello)\s+(?<name>\w+)$/;
+const simpleMatch = "hello world".match(SIMPLE_REGEX);
+expect(simpleMatch.groups).toEqual({
+    greeting: "hello",
+    name: "world",
+});
+
+const COMPOSED_REGEX = [
+    /^/,
+    /(?<tagName>[^[]+)/,
+    /(?:\[(?<attrName>[^\]=]+)=\"(?<attrValue>[^\"]+)\"\])?/,
+    /$/,
+]
+    .map((r) => r.source)
+    .join("");
+
+const composedMatch = 'w:tag[w:val="test"]'.match(COMPOSED_REGEX);
+expect(composedMatch.groups).toEqual({
+    tagName: "w:tag",
+    attrName: "w:val",
+    attrValue: "test",
+});
+
+const composedNoAttrMatch = "w:tag".match(COMPOSED_REGEX);
+expect(composedNoAttrMatch.groups).toEqual({
+    tagName: "w:tag",
+    attrName: undefined,
+    attrValue: undefined,
+});
+
+console.log("ok");

--- a/crates/swc/tests/fixture/issues-11xxx/11608/output/input.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11608/output/input.js
@@ -1,4 +1,4 @@
 var _wrap_reg_exp = require("@swc/helpers/_/_wrap_reg_exp");
 var match = "IJobHeader[[ModuleName]]".match(_wrap_reg_exp._(/IJobHeader\[\[([A-Za-z]+)\]\]/, {
     moduleName: 1
-}));
+}, "IJobHeader\\[\\[(?<moduleName>[A-Za-z]+)\\]\\]"));

--- a/crates/swc/tests/fixture/issues-11xxx/11754/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-11xxx/11754/input/.swcrc
@@ -1,0 +1,14 @@
+{
+  "sourceMaps": false,
+  "isModule": false,
+  "jsc": {
+    "parser": {
+      "syntax": "ecmascript"
+    },
+    "transform": {},
+    "externalHelpers": true
+  },
+  "env": {
+    "include": ["transform-named-capturing-groups-regex"]
+  }
+}

--- a/crates/swc/tests/fixture/issues-11xxx/11754/input/input.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11754/input/input.js
@@ -1,0 +1,15 @@
+const SIMPLE_REGEX = /^(?<greeting>hello)\s+(?<name>\w+)$/;
+
+const COMPOSED_REGEX = [
+    /^/,
+    /(?<tagName>[^[]+)/,
+    /(?:\[(?<attrName>[^\]=]+)=\"(?<attrValue>[^\"]+)\"\])?/,
+    /$/,
+]
+    .map((r) => r.source)
+    .join("");
+
+const match1 = "hello world".match(SIMPLE_REGEX);
+const match2 = 'w:tag[w:val="test"]'.match(COMPOSED_REGEX);
+
+console.log(match1?.groups, match2?.groups);

--- a/crates/swc/tests/fixture/issues-11xxx/11754/output/input.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11754/output/input.js
@@ -1,0 +1,21 @@
+var _wrap_reg_exp = require("@swc/helpers/_/_wrap_reg_exp");
+var SIMPLE_REGEX = _wrap_reg_exp._(/^(hello)\s+(\w+)$/, {
+    greeting: 1,
+    name: 2
+}, "^(?<greeting>hello)\\s+(?<name>\\w+)$");
+var COMPOSED_REGEX = [
+    /^/,
+    _wrap_reg_exp._(/([^[]+)/, {
+        tagName: 1
+    }, "(?<tagName>[^[]+)"),
+    _wrap_reg_exp._(/(?:\[([^\]=]+)=\"([^\"]+)\"\])?/, {
+        attrName: 1,
+        attrValue: 2
+    }, '(?:\\[(?<attrName>[^\\]=]+)=\\"(?<attrValue>[^\\"]+)\\"\\])?'),
+    /$/
+].map(function(r) {
+    return r.source;
+}).join("");
+var match1 = "hello world".match(SIMPLE_REGEX);
+var match2 = 'w:tag[w:val="test"]'.match(COMPOSED_REGEX);
+console.log(match1 === null || match1 === void 0 ? void 0 : match1.groups, match2 === null || match2 === void 0 ? void 0 : match2.groups);

--- a/crates/swc/tests/tsc-references/useRegexpGroups.1.normal.js
+++ b/crates/swc/tests/tsc-references/useRegexpGroups.1.normal.js
@@ -4,7 +4,7 @@ var re = _wrap_reg_exp(RegExp("(\\d{4})-(\\d{2})-(\\d{2})", "u"), {
     year: 1,
     month: 2,
     day: 3
-});
+}, "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})");
 var result = re.exec("2015-01-02");
 var date = result[0];
 var year1 = result.groups.year;
@@ -15,4 +15,4 @@ var day1 = result.groups.day;
 var day2 = result[3];
 var foo = "foo".match(_wrap_reg_exp(/(foo)/, {
     bar: 1
-})).groups.foo;
+}, "(?<bar>foo)")).groups.foo;

--- a/crates/swc/tests/tsc-references/useRegexpGroups.2.minified.js
+++ b/crates/swc/tests/tsc-references/useRegexpGroups.2.minified.js
@@ -4,7 +4,7 @@ var result = _wrap_reg_exp(RegExp("(\\d{4})-(\\d{2})-(\\d{2})", "u"), {
     year: 1,
     month: 2,
     day: 3
-}).exec("2015-01-02");
+}, "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})").exec("2015-01-02");
 result[0], result.groups.year, result[1], result.groups.month, result[2], result.groups.day, result[3], "foo".match(_wrap_reg_exp(/(foo)/, {
     bar: 1
-})).groups.foo;
+}, "(?<bar>foo)")).groups.foo;

--- a/crates/swc_ecma_preset_env/tests/fixtures/corejs3/usage-regexp/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/corejs3/usage-regexp/output.mjs
@@ -5,7 +5,7 @@ var a = _wrap_reg_exp(RegExp("(\\d{4})-(\\d{2})-(\\d{2})", "u"), {
     year: 1,
     month: 2,
     day: 3
-});
+}, "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})");
 var b = RegExp(".", "s");
 var c = RegExp(".", "imsuy");
 console.log(a.unicode);

--- a/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex/output.mjs
+++ b/crates/swc_ecma_preset_env/tests/fixtures/transform/named-capturing-groups-regex/output.mjs
@@ -2,22 +2,22 @@ var re = _wrap_reg_exp(/(\d{4})-(\d{2})-(\d{2})/, {
     year: 1,
     month: 2,
     day: 3
-});
+}, "(?<year>\\d{4})-(?<month>\\d{2})-(?<day>\\d{2})");
 var result = "2017-12-23".match(re);
 var re2 = _wrap_reg_exp(/IJobHeader\[\[([A-Za-z]+)\]\]/, {
     moduleName: 1
-});
+}, "IJobHeader\\[\\[(?<moduleName>[A-Za-z]+)\\]\\]");
 var re3 = _wrap_reg_exp(RegExp("<(\\d)+>.*?<\\/\\1>", "su"), {
     tag: 1
-});
+}, "<(?<tag>\\d)+>.*?<\\/\\k<tag>>");
 var re4 = _wrap_reg_exp(/(unnamed)(\d+)/, {
     named: 2
-});
+}, "(unnamed)(?<named>\\d+)");
 var re5 = _wrap_reg_exp(/((\d+))/, {
     outer: 1,
     inner: 2
-});
+}, "(?<outer>(?<inner>\\d+))");
 var re6 = _wrap_reg_exp(/(x)|(y)/, {
     a: 1,
     b: 2
-});
+}, "(?<a>x)|(?<b>y)");

--- a/crates/swc_ecma_transformer/src/regexp.rs
+++ b/crates/swc_ecma_transformer/src/regexp.rs
@@ -220,8 +220,10 @@ impl VisitMutHook<TraverseCtx> for RegexpPass {
             Expr::Lit(Lit::Regex(regex)) => {
                 // Try named groups transform first
                 if self.options.named_capturing_groups_regex && regex.exp.contains("(?<") {
+                    let original_exp = regex.exp.clone();
+
                     if let Some((stripped_exp, group_mapping)) =
-                        self.extract_and_strip_named_groups(&regex.exp, &regex.flags)
+                        self.extract_and_strip_named_groups(&original_exp, &regex.flags)
                     {
                         let Regex { flags, span, .. } = regex.take();
 
@@ -261,11 +263,16 @@ impl VisitMutHook<TraverseCtx> for RegexpPass {
                         };
 
                         let mapping_expr = self.build_mapping_object(group_mapping);
+                        let source_expr: Expr = original_exp.into();
 
                         *expr = CallExpr {
                             span,
                             callee: helper!(span, wrap_reg_exp),
-                            args: vec![regex_arg.as_arg(), mapping_expr.as_arg()],
+                            args: vec![
+                                regex_arg.as_arg(),
+                                mapping_expr.as_arg(),
+                                source_expr.as_arg(),
+                            ],
                             ..Default::default()
                         }
                         .into();

--- a/crates/swc_ecma_transforms_base/src/helpers/_wrap_reg_exp.js
+++ b/crates/swc_ecma_transforms_base/src/helpers/_wrap_reg_exp.js
@@ -1,15 +1,31 @@
-function _wrap_reg_exp(re, groups) {
-    _wrap_reg_exp = function(re, groups) {
-        return new WrappedRegExp(re, undefined, groups);
+function _wrap_reg_exp(re, groups, source) {
+    _wrap_reg_exp = function(re, groups, source) {
+        return new WrappedRegExp(re, undefined, groups, source);
     };
     var _super = RegExp.prototype;
     var _groups = new WeakMap();
-    function WrappedRegExp(re, flags, groups) {
+    var _sources = new WeakMap();
+    var _native_source = Object.getOwnPropertyDescriptor(_super, "source").get;
+    function WrappedRegExp(re, flags, groups, source) {
         var _re = new RegExp(re, flags);
         _groups.set(_re, groups || _groups.get(re));
+        _sources.set(_re, source !== undefined ? source : _sources.get(re));
         return _set_prototype_of(_re, WrappedRegExp.prototype);
     }
     _inherits(WrappedRegExp, RegExp);
+    Object.defineProperty(WrappedRegExp.prototype, "source", {
+        configurable: true,
+        get: function() {
+            var source = _sources.get(this);
+            if (source !== undefined) {
+                try {
+                    new RegExp(source, this.flags);
+                    return source;
+                } catch (_) {}
+            }
+            return _native_source.call(this);
+        }
+    });
     WrappedRegExp.prototype.exec = function(str) {
         var result = _super.exec.call(this, str);
         if (result) {

--- a/packages/helpers/esm/_wrap_reg_exp.js
+++ b/packages/helpers/esm/_wrap_reg_exp.js
@@ -1,18 +1,34 @@
 import { _ as _inherits } from "./_inherits.js";
 import { _ as _set_prototype_of } from "./_set_prototype_of.js";
 
-function _wrap_reg_exp(re, groups) {
-    _wrap_reg_exp = function(re, groups) {
-        return new WrappedRegExp(re, undefined, groups);
+function _wrap_reg_exp(re, groups, source) {
+    _wrap_reg_exp = function(re, groups, source) {
+        return new WrappedRegExp(re, undefined, groups, source);
     };
     var _super = RegExp.prototype;
     var _groups = new WeakMap();
-    function WrappedRegExp(re, flags, groups) {
+    var _sources = new WeakMap();
+    var _native_source = Object.getOwnPropertyDescriptor(_super, "source").get;
+    function WrappedRegExp(re, flags, groups, source) {
         var _re = new RegExp(re, flags);
         _groups.set(_re, groups || _groups.get(re));
+        _sources.set(_re, source !== undefined ? source : _sources.get(re));
         return _set_prototype_of(_re, WrappedRegExp.prototype);
     }
     _inherits(WrappedRegExp, RegExp);
+    Object.defineProperty(WrappedRegExp.prototype, "source", {
+        configurable: true,
+        get: function() {
+            var source = _sources.get(this);
+            if (source !== undefined) {
+                try {
+                    new RegExp(source, this.flags);
+                    return source;
+                } catch (_) {}
+            }
+            return _native_source.call(this);
+        }
+    });
     WrappedRegExp.prototype.exec = function(str) {
         var result = _super.exec.call(this, str);
         if (result) {


### PR DESCRIPTION
## Summary
- Preserve original named-group regex source in RegexpPass and pass it as an optional third arg to _wrap_reg_exp.
- Extend _wrap_reg_exp runtime helper signature to _wrap_reg_exp(re, groups, source?) while keeping backward compatibility.
- Add a safe source getter on wrapped regex objects: return preserved source only when it compiles with current flags, otherwise fall back to native RegExp.prototype.source.
- Add regression coverage for #11754 in fixture and exec tests.

## Tests
- git submodule update --init --recursive
- UPDATE=1 cargo test -p swc (fails on existing unrelated source_map::issue_622 assertion in this environment)
- cargo test -p swc (same unrelated source_map::issue_622)
- cargo test -p swc_ecma_transformer
- cargo test -p swc_ecma_transforms_base
- UPDATE=1 cargo test -p swc --test projects fixture_tests__fixture__issues_11xxx__11754__input -- --ignored --exact
- cargo test -p swc --test exec run_fixture_test_tests__exec__issues_11xxx__11754__exec_js -- --ignored --exact
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings

Fixes #11754
