### PR TITLE
ci: add manual Publish crates workflow

### DIFF
--- a/.github/workflows/publish-crates-manual.yml
+++ b/.github/workflows/publish-crates-manual.yml
@@ -1,0 +1,63 @@
+name: "Publish crates"
+
+env:
+  CI: 1
+  # 7 GiB by default on GitHub, setting to 6 GiB
+  # https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources
+  NODE_OPTIONS: --max-old-space-size=6144
+  GIT_AUTHOR_NAME: "SWC Bot"
+  GIT_AUTHOR_EMAIL: "bot@swc.rs"
+  GIT_COMMITTER_NAME: "SWC Bot"
+  GIT_COMMITTER_EMAIL: "bot@swc.rs"
+  # https://github.com/actions/setup-node/issues/899#issuecomment-1819151595
+  SKIP_YARN_COREPACK_CHECK: 1
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  publish-cargo:
+    name: "Publish cargo crates"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: "main"
+
+      - uses: ./.github/actions/setup-node
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly-2025-05-06
+
+      - name: Install cargo-edit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-edit@0.12.2
+
+      - name: Install git-cliff
+        uses: taiki-e/install-action@v2
+        with:
+          tool: git-cliff@2.8.0
+
+      - uses: webfactory/ssh-agent@v0.9.1
+        with:
+          ssh-private-key: ${{ secrets.SWC_BOT_SSH }}
+
+      - name: Publish crates
+        run: |
+          set -eux
+          git remote set-url origin "git@github.com:${{ github.repository }}.git"
+          git pull --ff-only origin main
+          cargo bump
+          git push origin main
+          git push origin --tags


### PR DESCRIPTION
## Summary
- add a new manual GitHub Actions workflow named `Publish crates`
- keep the existing auto workflow untouched
- run publish steps in fixed order: `git pull` -> `cargo bump` -> `git push` -> `git push --tags`

## Details
- add \.github/workflows/publish-crates-manual.yml
- trigger only via `workflow_dispatch` (no inputs)
- pin checkout to `main` with full history
- use SSH auth with `SWC_BOT_SSH` and force SSH remote URL before push
- set publish-bot git author/committer env vars for consistency
