### PR TITLE
chore: update cargo-mono to 0.6.5 in CI

### DIFF
--- a/.changeset/thin-rats-jog.md
+++ b/.changeset/thin-rats-jog.md
@@ -1,0 +1,5 @@
+---
+swc_core: patch
+---
+
+chore: update cargo-mono to 0.6.5 in CI

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install cargo-mono
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mono@0.5.3
+          tool: cargo-mono@0.6.5
 
       - name: List crates
         id: list-tests

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install cargo-mono
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mono@0.5.3
+          tool: cargo-mono@0.6.5
 
       - name: Update constant of swc_core
         run: npx ts-node .github/bot/src/cargo/update-constants.ts


### PR DESCRIPTION
## Summary
- update the cargo-mono install step in CI to 0.6.5
- update the cargo-mono install step in crate publishing workflow to 0.6.5

## Verification
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings