### PR TITLE
fix(minifier): guard expr-body iife inline for closure params

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -669,6 +669,16 @@ impl Optimizer<'_> {
                             return;
                         }
 
+                        // Keep this path conservative: expression-body IIFE inlining is only
+                        // safe if every parameter can be substituted directly. If we would need
+                        // to synthesize temporary param bindings / assignments, skip this
+                        // optimization to avoid introducing unbound references in closures.
+                        if !self
+                            .can_inline_expr_iife_params_without_tmp(param_ids.clone(), &call.args)
+                        {
+                            return;
+                        }
+
                         if let Expr::Lit(Lit::Num(..)) = &**body {
                             if self.ctx.bit_ctx.contains(BitCtx::InObjOfNonComputedMember) {
                                 return;
@@ -848,6 +858,50 @@ impl Optimizer<'_> {
             Expr::Fn(..) | Expr::Arrow(..) if usage.can_inline_fn_once() => true,
             _ => false,
         }
+    }
+
+    fn can_inline_expr_iife_params_without_tmp<'a>(
+        &self,
+        param_ids: impl ExactSizeIterator<Item = &'a Ident>,
+        args: &[ExprOrSpread],
+    ) -> bool {
+        for (idx, pid) in param_ids.enumerate() {
+            let Some(arg) = args.get(idx) else {
+                log_abort!(
+                    "iife: [x] Cannot inline expression-body iife due to missing argument for `{}`",
+                    pid
+                );
+                return false;
+            };
+
+            let Some(usage) = self.data.vars.get(&pid.to_id()) else {
+                log_abort!(
+                    "iife: [x] Cannot inline expression-body iife due to missing usage data for \
+                     `{}`",
+                    pid
+                );
+                return false;
+            };
+
+            // Keep the fast path equivalent to `inline_fn_param`'s no-temp branch.
+            if !(usage.ref_count == 1
+                && !usage.flags.contains(VarUsageInfoFlags::REASSIGNED)
+                && usage.property_mutation_count == 0
+                && matches!(
+                    &*arg.expr,
+                    Expr::Lit(Lit::Num(..) | Lit::Str(..) | Lit::Bool(..) | Lit::BigInt(..))
+                ))
+            {
+                log_abort!(
+                    "iife: [x] Cannot inline expression-body iife because `{}` needs temporary \
+                     binding",
+                    pid
+                );
+                return false;
+            }
+        }
+
+        true
     }
 
     fn can_extract_param<'a>(

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -11973,3 +11973,39 @@ console.log(getStatusMessage(999).message);
 "#;
     run_default_exec_test(src);
 }
+
+/// Issue #11755: Avoid unbound references when inlining expression-body IIFE
+/// params in closures.
+#[test]
+fn issue_11755() {
+    let src = r#"
+function f() {
+  const getConfigId = ({ id, configIndex }) => `${id}-${configIndex}`;
+  const createSelector = (id, configIndex) => (data) =>
+    data[getConfigId({ id, configIndex })];
+
+  const selector = createSelector("item-1", 0);
+  const result = selector({ "item-1-0": 100 });
+
+  if (result === 100) {
+    console.log("Test PASSED!");
+  } else {
+    console.log("Test FAILED!");
+  }
+}
+
+f();
+f();
+"#;
+
+    let config = r#"{
+    "defaults": false,
+    "toplevel": true,
+    "inline": 3,
+    "unused": true,
+    "collapse_vars": true,
+    "reduce_vars": false
+}"#;
+
+    run_exec_test(src, config, false);
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11755/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11755/input.js
@@ -1,0 +1,19 @@
+function f() {
+    const getConfigId = ({ id, configIndex }) => `${id}-${configIndex}`;
+    const createSelector = (id, configIndex) => (data) =>
+        data[getConfigId({ id, configIndex })];
+
+    const selector = createSelector("item-1", 0);
+    const result = selector({
+        "item-1-0": 100,
+    });
+
+    if (result === 100) {
+        console.log("Test PASSED!");
+    } else {
+        console.log("Test FAILED!");
+    }
+}
+
+f();
+f();

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11755/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11755/output.js
@@ -1,0 +1,9 @@
+function f() {
+    100 === ((id)=>(data)=>data[(({ id, configIndex })=>`${id}-${configIndex}`)({
+                id,
+                configIndex: 0
+            })])("item-1")({
+        "item-1-0": 100
+    }) ? console.log("Test PASSED!") : console.log("Test FAILED!");
+}
+f(), f();

--- a/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
+++ b/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
@@ -7,7 +7,7 @@
 | lodash.js | 531.35 KiB | 68.92 KiB | 24.60 KiB |
 | moment.js | 169.83 KiB | 57.34 KiB | 18.26 KiB |
 | react.js | 70.45 KiB | 22.45 KiB | 8.04 KiB |
-| terser.js | 1.08 MiB | 446.63 KiB | 120.49 KiB |
+| terser.js | 1.08 MiB | 446.73 KiB | 120.50 KiB |
 | three.js | 1.19 MiB | 630.55 KiB | 154.77 KiB |
 | typescript.js | 10.45 MiB | 3.17 MiB | 840.61 KiB |
 | victory.js | 2.30 MiB | 694.04 KiB | 154.18 KiB |


### PR DESCRIPTION
## Summary

Fixes #11755 by preventing an unsafe expression-body IIFE inlining case that could produce unbound references in closures.

In the reported pattern, `createSelector("item-1", 0)` could be inlined in a way that required synthesized temporary param bindings. That path could drop needed assignments, leading to `ReferenceError` (or `undefined` behavior when `unused=false`).

This PR applies a conservative guard for this specific path to prioritize correctness.

## Root Cause

For `invoke_iife` on arrow functions with `BlockStmtOrExpr::Expr`, we allowed inlining even when some params could not be substituted directly and would require temp param bindings/assignments.

That temp-binding path is unsafe in closure scenarios and can break identifier binding semantics.

## What Changed

### Minifier guard

- Updated `crates/swc_ecma_minifier/src/compress/optimize/iife.rs`.
- In `invoke_iife` (`Expr::Arrow` + expression body path), added a pre-check:
  - only proceed if all params are safe to inline without temporary bindings.
  - otherwise bail out and keep original call shape.
- Added helper:
  - `can_inline_expr_iife_params_without_tmp(...)`

### Regression coverage

- Added exec regression test:
  - `issue_11755` in `crates/swc_ecma_minifier/tests/exec.rs`
  - uses issue-shaped repro and validates runtime output stays correct.

- Added fixture regression:
  - `crates/swc_ecma_minifier/tests/fixture/issues/11755/input.js`
  - `crates/swc_ecma_minifier/tests/fixture/issues/11755/output.js`

## Verification

Executed:

- `git submodule update --init --recursive`
- `cargo test -p swc_ecma_minifier --test exec issue_11755 -- --nocapture`
- `cargo test -p swc_ecma_minifier --test exec issue_6641 -- --nocapture`
- `(cd crates/swc_ecma_minifier && ./scripts/exec.sh issue_11755)`
- `UPDATE=1 cargo test -p swc_ecma_minifier --test compress custom_fixture_tests__fixture__issues__11755__input_js -- --ignored`
- `cargo test -p swc_ecma_minifier --test compress custom_fixture_tests__fixture__issues__11755__input_js -- --ignored`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_minifier`

## Notes

- This is an intentionally conservative fix for the risky expression-body IIFE path.
- As expected, the optimization scope is slightly reduced in this edge case.
- `tests/libs-size.snapshot.md` was updated because `bench_libs` changed marginally for `terser.js` (small size increase due to the conservative guard).
