### PR TITLE
feat(ecma): add node ids and node-based scope analysis

### DIFF
--- a/crates/swc_ecma_ast/src/class.rs
+++ b/crates/swc_ecma_ast/src/class.rs
@@ -11,7 +11,7 @@ use crate::{
         Accessibility, TsExprWithTypeArgs, TsIndexSignature, TsTypeAnn, TsTypeParamDecl,
         TsTypeParamInstantiation,
     },
-    BigInt, ComputedPropName, EmptyStmt, Id, Ident, IdentName, Number,
+    BigInt, ComputedPropName, EmptyStmt, Id, Ident, IdentName, NodeId, Number,
 };
 
 #[ast_node]
@@ -20,6 +20,9 @@ use crate::{
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Class {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub ctxt: SyntaxContext,
 
@@ -99,7 +102,10 @@ pub enum ClassMember {
 
 impl Take for ClassMember {
     fn dummy() -> Self {
-        ClassMember::Empty(EmptyStmt { span: DUMMY_SP })
+        ClassMember::Empty(EmptyStmt {
+            span: DUMMY_SP,
+            node_id: Default::default(),
+        })
     }
 }
 
@@ -110,6 +116,9 @@ impl Take for ClassMember {
 pub struct ClassProp {
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub key: PropName,
 
@@ -170,6 +179,9 @@ pub struct PrivateProp {
     pub span: Span,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
     pub ctxt: SyntaxContext,
 
     pub key: PrivateName,
@@ -222,6 +234,9 @@ pub struct PrivateProp {
 pub struct ClassMethod {
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub key: PropName,
     pub function: Box<Function>,
     pub kind: MethodKind,
@@ -250,6 +265,9 @@ pub struct ClassMethod {
 pub struct PrivateMethod {
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub key: PrivateName,
     pub function: Box<Function>,
     pub kind: MethodKind,
@@ -277,6 +295,9 @@ pub struct PrivateMethod {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Constructor {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub ctxt: SyntaxContext,
 
@@ -308,6 +329,9 @@ pub struct Constructor {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Decorator {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
@@ -344,6 +368,9 @@ pub enum MethodKind {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct StaticBlock {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub body: BlockStmt,
 }
 
@@ -351,6 +378,7 @@ impl Take for StaticBlock {
     fn dummy() -> Self {
         StaticBlock {
             span: DUMMY_SP,
+            node_id: Default::default(),
             body: Take::dummy(),
         }
     }
@@ -399,6 +427,9 @@ pub struct AutoAccessor {
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub key: Key,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -443,6 +474,7 @@ impl Take for AutoAccessor {
     fn dummy() -> AutoAccessor {
         AutoAccessor {
             span: Take::dummy(),
+            node_id: Default::default(),
             key: Take::dummy(),
             value: Take::dummy(),
             type_ann: None,

--- a/crates/swc_ecma_ast/src/decl.rs
+++ b/crates/swc_ecma_ast/src/decl.rs
@@ -9,6 +9,7 @@ use crate::{
     ident::Ident,
     pat::Pat,
     typescript::{TsEnumDecl, TsInterfaceDecl, TsModuleDecl, TsTypeAliasDecl},
+    NodeId,
 };
 
 #[ast_node]
@@ -99,6 +100,9 @@ impl Take for Decl {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct FnDecl {
+    #[cfg_attr(feature = "serde-impl", serde(skip))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "identifier"))]
     pub ident: Ident,
 
@@ -113,6 +117,7 @@ pub struct FnDecl {
 impl Take for FnDecl {
     fn dummy() -> Self {
         FnDecl {
+            node_id: Default::default(),
             ident: Take::dummy(),
             declare: Default::default(),
             function: Take::dummy(),
@@ -125,6 +130,9 @@ impl Take for FnDecl {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ClassDecl {
+    #[cfg_attr(feature = "serde-impl", serde(skip))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "identifier"))]
     pub ident: Ident,
 
@@ -139,6 +147,7 @@ pub struct ClassDecl {
 impl Take for ClassDecl {
     fn dummy() -> Self {
         ClassDecl {
+            node_id: Default::default(),
             ident: Take::dummy(),
             declare: Default::default(),
             class: Take::dummy(),
@@ -152,6 +161,9 @@ impl Take for ClassDecl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct VarDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub ctxt: SyntaxContext,
 
@@ -200,6 +212,9 @@ pub enum VarDeclKind {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct VarDeclarator {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "id"))]
     pub name: Pat,
 
@@ -220,6 +235,7 @@ impl Take for VarDeclarator {
     fn dummy() -> Self {
         VarDeclarator {
             span: DUMMY_SP,
+            node_id: Default::default(),
             name: Take::dummy(),
             init: Take::dummy(),
             definite: Default::default(),
@@ -236,6 +252,9 @@ pub struct UsingDecl {
     pub span: Span,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
     pub is_await: bool,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -246,6 +265,7 @@ impl Take for UsingDecl {
     fn dummy() -> Self {
         Self {
             span: DUMMY_SP,
+            node_id: Default::default(),
             is_await: Default::default(),
             decls: Take::dummy(),
         }

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -23,7 +23,7 @@ use crate::{
         TsTypeAssertion, TsTypeParamDecl, TsTypeParamInstantiation,
     },
     ArrayPat, BindingIdent, ComputedPropName, Id, IdentName, ImportPhase, Invalid, KeyValueProp,
-    Number, ObjectPat, PropName, Str,
+    NodeId, Number, ObjectPat, PropName, Str,
 };
 
 #[ast_node(no_clone)]
@@ -181,9 +181,11 @@ impl Expr {
     pub fn undefined(span: Span) -> Box<Expr> {
         UnaryExpr {
             span,
+            node_id: Default::default(),
             op: op!("void"),
             arg: Lit::Num(Number {
                 span,
+                node_id: Default::default(),
                 value: 0.0,
                 raw: None,
             })
@@ -313,6 +315,7 @@ impl Expr {
         } else {
             SeqExpr {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 exprs,
             }
             .into()
@@ -434,7 +437,11 @@ impl Clone for Expr {
 
 impl Take for Expr {
     fn dummy() -> Self {
-        Invalid { span: DUMMY_SP }.into()
+        Invalid {
+            span: DUMMY_SP,
+            node_id: Default::default(),
+        }
+        .into()
     }
 }
 
@@ -500,11 +507,17 @@ boxed_expr!(Invalid);
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ThisExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(skip))]
+    pub node_id: NodeId,
 }
 
 impl Take for ThisExpr {
     fn dummy() -> Self {
-        ThisExpr { span: DUMMY_SP }
+        ThisExpr {
+            span: DUMMY_SP,
+            node_id: Default::default(),
+        }
     }
 }
 
@@ -515,6 +528,9 @@ impl Take for ThisExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ArrayLit {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(skip))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "elements"))]
     #[cfg_attr(
@@ -528,6 +544,7 @@ impl Take for ArrayLit {
     fn dummy() -> Self {
         ArrayLit {
             span: DUMMY_SP,
+            node_id: Default::default(),
             elems: Default::default(),
         }
     }
@@ -540,6 +557,9 @@ impl Take for ArrayLit {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ObjectLit {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "properties"))]
     pub props: Vec<PropOrSpread>,
@@ -582,6 +602,7 @@ impl ObjectLit {
 
         Some(ImportWith {
             span: self.span,
+            node_id: Default::default(),
             values,
         })
     }
@@ -591,11 +612,13 @@ impl From<ImportWith> for ObjectLit {
     fn from(v: ImportWith) -> Self {
         ObjectLit {
             span: v.span,
+            node_id: Default::default(),
             props: v
                 .values
                 .into_iter()
                 .map(|item| {
                     PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                        node_id: Default::default(),
                         key: PropName::Ident(item.key),
                         value: Lit::Str(item.value).into(),
                     })))
@@ -610,8 +633,14 @@ impl From<ImportWith> for ObjectLit {
 /// values:
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, EqIgnoreSpan)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImportWith {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub values: Vec<ImportWithItem>,
 }
 
@@ -628,6 +657,9 @@ impl ImportWith {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, EqIgnoreSpan)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
 pub struct ImportWithItem {
     pub key: IdentName,
     pub value: Str,
@@ -637,6 +669,7 @@ impl Take for ObjectLit {
     fn dummy() -> Self {
         ObjectLit {
             span: DUMMY_SP,
+            node_id: Default::default(),
             props: Default::default(),
         }
     }
@@ -660,6 +693,7 @@ bridge_from!(PropOrSpread, Box<Prop>, Prop);
 impl Take for PropOrSpread {
     fn dummy() -> Self {
         PropOrSpread::Spread(SpreadElement {
+            node_id: Default::default(),
             dot3_token: DUMMY_SP,
             expr: Take::dummy(),
         })
@@ -671,6 +705,9 @@ impl Take for PropOrSpread {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SpreadElement {
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "spread"))]
     #[span(lo)]
     pub dot3_token: Span,
@@ -683,6 +720,7 @@ pub struct SpreadElement {
 impl Take for SpreadElement {
     fn dummy() -> Self {
         SpreadElement {
+            node_id: Default::default(),
             dot3_token: DUMMY_SP,
             expr: Take::dummy(),
         }
@@ -696,6 +734,9 @@ impl Take for SpreadElement {
 pub struct UnaryExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "operator"))]
     pub op: UnaryOp,
 
@@ -707,6 +748,7 @@ impl Take for UnaryExpr {
     fn dummy() -> Self {
         UnaryExpr {
             span: DUMMY_SP,
+            node_id: Default::default(),
             op: op!("!"),
             arg: Take::dummy(),
         }
@@ -719,6 +761,9 @@ impl Take for UnaryExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct UpdateExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(rename = "operator"))]
     pub op: UpdateOp,
@@ -733,6 +778,7 @@ impl Take for UpdateExpr {
     fn dummy() -> Self {
         UpdateExpr {
             span: DUMMY_SP,
+            node_id: Default::default(),
             op: op!("++"),
             prefix: false,
             arg: Take::dummy(),
@@ -747,6 +793,9 @@ impl Take for UpdateExpr {
 pub struct BinExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "operator"))]
     pub op: BinaryOp,
 
@@ -759,6 +808,7 @@ impl Take for BinExpr {
     fn dummy() -> Self {
         BinExpr {
             span: DUMMY_SP,
+            node_id: Default::default(),
             op: op!("*"),
             left: Take::dummy(),
             right: Take::dummy(),
@@ -772,6 +822,9 @@ impl Take for BinExpr {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct FnExpr {
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "identifier"))]
     #[cfg_attr(
         feature = "encoding-impl",
@@ -787,6 +840,7 @@ pub struct FnExpr {
 impl Take for FnExpr {
     fn dummy() -> Self {
         FnExpr {
+            node_id: Default::default(),
             ident: None,
             function: Take::dummy(),
         }
@@ -796,6 +850,7 @@ impl Take for FnExpr {
 impl From<Box<Function>> for FnExpr {
     fn from(function: Box<Function>) -> Self {
         Self {
+            node_id: Default::default(),
             ident: None,
             function,
         }
@@ -811,6 +866,9 @@ bridge_expr_from!(FnExpr, Box<Function>);
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ClassExpr {
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "identifier"))]
     #[cfg_attr(
         feature = "encoding-impl",
@@ -826,6 +884,7 @@ pub struct ClassExpr {
 impl Take for ClassExpr {
     fn dummy() -> Self {
         ClassExpr {
+            node_id: Default::default(),
             ident: None,
             class: Take::dummy(),
         }
@@ -834,7 +893,11 @@ impl Take for ClassExpr {
 
 impl From<Box<Class>> for ClassExpr {
     fn from(class: Box<Class>) -> Self {
-        Self { ident: None, class }
+        Self {
+            node_id: Default::default(),
+            ident: None,
+            class,
+        }
     }
 }
 
@@ -848,6 +911,9 @@ bridge_expr_from!(ClassExpr, Box<Class>);
 pub struct AssignExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "operator"))]
     pub op: AssignOp,
 
@@ -860,6 +926,7 @@ impl Take for AssignExpr {
     fn dummy() -> Self {
         AssignExpr {
             span: DUMMY_SP,
+            node_id: Default::default(),
             op: op!("="),
             left: Take::dummy(),
             right: Take::dummy(),
@@ -879,6 +946,9 @@ impl AssignExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct MemberExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(rename = "object"))]
     pub obj: Box<Expr>,
@@ -913,6 +983,9 @@ impl MemberProp {
 pub struct SuperPropExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub obj: Super,
 
     #[cfg_attr(feature = "serde-impl", serde(rename = "property"))]
@@ -934,6 +1007,7 @@ impl Take for MemberExpr {
     fn dummy() -> Self {
         MemberExpr {
             span: DUMMY_SP,
+            node_id: Default::default(),
             obj: Take::dummy(),
             prop: Take::dummy(),
         }
@@ -971,6 +1045,9 @@ impl Default for SuperProp {
 pub struct CondExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub test: Box<Expr>,
 
     #[cfg_attr(feature = "serde-impl", serde(rename = "consequent"))]
@@ -984,6 +1061,7 @@ impl Take for CondExpr {
     fn dummy() -> Self {
         CondExpr {
             span: DUMMY_SP,
+            node_id: Default::default(),
             test: Take::dummy(),
             cons: Take::dummy(),
             alt: Take::dummy(),
@@ -997,6 +1075,9 @@ impl Take for CondExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct CallExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub ctxt: SyntaxContext,
 
     pub callee: Callee,
@@ -1025,6 +1106,9 @@ impl Take for CallExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct NewExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub ctxt: SyntaxContext,
 
@@ -1059,6 +1143,9 @@ impl Take for NewExpr {
 pub struct SeqExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "expressions"))]
     pub exprs: Vec<Box<Expr>>,
 }
@@ -1067,6 +1154,7 @@ impl Take for SeqExpr {
     fn dummy() -> Self {
         SeqExpr {
             span: DUMMY_SP,
+            node_id: Default::default(),
             exprs: Take::dummy(),
         }
     }
@@ -1078,6 +1166,9 @@ impl Take for SeqExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ArrowExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub ctxt: SyntaxContext,
 
@@ -1122,6 +1213,9 @@ impl Take for ArrowExpr {
 pub struct YieldExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "argument"))]
     #[cfg_attr(
         feature = "encoding-impl",
@@ -1137,6 +1231,7 @@ impl Take for YieldExpr {
     fn dummy() -> Self {
         YieldExpr {
             span: DUMMY_SP,
+            node_id: Default::default(),
             arg: Take::dummy(),
             delegate: false,
         }
@@ -1149,6 +1244,9 @@ impl Take for YieldExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct MetaPropExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub kind: MetaPropKind,
 }
 
@@ -1180,6 +1278,9 @@ pub enum MetaPropKind {
 pub struct AwaitExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "argument"))]
     pub arg: Box<Expr>,
 }
@@ -1191,6 +1292,9 @@ pub struct AwaitExpr {
 pub struct Tpl {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "expressions"))]
     pub exprs: Vec<Box<Expr>>,
 
@@ -1201,6 +1305,7 @@ impl Take for Tpl {
     fn dummy() -> Self {
         Tpl {
             span: DUMMY_SP,
+            node_id: Default::default(),
             exprs: Take::dummy(),
             quasis: Take::dummy(),
         }
@@ -1213,6 +1318,9 @@ impl Take for Tpl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TaggedTpl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub ctxt: SyntaxContext,
 
@@ -1241,6 +1349,9 @@ impl Take for TaggedTpl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TplElement {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub tail: bool,
 
     /// This value is never used by `swc_ecma_codegen`, and this fact is
@@ -1263,6 +1374,7 @@ impl Take for TplElement {
     fn dummy() -> Self {
         TplElement {
             span: DUMMY_SP,
+            node_id: Default::default(),
             tail: Default::default(),
             cooked: None,
             raw: Default::default(),
@@ -1294,6 +1406,9 @@ impl<'a> arbitrary::Arbitrary<'a> for TplElement {
 pub struct ParenExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
 }
@@ -1301,6 +1416,7 @@ impl Take for ParenExpr {
     fn dummy() -> Self {
         ParenExpr {
             span: DUMMY_SP,
+            node_id: Default::default(),
             expr: Take::dummy(),
         }
     }
@@ -1340,11 +1456,17 @@ impl Take for Callee {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Super {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 }
 
 impl Take for Super {
     fn dummy() -> Self {
-        Super { span: DUMMY_SP }
+        Super {
+            span: DUMMY_SP,
+            node_id: Default::default(),
+        }
     }
 }
 
@@ -1354,6 +1476,9 @@ impl Take for Super {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Import {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub phase: ImportPhase,
 }
 
@@ -1361,6 +1486,7 @@ impl Take for Import {
     fn dummy() -> Self {
         Import {
             span: DUMMY_SP,
+            node_id: Default::default(),
             phase: ImportPhase::default(),
         }
     }
@@ -1396,6 +1522,9 @@ impl Take for Import {
     derive(::swc_common::Encode, ::swc_common::Decode)
 )]
 pub struct ExprOrSpread {
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
     #[cfg_attr(
@@ -1435,7 +1564,11 @@ impl Spanned for ExprOrSpread {
 
 impl From<Box<Expr>> for ExprOrSpread {
     fn from(expr: Box<Expr>) -> Self {
-        Self { expr, spread: None }
+        Self {
+            node_id: Default::default(),
+            expr,
+            spread: None,
+        }
     }
 }
 
@@ -1719,6 +1852,9 @@ impl Take for AssignTarget {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct OptChainExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub optional: bool,
     /// This is boxed to reduce the type size of [Expr].
     pub base: Box<OptChainBase>,
@@ -1748,6 +1884,9 @@ impl Default for OptChainBase {
 pub struct OptCall {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub ctxt: SyntaxContext,
 
     pub callee: Box<Expr>,
@@ -1768,6 +1907,7 @@ impl Take for OptChainExpr {
     fn dummy() -> Self {
         Self {
             span: DUMMY_SP,
+            node_id: Default::default(),
             optional: false,
             base: Box::new(OptChainBase::Member(Take::dummy())),
         }
@@ -1779,6 +1919,7 @@ impl From<OptChainBase> for Expr {
         match opt {
             OptChainBase::Call(OptCall {
                 span,
+                node_id,
                 ctxt,
                 callee,
                 args,
@@ -1787,6 +1928,7 @@ impl From<OptChainBase> for Expr {
                 callee: Callee::Expr(callee),
                 args,
                 span,
+                node_id,
                 type_args,
                 ctxt,
             }),
@@ -1809,6 +1951,7 @@ impl From<OptCall> for CallExpr {
     fn from(
         OptCall {
             span,
+            node_id,
             ctxt,
             callee,
             args,
@@ -1817,6 +1960,7 @@ impl From<OptCall> for CallExpr {
     ) -> Self {
         Self {
             span,
+            node_id,
             callee: Callee::Expr(callee),
             args,
             type_args,

--- a/crates/swc_ecma_ast/src/function.rs
+++ b/crates/swc_ecma_ast/src/function.rs
@@ -6,6 +6,7 @@ use crate::{
     pat::Pat,
     stmt::BlockStmt,
     typescript::{TsParamProp, TsTypeAnn, TsTypeParamDecl},
+    NodeId,
 };
 
 /// Common parts of function and method.
@@ -20,6 +21,9 @@ pub struct Function {
     pub decorators: Vec<Decorator>,
 
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub ctxt: SyntaxContext,
 
@@ -67,6 +71,9 @@ impl Take for Function {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Param {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub decorators: Vec<Decorator>,
     pub pat: Pat,
@@ -76,6 +83,7 @@ impl From<Pat> for Param {
     fn from(pat: Pat) -> Self {
         Self {
             span: DUMMY_SP,
+            node_id: Default::default(),
             decorators: Default::default(),
             pat,
         }

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -12,7 +12,7 @@ use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Mark, Span, Spanned, SyntaxContext, DUMMY_SP,
 };
 
-use crate::{typescript::TsTypeAnn, Expr};
+use crate::{typescript::TsTypeAnn, Expr, NodeId};
 
 /// Identifier used as a pattern.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, EqIgnoreSpan, Default)]
@@ -45,6 +45,9 @@ use crate::{typescript::TsTypeAnn, Expr};
     derive(::swc_common::Encode, ::swc_common::Decode)
 )]
 pub struct BindingIdent {
+    #[cfg_attr(feature = "serde-impl", serde(skip))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(flatten))]
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
     pub id: Ident,
@@ -96,6 +99,7 @@ impl From<&'_ BindingIdent> for Ident {
     fn from(bi: &'_ BindingIdent) -> Self {
         Ident {
             span: bi.span,
+            node_id: bi.id.node_id,
             ctxt: bi.ctxt,
             sym: bi.sym.clone(),
             optional: bi.optional,
@@ -120,6 +124,7 @@ impl From<Ident> for BindingIdent {
     fn from(id: Ident) -> Self {
         BindingIdent {
             id,
+            node_id: Default::default(),
             ..Default::default()
         }
     }
@@ -183,6 +188,9 @@ bridge_from!(BindingIdent, Ident, Id);
 pub struct Ident {
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
     pub ctxt: SyntaxContext,
@@ -423,6 +431,9 @@ pub struct IdentName {
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "value"))]
     pub sym: Atom,
 }
@@ -431,6 +442,7 @@ impl From<Atom> for IdentName {
     fn from(sym: Atom) -> Self {
         IdentName {
             span: DUMMY_SP,
+            node_id: Default::default(),
             sym,
         }
     }
@@ -438,7 +450,11 @@ impl From<Atom> for IdentName {
 
 impl From<(Atom, Span)> for IdentName {
     fn from((sym, span): (Atom, Span)) -> Self {
-        IdentName { span, sym }
+        IdentName {
+            span,
+            node_id: Default::default(),
+            sym,
+        }
     }
 }
 
@@ -456,7 +472,11 @@ impl AsRef<str> for IdentName {
 
 impl IdentName {
     pub const fn new(sym: Atom, span: Span) -> Self {
-        Self { span, sym }
+        Self {
+            span,
+            node_id: NodeId::DUMMY,
+            sym,
+        }
     }
 }
 
@@ -470,6 +490,7 @@ impl From<Ident> for IdentName {
     fn from(i: Ident) -> Self {
         IdentName {
             span: i.span,
+            node_id: i.node_id,
             sym: i.sym,
         }
     }
@@ -570,6 +591,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Ident {
 
         Ok(Self {
             span,
+            node_id: Default::default(),
             sym,
             optional,
             ctxt: Default::default(),
@@ -583,6 +605,9 @@ impl<'a> arbitrary::Arbitrary<'a> for Ident {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct PrivateName {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "value"))]
     pub name: Atom,
 }
@@ -597,6 +622,7 @@ impl Ident {
     pub const fn new(sym: Atom, span: Span, ctxt: SyntaxContext) -> Self {
         Ident {
             span,
+            node_id: NodeId::DUMMY,
             ctxt,
             sym,
             optional: false,

--- a/crates/swc_ecma_ast/src/jsx.rs
+++ b/crates/swc_ecma_ast/src/jsx.rs
@@ -6,7 +6,7 @@ use crate::{
     expr::{Expr, SpreadElement},
     ident::Ident,
     typescript::TsTypeParamInstantiation,
-    IdentName, Str,
+    IdentName, NodeId, Str,
 };
 
 /// Used for `obj` property of `JSXMemberExpr`.
@@ -29,6 +29,9 @@ pub enum JSXObject {
 pub struct JSXMemberExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "object"))]
     pub obj: JSXObject,
 
@@ -43,6 +46,9 @@ pub struct JSXMemberExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXNamespacedName {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "namespace"))]
     pub ns: IdentName,
     pub name: IdentName,
@@ -54,6 +60,9 @@ pub struct JSXNamespacedName {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXEmptyExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 }
 
 #[ast_node("JSXExpressionContainer")]
@@ -62,6 +71,9 @@ pub struct JSXEmptyExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXExprContainer {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: JSXExpr,
 }
@@ -84,6 +96,9 @@ pub enum JSXExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXSpreadChild {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
 }
@@ -116,6 +131,9 @@ pub struct JSXOpeningElement {
 
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "attributes"))]
     pub attrs: Vec<JSXAttrOrSpread>,
 
@@ -137,6 +155,7 @@ impl Take for JSXOpeningElement {
         JSXOpeningElement {
             name: Take::dummy(),
             span: DUMMY_SP,
+            node_id: Default::default(),
             attrs: Take::dummy(),
             self_closing: Default::default(),
             type_args: Take::dummy(),
@@ -162,6 +181,9 @@ pub enum JSXAttrOrSpread {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXClosingElement {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub name: JSXElementName,
 }
 
@@ -171,6 +193,9 @@ pub struct JSXClosingElement {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXAttr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub name: JSXAttrName,
     /// Babel uses Expr instead of JSXAttrValue
     #[cfg_attr(
@@ -214,6 +239,9 @@ pub enum JSXAttrValue {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXText {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub value: Atom,
     pub raw: Atom,
 }
@@ -236,6 +264,9 @@ impl<'a> arbitrary::Arbitrary<'a> for JSXText {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXElement {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub opening: JSXOpeningElement,
     pub children: Vec<JSXElementChild>,
     #[cfg_attr(
@@ -249,6 +280,7 @@ impl Take for JSXElement {
     fn dummy() -> Self {
         JSXElement {
             span: DUMMY_SP,
+            node_id: Default::default(),
             opening: Take::dummy(),
             children: Take::dummy(),
             closing: Take::dummy(),
@@ -284,6 +316,9 @@ pub enum JSXElementChild {
 pub struct JSXFragment {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub opening: JSXOpeningFragment,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -296,6 +331,7 @@ impl Take for JSXFragment {
     fn dummy() -> Self {
         JSXFragment {
             span: DUMMY_SP,
+            node_id: Default::default(),
             opening: Take::dummy(),
             children: Take::dummy(),
             closing: Take::dummy(),
@@ -309,11 +345,17 @@ impl Take for JSXFragment {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXOpeningFragment {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 }
 
 impl Take for JSXOpeningFragment {
     fn dummy() -> Self {
-        JSXOpeningFragment { span: DUMMY_SP }
+        JSXOpeningFragment {
+            span: DUMMY_SP,
+            node_id: Default::default(),
+        }
     }
 }
 
@@ -323,10 +365,16 @@ impl Take for JSXOpeningFragment {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXClosingFragment {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 }
 
 impl Take for JSXClosingFragment {
     fn dummy() -> Self {
-        JSXClosingFragment { span: DUMMY_SP }
+        JSXClosingFragment {
+            span: DUMMY_SP,
+            node_id: Default::default(),
+        }
     }
 }

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -41,6 +41,7 @@ pub use self::{
         ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportPhase, ImportSpecifier,
         ImportStarAsSpecifier, ModuleDecl, ModuleExportName, NamedExport,
     },
+    node_id::NodeId,
     operators::{AssignOp, BinaryOp, UnaryOp, UpdateOp},
     pat::{
         ArrayPat, AssignPat, AssignPatProp, KeyValuePatProp, ObjectPat, ObjectPatProp, Pat, RestPat,
@@ -86,6 +87,7 @@ mod list;
 mod lit;
 mod module;
 mod module_decl;
+mod node_id;
 mod operators;
 mod pat;
 mod prop;
@@ -337,6 +339,9 @@ where
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Invalid {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 }
 
 impl Take for Invalid {

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -12,7 +12,7 @@ use swc_atoms::{
 };
 use swc_common::{ast_node, errors::HANDLER, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 
-use crate::{jsx::JSXText, TplElement};
+use crate::{jsx::JSXText, NodeId, TplElement};
 
 #[ast_node]
 #[derive(Eq, Hash, EqIgnoreSpan, Is)]
@@ -86,6 +86,9 @@ impl Lit {
 #[derive(Eq, Hash)]
 pub struct BigInt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(any(feature = "rkyv-impl"), rkyv(with = EncodeBigInt))]
     #[cfg_attr(feature = "encoding-impl", encoding(with = "EncodeBigInt2"))]
     pub value: Box<BigIntValue>,
@@ -210,6 +213,7 @@ impl From<BigIntValue> for BigInt {
     fn from(value: BigIntValue) -> Self {
         BigInt {
             span: DUMMY_SP,
+            node_id: Default::default(),
             value: Box::new(value),
             raw: None,
         }
@@ -222,6 +226,9 @@ impl From<BigIntValue> for BigInt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Str {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub value: Wtf8Atom,
 
@@ -238,6 +245,7 @@ impl Take for Str {
     fn dummy() -> Self {
         Str {
             span: DUMMY_SP,
+            node_id: Default::default(),
             value: Wtf8Atom::default(),
             raw: None,
         }
@@ -458,6 +466,7 @@ impl From<Atom> for Str {
     fn from(value: Atom) -> Self {
         Str {
             span: DUMMY_SP,
+            node_id: Default::default(),
             value: value.into(),
             raw: None,
         }
@@ -469,6 +478,7 @@ impl From<Wtf8Atom> for Str {
     fn from(value: Wtf8Atom) -> Self {
         Str {
             span: DUMMY_SP,
+            node_id: Default::default(),
             value,
             raw: None,
         }
@@ -494,6 +504,9 @@ bridge_from!(Str, Atom, Cow<'_, str>);
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Bool {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub value: bool,
 }
 
@@ -501,6 +514,7 @@ impl Take for Bool {
     fn dummy() -> Self {
         Bool {
             span: DUMMY_SP,
+            node_id: Default::default(),
             value: false,
         }
     }
@@ -511,6 +525,7 @@ impl From<bool> for Bool {
     fn from(value: bool) -> Self {
         Bool {
             span: DUMMY_SP,
+            node_id: Default::default(),
             value,
         }
     }
@@ -522,11 +537,17 @@ impl From<bool> for Bool {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Null {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 }
 
 impl Take for Null {
     fn dummy() -> Self {
-        Null { span: DUMMY_SP }
+        Null {
+            span: DUMMY_SP,
+            node_id: Default::default(),
+        }
     }
 }
 
@@ -535,6 +556,9 @@ impl Take for Null {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Regex {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(rename = "pattern"))]
     pub exp: Atom,
@@ -547,6 +571,7 @@ impl Take for Regex {
     fn dummy() -> Self {
         Self {
             span: DUMMY_SP,
+            node_id: Default::default(),
             exp: Default::default(),
             flags: Default::default(),
         }
@@ -582,6 +607,9 @@ impl<'a> arbitrary::Arbitrary<'a> for Regex {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Number {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     /// **Note**: This should not be `NaN`. Use [crate::Ident] to represent NaN.
     ///
     /// If you store `NaN` in this field, a hash map will behave strangely.
@@ -659,6 +687,7 @@ impl From<f64> for Number {
     fn from(value: f64) -> Self {
         Number {
             span: DUMMY_SP,
+            node_id: Default::default(),
             value,
             raw: None,
         }
@@ -670,6 +699,7 @@ impl From<usize> for Number {
     fn from(value: usize) -> Self {
         Number {
             span: DUMMY_SP,
+            node_id: Default::default(),
             value: value as _,
             raw: None,
         }

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -2,7 +2,7 @@ use is_macro::Is;
 use swc_atoms::Atom;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 
-use crate::{module_decl::ModuleDecl, stmt::Stmt};
+use crate::{module_decl::ModuleDecl, stmt::Stmt, NodeId};
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
@@ -26,6 +26,9 @@ impl Take for Program {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Module {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub body: Vec<ModuleItem>,
 
@@ -55,6 +58,7 @@ impl Take for Module {
     fn dummy() -> Self {
         Module {
             span: DUMMY_SP,
+            node_id: Default::default(),
             body: Take::dummy(),
             shebang: Take::dummy(),
         }
@@ -66,6 +70,9 @@ impl Take for Module {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Script {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub body: Vec<Stmt>,
 
@@ -95,6 +102,7 @@ impl Take for Script {
     fn dummy() -> Self {
         Script {
             span: DUMMY_SP,
+            node_id: Default::default(),
             body: Take::dummy(),
             shebang: Take::dummy(),
         }

--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -10,7 +10,7 @@ use crate::{
     ident::Ident,
     lit::Str,
     typescript::{TsExportAssignment, TsImportEqualsDecl, TsInterfaceDecl, TsNamespaceExportDecl},
-    BindingIdent, IdentName, ObjectLit,
+    BindingIdent, IdentName, NodeId, ObjectLit,
 };
 
 #[ast_node]
@@ -100,6 +100,9 @@ impl Take for ModuleDecl {
 pub struct ExportDefaultExpr {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
 }
@@ -111,6 +114,9 @@ pub struct ExportDefaultExpr {
 pub struct ExportDecl {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "declaration"))]
     pub decl: Decl,
 }
@@ -121,6 +127,9 @@ pub struct ExportDecl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub specifiers: Vec<ImportSpecifier>,
@@ -171,6 +180,7 @@ impl Take for ImportDecl {
     fn dummy() -> Self {
         ImportDecl {
             span: DUMMY_SP,
+            node_id: Default::default(),
             specifiers: Take::dummy(),
             src: Take::dummy(),
             type_only: Default::default(),
@@ -187,6 +197,9 @@ impl Take for ImportDecl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportAll {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(rename = "source"))]
     pub src: Box<Str>,
@@ -206,6 +219,7 @@ impl Take for ExportAll {
     fn dummy() -> Self {
         Self {
             span: DUMMY_SP,
+            node_id: Default::default(),
             src: Take::dummy(),
             type_only: Default::default(),
             with: Take::dummy(),
@@ -221,6 +235,9 @@ impl Take for ExportAll {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct NamedExport {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub specifiers: Vec<ExportSpecifier>,
 
@@ -246,6 +263,7 @@ impl Take for NamedExport {
     fn dummy() -> Self {
         Self {
             span: DUMMY_SP,
+            node_id: Default::default(),
             specifiers: Take::dummy(),
             src: Take::dummy(),
             type_only: Default::default(),
@@ -260,6 +278,9 @@ impl Take for NamedExport {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub decl: DefaultDecl,
 }
@@ -332,6 +353,9 @@ impl ImportSpecifier {
 pub struct ImportDefaultSpecifier {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub local: Ident,
 }
 /// e.g. `import * as foo from 'mod.js'`.
@@ -341,6 +365,9 @@ pub struct ImportDefaultSpecifier {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportStarAsSpecifier {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub local: Ident,
 }
@@ -353,6 +380,9 @@ pub struct ImportStarAsSpecifier {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportNamedSpecifier {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub local: Ident,
 
@@ -390,6 +420,9 @@ pub enum ExportSpecifier {
 pub struct ExportNamespaceSpecifier {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub name: ModuleExportName,
 }
 
@@ -399,6 +432,9 @@ pub struct ExportNamespaceSpecifier {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultSpecifier {
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[span]
     pub exported: Ident,
 }
@@ -409,6 +445,9 @@ pub struct ExportDefaultSpecifier {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportNamedSpecifier {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     /// `foo` in `export { foo as bar }`
     pub orig: ModuleExportName,
     /// `Some(bar)` in `export { foo as bar }`

--- a/crates/swc_ecma_ast/src/node_id.rs
+++ b/crates/swc_ecma_ast/src/node_id.rs
@@ -1,0 +1,41 @@
+use swc_common::EqIgnoreSpan;
+
+/// Identifier of an AST node.
+///
+/// `0` is reserved for the dummy value. Parsers or dedicated passes should
+/// assign concrete ids before node identity is used for analysis.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, EqIgnoreSpan, Default)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    any(feature = "rkyv-impl"),
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "rkyv-impl", repr(transparent))]
+#[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-impl", serde(transparent))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(
+    feature = "encoding-impl",
+    derive(::swc_common::Encode, ::swc_common::Decode)
+)]
+pub struct NodeId(pub u32);
+
+impl NodeId {
+    pub const DUMMY: Self = Self(0);
+
+    #[inline(always)]
+    pub const fn from_u32(value: u32) -> Self {
+        Self(value)
+    }
+
+    #[inline(always)]
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+
+    #[inline(always)]
+    pub const fn is_dummy(self) -> bool {
+        self.0 == 0
+    }
+}

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -6,7 +6,7 @@ use crate::{
     ident::{BindingIdent, Ident},
     prop::PropName,
     typescript::TsTypeAnn,
-    Id, IdentName, Invalid,
+    Id, IdentName, Invalid, NodeId,
 };
 
 #[ast_node(no_clone)]
@@ -58,7 +58,11 @@ impl Clone for Pat {
 
 impl Default for Pat {
     fn default() -> Self {
-        Invalid { span: DUMMY_SP }.into()
+        Invalid {
+            span: DUMMY_SP,
+            node_id: Default::default(),
+        }
+        .into()
     }
 }
 impl Take for Pat {
@@ -92,6 +96,9 @@ pat_to_other!(Box<Expr>);
 pub struct ArrayPat {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "elements"))]
     #[cfg_attr(
         feature = "encoding-impl",
@@ -118,6 +125,9 @@ pub struct ArrayPat {
 pub struct ObjectPat {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "serde-impl", serde(rename = "properties"))]
     pub props: Vec<ObjectPatProp>,
 
@@ -140,6 +150,9 @@ pub struct ObjectPat {
 pub struct AssignPat {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub left: Box<Pat>,
 
     pub right: Box<Expr>,
@@ -152,6 +165,9 @@ pub struct AssignPat {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct RestPat {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(rename = "rest"))]
     pub dot3_token: Span,
@@ -188,6 +204,9 @@ pub enum ObjectPatProp {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct KeyValuePatProp {
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     #[span(lo)]
     pub key: PropName,
 
@@ -201,6 +220,9 @@ pub struct KeyValuePatProp {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignPatProp {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     /// Note: This type is to help implementing visitor and the field `type_ann`
     /// is always [None].
     pub key: BindingIdent,

--- a/crates/swc_ecma_ast/src/prop.rs
+++ b/crates/swc_ecma_ast/src/prop.rs
@@ -8,7 +8,7 @@ use crate::{
     lit::{BigInt, Number, Str},
     stmt::BlockStmt,
     typescript::TsTypeAnn,
-    Id, IdentName, MemberProp, Pat,
+    Id, IdentName, MemberProp, NodeId, Pat,
 };
 
 #[ast_node]
@@ -45,6 +45,9 @@ bridge_from!(Prop, Ident, IdentName);
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct KeyValueProp {
+    #[cfg_attr(feature = "serde-impl", serde(skip))]
+    pub node_id: NodeId,
+
     #[span(lo)]
     pub key: PropName,
 
@@ -58,6 +61,9 @@ pub struct KeyValueProp {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignProp {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub key: Ident,
     pub value: Box<Expr>,
 }
@@ -68,6 +74,9 @@ pub struct AssignProp {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct GetterProp {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub key: PropName,
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "typeAnnotation"))]
     #[cfg_attr(
@@ -88,6 +97,9 @@ pub struct GetterProp {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SetterProp {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub key: PropName,
     #[cfg_attr(
         feature = "encoding-impl",
@@ -107,6 +119,9 @@ pub struct SetterProp {
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct MethodProp {
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub key: PropName,
 
     #[cfg_attr(feature = "serde-impl", serde(flatten))]
@@ -155,14 +170,17 @@ impl From<PropName> for MemberProp {
             PropName::Computed(p) => MemberProp::Computed(p),
             PropName::Str(p) => MemberProp::Computed(ComputedPropName {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 expr: p.into(),
             }),
             PropName::Num(p) => MemberProp::Computed(ComputedPropName {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 expr: p.into(),
             }),
             PropName::BigInt(p) => MemberProp::Computed(ComputedPropName {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 expr: p.into(),
             }),
             #[cfg(all(swc_ast_unknown, feature = "encoding-impl"))]
@@ -178,6 +196,9 @@ impl From<PropName> for MemberProp {
 pub struct ComputedPropName {
     /// Span including `[` and `]`.
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
 }
@@ -186,6 +207,7 @@ impl Take for ComputedPropName {
     fn dummy() -> Self {
         Self {
             span: DUMMY_SP,
+            node_id: Default::default(),
             expr: Take::dummy(),
         }
     }

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -5,7 +5,7 @@ use crate::{
     decl::{Decl, VarDecl},
     expr::Expr,
     pat::Pat,
-    Ident, Lit, Str, UsingDecl,
+    Ident, Lit, NodeId, Str, UsingDecl,
 };
 
 /// Use when only block statements are allowed.
@@ -17,6 +17,9 @@ pub struct BlockStmt {
     /// Span including the braces.
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub ctxt: SyntaxContext,
 
     pub stmts: Vec<Stmt>,
@@ -26,6 +29,7 @@ impl Take for BlockStmt {
     fn dummy() -> Self {
         BlockStmt {
             span: DUMMY_SP,
+            node_id: Default::default(),
             stmts: Vec::new(),
             ctxt: Default::default(),
         }
@@ -203,7 +207,10 @@ impl Clone for Stmt {
 
 impl Default for Stmt {
     fn default() -> Self {
-        Self::Empty(EmptyStmt { span: DUMMY_SP })
+        Self::Empty(EmptyStmt {
+            span: DUMMY_SP,
+            node_id: Default::default(),
+        })
     }
 }
 
@@ -219,6 +226,9 @@ impl Take for Stmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExprStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
 }
@@ -230,6 +240,9 @@ pub struct ExprStmt {
 pub struct EmptyStmt {
     /// Span of semicolon.
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 }
 
 #[ast_node("DebuggerStatement")]
@@ -238,6 +251,9 @@ pub struct EmptyStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct DebuggerStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 }
 
 #[ast_node("WithStatement")]
@@ -246,6 +262,9 @@ pub struct DebuggerStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct WithStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "object"))]
     pub obj: Box<Expr>,
     pub body: Box<Stmt>,
@@ -257,6 +276,9 @@ pub struct WithStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ReturnStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "argument"))]
     #[cfg_attr(
         feature = "encoding-impl",
@@ -271,6 +293,9 @@ pub struct ReturnStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct LabeledStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub label: Ident,
     pub body: Box<Stmt>,
 }
@@ -281,6 +306,9 @@ pub struct LabeledStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BreakStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(
         feature = "encoding-impl",
@@ -295,6 +323,9 @@ pub struct BreakStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ContinueStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(
         feature = "encoding-impl",
@@ -309,6 +340,9 @@ pub struct ContinueStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct IfStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub test: Box<Expr>,
 
     #[cfg_attr(feature = "serde-impl", serde(rename = "consequent"))]
@@ -328,6 +362,9 @@ pub struct IfStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SwitchStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub discriminant: Box<Expr>,
     pub cases: Vec<SwitchCase>,
 }
@@ -338,6 +375,9 @@ pub struct SwitchStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ThrowStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "argument"))]
     pub arg: Box<Expr>,
 }
@@ -348,6 +388,9 @@ pub struct ThrowStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TryStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub block: BlockStmt,
 
@@ -372,6 +415,9 @@ pub struct TryStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct WhileStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub test: Box<Expr>,
     pub body: Box<Stmt>,
 }
@@ -382,6 +428,9 @@ pub struct WhileStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct DoWhileStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub test: Box<Expr>,
     pub body: Box<Stmt>,
 }
@@ -392,6 +441,9 @@ pub struct DoWhileStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(
@@ -423,6 +475,9 @@ pub struct ForStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForInStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub left: ForHead,
     pub right: Box<Expr>,
     pub body: Box<Stmt>,
@@ -434,6 +489,9 @@ pub struct ForInStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForOfStmt {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     /// Span of the await token.
     ///
     /// es2018
@@ -459,6 +517,9 @@ impl Take for ForOfStmt {
 pub struct SwitchCase {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     /// None for `default:`
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(
@@ -475,6 +536,7 @@ impl Take for SwitchCase {
     fn dummy() -> Self {
         Self {
             span: DUMMY_SP,
+            node_id: Default::default(),
             test: None,
             cons: Vec::new(),
         }
@@ -487,6 +549,9 @@ impl Take for SwitchCase {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct CatchClause {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     /// es2019
     ///
     /// The param is null if the catch binding is omitted. E.g., try { foo() }

--- a/crates/swc_ecma_ast/src/typescript.rs
+++ b/crates/swc_ecma_ast/src/typescript.rs
@@ -20,7 +20,7 @@ use crate::{
     lit::{Bool, Number, Str},
     module::ModuleItem,
     pat::{ArrayPat, AssignPat, ObjectPat, Pat, RestPat},
-    BigInt, BindingIdent, IdentName, TplElement,
+    BigInt, BindingIdent, IdentName, NodeId, TplElement,
 };
 
 #[ast_node("TsTypeAnnotation")]
@@ -29,6 +29,9 @@ use crate::{
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeAnn {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
     pub type_ann: Box<TsType>,
 }
@@ -39,6 +42,9 @@ pub struct TsTypeAnn {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeParamDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "parameters"))]
     pub params: Vec<TsTypeParam>,
 }
@@ -49,6 +55,9 @@ pub struct TsTypeParamDecl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeParam {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub name: Ident,
 
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "in"))]
@@ -81,6 +90,9 @@ pub struct TsTypeParam {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeParamInstantiation {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub params: Vec<Box<TsType>>,
 }
 
@@ -90,6 +102,9 @@ pub struct TsTypeParamInstantiation {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsParamProp {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub decorators: Vec<Decorator>,
     /// At least one of `accessibility` or `readonly` must be set.
@@ -123,6 +138,9 @@ pub enum TsParamPropParam {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsQualifiedName {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub left: TsEntityName,
     pub right: IdentName,
 }
@@ -177,6 +195,9 @@ pub enum TsTypeElement {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsCallSignatureDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub params: Vec<TsFnParam>,
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "typeAnnotation"))]
     #[cfg_attr(
@@ -198,6 +219,9 @@ pub struct TsCallSignatureDecl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConstructSignatureDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub params: Vec<TsFnParam>,
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "typeAnnotation"))]
     #[cfg_attr(
@@ -219,6 +243,9 @@ pub struct TsConstructSignatureDecl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsPropertySignature {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub readonly: bool,
     pub key: Box<Expr>,
     pub computed: bool,
@@ -237,6 +264,9 @@ pub struct TsPropertySignature {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsGetterSignature {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub key: Box<Expr>,
     pub computed: bool,
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "typeAnnotation"))]
@@ -253,6 +283,9 @@ pub struct TsGetterSignature {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsSetterSignature {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub key: Box<Expr>,
     pub computed: bool,
     pub param: TsFnParam,
@@ -264,6 +297,9 @@ pub struct TsSetterSignature {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsMethodSignature {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub key: Box<Expr>,
     pub computed: bool,
     pub optional: bool,
@@ -299,6 +335,9 @@ pub struct TsIndexSignature {
     #[cfg_attr(feature = "serde-impl", serde(rename = "static"))]
     pub is_static: bool,
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 }
 
 // ================
@@ -446,6 +485,9 @@ impl From<TsIntersectionType> for TsType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsKeywordType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub kind: TsKeywordTypeKind,
 }
 
@@ -511,6 +553,9 @@ pub enum TsKeywordTypeKind {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsThisType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 }
 
 #[ast_node]
@@ -537,6 +582,9 @@ pub enum TsFnParam {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsFnType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub params: Vec<TsFnParam>,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -555,6 +603,9 @@ pub struct TsFnType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConstructorType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub params: Vec<TsFnParam>,
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(
@@ -573,6 +624,9 @@ pub struct TsConstructorType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeRef {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub type_name: TsEntityName,
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(
@@ -588,6 +642,9 @@ pub struct TsTypeRef {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypePredicate {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub asserts: bool,
     pub param_name: TsThisTypeOrIdent,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
@@ -618,6 +675,9 @@ pub enum TsThisTypeOrIdent {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeQuery {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub expr_name: TsTypeQueryExpr,
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "typeArguments"))]
     #[cfg_attr(
@@ -645,6 +705,9 @@ pub enum TsTypeQueryExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsImportCallOptions {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub with: Box<ObjectLit>,
 }
@@ -655,6 +718,9 @@ pub struct TsImportCallOptions {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsImportType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "argument"))]
     pub arg: Str,
     #[cfg_attr(
@@ -682,6 +748,9 @@ pub struct TsImportType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeLit {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub members: Vec<TsTypeElement>,
 }
 
@@ -691,6 +760,9 @@ pub struct TsTypeLit {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsArrayType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub elem_type: Box<TsType>,
 }
 
@@ -700,6 +772,9 @@ pub struct TsArrayType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTupleType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub elem_types: Vec<TsTupleElement>,
 }
 
@@ -709,6 +784,9 @@ pub struct TsTupleType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTupleElement {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     /// `Ident` or `RestPat { arg: Ident }`
     #[cfg_attr(
         feature = "encoding-impl",
@@ -724,6 +802,9 @@ pub struct TsTupleElement {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsOptionalType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
     pub type_ann: Box<TsType>,
 }
@@ -734,6 +815,9 @@ pub struct TsOptionalType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsRestType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
     pub type_ann: Box<TsType>,
 }
@@ -756,6 +840,9 @@ pub enum TsUnionOrIntersectionType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsUnionType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub types: Vec<Box<TsType>>,
 }
 
@@ -765,6 +852,9 @@ pub struct TsUnionType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsIntersectionType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub types: Vec<Box<TsType>>,
 }
 
@@ -774,6 +864,9 @@ pub struct TsIntersectionType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConditionalType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub check_type: Box<TsType>,
     pub extends_type: Box<TsType>,
     pub true_type: Box<TsType>,
@@ -786,6 +879,9 @@ pub struct TsConditionalType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInferType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub type_param: TsTypeParam,
 }
 
@@ -795,6 +891,9 @@ pub struct TsInferType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsParenthesizedType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
     pub type_ann: Box<TsType>,
 }
@@ -805,6 +904,9 @@ pub struct TsParenthesizedType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeOperator {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub op: TsTypeOperatorOp,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
     pub type_ann: Box<TsType>,
@@ -839,6 +941,9 @@ pub enum TsTypeOperatorOp {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsIndexedAccessType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub readonly: bool,
     #[cfg_attr(feature = "serde-impl", serde(rename = "objectType"))]
     pub obj_type: Box<TsType>,
@@ -928,6 +1033,9 @@ impl<'de> Deserialize<'de> for TruePlusMinus {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsMappedType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(
         feature = "encoding-impl",
@@ -961,6 +1069,9 @@ pub struct TsMappedType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsLitType {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "literal"))]
     pub lit: TsLit,
 }
@@ -993,6 +1104,9 @@ pub enum TsLit {
 pub struct TsTplLitType {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub types: Vec<Box<TsType>>,
 
     pub quasis: Vec<TplElement>,
@@ -1008,6 +1122,9 @@ pub struct TsTplLitType {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInterfaceDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub id: Ident,
     pub declare: bool,
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -1026,6 +1143,9 @@ pub struct TsInterfaceDecl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInterfaceBody {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub body: Vec<TsTypeElement>,
 }
 
@@ -1035,6 +1155,9 @@ pub struct TsInterfaceBody {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsExprWithTypeArgs {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "typeArguments"))]
@@ -1051,6 +1174,9 @@ pub struct TsExprWithTypeArgs {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeAliasDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub declare: bool,
     pub id: Ident,
     #[cfg_attr(feature = "serde-impl", serde(default))]
@@ -1069,6 +1195,9 @@ pub struct TsTypeAliasDecl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsEnumDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub declare: bool,
     pub is_const: bool,
     pub id: Ident,
@@ -1081,6 +1210,9 @@ pub struct TsEnumDecl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsEnumMember {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub id: TsEnumMemberId,
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(
@@ -1110,6 +1242,9 @@ pub enum TsEnumMemberId {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsModuleDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub declare: bool,
     /// In TypeScript, this is only available through`node.flags`.
     pub global: bool,
@@ -1144,6 +1279,9 @@ pub enum TsNamespaceBody {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsModuleBlock {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub body: Vec<ModuleItem>,
 }
 
@@ -1153,6 +1291,9 @@ pub struct TsModuleBlock {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsNamespaceDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub declare: bool,
     /// In TypeScript, this is only available through`node.flags`.
     pub global: bool,
@@ -1178,6 +1319,9 @@ pub enum TsModuleName {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsImportEqualsDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub is_export: bool,
     pub is_type_only: bool,
     pub id: Ident,
@@ -1203,6 +1347,9 @@ pub enum TsModuleRef {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsExternalModuleRef {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Str,
 }
@@ -1216,6 +1363,9 @@ pub struct TsExternalModuleRef {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsExportAssignment {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
 }
@@ -1226,6 +1376,9 @@ pub struct TsExportAssignment {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsNamespaceExportDecl {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub id: Ident,
 }
 
@@ -1239,6 +1392,9 @@ pub struct TsNamespaceExportDecl {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsAsExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
@@ -1251,6 +1407,9 @@ pub struct TsAsExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeAssertion {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
@@ -1263,6 +1422,9 @@ pub struct TsTypeAssertion {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsNonNullExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
 }
@@ -1273,6 +1435,9 @@ pub struct TsNonNullExpr {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsSatisfiesExpr {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeAnnotation"))]
@@ -1309,6 +1474,9 @@ pub enum Accessibility {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConstAssertion {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
 }
@@ -1319,6 +1487,9 @@ pub struct TsConstAssertion {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInstantiation {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     #[cfg_attr(feature = "serde-impl", serde(rename = "expression"))]
     pub expr: Box<Expr>,
     #[cfg_attr(feature = "serde-impl", serde(rename = "typeArguments"))]

--- a/crates/swc_ecma_ast/tests/lit.rs
+++ b/crates/swc_ecma_ast/tests/lit.rs
@@ -21,6 +21,7 @@ fn convert_wtf8_to_raw(s: &Wtf8) -> String {
 /// Helper function to test `Str::from_tpl_raw`
 fn test_from_tpl_raw(raw: &str, expected: &str) {
     let tpl = TplElement {
+        node_id: Default::default(),
         span: DUMMY_SP,
         tail: true,
         raw: Atom::new(raw.to_string()),

--- a/crates/swc_ecma_codegen/src/util.rs
+++ b/crates/swc_ecma_codegen/src/util.rs
@@ -313,6 +313,7 @@ impl StartsWithAlphaNum for ExprOrSpread {
             ExprOrSpread {
                 spread: None,
                 ref expr,
+                ..
             } => expr.starts_with_alpha_num(),
         }
     }

--- a/crates/swc_ecma_hooks/src/generated.rs
+++ b/crates/swc_ecma_hooks/src/generated.rs
@@ -1000,6 +1000,14 @@ pub trait VisitHook<C> {
     #[inline]
     #[allow(unused_variables)]
     fn exit_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `NodeId` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_node_id(&mut self, node: &NodeId, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `NodeId` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_node_id(&mut self, node: &NodeId, ctx: &mut C) {}
     #[doc = "Called when entering a node of type `Null` before visiting its children."]
     #[inline]
     #[allow(unused_variables)]
@@ -3971,6 +3979,18 @@ where
     fn exit_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {
         self.second.exit_new_expr(node, ctx);
         self.first.exit_new_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        self.first.enter_node_id(node, ctx);
+        self.second.enter_node_id(node, ctx);
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        self.second.exit_node_id(node, ctx);
+        self.first.exit_node_id(node, ctx);
     }
 
     #[inline]
@@ -8019,6 +8039,22 @@ where
         match self {
             Self::Left(hook) => hook.exit_new_expr(node, ctx),
             Self::Right(hook) => hook.exit_new_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_node_id(node, ctx),
+            Self::Right(hook) => hook.enter_node_id(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_node_id(node, ctx),
+            Self::Right(hook) => hook.exit_node_id(node, ctx),
         }
     }
 
@@ -12525,6 +12561,20 @@ where
     }
 
     #[inline]
+    fn enter_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_node_id(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_node_id(node, ctx);
+        }
+    }
+
+    #[inline]
     fn enter_null(&mut self, node: &Null, ctx: &mut C) {
         if let Some(hook) = self {
             hook.enter_null(node, ctx);
@@ -15980,6 +16030,14 @@ impl<H: VisitHook<C>, C> Visit for VisitWithHook<H, C> {
         self.hook.exit_new_expr(node, &mut self.context);
     }
 
+    #[doc = "Visits a node of type `NodeId` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_node_id(&mut self, node: &NodeId) {
+        self.hook.enter_node_id(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_node_id(node, &mut self.context);
+    }
+
     #[doc = "Visits a node of type `Null` using the hook's enter and exit methods."]
     #[inline]
     fn visit_null(&mut self, node: &Null) {
@@ -18468,6 +18526,14 @@ pub trait VisitMutHook<C> {
     #[inline]
     #[allow(unused_variables)]
     fn exit_new_expr(&mut self, node: &mut NewExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `NodeId` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `NodeId` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {}
     #[doc = "Called when entering a node of type `Null` before visiting its children."]
     #[inline]
     #[allow(unused_variables)]
@@ -21483,6 +21549,18 @@ where
     fn exit_new_expr(&mut self, node: &mut NewExpr, ctx: &mut C) {
         self.second.exit_new_expr(node, ctx);
         self.first.exit_new_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        self.first.enter_node_id(node, ctx);
+        self.second.enter_node_id(node, ctx);
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        self.second.exit_node_id(node, ctx);
+        self.first.exit_node_id(node, ctx);
     }
 
     #[inline]
@@ -25567,6 +25645,22 @@ where
         match self {
             Self::Left(hook) => hook.exit_new_expr(node, ctx),
             Self::Right(hook) => hook.exit_new_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_node_id(node, ctx),
+            Self::Right(hook) => hook.enter_node_id(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_node_id(node, ctx),
+            Self::Right(hook) => hook.exit_node_id(node, ctx),
         }
     }
 
@@ -30109,6 +30203,20 @@ where
     }
 
     #[inline]
+    fn enter_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_node_id(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_node_id(node, ctx);
+        }
+    }
+
+    #[inline]
     fn enter_null(&mut self, node: &mut Null, ctx: &mut C) {
         if let Some(hook) = self {
             hook.enter_null(node, ctx);
@@ -33590,6 +33698,14 @@ impl<H: VisitMutHook<C>, C> VisitMut for VisitMutWithHook<H, C> {
         self.hook.enter_new_expr(node, &mut self.context);
         node.visit_mut_children_with(self);
         self.hook.exit_new_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `NodeId` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_mut_node_id(&mut self, node: &mut NodeId) {
+        self.hook.enter_node_id(node, &mut self.context);
+        node.visit_mut_children_with(self);
+        self.hook.exit_node_id(node, &mut self.context);
     }
 
     #[doc = "Visits a node of type `Null` using the hook's enter and exit methods."]

--- a/crates/swc_ecma_hooks/tests/compose.rs
+++ b/crates/swc_ecma_hooks/tests/compose.rs
@@ -66,6 +66,7 @@ fn compose_visit() {
         span: DUMMY_SP,
         callee: Callee::Expr(
             AwaitExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 arg: Ident::new_no_ctxt(atom!("foo"), DUMMY_SP).into(),
             }

--- a/crates/swc_ecma_lexer/src/common/parser/class_and_fn.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/class_and_fn.rs
@@ -145,6 +145,7 @@ fn parse_decorator<'a, P: Parser<'a>>(p: &mut P) -> PResult<Decorator> {
     let expr = parse_maybe_decorator_args(p, expr)?;
 
     Ok(Decorator {
+        node_id: Default::default(),
         span: p.span(start),
         expr,
     })
@@ -314,6 +315,7 @@ where
         }
 
         Ok(Box::new(Function {
+            node_id: Default::default(),
             span: p.span(start),
             decorators,
             type_params,
@@ -548,6 +550,7 @@ where
             }
 
             Ok(PrivateMethod {
+                node_id: Default::default(),
                 span,
 
                 accessibility,
@@ -568,6 +571,7 @@ where
                 p.emit_err(span, SyntaxError::TS1245)
             }
             Ok(ClassMethod {
+                node_id: Default::default(),
                 span,
 
                 accessibility,
@@ -761,6 +765,7 @@ fn make_property<'a, P: Parser<'a>>(
 
         if accessor_token.is_some() {
             return Ok(ClassMember::AutoAccessor(AutoAccessor {
+                node_id: Default::default(),
                 span: p.span(start),
                 key,
                 value,
@@ -782,6 +787,7 @@ fn make_property<'a, P: Parser<'a>>(
                 }
 
                 PrivateProp {
+                    node_id: Default::default(),
                     span: p.span(start),
                     key,
                     value,
@@ -803,6 +809,7 @@ fn make_property<'a, P: Parser<'a>>(
                     p.emit_err(span, SyntaxError::TS1267)
                 }
                 ClassProp {
+                    node_id: Default::default(),
                     span,
                     key,
                     value,
@@ -834,7 +841,12 @@ fn parse_static_block<'a, P: Parser<'a>>(p: &mut P, start: BytePos) -> PResult<C
     )?;
 
     let span = p.span(start);
-    Ok(StaticBlock { span, body }.into())
+    Ok(StaticBlock {
+        node_id: Default::default(),
+        span,
+        body,
+    }
+    .into())
 }
 
 fn parse_class_member_with_is_static<'a, P: Parser<'a>>(
@@ -1510,7 +1522,10 @@ fn parse_class_body<'a, P: Parser<'a>>(p: &mut P) -> PResult<Vec<ClassMember>> {
         if p.input_mut().eat(&P::Token::SEMI) {
             let span = p.input().prev_span();
             debug_assert!(span.lo <= span.hi);
-            elems.push(ClassMember::Empty(EmptyStmt { span }));
+            elems.push(ClassMember::Empty(EmptyStmt {
+                node_id: Default::default(),
+                span,
+            }));
             continue;
         }
         let elem = p.do_inside_of_context(Context::AllowDirectSuper, parse_class_member)?;

--- a/crates/swc_ecma_lexer/src/common/parser/expr.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/expr.rs
@@ -94,7 +94,12 @@ pub fn parse_array_lit<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr>> {
     expect!(p, &P::Token::RBRACKET);
 
     let span = p.span(start);
-    Ok(ArrayLit { span, elems }.into())
+    Ok(ArrayLit {
+        node_id: Default::default(),
+        span,
+        elems,
+    }
+    .into())
 }
 
 pub fn at_possible_async<'a, P: Parser<'a>>(p: &P, expr: &Expr) -> bool {
@@ -129,6 +134,7 @@ fn parse_yield_expr<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr>> {
             )
         })?;
         Ok(YieldExpr {
+            node_id: Default::default(),
             span: p.span(start),
             arg: Some(arg),
             delegate: has_star,
@@ -145,6 +151,7 @@ fn parse_yield_expr<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr>> {
             && !cur.starts_expr()
     } {
         Ok(YieldExpr {
+            node_id: Default::default(),
             span: p.span(start),
             arg: None,
             delegate: false,
@@ -191,6 +198,7 @@ fn parse_tpl<'a, P: Parser<'a>>(p: &mut P, is_tagged_tpl: bool) -> PResult<Tpl> 
 
     let span = p.span(start);
     Ok(Tpl {
+        node_id: Default::default(),
         span,
         exprs,
         quasis,
@@ -228,6 +236,7 @@ pub fn parse_str_lit<'a>(p: &mut impl Parser<'a>) -> swc_ecma_ast::Str {
     let start = token_and_span.span().lo;
     let (value, raw) = p.input_mut().expect_string_token_and_bump();
     swc_ecma_ast::Str {
+        node_id: Default::default(),
         span: p.span(start),
         value,
         raw: Some(raw),
@@ -241,17 +250,25 @@ pub fn parse_lit<'a, P: Parser<'a>>(p: &mut P) -> PResult<Lit> {
     let v = if cur.is_null() {
         p.bump();
         let span = p.span(start);
-        Lit::Null(swc_ecma_ast::Null { span })
+        Lit::Null(swc_ecma_ast::Null {
+            node_id: Default::default(),
+            span,
+        })
     } else if cur.is_true() || cur.is_false() {
         let value = cur.is_true();
         p.bump();
         let span = p.span(start);
-        Lit::Bool(swc_ecma_ast::Bool { span, value })
+        Lit::Bool(swc_ecma_ast::Bool {
+            node_id: Default::default(),
+            span,
+            value,
+        })
     } else if cur.is_str() {
         Lit::Str(parse_str_lit(p))
     } else if cur.is_num() {
         let (value, raw) = p.input_mut().expect_number_token_and_bump();
         Lit::Num(swc_ecma_ast::Number {
+            node_id: Default::default(),
             span: p.span(start),
             value,
             raw: Some(raw),
@@ -259,6 +276,7 @@ pub fn parse_lit<'a, P: Parser<'a>>(p: &mut P) -> PResult<Lit> {
     } else if cur.is_bigint() {
         let (value, raw) = p.input_mut().expect_bigint_token_and_bump();
         Lit::BigInt(swc_ecma_ast::BigInt {
+            node_id: Default::default(),
             span: p.span(start),
             value,
             raw: Some(raw),
@@ -505,6 +523,7 @@ pub fn finish_assignment_expr<'a, P: Parser<'a>>(
         p.bump();
         let right = parse_assignment_expr(p)?;
         Ok(AssignExpr {
+            node_id: Default::default(),
             span: p.span(start),
             op,
             // TODO:
@@ -546,6 +565,7 @@ fn parse_cond_expr<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr>> {
 
         let span = Span::new_with_checked(start, alt.span_hi());
         Ok(CondExpr {
+            node_id: Default::default(),
             span,
             test,
             cons,
@@ -610,6 +630,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
             };
             return Ok((
                 TsNonNullExpr {
+                    node_id: Default::default(),
                     span: p.span(start),
                     expr,
                 }
@@ -663,6 +684,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
                             if let Expr::OptChain(..) = &**callee {
                                 return Ok(Some((
                                     OptChainExpr {
+                                        node_id: Default::default(),
                                         span: p.span(start),
                                         base: Box::new(OptChainBase::Call(OptCall {
                                             span: p.span(start),
@@ -706,6 +728,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
                     } else if cur.is_equal() || cur.is_as() || cur.is_satisfies() {
                         Ok(Some((
                             TsInstantiation {
+                                node_id: Default::default(),
                                 span: p.span(start),
                                 expr: match mut_obj_opt {
                                     Some(Callee::Expr(obj)) => obj.take(),
@@ -767,6 +790,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
         let span = Span::new_with_checked(obj.span_lo(), p.input().last_pos());
         debug_assert_eq!(obj.span_lo(), span.lo());
         let prop = ComputedPropName {
+            node_id: Default::default(),
             span: Span::new_with_checked(bracket_lo, p.input().last_pos()),
             expr: prop,
         };
@@ -793,6 +817,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
                         }
                     } else {
                         SuperPropExpr {
+                            node_id: Default::default(),
                             span,
                             obj,
                             prop: SuperProp::Computed(prop),
@@ -803,12 +828,14 @@ fn parse_subscript<'a, P: Parser<'a>>(
                 Callee::Expr(obj) => {
                     let is_opt_chain = unwrap_ts_non_null(&obj).is_opt_chain();
                     let expr = MemberExpr {
+                        node_id: Default::default(),
                         span,
                         obj,
                         prop: MemberProp::Computed(prop),
                     };
                     let expr = if is_opt_chain || question_dot_token.is_some() {
                         OptChainExpr {
+                            node_id: Default::default(),
                             span,
                             optional: question_dot_token.is_some(),
                             base: Box::new(OptChainBase::Member(expr)),
@@ -820,6 +847,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
 
                     if let Some(type_args) = type_args {
                         TsInstantiation {
+                            node_id: Default::default(),
                             expr: Box::new(expr),
                             type_args,
                             span: p.span(start),
@@ -863,6 +891,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
                 }
                 Callee::Expr(callee) => Ok((
                     OptChainExpr {
+                        node_id: Default::default(),
                         span,
                         optional: question_dot_token.is_some(),
                         base: Box::new(OptChainBase::Call(OptCall {
@@ -920,6 +949,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
                         }
                         match &*sym {
                             "meta" => MetaPropExpr {
+                                node_id: Default::default(),
                                 span,
                                 kind: MetaPropKind::ImportMeta,
                             }
@@ -956,6 +986,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
                     } else {
                         match prop {
                             MemberProp::Ident(ident) => SuperPropExpr {
+                                node_id: Default::default(),
                                 span,
                                 obj,
                                 prop: SuperProp::Ident(ident),
@@ -975,11 +1006,17 @@ fn parse_subscript<'a, P: Parser<'a>>(
                     }
                 }
                 Callee::Expr(obj) => {
-                    let expr = MemberExpr { span, obj, prop };
+                    let expr = MemberExpr {
+                        node_id: Default::default(),
+                        span,
+                        obj,
+                        prop,
+                    };
                     let expr = if unwrap_ts_non_null(&expr.obj).is_opt_chain()
                         || question_dot_token.is_some()
                     {
                         OptChainExpr {
+                            node_id: Default::default(),
                             span: p.span(start),
                             optional: question_dot_token.is_some(),
                             base: Box::new(OptChainBase::Member(expr)),
@@ -990,6 +1027,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
                     };
                     if let Some(type_args) = type_args {
                         TsInstantiation {
+                            node_id: Default::default(),
                             expr: Box::new(expr),
                             type_args,
                             span: p.span(start),
@@ -1010,6 +1048,7 @@ fn parse_subscript<'a, P: Parser<'a>>(
         Callee::Expr(expr) => {
             let expr = if let Some(type_args) = type_args {
                 TsInstantiation {
+                    node_id: Default::default(),
                     expr,
                     type_args,
                     span: p.span(start),
@@ -1064,6 +1103,7 @@ pub fn parse_dynamic_import_or_import_meta<'a, P: Parser<'a>>(
                     p.emit_err(span, SyntaxError::ImportMetaInScript);
                 }
                 let expr = MetaPropExpr {
+                    node_id: Default::default(),
                     span,
                     kind: MetaPropKind::ImportMeta,
                 };
@@ -1085,6 +1125,7 @@ fn parse_dynamic_import_call<'a>(
     phase: ImportPhase,
 ) -> PResult<Box<Expr>> {
     let import = Callee::Import(Import {
+        node_id: Default::default(),
         span: p.span(start),
         phase,
     });
@@ -1118,6 +1159,7 @@ fn parse_member_expr_or_new_expr_inner<'a, P: Parser<'a>>(
             if p.input_mut().eat(&P::Token::TARGET) {
                 let span = p.span(start);
                 let expr = MetaPropExpr {
+                    node_id: Default::default(),
                     span,
                     kind: MetaPropKind::NewTarget,
                 }
@@ -1217,6 +1259,7 @@ fn parse_member_expr_or_new_expr_inner<'a, P: Parser<'a>>(
 
     if p.input_mut().eat(&P::Token::SUPER) {
         let base = Callee::Super(Super {
+            node_id: Default::default(),
             span: p.span(start),
         });
         return parse_subscripts(p, base, true, false);
@@ -1234,6 +1277,7 @@ fn parse_member_expr_or_new_expr_inner<'a, P: Parser<'a>>(
     let obj = if let Some(type_args) = type_args {
         trace_cur!(p, parse_member_expr_or_new_expr__with_type_args);
         TsInstantiation {
+            node_id: Default::default(),
             expr: obj,
             type_args,
             span: p.span(start),
@@ -1272,7 +1316,11 @@ pub fn parse_bin_expr<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr>> {
                 || cur.is_bin_op()
             {
                 p.emit_err(p.input().cur_span(), SyntaxError::TS1109);
-                Invalid { span: err.span() }.into()
+                Invalid {
+                    node_id: Default::default(),
+                    span: err.span(),
+                }
+                .into()
             } else {
                 return Err(err);
             }
@@ -1343,6 +1391,7 @@ fn parse_bin_op_recursively_inner<'a, P: Parser<'a>>(
                 p.bump(); // as
                 p.bump(); // const
                 TsConstAssertion {
+                    node_id: Default::default(),
                     span: p.span(start),
                     expr,
                 }
@@ -1350,6 +1399,7 @@ fn parse_bin_op_recursively_inner<'a, P: Parser<'a>>(
             } else {
                 let type_ann = next_then_parse_ts_type(p)?;
                 TsAsExpr {
+                    node_id: Default::default(),
                     span: p.span(start),
                     expr,
                     type_ann,
@@ -1364,6 +1414,7 @@ fn parse_bin_op_recursively_inner<'a, P: Parser<'a>>(
             let node = {
                 let type_ann = next_then_parse_ts_type(p)?;
                 TsSatisfiesExpr {
+                    node_id: Default::default(),
                     span: p.span(start),
                     expr,
                     type_ann,
@@ -1470,6 +1521,7 @@ fn parse_bin_op_recursively_inner<'a, P: Parser<'a>>(
     }
 
     let node = BinExpr {
+        node_id: Default::default(),
         span: Span::new_with_checked(left.span_lo(), right.span_hi()),
         op,
         left,
@@ -1496,6 +1548,7 @@ pub(crate) fn parse_unary_expr<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr
             expect!(p, &P::Token::GREATER);
             let expr = p.parse_unary_expr()?;
             return Ok(TsConstAssertion {
+                node_id: Default::default(),
                 span: p.span(start),
                 expr,
             }
@@ -1519,6 +1572,7 @@ pub(crate) fn parse_unary_expr<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr
         p.check_assign_target(&arg, false);
 
         return Ok(UpdateExpr {
+            node_id: Default::default(),
             span,
             prefix: true,
             op,
@@ -1557,6 +1611,7 @@ pub(crate) fn parse_unary_expr<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr
             Err(err) => {
                 p.emit_error(err);
                 Invalid {
+                    node_id: Default::default(),
                     span: Span::new_with_checked(arg_start, arg_start),
                 }
                 .into()
@@ -1575,6 +1630,7 @@ pub(crate) fn parse_unary_expr<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr
         }
 
         return Ok(UnaryExpr {
+            node_id: Default::default(),
             span: Span::new_with_checked(start, arg.span_hi()),
             op,
             arg,
@@ -1604,6 +1660,7 @@ pub(crate) fn parse_unary_expr<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr
         p.bump();
 
         return Ok(UpdateExpr {
+            node_id: Default::default(),
             span: p.span(expr.span_lo()),
             prefix: false,
             op,
@@ -1665,6 +1722,7 @@ pub fn parse_await_expr<'a, P: Parser<'a>>(
 
     let arg = p.parse_unary_expr()?;
     Ok(AwaitExpr {
+        node_id: Default::default(),
         span: p.span(start),
         arg,
     }
@@ -1721,6 +1779,7 @@ pub fn parse_lhs_expr<'a, P: Parser<'a>, const PARSE_JSX: bool>(p: &mut P) -> PR
     if cur.is_super() {
         p.bump(); // eat `super`
         let obj = Callee::Super(Super {
+            node_id: Default::default(),
             span: p.span(start),
         });
         return parse_subscripts(p, obj, false, false);
@@ -1771,6 +1830,7 @@ pub fn parse_lhs_expr<'a, P: Parser<'a>, const PARSE_JSX: bool>(p: &mut P) -> PR
         let (callee, is_import) = match callee {
             _ if callee.is_ident_ref_to("import") => (
                 Callee::Import(Import {
+                    node_id: Default::default(),
                     span: callee.span(),
                     phase: Default::default(),
                 }),
@@ -1782,6 +1842,7 @@ pub fn parse_lhs_expr<'a, P: Parser<'a>, const PARSE_JSX: bool>(p: &mut P) -> PR
 
         let call_expr = match callee {
             Callee::Expr(e) if unwrap_ts_non_null(&e).is_opt_chain() => OptChainExpr {
+                node_id: Default::default(),
                 span: p.span(start),
                 base: Box::new(OptChainBase::Call(OptCall {
                     span: p.span(start),
@@ -1876,7 +1937,11 @@ fn parse_args_or_pats_inner<'a, P: Parser<'a>>(
                     expr
                 };
 
-                ExprOrSpread { spread, expr }
+                ExprOrSpread {
+                    node_id: Default::default(),
+                    spread,
+                    expr,
+                }
             } else {
                 p.allow_in_expr(|p| p.parse_expr_or_spread())?
             }
@@ -1918,8 +1983,10 @@ fn parse_args_or_pats_inner<'a, P: Parser<'a>>(
                     })?;
 
                     arg = ExprOrSpread {
+                        node_id: Default::default(),
                         spread: None,
                         expr: CondExpr {
+                            node_id: Default::default(),
                             span: Span::new_with_checked(start, alt.span_hi()),
                             test,
                             cons,
@@ -1955,6 +2022,7 @@ fn parse_args_or_pats_inner<'a, P: Parser<'a>>(
             }
             if let Some(span) = arg.spread {
                 pat = RestPat {
+                    node_id: Default::default(),
                     span: p.span(pat_start),
                     dot3_token: span,
                     arg: Box::new(pat),
@@ -2005,6 +2073,7 @@ fn parse_args_or_pats_inner<'a, P: Parser<'a>>(
             if p.input_mut().eat(&P::Token::EQUAL) {
                 let right = parse_assignment_expr(p)?;
                 pat = AssignPat {
+                    node_id: Default::default(),
                     span: p.span(pat_start),
                     left: Box::new(pat),
                     right,
@@ -2049,6 +2118,7 @@ fn parse_args_or_pats_inner<'a, P: Parser<'a>>(
             let span = p.span(start);
 
             items.push(AssignTargetOrSpread::ExprOrSpread(ExprOrSpread {
+                node_id: Default::default(),
                 expr: Box::new(
                     ArrowExpr {
                         span,
@@ -2269,10 +2339,12 @@ pub fn parse_paren_expr_or_arrow_fn<'a, P: Parser<'a>>(
             ExprOrSpread {
                 spread: Some(..),
                 ref expr,
+                ..
             } => syntax_error!(p, expr.span(), SyntaxError::SpreadInParenExpr),
             ExprOrSpread { expr, .. } => expr,
         };
         Ok(ParenExpr {
+            node_id: Default::default(),
             span: p.span(expr_start),
             expr,
         }
@@ -2286,6 +2358,7 @@ pub fn parse_paren_expr_or_arrow_fn<'a, P: Parser<'a>>(
                 ExprOrSpread {
                     spread: Some(..),
                     ref expr,
+                    ..
                 } => syntax_error!(p, expr.span(), SyntaxError::SpreadInParenExpr),
                 ExprOrSpread { expr, .. } => exprs.push(expr),
             }
@@ -2294,6 +2367,7 @@ pub fn parse_paren_expr_or_arrow_fn<'a, P: Parser<'a>>(
 
         // span of sequence expression should not include '(', ')'
         let seq_expr = SeqExpr {
+            node_id: Default::default(),
             span: Span::new_with_checked(
                 exprs.first().unwrap().span_lo(),
                 exprs.last().unwrap().span_hi(),
@@ -2302,6 +2376,7 @@ pub fn parse_paren_expr_or_arrow_fn<'a, P: Parser<'a>>(
         }
         .into();
         Ok(ParenExpr {
+            node_id: Default::default(),
             span: p.span(expr_start),
             expr: seq_expr,
         }
@@ -2361,6 +2436,7 @@ pub fn parse_primary_expr_rest<'a, P: Parser<'a>>(
                     // async as type
                     let type_ann = p.in_type(parse_ts_type)?;
                     return Ok(TsAsExpr {
+                        node_id: Default::default(),
                         span: p.span(start),
                         expr: Box::new(id.into()),
                         type_ann,
@@ -2430,6 +2506,7 @@ pub fn parse_primary_expr_rest<'a, P: Parser<'a>>(
         p.bump(); // consume `#`
         let id = parse_ident_name(p)?;
         Ok(PrivateName {
+            node_id: Default::default(),
             span: p.span(start),
             name: id.sym,
         }
@@ -2486,7 +2563,15 @@ pub fn try_parse_regexp<'a, P: Parser<'a>>(p: &mut P, start: BytePos) -> Option<
             p.emit_err(span, SyntaxError::DuplicatedRegExpFlags(*flag));
         }
 
-        Some(Lit::Regex(Regex { span, exp, flags }).into())
+        Some(
+            Lit::Regex(Regex {
+                node_id: Default::default(),
+                span,
+                exp,
+                flags,
+            })
+            .into(),
+        )
     } else {
         None
     }
@@ -2539,6 +2624,7 @@ pub fn parse_this_expr<'a>(p: &mut impl Parser<'a>, start: BytePos) -> PResult<B
     debug_assert!(p.input().cur().is_this());
     p.input_mut().bump();
     Ok(ThisExpr {
+        node_id: Default::default(),
         span: p.span(start),
     }
     .into())

--- a/crates/swc_ecma_lexer/src/common/parser/ident.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/ident.rs
@@ -58,6 +58,7 @@ pub fn parse_private_name<'a, P: Parser<'a>>(p: &mut P) -> PResult<PrivateName> 
     }
     let id = parse_ident_name(p)?;
     Ok(PrivateName {
+        node_id: Default::default(),
         span: p.span(start),
         name: id.sym,
     })

--- a/crates/swc_ecma_lexer/src/common/parser/jsx.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/jsx.rs
@@ -28,6 +28,7 @@ fn parse_jsx_closing_element_at<'a, P: Parser<'a>>(
 
     if p.input_mut().eat(&P::Token::JSX_TAG_END) {
         return Ok(Either::Left(JSXClosingFragment {
+            node_id: Default::default(),
             span: p.span(start),
         }));
     }
@@ -35,6 +36,7 @@ fn parse_jsx_closing_element_at<'a, P: Parser<'a>>(
     let name = parse_jsx_element_name(p)?;
     expect!(p, &P::Token::JSX_TAG_END);
     Ok(Either::Right(JSXClosingElement {
+        node_id: Default::default(),
         span: p.span(start),
         name,
     }))
@@ -54,6 +56,7 @@ pub fn parse_jsx_expr_container<'a, P: Parser<'a>>(p: &mut P) -> PResult<JSXExpr
     };
     expect!(p, &P::Token::RBRACE);
     Ok(JSXExprContainer {
+        node_id: Default::default(),
         span: p.span(start),
         expr,
     })
@@ -86,6 +89,7 @@ fn parse_jsx_namespaced_name<'a, P: Parser<'a>>(p: &mut P) -> PResult<JSXAttrNam
     }
     let name = parse_jsx_ident(p).map(IdentName::from)?;
     Ok(JSXAttrName::JSXNamespacedName(JSXNamespacedName {
+        node_id: Default::default(),
         span: Span::new_with_checked(start, name.span.hi),
         ns,
         name,
@@ -107,6 +111,7 @@ fn parse_jsx_element_name<'a, P: Parser<'a>>(p: &mut P) -> PResult<JSXElementNam
     while p.input_mut().eat(&P::Token::DOT) {
         let prop = parse_jsx_ident(p).map(IdentName::from)?;
         let new_node = JSXElementName::JSXMemberExpr(JSXMemberExpr {
+            node_id: Default::default(),
             span: p.span(start),
             obj: match node {
                 JSXElementName::Ident(i) => JSXObject::Ident(i),
@@ -127,6 +132,7 @@ pub fn parse_jsx_empty_expr<'a>(p: &mut impl Parser<'a>) -> JSXEmptyExpr {
     debug_assert!(p.input().syntax().jsx());
     let start = p.input().cur_pos();
     JSXEmptyExpr {
+        node_id: Default::default(),
         span: Span::new_with_checked(start, start),
     }
 }
@@ -138,7 +144,12 @@ pub fn parse_jsx_text<'a>(p: &mut impl Parser<'a>) -> JSXText {
     debug_assert!(cur.is_jsx_text());
     let (value, raw) = p.input_mut().expect_jsx_text_token_and_bump();
     let span = p.input().prev_span();
-    JSXText { span, value, raw }
+    JSXText {
+        node_id: Default::default(),
+        span,
+        value,
+        raw,
+    }
 }
 
 pub fn jsx_expr_container_to_jsx_attr_value<'a, P: Parser<'a>>(
@@ -196,6 +207,7 @@ fn parse_jsx_spread_child<'a, P: Parser<'a>>(p: &mut P) -> PResult<JSXSpreadChil
     expect!(p, &P::Token::RBRACE);
 
     Ok(JSXSpreadChild {
+        node_id: Default::default(),
         span: p.span(start),
         expr,
     })
@@ -214,7 +226,12 @@ fn parse_jsx_attr<'a, P: Parser<'a>>(p: &mut P) -> PResult<JSXAttrOrSpread> {
         let dot3_token = p.span(dot3_start);
         let expr = parse_assignment_expr(p)?;
         expect!(p, &P::Token::RBRACE);
-        return Ok(SpreadElement { dot3_token, expr }.into());
+        return Ok(SpreadElement {
+            node_id: Default::default(),
+            dot3_token,
+            expr,
+        }
+        .into());
     }
 
     let name = parse_jsx_namespaced_name(p)?;
@@ -229,6 +246,7 @@ fn parse_jsx_attr<'a, P: Parser<'a>>(p: &mut P) -> PResult<JSXAttrOrSpread> {
     };
 
     Ok(JSXAttr {
+        node_id: Default::default(),
         span: p.span(start),
         name,
         value,
@@ -245,6 +263,7 @@ fn parse_jsx_opening_element_at<'a, P: Parser<'a>>(
 
     if p.input_mut().eat(&P::Token::JSX_TAG_END) {
         return Ok(Either::Left(JSXOpeningFragment {
+            node_id: Default::default(),
             span: p.span(start),
         }));
     }
@@ -300,6 +319,7 @@ fn parse_jsx_opening_element_after_name<'a, P: Parser<'a>>(
         unexpected!(p, "> (jsx closing tag)");
     }
     Ok(JSXOpeningElement {
+        node_id: Default::default(),
         span: p.span(start),
         name,
         attrs,
@@ -397,12 +417,14 @@ fn parse_jsx_element_at<'a, P: Parser<'a>>(
                     );
                 }
                 (Either::Left(opening), Some(Either::Left(closing))) => Either::Left(JSXFragment {
+                    node_id: Default::default(),
                     span,
                     opening,
                     children,
                     closing,
                 }),
                 (Either::Right(opening), None) => Either::Right(JSXElement {
+                    node_id: Default::default(),
                     span,
                     opening,
                     children,
@@ -421,6 +443,7 @@ fn parse_jsx_element_at<'a, P: Parser<'a>>(
                         );
                     }
                     Either::Right(JSXElement {
+                        node_id: Default::default(),
                         span,
                         opening,
                         children,

--- a/crates/swc_ecma_lexer/src/common/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/mod.rs
@@ -339,6 +339,7 @@ pub trait Parser<'a>: Sized + Clone {
         };
         let tail = self.input_mut().is(&Self::Token::BACKQUOTE);
         Ok(TplElement {
+            node_id: Default::default(),
             span: self.span(start),
             raw,
             tail,
@@ -357,6 +358,7 @@ pub trait Parser<'a>: Sized + Clone {
             } else if cur.is_num() {
                 let (value, raw) = p.input_mut().expect_number_token_and_bump();
                 PropName::Num(Number {
+                    node_id: Default::default(),
                     span: p.span(start),
                     value,
                     raw: Some(raw),
@@ -364,6 +366,7 @@ pub trait Parser<'a>: Sized + Clone {
             } else if cur.is_bigint() {
                 let (value, raw) = p.input_mut().expect_bigint_token_and_bump();
                 PropName::BigInt(BigInt {
+                    node_id: Default::default(),
                     span: p.span(start),
                     value,
                     raw: Some(raw),
@@ -384,6 +387,7 @@ pub trait Parser<'a>: Sized + Clone {
                     p.emit_err(p.span(inner_start), SyntaxError::TS1171);
                     expr = Box::new(
                         SeqExpr {
+                            node_id: Default::default(),
                             span: p.span(inner_start),
                             exprs,
                         }
@@ -392,6 +396,7 @@ pub trait Parser<'a>: Sized + Clone {
                 }
                 expect!(p, &Self::Token::RBRACKET);
                 PropName::Computed(ComputedPropName {
+                    node_id: Default::default(),
                     span: p.span(start),
                     expr,
                 })
@@ -424,9 +429,17 @@ pub trait Parser<'a>: Sized + Clone {
                         },
                     )
                 })
-                .map(|expr| ExprOrSpread { spread, expr })
+                .map(|expr| ExprOrSpread {
+                    node_id: Default::default(),
+                    spread,
+                    expr,
+                })
         } else {
-            parse_assignment_expr(self).map(|expr| ExprOrSpread { spread: None, expr })
+            parse_assignment_expr(self).map(|expr| ExprOrSpread {
+                node_id: Default::default(),
+                spread: None,
+                expr,
+            })
         }
     }
 
@@ -444,6 +457,7 @@ pub trait Parser<'a>: Sized + Clone {
             }
 
             return Ok(SeqExpr {
+                node_id: Default::default(),
                 span: self.span(start),
                 exprs,
             }

--- a/crates/swc_ecma_lexer/src/common/parser/module_item.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/module_item.rs
@@ -114,6 +114,7 @@ fn parse_named_export_specifier<'a, P: Parser<'a>>(
                         }
 
                         return Ok(ExportNamedSpecifier {
+                            node_id: Default::default(),
                             span: p.span(start),
                             orig: ModuleExportName::Ident(possibly_orig),
                             exported: None,
@@ -134,6 +135,7 @@ fn parse_named_export_specifier<'a, P: Parser<'a>>(
 
                             debug_assert!(start <= orig_ident.span.hi());
                             return Ok(ExportNamedSpecifier {
+                                node_id: Default::default(),
                                 span: Span::new_with_checked(start, orig_ident.span.hi()),
                                 orig: ModuleExportName::Ident(possibly_orig),
                                 exported: Some(ModuleExportName::Ident(exported)),
@@ -142,6 +144,7 @@ fn parse_named_export_specifier<'a, P: Parser<'a>>(
                         } else {
                             // `export { type as as }`
                             return Ok(ExportNamedSpecifier {
+                                node_id: Default::default(),
                                 span: Span::new_with_checked(start, orig_ident.span.hi()),
                                 orig: ModuleExportName::Ident(orig_ident),
                                 exported: Some(ModuleExportName::Ident(maybe_as)),
@@ -151,6 +154,7 @@ fn parse_named_export_specifier<'a, P: Parser<'a>>(
                     } else {
                         // `export { type as xxx }`
                         return Ok(ExportNamedSpecifier {
+                            node_id: Default::default(),
                             span: Span::new_with_checked(start, orig_ident.span.hi()),
                             orig: ModuleExportName::Ident(orig_ident),
                             exported: Some(ModuleExportName::Ident(maybe_as)),
@@ -181,6 +185,7 @@ fn parse_named_export_specifier<'a, P: Parser<'a>>(
     };
 
     Ok(ExportNamedSpecifier {
+        node_id: Default::default(),
         span: p.span(start),
         orig,
         exported,
@@ -234,6 +239,7 @@ fn parse_import_specifier<'a, P: Parser<'a>>(
                         }
 
                         return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                            node_id: Default::default(),
                             span: p.span(start),
                             local: possibly_orig_name,
                             imported: None,
@@ -253,6 +259,7 @@ fn parse_import_specifier<'a, P: Parser<'a>>(
                             }
 
                             return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                                node_id: Default::default(),
                                 span: Span::new_with_checked(start, orig_name.span.hi()),
                                 local,
                                 imported: Some(ModuleExportName::Ident(possibly_orig_name)),
@@ -261,6 +268,7 @@ fn parse_import_specifier<'a, P: Parser<'a>>(
                         } else {
                             // `import { type as as } from 'mod'`
                             return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                                node_id: Default::default(),
                                 span: Span::new_with_checked(start, maybe_as.span.hi()),
                                 local: maybe_as,
                                 imported: Some(ModuleExportName::Ident(orig_name)),
@@ -270,6 +278,7 @@ fn parse_import_specifier<'a, P: Parser<'a>>(
                     } else {
                         // `import { type as xxx } from 'mod'`
                         return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                            node_id: Default::default(),
                             span: Span::new_with_checked(start, orig_name.span.hi()),
                             local: maybe_as,
                             imported: Some(ModuleExportName::Ident(orig_name)),
@@ -291,6 +300,7 @@ fn parse_import_specifier<'a, P: Parser<'a>>(
             if p.input_mut().eat(&P::Token::AS) {
                 let local: Ident = parse_binding_ident(p, false)?.into();
                 return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                    node_id: Default::default(),
                     span: Span::new_with_checked(start, local.span.hi()),
                     local,
                     imported: Some(ModuleExportName::Ident(orig_name)),
@@ -308,6 +318,7 @@ fn parse_import_specifier<'a, P: Parser<'a>>(
 
             let local = orig_name;
             Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                node_id: Default::default(),
                 span: p.span(start),
                 local,
                 imported: None,
@@ -318,6 +329,7 @@ fn parse_import_specifier<'a, P: Parser<'a>>(
             if p.input_mut().eat(&P::Token::AS) {
                 let local: Ident = parse_binding_ident(p, false)?.into();
                 Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                    node_id: Default::default(),
                     span: Span::new_with_checked(start, local.span.hi()),
                     local,
                     imported: Some(ModuleExportName::Str(orig_str)),
@@ -364,6 +376,7 @@ fn parse_export<'a, P: Parser<'a>>(
         // TODO: Remove
         if let Some(decl) = try_parse_ts_declare(p, after_export_start, decorators.clone())? {
             return Ok(ExportDecl {
+                node_id: Default::default(),
                 span: p.span(start),
                 decl,
             }
@@ -378,6 +391,7 @@ fn parse_export<'a, P: Parser<'a>>(
             // TODO: remove clone
             if let Some(decl) = try_parse_ts_export_decl(p, decorators.clone(), sym) {
                 return Ok(ExportDecl {
+                    node_id: Default::default(),
                     span: p.span(start),
                     decl,
                 }
@@ -411,6 +425,7 @@ fn parse_export<'a, P: Parser<'a>>(
             let expr = p.parse_expr()?;
             p.expect_general_semi()?;
             return Ok(TsExportAssignment {
+                node_id: Default::default(),
                 span: p.span(start),
                 expr,
             }
@@ -424,6 +439,7 @@ fn parse_export<'a, P: Parser<'a>>(
             let id = parse_ident(p, false, false)?;
             p.expect_general_semi()?;
             return Ok(TsNamespaceExportDecl {
+                node_id: Default::default(),
                 span: p.span(start),
                 id,
             }
@@ -476,6 +492,7 @@ fn parse_export<'a, P: Parser<'a>>(
                 p.assert_and_bump(&P::Token::INTERFACE);
                 let decl = parse_ts_interface_decl(p, interface_start).map(DefaultDecl::from)?;
                 return Ok(ExportDefaultDecl {
+                    node_id: Default::default(),
                     span: p.span(start),
                     decl,
                 }
@@ -506,6 +523,7 @@ fn parse_export<'a, P: Parser<'a>>(
             let expr = p.allow_in_expr(parse_assignment_expr)?;
             p.expect_general_semi()?;
             return Ok(ExportDefaultExpr {
+                node_id: Default::default(),
                 span: p.span(start),
                 expr,
             }
@@ -547,6 +565,7 @@ fn parse_export<'a, P: Parser<'a>>(
             .map(Decl::from)
             .map(|decl| {
                 ExportDecl {
+                    node_id: Default::default(),
                     span: p.span(start),
                     decl,
                 }
@@ -594,6 +613,7 @@ fn parse_export<'a, P: Parser<'a>>(
             // improve error message for `export * from foo`
             let (src, with) = parse_from_clause_and_semi(p)?;
             return Ok(ExportAll {
+                node_id: Default::default(),
                 span: p.span(start),
                 src,
                 type_only,
@@ -610,6 +630,7 @@ fn parse_export<'a, P: Parser<'a>>(
         if let Some(default) = default {
             has_default = true;
             specifiers.push(ExportSpecifier::Default(ExportDefaultSpecifier {
+                node_id: Default::default(),
                 exported: default,
             }))
         }
@@ -635,6 +656,7 @@ fn parse_export<'a, P: Parser<'a>>(
             expect!(p, &P::Token::AS);
             let name = parse_module_export_name(p)?;
             specifiers.push(ExportSpecifier::Namespace(ExportNamespaceSpecifier {
+                node_id: Default::default(),
                 span: p.span(ns_export_specifier_start),
                 name,
             }));
@@ -644,6 +666,7 @@ fn parse_export<'a, P: Parser<'a>>(
             if p.input().is(&P::Token::FROM) {
                 let (src, with) = parse_from_clause_and_semi(p)?;
                 return Ok(NamedExport {
+                    node_id: Default::default(),
                     span: p.span(start),
                     specifiers,
                     src: Some(src),
@@ -716,6 +739,7 @@ fn parse_export<'a, P: Parser<'a>>(
             None => (None, None),
         };
         return Ok(NamedExport {
+            node_id: Default::default(),
             span: p.span(start),
             specifiers,
             src,
@@ -726,6 +750,7 @@ fn parse_export<'a, P: Parser<'a>>(
     };
 
     Ok(ExportDecl {
+        node_id: Default::default(),
         span: p.span(start),
         decl,
     }
@@ -741,6 +766,7 @@ fn parse_import<'a, P: Parser<'a>>(p: &mut P) -> PResult<ModuleItem> {
         p.eat_general_semi();
 
         return Ok(ExprStmt {
+            node_id: Default::default(),
             span: p.span(start),
             expr,
         }
@@ -753,6 +779,7 @@ fn parse_import<'a, P: Parser<'a>>(p: &mut P) -> PResult<ModuleItem> {
         p.eat_general_semi();
 
         return Ok(ExprStmt {
+            node_id: Default::default(),
             span: p.span(start),
             expr,
         }
@@ -785,6 +812,7 @@ fn parse_import<'a, P: Parser<'a>>(p: &mut P) -> PResult<ModuleItem> {
         };
         p.eat_general_semi();
         return Ok(ImportDecl {
+            node_id: Default::default(),
             span: p.span(start),
             src,
             specifiers: Vec::new(),
@@ -858,6 +886,7 @@ fn parse_import<'a, P: Parser<'a>>(p: &mut P) -> PResult<ModuleItem> {
                 expect!(p, &P::Token::COMMA);
             }
             specifiers.push(ImportSpecifier::Default(ImportDefaultSpecifier {
+                node_id: Default::default(),
                 span: local.span,
                 local,
             }));
@@ -871,6 +900,7 @@ fn parse_import<'a, P: Parser<'a>>(p: &mut P) -> PResult<ModuleItem> {
             expect!(p, &P::Token::AS);
             let local = parse_imported_binding(p)?;
             specifiers.push(ImportSpecifier::Namespace(ImportStarAsSpecifier {
+                node_id: Default::default(),
                 span: p.span(import_spec_start),
                 local,
             }));
@@ -913,6 +943,7 @@ fn parse_import<'a, P: Parser<'a>>(p: &mut P) -> PResult<ModuleItem> {
     p.expect_general_semi()?;
 
     Ok(ImportDecl {
+        node_id: Default::default(),
         span: p.span(start),
         specifiers,
         src,

--- a/crates/swc_ecma_lexer/src/common/parser/object.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/object.rs
@@ -62,6 +62,7 @@ fn parse_binding_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<ObjectPatP
         let arg = Box::new(parse_binding_pat_or_ident(p, false)?);
 
         return Ok(ObjectPatProp::Rest(RestPat {
+            node_id: Default::default(),
             span: p.span(start),
             dot3_token,
             arg,
@@ -73,7 +74,11 @@ fn parse_binding_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<ObjectPatP
     if p.input_mut().eat(&P::Token::COLON) {
         let value = Box::new(parse_binding_element(p)?);
 
-        return Ok(ObjectPatProp::KeyValue(KeyValuePatProp { key, value }));
+        return Ok(ObjectPatProp::KeyValue(KeyValuePatProp {
+            node_id: Default::default(),
+            key,
+            value,
+        }));
     }
     let key = match key {
         PropName::Ident(ident) => ident,
@@ -91,6 +96,7 @@ fn parse_binding_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<ObjectPatP
     };
 
     Ok(ObjectPatProp::Assign(AssignPatProp {
+        node_id: Default::default(),
         span: p.span(start),
         key: key.into(),
         value,
@@ -128,6 +134,7 @@ fn make_binding_object<'a, P: Parser<'a>>(
         && p.input_mut().eat(&P::Token::QUESTION);
 
     Ok(ObjectPat {
+        node_id: Default::default(),
         span,
         props,
         optional,
@@ -151,7 +158,12 @@ fn make_expr_object<'a, P: Parser<'a>>(
             .trailing_commas
             .insert(span.lo, trailing_comma);
     }
-    Ok(ObjectLit { span, props }.into())
+    Ok(ObjectLit {
+        node_id: Default::default(),
+        span,
+        props,
+    }
+    .into())
 }
 
 fn parse_expr_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<PropOrSpread> {
@@ -166,7 +178,11 @@ fn parse_expr_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<PropOrSpread>
 
         let expr = p.allow_in_expr(parse_assignment_expr)?;
 
-        return Ok(PropOrSpread::Spread(SpreadElement { dot3_token, expr }));
+        return Ok(PropOrSpread::Spread(SpreadElement {
+            node_id: Default::default(),
+            dot3_token,
+            expr,
+        }));
     }
 
     if p.input_mut().eat(&P::Token::MUL) {
@@ -187,6 +203,7 @@ fn parse_expr_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<PropOrSpread>
             })
             .map(|function| {
                 PropOrSpread::Prop(Box::new(Prop::Method(MethodProp {
+                    node_id: Default::default(),
                     key: name,
                     function,
                 })))
@@ -217,8 +234,10 @@ fn parse_expr_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<PropOrSpread>
 
         p.emit_err(p.input().cur_span(), SyntaxError::TS1005);
         return Ok(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+            node_id: Default::default(),
             key,
             value: Invalid {
+                node_id: Default::default(),
                 span: p.span(start),
             }
             .into(),
@@ -232,6 +251,7 @@ fn parse_expr_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<PropOrSpread>
     if p.input_mut().eat(&P::Token::COLON) {
         let value = p.allow_in_expr(parse_assignment_expr)?;
         return Ok(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+            node_id: Default::default(),
             key,
             value,
         }))));
@@ -255,7 +275,13 @@ fn parse_expr_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<PropOrSpread>
                     )
                 })
             })
-            .map(|function| Box::new(Prop::Method(MethodProp { key, function })))
+            .map(|function| {
+                Box::new(Prop::Method(MethodProp {
+                    node_id: Default::default(),
+                    key,
+                    function,
+                }))
+            })
             .map(PropOrSpread::Prop);
     }
 
@@ -281,6 +307,7 @@ fn parse_expr_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<PropOrSpread>
             let value = p.allow_in_expr(parse_assignment_expr)?;
             let span = p.span(start);
             return Ok(PropOrSpread::Prop(Box::new(Prop::Assign(AssignProp {
+                node_id: Default::default(),
                 span,
                 key: ident.into(),
                 value,
@@ -337,6 +364,7 @@ fn parse_expr_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<PropOrSpread>
                                 }
 
                                 PropOrSpread::Prop(Box::new(Prop::Getter(GetterProp {
+                                    node_id: Default::default(),
                                     span: parser.span(start),
                                     key,
                                     type_ann: return_type,
@@ -392,13 +420,18 @@ fn parse_expr_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<PropOrSpread>
                                             || {
                                                 parser.emit_err(key_span, SyntaxError::SetterParam);
 
-                                                Invalid { span: DUMMY_SP }.into()
+                                                Invalid {
+                                                    node_id: Default::default(),
+                                                    span: DUMMY_SP,
+                                                }
+                                                .into()
                                             },
                                         ),
                                     );
 
                                     // debug_assert_eq!(params.len(), 1);
                                     PropOrSpread::Prop(Box::new(Prop::Setter(SetterProp {
+                                        node_id: Default::default(),
                                         span: parser.span(start),
                                         key,
                                         body,
@@ -418,7 +451,11 @@ fn parse_expr_object_prop<'a, P: Parser<'a>>(p: &mut P) -> PResult<PropOrSpread>
                             is_generator,
                         )
                         .map(|function| {
-                            PropOrSpread::Prop(Box::new(Prop::Method(MethodProp { key, function })))
+                            PropOrSpread::Prop(Box::new(Prop::Method(MethodProp {
+                                node_id: Default::default(),
+                                key,
+                                function,
+                            })))
                         }),
                         _ => unreachable!(),
                     }

--- a/crates/swc_ecma_lexer/src/common/parser/output_type.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/output_type.rs
@@ -44,7 +44,12 @@ impl OutputType for Box<Expr> {
         ident: Option<Ident>,
         function: Box<Function>,
     ) -> Result<Self, SyntaxError> {
-        Ok(FnExpr { ident, function }.into())
+        Ok(FnExpr {
+            node_id: Default::default(),
+            ident,
+            function,
+        }
+        .into())
     }
 
     fn finish_class(
@@ -52,7 +57,12 @@ impl OutputType for Box<Expr> {
         ident: Option<Ident>,
         class: Box<Class>,
     ) -> Result<Self, SyntaxError> {
-        Ok(ClassExpr { ident, class }.into())
+        Ok(ClassExpr {
+            node_id: Default::default(),
+            ident,
+            class,
+        }
+        .into())
     }
 }
 
@@ -65,8 +75,13 @@ impl OutputType for ExportDefaultDecl {
         function: Box<Function>,
     ) -> Result<Self, SyntaxError> {
         Ok(ExportDefaultDecl {
+            node_id: Default::default(),
             span,
-            decl: DefaultDecl::Fn(FnExpr { ident, function }),
+            decl: DefaultDecl::Fn(FnExpr {
+                node_id: Default::default(),
+                ident,
+                function,
+            }),
         })
     }
 
@@ -76,8 +91,13 @@ impl OutputType for ExportDefaultDecl {
         class: Box<Class>,
     ) -> Result<Self, SyntaxError> {
         Ok(ExportDefaultDecl {
+            node_id: Default::default(),
             span,
-            decl: DefaultDecl::Class(ClassExpr { ident, class }),
+            decl: DefaultDecl::Class(ClassExpr {
+                node_id: Default::default(),
+                ident,
+                class,
+            }),
         })
     }
 }
@@ -93,6 +113,7 @@ impl OutputType for Decl {
         let ident = ident.ok_or(SyntaxError::ExpectedIdent)?;
 
         Ok(FnDecl {
+            node_id: Default::default(),
             declare: false,
             ident,
             function,
@@ -104,6 +125,7 @@ impl OutputType for Decl {
         let ident = ident.ok_or(SyntaxError::ExpectedIdent)?;
 
         Ok(ClassDecl {
+            node_id: Default::default(),
             declare: false,
             ident,
             class,

--- a/crates/swc_ecma_lexer/src/common/parser/pat.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/pat.rs
@@ -161,7 +161,11 @@ fn reparse_expr_as_pat_inner<'a>(
     match *expr {
         Expr::Paren(..) => {
             p.emit_err(span, SyntaxError::InvalidPat);
-            Ok(Invalid { span }.into())
+            Ok(Invalid {
+                node_id: Default::default(),
+                span,
+            }
+            .into())
         }
         Expr::Assign(
             assign_expr @ AssignExpr {
@@ -173,6 +177,7 @@ fn reparse_expr_as_pat_inner<'a>(
                 span, left, right, ..
             } = assign_expr;
             Ok(AssignPat {
+                node_id: Default::default(),
                 span,
                 left: match left {
                     AssignTarget::Simple(left) => {
@@ -189,10 +194,12 @@ fn reparse_expr_as_pat_inner<'a>(
         Expr::Object(ObjectLit {
             span: object_span,
             props,
+            ..
         }) => {
             // {}
             let len = props.len();
             Ok(ObjectPat {
+                node_id: Default::default(),
                 span: object_span,
                 props: props
                     .into_iter()
@@ -202,12 +209,14 @@ fn reparse_expr_as_pat_inner<'a>(
                         match prop {
                             PropOrSpread::Prop(prop) => match *prop {
                                 Prop::Shorthand(id) => Ok(ObjectPatProp::Assign(AssignPatProp {
+                                    node_id: Default::default(),
                                     span: id.span(),
                                     key: id.into(),
                                     value: None,
                                 })),
                                 Prop::KeyValue(kv_prop) => {
                                     Ok(ObjectPatProp::KeyValue(KeyValuePatProp {
+                                        node_id: Default::default(),
                                         key: kv_prop.key,
                                         value: Box::new(reparse_expr_as_pat(
                                             p,
@@ -218,6 +227,7 @@ fn reparse_expr_as_pat_inner<'a>(
                                 }
                                 Prop::Assign(assign_prop) => {
                                     Ok(ObjectPatProp::Assign(AssignPatProp {
+                                        node_id: Default::default(),
                                         span,
                                         key: assign_prop.key.into(),
                                         value: Some(assign_prop.value),
@@ -226,7 +236,9 @@ fn reparse_expr_as_pat_inner<'a>(
                                 _ => syntax_error!(p, prop.span(), SyntaxError::InvalidPat),
                             },
 
-                            PropOrSpread::Spread(SpreadElement { dot3_token, expr }) => {
+                            PropOrSpread::Spread(SpreadElement {
+                                dot3_token, expr, ..
+                            }) => {
                                 if idx != len - 1 {
                                     p.emit_err(span, SyntaxError::NonLastRestParam)
                                 } else if let Some(trailing_comma) =
@@ -241,7 +253,10 @@ fn reparse_expr_as_pat_inner<'a>(
                                         i.into()
                                     } else {
                                         p.emit_err(span, SyntaxError::DotsWithoutIdentifier);
-                                        Pat::Invalid(Invalid { span })
+                                        Pat::Invalid(Invalid {
+                                            node_id: Default::default(),
+                                            span,
+                                        })
                                     }
                                 } else {
                                     reparse_expr_as_pat(p, element_pat_ty, expr)?
@@ -250,6 +265,7 @@ fn reparse_expr_as_pat_inner<'a>(
                                     p.emit_err(span, SyntaxError::TS1048)
                                 };
                                 Ok(ObjectPatProp::Rest(RestPat {
+                                    node_id: Default::default(),
                                     span,
                                     dot3_token,
                                     arg: Box::new(pat),
@@ -273,6 +289,7 @@ fn reparse_expr_as_pat_inner<'a>(
         }) => {
             if exprs.is_empty() {
                 return Ok(ArrayPat {
+                    node_id: Default::default(),
                     span,
                     elems: Vec::new(),
                     optional: false,
@@ -312,6 +329,7 @@ fn reparse_expr_as_pat_inner<'a>(
                     Some(ExprOrSpread {
                         spread: Some(dot3_token),
                         expr,
+                        ..
                     }) => {
                         // TODO: is BindingPat correct?
                         if let Expr::Assign(_) = *expr {
@@ -324,6 +342,7 @@ fn reparse_expr_as_pat_inner<'a>(
                         reparse_expr_as_pat(p, pat_ty.element(), expr)
                             .map(|pat| {
                                 RestPat {
+                                    node_id: Default::default(),
                                     span: expr_span,
                                     dot3_token,
                                     arg: Box::new(pat),
@@ -343,6 +362,7 @@ fn reparse_expr_as_pat_inner<'a>(
                 params.push(last);
             }
             Ok(ArrayPat {
+                node_id: Default::default(),
                 span,
                 elems: params,
                 optional: false,
@@ -355,18 +375,30 @@ fn reparse_expr_as_pat_inner<'a>(
         // Note that assignment expression with '=' is valid, and handled above.
         Expr::Lit(..) | Expr::Assign(..) => {
             p.emit_err(span, SyntaxError::InvalidPat);
-            Ok(Invalid { span }.into())
+            Ok(Invalid {
+                node_id: Default::default(),
+                span,
+            }
+            .into())
         }
 
         Expr::Yield(..) if p.ctx().contains(Context::InGenerator) => {
             p.emit_err(span, SyntaxError::InvalidPat);
-            Ok(Invalid { span }.into())
+            Ok(Invalid {
+                node_id: Default::default(),
+                span,
+            }
+            .into())
         }
 
         _ => {
             p.emit_err(span, SyntaxError::InvalidPat);
 
-            Ok(Invalid { span }.into())
+            Ok(Invalid {
+                node_id: Default::default(),
+                span,
+            }
+            .into())
         }
     }
 }
@@ -385,6 +417,7 @@ pub(super) fn parse_binding_element<'a, P: Parser<'a>>(p: &mut P) -> PResult<Pat
         }
 
         return Ok(AssignPat {
+            node_id: Default::default(),
             span: p.span(start),
             left: Box::new(left),
             right,
@@ -445,6 +478,7 @@ pub fn parse_array_binding_pat<'a, P: Parser<'a>>(p: &mut P) -> PResult<Pat> {
             let pat = parse_binding_pat_or_ident(p, false)?;
             rest_span = p.span(start);
             let pat = RestPat {
+                node_id: Default::default(),
                 span: rest_span,
                 dot3_token,
                 arg: Box::new(pat),
@@ -469,6 +503,7 @@ pub fn parse_array_binding_pat<'a, P: Parser<'a>>(p: &mut P) -> PResult<Pat> {
         && p.input_mut().eat(&P::Token::QUESTION);
 
     Ok(ArrayPat {
+        node_id: Default::default(),
         span: p.span(start),
         elems,
         optional,
@@ -571,6 +606,7 @@ fn parse_formal_param_pat<'a, P: Parser<'a>>(p: &mut P) -> PResult<Pat> {
         }
 
         AssignPat {
+            node_id: Default::default(),
             span: p.span(start),
             left: Box::new(pat),
             right,
@@ -606,6 +642,7 @@ fn parse_constructor_param<'a, P: Parser<'a>>(
     if accessibility.is_none() && !is_override && !readonly {
         let pat = parse_formal_param_pat(p)?;
         Ok(ParamOrTsParamProp::Param(Param {
+            node_id: Default::default(),
             span: p.span(param_start),
             decorators,
             pat,
@@ -617,6 +654,7 @@ fn parse_constructor_param<'a, P: Parser<'a>>(
             node => syntax_error!(p, node.span(), SyntaxError::TsInvalidParamPropPat),
         };
         Ok(ParamOrTsParamProp::TsParamProp(TsParamProp {
+            node_id: Default::default(),
             span: p.span(param_start),
             accessibility,
             is_override,
@@ -655,6 +693,7 @@ pub fn parse_constructor_params<'a, P: Parser<'a>>(p: &mut P) -> PResult<Vec<Par
 
             rest_span = p.span(pat_start);
             let pat = RestPat {
+                node_id: Default::default(),
                 span: rest_span,
                 dot3_token,
                 arg: Box::new(pat),
@@ -662,6 +701,7 @@ pub fn parse_constructor_params<'a, P: Parser<'a>>(p: &mut P) -> PResult<Vec<Par
             }
             .into();
             params.push(ParamOrTsParamProp::Param(Param {
+                node_id: Default::default(),
                 span: p.span(param_start),
                 decorators,
                 pat,
@@ -703,6 +743,7 @@ pub fn parse_formal_params<'a, P: Parser<'a>>(p: &mut P) -> PResult<Vec<Param>> 
                 let right = parse_assignment_expr(p)?;
                 p.emit_err(pat.span(), SyntaxError::TS1048);
                 pat = AssignPat {
+                    node_id: Default::default(),
                     span: p.span(pat_start),
                     left: Box::new(pat),
                     right,
@@ -720,6 +761,7 @@ pub fn parse_formal_params<'a, P: Parser<'a>>(p: &mut P) -> PResult<Vec<Param>> 
 
             rest_span = p.span(pat_start);
             let pat = RestPat {
+                node_id: Default::default(),
                 span: rest_span,
                 dot3_token,
                 arg: Box::new(pat),
@@ -739,6 +781,7 @@ pub fn parse_formal_params<'a, P: Parser<'a>>(p: &mut P) -> PResult<Vec<Param>> 
         let is_rest = matches!(pat, Pat::Rest(_));
 
         params.push(Param {
+            node_id: Default::default(),
             span: p.span(param_start),
             decorators,
             pat,
@@ -797,6 +840,7 @@ pub(super) fn parse_paren_items_as_params<'a, P: Parser<'a>>(
         AssignTargetOrSpread::ExprOrSpread(ExprOrSpread {
             spread: Some(dot3_token),
             expr,
+            ..
         }) => {
             if let Expr::Assign(_) = *expr {
                 p.emit_err(outer_expr_span, SyntaxError::TS1048)
@@ -807,6 +851,7 @@ pub(super) fn parse_paren_items_as_params<'a, P: Parser<'a>>(
             let expr_span = expr.span();
             reparse_expr_as_pat(p, pat_ty, expr).map(|pat| {
                 RestPat {
+                    node_id: Default::default(),
                     span: expr_span,
                     dot3_token,
                     arg: Box::new(pat),

--- a/crates/swc_ecma_lexer/src/common/parser/stmt.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/stmt.rs
@@ -96,6 +96,7 @@ pub fn parse_return_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
     };
     p.expect_general_semi()?;
     let stmt = Ok(ReturnStmt {
+        node_id: Default::default(),
         span: p.span(start),
         arg,
     }
@@ -189,6 +190,7 @@ fn parse_var_declarator<'a, P: Parser<'a>>(
     };
 
     Ok(VarDeclarator {
+        node_id: Default::default(),
         span: p.span(start),
         name,
         init,
@@ -365,6 +367,7 @@ pub fn parse_using_decl<'a, P: Parser<'a>>(
     p.expect_general_semi()?;
 
     Ok(Some(Box::new(UsingDecl {
+        node_id: Default::default(),
         span: p.span(start),
         is_await,
         decls,
@@ -459,6 +462,7 @@ pub fn parse_for_head<'a, P: Parser<'a>>(p: &mut P) -> PResult<TempForHead> {
     if is_using_decl {
         let name = parse_binding_ident(p, false)?;
         let decl = VarDeclarator {
+            node_id: Default::default(),
             name: name.into(),
             span: p.span(start),
             init: None,
@@ -466,6 +470,7 @@ pub fn parse_for_head<'a, P: Parser<'a>>(p: &mut P) -> PResult<TempForHead> {
         };
 
         let pat = Box::new(UsingDecl {
+            node_id: Default::default(),
             span: p.span(start),
             is_await: is_await_using_decl,
             decls: vec![decl],
@@ -544,6 +549,7 @@ fn parse_for_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
             }
 
             ForStmt {
+                node_id: Default::default(),
                 span,
                 init,
                 test,
@@ -558,6 +564,7 @@ fn parse_for_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
             }
 
             ForInStmt {
+                node_id: Default::default(),
                 span,
                 left,
                 right,
@@ -565,7 +572,8 @@ fn parse_for_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
             }
             .into()
         }
-        TempForHead::ForOf { left, right } => ForOfStmt {
+        TempForHead::ForOf { left, right, .. } => ForOfStmt {
+            node_id: Default::default(),
             span,
             is_await: await_token.is_some(),
             left,
@@ -686,6 +694,7 @@ fn parse_if_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<IfStmt> {
 
     let span = p.span(start);
     Ok(IfStmt {
+        node_id: Default::default(),
         span,
         test,
         cons,
@@ -707,7 +716,12 @@ fn parse_throw_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
     p.expect_general_semi()?;
 
     let span = p.span(start);
-    Ok(ThrowStmt { span, arg }.into())
+    Ok(ThrowStmt {
+        node_id: Default::default(),
+        span,
+        arg,
+    }
+    .into())
 }
 
 fn parse_with_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
@@ -736,7 +750,13 @@ fn parse_with_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
         .map(Box::new)?;
 
     let span = p.span(start);
-    Ok(WithStmt { span, obj, body }.into())
+    Ok(WithStmt {
+        node_id: Default::default(),
+        span,
+        obj,
+        body,
+    }
+    .into())
 }
 
 fn parse_while_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
@@ -756,7 +776,13 @@ fn parse_while_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
         .map(Box::new)?;
 
     let span = p.span(start);
-    Ok(WhileStmt { span, test, body }.into())
+    Ok(WhileStmt {
+        node_id: Default::default(),
+        span,
+        test,
+        body,
+    }
+    .into())
 }
 
 /// It's optional since es2019
@@ -776,6 +802,7 @@ fn parse_catch_param<'a, P: Parser<'a>>(p: &mut P) -> PResult<Option<Pat>> {
                 | Pat::Rest(RestPat { type_ann, .. })
                 | Pat::Object(ObjectPat { type_ann, .. }) => {
                     *type_ann = Some(Box::new(TsTypeAnn {
+                        node_id: Default::default(),
                         span: p.span(type_ann_start),
                         type_ann: ty,
                     }));
@@ -818,7 +845,13 @@ fn parse_do_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
 
     let span = p.span(start);
 
-    Ok(DoWhileStmt { span, test, body }.into())
+    Ok(DoWhileStmt {
+        node_id: Default::default(),
+        span,
+        test,
+        body,
+    }
+    .into())
 }
 
 fn parse_labelled_stmt<'a, P: Parser<'a>>(p: &mut P, l: Ident) -> PResult<Stmt> {
@@ -865,6 +898,7 @@ fn parse_labelled_stmt<'a, P: Parser<'a>>(p: &mut P, l: Ident) -> PResult<Stmt> 
             }
 
             Ok(LabeledStmt {
+                node_id: Default::default(),
                 span: p.span(start),
                 label: l,
                 body,
@@ -885,6 +919,7 @@ pub fn parse_block<'a, P: Parser<'a>>(p: &mut P, allow_directives: bool) -> PRes
 
     let span = p.span(start);
     Ok(BlockStmt {
+        node_id: Default::default(),
         span,
         stmts,
         ctxt: Default::default(),
@@ -905,6 +940,7 @@ fn parse_catch_clause<'a, P: Parser<'a>>(p: &mut P) -> PResult<Option<CatchClaus
         let param = parse_catch_param(p)?;
         parse_block(p, false)
             .map(|body| CatchClause {
+                node_id: Default::default(),
                 span: p.span(start),
                 param,
                 body,
@@ -934,6 +970,7 @@ fn parse_try_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
 
     let span = p.span(start);
     Ok(TryStmt {
+        node_id: Default::default(),
         span,
         block,
         handler,
@@ -985,6 +1022,7 @@ fn parse_switch_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
             }
 
             cases.push(SwitchCase {
+                node_id: Default::default(),
                 span: Span::new_with_checked(case_start, p.input().prev_span().hi),
                 test,
                 cons,
@@ -998,6 +1036,7 @@ fn parse_switch_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
     expect!(p, &P::Token::RBRACE);
 
     Ok(SwitchStmt {
+        node_id: Default::default(),
         span: p.span(switch_start),
         discriminant,
         cases,
@@ -1049,6 +1088,7 @@ fn handle_import_export<'a, P: Parser<'a>>(p: &mut P, _: Vec<Decorator>) -> PRes
         p.eat_general_semi();
 
         return Ok(ExprStmt {
+            node_id: Default::default(),
             span: p.span(start),
             expr,
         }
@@ -1061,6 +1101,7 @@ fn handle_import_export<'a, P: Parser<'a>>(p: &mut P, _: Vec<Decorator>) -> PRes
         p.eat_general_semi();
 
         return Ok(ExprStmt {
+            node_id: Default::default(),
             span: p.span(start),
             expr,
         }
@@ -1117,7 +1158,12 @@ fn parse_stmt_internal<'a, P: Parser<'a>>(
             p.eat_general_semi();
 
             let span = p.span(start);
-            return Ok(ExprStmt { span, expr }.into());
+            return Ok(ExprStmt {
+                node_id: Default::default(),
+                span,
+                expr,
+            }
+            .into());
         }
     } else if cur.is_break() || cur.is_continue() {
         let is_break = p.input().is(&P::Token::BREAK);
@@ -1142,14 +1188,25 @@ fn parse_stmt_internal<'a, P: Parser<'a>>(
             p.emit_err(span, SyntaxError::TS1107);
         }
         return Ok(if is_break {
-            BreakStmt { span, label }.into()
+            BreakStmt {
+                node_id: Default::default(),
+                span,
+                label,
+            }
+            .into()
         } else {
-            ContinueStmt { span, label }.into()
+            ContinueStmt {
+                node_id: Default::default(),
+                span,
+                label,
+            }
+            .into()
         });
     } else if cur.is_debugger() {
         p.bump();
         p.expect_general_semi()?;
         return Ok(DebuggerStmt {
+            node_id: Default::default(),
             span: p.span(start),
         }
         .into());
@@ -1184,8 +1241,13 @@ fn parse_stmt_internal<'a, P: Parser<'a>>(
         let _ = parse_finally_block(p);
 
         return Ok(ExprStmt {
+            node_id: Default::default(),
             span,
-            expr: Invalid { span }.into(),
+            expr: Invalid {
+                node_id: Default::default(),
+                span,
+            }
+            .into(),
         }
         .into());
     } else if cur.is_finally() {
@@ -1196,8 +1258,13 @@ fn parse_stmt_internal<'a, P: Parser<'a>>(
         let _ = parse_finally_block(p);
 
         return Ok(ExprStmt {
+            node_id: Default::default(),
             span,
-            expr: Invalid { span }.into(),
+            expr: Invalid {
+                node_id: Default::default(),
+                span,
+            }
+            .into(),
         }
         .into());
     } else if cur.is_try() {
@@ -1256,6 +1323,7 @@ fn parse_stmt_internal<'a, P: Parser<'a>>(
     } else if cur.is_semi() {
         p.bump();
         return Ok(EmptyStmt {
+            node_id: Default::default(),
             span: p.span(start),
         }
         .into());
@@ -1295,6 +1363,7 @@ fn parse_stmt_internal<'a, P: Parser<'a>>(
             p.eat_general_semi();
 
             return Ok(ExprStmt {
+                node_id: Default::default(),
                 span: p.span(start),
                 expr,
             }
@@ -1326,6 +1395,7 @@ fn parse_stmt_internal<'a, P: Parser<'a>>(
 
     if p.eat_general_semi() {
         Ok(ExprStmt {
+            node_id: Default::default(),
             span: p.span(start),
             expr,
         }
@@ -1336,6 +1406,7 @@ fn parse_stmt_internal<'a, P: Parser<'a>>(
             p.emit_err(p.input().cur_span(), SyntaxError::TS1005);
             let expr = parse_bin_op_recursively(p, expr, 0)?;
             return Ok(ExprStmt {
+                node_id: Default::default(),
                 span: p.span(start),
                 expr,
             }

--- a/crates/swc_ecma_lexer/src/common/parser/typescript.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/typescript.rs
@@ -300,11 +300,13 @@ where
 
         return Ok(Box::new(TsType::TsUnionOrIntersectionType(match kind {
             UnionOrIntersection::Union => TsUnionOrIntersectionType::TsUnionType(TsUnionType {
+                node_id: Default::default(),
                 span: p.span(start),
                 types,
             }),
             UnionOrIntersection::Intersection => {
                 TsUnionOrIntersectionType::TsIntersectionType(TsIntersectionType {
+                    node_id: Default::default(),
                     span: p.span(start),
                     types,
                 })
@@ -407,6 +409,7 @@ pub fn parse_ts_this_type_node<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsThisTy
     debug_assert!(p.input().syntax().typescript());
     expect!(p, &P::Token::THIS);
     Ok(TsThisType {
+        node_id: Default::default(),
         span: p.input().prev_span(),
     })
 }
@@ -443,7 +446,12 @@ pub fn parse_ts_entity_name<'a, P: Parser<'a>>(
             parse_ident(p, false, false)?.into()
         };
         let span = p.span(start);
-        entity = TsEntityName::TsQualifiedName(Box::new(TsQualifiedName { span, left, right }));
+        entity = TsEntityName::TsQualifiedName(Box::new(TsQualifiedName {
+            node_id: Default::default(),
+            span,
+            left,
+            right,
+        }));
     }
     Ok(entity)
 }
@@ -494,7 +502,11 @@ pub fn parse_ts_type_args<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<TsTypePar
         p.emit_err(span, SyntaxError::EmptyTypeArgumentList);
     }
 
-    Ok(Box::new(TsTypeParamInstantiation { span, params }))
+    Ok(Box::new(TsTypeParamInstantiation {
+        node_id: Default::default(),
+        span,
+        params,
+    }))
 }
 
 /// `tsParseTypeReference`
@@ -523,6 +535,7 @@ pub fn parse_ts_type_ref<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsTypeRef> {
     }
 
     Ok(TsTypeRef {
+        node_id: Default::default(),
         span: p.span(start),
         type_name,
         type_params,
@@ -552,6 +565,7 @@ pub fn parse_ts_type_ann<'a, P: Parser<'a>>(
         let type_ann = parse_ts_type(p)?;
 
         Ok(Box::new(TsTypeAnn {
+            node_id: Default::default(),
             span: p.span(start),
             type_ann,
         }))
@@ -579,6 +593,7 @@ pub fn parse_ts_this_type_predicate<'a, P: Parser<'a>>(
     };
 
     Ok(TsTypePredicate {
+        node_id: Default::default(),
         span: p.span(start),
         asserts: has_asserts_keyword,
         param_name,
@@ -638,6 +653,7 @@ fn parse_ts_mapped_type_param<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsTypePar
     let constraint = Some(expect_then_parse_ts_type(p, &P::Token::IN, "in")?);
 
     Ok(TsTypeParam {
+        node_id: Default::default(),
         span: p.span(start),
         name: name.into(),
         is_in: false,
@@ -714,6 +730,7 @@ fn parse_ts_type_param<'a, P: Parser<'a>>(
     let default = eat_then_parse_ts_type(p, &P::Token::EQUAL)?;
 
     Ok(TsTypeParam {
+        node_id: Default::default(),
         span: p.span(start),
         name,
         is_in,
@@ -749,6 +766,7 @@ pub fn parse_ts_type_params<'a, P: Parser<'a>>(
             )?;
 
             Ok(Box::new(TsTypeParamDecl {
+                node_id: Default::default(),
                 span: p.span(start),
                 params,
             }))
@@ -834,6 +852,7 @@ pub fn parse_ts_type_or_type_predicate_ann<'a, P: Parser<'a>>(
         };
 
         let node = Box::new(TsType::TsTypePredicate(TsTypePredicate {
+            node_id: Default::default(),
             span: p.span(type_pred_start),
             asserts: has_type_pred_asserts,
             param_name: TsThisTypeOrIdent::Ident(type_pred_var.into()),
@@ -841,6 +860,7 @@ pub fn parse_ts_type_or_type_predicate_ann<'a, P: Parser<'a>>(
         }));
 
         Ok(Box::new(TsTypeAnn {
+            node_id: Default::default(),
             span: p.span(return_token_start),
             type_ann: node,
         }))
@@ -973,6 +993,7 @@ fn parse_ts_enum_member<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsEnumMember> {
         p.emit_err(span, SyntaxError::TS2452);
 
         TsEnumMemberId::Str(Str {
+            node_id: Default::default(),
             span,
             value: value.to_string().into(),
             raw: Some(new_raw.into()),
@@ -997,6 +1018,7 @@ fn parse_ts_enum_member<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsEnumMember> {
                 let value = tpl.cooked.unwrap();
 
                 TsEnumMemberId::Str(Str {
+                    node_id: Default::default(),
                     span,
                     value,
                     raw: None,
@@ -1030,6 +1052,7 @@ fn parse_ts_enum_member<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsEnumMember> {
     };
 
     Ok(TsEnumMember {
+        node_id: Default::default(),
         span: p.span(start),
         id,
         init,
@@ -1050,6 +1073,7 @@ pub fn parse_ts_enum_decl<'a, P: Parser<'a>>(
     expect!(p, &P::Token::RBRACE);
 
     Ok(Box::new(TsEnumDecl {
+        node_id: Default::default(),
         span: p.span(start),
         declare: false,
         is_const,
@@ -1088,6 +1112,7 @@ fn parse_ts_tpl_lit_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsTplLitType> 
     expect!(p, &P::Token::BACKQUOTE);
 
     Ok(TsTplLitType {
+        node_id: Default::default(),
         span: p.span(start),
         types,
         quasis,
@@ -1141,6 +1166,7 @@ fn parse_ts_lit_type_node<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsLitType> {
     };
 
     Ok(TsLitType {
+        node_id: Default::default(),
         span: p.span(start),
         lit,
     })
@@ -1175,6 +1201,7 @@ fn parse_ts_heritage_clause_element<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsE
 
     match *expr {
         Expr::TsInstantiation(v) => Ok(TsExprWithTypeArgs {
+            node_id: Default::default(),
             span: v.span,
             expr: v.expr,
             type_args: Some(v.type_args),
@@ -1189,6 +1216,7 @@ fn parse_ts_heritage_clause_element<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsE
             };
 
             Ok(TsExprWithTypeArgs {
+                node_id: Default::default(),
                 span: p.span(start),
                 expr,
                 type_args,
@@ -1313,6 +1341,7 @@ pub fn try_parse_ts_index_signature<'a, P: Parser<'a>>(
     parse_ts_type_member_semicolon(p)?;
 
     Ok(Some(TsIndexSignature {
+        node_id: Default::default(),
         span: p.span(index_signature_start),
         readonly,
         is_static,
@@ -1355,6 +1384,7 @@ fn parse_ts_external_module_ref<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsExter
     let expr = parse_str_lit(p);
     expect!(p, &P::Token::RPAREN);
     Ok(TsExternalModuleRef {
+        node_id: Default::default(),
         span: p.span(start),
         expr,
     })
@@ -1375,6 +1405,7 @@ pub fn parse_ts_import_equals_decl<'a, P: Parser<'a>>(
     p.expect_general_semi()?;
 
     Ok(Box::new(TsImportEqualsDecl {
+        node_id: Default::default(),
         span: p.span(start),
         id,
         is_export,
@@ -1465,6 +1496,7 @@ fn parse_ts_signature_member<'a, P: Parser<'a>>(
 
     match kind {
         SignatureParsingMode::TSCallSignatureDeclaration => Ok(Either::Left(TsCallSignatureDecl {
+            node_id: Default::default(),
             span: p.span(start),
             params,
             type_ann,
@@ -1472,6 +1504,7 @@ fn parse_ts_signature_member<'a, P: Parser<'a>>(
         })),
         SignatureParsingMode::TSConstructSignatureDeclaration => {
             Ok(Either::Right(TsConstructSignatureDecl {
+                node_id: Default::default(),
                 span: p.span(start),
                 params,
                 type_ann,
@@ -1504,6 +1537,7 @@ fn try_parse_ts_tuple_element_name<'a, P: Parser<'a>>(p: &mut P) -> Option<Pat> 
 
         Ok(Some(if let Some(dot3_token) = rest {
             RestPat {
+                node_id: Default::default(),
                 span: p.span(start),
                 dot3_token,
                 arg: ident.into(),
@@ -1528,9 +1562,11 @@ fn parse_ts_tuple_element_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsTupleE
     if p.input_mut().eat(&P::Token::DOTDOTDOT) {
         let type_ann = parse_ts_type(p)?;
         return Ok(TsTupleElement {
+            node_id: Default::default(),
             span: p.span(start),
             label,
             ty: Box::new(TsType::TsRestType(TsRestType {
+                node_id: Default::default(),
                 span: p.span(start),
                 type_ann,
             })),
@@ -1542,9 +1578,11 @@ fn parse_ts_tuple_element_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsTupleE
     if p.input_mut().eat(&P::Token::QUESTION) {
         let type_ann = ty;
         return Ok(TsTupleElement {
+            node_id: Default::default(),
             span: p.span(start),
             label,
             ty: Box::new(TsType::TsOptionalType(TsOptionalType {
+                node_id: Default::default(),
                 span: p.span(start),
                 type_ann,
             })),
@@ -1552,6 +1590,7 @@ fn parse_ts_tuple_element_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsTupleE
     }
 
     Ok(TsTupleElement {
+        node_id: Default::default(),
         span: p.span(start),
         label,
         ty,
@@ -1591,6 +1630,7 @@ pub fn parse_ts_tuple_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsTupleType>
     }
 
     Ok(TsTupleType {
+        node_id: Default::default(),
         span: p.span(start),
         elem_types: elems,
     })
@@ -1644,6 +1684,7 @@ pub fn parse_ts_mapped_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsMappedTyp
     expect!(p, &P::Token::RBRACE);
 
     Ok(TsMappedType {
+        node_id: Default::default(),
         span: p.span(start),
         readonly,
         optional,
@@ -1663,6 +1704,7 @@ pub fn parse_ts_parenthesized_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsPa
     let type_ann = parse_ts_type(p)?;
     expect!(p, &P::Token::RPAREN);
     Ok(TsParenthesizedType {
+        node_id: Default::default(),
         span: p.span(start),
         type_ann,
     })
@@ -1680,6 +1722,7 @@ pub fn parse_ts_type_alias_decl<'a, P: Parser<'a>>(
     let type_ann = expect_then_parse_ts_type(p, &P::Token::EQUAL, "=")?;
     p.expect_general_semi()?;
     Ok(Box::new(TsTypeAliasDecl {
+        node_id: Default::default(),
         declare: false,
         span: p.span(start),
         id: id.into(),
@@ -1716,6 +1759,7 @@ fn parse_ts_fn_or_constructor_type<'a, P: Parser<'a>>(
 
     Ok(if is_fn_type {
         TsFnOrConstructorType::TsFnType(TsFnType {
+            node_id: Default::default(),
             span: p.span(start),
             type_params,
             params,
@@ -1723,6 +1767,7 @@ fn parse_ts_fn_or_constructor_type<'a, P: Parser<'a>>(
         })
     } else {
         TsFnOrConstructorType::TsConstructorType(TsConstructorType {
+            node_id: Default::default(),
             span: p.span(start),
             type_params,
             params,
@@ -1809,6 +1854,7 @@ fn parse_ts_type_operator<'a, P: Parser<'a>>(
 
     let type_ann = parse_ts_type_operator_or_higher(p)?;
     Ok(TsTypeOperator {
+        node_id: Default::default(),
         span: p.span(start),
         op,
         type_ann,
@@ -1833,6 +1879,7 @@ fn parse_ts_infer_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsInferType> {
         }
     });
     let type_param = TsTypeParam {
+        node_id: Default::default(),
         span: type_param_name.span(),
         name: type_param_name.into(),
         is_in: false,
@@ -1842,6 +1889,7 @@ fn parse_ts_infer_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsInferType> {
         default: None,
     };
     Ok(TsInferType {
+        node_id: Default::default(),
         span: p.span(start),
         type_param,
     })
@@ -1883,6 +1931,7 @@ fn parse_ts_array_type_or_higher<'a, P: Parser<'a>>(
     while !p.input().had_line_break_before_cur() && p.input_mut().eat(&P::Token::LBRACKET) {
         if p.input_mut().eat(&P::Token::RBRACKET) {
             ty = Box::new(TsType::TsArrayType(TsArrayType {
+                node_id: Default::default(),
                 span: p.span(ty.span_lo()),
                 elem_type: ty,
             }));
@@ -1890,6 +1939,7 @@ fn parse_ts_array_type_or_higher<'a, P: Parser<'a>>(
             let index_type = parse_ts_type(p)?;
             expect!(p, &P::Token::RBRACKET);
             ty = Box::new(TsType::TsIndexedAccessType(TsIndexedAccessType {
+                node_id: Default::default(),
                 span: p.span(ty.span_lo()),
                 readonly,
                 obj_type: ty,
@@ -1935,6 +1985,7 @@ pub fn parse_ts_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<TsType>> {
         let false_type = parse_ts_type(p)?;
 
         Ok(Box::new(TsType::TsConditionalType(TsConditionalType {
+            node_id: Default::default(),
             span: p.span(start),
             check_type,
             extends_type,
@@ -2009,6 +2060,7 @@ fn parse_ts_property_or_method_signature<'a, P: Parser<'a>>(
 
         parse_ts_type_member_semicolon(p)?;
         Ok(Either::Right(TsMethodSignature {
+            node_id: Default::default(),
             span: p.span(start),
             computed,
             key,
@@ -2022,6 +2074,7 @@ fn parse_ts_property_or_method_signature<'a, P: Parser<'a>>(
 
         parse_ts_type_member_semicolon(p)?;
         Ok(Either::Left(TsPropertySignature {
+            node_id: Default::default(),
             span: p.span(start),
             computed,
             readonly,
@@ -2084,6 +2137,7 @@ fn parse_ts_type_member<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsTypeElement> 
             parse_ts_type_member_semicolon(p)?;
 
             Ok(Some(TsTypeElement::TsGetterSignature(TsGetterSignature {
+                node_id: Default::default(),
                 span: p.span(start),
                 key,
                 computed,
@@ -2100,6 +2154,7 @@ fn parse_ts_type_member<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsTypeElement> 
             parse_ts_type_member_semicolon(p)?;
 
             Ok(Some(TsTypeElement::TsSetterSignature(TsSetterSignature {
+                node_id: Default::default(),
                 span: p.span(start),
                 key,
                 computed,
@@ -2133,6 +2188,7 @@ pub fn parse_ts_type_lit<'a>(p: &mut impl Parser<'a>) -> PResult<TsTypeLit> {
     let start = p.cur_pos();
     let members = parse_ts_object_type_members(p)?;
     Ok(TsTypeLit {
+        node_id: Default::default(),
         span: p.span(start),
         members,
     })
@@ -2176,10 +2232,12 @@ pub fn parse_ts_interface_decl<'a, P: Parser<'a>>(
     let body_start = p.cur_pos();
     let body = p.in_type(parse_ts_object_type_members)?;
     let body = TsInterfaceBody {
+        node_id: Default::default(),
         span: p.span(body_start),
         body,
     };
     Ok(Box::new(TsInterfaceDecl {
+        node_id: Default::default(),
         span: p.span(start),
         declare: false,
         id: id.into(),
@@ -2207,6 +2265,7 @@ pub fn parse_ts_type_assertion<'a, P: Parser<'a>>(
     expect!(p, &P::Token::GREATER);
     let expr = p.parse_unary_expr()?;
     Ok(TsTypeAssertion {
+        node_id: Default::default(),
         span: p.span(start),
         type_ann,
         expr,
@@ -2232,6 +2291,7 @@ fn parse_ts_import_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsImportType> {
         p.bump();
         p.emit_err(arg_span, SyntaxError::TS1141);
         Str {
+            node_id: Default::default(),
             span: arg_span,
             value: Wtf8Atom::default(),
             raw: Some(atom!("\"\"")),
@@ -2266,6 +2326,7 @@ fn parse_ts_import_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsImportType> {
     };
 
     Ok(TsImportType {
+        node_id: Default::default(),
         span: p.span(start),
         arg,
         qualifier,
@@ -2289,6 +2350,7 @@ fn parse_ts_call_options<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsImportCallOp
     p.input_mut().eat(&P::Token::COMMA);
     expect!(p, &P::Token::RBRACE);
     Ok(TsImportCallOptions {
+        node_id: Default::default(),
         span: p.span(start),
         with: Box::new(value),
     })
@@ -2319,6 +2381,7 @@ fn parse_ts_type_query<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsTypeQuery> {
     };
 
     Ok(TsTypeQuery {
+        node_id: Default::default(),
         span: p.span(start),
         expr_name,
         type_args,
@@ -2340,6 +2403,7 @@ fn parse_ts_module_block<'a, P: Parser<'a>>(p: &mut P) -> PResult<TsModuleBlock>
     })?;
 
     Ok(TsModuleBlock {
+        node_id: Default::default(),
         span: p.span(start),
         body,
     })
@@ -2358,6 +2422,7 @@ fn parse_ts_module_or_ns_decl<'a, P: Parser<'a>>(
         let inner_start = p.cur_pos();
         let inner = parse_ts_module_or_ns_decl(p, inner_start, namespace)?;
         let inner = TsNamespaceDecl {
+            node_id: Default::default(),
             span: inner.span,
             id: match inner.id {
                 TsModuleName::Ident(i) => i,
@@ -2373,6 +2438,7 @@ fn parse_ts_module_or_ns_decl<'a, P: Parser<'a>>(
     };
 
     Ok(Box::new(TsModuleDecl {
+        node_id: Default::default(),
         span: p.span(start),
         declare: false,
         id: TsModuleName::Ident(id.into()),
@@ -2407,6 +2473,7 @@ fn parse_ts_ambient_external_module_decl<'a, P: Parser<'a>>(
     };
 
     Ok(Box::new(TsModuleDecl {
+        node_id: Default::default(),
         span: p.span(start),
         declare: false,
         id,
@@ -2478,6 +2545,7 @@ fn parse_ts_non_array_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<TsType>>
             Some(kind) if !peeked_is_dot => {
                 p.bump();
                 return Ok(Box::new(TsType::TsKeywordType(TsKeywordType {
+                    node_id: Default::default(),
                     span: p.span(start),
                     kind,
                 })));
@@ -2508,7 +2576,9 @@ fn parse_ts_non_array_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<TsType>>
 
         let lit = parse_lit(p)?;
         let lit = match lit {
-            Lit::Num(Number { span, value, raw }) => {
+            Lit::Num(Number {
+                span, value, raw, ..
+            }) => {
                 let mut new_raw = String::from("-");
 
                 match raw {
@@ -2521,12 +2591,15 @@ fn parse_ts_non_array_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<TsType>>
                 };
 
                 TsLit::Number(Number {
+                    node_id: Default::default(),
                     span,
                     value: -value,
                     raw: Some(new_raw.into()),
                 })
             }
-            Lit::BigInt(BigInt { span, value, raw }) => {
+            Lit::BigInt(BigInt {
+                span, value, raw, ..
+            }) => {
                 let mut new_raw = String::from("-");
 
                 match raw {
@@ -2539,6 +2612,7 @@ fn parse_ts_non_array_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<TsType>>
                 };
 
                 TsLit::BigInt(BigInt {
+                    node_id: Default::default(),
                     span,
                     value: Box::new(-*value),
                     raw: Some(new_raw.into()),
@@ -2548,6 +2622,7 @@ fn parse_ts_non_array_type<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<TsType>>
         };
 
         return Ok(Box::new(TsType::TsLitType(TsLitType {
+            node_id: Default::default(),
             span: p.span(start),
             lit,
         })));
@@ -2623,6 +2698,7 @@ pub fn parse_ts_expr_stmt<'a, P: Parser<'a>>(
                     .map(Some)?;
                 Ok(Some(
                     TsModuleDecl {
+                        node_id: Default::default(),
                         span: p.span(start),
                         global,
                         declare: false,

--- a/crates/swc_ecma_lexer/src/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/parser/mod.rs
@@ -152,6 +152,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
         let shebang = parse_shebang(self)?;
 
         let ret = parse_stmt_block_body(self, true, None).map(|body| Script {
+            node_id: Default::default(),
             span: self.span(start),
             body,
             shebang,
@@ -173,6 +174,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
         let shebang = parse_shebang(self)?;
 
         let ret = parse_stmt_block_body(self, true, None).map(|body| Script {
+            node_id: Default::default(),
             span: self.span(start),
             body,
             shebang,
@@ -198,6 +200,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
         let shebang = parse_shebang(self)?;
 
         let ret = parse_module_item_block_body(self, true, None).map(|body| Module {
+            node_id: Default::default(),
             span: self.span(start),
             body,
             shebang,
@@ -238,6 +241,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
 
         let ret = if has_module_item {
             Program::Module(Module {
+                node_id: Default::default(),
                 span: self.span(start),
                 body,
                 shebang,
@@ -256,6 +260,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
                 })
                 .collect();
             Program::Script(Script {
+                node_id: Default::default(),
                 span: self.span(start),
                 body,
                 shebang,
@@ -281,6 +286,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
         let shebang = parse_shebang(self)?;
 
         let ret = parse_module_item_block_body(self, true, None).map(|body| Module {
+            node_id: Default::default(),
             span: self.span(start),
             body,
             shebang,

--- a/crates/swc_ecma_lints/src/rules/critical_rules.rs
+++ b/crates/swc_ecma_lints/src/rules/critical_rules.rs
@@ -329,6 +329,7 @@ impl Visit for CriticalRules {
                         DefaultDecl::Fn(FnExpr {
                             ident: Some(ident),
                             function: f,
+                            ..
                         }),
                     ..
                 }),

--- a/crates/swc_ecma_parser/Cargo.toml
+++ b/crates/swc_ecma_parser/Cargo.toml
@@ -27,7 +27,7 @@ flow          = ["typescript"]
 tracing-spans = []
 typescript    = []
 unstable      = []
-verify        = ["swc_ecma_visit"]
+verify        = []
 
 [dependencies]
 bitflags       = { workspace = true }
@@ -41,7 +41,7 @@ smartstring    = { workspace = true }
 swc_atoms      = { version = "9.0.0", path = "../swc_atoms" }
 swc_common     = { version = "21.0.0", path = "../swc_common" }
 swc_ecma_ast   = { version = "23.0.0", path = "../swc_ecma_ast" }
-swc_ecma_visit = { version = "23.0.0", path = "../swc_ecma_visit", optional = true }
+swc_ecma_visit = { version = "23.0.0", path = "../swc_ecma_visit" }
 tracing        = { workspace = true }
 
 [target.'cfg(not(any(target_arch = "wasm32", target_arch = "arm")))'.dependencies]

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -152,6 +152,7 @@ pub mod unstable {
 use error::Error;
 use swc_common::{comments::Comments, input::SourceFileInput, SourceFile};
 use swc_ecma_ast::*;
+use swc_ecma_visit::assign_node_ids;
 
 mod context;
 pub mod error;
@@ -226,7 +227,10 @@ expose!(parse_file_as_expr, Box<Expr>, |p| {
     // This allow to parse `import.meta`
     let ctx = p.ctx();
     p.set_ctx(ctx.union(Context::CanBeModule));
-    p.parse_expr()
+    p.parse_expr().map(|mut expr| {
+        assign_node_ids(&mut expr);
+        expr
+    })
 });
 expose!(parse_file_as_module, Module, |p| { p.parse_module() });
 expose!(parse_file_as_script, Script, |p| { p.parse_script() });

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -135,6 +135,7 @@ impl<I: Tokens> Parser<I> {
         let expr = self.parse_maybe_decorator_args(expr)?;
 
         Ok(Decorator {
+            node_id: Default::default(),
             span: self.span(start),
             expr,
         })
@@ -369,6 +370,7 @@ impl<I: Tokens> Parser<I> {
             }
 
             Ok(Box::new(Function {
+                node_id: Default::default(),
                 span: p.span(start),
                 decorators,
                 type_params,
@@ -599,6 +601,7 @@ impl<I: Tokens> Parser<I> {
                 }
 
                 Ok(PrivateMethod {
+                    node_id: Default::default(),
                     span,
 
                     accessibility,
@@ -619,6 +622,7 @@ impl<I: Tokens> Parser<I> {
                     self.emit_err(span, SyntaxError::TS1245)
                 }
                 Ok(ClassMethod {
+                    node_id: Default::default(),
                     span,
 
                     accessibility,
@@ -849,6 +853,7 @@ impl<I: Tokens> Parser<I> {
 
             if accessor_token.is_some() {
                 return Ok(ClassMember::AutoAccessor(AutoAccessor {
+                    node_id: Default::default(),
                     span: p.span(start),
                     key,
                     value,
@@ -870,6 +875,7 @@ impl<I: Tokens> Parser<I> {
                     }
 
                     PrivateProp {
+                        node_id: Default::default(),
                         span: p.span(start),
                         key,
                         value,
@@ -891,6 +897,7 @@ impl<I: Tokens> Parser<I> {
                         p.emit_err(span, SyntaxError::TS1267)
                     }
                     ClassProp {
+                        node_id: Default::default(),
                         span,
                         key,
                         value,
@@ -922,7 +929,12 @@ impl<I: Tokens> Parser<I> {
         )?;
 
         let span = self.span(start);
-        Ok(StaticBlock { span, body }.into())
+        Ok(StaticBlock {
+            node_id: Default::default(),
+            span,
+            body,
+        }
+        .into())
     }
 
     fn parse_class_member_with_is_static(
@@ -1699,7 +1711,10 @@ impl<I: Tokens> Parser<I> {
             if self.input_mut().eat(Token::Semi) {
                 let span = self.input().prev_span();
                 debug_assert!(span.lo <= span.hi);
-                elems.push(ClassMember::Empty(EmptyStmt { span }));
+                elems.push(ClassMember::Empty(EmptyStmt {
+                    node_id: Default::default(),
+                    span,
+                }));
                 continue;
             }
             let elem =
@@ -1993,7 +2008,12 @@ impl OutputType for Box<Expr> {
         ident: Option<Ident>,
         function: Box<Function>,
     ) -> Result<Self, SyntaxError> {
-        Ok(FnExpr { ident, function }.into())
+        Ok(FnExpr {
+            node_id: Default::default(),
+            ident,
+            function,
+        }
+        .into())
     }
 
     fn finish_class(
@@ -2001,7 +2021,12 @@ impl OutputType for Box<Expr> {
         ident: Option<Ident>,
         class: Box<Class>,
     ) -> Result<Self, SyntaxError> {
-        Ok(ClassExpr { ident, class }.into())
+        Ok(ClassExpr {
+            node_id: Default::default(),
+            ident,
+            class,
+        }
+        .into())
     }
 }
 
@@ -2014,8 +2039,13 @@ impl OutputType for ExportDefaultDecl {
         function: Box<Function>,
     ) -> Result<Self, SyntaxError> {
         Ok(ExportDefaultDecl {
+            node_id: Default::default(),
             span,
-            decl: DefaultDecl::Fn(FnExpr { ident, function }),
+            decl: DefaultDecl::Fn(FnExpr {
+                node_id: Default::default(),
+                ident,
+                function,
+            }),
         })
     }
 
@@ -2025,8 +2055,13 @@ impl OutputType for ExportDefaultDecl {
         class: Box<Class>,
     ) -> Result<Self, SyntaxError> {
         Ok(ExportDefaultDecl {
+            node_id: Default::default(),
             span,
-            decl: DefaultDecl::Class(ClassExpr { ident, class }),
+            decl: DefaultDecl::Class(ClassExpr {
+                node_id: Default::default(),
+                ident,
+                class,
+            }),
         })
     }
 }
@@ -2042,6 +2077,7 @@ impl OutputType for Decl {
         let ident = ident.ok_or(SyntaxError::ExpectedIdent)?;
 
         Ok(FnDecl {
+            node_id: Default::default(),
             declare: false,
             ident,
             function,
@@ -2053,6 +2089,7 @@ impl OutputType for Decl {
         let ident = ident.ok_or(SyntaxError::ExpectedIdent)?;
 
         Ok(ClassDecl {
+            node_id: Default::default(),
             declare: false,
             ident,
             class,
@@ -2121,8 +2158,10 @@ mod tests {
         assert_eq_ignore_span!(
             expr("(class extends a {})"),
             Box::new(Expr::Paren(ParenExpr {
+                node_id: Default::default(),
                 span,
                 expr: Box::new(Expr::Class(ClassExpr {
+                    node_id: Default::default(),
                     ident: None,
                     class: Box::new(Class {
                         decorators: Vec::new(),

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -31,6 +31,7 @@ impl<I: Tokens> Parser<I> {
             }
 
             return Ok(SeqExpr {
+                node_id: Default::default(),
                 span: self.span(start),
                 exprs,
             }
@@ -59,10 +60,17 @@ impl<I: Tokens> Parser<I> {
                         },
                     )
                 })
-                .map(|expr| ExprOrSpread { spread, expr })
+                .map(|expr| ExprOrSpread {
+                    node_id: Default::default(),
+                    spread,
+                    expr,
+                })
         } else {
-            self.parse_assignment_expr()
-                .map(|expr| ExprOrSpread { spread: None, expr })
+            self.parse_assignment_expr().map(|expr| ExprOrSpread {
+                node_id: Default::default(),
+                spread: None,
+                expr,
+            })
         }
     }
 
@@ -212,6 +220,7 @@ impl<I: Tokens> Parser<I> {
                 self.expect(Token::Gt)?;
                 let expr = self.parse_unary_expr()?;
                 Ok(TsConstAssertion {
+                    node_id: Default::default(),
                     span: self.span(start),
                     expr,
                 }
@@ -248,6 +257,7 @@ impl<I: Tokens> Parser<I> {
             self.check_assign_target(&arg, false);
 
             return Ok(UpdateExpr {
+                node_id: Default::default(),
                 span,
                 prefix: true,
                 op,
@@ -286,6 +296,7 @@ impl<I: Tokens> Parser<I> {
                 Err(err) => {
                     self.emit_error(err);
                     Invalid {
+                        node_id: Default::default(),
                         span: Span::new_with_checked(arg_start, arg_start),
                     }
                     .into()
@@ -316,6 +327,7 @@ impl<I: Tokens> Parser<I> {
             }
 
             return Ok(UnaryExpr {
+                node_id: Default::default(),
                 span: Span::new_with_checked(start, arg.span_hi()),
                 op,
                 arg,
@@ -348,6 +360,7 @@ impl<I: Tokens> Parser<I> {
             self.bump();
 
             return Ok(UpdateExpr {
+                node_id: Default::default(),
                 span: self.span(expr.span_lo()),
                 prefix: false,
                 op,
@@ -428,6 +441,7 @@ impl<I: Tokens> Parser<I> {
         if cur == Token::Super {
             self.bump(); // eat `super`
             let obj = Callee::Super(Super {
+                node_id: Default::default(),
                 span: self.span(start),
             });
             return self.parse_subscripts(obj, false, false);
@@ -478,6 +492,7 @@ impl<I: Tokens> Parser<I> {
             let (callee, is_import) = match callee {
                 _ if callee.is_ident_ref_to("import") => (
                     Callee::Import(Import {
+                        node_id: Default::default(),
                         span: callee.span(),
                         phase: Default::default(),
                     }),
@@ -489,6 +504,7 @@ impl<I: Tokens> Parser<I> {
 
             let call_expr = match callee {
                 Callee::Expr(e) if unwrap_ts_non_null(&e).is_opt_chain() => OptChainExpr {
+                    node_id: Default::default(),
                     span: self.span(start),
                     base: Box::new(OptChainBase::Call(OptCall {
                         span: self.span(start),
@@ -557,7 +573,12 @@ impl<I: Tokens> Parser<I> {
         expect!(self, Token::RBracket);
 
         let span = self.span(start);
-        Ok(ArrayLit { span, elems }.into())
+        Ok(ArrayLit {
+            node_id: Default::default(),
+            span,
+            elems,
+        }
+        .into())
     }
 
     fn at_possible_async(&mut self, expr: &Expr) -> bool {
@@ -592,6 +613,7 @@ impl<I: Tokens> Parser<I> {
                 )
             })?;
             Ok(YieldExpr {
+                node_id: Default::default(),
                 span: p.span(start),
                 arg: Some(arg),
                 delegate: has_star,
@@ -608,6 +630,7 @@ impl<I: Tokens> Parser<I> {
                 && !cur.starts_expr()
         } {
             Ok(YieldExpr {
+                node_id: Default::default(),
                 span: self.span(start),
                 arg: None,
                 delegate: false,
@@ -696,9 +719,11 @@ impl<I: Tokens> Parser<I> {
         self.bump();
 
         Ok(Tpl {
+            node_id: Default::default(),
             span: self.span(start),
             exprs: vec![],
             quasis: vec![TplElement {
+                node_id: Default::default(),
                 span,
                 tail: true,
                 raw,
@@ -730,6 +755,7 @@ impl<I: Tokens> Parser<I> {
         self.bump();
 
         Ok(TplElement {
+            node_id: Default::default(),
             span,
             raw,
             tail: false,
@@ -746,6 +772,7 @@ impl<I: Tokens> Parser<I> {
         let (exprs, quasis) = self.parse_tpl_elements(is_tagged_tpl)?;
 
         Ok(Tpl {
+            node_id: Default::default(),
             span: self.span(start),
             exprs,
             quasis,
@@ -805,6 +832,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(TplElement {
+            node_id: Default::default(),
             span,
             raw,
             tail,
@@ -844,9 +872,11 @@ impl<I: Tokens> Parser<I> {
         self.bump();
 
         Ok(TsTplLitType {
+            node_id: Default::default(),
             span: self.span(start),
             types: vec![],
             quasis: vec![TplElement {
+                node_id: Default::default(),
                 span,
                 tail: true,
                 raw,
@@ -867,6 +897,7 @@ impl<I: Tokens> Parser<I> {
         let _ = self.input.cur();
 
         Ok(TsTplLitType {
+            node_id: Default::default(),
             span: self.span(start),
             types,
             quasis,
@@ -886,6 +917,7 @@ impl<I: Tokens> Parser<I> {
         tpl_ty.map(|tpl_ty| {
             let lit = TsLit::Tpl(tpl_ty);
             TsLitType {
+                node_id: Default::default(),
                 span: self.span(start),
                 lit,
             }
@@ -900,6 +932,7 @@ impl<I: Tokens> Parser<I> {
         self.bump();
 
         swc_ecma_ast::Str {
+            node_id: Default::default(),
             span: self.span(start),
             value,
             raw: Some(raw),
@@ -913,12 +946,19 @@ impl<I: Tokens> Parser<I> {
         let v = if cur == Token::Null {
             self.bump();
             let span = self.span(start);
-            Lit::Null(swc_ecma_ast::Null { span })
+            Lit::Null(swc_ecma_ast::Null {
+                node_id: Default::default(),
+                span,
+            })
         } else if cur == Token::True || cur == Token::False {
             let value = cur == Token::True;
             self.bump();
             let span = self.span(start);
-            Lit::Bool(swc_ecma_ast::Bool { span, value })
+            Lit::Bool(swc_ecma_ast::Bool {
+                node_id: Default::default(),
+                span,
+                value,
+            })
         } else if cur == Token::Str {
             Lit::Str(self.parse_str_lit())
         } else if cur == Token::Num {
@@ -927,6 +967,7 @@ impl<I: Tokens> Parser<I> {
             self.bump();
 
             Lit::Num(swc_ecma_ast::Number {
+                node_id: Default::default(),
                 span: self.span(start),
                 value,
                 raw: Some(raw),
@@ -937,6 +978,7 @@ impl<I: Tokens> Parser<I> {
             self.bump();
 
             Lit::BigInt(swc_ecma_ast::BigInt {
+                node_id: Default::default(),
                 span: self.span(start),
                 value,
                 raw: Some(raw),
@@ -1029,6 +1071,7 @@ impl<I: Tokens> Parser<I> {
             self.bump();
             let right = self.parse_assignment_expr()?;
             Ok(AssignExpr {
+                node_id: Default::default(),
                 span: self.span(start),
                 op,
                 // TODO:
@@ -1073,6 +1116,7 @@ impl<I: Tokens> Parser<I> {
 
             let span = Span::new_with_checked(start, alt.span_hi());
             Ok(CondExpr {
+                node_id: Default::default(),
                 span,
                 test,
                 cons,
@@ -1125,6 +1169,7 @@ impl<I: Tokens> Parser<I> {
                 self.assert_and_bump(Token::Bang);
 
                 let expr = Box::new(Expr::TsNonNull(TsNonNullExpr {
+                    node_id: Default::default(),
                     span: self.span(start),
                     expr: callee,
                 }));
@@ -1161,6 +1206,7 @@ impl<I: Tokens> Parser<I> {
 
                             let expr = if callee.is_opt_chain() {
                                 Expr::OptChain(OptChainExpr {
+                                    node_id: Default::default(),
                                     span: p.span(start),
                                     base: Box::new(OptChainBase::Call(OptCall {
                                         span: p.span(start),
@@ -1193,6 +1239,7 @@ impl<I: Tokens> Parser<I> {
                                 .map(Some)
                         } else if matches!(cur, Token::Eq | Token::As | Token::Satisfies) {
                             let expr = Expr::TsInstantiation(TsInstantiation {
+                                node_id: Default::default(),
                                 span: p.span(start),
                                 expr: callee.take(),
                                 type_args,
@@ -1243,6 +1290,7 @@ impl<I: Tokens> Parser<I> {
             let span = Span::new_with_checked(callee.span_lo(), self.input().last_pos());
             debug_assert_eq!(callee.span_lo(), span.lo());
             let prop = ComputedPropName {
+                node_id: Default::default(),
                 span: Span::new_with_checked(bracket_lo, self.input().last_pos()),
                 expr: prop,
             };
@@ -1255,12 +1303,14 @@ impl<I: Tokens> Parser<I> {
 
             let is_opt_chain = unwrap_ts_non_null(&callee).is_opt_chain();
             let expr = MemberExpr {
+                node_id: Default::default(),
                 span,
                 obj: callee,
                 prop: MemberProp::Computed(prop),
             };
             let expr = if is_opt_chain || question_dot {
                 OptChainExpr {
+                    node_id: Default::default(),
                     span,
                     optional: question_dot,
                     base: Box::new(OptChainBase::Member(expr)),
@@ -1272,6 +1322,7 @@ impl<I: Tokens> Parser<I> {
 
             let expr = if let Some(type_args) = type_args {
                 Expr::TsInstantiation(TsInstantiation {
+                    node_id: Default::default(),
                     expr: Box::new(expr),
                     type_args,
                     span: self.span(start),
@@ -1296,6 +1347,7 @@ impl<I: Tokens> Parser<I> {
             let span = self.span(start);
             return if question_dot || unwrap_ts_non_null(&callee).is_opt_chain() {
                 let expr = OptChainExpr {
+                    node_id: Default::default(),
                     span,
                     optional: question_dot,
                     base: Box::new(OptChainBase::Call(OptCall {
@@ -1342,12 +1394,14 @@ impl<I: Tokens> Parser<I> {
             };
 
             let expr = MemberExpr {
+                node_id: Default::default(),
                 span,
                 obj: callee,
                 prop,
             };
             let expr = if unwrap_ts_non_null(&expr.obj).is_opt_chain() || question_dot {
                 OptChainExpr {
+                    node_id: Default::default(),
                     span: self.span(start),
                     optional: question_dot,
                     base: Box::new(OptChainBase::Member(expr)),
@@ -1359,6 +1413,7 @@ impl<I: Tokens> Parser<I> {
 
             let expr = if let Some(type_args) = type_args {
                 Expr::TsInstantiation(TsInstantiation {
+                    node_id: Default::default(),
                     expr: Box::new(expr),
                     type_args,
                     span: self.span(start),
@@ -1372,6 +1427,7 @@ impl<I: Tokens> Parser<I> {
 
         let expr = if let Some(type_args) = ts_instantiation {
             TsInstantiation {
+                node_id: Default::default(),
                 expr: callee,
                 type_args,
                 span: self.span(start),
@@ -1414,6 +1470,7 @@ impl<I: Tokens> Parser<I> {
                 let span = Span::new_with_checked(lhs.span_lo(), self.input().last_pos());
                 debug_assert_eq!(lhs.span_lo(), span.lo());
                 let prop = ComputedPropName {
+                    node_id: Default::default(),
                     span: Span::new_with_checked(bracket_lo, self.input().last_pos()),
                     expr: prop,
                 };
@@ -1424,6 +1481,7 @@ impl<I: Tokens> Parser<I> {
                     syntax_error!(self, lhs.span, SyntaxError::InvalidSuper)
                 } else {
                     Ok(Box::new(Expr::SuperProp(SuperPropExpr {
+                        node_id: Default::default(),
                         span,
                         obj: lhs,
                         prop: SuperProp::Computed(prop),
@@ -1460,6 +1518,7 @@ impl<I: Tokens> Parser<I> {
                 } else {
                     let expr = match prop {
                         MemberProp::Ident(ident) => SuperPropExpr {
+                            node_id: Default::default(),
                             span,
                             obj: lhs,
                             prop: SuperProp::Ident(ident),
@@ -1539,6 +1598,7 @@ impl<I: Tokens> Parser<I> {
                         self.emit_err(span, SyntaxError::ImportMetaInScript);
                     }
                     let expr = MetaPropExpr {
+                        node_id: Default::default(),
                         span,
                         kind: MetaPropKind::ImportMeta,
                     };
@@ -1559,6 +1619,7 @@ impl<I: Tokens> Parser<I> {
         phase: ImportPhase,
     ) -> PResult<Box<Expr>> {
         let import = Callee::Import(Import {
+            node_id: Default::default(),
             span: self.span(start),
             phase,
         });
@@ -1585,6 +1646,7 @@ impl<I: Tokens> Parser<I> {
                 if self.input_mut().eat(Token::Target) {
                     let span = self.span(start);
                     let expr = MetaPropExpr {
+                        node_id: Default::default(),
                         span,
                         kind: MetaPropKind::NewTarget,
                     }
@@ -1690,6 +1752,7 @@ impl<I: Tokens> Parser<I> {
 
         if self.input_mut().eat(Token::Super) {
             let base = Callee::Super(Super {
+                node_id: Default::default(),
                 span: self.span(start),
             });
             return self.parse_subscripts(base, true, false);
@@ -1707,6 +1770,7 @@ impl<I: Tokens> Parser<I> {
         let obj = if let Some(type_args) = type_args {
             trace_cur!(self, parse_member_expr_or_new_expr__with_type_args);
             TsInstantiation {
+                node_id: Default::default(),
                 expr: obj,
                 type_args,
                 span: self.span(start),
@@ -1745,7 +1809,11 @@ impl<I: Tokens> Parser<I> {
                     || cur.is_bin_op()
                 {
                     self.emit_err(self.input().cur_span(), SyntaxError::TS1109);
-                    Invalid { span: err.span() }.into()
+                    Invalid {
+                        node_id: Default::default(),
+                        span: err.span(),
+                    }
+                    .into()
                 } else {
                     return Err(err);
                 }
@@ -1816,6 +1884,7 @@ impl<I: Tokens> Parser<I> {
                     self.bump(); // as
                     self.bump(); // const
                     TsConstAssertion {
+                        node_id: Default::default(),
                         span: self.span(start),
                         expr,
                     }
@@ -1823,6 +1892,7 @@ impl<I: Tokens> Parser<I> {
                 } else {
                     let type_ann = self.next_then_parse_ts_type()?;
                     TsAsExpr {
+                        node_id: Default::default(),
                         span: self.span(start),
                         expr,
                         type_ann,
@@ -1837,6 +1907,7 @@ impl<I: Tokens> Parser<I> {
                 let node = {
                     let type_ann = self.next_then_parse_ts_type()?;
                     TsSatisfiesExpr {
+                        node_id: Default::default(),
                         span: self.span(start),
                         expr,
                         type_ann,
@@ -1954,6 +2025,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         let node = BinExpr {
+            node_id: Default::default(),
             span: Span::new_with_checked(left.span_lo(), right.span_hi()),
             op,
             left,
@@ -2018,6 +2090,7 @@ impl<I: Tokens> Parser<I> {
 
         let arg = self.parse_unary_expr()?;
         Ok(AwaitExpr {
+            node_id: Default::default(),
             span: self.span(start),
             arg,
         }
@@ -2088,7 +2161,11 @@ impl<I: Tokens> Parser<I> {
                         expr
                     };
 
-                    ExprOrSpread { spread, expr }
+                    ExprOrSpread {
+                        node_id: Default::default(),
+                        spread,
+                        expr,
+                    }
                 } else {
                     self.allow_in_expr(|p| p.parse_expr_or_spread())?
                 }
@@ -2137,8 +2214,10 @@ impl<I: Tokens> Parser<I> {
                         })?;
 
                         arg = ExprOrSpread {
+                            node_id: Default::default(),
                             spread: None,
                             expr: CondExpr {
+                                node_id: Default::default(),
                                 span: Span::new_with_checked(start, alt.span_hi()),
                                 test,
                                 cons,
@@ -2182,9 +2261,11 @@ impl<I: Tokens> Parser<I> {
                         let cast_span =
                             Span::new_with_checked(arg.expr.span_lo(), self.input().prev_span().hi);
                         items.push(AssignTargetOrSpread::ExprOrSpread(ExprOrSpread {
+                            node_id: Default::default(),
                             spread: None,
                             expr: Box::new(
                                 TsAsExpr {
+                                    node_id: Default::default(),
                                     span: cast_span,
                                     expr: arg.expr,
                                     type_ann: type_ann.type_ann,
@@ -2215,6 +2296,7 @@ impl<I: Tokens> Parser<I> {
                 }
                 if let Some(span) = arg.spread {
                     pat = RestPat {
+                        node_id: Default::default(),
                         span: self.span(pat_start),
                         dot3_token: span,
                         arg: Box::new(pat),
@@ -2269,6 +2351,7 @@ impl<I: Tokens> Parser<I> {
                 if self.input_mut().eat(Token::Eq) {
                     let right = self.parse_assignment_expr()?;
                     pat = AssignPat {
+                        node_id: Default::default(),
                         span: self.span(pat_start),
                         left: Box::new(pat),
                         right,
@@ -2312,6 +2395,7 @@ impl<I: Tokens> Parser<I> {
                 let span = self.span(start);
 
                 items.push(AssignTargetOrSpread::ExprOrSpread(ExprOrSpread {
+                    node_id: Default::default(),
                     expr: Box::new(
                         ArrowExpr {
                             span,
@@ -2548,7 +2632,8 @@ impl<I: Tokens> Parser<I> {
                         AssignTargetOrSpread::ExprOrSpread(ExprOrSpread {
                             spread: None,
                             expr
-                        }) if matches!(expr.as_ref(), Expr::TsAs(..))
+                        ,
+                            ..}) if matches!(expr.as_ref(), Expr::TsAs(..))
                     )
                 })
             {
@@ -2602,10 +2687,12 @@ impl<I: Tokens> Parser<I> {
                 ExprOrSpread {
                     spread: Some(..),
                     ref expr,
+                    ..
                 } => syntax_error!(self, expr.span(), SyntaxError::SpreadInParenExpr),
                 ExprOrSpread { expr, .. } => expr,
             };
             Ok(ParenExpr {
+                node_id: Default::default(),
                 span: self.span(expr_start),
                 expr,
             }
@@ -2619,6 +2706,7 @@ impl<I: Tokens> Parser<I> {
                     ExprOrSpread {
                         spread: Some(..),
                         ref expr,
+                        ..
                     } => syntax_error!(self, expr.span(), SyntaxError::SpreadInParenExpr),
                     ExprOrSpread { expr, .. } => exprs.push(expr),
                 }
@@ -2627,6 +2715,7 @@ impl<I: Tokens> Parser<I> {
 
             // span of sequence expression should not include '(', ')'
             let seq_expr = SeqExpr {
+                node_id: Default::default(),
                 span: Span::new_with_checked(
                     exprs.first().unwrap().span_lo(),
                     exprs.last().unwrap().span_hi(),
@@ -2635,6 +2724,7 @@ impl<I: Tokens> Parser<I> {
             }
             .into();
             Ok(ParenExpr {
+                node_id: Default::default(),
                 span: self.span(expr_start),
                 expr: seq_expr,
             }
@@ -2699,6 +2789,7 @@ impl<I: Tokens> Parser<I> {
                         // async as type
                         let type_ann = p.in_type(Self::parse_ts_type)?;
                         return Ok(TsAsExpr {
+                            node_id: Default::default(),
                             span: p.span(start),
                             expr: Box::new(id.into()),
                             type_ann,
@@ -2767,6 +2858,7 @@ impl<I: Tokens> Parser<I> {
                 self.emit_err(self.span(start), SyntaxError::TS1003);
             }
             Ok(PrivateName {
+                node_id: Default::default(),
                 span: self.span(start),
                 name: id.sym,
             }
@@ -2821,7 +2913,15 @@ impl<I: Tokens> Parser<I> {
 
             self.bump();
             let span = self.span(start);
-            Some(Lit::Regex(Regex { span, exp, flags }).into())
+            Some(
+                Lit::Regex(Regex {
+                    node_id: Default::default(),
+                    span,
+                    exp,
+                    flags,
+                })
+                .into(),
+            )
         } else {
             None
         }
@@ -2867,6 +2967,7 @@ impl<I: Tokens> Parser<I> {
         debug_assert!(self.input().cur() == Token::This);
         self.input_mut().bump();
         Ok(ThisExpr {
+            node_id: Default::default(),
             span: self.span(start),
         }
         .into())

--- a/crates/swc_ecma_parser/src/parser/ident.rs
+++ b/crates/swc_ecma_parser/src/parser/ident.rs
@@ -57,6 +57,7 @@ impl<I: Tokens> Parser<I> {
         }
         let id = self.parse_ident_name()?;
         Ok(PrivateName {
+            node_id: Default::default(),
             span: self.span(start),
             name: id.sym,
         })

--- a/crates/swc_ecma_parser/src/parser/jsx.rs
+++ b/crates/swc_ecma_parser/src/parser/jsx.rs
@@ -24,6 +24,7 @@ impl<I: Tokens> Parser<I> {
         };
         expect!(self, Token::RBrace);
         Ok(JSXExprContainer {
+            node_id: Default::default(),
             span: self.span(start),
             expr,
         })
@@ -36,6 +37,7 @@ impl<I: Tokens> Parser<I> {
         debug_assert!(self.input().syntax().jsx());
         let start = self.input().cur_pos();
         JSXEmptyExpr {
+            node_id: Default::default(),
             span: Span::new_with_checked(start, start),
         }
     }
@@ -65,7 +67,12 @@ impl<I: Tokens> Parser<I> {
 
         self.input.scan_jsx_token();
         let span = self.input().prev_span();
-        JSXText { span, value, raw }
+        JSXText {
+            node_id: Default::default(),
+            span,
+            value,
+            raw,
+        }
     }
 
     fn parse_jsx_ident(&mut self) -> PResult<Ident> {
@@ -100,6 +107,7 @@ impl<I: Tokens> Parser<I> {
             self.input_mut().scan_jsx_identifier();
             let name: IdentName = self.parse_jsx_ident()?.into();
             JSXAttrName::JSXNamespacedName(JSXNamespacedName {
+                node_id: Default::default(),
                 span: Span::new_with_checked(start, name.span.hi),
                 ns,
                 name,
@@ -123,6 +131,7 @@ impl<I: Tokens> Parser<I> {
             self.input_mut().scan_jsx_identifier();
             let prop: IdentName = self.parse_jsx_ident()?.into();
             let new_node = JSXElementName::JSXMemberExpr(JSXMemberExpr {
+                node_id: Default::default(),
                 span: self.span(start),
                 obj: match node {
                     JSXElementName::Ident(i) => JSXObject::Ident(i),
@@ -169,6 +178,7 @@ impl<I: Tokens> Parser<I> {
 
         let span = self.span(start);
         Ok(JSXClosingElement {
+            node_id: Default::default(),
             span,
             name: tagname,
         })
@@ -190,7 +200,10 @@ impl<I: Tokens> Parser<I> {
             self.input_mut().scan_jsx_token();
         }
         let span = self.span(start);
-        Ok(JSXClosingFragment { span })
+        Ok(JSXClosingFragment {
+            node_id: Default::default(),
+            span,
+        })
     }
 
     fn parse_jsx_children(&mut self) -> Vec<JSXElementChild> {
@@ -222,6 +235,7 @@ impl<I: Tokens> Parser<I> {
                             p.expect_without_advance(Token::RBrace)?;
                             p.input_mut().scan_jsx_token();
                             JSXElementChild::JSXSpreadChild(JSXSpreadChild {
+                                node_id: Default::default(),
                                 span: p.span(start),
                                 expr,
                             })
@@ -234,6 +248,7 @@ impl<I: Tokens> Parser<I> {
                             p.expect_without_advance(Token::RBrace)?;
                             p.input_mut().scan_jsx_token();
                             JSXElementChild::JSXExprContainer(JSXExprContainer {
+                                node_id: Default::default(),
                                 span: p.span(start),
                                 expr,
                             })
@@ -270,6 +285,7 @@ impl<I: Tokens> Parser<I> {
             self.input_mut().scan_jsx_identifier();
             let name = self.parse_jsx_ident()?;
             Ok(JSXAttrName::JSXNamespacedName(JSXNamespacedName {
+                node_id: Default::default(),
                 span: Span::new_with_checked(start, name.span.hi),
                 ns: attr_name.into(),
                 name: name.into(),
@@ -320,6 +336,7 @@ impl<I: Tokens> Parser<I> {
             let expr = self.parse_assignment_expr()?;
             self.expect(Token::RBrace)?;
             Ok(JSXAttrOrSpread::SpreadElement(SpreadElement {
+                node_id: Default::default(),
                 dot3_token,
                 expr,
             }))
@@ -331,6 +348,7 @@ impl<I: Tokens> Parser<I> {
                 |p| p.parse_jsx_attr_value(),
             )?;
             Ok(JSXAttrOrSpread::JSXAttr(JSXAttr {
+                node_id: Default::default(),
                 span: self.span(start),
                 name,
                 value,
@@ -376,12 +394,14 @@ impl<I: Tokens> Parser<I> {
                 // <>xxxxxx</>
                 p.input_mut().scan_jsx_token();
                 let opening = JSXOpeningFragment {
+                    node_id: Default::default(),
                     span: p.span(start),
                 };
                 let children = p.parse_jsx_children();
                 let closing = p.parse_jsx_closing_fragment(in_expr_context)?;
                 let span = p.span(start);
                 Ok(either::Either::Left(JSXFragment {
+                    node_id: Default::default(),
                     span,
                     opening,
                     children,
@@ -406,6 +426,7 @@ impl<I: Tokens> Parser<I> {
                     p.input_mut().scan_jsx_token();
                     let span = Span::new_with_checked(start, p.input.get_cur().span.lo);
                     let opening = JSXOpeningElement {
+                        node_id: Default::default(),
                         span,
                         name,
                         type_args,
@@ -420,6 +441,7 @@ impl<I: Tokens> Parser<I> {
                         Span::new_with_checked(start, p.cur_pos())
                     };
                     Ok(either::Either::Right(JSXElement {
+                        node_id: Default::default(),
                         span,
                         opening,
                         children,
@@ -446,8 +468,10 @@ impl<I: Tokens> Parser<I> {
                         Span::new_with_checked(start, p.cur_pos())
                     };
                     Ok(either::Either::Right(JSXElement {
+                        node_id: Default::default(),
                         span,
                         opening: JSXOpeningElement {
+                            node_id: Default::default(),
                             span,
                             name,
                             type_args,
@@ -514,8 +538,10 @@ mod tests {
         assert_eq_ignore_span!(
             jsx("<a />"),
             Box::new(Expr::JSXElement(Box::new(JSXElement {
+                node_id: Default::default(),
                 span,
                 opening: JSXOpeningElement {
+                    node_id: Default::default(),
                     span,
                     name: JSXElementName::Ident(Ident::new_no_ctxt(atom!("a"), span)),
                     self_closing: true,
@@ -533,8 +559,10 @@ mod tests {
         assert_eq_ignore_span!(
             jsx("<a>foo</a>"),
             Box::new(Expr::JSXElement(Box::new(JSXElement {
+                node_id: Default::default(),
                 span,
                 opening: JSXOpeningElement {
+                    node_id: Default::default(),
                     span,
                     name: JSXElementName::Ident(Ident::new_no_ctxt(atom!("a"), span)),
                     self_closing: false,
@@ -542,11 +570,13 @@ mod tests {
                     type_args: None,
                 },
                 children: vec![JSXElementChild::JSXText(JSXText {
+                    node_id: Default::default(),
                     span,
                     raw: atom!("foo"),
                     value: atom!("foo"),
                 })],
                 closing: Some(JSXClosingElement {
+                    node_id: Default::default(),
                     span,
                     name: JSXElementName::Ident(Ident::new_no_ctxt(atom!("a"), span)),
                 })
@@ -559,13 +589,17 @@ mod tests {
         assert_eq_ignore_span!(
             jsx(r#"<div id="w &lt; w" />;"#),
             Box::new(Expr::JSXElement(Box::new(JSXElement {
+                node_id: Default::default(),
                 span,
                 opening: JSXOpeningElement {
+                    node_id: Default::default(),
                     span,
                     attrs: vec![JSXAttrOrSpread::JSXAttr(JSXAttr {
+                        node_id: Default::default(),
                         span,
                         name: JSXAttrName::Ident(IdentName::new(atom!("id"), span)),
                         value: Some(JSXAttrValue::Str(Str {
+                            node_id: Default::default(),
                             span,
                             value: atom!("w < w").into(),
                             raw: Some(atom!("\"w &lt; w\"")),
@@ -586,16 +620,21 @@ mod tests {
         assert_eq_ignore_span!(
             jsx(r#"<test other={4} />;"#),
             Box::new(Expr::JSXElement(Box::new(JSXElement {
+                node_id: Default::default(),
                 span,
                 opening: JSXOpeningElement {
+                    node_id: Default::default(),
                     span,
                     name: JSXElementName::Ident(Ident::new_no_ctxt(atom!("test"), span)),
                     attrs: vec![JSXAttrOrSpread::JSXAttr(JSXAttr {
+                        node_id: Default::default(),
                         span,
                         name: JSXAttrName::Ident(IdentName::new(atom!("other"), span)),
                         value: Some(JSXAttrValue::JSXExprContainer(JSXExprContainer {
+                            node_id: Default::default(),
                             span,
                             expr: JSXExpr::Expr(Box::new(Expr::Lit(Lit::Num(Number {
+                                node_id: Default::default(),
                                 span,
                                 value: 4.0,
                                 raw: Some(atom!("4"))

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -5,6 +5,7 @@ use rustc_hash::FxHashMap;
 use swc_atoms::Atom;
 use swc_common::{comments::Comments, input::StringInput, BytePos, Span, Spanned};
 use swc_ecma_ast::*;
+use swc_ecma_visit::assign_node_ids;
 
 #[cfg(feature = "typescript")]
 use crate::lexer::TokenAndSpan;
@@ -222,7 +223,8 @@ impl<I: Tokens> Parser<I> {
 
         let shebang = self.parse_shebang()?;
 
-        let ret = self.parse_stmt_block_body(true, None).map(|body| Script {
+        let mut ret = self.parse_stmt_block_body(true, None).map(|body| Script {
+            node_id: Default::default(),
             span: self.span(start),
             body,
             shebang,
@@ -230,6 +232,8 @@ impl<I: Tokens> Parser<I> {
 
         debug_assert!(self.input().cur() == Token::Eof);
         self.input_mut().bump();
+
+        assign_node_ids(&mut ret);
 
         Ok(ret)
     }
@@ -246,7 +250,8 @@ impl<I: Tokens> Parser<I> {
         let start = self.cur_pos();
         let shebang = self.parse_shebang()?;
 
-        let ret = self.parse_stmt_block_body(true, None).map(|body| Script {
+        let mut ret = self.parse_stmt_block_body(true, None).map(|body| Script {
+            node_id: Default::default(),
             span: self.span(start),
             body,
             shebang,
@@ -254,6 +259,8 @@ impl<I: Tokens> Parser<I> {
 
         debug_assert!(self.input().cur() == Token::Eof);
         self.input_mut().bump();
+
+        assign_node_ids(&mut ret);
 
         Ok(ret)
     }
@@ -271,9 +278,10 @@ impl<I: Tokens> Parser<I> {
         let start = self.cur_pos();
         let shebang = self.parse_shebang()?;
 
-        let ret = self
+        let mut ret = self
             .parse_module_item_block_body(true, None)
             .map(|body| Module {
+                node_id: Default::default(),
                 span: self.span(start),
                 body,
                 shebang,
@@ -281,6 +289,8 @@ impl<I: Tokens> Parser<I> {
 
         debug_assert!(self.input().cur() == Token::Eof);
         self.input_mut().bump();
+
+        assign_node_ids(&mut ret);
 
         Ok(ret)
     }
@@ -312,11 +322,12 @@ impl<I: Tokens> Parser<I> {
             self.input.set_ctx(ctx);
         }
 
-        let ret = if has_module_item {
+        let mut ret = if has_module_item {
             if self.syntax().flow() {
                 self.report_duplicate_exports(&body);
             }
             Program::Module(Module {
+                node_id: Default::default(),
                 span: self.span(start),
                 body,
                 shebang,
@@ -332,6 +343,7 @@ impl<I: Tokens> Parser<I> {
                 })
                 .collect();
             Program::Script(Script {
+                node_id: Default::default(),
                 span: self.span(start),
                 body,
                 shebang,
@@ -340,6 +352,8 @@ impl<I: Tokens> Parser<I> {
 
         debug_assert!(self.input().cur() == Token::Eof);
         self.input_mut().bump();
+
+        assign_node_ids(&mut ret);
 
         Ok(ret)
     }
@@ -356,9 +370,10 @@ impl<I: Tokens> Parser<I> {
         let start = self.cur_pos();
         let shebang = self.parse_shebang()?;
 
-        let ret = self
+        let mut ret = self
             .parse_module_item_block_body(true, None)
             .map(|body| Module {
+                node_id: Default::default(),
                 span: self.span(start),
                 body,
                 shebang,
@@ -369,6 +384,8 @@ impl<I: Tokens> Parser<I> {
 
         debug_assert!(self.input().cur() == Token::Eof);
         self.input_mut().bump();
+
+        assign_node_ids(&mut ret);
 
         Ok(ret)
     }
@@ -754,6 +771,7 @@ impl<I: Tokens> Parser<I> {
 
                 let raw = p.input.iter.read_string(token_span);
                 PropName::Num(Number {
+                    node_id: Default::default(),
                     span: p.span(start),
                     value,
                     raw: Some(Atom::new(raw)),
@@ -765,6 +783,7 @@ impl<I: Tokens> Parser<I> {
 
                 let raw = p.input.iter.read_string(token_span);
                 PropName::BigInt(BigInt {
+                    node_id: Default::default(),
                     span: p.span(start),
                     value,
                     raw: Some(Atom::new(raw)),
@@ -780,6 +799,7 @@ impl<I: Tokens> Parser<I> {
                 }
                 let key = p.input_mut().expect_word_token_and_bump();
                 PropName::Str(Str {
+                    node_id: Default::default(),
                     span: p.span(start),
                     value: format!("@@{key}").into(),
                     raw: None,
@@ -800,6 +820,7 @@ impl<I: Tokens> Parser<I> {
                     p.emit_err(p.span(inner_start), SyntaxError::TS1171);
                     expr = Box::new(
                         SeqExpr {
+                            node_id: Default::default(),
                             span: p.span(inner_start),
                             exprs,
                         }
@@ -808,6 +829,7 @@ impl<I: Tokens> Parser<I> {
                 }
                 expect!(p, Token::RBracket);
                 PropName::Computed(ComputedPropName {
+                    node_id: Default::default(),
                     span: p.span(start),
                     expr,
                 })

--- a/crates/swc_ecma_parser/src/parser/module_item.rs
+++ b/crates/swc_ecma_parser/src/parser/module_item.rs
@@ -72,6 +72,7 @@ impl<I: Tokens> Parser<I> {
                             }
 
                             return Ok(ExportNamedSpecifier {
+                                node_id: Default::default(),
                                 span: self.span(start),
                                 orig: ModuleExportName::Ident(possibly_orig),
                                 exported: None,
@@ -93,6 +94,7 @@ impl<I: Tokens> Parser<I> {
 
                                 debug_assert!(start <= orig_ident.span.hi());
                                 return Ok(ExportNamedSpecifier {
+                                    node_id: Default::default(),
                                     span: Span::new_with_checked(start, orig_ident.span.hi()),
                                     orig: ModuleExportName::Ident(possibly_orig),
                                     exported: Some(ModuleExportName::Ident(exported)),
@@ -101,6 +103,7 @@ impl<I: Tokens> Parser<I> {
                             } else {
                                 // `export { type as as }`
                                 return Ok(ExportNamedSpecifier {
+                                    node_id: Default::default(),
                                     span: Span::new_with_checked(start, orig_ident.span.hi()),
                                     orig: ModuleExportName::Ident(orig_ident),
                                     exported: Some(ModuleExportName::Ident(maybe_as)),
@@ -110,6 +113,7 @@ impl<I: Tokens> Parser<I> {
                         } else {
                             // `export { type as xxx }`
                             return Ok(ExportNamedSpecifier {
+                                node_id: Default::default(),
                                 span: Span::new_with_checked(start, orig_ident.span.hi()),
                                 orig: ModuleExportName::Ident(orig_ident),
                                 exported: Some(ModuleExportName::Ident(maybe_as)),
@@ -140,6 +144,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(ExportNamedSpecifier {
+            node_id: Default::default(),
             span: self.span(start),
             orig,
             exported,
@@ -216,6 +221,7 @@ impl<I: Tokens> Parser<I> {
                         }
 
                         return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                            node_id: Default::default(),
                             span: Span::new_with_checked(start, local.span.hi()),
                             local,
                             imported: Some(imported),
@@ -241,6 +247,7 @@ impl<I: Tokens> Parser<I> {
                         }
 
                         return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                            node_id: Default::default(),
                             span: Span::new_with_checked(start, local.span.hi()),
                             local,
                             imported: Some(imported),
@@ -267,6 +274,7 @@ impl<I: Tokens> Parser<I> {
                                 }
 
                                 return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                                    node_id: Default::default(),
                                     span: self.span(start),
                                     local: possibly_orig_name,
                                     imported: None,
@@ -287,6 +295,7 @@ impl<I: Tokens> Parser<I> {
                                     }
 
                                     return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                                        node_id: Default::default(),
                                         span: Span::new_with_checked(start, local.span.hi()),
                                         local,
                                         imported: Some(ModuleExportName::Ident(possibly_orig_name)),
@@ -295,6 +304,7 @@ impl<I: Tokens> Parser<I> {
                                 } else {
                                     // `import { type as as } from 'mod'`
                                     return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                                        node_id: Default::default(),
                                         span: Span::new_with_checked(start, maybe_as.span.hi()),
                                         local: maybe_as,
                                         imported: Some(ModuleExportName::Ident(orig_name)),
@@ -304,6 +314,7 @@ impl<I: Tokens> Parser<I> {
                             } else {
                                 // `import { type as xxx } from 'mod'`
                                 return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                                    node_id: Default::default(),
                                     span: Span::new_with_checked(start, maybe_as.span.hi()),
                                     local: maybe_as,
                                     imported: Some(ModuleExportName::Ident(orig_name)),
@@ -329,6 +340,7 @@ impl<I: Tokens> Parser<I> {
                         self.emit_flow_reserved_type_name_error(local.span, &local.sym);
                     }
                     return Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                        node_id: Default::default(),
                         span: Span::new_with_checked(start, local.span.hi()),
                         local,
                         imported: Some(ModuleExportName::Ident(orig_name)),
@@ -354,6 +366,7 @@ impl<I: Tokens> Parser<I> {
                     self.emit_flow_reserved_type_name_error(local.span, &local.sym);
                 }
                 Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                    node_id: Default::default(),
                     span: self.span(start),
                     local,
                     imported: None,
@@ -364,6 +377,7 @@ impl<I: Tokens> Parser<I> {
                 if self.input_mut().eat(Token::As) {
                     let local: Ident = self.parse_binding_ident(false)?.into();
                     Ok(ImportSpecifier::Named(ImportNamedSpecifier {
+                        node_id: Default::default(),
                         span: Span::new_with_checked(start, local.span.hi()),
                         local,
                         imported: Some(ModuleExportName::Str(orig_str)),
@@ -406,6 +420,7 @@ impl<I: Tokens> Parser<I> {
             // TODO: Remove
             if let Some(decl) = self.try_parse_ts_declare(after_export_start, decorators.clone())? {
                 return Ok(ExportDecl {
+                    node_id: Default::default(),
                     span: self.span(start),
                     decl,
                 }
@@ -420,6 +435,7 @@ impl<I: Tokens> Parser<I> {
                 // TODO: remove clone
                 if let Some(decl) = self.try_parse_ts_export_decl(decorators.clone(), sym) {
                     return Ok(ExportDecl {
+                        node_id: Default::default(),
                         span: self.span(start),
                         decl,
                     }
@@ -453,6 +469,7 @@ impl<I: Tokens> Parser<I> {
                 let expr = self.parse_expr()?;
                 self.expect_general_semi()?;
                 return Ok(TsExportAssignment {
+                    node_id: Default::default(),
                     span: self.span(start),
                     expr,
                 }
@@ -466,6 +483,7 @@ impl<I: Tokens> Parser<I> {
                 let id = self.parse_ident(false, false)?;
                 self.expect_general_semi()?;
                 return Ok(TsNamespaceExportDecl {
+                    node_id: Default::default(),
                     span: self.span(start),
                     id,
                 }
@@ -527,6 +545,7 @@ impl<I: Tokens> Parser<I> {
                         .parse_ts_interface_decl(interface_start)
                         .map(DefaultDecl::from)?;
                     return Ok(ExportDefaultDecl {
+                        node_id: Default::default(),
                         span: self.span(start),
                         decl,
                     }
@@ -541,14 +560,17 @@ impl<I: Tokens> Parser<I> {
                         {
                             return match decl {
                                 Decl::Fn(fn_decl) => Ok(ExportDefaultDecl {
+                                    node_id: Default::default(),
                                     span: self.span(start),
                                     decl: DefaultDecl::Fn(FnExpr {
+                                        node_id: Default::default(),
                                         ident: Some(fn_decl.ident),
                                         function: fn_decl.function,
                                     }),
                                 }
                                 .into()),
                                 _ => Ok(ExportDecl {
+                                    node_id: Default::default(),
                                     span: self.span(start),
                                     decl,
                                 }
@@ -584,6 +606,7 @@ impl<I: Tokens> Parser<I> {
                 // `export default enum` is valid in Flow, but SWC's default export decl AST
                 // variant does not model enum declarations.
                 return Ok(ExportDecl {
+                    node_id: Default::default(),
                     span: self.span(start),
                     decl: Decl::TsEnum(decl),
                 }
@@ -603,6 +626,7 @@ impl<I: Tokens> Parser<I> {
                 let expr = self.allow_in_expr(Self::parse_assignment_expr)?;
                 self.expect_general_semi()?;
                 return Ok(ExportDefaultExpr {
+                    node_id: Default::default(),
                     span: self.span(start),
                     expr,
                 }
@@ -662,6 +686,7 @@ impl<I: Tokens> Parser<I> {
                 .map(Decl::from)
                 .map(|decl| {
                     ExportDecl {
+                        node_id: Default::default(),
                         span: self.span(start),
                         decl,
                     }
@@ -711,6 +736,7 @@ impl<I: Tokens> Parser<I> {
                 // improve error message for `export * from foo`
                 let (src, with) = self.parse_from_clause_and_semi()?;
                 return Ok(ExportAll {
+                    node_id: Default::default(),
                     span: self.span(start),
                     src,
                     type_only,
@@ -727,6 +753,7 @@ impl<I: Tokens> Parser<I> {
             if let Some(default) = default {
                 has_default = true;
                 specifiers.push(ExportSpecifier::Default(ExportDefaultSpecifier {
+                    node_id: Default::default(),
                     exported: default,
                 }))
             }
@@ -761,6 +788,7 @@ impl<I: Tokens> Parser<I> {
                     self.emit_err(name_span, SyntaxError::TS1003);
                 }
                 specifiers.push(ExportSpecifier::Namespace(ExportNamespaceSpecifier {
+                    node_id: Default::default(),
                     span: self.span(ns_export_specifier_start),
                     name,
                 }));
@@ -770,6 +798,7 @@ impl<I: Tokens> Parser<I> {
                 if self.input().is(Token::From) {
                     let (src, with) = self.parse_from_clause_and_semi()?;
                     return Ok(NamedExport {
+                        node_id: Default::default(),
                         span: self.span(start),
                         specifiers,
                         src: Some(src),
@@ -848,6 +877,7 @@ impl<I: Tokens> Parser<I> {
                 None => (None, None),
             };
             return Ok(NamedExport {
+                node_id: Default::default(),
                 span: self.span(start),
                 specifiers,
                 src,
@@ -858,6 +888,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(ExportDecl {
+            node_id: Default::default(),
             span: self.span(start),
             decl,
         }
@@ -873,6 +904,7 @@ impl<I: Tokens> Parser<I> {
             self.eat_general_semi();
 
             return Ok(ExprStmt {
+                node_id: Default::default(),
                 span: self.span(start),
                 expr,
             }
@@ -885,6 +917,7 @@ impl<I: Tokens> Parser<I> {
             self.eat_general_semi();
 
             return Ok(ExprStmt {
+                node_id: Default::default(),
                 span: self.span(start),
                 expr,
             }
@@ -917,6 +950,7 @@ impl<I: Tokens> Parser<I> {
             };
             self.eat_general_semi();
             return Ok(ImportDecl {
+                node_id: Default::default(),
                 span: self.span(start),
                 src,
                 specifiers: Vec::new(),
@@ -1023,6 +1057,7 @@ impl<I: Tokens> Parser<I> {
                     expect!(self, Token::Comma);
                 }
                 specifiers.push(ImportSpecifier::Default(ImportDefaultSpecifier {
+                    node_id: Default::default(),
                     span: local.span,
                     local,
                 }));
@@ -1042,6 +1077,7 @@ impl<I: Tokens> Parser<I> {
                     self.emit_flow_reserved_type_name_error(local.span, &local.sym);
                 }
                 specifiers.push(ImportSpecifier::Namespace(ImportStarAsSpecifier {
+                    node_id: Default::default(),
                     span: self.span(import_spec_start),
                     local,
                 }));
@@ -1084,6 +1120,7 @@ impl<I: Tokens> Parser<I> {
         self.expect_general_semi()?;
 
         Ok(ImportDecl {
+            node_id: Default::default(),
             span: self.span(start),
             specifiers,
             src,

--- a/crates/swc_ecma_parser/src/parser/object.rs
+++ b/crates/swc_ecma_parser/src/parser/object.rs
@@ -56,6 +56,7 @@ impl<I: Tokens> Parser<I> {
             let arg = Box::new(self.parse_binding_pat_or_ident(false)?);
 
             return Ok(ObjectPatProp::Rest(RestPat {
+                node_id: Default::default(),
                 span: self.span(start),
                 dot3_token,
                 arg,
@@ -67,7 +68,11 @@ impl<I: Tokens> Parser<I> {
         if self.input_mut().eat(Token::Colon) {
             let value = Box::new(self.parse_binding_element()?);
 
-            return Ok(ObjectPatProp::KeyValue(KeyValuePatProp { key, value }));
+            return Ok(ObjectPatProp::KeyValue(KeyValuePatProp {
+                node_id: Default::default(),
+                key,
+                value,
+            }));
         }
         let key = match key {
             PropName::Ident(ident) => ident,
@@ -113,6 +118,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(ObjectPatProp::Assign(AssignPatProp {
+            node_id: Default::default(),
             span: self.span(start),
             key: key.into(),
             value,
@@ -150,6 +156,7 @@ impl<I: Tokens> Parser<I> {
             && self.input_mut().eat(Token::QuestionMark);
 
         Ok(ObjectPat {
+            node_id: Default::default(),
             span,
             props,
             optional,
@@ -173,7 +180,12 @@ impl<I: Tokens> Parser<I> {
                 .trailing_commas
                 .insert(span.lo, trailing_comma);
         }
-        Ok(ObjectLit { span, props }.into())
+        Ok(ObjectLit {
+            node_id: Default::default(),
+            span,
+            props,
+        }
+        .into())
     }
 
     fn parse_expr_object_prop(&mut self) -> PResult<PropOrSpread> {
@@ -188,7 +200,11 @@ impl<I: Tokens> Parser<I> {
 
             let expr = self.allow_in_expr(Self::parse_assignment_expr)?;
 
-            return Ok(PropOrSpread::Spread(SpreadElement { dot3_token, expr }));
+            return Ok(PropOrSpread::Spread(SpreadElement {
+                node_id: Default::default(),
+                dot3_token,
+                expr,
+            }));
         }
 
         if self.input_mut().eat(Token::Asterisk) {
@@ -208,6 +224,7 @@ impl<I: Tokens> Parser<I> {
                 })
                 .map(|function| {
                     PropOrSpread::Prop(Box::new(Prop::Method(MethodProp {
+                        node_id: Default::default(),
                         key: name,
                         function,
                     })))
@@ -241,8 +258,10 @@ impl<I: Tokens> Parser<I> {
 
             self.emit_err(self.input().cur_span(), SyntaxError::TS1005);
             return Ok(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                node_id: Default::default(),
                 key,
                 value: Invalid {
+                    node_id: Default::default(),
                     span: self.span(start),
                 }
                 .into(),
@@ -256,6 +275,7 @@ impl<I: Tokens> Parser<I> {
         if self.input_mut().eat(Token::Colon) {
             let value = self.allow_in_expr(Self::parse_assignment_expr)?;
             return Ok(PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                node_id: Default::default(),
                 key,
                 value,
             }))));
@@ -289,7 +309,13 @@ impl<I: Tokens> Parser<I> {
                         )
                     })
                 })
-                .map(|function| Box::new(Prop::Method(MethodProp { key, function })))
+                .map(|function| {
+                    Box::new(Prop::Method(MethodProp {
+                        node_id: Default::default(),
+                        key,
+                        function,
+                    }))
+                })
                 .map(PropOrSpread::Prop);
         }
 
@@ -349,6 +375,7 @@ impl<I: Tokens> Parser<I> {
                 let value = self.allow_in_expr(Self::parse_assignment_expr)?;
                 let span = self.span(start);
                 return Ok(PropOrSpread::Prop(Box::new(Prop::Assign(AssignProp {
+                    node_id: Default::default(),
                     span,
                     key: ident.into(),
                     value,
@@ -409,6 +436,7 @@ impl<I: Tokens> Parser<I> {
                                         }
 
                                         PropOrSpread::Prop(Box::new(Prop::Getter(GetterProp {
+                                            node_id: Default::default(),
                                             span: p.span(start),
                                             key,
                                             type_ann: return_type,
@@ -466,12 +494,17 @@ impl<I: Tokens> Parser<I> {
                                                 .unwrap_or_else(|| {
                                                     p.emit_err(key_span, SyntaxError::SetterParam);
 
-                                                    Invalid { span: DUMMY_SP }.into()
+                                                    Invalid {
+                                                        node_id: Default::default(),
+                                                        span: DUMMY_SP,
+                                                    }
+                                                    .into()
                                                 }),
                                         );
 
                                         // debug_assert_eq!(params.len(), 1);
                                         PropOrSpread::Prop(Box::new(Prop::Setter(SetterProp {
+                                            node_id: Default::default(),
                                             span: p.span(start),
                                             key,
                                             body,
@@ -492,6 +525,7 @@ impl<I: Tokens> Parser<I> {
                                 )
                                 .map(|function| {
                                     PropOrSpread::Prop(Box::new(Prop::Method(MethodProp {
+                                        node_id: Default::default(),
                                         key,
                                         function,
                                     })))

--- a/crates/swc_ecma_parser/src/parser/pat.rs
+++ b/crates/swc_ecma_parser/src/parser/pat.rs
@@ -78,7 +78,11 @@ impl<I: Tokens> Parser<I> {
     }
 
     fn assign_pat_type_ann(&mut self, pat: &mut Pat, span: Span, type_ann: Box<TsType>) {
-        let type_ann = Some(Box::new(TsTypeAnn { span, type_ann }));
+        let type_ann = Some(Box::new(TsTypeAnn {
+            node_id: Default::default(),
+            span,
+            type_ann,
+        }));
 
         match pat {
             Pat::Ident(BindingIdent {
@@ -134,16 +138,19 @@ impl<I: Tokens> Parser<I> {
                     expr,
                     type_ann,
                     span,
+                    ..
                 })
                 | Expr::TsTypeAssertion(TsTypeAssertion {
                     expr,
                     type_ann,
                     span,
+                    ..
                 })
                 | Expr::TsSatisfies(TsSatisfiesExpr {
                     expr,
                     type_ann,
                     span,
+                    ..
                 }) => {
                     let mut pat = self.reparse_expr_as_pat_inner(pat_ty, expr)?;
                     self.assign_pat_type_ann(&mut pat, span, type_ann);
@@ -222,7 +229,11 @@ impl<I: Tokens> Parser<I> {
         match *expr {
             Expr::Paren(..) => {
                 self.emit_err(span, SyntaxError::InvalidPat);
-                Ok(Invalid { span }.into())
+                Ok(Invalid {
+                    node_id: Default::default(),
+                    span,
+                }
+                .into())
             }
             Expr::Assign(
                 assign_expr @ AssignExpr {
@@ -234,6 +245,7 @@ impl<I: Tokens> Parser<I> {
                     span, left, right, ..
                 } = assign_expr;
                 Ok(AssignPat {
+                    node_id: Default::default(),
                     span,
                     left: match left {
                         AssignTarget::Simple(left) => {
@@ -250,10 +262,12 @@ impl<I: Tokens> Parser<I> {
             Expr::Object(ObjectLit {
                 span: object_span,
                 props,
+                ..
             }) => {
                 // {}
                 let len = props.len();
                 Ok(ObjectPat {
+                    node_id: Default::default(),
                     span: object_span,
                     props: props
                         .into_iter()
@@ -264,6 +278,7 @@ impl<I: Tokens> Parser<I> {
                                 PropOrSpread::Prop(prop) => match *prop {
                                     Prop::Shorthand(id) => {
                                         Ok(ObjectPatProp::Assign(AssignPatProp {
+                                            node_id: Default::default(),
                                             span: id.span(),
                                             key: id.into(),
                                             value: None,
@@ -271,6 +286,7 @@ impl<I: Tokens> Parser<I> {
                                     }
                                     Prop::KeyValue(kv_prop) => {
                                         Ok(ObjectPatProp::KeyValue(KeyValuePatProp {
+                                            node_id: Default::default(),
                                             key: kv_prop.key,
                                             value: Box::new(self.reparse_expr_as_pat(
                                                 pat_ty.element(),
@@ -280,6 +296,7 @@ impl<I: Tokens> Parser<I> {
                                     }
                                     Prop::Assign(assign_prop) => {
                                         Ok(ObjectPatProp::Assign(AssignPatProp {
+                                            node_id: Default::default(),
                                             span,
                                             key: assign_prop.key.into(),
                                             value: Some(assign_prop.value),
@@ -288,7 +305,9 @@ impl<I: Tokens> Parser<I> {
                                     _ => syntax_error!(self, prop.span(), SyntaxError::InvalidPat),
                                 },
 
-                                PropOrSpread::Spread(SpreadElement { dot3_token, expr }) => {
+                                PropOrSpread::Spread(SpreadElement {
+                                    dot3_token, expr, ..
+                                }) => {
                                     if idx != len - 1 {
                                         self.emit_err(span, SyntaxError::NonLastRestParam)
                                     } else if let Some(trailing_comma) =
@@ -306,7 +325,10 @@ impl<I: Tokens> Parser<I> {
                                             i.into()
                                         } else {
                                             self.emit_err(span, SyntaxError::DotsWithoutIdentifier);
-                                            Pat::Invalid(Invalid { span })
+                                            Pat::Invalid(Invalid {
+                                                node_id: Default::default(),
+                                                span,
+                                            })
                                         }
                                     } else {
                                         self.reparse_expr_as_pat(element_pat_ty, expr)?
@@ -315,6 +337,7 @@ impl<I: Tokens> Parser<I> {
                                         self.emit_err(span, SyntaxError::TS1048)
                                     };
                                     Ok(ObjectPatProp::Rest(RestPat {
+                                        node_id: Default::default(),
                                         span,
                                         dot3_token,
                                         arg: Box::new(pat),
@@ -337,6 +360,7 @@ impl<I: Tokens> Parser<I> {
             }) => {
                 if exprs.is_empty() {
                     return Ok(ArrayPat {
+                        node_id: Default::default(),
                         span,
                         elems: Vec::new(),
                         optional: false,
@@ -377,6 +401,7 @@ impl<I: Tokens> Parser<I> {
                         Some(ExprOrSpread {
                             spread: Some(dot3_token),
                             expr,
+                            ..
                         }) => {
                             // TODO: is BindingPat correct?
                             if let Expr::Assign(_) = *expr {
@@ -390,6 +415,7 @@ impl<I: Tokens> Parser<I> {
                             self.reparse_expr_as_pat(pat_ty.element(), expr)
                                 .map(|pat| {
                                     RestPat {
+                                        node_id: Default::default(),
                                         span: expr_span,
                                         dot3_token,
                                         arg: Box::new(pat),
@@ -409,6 +435,7 @@ impl<I: Tokens> Parser<I> {
                     params.push(last);
                 }
                 Ok(ArrayPat {
+                    node_id: Default::default(),
                     span,
                     elems: params,
                     optional: false,
@@ -421,18 +448,30 @@ impl<I: Tokens> Parser<I> {
             // Note that assignment expression with '=' is valid, and handled above.
             Expr::Lit(..) | Expr::Assign(..) => {
                 self.emit_err(span, SyntaxError::InvalidPat);
-                Ok(Invalid { span }.into())
+                Ok(Invalid {
+                    node_id: Default::default(),
+                    span,
+                }
+                .into())
             }
 
             Expr::Yield(..) if self.ctx().contains(Context::InGenerator) => {
                 self.emit_err(span, SyntaxError::InvalidPat);
-                Ok(Invalid { span }.into())
+                Ok(Invalid {
+                    node_id: Default::default(),
+                    span,
+                }
+                .into())
             }
 
             _ => {
                 self.emit_err(span, SyntaxError::InvalidPat);
 
-                Ok(Invalid { span }.into())
+                Ok(Invalid {
+                    node_id: Default::default(),
+                    span,
+                }
+                .into())
             }
         }
     }
@@ -458,6 +497,7 @@ impl<I: Tokens> Parser<I> {
             }
 
             return Ok(AssignPat {
+                node_id: Default::default(),
                 span: self.span(start),
                 left: Box::new(left),
                 right,
@@ -515,6 +555,7 @@ impl<I: Tokens> Parser<I> {
                 let pat = self.parse_binding_pat_or_ident(false)?;
                 rest_span = self.span(start);
                 let pat = RestPat {
+                    node_id: Default::default(),
                     span: rest_span,
                     dot3_token,
                     arg: Box::new(pat),
@@ -539,6 +580,7 @@ impl<I: Tokens> Parser<I> {
             && self.input_mut().eat(Token::QuestionMark);
 
         Ok(ArrayPat {
+            node_id: Default::default(),
             span: self.span(start),
             elems,
             optional,
@@ -649,6 +691,7 @@ impl<I: Tokens> Parser<I> {
             }
 
             AssignPat {
+                node_id: Default::default(),
                 span: self.span(start),
                 left: Box::new(pat),
                 right,
@@ -684,6 +727,7 @@ impl<I: Tokens> Parser<I> {
         if accessibility.is_none() && !is_override && !readonly {
             let pat = self.parse_formal_param_pat()?;
             Ok(ParamOrTsParamProp::Param(Param {
+                node_id: Default::default(),
                 span: self.span(param_start),
                 decorators,
                 pat,
@@ -695,6 +739,7 @@ impl<I: Tokens> Parser<I> {
                 node => syntax_error!(self, node.span(), SyntaxError::TsInvalidParamPropPat),
             };
             Ok(ParamOrTsParamProp::TsParamProp(TsParamProp {
+                node_id: Default::default(),
                 span: self.span(param_start),
                 accessibility,
                 is_override,
@@ -734,6 +779,7 @@ impl<I: Tokens> Parser<I> {
 
                 rest_span = self.span(pat_start);
                 let pat = RestPat {
+                    node_id: Default::default(),
                     span: rest_span,
                     dot3_token,
                     arg: Box::new(pat),
@@ -741,6 +787,7 @@ impl<I: Tokens> Parser<I> {
                 }
                 .into();
                 params.push(ParamOrTsParamProp::Param(Param {
+                    node_id: Default::default(),
                     span: self.span(param_start),
                     decorators,
                     pat,
@@ -782,6 +829,7 @@ impl<I: Tokens> Parser<I> {
                     let right = self.parse_assignment_expr()?;
                     self.emit_err(pat.span(), SyntaxError::TS1048);
                     pat = AssignPat {
+                        node_id: Default::default(),
                         span: self.span(pat_start),
                         left: Box::new(pat),
                         right,
@@ -800,6 +848,7 @@ impl<I: Tokens> Parser<I> {
 
                 rest_span = self.span(pat_start);
                 let pat = RestPat {
+                    node_id: Default::default(),
                     span: rest_span,
                     dot3_token,
                     arg: Box::new(pat),
@@ -819,6 +868,7 @@ impl<I: Tokens> Parser<I> {
             let is_rest = matches!(pat, Pat::Rest(_));
 
             params.push(Param {
+                node_id: Default::default(),
                 span: self.span(param_start),
                 decorators,
                 pat,
@@ -897,6 +947,7 @@ impl<I: Tokens> Parser<I> {
             AssignTargetOrSpread::ExprOrSpread(ExprOrSpread {
                 spread: Some(dot3_token),
                 expr,
+                ..
             }) => {
                 if let Expr::Assign(_) = *expr {
                     self.emit_err(outer_expr_span, SyntaxError::TS1048)
@@ -907,6 +958,7 @@ impl<I: Tokens> Parser<I> {
                 let expr_span = expr.span();
                 self.reparse_expr_as_pat(pat_ty, expr).map(|pat| {
                     RestPat {
+                        node_id: Default::default(),
                         span: expr_span,
                         dot3_token,
                         arg: Box::new(pat),
@@ -967,6 +1019,7 @@ mod tests {
     fn rest() -> Option<Pat> {
         Some(
             RestPat {
+                node_id: Default::default(),
                 span,
                 dot3_token: span,
                 type_ann: None,
@@ -981,17 +1034,20 @@ mod tests {
         assert_eq_ignore_span!(
             array_pat("[a, [b], [c]]"),
             Pat::Array(ArrayPat {
+                node_id: Default::default(),
                 span,
                 optional: false,
                 elems: vec![
                     Some(Pat::Ident(ident("a").into())),
                     Some(Pat::Array(ArrayPat {
+                        node_id: Default::default(),
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("b").into()))],
                         type_ann: None
                     })),
                     Some(Pat::Array(ArrayPat {
+                        node_id: Default::default(),
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("c").into()))],
@@ -1008,18 +1064,21 @@ mod tests {
         assert_eq_ignore_span!(
             array_pat("[, a, [b], [c]]"),
             Pat::Array(ArrayPat {
+                node_id: Default::default(),
                 span,
                 optional: false,
                 elems: vec![
                     None,
                     Some(Pat::Ident(ident("a").into())),
                     Some(Pat::Array(ArrayPat {
+                        node_id: Default::default(),
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("b").into()))],
                         type_ann: None
                     })),
                     Some(Pat::Array(ArrayPat {
+                        node_id: Default::default(),
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("c").into()))],
@@ -1036,18 +1095,21 @@ mod tests {
         assert_eq_ignore_span!(
             array_pat("[a, , [b], [c]]"),
             Pat::Array(ArrayPat {
+                node_id: Default::default(),
                 span,
                 optional: false,
                 elems: vec![
                     Some(Pat::Ident(ident("a").into())),
                     None,
                     Some(Pat::Array(ArrayPat {
+                        node_id: Default::default(),
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("b").into()))],
                         type_ann: None
                     })),
                     Some(Pat::Array(ArrayPat {
+                        node_id: Default::default(),
                         span,
                         optional: false,
                         elems: vec![Some(Pat::Ident(ident("c").into()))],
@@ -1064,6 +1126,7 @@ mod tests {
         assert_eq_ignore_span!(
             array_pat("[a, ,]"),
             Pat::Array(ArrayPat {
+                node_id: Default::default(),
                 span,
                 optional: false,
                 elems: vec![Some(Pat::Ident(ident("a").into())), None,],
@@ -1077,6 +1140,7 @@ mod tests {
         assert_eq_ignore_span!(
             array_pat("[...tail]"),
             Pat::Array(ArrayPat {
+                node_id: Default::default(),
                 span,
                 optional: false,
                 elems: vec![rest()],
@@ -1090,14 +1154,17 @@ mod tests {
         assert_eq_ignore_span!(
             array_pat("[,a=1,]"),
             Pat::Array(ArrayPat {
+                node_id: Default::default(),
                 span,
                 optional: false,
                 elems: vec![
                     None,
                     Some(Pat::Assign(AssignPat {
+                        node_id: Default::default(),
                         span,
                         left: Box::new(Pat::Ident(ident("a").into())),
                         right: Box::new(Expr::Lit(Lit::Num(Number {
+                            node_id: Default::default(),
                             span,
                             value: 1.0,
                             raw: Some(atom!("1"))
@@ -1114,6 +1181,7 @@ mod tests {
         assert_eq_ignore_span!(
             array_pat("[,,,...tail]"),
             Pat::Array(ArrayPat {
+                node_id: Default::default(),
                 span,
                 optional: false,
                 elems: vec![None, None, None, rest()],
@@ -1127,6 +1195,7 @@ mod tests {
         assert_eq_ignore_span!(
             array_pat("[,,,...[...tail]]"),
             Pat::Array(ArrayPat {
+                node_id: Default::default(),
                 span,
                 optional: false,
                 elems: vec![
@@ -1134,10 +1203,12 @@ mod tests {
                     None,
                     None,
                     Some(Pat::Rest(RestPat {
+                        node_id: Default::default(),
                         span,
                         dot3_token: span,
                         type_ann: None,
                         arg: Box::new(Pat::Array(ArrayPat {
+                            node_id: Default::default(),
                             span,
                             optional: false,
                             elems: vec![rest()],
@@ -1155,10 +1226,12 @@ mod tests {
         assert_eq_ignore_span!(
             object_pat("{...obj}"),
             Pat::Object(ObjectPat {
+                node_id: Default::default(),
                 span,
                 type_ann: None,
                 optional: false,
                 props: vec![ObjectPatProp::Rest(RestPat {
+                    node_id: Default::default(),
                     span,
                     dot3_token: span,
                     type_ann: None,
@@ -1173,13 +1246,16 @@ mod tests {
         assert_eq_ignore_span!(
             object_pat("{prop = 10 }"),
             Pat::Object(ObjectPat {
+                node_id: Default::default(),
                 span,
                 type_ann: None,
                 optional: false,
                 props: vec![ObjectPatProp::Assign(AssignPatProp {
+                    node_id: Default::default(),
                     span,
                     key: ident("prop").into(),
                     value: Some(Box::new(Expr::Lit(Lit::Num(Number {
+                        node_id: Default::default(),
                         span,
                         value: 10.0,
                         raw: Some(atom!("10"))
@@ -1193,8 +1269,10 @@ mod tests {
     fn object_binding_pattern_with_prop_and_label() {
         fn prop(key: PropName, assign_name: &str, expr: Expr) -> PropOrSpread {
             PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                node_id: Default::default(),
                 key,
                 value: AssignExpr {
+                    node_id: Default::default(),
                     span,
                     op: AssignOp::Assign,
                     left: ident(assign_name).into(),
@@ -1209,19 +1287,23 @@ mod tests {
                 "{obj = {$: num = 10, '': sym = '', \" \": quote = \" \", _: under = [...tail],}}"
             ),
             Pat::Object(ObjectPat {
+                node_id: Default::default(),
                 span,
                 type_ann: None,
                 optional: false,
                 props: vec![ObjectPatProp::Assign(AssignPatProp {
+                    node_id: Default::default(),
                     span,
                     key: ident("obj").into(),
                     value: Some(Box::new(Expr::Object(ObjectLit {
+                        node_id: Default::default(),
                         span,
                         props: vec![
                             prop(
                                 PropName::Ident(ident_name("$")),
                                 "num",
                                 Expr::Lit(Lit::Num(Number {
+                                    node_id: Default::default(),
                                     span,
                                     value: 10.0,
                                     raw: Some(atom!("10"))
@@ -1229,12 +1311,14 @@ mod tests {
                             ),
                             prop(
                                 PropName::Str(Str {
+                                    node_id: Default::default(),
                                     span,
                                     value: atom!("").into(),
                                     raw: Some(atom!("''")),
                                 }),
                                 "sym",
                                 Expr::Lit(Lit::Str(Str {
+                                    node_id: Default::default(),
                                     span,
                                     value: atom!("").into(),
                                     raw: Some(atom!("''")),
@@ -1242,12 +1326,14 @@ mod tests {
                             ),
                             prop(
                                 PropName::Str(Str {
+                                    node_id: Default::default(),
                                     span,
                                     value: atom!(" ").into(),
                                     raw: Some(atom!("\" \"")),
                                 }),
                                 "quote",
                                 Expr::Lit(Lit::Str(Str {
+                                    node_id: Default::default(),
                                     span,
                                     value: atom!(" ").into(),
                                     raw: Some(atom!("\" \"")),
@@ -1257,8 +1343,10 @@ mod tests {
                                 PropName::Ident(ident_name("_")),
                                 "under",
                                 Expr::Array(ArrayLit {
+                                    node_id: Default::default(),
                                     span,
                                     elems: vec![Some(ExprOrSpread {
+                                        node_id: Default::default(),
                                         spread: Some(span),
                                         expr: Box::new(Expr::Ident(ident("tail")))
                                     })]

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -108,6 +108,7 @@ impl<I: Tokens> Parser<I> {
         };
         self.expect_general_semi()?;
         let stmt = Ok(ReturnStmt {
+            node_id: Default::default(),
             span: self.span(start),
             arg,
         }
@@ -202,6 +203,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(VarDeclarator {
+            node_id: Default::default(),
             span: self.span(start),
             name,
             init,
@@ -378,6 +380,7 @@ impl<I: Tokens> Parser<I> {
         self.expect_general_semi()?;
 
         Ok(Some(Box::new(UsingDecl {
+            node_id: Default::default(),
             span: self.span(start),
             is_await,
             decls,
@@ -483,6 +486,7 @@ impl<I: Tokens> Parser<I> {
         if is_using_decl {
             let name = self.parse_binding_ident(false)?;
             let decl = VarDeclarator {
+                node_id: Default::default(),
                 name: name.into(),
                 span: self.span(start),
                 init: None,
@@ -490,6 +494,7 @@ impl<I: Tokens> Parser<I> {
             };
 
             let pat = Box::new(UsingDecl {
+                node_id: Default::default(),
                 span: self.span(start),
                 is_await: is_await_using_decl,
                 decls: vec![decl],
@@ -568,6 +573,7 @@ impl<I: Tokens> Parser<I> {
                 }
 
                 ForStmt {
+                    node_id: Default::default(),
                     span,
                     init,
                     test,
@@ -582,6 +588,7 @@ impl<I: Tokens> Parser<I> {
                 }
 
                 ForInStmt {
+                    node_id: Default::default(),
                     span,
                     left,
                     right,
@@ -598,6 +605,7 @@ impl<I: Tokens> Parser<I> {
                 }
 
                 ForOfStmt {
+                    node_id: Default::default(),
                     span,
                     is_await: await_token.is_some(),
                     left,
@@ -720,6 +728,7 @@ impl<I: Tokens> Parser<I> {
 
         let span = self.span(start);
         Ok(IfStmt {
+            node_id: Default::default(),
             span,
             test,
             cons,
@@ -741,7 +750,12 @@ impl<I: Tokens> Parser<I> {
         self.expect_general_semi()?;
 
         let span = self.span(start);
-        Ok(ThrowStmt { span, arg }.into())
+        Ok(ThrowStmt {
+            node_id: Default::default(),
+            span,
+            arg,
+        }
+        .into())
     }
 
     fn parse_with_stmt(&mut self) -> PResult<Stmt> {
@@ -770,7 +784,13 @@ impl<I: Tokens> Parser<I> {
             .map(Box::new)?;
 
         let span = self.span(start);
-        Ok(WithStmt { span, obj, body }.into())
+        Ok(WithStmt {
+            node_id: Default::default(),
+            span,
+            obj,
+            body,
+        }
+        .into())
     }
 
     fn parse_while_stmt(&mut self) -> PResult<Stmt> {
@@ -790,7 +810,13 @@ impl<I: Tokens> Parser<I> {
             .map(Box::new)?;
 
         let span = self.span(start);
-        Ok(WhileStmt { span, test, body }.into())
+        Ok(WhileStmt {
+            node_id: Default::default(),
+            span,
+            test,
+            body,
+        }
+        .into())
     }
 
     /// It's optional since es2019
@@ -810,6 +836,7 @@ impl<I: Tokens> Parser<I> {
                     | Pat::Rest(RestPat { type_ann, .. })
                     | Pat::Object(ObjectPat { type_ann, .. }) => {
                         *type_ann = Some(Box::new(TsTypeAnn {
+                            node_id: Default::default(),
                             span: self.span(type_ann_start),
                             type_ann: ty,
                         }));
@@ -852,7 +879,13 @@ impl<I: Tokens> Parser<I> {
 
         let span = self.span(start);
 
-        Ok(DoWhileStmt { span, test, body }.into())
+        Ok(DoWhileStmt {
+            node_id: Default::default(),
+            span,
+            test,
+            body,
+        }
+        .into())
     }
 
     fn parse_labelled_stmt(&mut self, l: Ident) -> PResult<Stmt> {
@@ -899,6 +932,7 @@ impl<I: Tokens> Parser<I> {
                 }
 
                 Ok(LabeledStmt {
+                    node_id: Default::default(),
                     span: p.span(start),
                     label: l,
                     body,
@@ -919,6 +953,7 @@ impl<I: Tokens> Parser<I> {
 
         let span = self.span(start);
         Ok(BlockStmt {
+            node_id: Default::default(),
             span,
             stmts,
             ctxt: Default::default(),
@@ -939,6 +974,7 @@ impl<I: Tokens> Parser<I> {
             let param = self.parse_catch_param()?;
             self.parse_block(false)
                 .map(|body| CatchClause {
+                    node_id: Default::default(),
                     span: self.span(start),
                     param,
                     body,
@@ -968,6 +1004,7 @@ impl<I: Tokens> Parser<I> {
 
         let span = self.span(start);
         Ok(TryStmt {
+            node_id: Default::default(),
             span,
             block,
             handler,
@@ -1021,6 +1058,7 @@ impl<I: Tokens> Parser<I> {
                 }
 
                 cases.push(SwitchCase {
+                    node_id: Default::default(),
                     span: Span::new_with_checked(case_start, p.input().prev_span().hi),
                     test,
                     cons,
@@ -1034,6 +1072,7 @@ impl<I: Tokens> Parser<I> {
         expect!(self, Token::RBrace);
 
         Ok(SwitchStmt {
+            node_id: Default::default(),
             span: self.span(switch_start),
             discriminant,
             cases,
@@ -1061,7 +1100,11 @@ impl<I: Tokens> Parser<I> {
     }
 
     fn flow_match_true_expr(&self, span: Span) -> Box<Expr> {
-        Box::new(Expr::Lit(Lit::Bool(Bool { span, value: true })))
+        Box::new(Expr::Lit(Lit::Bool(Bool {
+            node_id: Default::default(),
+            span,
+            value: true,
+        })))
     }
 
     fn flow_match_bin_expr(
@@ -1072,6 +1115,7 @@ impl<I: Tokens> Parser<I> {
         right: Box<Expr>,
     ) -> Box<Expr> {
         Box::new(Expr::Bin(BinExpr {
+            node_id: Default::default(),
             span,
             op,
             left,
@@ -1095,18 +1139,25 @@ impl<I: Tokens> Parser<I> {
         let prop = match key {
             PropName::Ident(id) => MemberProp::Ident(id.clone()),
             _ => MemberProp::Computed(ComputedPropName {
+                node_id: Default::default(),
                 span,
                 expr: self.flow_match_prop_key_expr(key),
             }),
         };
 
-        Box::new(Expr::Member(MemberExpr { span, obj, prop }))
+        Box::new(Expr::Member(MemberExpr {
+            node_id: Default::default(),
+            span,
+            obj,
+            prop,
+        }))
     }
 
     #[allow(unreachable_patterns)]
     fn flow_match_prop_key_expr(&self, key: &PropName) -> Box<Expr> {
         match key {
             PropName::Ident(id) => Box::new(Expr::Lit(Lit::Str(Str {
+                node_id: Default::default(),
                 span: id.span,
                 value: id.sym.clone().into(),
                 raw: None,
@@ -1183,21 +1234,27 @@ impl<I: Tokens> Parser<I> {
                     self.flow_match_eq_expr(
                         span,
                         Box::new(Expr::Unary(UnaryExpr {
+                            node_id: Default::default(),
                             span,
                             op: op!("typeof"),
                             arg: value.clone(),
                         })),
                         Box::new(Expr::Lit(Lit::Str(Str {
+                            node_id: Default::default(),
                             span,
                             value: atom!("object").into(),
                             raw: None,
                         }))),
                     ),
                     Box::new(Expr::Bin(BinExpr {
+                        node_id: Default::default(),
                         span,
                         op: BinaryOp::NotEqEq,
                         left: value.clone(),
-                        right: Box::new(Expr::Lit(Lit::Null(Null { span }))),
+                        right: Box::new(Expr::Lit(Lit::Null(Null {
+                            node_id: Default::default(),
+                            span,
+                        }))),
                     })),
                 );
                 let mut bindings = Vec::new();
@@ -1236,6 +1293,7 @@ impl<I: Tokens> Parser<I> {
             }
             FlowMatchPattern::Array { elems, rest } => {
                 let array_ctor = Box::new(Expr::Member(MemberExpr {
+                    node_id: Default::default(),
                     span,
                     obj: Box::new(Expr::Ident(Ident::new_no_ctxt(atom!("Array"), span))),
                     prop: MemberProp::Ident(IdentName::new(atom!("isArray"), span)),
@@ -1244,6 +1302,7 @@ impl<I: Tokens> Parser<I> {
                     span,
                     callee: Callee::Expr(array_ctor),
                     args: vec![ExprOrSpread {
+                        node_id: Default::default(),
                         spread: None,
                         expr: value.clone(),
                     }],
@@ -1263,6 +1322,7 @@ impl<I: Tokens> Parser<I> {
                         BinaryOp::GtEq,
                         len_expr,
                         Box::new(Expr::Lit(Lit::Num(Number {
+                            node_id: Default::default(),
                             span,
                             value: elems.len() as f64,
                             raw: None,
@@ -1276,6 +1336,7 @@ impl<I: Tokens> Parser<I> {
                         span,
                         value.clone(),
                         &PropName::Num(Number {
+                            node_id: Default::default(),
                             span,
                             value: idx as f64,
                             raw: None,
@@ -1288,6 +1349,7 @@ impl<I: Tokens> Parser<I> {
 
                 if let Some(Some(binding)) = rest {
                     let slice_callee = Box::new(Expr::Member(MemberExpr {
+                        node_id: Default::default(),
                         span,
                         obj: value.clone(),
                         prop: MemberProp::Ident(IdentName::new(atom!("slice"), span)),
@@ -1299,8 +1361,10 @@ impl<I: Tokens> Parser<I> {
                             span,
                             callee: Callee::Expr(slice_callee),
                             args: vec![ExprOrSpread {
+                                node_id: Default::default(),
                                 spread: None,
                                 expr: Box::new(Expr::Lit(Lit::Num(Number {
+                                    node_id: Default::default(),
                                     span,
                                     value: elems.len() as f64,
                                     raw: None,
@@ -1326,6 +1390,7 @@ impl<I: Tokens> Parser<I> {
             kind: binding.kind,
             declare: false,
             decls: vec![VarDeclarator {
+                node_id: Default::default(),
                 span: binding.span,
                 name: binding.pat,
                 init: Some(binding.init),
@@ -1372,6 +1437,7 @@ impl<I: Tokens> Parser<I> {
             if self.input_mut().eat(Token::Dot) {
                 let prop = self.parse_ident_name()?;
                 expr = Box::new(Expr::Member(MemberExpr {
+                    node_id: Default::default(),
                     span: self.span(start),
                     obj: expr,
                     prop: MemberProp::Ident(prop),
@@ -1383,9 +1449,11 @@ impl<I: Tokens> Parser<I> {
                 let prop_expr = self.allow_in_expr(Self::parse_assignment_expr)?;
                 expect!(self, Token::RBracket);
                 expr = Box::new(Expr::Member(MemberExpr {
+                    node_id: Default::default(),
                     span: self.span(start),
                     obj: expr,
                     prop: MemberProp::Computed(ComputedPropName {
+                        node_id: Default::default(),
                         span: self.span(start),
                         expr: prop_expr,
                     }),
@@ -1549,6 +1617,7 @@ impl<I: Tokens> Parser<I> {
             }
             let lit = self.parse_lit()?;
             return Ok(FlowMatchPattern::Value(Box::new(Expr::Unary(UnaryExpr {
+                node_id: Default::default(),
                 span: self.span(start),
                 op,
                 arg: Box::new(Expr::Lit(lit)),
@@ -1603,6 +1672,7 @@ impl<I: Tokens> Parser<I> {
         if args.is_empty() {
             self.emit_err(self.span(start), SyntaxError::TS1003);
             return Ok(Box::new(Expr::Invalid(Invalid {
+                node_id: Default::default(),
                 span: self.span(start),
             })));
         }
@@ -1613,6 +1683,7 @@ impl<I: Tokens> Parser<I> {
                 self.emit_err(arg.expr.span(), SyntaxError::TS1003);
             }
             elems.push(Some(ExprOrSpread {
+                node_id: Default::default(),
                 spread: None,
                 expr: arg.expr,
             }));
@@ -1622,6 +1693,7 @@ impl<I: Tokens> Parser<I> {
             Ok(elems.pop().unwrap().unwrap().expr)
         } else {
             Ok(Box::new(Expr::Array(ArrayLit {
+                node_id: Default::default(),
                 span: self.span(start),
                 elems,
             })))
@@ -1638,8 +1710,10 @@ impl<I: Tokens> Parser<I> {
             kind: VarDeclKind::Const,
             declare: false,
             decls: vec![VarDeclarator {
+                node_id: Default::default(),
                 span,
                 name: Pat::Ident(BindingIdent {
+                    node_id: Default::default(),
                     id: ident.clone(),
                     type_ann: None,
                 }),
@@ -1653,6 +1727,7 @@ impl<I: Tokens> Parser<I> {
     fn flow_match_non_exhaustive_throw(&self, span: Span) -> Stmt {
         let error_ctor = Box::new(Expr::Ident(Ident::new_no_ctxt(atom!("Error"), span)));
         let arg = Box::new(Expr::Lit(Lit::Str(Str {
+            node_id: Default::default(),
             span,
             value: atom!("Non-exhaustive match").into(),
             raw: None,
@@ -1661,23 +1736,31 @@ impl<I: Tokens> Parser<I> {
             span,
             callee: error_ctor,
             args: Some(vec![ExprOrSpread {
+                node_id: Default::default(),
                 spread: None,
                 expr: arg,
             }]),
             ..Default::default()
         }));
 
-        Stmt::Throw(ThrowStmt { span, arg: err })
+        Stmt::Throw(ThrowStmt {
+            node_id: Default::default(),
+            span,
+            arg: err,
+        })
     }
 
     fn flow_match_make_iife_expr(&self, span: Span, stmts: Vec<Stmt>) -> Box<Expr> {
         let fn_expr = Box::new(Expr::Fn(FnExpr {
+            node_id: Default::default(),
             ident: None,
             function: Box::new(Function {
+                node_id: Default::default(),
                 span,
                 params: Vec::new(),
                 decorators: Vec::new(),
                 body: Some(BlockStmt {
+                    node_id: Default::default(),
                     span,
                     stmts,
                     ctxt: Default::default(),
@@ -1730,14 +1813,17 @@ impl<I: Tokens> Parser<I> {
                 .map(|binding| self.flow_match_binding_to_stmt(binding))
                 .collect::<Vec<_>>();
             cons_stmts.push(Stmt::Return(ReturnStmt {
+                node_id: Default::default(),
                 span,
                 arg: Some(body),
             }));
 
             stmts.push(Stmt::If(IfStmt {
+                node_id: Default::default(),
                 span,
                 test,
                 cons: Box::new(Stmt::Block(BlockStmt {
+                    node_id: Default::default(),
                     span,
                     stmts: cons_stmts,
                     ctxt: Default::default(),
@@ -1777,8 +1863,13 @@ impl<I: Tokens> Parser<I> {
                 self.emit_err(self.input().cur_span(), SyntaxError::TS1003);
                 let expr = self.allow_in_expr(Self::parse_assignment_expr)?;
                 BlockStmt {
+                    node_id: Default::default(),
                     span,
-                    stmts: vec![Stmt::Expr(ExprStmt { span, expr })],
+                    stmts: vec![Stmt::Expr(ExprStmt {
+                        node_id: Default::default(),
+                        span,
+                        expr,
+                    })],
                     ctxt: Default::default(),
                 }
             };
@@ -1797,9 +1888,11 @@ impl<I: Tokens> Parser<I> {
             stmts.extend(body.stmts);
 
             cases.push(IfStmt {
+                node_id: Default::default(),
                 span,
                 test,
                 cons: Box::new(Stmt::Block(BlockStmt {
+                    node_id: Default::default(),
                     span,
                     stmts,
                     ctxt: Default::default(),
@@ -1824,6 +1917,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         Ok(Stmt::Block(BlockStmt {
+            node_id: Default::default(),
             span,
             stmts,
             ctxt: Default::default(),
@@ -1922,7 +2016,12 @@ impl<I: Tokens> Parser<I> {
                 self.eat_general_semi();
 
                 let span = self.span(start);
-                return Ok(ExprStmt { span, expr }.into());
+                return Ok(ExprStmt {
+                    node_id: Default::default(),
+                    span,
+                    expr,
+                }
+                .into());
             }
         } else if cur == Token::Break || cur == Token::Continue {
             let is_break = self.input().is(Token::Break);
@@ -1948,14 +2047,25 @@ impl<I: Tokens> Parser<I> {
                 self.emit_err(span, SyntaxError::TS1107);
             }
             return Ok(if is_break {
-                BreakStmt { span, label }.into()
+                BreakStmt {
+                    node_id: Default::default(),
+                    span,
+                    label,
+                }
+                .into()
             } else {
-                ContinueStmt { span, label }.into()
+                ContinueStmt {
+                    node_id: Default::default(),
+                    span,
+                    label,
+                }
+                .into()
             });
         } else if cur == Token::Debugger {
             self.bump();
             self.expect_general_semi()?;
             return Ok(DebuggerStmt {
+                node_id: Default::default(),
                 span: self.span(start),
             }
             .into());
@@ -1992,8 +2102,13 @@ impl<I: Tokens> Parser<I> {
             let _ = self.parse_finally_block();
 
             return Ok(ExprStmt {
+                node_id: Default::default(),
                 span,
-                expr: Invalid { span }.into(),
+                expr: Invalid {
+                    node_id: Default::default(),
+                    span,
+                }
+                .into(),
             }
             .into());
         } else if cur == Token::Finally {
@@ -2004,8 +2119,13 @@ impl<I: Tokens> Parser<I> {
             let _ = self.parse_finally_block();
 
             return Ok(ExprStmt {
+                node_id: Default::default(),
                 span,
-                expr: Invalid { span }.into(),
+                expr: Invalid {
+                    node_id: Default::default(),
+                    span,
+                }
+                .into(),
             }
             .into());
         } else if cur == Token::Try {
@@ -2065,6 +2185,7 @@ impl<I: Tokens> Parser<I> {
         } else if cur == Token::Semi {
             self.bump();
             return Ok(EmptyStmt {
+                node_id: Default::default(),
                 span: self.span(start),
             }
             .into());
@@ -2105,6 +2226,7 @@ impl<I: Tokens> Parser<I> {
             self.eat_general_semi();
 
             return Ok(ExprStmt {
+                node_id: Default::default(),
                 span: self.span(start),
                 expr,
             }
@@ -2132,6 +2254,7 @@ impl<I: Tokens> Parser<I> {
 
         if self.eat_general_semi() {
             Ok(ExprStmt {
+                node_id: Default::default(),
                 span: self.span(start),
                 expr,
             }
@@ -2142,6 +2265,7 @@ impl<I: Tokens> Parser<I> {
                 self.emit_err(self.input().cur_span(), SyntaxError::TS1005);
                 let expr = self.parse_bin_op_recursively(expr, 0)?;
                 return Ok(ExprStmt {
+                    node_id: Default::default(),
                     span: self.span(start),
                     expr,
                 }
@@ -2231,6 +2355,7 @@ fn handle_import_export<I: Tokens>(p: &mut Parser<I>, _: Vec<Decorator>) -> PRes
         p.eat_general_semi();
 
         return Ok(ExprStmt {
+            node_id: Default::default(),
             span: p.span(start),
             expr,
         }
@@ -2243,6 +2368,7 @@ fn handle_import_export<I: Tokens>(p: &mut Parser<I>, _: Vec<Decorator>) -> PRes
         p.eat_general_semi();
 
         return Ok(ExprStmt {
+            node_id: Default::default(),
             span: p.span(start),
             expr,
         }
@@ -2277,6 +2403,7 @@ mod tests {
         assert_eq_ignore_span!(
             stmt("a + b + c"),
             Stmt::Expr(ExprStmt {
+                node_id: Default::default(),
                 span,
                 expr: expr("a + b + c")
             })
@@ -2288,17 +2415,21 @@ mod tests {
         assert_eq_ignore_span!(
             stmt("try {} catch({ ...a34 }) {}"),
             Stmt::Try(Box::new(TryStmt {
+                node_id: Default::default(),
                 span,
                 block: BlockStmt {
                     span,
                     ..Default::default()
                 },
                 handler: Some(CatchClause {
+                    node_id: Default::default(),
                     span,
                     param: Pat::Object(ObjectPat {
+                        node_id: Default::default(),
                         span,
                         optional: false,
                         props: vec![ObjectPatProp::Rest(RestPat {
+                            node_id: Default::default(),
                             span,
                             dot3_token: span,
                             arg: Box::new(Pat::Ident(
@@ -2324,6 +2455,7 @@ mod tests {
         assert_eq_ignore_span!(
             stmt("throw this"),
             Stmt::Throw(ThrowStmt {
+                node_id: Default::default(),
                 span,
                 arg: expr("this"),
             })
@@ -2335,12 +2467,14 @@ mod tests {
         assert_eq_ignore_span!(
             stmt("for await (const a of b) ;"),
             Stmt::ForOf(ForOfStmt {
+                node_id: Default::default(),
                 span,
                 is_await: true,
                 left: ForHead::VarDecl(Box::new(VarDecl {
                     span,
                     kind: VarDeclKind::Const,
                     decls: vec![VarDeclarator {
+                        node_id: Default::default(),
                         span,
                         init: None,
                         name: Pat::Ident(Ident::new_no_ctxt(atom!("a"), span).into()),
@@ -2350,7 +2484,10 @@ mod tests {
                 })),
                 right: Box::new(Expr::Ident(Ident::new_no_ctxt(atom!("b"), span))),
 
-                body: Box::new(Stmt::Empty(EmptyStmt { span })),
+                body: Box::new(Stmt::Empty(EmptyStmt {
+                    node_id: Default::default(),
+                    span
+                })),
             })
         )
     }
@@ -2381,6 +2518,7 @@ mod tests {
         assert_eq_ignore_span!(
             stmt("if (a) b; else c"),
             Stmt::If(IfStmt {
+                node_id: Default::default(),
                 span,
                 test: expr("a"),
                 cons: Box::new(stmt("b;")),
@@ -2405,15 +2543,18 @@ mod tests {
                 |p| p.parse_stmt_list_item(),
             ),
             Stmt::Decl(Decl::Class(ClassDecl {
+                node_id: Default::default(),
                 ident: Ident::new_no_ctxt(atom!("Foo"), span),
                 class: Box::new(Class {
                     span,
                     decorators: vec![
                         Decorator {
+                            node_id: Default::default(),
                             span,
                             expr: expr("decorator")
                         },
                         Decorator {
+                            node_id: Default::default(),
                             span,
                             expr: expr("dec2")
                         }
@@ -2828,8 +2969,10 @@ export default function waitUntil(callback, options = {}) {
                     declare: false,
                     kind: VarDeclKind::Let,
                     decls: vec![VarDeclarator {
+                        node_id: Default::default(),
                         span,
                         name: Pat::Array(ArrayPat {
+                            node_id: Default::default(),
                             span,
                             type_ann: None,
                             optional: false,
@@ -2860,12 +3003,15 @@ export default function waitUntil(callback, options = {}) {
                     span,
                     kind: VarDeclKind::Let,
                     decls: vec![VarDeclarator {
+                        node_id: Default::default(),
                         span,
                         name: Pat::Object(ObjectPat {
+                            node_id: Default::default(),
                             optional: false,
                             type_ann: None,
                             span,
                             props: vec![ObjectPatProp::Assign(AssignPatProp {
+                                node_id: Default::default(),
                                 span,
                                 key: Ident::new_no_ctxt(atom!("num"), span).into(),
                                 value: None
@@ -3023,6 +3169,7 @@ export default function waitUntil(callback, options = {}) {
         assert_eq_ignore_span!(
             test_parser(src, Syntax::Es(Default::default()), |p| p.parse_expr()),
             Box::new(Expr::Class(ClassExpr {
+                node_id: Default::default(),
                 ident: Some(Ident {
                     span,
                     sym: atom!("Foo"),
@@ -3037,6 +3184,7 @@ export default function waitUntil(callback, options = {}) {
                     is_abstract: false,
                     implements: Vec::new(),
                     body: vec!(ClassMember::StaticBlock(StaticBlock {
+                        node_id: Default::default(),
                         span,
                         body: BlockStmt {
                             span,
@@ -3056,6 +3204,7 @@ export default function waitUntil(callback, options = {}) {
         assert_eq_ignore_span!(
             test_parser(src, Syntax::Es(Default::default()), |p| p.parse_expr()),
             Box::new(Expr::Class(ClassExpr {
+                node_id: Default::default(),
                 ident: Some(Ident {
                     span,
                     sym: atom!("Foo"),
@@ -3068,6 +3217,7 @@ export default function waitUntil(callback, options = {}) {
                     is_abstract: false,
                     body: vec!(
                         ClassMember::StaticBlock(StaticBlock {
+                            node_id: Default::default(),
                             span,
                             body: BlockStmt {
                                 span,
@@ -3076,6 +3226,7 @@ export default function waitUntil(callback, options = {}) {
                             },
                         }),
                         ClassMember::StaticBlock(StaticBlock {
+                            node_id: Default::default(),
                             span,
                             body: BlockStmt {
                                 span,
@@ -3101,6 +3252,7 @@ export default function waitUntil(callback, options = {}) {
         assert_eq_ignore_span!(
             test_parser(src, Syntax::Es(Default::default()), |p| p.parse_expr()),
             Box::new(Expr::Class(ClassExpr {
+                node_id: Default::default(),
                 ident: Some(Ident {
                     span,
                     sym: atom!("Foo"),
@@ -3110,6 +3262,7 @@ export default function waitUntil(callback, options = {}) {
                     span,
                     is_abstract: false,
                     body: vec!(ClassMember::StaticBlock(StaticBlock {
+                        node_id: Default::default(),
                         span,
                         body: BlockStmt {
                             span,
@@ -3132,6 +3285,7 @@ export default function waitUntil(callback, options = {}) {
         assert_eq_ignore_span!(
             test_parser(src, Syntax::Es(Default::default()), |p| p.parse_expr()),
             Box::new(Expr::Class(ClassExpr {
+                node_id: Default::default(),
                 ident: Some(Ident {
                     span,
                     sym: atom!("Foo"),
@@ -3141,6 +3295,7 @@ export default function waitUntil(callback, options = {}) {
                     span,
                     is_abstract: false,
                     body: vec!(ClassMember::StaticBlock(StaticBlock {
+                        node_id: Default::default(),
                         span,
                         body: BlockStmt {
                             span,

--- a/crates/swc_ecma_parser/src/parser/tests.rs
+++ b/crates/swc_ecma_parser/src/parser/tests.rs
@@ -1,8 +1,10 @@
 use std::hint::black_box;
 
+use serde_json::Value;
 use swc_atoms::atom;
 use swc_common::{comments::SingleThreadedComments, BytePos, FileName, SourceMap, DUMMY_SP};
-use swc_ecma_visit::assert_eq_ignore_span;
+use swc_ecma_ast::NodeId;
+use swc_ecma_visit::{assert_eq_ignore_span, assign_node_ids, Visit, VisitWith};
 
 use super::*;
 use crate::{parse_file_as_expr, EsSyntax, TsSyntax};
@@ -19,6 +21,45 @@ fn module(src: &'static str) -> Module {
 /// Assert that Parser.parse_program returns [Program::Script].
 fn script(src: &'static str) -> Script {
     program(src).expect_script()
+}
+
+#[derive(Default)]
+struct NodeIdChecker {
+    count: usize,
+}
+
+impl Visit for NodeIdChecker {
+    fn visit_node_id(&mut self, node: &NodeId) {
+        self.count += 1;
+        assert_ne!(*node, NodeId::DUMMY, "found a dummy node id");
+    }
+}
+
+fn assert_all_node_ids_assigned<N>(node: &N)
+where
+    N: VisitWith<NodeIdChecker>,
+{
+    let mut checker = NodeIdChecker::default();
+    node.visit_with(&mut checker);
+    assert!(checker.count > 0, "expected at least one node id");
+}
+
+fn strip_node_ids(value: &mut Value) {
+    match value {
+        Value::Array(items) => {
+            for item in items {
+                strip_node_ids(item);
+            }
+        }
+        Value::Object(map) => {
+            map.remove("nodeId");
+
+            for value in map.values_mut() {
+                strip_node_ids(value);
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Assert that Parser.parse_program returns [Program::Module] and has errors.
@@ -63,6 +104,44 @@ fn parse_program_module_02() {
         export default foo;
         ",
     );
+}
+
+#[test]
+fn parsed_program_has_assigned_node_ids() {
+    let program = program(
+        "
+        let a = 1;
+        function foo(b) {
+            return a + b;
+        }
+        foo(2);
+        ",
+    );
+
+    assert_all_node_ids_assigned(&program);
+}
+
+#[test]
+fn assign_node_ids_after_deserializing_without_node_id() {
+    let program = program(
+        "
+        import { Foo } from 'foo';
+        class Bar {
+            method() {
+                return Foo;
+            }
+        }
+        ",
+    );
+
+    let mut json = serde_json::to_value(&program).expect("failed to serialize program");
+    strip_node_ids(&mut json);
+
+    let mut program: Program =
+        serde_json::from_value(json).expect("failed to deserialize program without node ids");
+    assign_node_ids(&mut program);
+
+    assert_all_node_ids_assigned(&program);
 }
 
 #[test]
@@ -501,11 +580,13 @@ fn expr(s: &'static str) -> Box<Expr> {
 }
 fn regex_expr() -> Box<Expr> {
     AssignExpr {
+        node_id: Default::default(),
         span: DUMMY_SP,
         left: Ident::new_no_ctxt(atom!("re"), DUMMY_SP).into(),
         op: AssignOp::Assign,
         right: Box::new(
             Lit::Regex(Regex {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 exp: atom!("w+"),
                 flags: atom!(""),
@@ -525,6 +606,7 @@ fn simple() {
     assert_eq_ignore_span!(
         bin("5 + 4 * 7"),
         Box::new(Expr::Bin(BinExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             op: op!(bin, "+"),
             left: bin("5"),
@@ -538,6 +620,7 @@ fn same_prec() {
     assert_eq_ignore_span!(
         bin("5 + 4 + 7"),
         Box::new(Expr::Bin(BinExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             op: op!(bin, "+"),
             left: bin("5 + 4"),
@@ -580,6 +663,7 @@ fn arrow_assign() {
     assert_eq_ignore_span!(
         expr("a = b => false"),
         Box::new(Expr::Assign(AssignExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             left: Ident::new_no_ctxt(atom!("a"), DUMMY_SP).into(),
             op: op!("="),
@@ -625,9 +709,11 @@ fn object_rest_pat() {
             is_async: false,
             is_generator: false,
             params: vec![Pat::Object(ObjectPat {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 optional: false,
                 props: vec![ObjectPatProp::Rest(RestPat {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     dot3_token: DUMMY_SP,
                     arg: Box::new(Pat::Ident(
@@ -651,14 +737,17 @@ fn object_spread() {
     assert_eq_ignore_span!(
         expr("foo = {a, ...bar, b}"),
         Box::new(Expr::Assign(AssignExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             left: Ident::new_no_ctxt(atom!("foo"), DUMMY_SP).into(),
             op: op!("="),
             right: Box::new(Expr::Object(ObjectLit {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 props: vec![
                     PropOrSpread::Prop(Box::new(Ident::new_no_ctxt(atom!("a"), DUMMY_SP).into())),
                     PropOrSpread::Spread(SpreadElement {
+                        node_id: Default::default(),
                         dot3_token: DUMMY_SP,
                         expr: Box::new(Expr::Ident(Ident::new_no_ctxt(atom!("bar"), DUMMY_SP))),
                     }),
@@ -674,6 +763,7 @@ fn new_expr_should_not_eat_too_much() {
     assert_eq_ignore_span!(
         new_expr("new Date().toString()"),
         Box::new(Expr::Member(MemberExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             obj: member_expr("new Date()"),
             prop: MemberProp::Ident(IdentName::new(atom!("toString"), DUMMY_SP)),
@@ -743,6 +833,7 @@ fn arrow_fn_rest() {
             is_async: false,
             is_generator: false,
             params: vec![Pat::Rest(RestPat {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 dot3_token: DUMMY_SP,
                 arg: Box::new(Pat::Ident(Ident::new_no_ctxt(atom!("a"), DUMMY_SP).into())),
@@ -798,9 +889,11 @@ fn array_lit() {
     assert_eq_ignore_span!(
         expr("[a,,,,, ...d,, e]"),
         Box::new(Expr::Array(ArrayLit {
+            node_id: Default::default(),
             span: DUMMY_SP,
             elems: vec![
                 Some(ExprOrSpread {
+                    node_id: Default::default(),
                     spread: None,
                     expr: Box::new(Expr::Ident(Ident::new_no_ctxt(atom!("a"), DUMMY_SP))),
                 }),
@@ -809,11 +902,13 @@ fn array_lit() {
                 None,
                 None,
                 Some(ExprOrSpread {
+                    node_id: Default::default(),
                     spread: Some(DUMMY_SP),
                     expr: Box::new(Expr::Ident(Ident::new_no_ctxt(atom!("d"), DUMMY_SP))),
                 }),
                 None,
                 Some(ExprOrSpread {
+                    node_id: Default::default(),
                     spread: None,
                     expr: Box::new(Expr::Ident(Ident::new_no_ctxt(atom!("e"), DUMMY_SP))),
                 }),
@@ -827,6 +922,7 @@ fn max_integer() {
     assert_eq_ignore_span!(
         expr("1.7976931348623157e+308"),
         Box::new(Expr::Lit(Lit::Num(Number {
+            node_id: Default::default(),
             span: DUMMY_SP,
             value: 1.797_693_134_862_315_7e308,
             raw: Some(atom!("1.7976931348623157e+308")),
@@ -855,6 +951,7 @@ fn issue_319_1() {
             span: DUMMY_SP,
             callee: Callee::Expr(expr("obj")),
             args: vec![ExprOrSpread {
+                node_id: Default::default(),
                 spread: None,
                 expr: expr("({ async f() { await g(); } })"),
             }],
@@ -870,16 +967,20 @@ fn issue_328() {
             p.parse_stmt()
         }),
         Stmt::Expr(ExprStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             expr: Box::new(Expr::Call(CallExpr {
                 span: DUMMY_SP,
                 callee: Callee::Import(Import {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     phase: Default::default()
                 }),
                 args: vec![ExprOrSpread {
+                    node_id: Default::default(),
                     spread: None,
                     expr: Box::new(Expr::Lit(Lit::Str(Str {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         value: atom!("test").into(),
                         raw: Some(atom!("'test'")),
@@ -909,6 +1010,7 @@ ok\
 hehe.";"#,
         ),
         Box::new(Expr::Lit(Lit::Str(Str {
+            node_id: Default::default(),
             span: DUMMY_SP,
             value: atom!("okokhehe.").into(),
             raw: Some(atom!("\"ok\\\nok\\\nhehe.\"")),
@@ -940,9 +1042,14 @@ fn super_expr() {
         Box::new(Expr::Call(CallExpr {
             span: DUMMY_SP,
             callee: Callee::Expr(Box::new(Expr::SuperProp(SuperPropExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
-                obj: Super { span: DUMMY_SP },
+                obj: Super {
+                    node_id: Default::default(),
+                    span: DUMMY_SP
+                },
                 prop: SuperProp::Ident(IdentName {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     sym: atom!("foo"),
                 })
@@ -957,12 +1064,18 @@ fn super_expr_computed() {
     assert_eq_ignore_span!(
         expr("super[a] ??= 123;"),
         Box::new(Expr::Assign(AssignExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             op: AssignOp::NullishAssign,
             left: SuperPropExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
-                obj: Super { span: DUMMY_SP },
+                obj: Super {
+                    node_id: Default::default(),
+                    span: DUMMY_SP
+                },
                 prop: SuperProp::Computed(ComputedPropName {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     expr: Box::new(Expr::Ident(Ident {
                         span: DUMMY_SP,
@@ -973,6 +1086,7 @@ fn super_expr_computed() {
             }
             .into(),
             right: Box::new(Expr::Lit(Lit::Num(Number {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 value: 123f64,
                 raw: Some(atom!("123")),

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -121,6 +121,7 @@ enum FlowComponentParam {
 impl<I: Tokens> Parser<I> {
     fn make_flow_any_keyword_type(&mut self, start: BytePos) -> Box<TsType> {
         Box::new(TsType::TsKeywordType(TsKeywordType {
+            node_id: Default::default(),
             span: self.span(start),
             kind: TsKeywordTypeKind::TsAnyKeyword,
         }))
@@ -163,6 +164,7 @@ impl<I: Tokens> Parser<I> {
 
     fn make_flow_component_fallback_binding(&mut self, span: Span) -> Pat {
         Pat::Ident(BindingIdent {
+            node_id: Default::default(),
             id: Ident::new_no_ctxt(atom!("component_prop"), span),
             type_ann: None,
         })
@@ -170,6 +172,7 @@ impl<I: Tokens> Parser<I> {
 
     fn make_flow_component_rest_fallback_binding(&mut self, span: Span) -> Pat {
         Pat::Ident(BindingIdent {
+            node_id: Default::default(),
             id: Ident::new_no_ctxt(atom!("component_rest"), span),
             type_ann: None,
         })
@@ -230,12 +233,14 @@ impl<I: Tokens> Parser<I> {
                     let type_ann_span = type_ann.span();
                     return Ok(FlowComponentParam::Rest {
                         rest: RestPat {
+                            node_id: Default::default(),
                             span: self.span(start),
                             dot3_token,
                             arg: Box::new(
                                 self.make_flow_component_rest_fallback_binding(self.span(start)),
                             ),
                             type_ann: Some(Box::new(TsTypeAnn {
+                                node_id: Default::default(),
                                 span: type_ann_span,
                                 type_ann,
                             })),
@@ -257,6 +262,7 @@ impl<I: Tokens> Parser<I> {
 
             return Ok(FlowComponentParam::Rest {
                 rest: RestPat {
+                    node_id: Default::default(),
                     span: self.span(start),
                     dot3_token,
                     arg: Box::new(arg),
@@ -278,6 +284,7 @@ impl<I: Tokens> Parser<I> {
             if self.input_mut().eat(Token::Eq) {
                 let right = self.parse_assignment_expr()?;
                 value = Pat::Assign(AssignPat {
+                    node_id: Default::default(),
                     span: self.span(start),
                     left: Box::new(value),
                     right,
@@ -309,6 +316,7 @@ impl<I: Tokens> Parser<I> {
         } else {
             match &key {
                 PropName::Ident(id) => Pat::Ident(BindingIdent {
+                    node_id: Default::default(),
                     id: Ident::new_no_ctxt(id.sym.clone(), id.span),
                     type_ann: None,
                 }),
@@ -339,6 +347,7 @@ impl<I: Tokens> Parser<I> {
         if self.input_mut().eat(Token::Eq) {
             let right = self.parse_assignment_expr()?;
             value = Pat::Assign(AssignPat {
+                node_id: Default::default(),
                 span: self.span(start),
                 left: Box::new(value),
                 right,
@@ -393,6 +402,7 @@ impl<I: Tokens> Parser<I> {
             match param {
                 FlowComponentParam::Prop { key, value, .. } => {
                     props.push(ObjectPatProp::KeyValue(KeyValuePatProp {
+                        node_id: Default::default(),
                         key,
                         value: Box::new(value),
                     }));
@@ -404,6 +414,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         ObjectPat {
+            node_id: Default::default(),
             span: self.span(start),
             props,
             optional: false,
@@ -421,6 +432,7 @@ impl<I: Tokens> Parser<I> {
 
         let type_ann = self.in_type(Self::parse_ts_type)?;
         Ok(Some(Box::new(TsTypeAnn {
+            node_id: Default::default(),
             span: self.span(start),
             type_ann,
         })))
@@ -437,6 +449,7 @@ impl<I: Tokens> Parser<I> {
         let type_params = self.try_parse_ts_type_params(false, true)?;
         let component_params = self.parse_flow_component_params(declare, !declare, declare)?;
         let params = vec![Param {
+            node_id: Default::default(),
             span: self.span(start),
             decorators: Vec::new(),
             pat: Pat::Object(self.make_flow_component_props_pat(start, component_params)),
@@ -454,9 +467,11 @@ impl<I: Tokens> Parser<I> {
         }
 
         Ok(Decl::Fn(FnDecl {
+            node_id: Default::default(),
             declare,
             ident,
             function: Box::new(Function {
+                node_id: Default::default(),
                 span: self.span(start),
                 decorators,
                 type_params,
@@ -489,6 +504,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         Ok(Decl::Fn(FnDecl {
+            node_id: Default::default(),
             declare,
             ident,
             function,
@@ -508,6 +524,7 @@ impl<I: Tokens> Parser<I> {
             renders
         } else {
             Box::new(TsTypeAnn {
+                node_id: Default::default(),
                 span: self.span(start),
                 type_ann: self.make_flow_any_keyword_type(start),
             })
@@ -519,6 +536,7 @@ impl<I: Tokens> Parser<I> {
 
         Ok(TsType::TsFnOrConstructorType(
             TsFnOrConstructorType::TsFnType(TsFnType {
+                node_id: Default::default(),
                 span: self.span(start),
                 params,
                 type_params,
@@ -558,6 +576,7 @@ impl<I: Tokens> Parser<I> {
 
         Ok(TsType::TsFnOrConstructorType(
             TsFnOrConstructorType::TsFnType(TsFnType {
+                node_id: Default::default(),
                 span: self.span(start),
                 params,
                 type_params,
@@ -642,7 +661,9 @@ impl<I: Tokens> Parser<I> {
             DefaultDecl::Class(ClassExpr {
                 ident: Some(ident),
                 class,
+                ..
             }) => Decl::Class(ClassDecl {
+                node_id: Default::default(),
                 declare: true,
                 ident,
                 class: Box::new(Class {
@@ -656,7 +677,9 @@ impl<I: Tokens> Parser<I> {
             DefaultDecl::Fn(FnExpr {
                 ident: Some(ident),
                 function,
+                ..
             }) => Decl::Fn(FnDecl {
+                node_id: Default::default(),
                 declare: true,
                 ident,
                 function: Box::new(Function {
@@ -947,11 +970,13 @@ impl<I: Tokens> Parser<I> {
 
             return Ok(Box::new(TsType::TsUnionOrIntersectionType(match kind {
                 UnionOrIntersection::Union => TsUnionOrIntersectionType::TsUnionType(TsUnionType {
+                    node_id: Default::default(),
                     span: self.span(start),
                     types,
                 }),
                 UnionOrIntersection::Intersection => {
                     TsUnionOrIntersectionType::TsIntersectionType(TsIntersectionType {
+                        node_id: Default::default(),
                         span: self.span(start),
                         types,
                     })
@@ -1057,6 +1082,7 @@ impl<I: Tokens> Parser<I> {
         debug_assert!(self.input().syntax().typescript());
         expect!(self, Token::This);
         Ok(TsThisType {
+            node_id: Default::default(),
             span: self.input().prev_span(),
         })
     }
@@ -1091,7 +1117,12 @@ impl<I: Tokens> Parser<I> {
                 self.parse_ident(false, false)?.into()
             };
             let span = self.span(start);
-            entity = TsEntityName::TsQualifiedName(Box::new(TsQualifiedName { span, left, right }));
+            entity = TsEntityName::TsQualifiedName(Box::new(TsQualifiedName {
+                node_id: Default::default(),
+                span,
+                left,
+                right,
+            }));
         }
         Ok(entity)
     }
@@ -1154,7 +1185,11 @@ impl<I: Tokens> Parser<I> {
             self.emit_err(span, SyntaxError::EmptyTypeArgumentList);
         }
 
-        Ok(Box::new(TsTypeParamInstantiation { span, params }))
+        Ok(Box::new(TsTypeParamInstantiation {
+            node_id: Default::default(),
+            span,
+            params,
+        }))
     }
 
     /// `tsParseTypeReference`
@@ -1193,6 +1228,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         Ok(TsTypeRef {
+            node_id: Default::default(),
             span: self.span(start),
             type_name,
             type_params,
@@ -1222,6 +1258,7 @@ impl<I: Tokens> Parser<I> {
             let type_ann = p.parse_ts_type()?;
 
             Ok(Box::new(TsTypeAnn {
+                node_id: Default::default(),
                 span: p.span(start),
                 type_ann,
             }))
@@ -1246,6 +1283,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(TsTypePredicate {
+            node_id: Default::default(),
             span: self.span(start),
             asserts: has_asserts_keyword,
             param_name,
@@ -1302,6 +1340,7 @@ impl<I: Tokens> Parser<I> {
         let constraint = Some(self.expect_then_parse_ts_type(Token::In, "in")?);
 
         Ok(TsTypeParam {
+            node_id: Default::default(),
             span: self.span(start),
             name: name.into(),
             is_in: false,
@@ -1471,6 +1510,7 @@ impl<I: Tokens> Parser<I> {
         let default = self.eat_then_parse_ts_type(Token::Eq)?;
 
         Ok(TsTypeParam {
+            node_id: Default::default(),
             span: self.span(start),
             name,
             is_in,
@@ -1522,6 +1562,7 @@ impl<I: Tokens> Parser<I> {
                 }
 
                 Ok(Box::new(TsTypeParamDecl {
+                    node_id: Default::default(),
                     span: p.span(start),
                     params,
                 }))
@@ -1583,6 +1624,7 @@ impl<I: Tokens> Parser<I> {
                 }
 
                 return Ok(Box::new(TsTypeAnn {
+                    node_id: Default::default(),
                     span: p.span(return_token_start),
                     type_ann: p.make_flow_any_keyword_type(return_token_start),
                 }));
@@ -1658,6 +1700,7 @@ impl<I: Tokens> Parser<I> {
             };
 
             let node = Box::new(TsType::TsTypePredicate(TsTypePredicate {
+                node_id: Default::default(),
                 span: p.span(type_pred_start),
                 asserts: has_type_pred_asserts,
                 param_name,
@@ -1665,6 +1708,7 @@ impl<I: Tokens> Parser<I> {
             }));
 
             Ok(Box::new(TsTypeAnn {
+                node_id: Default::default(),
                 span: p.span(return_token_start),
                 type_ann: node,
             }))
@@ -1867,6 +1911,7 @@ impl<I: Tokens> Parser<I> {
         let span = self.span(start);
         Ok((
             TsEnumMember {
+                node_id: Default::default(),
                 span,
                 id: TsEnumMemberId::Ident(id.into()),
                 init,
@@ -2024,6 +2069,7 @@ impl<I: Tokens> Parser<I> {
         self.validate_flow_enum_members(explicit_kind, &member_meta);
 
         Ok(Box::new(TsEnumDecl {
+            node_id: Default::default(),
             span: self.span(start),
             declare: false,
             is_const,
@@ -2061,6 +2107,7 @@ impl<I: Tokens> Parser<I> {
             self.emit_err(span, SyntaxError::TS2452);
 
             TsEnumMemberId::Str(Str {
+                node_id: Default::default(),
                 span,
                 value: value.to_string().into(),
                 raw: Some(new_raw.into()),
@@ -2085,6 +2132,7 @@ impl<I: Tokens> Parser<I> {
                     let value = tpl.cooked.unwrap();
 
                     TsEnumMemberId::Str(Str {
+                        node_id: Default::default(),
                         span,
                         value,
                         raw: None,
@@ -2120,6 +2168,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(TsEnumMember {
+            node_id: Default::default(),
             span: self.span(start),
             id,
             init,
@@ -2145,6 +2194,7 @@ impl<I: Tokens> Parser<I> {
         expect!(self, Token::RBrace);
 
         Ok(Box::new(TsEnumDecl {
+            node_id: Default::default(),
             span: self.span(start),
             declare: false,
             is_const,
@@ -2182,6 +2232,7 @@ impl<I: Tokens> Parser<I> {
         expect!(self, Token::BackQuote);
 
         Ok(TsTplLitType {
+            node_id: Default::default(),
             span: self.span(start),
             types,
             quasis,
@@ -2247,6 +2298,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(TsLitType {
+            node_id: Default::default(),
             span: self.span(start),
             lit,
         })
@@ -2280,6 +2332,7 @@ impl<I: Tokens> Parser<I> {
 
         match *expr {
             Expr::TsInstantiation(v) => Ok(TsExprWithTypeArgs {
+                node_id: Default::default(),
                 span: v.span,
                 expr: v.expr,
                 type_args: Some(v.type_args),
@@ -2294,6 +2347,7 @@ impl<I: Tokens> Parser<I> {
                 };
 
                 Ok(TsExprWithTypeArgs {
+                    node_id: Default::default(),
                     span: self.span(start),
                     expr,
                     type_args,
@@ -2451,6 +2505,7 @@ impl<I: Tokens> Parser<I> {
         self.parse_ts_type_member_semicolon()?;
 
         Ok(Some(TsIndexSignature {
+            node_id: Default::default(),
             span: self.span(index_signature_start),
             readonly,
             is_static,
@@ -2494,6 +2549,7 @@ impl<I: Tokens> Parser<I> {
         let expr = self.parse_str_lit();
         expect!(self, Token::RParen);
         Ok(TsExternalModuleRef {
+            node_id: Default::default(),
             span: self.span(start),
             expr,
         })
@@ -2514,6 +2570,7 @@ impl<I: Tokens> Parser<I> {
         self.expect_general_semi()?;
 
         Ok(Box::new(TsImportEqualsDecl {
+            node_id: Default::default(),
             span: self.span(start),
             id,
             is_export,
@@ -2584,6 +2641,7 @@ impl<I: Tokens> Parser<I> {
                             let right = self.parse_assignment_expr()?;
                             self.emit_err(pat.span(), SyntaxError::TS1048);
                             pat = AssignPat {
+                                node_id: Default::default(),
                                 span: self.span(pat_start),
                                 left: Box::new(pat),
                                 right,
@@ -2601,6 +2659,7 @@ impl<I: Tokens> Parser<I> {
                         };
 
                         let pat: Pat = RestPat {
+                            node_id: Default::default(),
                             span: self.span(pat_start),
                             dot3_token,
                             arg: Box::new(pat),
@@ -2704,6 +2763,7 @@ impl<I: Tokens> Parser<I> {
         match kind {
             SignatureParsingMode::TSCallSignatureDeclaration => {
                 Ok(Either::Left(TsCallSignatureDecl {
+                    node_id: Default::default(),
                     span: self.span(start),
                     params,
                     type_ann,
@@ -2712,6 +2772,7 @@ impl<I: Tokens> Parser<I> {
             }
             SignatureParsingMode::TSConstructSignatureDeclaration => {
                 Ok(Either::Right(TsConstructSignatureDecl {
+                    node_id: Default::default(),
                     span: self.span(start),
                     params,
                     type_ann,
@@ -2748,6 +2809,7 @@ impl<I: Tokens> Parser<I> {
 
             Ok(Some(if let Some(dot3_token) = rest {
                 RestPat {
+                    node_id: Default::default(),
                     span: p.span(start),
                     dot3_token,
                     arg: ident.into(),
@@ -2824,9 +2886,11 @@ impl<I: Tokens> Parser<I> {
                 self.parse_ts_type()?
             };
             return Ok(TsTupleElement {
+                node_id: Default::default(),
                 span: self.span(start),
                 label,
                 ty: Box::new(TsType::TsRestType(TsRestType {
+                    node_id: Default::default(),
                     span: self.span(start),
                     type_ann,
                 })),
@@ -2838,9 +2902,11 @@ impl<I: Tokens> Parser<I> {
         if self.input_mut().eat(Token::QuestionMark) {
             let type_ann = ty;
             return Ok(TsTupleElement {
+                node_id: Default::default(),
                 span: self.span(start),
                 label,
                 ty: Box::new(TsType::TsOptionalType(TsOptionalType {
+                    node_id: Default::default(),
                     span: self.span(start),
                     type_ann,
                 })),
@@ -2848,6 +2914,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         Ok(TsTupleElement {
+            node_id: Default::default(),
             span: self.span(start),
             label,
             ty,
@@ -2897,6 +2964,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         Ok(TsTupleType {
+            node_id: Default::default(),
             span: self.span(start),
             elem_types: elems,
         })
@@ -2954,6 +3022,7 @@ impl<I: Tokens> Parser<I> {
         expect!(self, Token::RBrace);
 
         Ok(TsMappedType {
+            node_id: Default::default(),
             span: self.span(start),
             readonly,
             optional,
@@ -2977,6 +3046,7 @@ impl<I: Tokens> Parser<I> {
         };
         expect!(self, Token::RParen);
         Ok(TsParenthesizedType {
+            node_id: Default::default(),
             span: self.span(start),
             type_ann,
         })
@@ -2997,6 +3067,7 @@ impl<I: Tokens> Parser<I> {
         let type_ann = self.expect_then_parse_ts_type(Token::Eq, "=")?;
         self.expect_general_semi()?;
         Ok(Box::new(TsTypeAliasDecl {
+            node_id: Default::default(),
             declare: false,
             span: self.span(start),
             id: id.into(),
@@ -3012,6 +3083,7 @@ impl<I: Tokens> Parser<I> {
         type_ann: Box<TsType>,
     ) -> Box<TsTypeAliasDecl> {
         Box::new(TsTypeAliasDecl {
+            node_id: Default::default(),
             declare: false,
             span: self.span(start),
             id: Ident::new_no_ctxt(id, self.span(start)),
@@ -3050,6 +3122,7 @@ impl<I: Tokens> Parser<I> {
         self.expect_general_semi()?;
 
         Ok(Box::new(TsTypeAliasDecl {
+            node_id: Default::default(),
             declare: false,
             span: self.span(start),
             id: id.into(),
@@ -3086,6 +3159,7 @@ impl<I: Tokens> Parser<I> {
 
         Ok(if is_fn_type {
             TsFnOrConstructorType::TsFnType(TsFnType {
+                node_id: Default::default(),
                 span: self.span(start),
                 type_params,
                 params,
@@ -3093,6 +3167,7 @@ impl<I: Tokens> Parser<I> {
             })
         } else {
             TsFnOrConstructorType::TsConstructorType(TsConstructorType {
+                node_id: Default::default(),
                 span: self.span(start),
                 type_params,
                 params,
@@ -3111,11 +3186,13 @@ impl<I: Tokens> Parser<I> {
     ) -> TsFnParam {
         let ann_span = type_ann.span();
         let type_ann = Some(Box::new(TsTypeAnn {
+            node_id: Default::default(),
             span: ann_span,
             type_ann,
         }));
         let param_span = Span::new_with_checked(start, ann_span.hi);
         let ident = BindingIdent {
+            node_id: Default::default(),
             id: Ident::new_no_ctxt(
                 format!("__flow_anon_param_{index}").into(),
                 Span::new_with_checked(param_span.lo, param_span.lo),
@@ -3125,6 +3202,7 @@ impl<I: Tokens> Parser<I> {
 
         if let Some(dot3_token) = dot3_token {
             TsFnParam::Rest(RestPat {
+                node_id: Default::default(),
                 span: param_span,
                 dot3_token,
                 arg: Box::new(Pat::Ident(ident)),
@@ -3270,6 +3348,7 @@ impl<I: Tokens> Parser<I> {
 
         let type_ann = self.parse_ts_type_or_type_predicate_ann(Token::Arrow)?;
         Ok(Some(TsFnType {
+            node_id: Default::default(),
             span: self.span(start),
             params,
             type_params: None,
@@ -3349,6 +3428,7 @@ impl<I: Tokens> Parser<I> {
                         let type_ann = self.parse_ts_type_or_type_predicate_ann(Token::Arrow)?;
                         return Ok(Box::new(TsType::TsFnOrConstructorType(
                             TsFnOrConstructorType::TsFnType(TsFnType {
+                                node_id: Default::default(),
                                 span: self.span(start),
                                 type_params: None,
                                 params: vec![param],
@@ -3378,6 +3458,7 @@ impl<I: Tokens> Parser<I> {
 
         let type_ann = self.parse_ts_type_operator_or_higher()?;
         Ok(TsTypeOperator {
+            node_id: Default::default(),
             span: self.span(start),
             op,
             type_ann,
@@ -3403,6 +3484,7 @@ impl<I: Tokens> Parser<I> {
             }
         });
         let type_param = TsTypeParam {
+            node_id: Default::default(),
             span: type_param_name.span(),
             name: type_param_name.into(),
             is_in: false,
@@ -3412,6 +3494,7 @@ impl<I: Tokens> Parser<I> {
             default: None,
         };
         Ok(TsInferType {
+            node_id: Default::default(),
             span: self.span(start),
             type_param,
         })
@@ -3491,6 +3574,7 @@ impl<I: Tokens> Parser<I> {
 
             if self.input_mut().eat(Token::RBracket) {
                 ty = Box::new(TsType::TsArrayType(TsArrayType {
+                    node_id: Default::default(),
                     span: self.span(ty.span_lo()),
                     elem_type: ty,
                 }));
@@ -3498,6 +3582,7 @@ impl<I: Tokens> Parser<I> {
                 let index_type = self.parse_ts_type()?;
                 expect!(self, Token::RBracket);
                 ty = Box::new(TsType::TsIndexedAccessType(TsIndexedAccessType {
+                    node_id: Default::default(),
                     span: self.span(ty.span_lo()),
                     readonly,
                     obj_type: ty,
@@ -3530,12 +3615,14 @@ impl<I: Tokens> Parser<I> {
             {
                 if let TsType::TsThisType(this_ty) = &*ty {
                     let this_ident = BindingIdent {
+                        node_id: Default::default(),
                         id: Ident::new_no_ctxt(atom!("this"), this_ty.span),
                         type_ann: None,
                     };
                     let type_ann = p.parse_ts_type_or_type_predicate_ann(Token::Arrow)?;
                     return Ok(Box::new(TsType::TsFnOrConstructorType(
                         TsFnOrConstructorType::TsFnType(TsFnType {
+                            node_id: Default::default(),
                             span: p.span(start),
                             type_params: None,
                             params: vec![TsFnParam::Ident(this_ident)],
@@ -3563,6 +3650,7 @@ impl<I: Tokens> Parser<I> {
             let false_type = p.parse_ts_type()?;
 
             Ok(Box::new(TsType::TsConditionalType(TsConditionalType {
+                node_id: Default::default(),
                 span: p.span(start),
                 check_type,
                 extends_type,
@@ -3592,6 +3680,7 @@ impl<I: Tokens> Parser<I> {
             (
                 false,
                 Box::new(Expr::Lit(Lit::Str(Str {
+                    node_id: Default::default(),
                     span: self.span(start),
                     value: format!("@@{key}").into(),
                     raw: None,
@@ -3663,6 +3752,7 @@ impl<I: Tokens> Parser<I> {
 
             self.parse_ts_type_member_semicolon()?;
             Ok(Either::Right(TsMethodSignature {
+                node_id: Default::default(),
                 span: self.span(start),
                 computed,
                 key,
@@ -3680,6 +3770,7 @@ impl<I: Tokens> Parser<I> {
 
             self.parse_ts_type_member_semicolon()?;
             Ok(Either::Left(TsPropertySignature {
+                node_id: Default::default(),
                 span: self.span(start),
                 computed,
                 readonly,
@@ -3741,6 +3832,7 @@ impl<I: Tokens> Parser<I> {
 
                 Ok(Some(TsTypeElement::TsPropertySignature(
                     TsPropertySignature {
+                        node_id: Default::default(),
                         span: p.span(start),
                         computed: false,
                         readonly,
@@ -3772,6 +3864,7 @@ impl<I: Tokens> Parser<I> {
             } else {
                 let type_ann = self.parse_ts_type()?;
                 Some(Box::new(TsTypeAnn {
+                    node_id: Default::default(),
                     span: Span::new_with_checked(start, self.input().prev_span().hi),
                     type_ann,
                 }))
@@ -3781,6 +3874,7 @@ impl<I: Tokens> Parser<I> {
             self.input_mut().eat(Token::Semi);
 
             return Ok(TsPropertySignature {
+                node_id: Default::default(),
                 span: self.span(start),
                 computed: false,
                 readonly: false,
@@ -3823,6 +3917,7 @@ impl<I: Tokens> Parser<I> {
                 p.parse_ts_type_member_semicolon()?;
 
                 Ok(Some(TsTypeElement::TsGetterSignature(TsGetterSignature {
+                    node_id: Default::default(),
                     span: p.span(start),
                     key,
                     computed,
@@ -3843,6 +3938,7 @@ impl<I: Tokens> Parser<I> {
                 p.parse_ts_type_member_semicolon()?;
 
                 Ok(Some(TsTypeElement::TsSetterSignature(TsSetterSignature {
+                    node_id: Default::default(),
                     span: p.span(start),
                     key,
                     computed,
@@ -3927,6 +4023,7 @@ impl<I: Tokens> Parser<I> {
         let start = self.cur_pos();
         let members = self.parse_ts_object_type_members()?;
         Ok(TsTypeLit {
+            node_id: Default::default(),
             span: self.span(start),
             members,
         })
@@ -3986,10 +4083,12 @@ impl<I: Tokens> Parser<I> {
         }
 
         let body = TsInterfaceBody {
+            node_id: Default::default(),
             span: self.span(body_start),
             body: body_members,
         };
         Ok(Box::new(TsInterfaceDecl {
+            node_id: Default::default(),
             span: self.span(start),
             declare: false,
             id: id.into(),
@@ -4014,6 +4113,7 @@ impl<I: Tokens> Parser<I> {
         expect!(self, Token::Gt);
         let expr = self.parse_unary_expr()?;
         Ok(TsTypeAssertion {
+            node_id: Default::default(),
             span: self.span(start),
             type_ann,
             expr,
@@ -4039,6 +4139,7 @@ impl<I: Tokens> Parser<I> {
             self.bump();
             self.emit_err(arg_span, SyntaxError::TS1141);
             Str {
+                node_id: Default::default(),
                 span: arg_span,
                 value: Wtf8Atom::default(),
                 raw: Some(atom!("\"\"")),
@@ -4076,6 +4177,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(TsImportType {
+            node_id: Default::default(),
             span: self.span(start),
             arg,
             qualifier,
@@ -4099,6 +4201,7 @@ impl<I: Tokens> Parser<I> {
         self.input_mut().eat(Token::Comma);
         expect!(self, Token::RBrace);
         Ok(TsImportCallOptions {
+            node_id: Default::default(),
             span: self.span(start),
             with: Box::new(value),
         })
@@ -4136,6 +4239,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(TsTypeQuery {
+            node_id: Default::default(),
             span: self.span(start),
             expr_name,
             type_args,
@@ -4157,6 +4261,7 @@ impl<I: Tokens> Parser<I> {
         })?;
 
         Ok(TsModuleBlock {
+            node_id: Default::default(),
             span: self.span(start),
             body,
         })
@@ -4175,6 +4280,7 @@ impl<I: Tokens> Parser<I> {
             let inner_start = self.cur_pos();
             let inner = self.parse_ts_module_or_ns_decl(inner_start, namespace)?;
             let inner = TsNamespaceDecl {
+                node_id: Default::default(),
                 span: inner.span,
                 id: match inner.id {
                     TsModuleName::Ident(i) => i,
@@ -4190,6 +4296,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(Box::new(TsModuleDecl {
+            node_id: Default::default(),
             span: self.span(start),
             declare: false,
             id: TsModuleName::Ident(id.into()),
@@ -4224,6 +4331,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         Ok(Box::new(TsModuleDecl {
+            node_id: Default::default(),
             span: self.span(start),
             declare: false,
             id,
@@ -4340,6 +4448,7 @@ impl<I: Tokens> Parser<I> {
                 Some(kind) if !peeked_is_dot => {
                     self.bump();
                     return Ok(Box::new(TsType::TsKeywordType(TsKeywordType {
+                        node_id: Default::default(),
                         span: self.span(start),
                         kind,
                     })));
@@ -4373,7 +4482,9 @@ impl<I: Tokens> Parser<I> {
 
             let lit = self.parse_lit()?;
             let lit = match lit {
-                Lit::Num(Number { span, value, raw }) => {
+                Lit::Num(Number {
+                    span, value, raw, ..
+                }) => {
                     if self.input().syntax().flow()
                         && raw.as_deref().is_some_and(is_legacy_octal_number_raw)
                     {
@@ -4392,12 +4503,15 @@ impl<I: Tokens> Parser<I> {
                     };
 
                     TsLit::Number(Number {
+                        node_id: Default::default(),
                         span,
                         value: -value,
                         raw: Some(new_raw.into()),
                     })
                 }
-                Lit::BigInt(BigInt { span, value, raw }) => {
+                Lit::BigInt(BigInt {
+                    span, value, raw, ..
+                }) => {
                     let mut new_raw = String::from("-");
 
                     match raw {
@@ -4410,6 +4524,7 @@ impl<I: Tokens> Parser<I> {
                     };
 
                     TsLit::BigInt(BigInt {
+                        node_id: Default::default(),
                         span,
                         value: Box::new(-*value),
                         raw: Some(new_raw.into()),
@@ -4419,6 +4534,7 @@ impl<I: Tokens> Parser<I> {
             };
 
             return Ok(Box::new(TsType::TsLitType(TsLitType {
+                node_id: Default::default(),
                 span: self.span(start),
                 lit,
             })));
@@ -4454,16 +4570,19 @@ impl<I: Tokens> Parser<I> {
             let span = self.span(start);
 
             let null_type = Box::new(TsType::TsKeywordType(TsKeywordType {
+                node_id: Default::default(),
                 span,
                 kind: TsKeywordTypeKind::TsNullKeyword,
             }));
             let undefined_type = Box::new(TsType::TsKeywordType(TsKeywordType {
+                node_id: Default::default(),
                 span,
                 kind: TsKeywordTypeKind::TsUndefinedKeyword,
             }));
 
             return Ok(Box::new(TsType::TsUnionOrIntersectionType(
                 TsUnionOrIntersectionType::TsUnionType(TsUnionType {
+                    node_id: Default::default(),
                     span,
                     types: vec![inner_type, null_type, undefined_type],
                 }),
@@ -4471,6 +4590,7 @@ impl<I: Tokens> Parser<I> {
         } else if self.input().syntax().flow() && cur == Token::Asterisk {
             self.bump();
             return Ok(Box::new(TsType::TsKeywordType(TsKeywordType {
+                node_id: Default::default(),
                 span: self.span(start),
                 kind: TsKeywordTypeKind::TsAnyKeyword,
             })));
@@ -4548,6 +4668,7 @@ impl<I: Tokens> Parser<I> {
                         .map(Some)?;
                     Ok(Some(
                         TsModuleDecl {
+                            node_id: Default::default(),
                             span: self.span(start),
                             global,
                             declare: false,
@@ -5131,30 +5252,49 @@ mod tests {
     use swc_atoms::atom;
     use swc_common::DUMMY_SP;
     use swc_ecma_ast::*;
-    use swc_ecma_visit::assert_eq_ignore_span;
+    use swc_ecma_visit::{assert_eq_ignore_span, VisitMut, VisitMutWith};
 
     use crate::{test_parser, Syntax};
 
+    struct NodeIdStripper;
+
+    impl VisitMut for NodeIdStripper {
+        fn visit_mut_node_id(&mut self, node_id: &mut NodeId) {
+            *node_id = NodeId::DUMMY;
+        }
+    }
+
+    fn strip_node_ids<N>(node: &mut N)
+    where
+        N: VisitMutWith<NodeIdStripper>,
+    {
+        node.visit_mut_with(&mut NodeIdStripper);
+    }
+
     #[test]
     fn issue_708_1() {
-        let actual = test_parser(
+        let mut actual = test_parser(
             "type test = -1;",
             Syntax::Typescript(Default::default()),
             |p| p.parse_module(),
         );
 
-        let expected = Module {
+        let mut expected = Module {
+            node_id: Default::default(),
             span: DUMMY_SP,
             shebang: None,
             body: {
                 let first = TsTypeAliasDecl {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     declare: false,
                     id: Ident::new_no_ctxt(atom!("test"), DUMMY_SP),
                     type_params: None,
                     type_ann: Box::new(TsType::TsLitType(TsLitType {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         lit: TsLit::Number(Number {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             value: -1.0,
                             raw: Some(atom!("-1")),
@@ -5166,18 +5306,21 @@ mod tests {
             },
         };
 
+        strip_node_ids(&mut actual);
+        strip_node_ids(&mut expected);
         assert_eq_ignore_span!(actual, expected);
     }
 
     #[test]
     fn issue_708_2() {
-        let actual = test_parser(
+        let mut actual = test_parser(
             "const t = -1;",
             Syntax::Typescript(Default::default()),
             |p| p.parse_module(),
         );
 
-        let expected = Module {
+        let mut expected = Module {
+            node_id: Default::default(),
             span: DUMMY_SP,
             shebang: None,
             body: {
@@ -5186,12 +5329,15 @@ mod tests {
                     kind: VarDeclKind::Const,
                     declare: false,
                     decls: vec![VarDeclarator {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         name: Pat::Ident(Ident::new_no_ctxt(atom!("t"), DUMMY_SP).into()),
                         init: Some(Box::new(Expr::Unary(UnaryExpr {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             op: op!(unary, "-"),
                             arg: Box::new(Expr::Lit(Lit::Num(Number {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 value: 1.0,
                                 raw: Some(atom!("1")),
@@ -5206,6 +5352,8 @@ mod tests {
             },
         };
 
+        strip_node_ids(&mut actual);
+        strip_node_ids(&mut expected);
         assert_eq_ignore_span!(actual, expected);
     }
 }

--- a/crates/swc_ecma_parser/tests/common/mod.rs
+++ b/crates/swc_ecma_parser/tests/common/mod.rs
@@ -31,7 +31,9 @@ impl Fold for Normalizer {
             }
             .into(),
             // Flatten comma expressions.
-            Expr::Seq(SeqExpr { mut exprs, span }) => {
+            Expr::Seq(SeqExpr {
+                mut exprs, span, ..
+            }) => {
                 let need_work = exprs.iter().any(|n| matches!(**n, Expr::Seq(..)));
 
                 if need_work {
@@ -43,7 +45,12 @@ impl Fold for Normalizer {
                         v
                     });
                 }
-                SeqExpr { exprs, span }.into()
+                SeqExpr {
+                    node_id: Default::default(),
+                    exprs,
+                    span,
+                }
+                .into()
             }
             _ => e,
         }
@@ -105,11 +112,13 @@ impl Fold for Normalizer {
 
         match n {
             PropName::Ident(IdentName { span, sym, .. }) => PropName::Str(Str {
+                node_id: Default::default(),
                 span,
                 value: sym.into(),
                 raw: None,
             }),
             PropName::Num(num) => PropName::Str(Str {
+                node_id: Default::default(),
                 span: num.span,
                 value: num.to_string().into(),
                 raw: None,
@@ -131,6 +140,7 @@ impl Fold for Normalizer {
 
         if self.is_test262 {
             Str {
+                node_id: Default::default(),
                 span,
                 value: s.value,
                 raw: None,

--- a/crates/swc_ecma_parser/tests/test262.rs
+++ b/crates/swc_ecma_parser/tests/test262.rs
@@ -12,7 +12,7 @@ use std::{
 use common::Normalizer;
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, PResult, Parser, Syntax};
-use swc_ecma_visit::FoldWith;
+use swc_ecma_visit::{Fold, FoldWith};
 use test::{
     test_main, DynTestFn, Options, ShouldPanic::No, TestDesc, TestDescAndFn, TestName, TestType,
 };
@@ -291,14 +291,13 @@ fn identity_tests(tests: &mut Vec<TestDescAndFn>) -> Result<(), io::Error> {
                 let json =
                     serde_json::to_string_pretty(&src).expect("failed to serialize module as json");
 
-                let deser = serde_json::from_str::<Module>(&json)
-                    .unwrap_or_else(|err| {
-                        panic!("failed to deserialize json back to module: {err}\n{json}")
-                    })
-                    .fold_with(&mut Normalizer {
-                        drop_span: true,
-                        is_test262: true,
-                    });
+                let deser = normalize(
+                    serde_json::from_str::<serde_json::Value>(&json)
+                        .and_then(serde_json::from_value::<Module>)
+                        .unwrap_or_else(|err| {
+                            panic!("failed to deserialize json back to module: {err}\n{json}")
+                        }),
+                );
                 assert_eq!(src, deser, "JSON:\n{json}");
             } else {
                 let p = |explicit| {
@@ -371,13 +370,21 @@ fn error() {
     test_main(&args, tests, Some(Options::new()));
 }
 
-pub fn normalize<T>(t: T) -> T
+fn normalize<T>(t: T) -> T
 where
-    T: FoldWith<Normalizer>,
+    T: FoldWith<Normalizer> + FoldWith<NodeIdNormalizer>,
 {
     let mut n = Normalizer {
         drop_span: true,
         is_test262: true,
     };
-    t.fold_with(&mut n)
+    t.fold_with(&mut n).fold_with(&mut NodeIdNormalizer)
+}
+
+struct NodeIdNormalizer;
+
+impl Fold for NodeIdNormalizer {
+    fn fold_node_id(&mut self, _: NodeId) -> NodeId {
+        NodeId::DUMMY
+    }
 }

--- a/crates/swc_ecma_quote_macros/src/ast/mod.rs
+++ b/crates/swc_ecma_quote_macros/src/ast/mod.rs
@@ -67,7 +67,7 @@ macro_rules! impl_struct {
             fn to_code(&self, cx: &crate::ctxt::Ctx) -> syn::Expr {
                 let mut builder = crate::builder::Builder::new(stringify!($name));
 
-                let Self { $($v,)* } = self;
+                let Self { $($v,)* .. } = self;
 
                 $(
                     builder.add(

--- a/crates/swc_ecma_transformer/src/common/statement_injector.rs
+++ b/crates/swc_ecma_transformer/src/common/statement_injector.rs
@@ -89,6 +89,7 @@ impl VisitMutHook<TraverseCtx> for StmtInjector {
             *node.body = BlockStmtOrExpr::BlockStmt(BlockStmt {
                 span: DUMMY_SP,
                 stmts: vec![Stmt::Return(ReturnStmt {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     arg: Some(expr.take()),
                 })],
@@ -211,8 +212,10 @@ mod tests {
 
     fn labeled_stmt(label: &str) -> Stmt {
         Stmt::Expr(ExprStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             expr: Box::new(Expr::Lit(Lit::Str(Str {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 value: label.into(),
                 raw: None,
@@ -233,6 +236,7 @@ mod tests {
 
     fn empty_named_export() -> ModuleItem {
         ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(NamedExport {
+            node_id: Default::default(),
             span: DUMMY_SP,
             specifiers: Vec::new(),
             src: None,

--- a/crates/swc_ecma_transformer/src/common/var_declarations.rs
+++ b/crates/swc_ecma_transformer/src/common/var_declarations.rs
@@ -74,6 +74,7 @@ impl VarDeclarationsStore {
     #[inline]
     pub fn insert_var(&mut self, ident: BindingIdent, init: Option<Box<Expr>>) {
         let declarator = VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: Pat::Ident(ident),
             init,
@@ -87,6 +88,7 @@ impl VarDeclarationsStore {
     #[inline]
     pub fn insert_let(&mut self, ident: BindingIdent, init: Option<Box<Expr>>) {
         let declarator = VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: Pat::Ident(ident),
             init,
@@ -100,6 +102,7 @@ impl VarDeclarationsStore {
     #[inline]
     pub fn insert_var_pattern(&mut self, pattern: Pat, init: Option<Box<Expr>>) {
         let declarator = VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: pattern,
             init,
@@ -113,6 +116,7 @@ impl VarDeclarationsStore {
     #[inline]
     pub fn insert_let_pattern(&mut self, pattern: Pat, init: Option<Box<Expr>>) {
         let declarator = VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: pattern,
             init,

--- a/crates/swc_ecma_transformer/src/es2015/duplicate_keys.rs
+++ b/crates/swc_ecma_transformer/src/es2015/duplicate_keys.rs
@@ -85,7 +85,9 @@ impl PropFolder {
                     || !self.setter_props.insert(ident.sym.clone())
                 {
                     *prop = Prop::KeyValue(KeyValueProp {
+                        node_id: Default::default(),
                         key: PropName::Computed(ComputedPropName {
+                            node_id: Default::default(),
                             span: ident.span,
                             expr: quote_str!(ident.sym.clone()).into(),
                         }),
@@ -125,8 +127,10 @@ impl PropFolder {
                         }
                         if should_transform {
                             *key = PropName::Computed(ComputedPropName {
+                                node_id: Default::default(),
                                 span,
                                 expr: Lit::Str(Str {
+                                    node_id: Default::default(),
                                     span,
                                     raw: None,
                                     value: ident.sym.clone().into(),
@@ -145,6 +149,7 @@ impl PropFolder {
                         }
                         if should_transform {
                             *key = PropName::Computed(ComputedPropName {
+                                node_id: Default::default(),
                                 span: s.span,
                                 expr: s.clone().into(),
                             });
@@ -177,8 +182,10 @@ impl PropFolder {
             PropName::Ident(ident) => {
                 if !props.insert(ident.sym.clone()) {
                     *name = PropName::Computed(ComputedPropName {
+                        node_id: Default::default(),
                         span,
                         expr: Lit::Str(Str {
+                            node_id: Default::default(),
                             span,
                             raw: None,
                             value: ident.sym.clone().into(),
@@ -190,6 +197,7 @@ impl PropFolder {
             PropName::Str(s) => {
                 if !props.insert(atom_from_wtf8(&s.value)) {
                     *name = PropName::Computed(ComputedPropName {
+                        node_id: Default::default(),
                         span: s.span,
                         expr: s.clone().into(),
                     })

--- a/crates/swc_ecma_transformer/src/es2015/instanceof.rs
+++ b/crates/swc_ecma_transformer/src/es2015/instanceof.rs
@@ -60,6 +60,7 @@ impl VisitMutHook<TraverseCtx> for InstanceOfPass {
             left,
             op: op!("instanceof"),
             right,
+            ..
         }) = expr
         {
             let instanceof_span = Span {

--- a/crates/swc_ecma_transformer/src/es2015/shorthand.rs
+++ b/crates/swc_ecma_transformer/src/es2015/shorthand.rs
@@ -49,8 +49,10 @@ impl VisitMutHook<TraverseCtx> for ShorthandPass {
                 let value = ident.clone().into();
 
                 *prop = Prop::KeyValue(KeyValueProp {
+                    node_id: Default::default(),
                     key: if ident.sym == "__proto__" {
                         PropName::Computed(ComputedPropName {
+                            node_id: Default::default(),
                             span: ident.span,
                             expr: ident.sym.clone().into(),
                         })
@@ -60,10 +62,11 @@ impl VisitMutHook<TraverseCtx> for ShorthandPass {
                     value,
                 });
             }
-            Prop::Method(MethodProp { key, function }) => {
+            Prop::Method(MethodProp { key, function, .. }) => {
                 let key = match key.take() {
                     PropName::Ident(IdentName { span, sym, .. }) if sym == "__proto__" => {
                         ComputedPropName {
+                            node_id: Default::default(),
                             span,
                             expr: sym.into(),
                         }
@@ -73,6 +76,7 @@ impl VisitMutHook<TraverseCtx> for ShorthandPass {
                         if s.value.as_str() == Some("__proto__") =>
                     {
                         ComputedPropName {
+                            node_id: Default::default(),
                             span,
                             expr: s.into(),
                         }
@@ -81,8 +85,10 @@ impl VisitMutHook<TraverseCtx> for ShorthandPass {
                     key => key,
                 };
                 *prop = Prop::KeyValue(KeyValueProp {
+                    node_id: Default::default(),
                     key,
                     value: FnExpr {
+                        node_id: Default::default(),
                         ident: None,
                         function: function.take(),
                     }

--- a/crates/swc_ecma_transformer/src/es2015/sticky_regex.rs
+++ b/crates/swc_ecma_transformer/src/es2015/sticky_regex.rs
@@ -34,7 +34,10 @@ struct StickyRegexPass;
 
 impl VisitMutHook<TraverseCtx> for StickyRegexPass {
     fn exit_expr(&mut self, e: &mut Expr, _ctx: &mut TraverseCtx) {
-        if let Expr::Lit(Lit::Regex(Regex { exp, flags, span })) = e {
+        if let Expr::Lit(Lit::Regex(Regex {
+            exp, flags, span, ..
+        })) = e
+        {
             if flags.contains('y') {
                 *e = NewExpr {
                     span: *span,

--- a/crates/swc_ecma_transformer/src/es2015/typeof_symbol.rs
+++ b/crates/swc_ecma_transformer/src/es2015/typeof_symbol.rs
@@ -111,6 +111,7 @@ impl VisitMutHook<TraverseCtx> for TypeofSymbolPass {
             span,
             op: op!("typeof"),
             arg,
+            ..
         }) = expr
         {
             match &**arg {
@@ -118,10 +119,12 @@ impl VisitMutHook<TraverseCtx> for TypeofSymbolPass {
                     let undefined_str: Box<Expr> = quote_str!("undefined").into();
 
                     let test = BinExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         op: op!("==="),
                         left: Box::new(
                             UnaryExpr {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 op: op!("typeof"),
                                 arg: arg.clone(),
@@ -141,6 +144,7 @@ impl VisitMutHook<TraverseCtx> for TypeofSymbolPass {
                     .into();
 
                     *expr = CondExpr {
+                        node_id: Default::default(),
                         span: *span,
                         test,
                         cons: undefined_str,

--- a/crates/swc_ecma_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/swc_ecma_transformer/src/es2016/exponentiation_operator.rs
@@ -93,9 +93,11 @@ impl ExponentiationOperatorPass {
                 let pow_call = create_math_pow(pow_left, right);
 
                 *expr = Expr::Assign(AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: AssignOp::Assign,
                     left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                        node_id: Default::default(),
                         id: left,
                         type_ann: None,
                     })),
@@ -145,9 +147,11 @@ impl ExponentiationOperatorPass {
 
             // Add assignment to sequence: _obj = obj
             sequence_exprs.push(Expr::Assign(AssignExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 op: AssignOp::Assign,
                 left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                    node_id: Default::default(),
                     id: temp_ident.clone(),
                     type_ann: None,
                 })),
@@ -165,6 +169,7 @@ impl ExponentiationOperatorPass {
             MemberProp::Ident(prop_name) => {
                 // Create Math.pow(obj.prop, right)
                 let pow_left = Box::new(Expr::Member(MemberExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     obj: obj_for_pow,
                     prop: MemberProp::Ident(prop_name.clone()),
@@ -173,9 +178,11 @@ impl ExponentiationOperatorPass {
 
                 // obj.prop = Math.pow(obj.prop, right)
                 let assignment = Expr::Assign(AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: AssignOp::Assign,
                     left: AssignTarget::Simple(SimpleAssignTarget::Member(MemberExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         obj: final_obj,
                         prop: MemberProp::Ident(prop_name),
@@ -186,6 +193,7 @@ impl ExponentiationOperatorPass {
                 if needs_obj_temp {
                     sequence_exprs.push(assignment);
                     *expr = Expr::Seq(SeqExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         exprs: sequence_exprs.into_iter().map(Box::new).collect(),
                     });
@@ -214,9 +222,11 @@ impl ExponentiationOperatorPass {
 
                     // Add assignment to sequence: _prop = prop
                     sequence_exprs.push(Expr::Assign(AssignExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         op: AssignOp::Assign,
                         left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                            node_id: Default::default(),
                             id: temp_ident.clone(),
                             type_ann: None,
                         })),
@@ -231,9 +241,11 @@ impl ExponentiationOperatorPass {
 
                 // Create Math.pow(obj[computed], right)
                 let pow_left = Box::new(Expr::Member(MemberExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     obj: obj_for_pow,
                     prop: MemberProp::Computed(ComputedPropName {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         expr: prop_for_pow,
                     }),
@@ -242,12 +254,15 @@ impl ExponentiationOperatorPass {
 
                 // obj[computed] = Math.pow(obj[computed], right)
                 let assignment = Expr::Assign(AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: AssignOp::Assign,
                     left: AssignTarget::Simple(SimpleAssignTarget::Member(MemberExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         obj: final_obj,
                         prop: MemberProp::Computed(ComputedPropName {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             expr: final_prop,
                         }),
@@ -258,6 +273,7 @@ impl ExponentiationOperatorPass {
                 if needs_obj_temp || needs_prop_temp {
                     sequence_exprs.push(assignment);
                     *expr = Expr::Seq(SeqExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         exprs: sequence_exprs.into_iter().map(Box::new).collect(),
                     });
@@ -281,27 +297,33 @@ fn is_literal_expr(expr: &Expr) -> bool {
 /// Create `Math.pow(left, right)` call expression
 fn create_math_pow(left: Box<Expr>, right: Box<Expr>) -> Expr {
     Expr::Call(CallExpr {
+        node_id: Default::default(),
         span: DUMMY_SP,
         ctxt: SyntaxContext::empty(),
         callee: Callee::Expr(Box::new(Expr::Member(MemberExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             obj: Box::new(Expr::Ident(Ident {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 ctxt: SyntaxContext::empty(),
                 sym: "Math".into(),
                 optional: false,
             })),
             prop: MemberProp::Ident(IdentName {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 sym: "pow".into(),
             }),
         }))),
         args: vec![
             ExprOrSpread {
+                node_id: Default::default(),
                 spread: None,
                 expr: left,
             },
             ExprOrSpread {
+                node_id: Default::default(),
                 spread: None,
                 expr: right,
             },

--- a/crates/swc_ecma_transformer/src/es2017/async_to_generator.rs
+++ b/crates/swc_ecma_transformer/src/es2017/async_to_generator.rs
@@ -100,6 +100,7 @@ impl VisitMutHook<TraverseCtx> for AsyncToGeneratorPass {
                     .count();
                 for i in 0..fn_len {
                     params.push(Param {
+                        node_id: Default::default(),
                         pat: private_ident!(format!("_{}", i)).into(),
                         span: DUMMY_SP,
                         decorators: vec![],
@@ -287,9 +288,11 @@ impl VisitMutHook<TraverseCtx> for AsyncToGeneratorPass {
 
                         // Add `var _this;` at the beginning
                         let decl = VarDecl {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             kind: VarDeclKind::Var,
                             decls: vec![VarDeclarator {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 name: this_var.into(),
                                 init: None,
@@ -340,7 +343,7 @@ impl VisitMutHook<TraverseCtx> for AsyncToGeneratorPass {
             Expr::Ident(Ident { sym, .. }) if sym == "arguments" => {
                 fn_state.use_arguments = true;
             }
-            Expr::Await(AwaitExpr { arg, span }) => {
+            Expr::Await(AwaitExpr { arg, span, .. }) => {
                 *expr = if fn_state.is_generator {
                     let callee = helper!(await_async_generator);
                     let arg = CallExpr {
@@ -351,12 +354,14 @@ impl VisitMutHook<TraverseCtx> for AsyncToGeneratorPass {
                     }
                     .into();
                     YieldExpr {
+                        node_id: Default::default(),
                         span: *span,
                         delegate: false,
                         arg: Some(arg),
                     }
                 } else {
                     YieldExpr {
+                        node_id: Default::default(),
                         span: *span,
                         delegate: false,
                         arg: Some(arg.take()),
@@ -368,6 +373,7 @@ impl VisitMutHook<TraverseCtx> for AsyncToGeneratorPass {
                 span,
                 arg: Some(arg),
                 delegate: true,
+                ..
             }) => {
                 let async_iter =
                     helper_expr!(async_iterator).as_call(DUMMY_SP, vec![arg.take().as_arg()]);
@@ -377,6 +383,7 @@ impl VisitMutHook<TraverseCtx> for AsyncToGeneratorPass {
                     .into();
 
                 *expr = YieldExpr {
+                    node_id: Default::default(),
                     span: *span,
                     delegate: true,
                     arg: Some(arg),
@@ -417,7 +424,10 @@ fn make_fn_ref(fn_state: &FnState, params: Vec<Param>, body: BlockStmt) -> Expr 
         helper_expr!(DUMMY_SP, async_to_generator)
     }
     .as_callee();
-    let this = ThisExpr { span: DUMMY_SP };
+    let this = ThisExpr {
+        node_id: Default::default(),
+        span: DUMMY_SP,
+    };
     let arguments = quote_ident!("arguments");
 
     let inner_fn = Function {
@@ -506,6 +516,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
         {
             // let value = _step.value;
             let value_var = VarDeclarator {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 name: value.clone().into(),
                 init: Some(step.clone().make_member(quote_ident!("value")).into()),
@@ -527,6 +538,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             ForHead::VarDecl(v) => {
                 let var = v.decls.into_iter().next().unwrap();
                 let var_decl = VarDeclarator {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     name: var.name,
                     init: Some(value.into()),
@@ -546,8 +558,10 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             ForHead::Pat(p) => {
                 for_loop_body.push(
                     ExprStmt {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         expr: AssignExpr {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             op: op!("="),
                             left: p.try_into().unwrap(),
@@ -577,6 +591,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
         let mut init_var_decls = Vec::new();
         // _iterator = _async_iterator(lol())
         init_var_decls.push(VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: iterator.clone().into(),
             init: {
@@ -595,6 +610,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             definite: false,
         });
         init_var_decls.push(VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: step.clone().into(),
             init: None,
@@ -602,6 +618,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
         });
 
         let for_stmt = ForStmt {
+            node_id: Default::default(),
             span: s.span,
             // var _iterator = _async_iterator(lol()), _step;
             init: Some(
@@ -637,10 +654,12 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
                 };
 
                 let assign_to_step: Expr = AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: op!("="),
                     left: step.into(),
                     right: YieldExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         arg: Some(yield_arg),
                         delegate: false,
@@ -650,6 +669,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
                 .into();
 
                 let right = UnaryExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: op!("!"),
                     arg: assign_to_step.make_member(quote_ident!("done")).into(),
@@ -660,6 +680,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
 
                 Some(
                     AssignExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         op: op!("="),
                         left,
@@ -671,6 +692,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             // _iteratorNormalCompletion = true
             update: Some(
                 AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: op!("="),
                     left: iterator_abrupt_completion.clone().into(),
@@ -692,8 +714,10 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
     let catch_clause = {
         // _didIteratorError = true;
         let mark_as_errorred = ExprStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             expr: AssignExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 op: op!("="),
                 left: did_iteration_error.clone().into(),
@@ -704,8 +728,10 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
         .into();
         // _iteratorError = err;
         let store_error = ExprStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             expr: AssignExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 op: op!("="),
                 left: iterator_error.clone().into(),
@@ -716,6 +742,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
         .into();
 
         CatchClause {
+            node_id: Default::default(),
             span: DUMMY_SP,
             param: Some(err_param.into()),
             body: BlockStmt {
@@ -727,11 +754,13 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
 
     let finally_block = {
         let throw_iterator_error = ThrowStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             arg: iterator_error.clone().into(),
         }
         .into();
         let throw_iterator_error = IfStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             test: did_iteration_error.clone().into(),
             cons: Box::new(Stmt::Block(BlockStmt {
@@ -758,8 +787,10 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
         // or
         // yield _awaitAsyncGenerator(_iterator.return());
         let yield_stmt = ExprStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             expr: YieldExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 delegate: false,
                 arg: Some(if is_async_generator {
@@ -779,9 +810,11 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
         .into();
 
         let conditional_yield = IfStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             // _iteratorAbruptCompletion && _iterator.return != null
             test: BinExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 op: op!("&&"),
                 // _iteratorAbruptCompletion
@@ -789,10 +822,15 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
                 // _iterator.return != null
                 right: Box::new(
                     BinExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         op: op!("!="),
                         left: iterator.make_member(quote_ident!("return")).into(),
-                        right: Null { span: DUMMY_SP }.into(),
+                        right: Null {
+                            node_id: Default::default(),
+                            span: DUMMY_SP,
+                        }
+                        .into(),
                     }
                     .into(),
                 ),
@@ -811,6 +849,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
         };
 
         let inner_try = TryStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             block: body,
             handler: None,
@@ -827,6 +866,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
     };
 
     let try_stmt = TryStmt {
+        node_id: Default::default(),
         span: s.span,
         block: try_body,
         handler: Some(catch_clause),
@@ -839,6 +879,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
             decls: vec![
                 // var _iteratorAbruptCompletion = false;
                 VarDeclarator {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     name: iterator_abrupt_completion.into(),
                     init: Some(false.into()),
@@ -846,6 +887,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
                 },
                 // var _didIteratorError = false;
                 VarDeclarator {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     name: did_iteration_error.into(),
                     init: Some(false.into()),
@@ -853,6 +895,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
                 },
                 // var _iteratorError;
                 VarDeclarator {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     name: iterator_error.into(),
                     init: None,

--- a/crates/swc_ecma_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transformer/src/es2018/object_rest_spread.rs
@@ -65,7 +65,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
     // Object Spread and Rest: Transform { ...x } and ({ ...x } = y)
     fn exit_expr(&mut self, expr: &mut Expr, ctx: &mut TraverseCtx) {
         // Handle object spread FIRST (fast path for most common case)
-        if let Expr::Object(ObjectLit { span, props }) = expr {
+        if let Expr::Object(ObjectLit { span, props, .. }) = expr {
             // Quick check for spread
             if !props.iter().any(|p| matches!(p, PropOrSpread::Spread(..))) {
                 return;
@@ -81,6 +81,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
             let args = {
                 let mut buf = Vec::new();
                 let mut obj = ObjectLit {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     props: Vec::new(),
                 };
@@ -149,6 +150,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
             left: AssignTarget::Pat(pat),
             op: op!("="),
             right,
+            ..
         }) = expr
         else {
             return;
@@ -174,6 +176,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
             out.ctx
                 .var_declarations
                 .insert_var_declarator(VarDeclarator {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     name: ref_ident.clone().into(),
                     init: None,
@@ -182,6 +185,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
             // _ref = source
             out.exprs.push(
                 AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     left: ref_ident.clone().into(),
                     op: op!("="),
@@ -199,7 +203,12 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
         let exprs = lowerer.out.into_exprs();
 
         let exprs = exprs.into_iter().map(Box::new).collect();
-        *expr = SeqExpr { span: *span, exprs }.into();
+        *expr = SeqExpr {
+            node_id: Default::default(),
+            span: *span,
+            exprs,
+        }
+        .into();
     }
 
     // Object Rest: Transform variable declarations
@@ -232,6 +241,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
             let source_init = if aliased {
                 // Need temp variable for complex expression
                 new_decls.push(VarDeclarator {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     name: ref_ident.clone().into(),
                     init: Some(init),
@@ -309,6 +319,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
                         let mut body_stmts = stmts;
                         body_stmts.push(
                             ReturnStmt {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 arg: Some(expr.take()),
                             }
@@ -453,6 +464,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
                 ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(ExportDecl {
                     span,
                     decl: Decl::Var(var_decl),
+                    ..
                 })) => {
                     let var_decl_ptr = &*var_decl as *const VarDecl;
 
@@ -462,11 +474,13 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
                         if !exported_names.is_empty() {
                             rewritten.push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(
                                 NamedExport {
+                                    node_id: Default::default(),
                                     span,
                                     specifiers: exported_names
                                         .into_iter()
                                         .map(|id| {
                                             ExportSpecifier::Named(ExportNamedSpecifier {
+                                                node_id: Default::default(),
                                                 span: DUMMY_SP,
                                                 orig: ModuleExportName::Ident(id),
                                                 exported: None,
@@ -483,6 +497,7 @@ impl VisitMutHook<TraverseCtx> for ObjectRestSpreadPass {
                     } else {
                         rewritten.push(ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(
                             ExportDecl {
+                                node_id: Default::default(),
                                 span,
                                 decl: Decl::Var(var_decl),
                             },
@@ -548,6 +563,7 @@ impl ObjectRestSpreadPass {
                 let ref_ident = private_ident!("_ref");
 
                 ctx.var_declarations.insert_var_declarator(VarDeclarator {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     name: ref_ident.clone().into(),
                     init: None,
@@ -564,6 +580,7 @@ impl ObjectRestSpreadPass {
 
                 let exprs = exprs.into_iter().map(Box::new).collect();
                 let assign_stmt: Stmt = SeqExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     exprs,
                 }
@@ -801,6 +818,7 @@ impl<O: RestOutput> RestLowerer<O> {
         // Continue with remaining properties
         if let Some(after_init) = after_init {
             let remaining = ObjectPat {
+                node_id: Default::default(),
                 span,
                 props: remaining_props,
                 optional: false,
@@ -872,6 +890,7 @@ impl<O: RestOutput> RestLowerer<O> {
         let remaining = if !remaining_elems.is_empty() {
             let tail_ref = self.out.declare_temp("_rest");
             arr.elems.push(Some(Pat::Rest(RestPat {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 arg: Box::new(tail_ref.clone().into()),
                 dot3_token: DUMMY_SP,
@@ -891,6 +910,7 @@ impl<O: RestOutput> RestLowerer<O> {
         // Continue with remaining elements
         if let Some((tail_ref, remaining_elems)) = remaining {
             let remaining_arr = ArrayPat {
+                node_id: Default::default(),
                 span,
                 elems: remaining_elems,
                 optional: false,
@@ -927,6 +947,7 @@ impl<'a> DeclOutput<'a> {
 impl<'a> RestOutput for DeclOutput<'a> {
     fn assign(&mut self, pat: Pat, init: Box<Expr>) {
         self.decls.push(VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: pat,
             init: Some(init),
@@ -944,6 +965,7 @@ impl<'a> RestOutput for DeclOutput<'a> {
             _ => {
                 let temp = private_ident!("_ref");
                 self.decls.push(VarDeclarator {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     name: temp.clone().into(),
                     init: Some(init),
@@ -979,6 +1001,7 @@ impl<'a> RestOutput for ExprOutput<'a> {
         if let Ok(target) = pat.try_into() {
             self.exprs.push(
                 AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     left: target,
                     op: op!("="),
@@ -995,6 +1018,7 @@ impl<'a> RestOutput for ExprOutput<'a> {
         self.ctx
             .var_declarations
             .insert_var_declarator(VarDeclarator {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 name: temp.clone().into(),
                 init: None,
@@ -1011,6 +1035,7 @@ impl<'a> RestOutput for ExprOutput<'a> {
                 let temp = self.declare_temp("_ref");
                 self.exprs.push(
                     AssignExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         left: temp.clone().into(),
                         op: op!("="),
@@ -1056,6 +1081,7 @@ fn make_rest_call(config: Config, source: Ident, excluded: Vec<PropName>) -> Exp
                 PropName::Ident(id) => Expr::Lit(Lit::Str(id.sym.into())),
                 PropName::Str(s) => Expr::Lit(Lit::Str(s)),
                 PropName::Num(n) => Expr::Lit(Lit::Str(Str {
+                    node_id: Default::default(),
                     span: n.span,
                     value: n.value.to_string().into(),
                     raw: None,
@@ -1068,6 +1094,7 @@ fn make_rest_call(config: Config, source: Ident, excluded: Vec<PropName>) -> Exp
                 .into(),
                 PropName::Computed(c) => *c.expr,
                 PropName::BigInt(b) => Expr::Lit(Lit::Str(Str {
+                    node_id: Default::default(),
                     span: b.span,
                     value: b.value.to_string().into(),
                     raw: None,
@@ -1129,6 +1156,7 @@ impl<'a> ParamCollector<'a> {
             Pat::Rest(rest_pat) => mem::replace(&mut *rest_pat.arg, temp.clone().into()),
             Pat::Assign(pat) => {
                 let init = AssignPat {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     left: Box::new(temp.clone().into()),
                     right: Expr::undefined(DUMMY_SP),
@@ -1174,6 +1202,7 @@ impl<'a> ParamCollector<'a> {
                         VarDecl {
                             kind: VarDeclKind::Let,
                             decls: vec![VarDeclarator {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 name: pat,
                                 init: Some(init_arg.expr),
@@ -1202,10 +1231,12 @@ impl<'a> ParamCollector<'a> {
             // Step 1: Create array variable: _ref = [temps...]
             let array_temp = private_ident!("_ref");
             decls.push(VarDeclarator {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 name: array_temp.clone().into(),
                 init: Some(Box::new(
                     ArrayLit {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         elems: self.temp_exprs.into_iter().map(Some).collect(),
                     }
@@ -1236,6 +1267,7 @@ impl<'a> ParamCollector<'a> {
                     // Create the element pattern, preserving default value if present
                     let elem_pat = if let Pat::Assign(ref assign_pat) = pat {
                         Pat::Assign(AssignPat {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             left: Box::new(temp.clone().into()),
                             right: assign_pat.right.clone(),
@@ -1248,8 +1280,10 @@ impl<'a> ParamCollector<'a> {
                     if is_last {
                         // Last element: [temp] = current_array or [temp = default] = current_array
                         decls.push(VarDeclarator {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             name: ArrayPat {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 elems: vec![Some(elem_pat)],
                                 optional: false,
@@ -1264,12 +1298,15 @@ impl<'a> ParamCollector<'a> {
                         // current_array
                         let rest = private_ident!("_rest");
                         decls.push(VarDeclarator {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             name: ArrayPat {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 elems: vec![
                                     Some(elem_pat),
                                     Some(Pat::Rest(RestPat {
+                                        node_id: Default::default(),
                                         span: DUMMY_SP,
                                         arg: Box::new(rest.clone().into()),
                                         dot3_token: DUMMY_SP,
@@ -1301,8 +1338,10 @@ impl<'a> ParamCollector<'a> {
                     if is_last {
                         // Last element: [pattern] = current_array
                         decls.push(VarDeclarator {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             name: ArrayPat {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 elems: vec![Some(pat)],
                                 optional: false,
@@ -1316,12 +1355,15 @@ impl<'a> ParamCollector<'a> {
                         // Not last: [pattern, ...rest] = current_array
                         let rest = private_ident!("_rest");
                         decls.push(VarDeclarator {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             name: ArrayPat {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 elems: vec![
                                     Some(pat),
                                     Some(Pat::Rest(RestPat {
+                                        node_id: Default::default(),
                                         span: DUMMY_SP,
                                         arg: Box::new(rest.clone().into()),
                                         dot3_token: DUMMY_SP,
@@ -1351,6 +1393,7 @@ impl<'a> ParamCollector<'a> {
         } else {
             // No rest - simple array destructuring
             let array_pat = Pat::Array(ArrayPat {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 elems: self.collected_pats.into_iter().map(Some).collect(),
                 optional: false,
@@ -1359,6 +1402,7 @@ impl<'a> ParamCollector<'a> {
 
             let array_init = Box::new(
                 ArrayLit {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     elems: self.temp_exprs.into_iter().map(Some).collect(),
                 }
@@ -1369,6 +1413,7 @@ impl<'a> ParamCollector<'a> {
                 VarDecl {
                     kind: VarDeclKind::Let,
                     decls: vec![VarDeclarator {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         name: array_pat,
                         init: Some(array_init),
@@ -1410,8 +1455,12 @@ fn collect_idents_from_pat(pat: &Pat, out: &mut Vec<Ident>) {
 }
 
 fn pat_to_assign_target_pat(pat: Pat) -> AssignTargetPat {
-    pat.try_into()
-        .unwrap_or_else(|p: Pat| AssignTargetPat::Invalid(Invalid { span: p.span() }))
+    pat.try_into().unwrap_or_else(|p: Pat| {
+        AssignTargetPat::Invalid(Invalid {
+            node_id: Default::default(),
+            span: p.span(),
+        })
+    })
 }
 
 fn is_lit_str(expr: &Expr) -> bool {

--- a/crates/swc_ecma_transformer/src/es2020/export_namespace_from.rs
+++ b/crates/swc_ecma_transformer/src/es2020/export_namespace_from.rs
@@ -38,6 +38,7 @@ impl ExportNamespaceFromPass {
                     src: Some(src),
                     type_only: false,
                     with,
+                    ..
                 })) if specifiers.iter().any(|s| s.is_namespace()) => {
                     let mut origin_specifiers = Vec::new();
 
@@ -46,7 +47,11 @@ impl ExportNamespaceFromPass {
 
                     for s in specifiers.into_iter() {
                         match s {
-                            ExportSpecifier::Namespace(ExportNamespaceSpecifier { span, name }) => {
+                            ExportSpecifier::Namespace(ExportNamespaceSpecifier {
+                                span,
+                                name,
+                                ..
+                            }) => {
                                 let local_bridge = private_ident!(format!(
                                     "_{}",
                                     normalize_module_export_name(&name)
@@ -54,12 +59,14 @@ impl ExportNamespaceFromPass {
 
                                 import_specifiers.push(ImportSpecifier::Namespace(
                                     ImportStarAsSpecifier {
+                                        node_id: Default::default(),
                                         span,
                                         local: local_bridge.clone(),
                                     },
                                 ));
                                 export_specifiers.push(ExportSpecifier::Named(
                                     ExportNamedSpecifier {
+                                        node_id: Default::default(),
                                         span,
                                         orig: local_bridge.into(),
                                         exported: Some(name),
@@ -77,6 +84,7 @@ impl ExportNamespaceFromPass {
 
                     stmts.push(
                         ImportDecl {
+                            node_id: Default::default(),
                             span,
                             specifiers: import_specifiers,
                             src: src.clone(),
@@ -89,6 +97,7 @@ impl ExportNamespaceFromPass {
 
                     stmts.push(
                         NamedExport {
+                            node_id: Default::default(),
                             span,
                             specifiers: export_specifiers,
                             src: None,
@@ -101,6 +110,7 @@ impl ExportNamespaceFromPass {
                     if !origin_specifiers.is_empty() {
                         stmts.push(
                             NamedExport {
+                                node_id: Default::default(),
                                 span,
                                 specifiers: origin_specifiers,
                                 src: Some(src),

--- a/crates/swc_ecma_transformer/src/es2020/nullish_coalescing.rs
+++ b/crates/swc_ecma_transformer/src/es2020/nullish_coalescing.rs
@@ -97,9 +97,11 @@ impl NullishCoalescingPass {
         let (test_expr, cons_expr) = if needs_temp {
             // Complex left side: (_ref = left) !== null && _ref !== void 0 ? _ref : right
             let assign_expr = Box::new(Expr::Assign(AssignExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 op: AssignOp::Assign,
                 left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                    node_id: Default::default(),
                     id: alias_ident.clone(),
                     type_ann: None,
                 })),
@@ -119,6 +121,7 @@ impl NullishCoalescingPass {
         };
 
         *expr = Expr::Cond(CondExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             test: test_expr,
             cons: cons_expr,
@@ -149,13 +152,16 @@ impl NullishCoalescingPass {
                 );
 
                 *expr = Expr::Assign(AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: AssignOp::Assign,
                     left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                        node_id: Default::default(),
                         id: ident_ref.clone(),
                         type_ann: None,
                     })),
                     right: Box::new(Expr::Cond(CondExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         test,
                         cons: Box::new(Expr::Ident(ident_ref)),
@@ -175,9 +181,11 @@ impl NullishCoalescingPass {
 
                 // Create: (_ref = left) !== null && _ref !== void 0 ? _ref : (left = right)
                 let assign_to_temp = Box::new(Expr::Assign(AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: AssignOp::Assign,
                     left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                        node_id: Default::default(),
                         id: alias.clone(),
                         type_ann: None,
                     })),
@@ -189,6 +197,7 @@ impl NullishCoalescingPass {
                 let cons = Box::new(Expr::Ident(alias.clone()));
 
                 let alt = Box::new(Expr::Assign(AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: AssignOp::Assign,
                     left: AssignTarget::Simple(left_clone),
@@ -198,13 +207,16 @@ impl NullishCoalescingPass {
                 // Final: _ref = (_ref = left) !== null && _ref !== void 0 ? _ref : (left =
                 // right)
                 *expr = Expr::Assign(AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: AssignOp::Assign,
                     left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                        node_id: Default::default(),
                         id: alias,
                         type_ann: None,
                     })),
                     right: Box::new(Expr::Cond(CondExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         test,
                         cons,
@@ -226,23 +238,33 @@ fn create_nullish_test(no_document_all: bool, test_expr: Box<Expr>, alias: &Iden
     if no_document_all {
         // Simplified: test_expr != null
         Box::new(Expr::Bin(BinExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             left: test_expr,
             op: BinaryOp::NotEq,
-            right: Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP }))),
+            right: Box::new(Expr::Lit(Lit::Null(Null {
+                node_id: Default::default(),
+                span: DUMMY_SP,
+            }))),
         }))
     } else {
         // Standard: test_expr !== null && alias !== void 0
         Box::new(Expr::Bin(BinExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             left: Box::new(Expr::Bin(BinExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 left: test_expr,
                 op: BinaryOp::NotEqEq,
-                right: Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP }))),
+                right: Box::new(Expr::Lit(Lit::Null(Null {
+                    node_id: Default::default(),
+                    span: DUMMY_SP,
+                }))),
             })),
             op: BinaryOp::LogicalAnd,
             right: Box::new(Expr::Bin(BinExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 left: Box::new(Expr::Ident(alias.clone())),
                 op: BinaryOp::NotEqEq,

--- a/crates/swc_ecma_transformer/src/es2021/logical_assignment_operators.rs
+++ b/crates/swc_ecma_transformer/src/es2021/logical_assignment_operators.rs
@@ -97,6 +97,7 @@ impl VisitMutHook<TraverseCtx> for LogicalAssignmentOperatorsPass {
 
         // Create assignment: `assign_target = right`
         let assignment = Box::new(Expr::Assign(AssignExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             op: AssignOp::Assign,
             left: AssignTarget::Simple(assign_target),
@@ -105,6 +106,7 @@ impl VisitMutHook<TraverseCtx> for LogicalAssignmentOperatorsPass {
 
         // Create binary expression: `left_expr op assignment`
         *expr = Expr::Bin(BinExpr {
+            node_id: Default::default(),
             span,
             op,
             left: left_expr,
@@ -131,9 +133,11 @@ impl LogicalAssignmentOperatorsPass {
                 self.inject_var_decl(&alias, ctx);
 
                 let left_obj = Box::new(Expr::Assign(AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: AssignOp::Assign,
                     left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                        node_id: Default::default(),
                         id: alias.clone(),
                         type_ann: None,
                     })),
@@ -155,11 +159,14 @@ impl LogicalAssignmentOperatorsPass {
                 self.inject_var_decl(&alias, ctx);
 
                 let left_prop = MemberProp::Computed(ComputedPropName {
+                    node_id: Default::default(),
                     span: computed.span,
                     expr: Box::new(Expr::Assign(AssignExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         op: AssignOp::Assign,
                         left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                            node_id: Default::default(),
                             id: alias.clone(),
                             type_ann: None,
                         })),
@@ -168,6 +175,7 @@ impl LogicalAssignmentOperatorsPass {
                 });
 
                 let right_prop = MemberProp::Computed(ComputedPropName {
+                    node_id: Default::default(),
                     span: computed.span,
                     expr: Box::new(Expr::Ident(alias)),
                 });
@@ -180,6 +188,7 @@ impl LogicalAssignmentOperatorsPass {
 
         // Build left expression: `(_a = a).b` or `(_a = a)[_b = b]`
         let left_expr = Box::new(Expr::Member(MemberExpr {
+            node_id: Default::default(),
             span: member_expr.span,
             obj: left_obj,
             prop: left_prop,
@@ -187,6 +196,7 @@ impl LogicalAssignmentOperatorsPass {
 
         // Build assignment target: `_a.b` or `_a[_b]`
         let assign_target = SimpleAssignTarget::Member(MemberExpr {
+            node_id: Default::default(),
             span: member_expr.span,
             obj: right_obj,
             prop: right_prop,
@@ -208,11 +218,14 @@ impl LogicalAssignmentOperatorsPass {
                 self.inject_var_decl(&alias, ctx);
 
                 let left_prop = SuperProp::Computed(ComputedPropName {
+                    node_id: Default::default(),
                     span: computed.span,
                     expr: Box::new(Expr::Assign(AssignExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         op: AssignOp::Assign,
                         left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                            node_id: Default::default(),
                             id: alias.clone(),
                             type_ann: None,
                         })),
@@ -221,6 +234,7 @@ impl LogicalAssignmentOperatorsPass {
                 });
 
                 let right_prop = SuperProp::Computed(ComputedPropName {
+                    node_id: Default::default(),
                     span: computed.span,
                     expr: Box::new(Expr::Ident(alias)),
                 });
@@ -231,12 +245,14 @@ impl LogicalAssignmentOperatorsPass {
         };
 
         let left_expr = Box::new(Expr::SuperProp(SuperPropExpr {
+            node_id: Default::default(),
             span: super_prop_expr.span,
             obj: super_prop_expr.obj,
             prop: left_prop,
         }));
 
         let assign_target = SimpleAssignTarget::SuperProp(SuperPropExpr {
+            node_id: Default::default(),
             span: super_prop_expr.span,
             obj: super_prop_expr.obj,
             prop: right_prop,
@@ -248,6 +264,7 @@ impl LogicalAssignmentOperatorsPass {
     fn inject_var_decl(&mut self, ident: &Ident, ctx: &mut TraverseCtx) {
         ctx.var_declarations.insert_var(
             BindingIdent {
+                node_id: Default::default(),
                 id: ident.clone(),
                 type_ann: None,
             },

--- a/crates/swc_ecma_transformer/src/es2022/class_static_block.rs
+++ b/crates/swc_ecma_transformer/src/es2022/class_static_block.rs
@@ -124,9 +124,11 @@ impl ClassStaticBlock {
         };
 
         ClassMember::PrivateProp(PrivateProp {
+            node_id: Default::default(),
             span,
             ctxt: Default::default(),
             key: PrivateName {
+                node_id: Default::default(),
                 // Use PLACEHOLDER_SP to signal to class_properties
                 // that this came from a static block
                 span: PLACEHOLDER_SP,
@@ -147,9 +149,11 @@ impl ClassStaticBlock {
     /// Wrap statements in an immediately-invoked arrow function expression
     fn wrap_in_iife(&self, stmts: Vec<Stmt>) -> Expr {
         let arrow = ArrowExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             params: vec![],
             body: Box::new(BlockStmtOrExpr::BlockStmt(BlockStmt {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 stmts,
                 ctxt: Default::default(),
@@ -162,6 +166,7 @@ impl ClassStaticBlock {
         };
 
         CallExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             callee: arrow.as_callee(),
             args: vec![],

--- a/crates/swc_ecma_transformer/src/es2022/private_property_in_object.rs
+++ b/crates/swc_ecma_transformer/src/es2022/private_property_in_object.rs
@@ -72,6 +72,7 @@ impl Mode {
         match self {
             Mode::ClassExpr { vars, init_exprs } => {
                 vars.push(VarDeclarator {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     name: n.clone().into(),
                     init: None,
@@ -80,9 +81,11 @@ impl Mode {
                 if let Some(init) = init {
                     init_exprs.push(
                         AssignExpr {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             op: op!("="),
                             left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                                node_id: Default::default(),
                                 id: n,
                                 type_ann: None,
                             })),
@@ -94,6 +97,7 @@ impl Mode {
             }
             Mode::ClassDecl { vars } => {
                 vars.push(VarDeclarator {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     name: n.into(),
                     init,
@@ -209,6 +213,7 @@ impl PrivatePropertyInObjectPass {
                 for expr in take(&mut self.cls.constructor_exprs) {
                     body.stmts.push(
                         ExprStmt {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             expr: Box::new(expr),
                         }
@@ -297,6 +302,7 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
             };
             bs.stmts.push(
                 ReturnStmt {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     arg: Some(p.right.take()),
                 }
@@ -304,8 +310,10 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
             );
 
             p.right = CallExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 callee: ArrowExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     params: Default::default(),
                     body: Box::new(BlockStmtOrExpr::BlockStmt(bs)),
@@ -349,6 +357,7 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                 _ => {
                     prepend_exprs.push(e.take());
                     *e = SeqExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         exprs: prepend_exprs.into_iter().map(Box::new).collect(),
                     }
@@ -365,6 +374,7 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                 op: op!("in"),
                 left,
                 right,
+                ..
             }) if left.is_private_name() => {
                 let left = left.take().expect_private_name();
 
@@ -375,6 +385,7 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                 if let Some(cls_ident) = self.cls.ident.clone() {
                     if is_static && is_method {
                         *e = BinExpr {
+                            node_id: Default::default(),
                             span: *span,
                             op: op!("==="),
                             left: cls_ident.into(),
@@ -395,6 +406,7 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                         var_name.clone(),
                         Some(
                             NewExpr {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 callee: Box::new(quote_ident!("WeakSet").into()),
                                 args: Some(Default::default()),
@@ -409,14 +421,22 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                     if is_method {
                         self.cls.constructor_exprs.push(
                             CallExpr {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 callee: var_name
                                     .clone()
                                     .make_member(quote_ident!("add"))
                                     .as_callee(),
                                 args: vec![ExprOrSpread {
+                                    node_id: Default::default(),
                                     spread: None,
-                                    expr: Box::new(ThisExpr { span: DUMMY_SP }.into()),
+                                    expr: Box::new(
+                                        ThisExpr {
+                                            node_id: Default::default(),
+                                            span: DUMMY_SP,
+                                        }
+                                        .into(),
+                                    ),
                                 }],
                                 type_args: Default::default(),
                                 ctxt: Default::default(),
@@ -428,9 +448,11 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
 
                 // Transform to WeakSet.has() call
                 *e = CallExpr {
+                    node_id: Default::default(),
                     span: *span,
                     callee: var_name.make_member(quote_ident!("has")).as_callee(),
                     args: vec![ExprOrSpread {
+                        node_id: Default::default(),
                         spread: None,
                         expr: right.take(),
                     }],
@@ -460,9 +482,11 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                 self.cls.vars.push_var(tmp.clone(), None);
 
                 let assign = AssignExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     op: op!("="),
                     left: AssignTarget::Simple(SimpleAssignTarget::Ident(BindingIdent {
+                        node_id: Default::default(),
                         id: tmp.clone(),
                         type_ann: None,
                     })),
@@ -471,11 +495,19 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                 .into();
 
                 let add_to_checker = CallExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     callee: var_name.make_member(quote_ident!("add")).as_callee(),
                     args: vec![ExprOrSpread {
+                        node_id: Default::default(),
                         spread: None,
-                        expr: Box::new(ThisExpr { span: DUMMY_SP }.into()),
+                        expr: Box::new(
+                            ThisExpr {
+                                node_id: Default::default(),
+                                span: DUMMY_SP,
+                            }
+                            .into(),
+                        ),
                     }],
                     type_args: Default::default(),
                     ctxt: Default::default(),
@@ -483,6 +515,7 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                 .into();
 
                 *init = SeqExpr {
+                    node_id: Default::default(),
                     span: init_span,
                     exprs: vec![
                         Box::new(assign),
@@ -495,15 +528,24 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
             None => {
                 n.value = Some(
                     UnaryExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         op: op!("void"),
                         arg: Box::new(
                             CallExpr {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 callee: var_name.make_member(quote_ident!("add")).as_callee(),
                                 args: vec![ExprOrSpread {
+                                    node_id: Default::default(),
                                     spread: None,
-                                    expr: Box::new(ThisExpr { span: DUMMY_SP }.into()),
+                                    expr: Box::new(
+                                        ThisExpr {
+                                            node_id: Default::default(),
+                                            span: DUMMY_SP,
+                                        }
+                                        .into(),
+                                    ),
                                 }],
                                 type_args: Default::default(),
                                 ctxt: Default::default(),
@@ -525,6 +567,7 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
         s.insert(
             0,
             VarDecl {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 kind: VarDeclKind::Var,
                 declare: Default::default(),
@@ -543,6 +586,7 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
         items.insert(
             0,
             VarDecl {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 kind: VarDeclKind::Var,
                 declare: Default::default(),

--- a/crates/swc_ecma_transformer/src/regexp.rs
+++ b/crates/swc_ecma_transformer/src/regexp.rs
@@ -194,11 +194,14 @@ impl RegexpPass {
             .into_iter()
             .map(|(name, idx)| {
                 PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                    node_id: Default::default(),
                     key: PropName::Ident(IdentName {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         sym: name,
                     }),
                     value: Box::new(Expr::Lit(Lit::Num(Number {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         value: idx as f64,
                         raw: None,
@@ -208,6 +211,7 @@ impl RegexpPass {
             .collect();
 
         Expr::Object(ObjectLit {
+            node_id: Default::default(),
             span: DUMMY_SP,
             props,
         })
@@ -255,6 +259,7 @@ impl VisitMutHook<TraverseCtx> for RegexpPass {
                         } else {
                             // Keep as regex literal with stripped named groups
                             Lit::Regex(Regex {
+                                node_id: Default::default(),
                                 span,
                                 exp: stripped_exp.into(),
                                 flags,
@@ -285,7 +290,9 @@ impl VisitMutHook<TraverseCtx> for RegexpPass {
                 let needs_transform = self.needs_regexp_constructor(&regex.exp, &regex.flags);
 
                 if needs_transform {
-                    let Regex { exp, flags, span } = regex.take();
+                    let Regex {
+                        exp, flags, span, ..
+                    } = regex.take();
 
                     // Transform the pattern if it contains unicode property escapes
                     let transformed_pattern = self

--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -201,6 +201,7 @@ impl VisitMut for Fixer<'_> {
             AssignTarget::Pat(b) => {
                 if let AssignTargetPat::Invalid(_) = b {
                     *n = AssignTarget::Simple(SimpleAssignTarget::Invalid(Invalid {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                     }));
                 }
@@ -840,7 +841,7 @@ impl Fixer<'_> {
             }
 
             // Flatten seq expr
-            Expr::Seq(SeqExpr { span, exprs }) => {
+            Expr::Seq(SeqExpr { span, exprs, .. }) => {
                 let len = exprs
                     .iter()
                     .map(|expr| match **expr {
@@ -948,7 +949,12 @@ impl Fixer<'_> {
                     }
                 }
 
-                let mut expr = SeqExpr { span: *span, exprs }.into();
+                let mut expr = SeqExpr {
+                    node_id: Default::default(),
+                    span: *span,
+                    exprs,
+                }
+                .into();
 
                 if let Context::ForcedExpr = self.ctx {
                     self.wrap(&mut expr);
@@ -1057,7 +1063,12 @@ impl Fixer<'_> {
         }
 
         let expr = Box::new(e.take());
-        *e = ParenExpr { expr, span }.into();
+        *e = ParenExpr {
+            node_id: Default::default(),
+            expr,
+            span,
+        }
+        .into();
     }
 
     /// Removes paren
@@ -1127,7 +1138,7 @@ fn ignore_return_value(expr: Box<Expr>, has_padding_value: &mut bool) -> Option<
                 Some(expr)
             }
         }
-        Expr::Seq(SeqExpr { span, exprs }) => {
+        Expr::Seq(SeqExpr { span, exprs, .. }) => {
             let len = exprs.len();
             let mut exprs: Vec<_> = exprs
                 .into_iter()
@@ -1143,7 +1154,14 @@ fn ignore_return_value(expr: Box<Expr>, has_padding_value: &mut bool) -> Option<
 
             match exprs.len() {
                 0 | 1 => exprs.pop(),
-                _ => Some(SeqExpr { span, exprs }.into()),
+                _ => Some(
+                    SeqExpr {
+                        node_id: Default::default(),
+                        span,
+                        exprs,
+                    }
+                    .into(),
+                ),
             }
         }
         Expr::Unary(UnaryExpr {

--- a/crates/swc_ecma_transforms_base/src/helpers/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/helpers/mod.rs
@@ -70,6 +70,7 @@ macro_rules! add_import_to {
         if enable {
             let ctxt = SyntaxContext::empty().apply_mark($mark);
             let s = ImportSpecifier::Named(ImportNamedSpecifier {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 local: Ident::new(concat!("_", stringify!($name)).into(), DUMMY_SP, ctxt),
                 imported: Some(quote_ident!("_").into()),
@@ -79,6 +80,7 @@ macro_rules! add_import_to {
             let src: Str = concat!("@swc/helpers/_/_", stringify!($name)).into();
 
             $buf.push(ModuleItem::ModuleDecl(ModuleDecl::Import(ImportDecl {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 specifiers: vec![s],
                 src: Box::new(src),
@@ -484,6 +486,7 @@ impl InjectHelpers {
             })
             .as_callee(),
             args: vec![Str {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 value: format!("@swc/helpers/_/_{name}").into(),
                 raw: None,
@@ -495,6 +498,7 @@ impl InjectHelpers {
         VarDecl {
             kind: VarDeclKind::Var,
             decls: vec![VarDeclarator {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 name: Pat::Ident(Ident::new(format!("_{name}").into(), DUMMY_SP, ctxt).into()),
                 init: Some(c.into()),
@@ -512,6 +516,7 @@ impl InjectHelpers {
                 let ident = ref_ident.clone().without_loc();
 
                 MemberExpr {
+                    node_id: Default::default(),
                     span: ref_ident.span,
                     obj: Box::new(ident.into()),
                     prop: MemberProp::Ident(atom!("_").into()),

--- a/crates/swc_ecma_transforms_base/src/hygiene/tests.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/tests.rs
@@ -90,6 +90,7 @@ where
     test_module(
         |tester| {
             Ok(Module {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 body: op(tester)?.into_iter().map(ModuleItem::Stmt).collect(),
                 shebang: None,
@@ -438,6 +439,7 @@ fn mark_root() {
             Ok(vec![
                 tester.parse_stmt("actual1.js", "var foo = 'bar';")?,
                 Stmt::Decl(Decl::Fn(FnDecl {
+                    node_id: Default::default(),
                     ident: quote_ident!("Foo").into(),
                     function: Box::new(Function {
                         span: DUMMY_SP,
@@ -524,6 +526,7 @@ fn fn_args() {
             let mark2 = Mark::fresh(Mark::root());
 
             Ok(vec![Stmt::Decl(Decl::Fn(FnDecl {
+                node_id: Default::default(),
                 ident: quote_ident!("Foo").into(),
                 function: Box::new(Function {
                     span: DUMMY_SP,
@@ -537,6 +540,7 @@ fn fn_args() {
                         ..Default::default()
                     }),
                     params: vec![Param {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         decorators: Vec::new(),
                         pat: quote_ident!("force").into(),
@@ -564,6 +568,7 @@ fn block_in_fn() {
             let mark2 = Mark::fresh(mark1);
 
             Ok(vec![Stmt::Decl(Decl::Fn(FnDecl {
+                node_id: Default::default(),
                 ident: quote_ident!("Foo").into(),
                 function: Box::new(Function {
                     span: DUMMY_SP,
@@ -616,6 +621,7 @@ fn flat_in_fn() {
             let mark2 = Mark::fresh(mark1);
 
             Ok(vec![Stmt::Decl(Decl::Fn(FnDecl {
+                node_id: Default::default(),
                 ident: quote_ident!("Foo").into(),
                 function: Box::new(Function {
                     span: DUMMY_SP,
@@ -657,6 +663,7 @@ fn params_in_fn() {
             let mark2 = Mark::fresh(Mark::root());
 
             Ok(vec![Stmt::Decl(Decl::Fn(FnDecl {
+                node_id: Default::default(),
                 ident: quote_ident!("Foo").into(),
                 function: Box::new(Function {
                     span: DUMMY_SP,
@@ -668,6 +675,7 @@ fn params_in_fn() {
                     }),
                     params: vec![
                         Param {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             decorators: Default::default(),
                             pat: Ident::new(
@@ -678,6 +686,7 @@ fn params_in_fn() {
                             .into(),
                         },
                         Param {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             decorators: Default::default(),
                             pat: Ident::new(

--- a/crates/swc_ecma_transforms_base/src/rename/ops.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/ops.rs
@@ -54,6 +54,7 @@ where
         class.visit_mut_with(self);
 
         let class_expr = ClassExpr {
+            node_id: Default::default(),
             ident: Some(orig_name),
             class: Box::new(class.take()),
         };
@@ -128,6 +129,7 @@ where
                 let expr = self.keep_class_name(&mut cls.ident, &mut cls.class);
                 if let Some(expr) = expr {
                     let var = VarDeclarator {
+                        node_id: Default::default(),
                         span,
                         name: cls.ident.clone().into(),
                         init: Some(expr.into()),
@@ -245,8 +247,10 @@ where
                 self.extra
                     .push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(
                         NamedExport {
+                            node_id: Default::default(),
                             span,
                             specifiers: vec![ExportSpecifier::Named(ExportNamedSpecifier {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 orig: $ident,
                                 exported: Some($orig),
@@ -268,7 +272,9 @@ where
                         ident,
                         class,
                         declare,
+                        ..
                     }),
+                ..
             })) => {
                 let mut ident = ident.take();
                 let mut class = class.take();
@@ -278,6 +284,7 @@ where
                 match self.rename_ident(&mut ident) {
                     Ok(..) => {
                         *item = ClassDecl {
+                            node_id: Default::default(),
                             ident: ident.clone(),
                             class: class.take(),
                             declare: *declare,
@@ -290,8 +297,10 @@ where
                     }
                     Err(..) => {
                         *item = ExportDecl {
+                            node_id: Default::default(),
                             span: *span,
                             decl: ClassDecl {
+                                node_id: Default::default(),
                                 ident: ident.take(),
                                 class: class.take(),
                                 declare: *declare,
@@ -309,7 +318,9 @@ where
                         ident,
                         function,
                         declare,
+                        ..
                     }),
+                ..
             })) => {
                 let mut ident = ident.take();
                 let mut function = function.take();
@@ -319,6 +330,7 @@ where
                 match self.rename_ident(&mut ident) {
                     Ok(..) => {
                         *item = FnDecl {
+                            node_id: Default::default(),
                             ident: ident.clone(),
                             function,
                             declare: *declare,
@@ -331,8 +343,10 @@ where
                     }
                     Err(..) => {
                         *item = ExportDecl {
+                            node_id: Default::default(),
                             span: *span,
                             decl: FnDecl {
+                                node_id: Default::default(),
                                 ident,
                                 function,
                                 declare: *declare,
@@ -361,6 +375,7 @@ where
 
                 if renamed.is_empty() {
                     *item = ExportDecl {
+                        node_id: Default::default(),
                         span,
                         decl: VarDecl {
                             decls,
@@ -378,6 +393,7 @@ where
                 .into();
                 self.extra.push(
                     NamedExport {
+                        node_id: Default::default(),
                         span,
                         specifiers: renamed,
                         src: None,
@@ -473,9 +489,11 @@ where
                 }
 
                 *n = KeyValuePatProp {
+                    node_id: Default::default(),
                     key: PropName::Ident(p.key.take().into()),
                     value: match p.value.take() {
                         Some(default_expr) => AssignPat {
+                            node_id: Default::default(),
                             span: p.span,
                             left: renamed.into(),
                             right: default_expr,
@@ -505,7 +523,9 @@ where
                     }
 
                     *prop = Prop::KeyValue(KeyValueProp {
+                        node_id: Default::default(),
                         key: PropName::Ident(IdentName {
+                            node_id: Default::default(),
                             // clear mark
                             span: i.span,
                             sym: i.sym.clone(),
@@ -636,6 +656,7 @@ where
         if self.orig.rename_ident(i).is_ok() {
             self.renamed
                 .push(ExportSpecifier::Named(ExportNamedSpecifier {
+                    node_id: Default::default(),
                     span: i.span,
                     exported: Some(ModuleExportName::Ident(orig)),
                     orig: ModuleExportName::Ident(i.clone()),

--- a/crates/swc_ecma_transforms_base/src/resolver/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/resolver/mod.rs
@@ -1,14 +1,17 @@
+use std::{cell::RefCell, rc::Rc};
+
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::Atom;
 use swc_common::{Mark, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{find_pat_ids, stack_size::maybe_grow_default};
 use swc_ecma_visit::{
-    noop_visit_mut_type, visit_mut_obj_and_computed, visit_mut_pass, VisitMut, VisitMutWith,
+    assign_node_ids, noop_visit_mut_type, visit_mut_obj_and_computed, visit_mut_pass, VisitMut,
+    VisitMutWith,
 };
 use tracing::{debug, span, Level};
 
-use crate::scope::{DeclKind, IdentType, ScopeKind};
+use crate::scope::{CanonicalBinding, DeclKind, IdentType, ScopeData, ScopeKind};
 
 #[cfg(test)]
 mod tests;
@@ -142,19 +145,55 @@ pub fn resolver(
     let _ = SyntaxContext::empty().apply_mark(top_level_mark);
 
     visit_mut_pass(Resolver {
-        current: Scope::new(ScopeKind::Fn, top_level_mark, None),
+        current: Scope::new(ScopeKind::Fn, top_level_mark, NodeId::DUMMY, None),
         ident_type: IdentType::Ref,
         in_type: false,
         is_module: false,
         in_ts_module: false,
         decl_kind: DeclKind::Lexical,
         strict_mode: false,
+        scope_data: Rc::new(RefCell::new(ScopeData::default())),
         config: InnerConfig {
             handle_types: typescript,
             unresolved_mark,
             top_level_mark,
         },
     })
+}
+
+pub(crate) fn analyze_scope(program: &Program, typescript: bool) -> ScopeData {
+    let unresolved_mark = Mark::new();
+    let top_level_mark = Mark::new();
+    let _ = SyntaxContext::empty().apply_mark(unresolved_mark);
+    let _ = SyntaxContext::empty().apply_mark(top_level_mark);
+
+    let mut program = program.clone();
+    assign_node_ids(&mut program);
+
+    let scope_data = Rc::new(RefCell::new(ScopeData::default()));
+
+    let mut resolver = Resolver {
+        current: Scope::new(ScopeKind::Fn, top_level_mark, NodeId::DUMMY, None),
+        ident_type: IdentType::Ref,
+        in_type: false,
+        is_module: false,
+        in_ts_module: false,
+        decl_kind: DeclKind::Lexical,
+        strict_mode: false,
+        scope_data: Rc::clone(&scope_data),
+        config: InnerConfig {
+            handle_types: typescript,
+            unresolved_mark,
+            top_level_mark,
+        },
+    };
+
+    program.visit_mut_with(&mut resolver);
+    drop(resolver);
+
+    Rc::try_unwrap(scope_data)
+        .expect("scope analysis should not retain shared state")
+        .into_inner()
 }
 
 #[derive(Debug, Clone)]
@@ -168,21 +207,38 @@ struct Scope<'a> {
     /// [Mark] of the current scope.
     mark: Mark,
 
+    /// Identifier of the AST node that owns this scope.
+    scope_id: NodeId,
+
     /// All declarations in the scope
     declared_symbols: FxHashMap<Atom, DeclKind>,
 
     /// All types declared in the scope
     declared_types: FxHashSet<Atom>,
+
+    /// Canonical value bindings visible in this scope.
+    bindings: FxHashMap<Atom, CanonicalBinding>,
+
+    /// Canonical type bindings visible in this scope.
+    type_bindings: FxHashMap<Atom, CanonicalBinding>,
 }
 
 impl<'a> Scope<'a> {
-    pub fn new(kind: ScopeKind, mark: Mark, parent: Option<&'a Scope<'a>>) -> Self {
+    pub fn new(
+        kind: ScopeKind,
+        mark: Mark,
+        scope_id: NodeId,
+        parent: Option<&'a Scope<'a>>,
+    ) -> Self {
         Scope {
             parent,
             kind,
             mark,
+            scope_id,
             declared_symbols: Default::default(),
             declared_types: Default::default(),
+            bindings: Default::default(),
+            type_bindings: Default::default(),
         }
     }
 
@@ -190,6 +246,14 @@ impl<'a> Scope<'a> {
         self.declared_symbols
             .get(symbol)
             .or_else(|| self.parent?.is_declared(symbol))
+    }
+
+    fn visible_scope_id(&self) -> Option<NodeId> {
+        if !self.scope_id.is_dummy() {
+            Some(self.scope_id)
+        } else {
+            self.parent.and_then(Scope::visible_scope_id)
+        }
     }
 }
 
@@ -207,7 +271,14 @@ struct Resolver<'a> {
     decl_kind: DeclKind,
     strict_mode: bool,
 
+    scope_data: Rc<RefCell<ScopeData>>,
     config: InnerConfig,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResolvedBinding {
+    mark: Mark,
+    canonical: Option<CanonicalBinding>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -230,17 +301,23 @@ impl<'a> Resolver<'a> {
             config,
             decl_kind: DeclKind::Lexical,
             strict_mode: false,
+            scope_data: Rc::new(RefCell::new(ScopeData::default())),
         }
     }
 
-    fn with_child<F>(&self, kind: ScopeKind, op: F)
+    fn with_child<F>(&self, kind: ScopeKind, scope_id: NodeId, op: F)
     where
         F: for<'aa> FnOnce(&mut Resolver<'aa>),
     {
+        self.scope_data
+            .borrow_mut()
+            .record_scope(scope_id, self.current.visible_scope_id(), kind);
+
         let mut child = Resolver {
             current: Scope::new(
                 kind,
                 Mark::fresh(self.config.top_level_mark),
+                scope_id,
                 Some(&self.current),
             ),
             ident_type: IdentType::Ref,
@@ -250,13 +327,19 @@ impl<'a> Resolver<'a> {
             in_ts_module: self.in_ts_module,
             decl_kind: self.decl_kind,
             strict_mode: self.strict_mode,
+            scope_data: Rc::clone(&self.scope_data),
         };
 
         op(&mut child);
     }
 
     fn visit_mut_stmt_within_child_scope(&mut self, s: &mut Stmt) {
-        self.with_child(ScopeKind::Block, |child| match s {
+        let scope_id = match s {
+            Stmt::Block(block) => block.node_id,
+            _ => NodeId::DUMMY,
+        };
+
+        self.with_child(ScopeKind::Block, scope_id, |child| match s {
             Stmt::Block(s) => {
                 child.mark_block(&mut s.ctxt);
                 s.visit_mut_children_with(child);
@@ -267,22 +350,44 @@ impl<'a> Resolver<'a> {
 
     /// Returns a [Mark] for an identifier reference.
     fn mark_for_ref(&self, sym: &Atom) -> Option<Mark> {
-        self.mark_for_ref_inner(sym, false)
+        self.resolve_ref_inner(sym, false)
+            .map(|resolved| resolved.mark)
     }
 
     fn mark_for_ref_inner(&self, sym: &Atom, stop_an_fn_scope: bool) -> Option<Mark> {
+        self.resolve_ref_inner(sym, stop_an_fn_scope)
+            .map(|resolved| resolved.mark)
+    }
+
+    fn resolve_ref(&self, sym: &Atom) -> Option<ResolvedBinding> {
+        self.resolve_ref_inner(sym, false)
+    }
+
+    fn resolve_ref_inner(&self, sym: &Atom, stop_an_fn_scope: bool) -> Option<ResolvedBinding> {
         if self.config.handle_types && self.in_type {
             let mut mark = self.current.mark;
             let mut scope = Some(&self.current);
 
             while let Some(cur) = scope {
-                // if cur.declared_types.contains(sym) ||
-                // cur.hoisted_symbols.borrow().contains(sym) {
+                if let Some(binding) = cur.type_bindings.get(sym).copied() {
+                    if mark == Mark::root() {
+                        break;
+                    }
+                    return Some(ResolvedBinding {
+                        mark,
+                        canonical: Some(binding),
+                    });
+                }
+
                 if cur.declared_types.contains(sym) {
                     if mark == Mark::root() {
                         break;
                     }
-                    return Some(mark);
+
+                    return Some(ResolvedBinding {
+                        mark,
+                        canonical: None,
+                    });
                 }
 
                 if cur.kind == ScopeKind::Fn && stop_an_fn_scope {
@@ -300,21 +405,48 @@ impl<'a> Resolver<'a> {
         let mut scope = Some(&self.current);
 
         while let Some(cur) = scope {
-            if cur.declared_symbols.contains_key(sym) {
+            if let Some(binding) = cur.bindings.get(sym).copied() {
                 if mark == Mark::root() {
                     return None;
                 }
 
-                return match &**sym {
+                return Some(match &**sym {
                     // https://tc39.es/ecma262/multipage/global-object.html#sec-value-properties-of-the-global-object-infinity
                     // non configurable global value
                     "undefined" | "NaN" | "Infinity"
                         if mark == self.config.top_level_mark && !self.is_module =>
                     {
-                        Some(self.config.unresolved_mark)
+                        ResolvedBinding {
+                            mark: self.config.unresolved_mark,
+                            canonical: None,
+                        }
                     }
-                    _ => Some(mark),
-                };
+                    _ => ResolvedBinding {
+                        mark,
+                        canonical: Some(binding),
+                    },
+                });
+            }
+
+            if cur.declared_symbols.contains_key(sym) {
+                if mark == Mark::root() {
+                    return None;
+                }
+
+                return Some(match &**sym {
+                    "undefined" | "NaN" | "Infinity"
+                        if mark == self.config.top_level_mark && !self.is_module =>
+                    {
+                        ResolvedBinding {
+                            mark: self.config.unresolved_mark,
+                            canonical: None,
+                        }
+                    }
+                    _ => ResolvedBinding {
+                        mark,
+                        canonical: None,
+                    },
+                });
             }
 
             if cur.kind == ScopeKind::Fn && stop_an_fn_scope {
@@ -345,8 +477,32 @@ impl<'a> Resolver<'a> {
 
         if self.in_type {
             self.current.declared_types.insert(id.sym.clone());
+            let canonical =
+                *self
+                    .current
+                    .type_bindings
+                    .entry(id.sym.clone())
+                    .or_insert(CanonicalBinding {
+                        decl_node_id: id.node_id,
+                        decl_kind: kind,
+                    });
+            self.scope_data
+                .borrow_mut()
+                .record_decl(id.node_id, canonical);
         } else {
             self.current.declared_symbols.insert(id.sym.clone(), kind);
+            let canonical =
+                *self
+                    .current
+                    .bindings
+                    .entry(id.sym.clone())
+                    .or_insert(CanonicalBinding {
+                        decl_node_id: id.node_id,
+                        decl_kind: kind,
+                    });
+            self.scope_data
+                .borrow_mut()
+                .record_decl(id.node_id, canonical);
         }
 
         let mark = self.current.mark;
@@ -365,6 +521,34 @@ impl<'a> Resolver<'a> {
 
         if mark != Mark::root() {
             *ctxt = ctxt.apply_mark(mark)
+        }
+    }
+
+    fn declare_type_binding(&mut self, id: &Ident, kind: DeclKind) {
+        self.current.declared_types.insert(id.sym.clone());
+
+        let canonical =
+            *self
+                .current
+                .type_bindings
+                .entry(id.sym.clone())
+                .or_insert(CanonicalBinding {
+                    decl_node_id: id.node_id,
+                    decl_kind: kind,
+                });
+
+        self.scope_data
+            .borrow_mut()
+            .record_decl(id.node_id, canonical);
+    }
+
+    fn ensure_current_scope_id(&mut self, scope_id: NodeId) {
+        if self.current.scope_id.is_dummy() && !scope_id.is_dummy() {
+            let parent_scope_id = self.current.parent.and_then(Scope::visible_scope_id);
+            self.scope_data
+                .borrow_mut()
+                .record_scope(scope_id, parent_scope_id, self.current.kind);
+            self.current.scope_id = scope_id;
         }
     }
 
@@ -526,7 +710,7 @@ impl VisitMut for Resolver<'_> {
     typed!(visit_mut_ts_namespace_export_decl, TsNamespaceExportDecl);
 
     fn visit_mut_arrow_expr(&mut self, e: &mut ArrowExpr) {
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, e.node_id, |child| {
             e.type_params.visit_mut_with(child);
 
             let old = child.ident_type;
@@ -593,7 +777,7 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_block_stmt(&mut self, block: &mut BlockStmt) {
-        self.with_child(ScopeKind::Block, |child| {
+        self.with_child(ScopeKind::Block, block.node_id, |child| {
             child.mark_block(&mut block.ctxt);
             block.visit_mut_children_with(child);
         })
@@ -609,7 +793,7 @@ impl VisitMut for Resolver<'_> {
     fn visit_mut_catch_clause(&mut self, c: &mut CatchClause) {
         // Child folder
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, c.node_id, |child| {
             child.ident_type = IdentType::Binding;
             c.param.visit_mut_with(child);
             child.ident_type = IdentType::Ref;
@@ -654,7 +838,7 @@ impl VisitMut for Resolver<'_> {
 
         // Create a child scope. The class name is only accessible within the class.
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, n.node_id, |child| {
             child.ident_type = IdentType::Ref;
 
             n.class.visit_mut_with(child);
@@ -666,7 +850,7 @@ impl VisitMut for Resolver<'_> {
 
         n.class.super_class.visit_mut_with(self);
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, n.node_id, |child| {
             child.ident_type = IdentType::Binding;
             n.ident.visit_mut_with(child);
             child.ident_type = IdentType::Ref;
@@ -682,7 +866,9 @@ impl VisitMut for Resolver<'_> {
             p.decorators.visit_mut_with(self);
         }
 
-        self.with_child(ScopeKind::Fn, |child| m.function.visit_mut_with(child));
+        self.with_child(ScopeKind::Fn, m.function.node_id, |child| {
+            m.function.visit_mut_with(child);
+        });
     }
 
     fn visit_mut_class_prop(&mut self, p: &mut ClassProp) {
@@ -703,6 +889,13 @@ impl VisitMut for Resolver<'_> {
         p.type_ann.visit_mut_with(self);
     }
 
+    fn visit_mut_static_block(&mut self, block: &mut StaticBlock) {
+        self.with_child(ScopeKind::Block, block.node_id, |child| {
+            child.mark_block(&mut block.body.ctxt);
+            block.body.visit_mut_children_with(child);
+        });
+    }
+
     fn visit_mut_constructor(&mut self, c: &mut Constructor) {
         for p in c.params.iter_mut() {
             match p {
@@ -717,7 +910,7 @@ impl VisitMut for Resolver<'_> {
             }
         }
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, c.node_id, |child| {
             let old = child.ident_type;
             child.ident_type = IdentType::Binding;
             {
@@ -759,7 +952,7 @@ impl VisitMut for Resolver<'_> {
         match &mut e.decl {
             DefaultDecl::Fn(f) => {
                 if f.ident.is_some() {
-                    self.with_child(ScopeKind::Fn, |child| {
+                    self.with_child(ScopeKind::Fn, f.function.node_id, |child| {
                         f.function.visit_mut_with(child);
                     });
                 } else {
@@ -827,28 +1020,30 @@ impl VisitMut for Resolver<'_> {
         // We don't fold ident as Hoister handles this.
         node.function.decorators.visit_mut_with(self);
 
-        self.with_child(ScopeKind::Fn, |child| node.function.visit_mut_with(child));
+        self.with_child(ScopeKind::Fn, node.function.node_id, |child| {
+            node.function.visit_mut_with(child);
+        });
     }
 
     fn visit_mut_fn_expr(&mut self, e: &mut FnExpr) {
         e.function.decorators.visit_mut_with(self);
 
         if let Some(ident) = &mut e.ident {
-            self.with_child(ScopeKind::Fn, |child| {
+            self.with_child(ScopeKind::Fn, e.node_id, |child| {
                 child.modify(ident, DeclKind::Function);
-                child.with_child(ScopeKind::Fn, |child| {
+                child.with_child(ScopeKind::Fn, e.function.node_id, |child| {
                     e.function.visit_mut_with(child);
                 });
             });
         } else {
-            self.with_child(ScopeKind::Fn, |child| {
+            self.with_child(ScopeKind::Fn, e.function.node_id, |child| {
                 e.function.visit_mut_with(child);
             });
         }
     }
 
     fn visit_mut_for_in_stmt(&mut self, n: &mut ForInStmt) {
-        self.with_child(ScopeKind::Block, |child| {
+        self.with_child(ScopeKind::Block, n.node_id, |child| {
             n.left.visit_mut_with(child);
             n.right.visit_mut_with(child);
 
@@ -857,7 +1052,7 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_for_of_stmt(&mut self, n: &mut ForOfStmt) {
-        self.with_child(ScopeKind::Block, |child| {
+        self.with_child(ScopeKind::Block, n.node_id, |child| {
             n.left.visit_mut_with(child);
             n.right.visit_mut_with(child);
 
@@ -866,7 +1061,7 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_for_stmt(&mut self, n: &mut ForStmt) {
-        self.with_child(ScopeKind::Block, |child| {
+        self.with_child(ScopeKind::Block, n.node_id, |child| {
             child.ident_type = IdentType::Binding;
             n.init.visit_mut_with(child);
             child.ident_type = IdentType::Ref;
@@ -969,13 +1164,19 @@ impl VisitMut for Resolver<'_> {
                     return;
                 }
 
-                if let Some(mark) = self.mark_for_ref(sym) {
-                    let ctxt = ctxt.apply_mark(mark);
+                if let Some(resolved) = self.resolve_ref(sym) {
+                    let ctxt = ctxt.apply_mark(resolved.mark);
 
                     if cfg!(debug_assertions) && LOG {
                         debug!("\t -> {:?}", ctxt);
                     }
                     i.ctxt = ctxt;
+
+                    if let Some(canonical) = resolved.canonical {
+                        self.scope_data
+                            .borrow_mut()
+                            .record_ref(i.node_id, canonical.decl_node_id);
+                    }
                 } else {
                     if cfg!(debug_assertions) && LOG {
                         debug!("\t -> Unresolved");
@@ -1012,7 +1213,7 @@ impl VisitMut for Resolver<'_> {
         self.ident_type = IdentType::Binding;
         s.local.visit_mut_with(self);
         if self.config.handle_types {
-            self.current.declared_types.insert(s.local.sym.clone());
+            self.declare_type_binding(&s.local, DeclKind::Lexical);
         }
         self.ident_type = old;
     }
@@ -1056,12 +1257,15 @@ impl VisitMut for Resolver<'_> {
         m.key.visit_mut_with(self);
 
         // Child folder
-        self.with_child(ScopeKind::Fn, |child| m.function.visit_mut_with(child));
+        self.with_child(ScopeKind::Fn, m.function.node_id, |child| {
+            m.function.visit_mut_with(child);
+        });
     }
 
     fn visit_mut_module(&mut self, module: &mut Module) {
         self.strict_mode = true;
         self.is_module = true;
+        self.ensure_current_scope_id(module.node_id);
         module.visit_mut_children_with(self)
     }
 
@@ -1096,7 +1300,7 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_object_lit(&mut self, o: &mut ObjectLit) {
-        self.with_child(ScopeKind::Block, |child| {
+        self.with_child(ScopeKind::Block, o.node_id, |child| {
             o.visit_mut_children_with(child);
         });
     }
@@ -1116,7 +1320,9 @@ impl VisitMut for Resolver<'_> {
         {
             // Child folder
 
-            self.with_child(ScopeKind::Fn, |child| m.function.visit_mut_with(child));
+            self.with_child(ScopeKind::Fn, m.function.node_id, |child| {
+                m.function.visit_mut_with(child);
+            });
         }
     }
 
@@ -1134,6 +1340,7 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_script(&mut self, script: &mut Script) {
+        self.ensure_current_scope_id(script.node_id);
         self.strict_mode = script
             .body
             .first()
@@ -1146,7 +1353,7 @@ impl VisitMut for Resolver<'_> {
         n.key.visit_mut_with(self);
 
         {
-            self.with_child(ScopeKind::Fn, |child| {
+            self.with_child(ScopeKind::Fn, n.node_id, |child| {
                 child.ident_type = IdentType::Binding;
                 n.this_param.visit_mut_with(child);
                 n.param.visit_mut_with(child);
@@ -1194,7 +1401,7 @@ impl VisitMut for Resolver<'_> {
     fn visit_mut_switch_stmt(&mut self, s: &mut SwitchStmt) {
         s.discriminant.visit_mut_with(self);
 
-        self.with_child(ScopeKind::Block, |child| {
+        self.with_child(ScopeKind::Block, s.node_id, |child| {
             s.cases.visit_mut_with(child);
         });
     }
@@ -1212,7 +1419,7 @@ impl VisitMut for Resolver<'_> {
             return;
         }
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, n.node_id, |child| {
             child.in_type = true;
 
             n.type_params.visit_mut_with(child);
@@ -1227,7 +1434,7 @@ impl VisitMut for Resolver<'_> {
         }
 
         // Child folder
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, decl.node_id, |child| {
             child.in_type = true;
 
             // order is important
@@ -1242,7 +1449,7 @@ impl VisitMut for Resolver<'_> {
             return;
         }
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, ty.node_id, |child| {
             child.in_type = true;
 
             ty.type_params.visit_mut_with(child);
@@ -1257,7 +1464,7 @@ impl VisitMut for Resolver<'_> {
         }
         self.modify(&mut decl.id, DeclKind::Lexical);
 
-        self.with_child(ScopeKind::Block, |child| {
+        self.with_child(ScopeKind::Block, decl.node_id, |child| {
             // add the enum member names as declared symbols for this scope
             // Ex. `enum Foo { a, b = a }`
             let member_names = decl.members.iter().filter_map(|m| match &m.id {
@@ -1296,7 +1503,7 @@ impl VisitMut for Resolver<'_> {
             return;
         }
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, ty.node_id, |child| {
             child.in_type = true;
 
             ty.type_params.visit_mut_with(child);
@@ -1343,7 +1550,7 @@ impl VisitMut for Resolver<'_> {
             return;
         }
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, n.node_id, |child| {
             child.in_type = true;
 
             n.type_params.visit_mut_with(child);
@@ -1374,7 +1581,7 @@ impl VisitMut for Resolver<'_> {
             return;
         }
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, n.node_id, |child| {
             child.in_type = true;
 
             n.type_params.visit_mut_with(child);
@@ -1400,7 +1607,7 @@ impl VisitMut for Resolver<'_> {
             _ => {}
         }
 
-        self.with_child(ScopeKind::Block, |child| {
+        self.with_child(ScopeKind::Block, decl.node_id, |child| {
             child.in_ts_module = true;
 
             decl.body.visit_mut_children_with(child);
@@ -1431,7 +1638,7 @@ impl VisitMut for Resolver<'_> {
             n.key.visit_mut_with(self);
         }
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, n.node_id, |child| {
             child.in_type = true;
 
             n.type_ann.visit_mut_with(child);
@@ -1479,7 +1686,7 @@ impl VisitMut for Resolver<'_> {
             return;
         }
 
-        self.with_child(ScopeKind::Fn, |child| {
+        self.with_child(ScopeKind::Fn, n.node_id, |child| {
             child.in_type = true;
 
             n.type_params.visit_mut_with(child);
@@ -1690,9 +1897,7 @@ impl VisitMut for Hoister<'_, '_> {
 
         if self.resolver.config.handle_types {
             self.resolver
-                .current
-                .declared_types
-                .insert(node.ident.sym.clone());
+                .declare_type_binding(&node.ident, DeclKind::Lexical);
         }
     }
 
@@ -1818,9 +2023,7 @@ impl VisitMut for Hoister<'_, '_> {
 
         if self.resolver.config.handle_types {
             self.resolver
-                .current
-                .declared_types
-                .insert(n.local.sym.clone());
+                .declare_type_binding(&n.local, DeclKind::Lexical);
         }
     }
 
@@ -1831,9 +2034,7 @@ impl VisitMut for Hoister<'_, '_> {
 
         if self.resolver.config.handle_types {
             self.resolver
-                .current
-                .declared_types
-                .insert(n.local.sym.clone());
+                .declare_type_binding(&n.local, DeclKind::Lexical);
         }
     }
 
@@ -1844,9 +2045,7 @@ impl VisitMut for Hoister<'_, '_> {
 
         if self.resolver.config.handle_types {
             self.resolver
-                .current
-                .declared_types
-                .insert(n.local.sym.clone());
+                .declare_type_binding(&n.local, DeclKind::Lexical);
         }
     }
 

--- a/crates/swc_ecma_transforms_base/src/resolver/tests.rs
+++ b/crates/swc_ecma_transforms_base/src/resolver/tests.rs
@@ -1,8 +1,11 @@
 use swc_atoms::atom;
-use swc_ecma_parser::Syntax;
+use swc_common::{FileName, Globals, GLOBALS};
+use swc_ecma_ast::NodeId;
+use swc_ecma_parser::{Parser, StringInput, Syntax, TsSyntax};
+use swc_ecma_visit::{Visit, VisitWith};
 
 use super::*;
-use crate::hygiene::Config;
+use crate::{hygiene::Config, scope::ScopeData};
 
 // struct TsHygiene {
 //     top_level_mark: Mark,
@@ -54,6 +57,126 @@ fn run_test_with_config<F, V>(
     crate::tests::test_transform(syntax, |_| tr(), src, to, true, config);
 }
 
+fn parse_program(syntax: Syntax, src: &str) -> Program {
+    ::testing::run_test(false, |cm, handler| {
+        let fm = cm.new_source_file(
+            FileName::Custom("resolver-scope-test.js".into()).into(),
+            src.to_string(),
+        );
+
+        let mut parser = Parser::new(syntax, StringInput::from(&*fm), None);
+        let program = parser
+            .parse_program()
+            .map_err(|err| err.into_diagnostic(handler).emit())?;
+
+        for err in parser.take_errors() {
+            err.into_diagnostic(handler).emit();
+        }
+
+        Ok(program)
+    })
+    .unwrap()
+}
+
+fn analyze_scope_data(program: &Program, typescript: bool) -> ScopeData {
+    let globals = Globals::new();
+    GLOBALS.set(&globals, || ScopeData::analyze(program, typescript))
+}
+
+#[derive(Default)]
+struct IdentCollector {
+    bindings: Vec<(String, NodeId)>,
+    value_refs: Vec<(String, NodeId)>,
+    type_refs: Vec<(String, NodeId)>,
+    in_type: bool,
+}
+
+impl IdentCollector {
+    fn binding_ids(&self, sym: &str) -> Vec<NodeId> {
+        self.bindings
+            .iter()
+            .filter_map(|(name, node_id)| (name == sym).then_some(*node_id))
+            .collect()
+    }
+
+    fn value_ref_ids(&self, sym: &str) -> Vec<NodeId> {
+        self.value_refs
+            .iter()
+            .filter_map(|(name, node_id)| (name == sym).then_some(*node_id))
+            .collect()
+    }
+
+    fn type_ref_ids(&self, sym: &str) -> Vec<NodeId> {
+        self.type_refs
+            .iter()
+            .filter_map(|(name, node_id)| (name == sym).then_some(*node_id))
+            .collect()
+    }
+
+    fn record_binding(&mut self, ident: &Ident) {
+        self.bindings.push((ident.sym.to_string(), ident.node_id));
+    }
+}
+
+impl Visit for IdentCollector {
+    fn visit_binding_ident(&mut self, node: &BindingIdent) {
+        self.record_binding(&node.id);
+        node.type_ann.visit_with(self);
+    }
+
+    fn visit_class_decl(&mut self, node: &ClassDecl) {
+        self.record_binding(&node.ident);
+        node.class.visit_with(self);
+    }
+
+    fn visit_fn_decl(&mut self, node: &FnDecl) {
+        self.record_binding(&node.ident);
+        node.function.visit_with(self);
+    }
+
+    fn visit_ident(&mut self, node: &Ident) {
+        let refs = if self.in_type {
+            &mut self.type_refs
+        } else {
+            &mut self.value_refs
+        };
+
+        refs.push((node.sym.to_string(), node.node_id));
+    }
+
+    fn visit_import_default_specifier(&mut self, node: &ImportDefaultSpecifier) {
+        self.record_binding(&node.local);
+    }
+
+    fn visit_import_named_specifier(&mut self, node: &ImportNamedSpecifier) {
+        self.record_binding(&node.local);
+    }
+
+    fn visit_import_star_as_specifier(&mut self, node: &ImportStarAsSpecifier) {
+        self.record_binding(&node.local);
+    }
+
+    fn visit_ts_type(&mut self, node: &TsType) {
+        let old_in_type = self.in_type;
+        self.in_type = true;
+        node.visit_children_with(self);
+        self.in_type = old_in_type;
+    }
+}
+
+fn collect_idents(program: &Program) -> IdentCollector {
+    let mut collector = IdentCollector::default();
+    program.visit_with(&mut collector);
+    collector
+}
+
+fn only_node_id(ids: Vec<NodeId>) -> NodeId {
+    match &ids[..] {
+        [node_id] => *node_id,
+        _ => panic!("expected exactly one node id, got {ids:?}"),
+    }
+}
+
 #[test]
 fn test_mark_for() {
     ::testing::run_test(false, |_, _| {
@@ -63,7 +186,7 @@ fn test_mark_for() {
         let mark4 = Mark::fresh(mark3);
 
         let folder1 = Resolver::new(
-            Scope::new(ScopeKind::Block, mark1, None),
+            Scope::new(ScopeKind::Block, mark1, NodeId::DUMMY, None),
             InnerConfig {
                 handle_types: true,
                 unresolved_mark: Mark::fresh(Mark::root()),
@@ -71,7 +194,12 @@ fn test_mark_for() {
             },
         );
         let mut folder2 = Resolver::new(
-            Scope::new(ScopeKind::Block, mark2, Some(&folder1.current)),
+            Scope::new(
+                ScopeKind::Block,
+                mark2,
+                NodeId::DUMMY,
+                Some(&folder1.current),
+            ),
             InnerConfig {
                 handle_types: true,
                 unresolved_mark: Mark::fresh(Mark::root()),
@@ -84,7 +212,12 @@ fn test_mark_for() {
             .insert(atom!("foo"), DeclKind::Var);
 
         let mut folder3 = Resolver::new(
-            Scope::new(ScopeKind::Block, mark3, Some(&folder2.current)),
+            Scope::new(
+                ScopeKind::Block,
+                mark3,
+                NodeId::DUMMY,
+                Some(&folder2.current),
+            ),
             InnerConfig {
                 handle_types: true,
                 unresolved_mark: Mark::fresh(Mark::root()),
@@ -98,7 +231,12 @@ fn test_mark_for() {
         assert_eq!(folder3.mark_for_ref(&atom!("bar")), Some(mark3));
 
         let mut folder4 = Resolver::new(
-            Scope::new(ScopeKind::Block, mark4, Some(&folder3.current)),
+            Scope::new(
+                ScopeKind::Block,
+                mark4,
+                NodeId::DUMMY,
+                Some(&folder3.current),
+            ),
             InnerConfig {
                 handle_types: true,
                 unresolved_mark: Mark::fresh(Mark::root()),
@@ -115,6 +253,133 @@ fn test_mark_for() {
         Ok(())
     })
     .unwrap();
+}
+
+#[test]
+fn scope_data_tracks_shadowing_and_scope_hierarchy() {
+    let program = parse_program(Syntax::Es(Default::default()), "let a; { let a; a; } a;");
+    let scope_data = analyze_scope_data(&program, false);
+    let ids = collect_idents(&program);
+
+    let binding_ids = ids.binding_ids("a");
+    assert_eq!(binding_ids.len(), 2);
+    let inner_ref = only_node_id(vec![ids.value_ref_ids("a")[0]]);
+    let outer_ref = only_node_id(vec![ids.value_ref_ids("a")[1]]);
+
+    assert_eq!(
+        scope_data.canonical_decl_for_decl(binding_ids[0]),
+        Some(binding_ids[0])
+    );
+    assert_eq!(
+        scope_data.canonical_decl_for_decl(binding_ids[1]),
+        Some(binding_ids[1])
+    );
+    assert_eq!(
+        scope_data.canonical_decl_for_ref(inner_ref),
+        Some(binding_ids[1])
+    );
+    assert_eq!(
+        scope_data.canonical_decl_for_ref(outer_ref),
+        Some(binding_ids[0])
+    );
+
+    let (script_id, block_id) = match &program {
+        Program::Script(script) => match &script.body[1] {
+            Stmt::Block(block) => (script.node_id, block.node_id),
+            other => panic!("expected block statement, got {other:?}"),
+        },
+        other => panic!("expected script program, got {other:?}"),
+    };
+
+    assert_eq!(scope_data.scope_kind.get(&script_id), Some(&ScopeKind::Fn));
+    assert_eq!(
+        scope_data.scope_kind.get(&block_id),
+        Some(&ScopeKind::Block)
+    );
+    assert_eq!(scope_data.scope_parent.get(&block_id), Some(&script_id));
+}
+
+#[test]
+fn scope_data_canonicalizes_duplicate_var_decls() {
+    let program = parse_program(Syntax::Es(Default::default()), "var a; var a; a;");
+    let scope_data = analyze_scope_data(&program, false);
+    let ids = collect_idents(&program);
+
+    let binding_ids = ids.binding_ids("a");
+    let ref_id = only_node_id(ids.value_ref_ids("a"));
+
+    assert_eq!(binding_ids.len(), 2);
+    assert_eq!(
+        scope_data.canonical_decl_for_decl(binding_ids[0]),
+        Some(binding_ids[0])
+    );
+    assert_eq!(
+        scope_data.canonical_decl_for_decl(binding_ids[1]),
+        Some(binding_ids[0])
+    );
+    assert_eq!(
+        scope_data.canonical_decl_for_ref(ref_id),
+        Some(binding_ids[0])
+    );
+    assert_eq!(
+        scope_data.decl_kind.get(&binding_ids[0]),
+        Some(&DeclKind::Var)
+    );
+}
+
+#[test]
+fn scope_data_tracks_import_bindings_in_type_and_value_positions() {
+    let program = parse_program(
+        Syntax::Typescript(TsSyntax {
+            ..Default::default()
+        }),
+        "import { Foo } from 'foo'; let value: Foo; Foo;",
+    );
+    let scope_data = analyze_scope_data(&program, true);
+    let ids = collect_idents(&program);
+
+    let import_binding = only_node_id(ids.binding_ids("Foo"));
+    let type_ref = only_node_id(ids.type_ref_ids("Foo"));
+    let value_ref = only_node_id(ids.value_ref_ids("Foo"));
+
+    assert_eq!(
+        scope_data.canonical_decl_for_decl(import_binding),
+        Some(import_binding)
+    );
+    assert_eq!(
+        scope_data.canonical_decl_for_ref(type_ref),
+        Some(import_binding)
+    );
+    assert_eq!(
+        scope_data.canonical_decl_for_ref(value_ref),
+        Some(import_binding)
+    );
+    assert_eq!(
+        scope_data.decl_kind.get(&import_binding),
+        Some(&DeclKind::Lexical)
+    );
+}
+
+#[test]
+fn scope_data_tracks_catch_param_refs() {
+    let program = parse_program(
+        Syntax::Es(Default::default()),
+        "try { throw 1; } catch (e) { e; }",
+    );
+    let scope_data = analyze_scope_data(&program, false);
+    let ids = collect_idents(&program);
+
+    let catch_binding = only_node_id(ids.binding_ids("e"));
+    let catch_ref = only_node_id(ids.value_ref_ids("e"));
+
+    assert_eq!(
+        scope_data.canonical_decl_for_decl(catch_binding),
+        Some(catch_binding)
+    );
+    assert_eq!(
+        scope_data.canonical_decl_for_ref(catch_ref),
+        Some(catch_binding)
+    );
 }
 
 #[test]

--- a/crates/swc_ecma_transforms_base/src/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/scope.rs
@@ -1,20 +1,21 @@
-use swc_ecma_ast::VarDeclKind;
+use rustc_hash::FxHashMap;
+use swc_ecma_ast::{NodeId, Program, VarDeclKind};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 pub enum ScopeKind {
     Block,
     #[default]
     Fn,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum IdentType {
     Binding,
     Ref,
     Label,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DeclKind {
     Lexical,
     Param,
@@ -22,6 +23,74 @@ pub enum DeclKind {
     Function,
     /// don't actually get stored
     Type,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct CanonicalBinding {
+    pub decl_node_id: NodeId,
+    pub decl_kind: DeclKind,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ScopeData {
+    pub ref_to_decl: FxHashMap<NodeId, NodeId>,
+    pub decl_to_canonical: FxHashMap<NodeId, NodeId>,
+    pub scope_parent: FxHashMap<NodeId, NodeId>,
+    pub scope_kind: FxHashMap<NodeId, ScopeKind>,
+    pub decl_kind: FxHashMap<NodeId, DeclKind>,
+}
+
+impl ScopeData {
+    pub fn analyze(program: &Program, typescript: bool) -> Self {
+        crate::resolver::analyze_scope(program, typescript)
+    }
+
+    #[inline]
+    pub fn canonical_decl_for_ref(&self, node_id: NodeId) -> Option<NodeId> {
+        self.ref_to_decl.get(&node_id).copied()
+    }
+
+    #[inline]
+    pub fn canonical_decl_for_decl(&self, node_id: NodeId) -> Option<NodeId> {
+        self.decl_to_canonical.get(&node_id).copied()
+    }
+
+    pub(crate) fn record_scope(
+        &mut self,
+        scope_id: NodeId,
+        parent_scope_id: Option<NodeId>,
+        kind: ScopeKind,
+    ) {
+        if scope_id.is_dummy() {
+            return;
+        }
+
+        self.scope_kind.entry(scope_id).or_insert(kind);
+
+        if let Some(parent_scope_id) = parent_scope_id.filter(|id| !id.is_dummy()) {
+            self.scope_parent.entry(scope_id).or_insert(parent_scope_id);
+        }
+    }
+
+    pub(crate) fn record_decl(&mut self, decl_node_id: NodeId, canonical: CanonicalBinding) {
+        if decl_node_id.is_dummy() || canonical.decl_node_id.is_dummy() {
+            return;
+        }
+
+        self.decl_to_canonical
+            .insert(decl_node_id, canonical.decl_node_id);
+        self.decl_kind
+            .entry(canonical.decl_node_id)
+            .or_insert(canonical.decl_kind);
+    }
+
+    pub(crate) fn record_ref(&mut self, ref_node_id: NodeId, canonical_decl_id: NodeId) {
+        if ref_node_id.is_dummy() || canonical_decl_id.is_dummy() {
+            return;
+        }
+
+        self.ref_to_decl.insert(ref_node_id, canonical_decl_id);
+    }
 }
 
 impl From<VarDeclKind> for DeclKind {

--- a/crates/swc_ecma_transforms_base/tests/fixer_test262.rs
+++ b/crates/swc_ecma_transforms_base/tests/fixer_test262.rs
@@ -308,6 +308,7 @@ impl Fold for Normalizer {
 
     fn fold_number(&mut self, n: Number) -> Number {
         Number {
+            node_id: Default::default(),
             span: n.span,
             value: n.value,
             raw: None,
@@ -319,6 +320,7 @@ impl Fold for Normalizer {
 
         match name {
             PropName::Ident(i) => PropName::Str(Str {
+                node_id: Default::default(),
                 raw: None,
                 value: i.sym.into(),
                 span: i.span,
@@ -334,6 +336,7 @@ impl Fold for Normalizer {
                     format!("{}", n.value).into()
                 };
                 PropName::Str(Str {
+                    node_id: Default::default(),
                     raw: None,
                     value: value.into(),
                     span: n.span,
@@ -362,9 +365,19 @@ impl Fold for Normalizer {
         let stmt = stmt.fold_children_with(self);
 
         match stmt {
-            Stmt::Expr(ExprStmt { span, expr }) => match *expr {
-                Expr::Paren(ParenExpr { expr, .. }) => ExprStmt { span, expr }.into(),
-                _ => ExprStmt { span, expr }.into(),
+            Stmt::Expr(ExprStmt { span, expr, .. }) => match *expr {
+                Expr::Paren(ParenExpr { expr, .. }) => ExprStmt {
+                    node_id: Default::default(),
+                    span,
+                    expr,
+                }
+                .into(),
+                _ => ExprStmt {
+                    node_id: Default::default(),
+                    span,
+                    expr,
+                }
+                .into(),
             },
             _ => stmt,
         }
@@ -372,6 +385,7 @@ impl Fold for Normalizer {
 
     fn fold_str(&mut self, s: Str) -> Str {
         Str {
+            node_id: Default::default(),
             span: s.span,
             value: s.value,
             raw: None,

--- a/crates/swc_ecma_transforms_classes/src/super_field.rs
+++ b/crates/swc_ecma_transforms_classes/src/super_field.rs
@@ -73,7 +73,7 @@ impl VisitMut for SuperFieldAccessFolder<'_> {
 
     fn visit_mut_expr(&mut self, n: &mut Expr) {
         match n {
-            Expr::This(ThisExpr { span }) if self.in_nested_scope => {
+            Expr::This(ThisExpr { span, .. }) if self.in_nested_scope => {
                 *n = quote_ident!(
                     SyntaxContext::empty().apply_mark(
                         *self
@@ -203,7 +203,11 @@ impl SuperFieldAccessFolder<'_> {
                             ident
                         }
                     }
-                    _ => ThisExpr { span: DUMMY_SP }.as_arg(),
+                    _ => ThisExpr {
+                        node_id: Default::default(),
+                        span: DUMMY_SP,
+                    }
+                    .as_arg(),
                 };
 
                 let callee = self.super_to_get_call(*super_token, prop.clone());
@@ -248,7 +252,9 @@ impl SuperFieldAccessFolder<'_> {
         if let Expr::Assign(AssignExpr {
             left:
                 AssignTarget::Simple(SimpleAssignTarget::SuperProp(SuperPropExpr {
-                    obj: Super { span: super_token },
+                    obj: Super {
+                        span: super_token, ..
+                    },
                     prop,
                     ..
                 })),
@@ -271,7 +277,9 @@ impl SuperFieldAccessFolder<'_> {
     /// ```
     fn visit_mut_super_member_get(&mut self, n: &mut Expr) {
         if let Expr::SuperProp(SuperPropExpr {
-            obj: Super { span: super_token },
+            obj: Super {
+                span: super_token, ..
+            },
             prop,
             ..
         }) = n
@@ -294,7 +302,9 @@ impl SuperFieldAccessFolder<'_> {
 
             if let AssignTarget::Simple(expr) = left {
                 if let SimpleAssignTarget::SuperProp(SuperPropExpr {
-                    obj: Super { span: super_token },
+                    obj: Super {
+                        span: super_token, ..
+                    },
                     prop,
                     ..
                 }) = expr.take()
@@ -308,6 +318,7 @@ impl SuperFieldAccessFolder<'_> {
     fn super_to_get_call(&mut self, super_token: Span, prop: SuperProp) -> Box<Expr> {
         if self.constant_super {
             MemberExpr {
+                node_id: Default::default(),
                 span: super_token,
                 obj: Box::new({
                     let name = self.super_class.clone().unwrap_or_else(|| {
@@ -361,11 +372,16 @@ impl SuperFieldAccessFolder<'_> {
                 "_this"
             )
             .into(),
-            None => ThisExpr { span: super_token }.into(),
+            None => ThisExpr {
+                node_id: Default::default(),
+                span: super_token,
+            }
+            .into(),
         });
 
         if self.constant_super {
             let left = MemberExpr {
+                node_id: Default::default(),
                 span: super_token,
                 obj: this_expr,
                 prop: match prop {
@@ -377,6 +393,7 @@ impl SuperFieldAccessFolder<'_> {
             };
 
             AssignExpr {
+                node_id: Default::default(),
                 span: super_token,
                 left: left.into(),
                 op,
@@ -451,6 +468,7 @@ impl SuperFieldAccessFolder<'_> {
             let this = quote_ident!(SyntaxContext::empty().apply_mark(mark), "_this");
 
             proto_arg = SeqExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 exprs: vec![
                     Expr::Call(CallExpr {
@@ -477,7 +495,11 @@ impl SuperFieldAccessFolder<'_> {
                 "_this"
             )
             .into(),
-            None => ThisExpr { span: super_token }.into(),
+            None => ThisExpr {
+                node_id: Default::default(),
+                span: super_token,
+            }
+            .into(),
         }
     }
 }
@@ -494,6 +516,7 @@ fn prop_arg(prop: SuperProp) -> Expr {
         SuperProp::Ident(IdentName {
             sym: value, span, ..
         }) => Lit::Str(Str {
+            node_id: Default::default(),
             span,
             raw: None,
             value: value.into(),

--- a/crates/swc_ecma_transforms_optimization/src/const_modules.rs
+++ b/crates/swc_ecma_transforms_optimization/src/const_modules.rs
@@ -219,6 +219,7 @@ impl VisitMut for ConstModules {
                 let sym_wtf8: Wtf8Atom = id.sym.clone().into();
                 if let Some(value) = self.scope.imported.get(&sym_wtf8) {
                     *n = Prop::KeyValue(KeyValueProp {
+                        node_id: Default::default(),
                         key: id.take().into(),
                         value: Box::new((**value).clone()),
                     });

--- a/crates/swc_ecma_transforms_optimization/src/inline_globals.rs
+++ b/crates/swc_ecma_transforms_optimization/src/inline_globals.rs
@@ -105,6 +105,7 @@ impl VisitMut for InlineGlobals {
                     // It's ok because we don't recurse into member expressions.
                     if let Some(value) = self.typeofs.get(sym).cloned() {
                         *expr = Lit::Str(Str {
+                            node_id: Default::default(),
                             span: *span,
                             raw: None,
                             value: value.into(),
@@ -177,6 +178,7 @@ impl VisitMut for InlineGlobals {
             if let Some(mut value) = self.globals.get(&i.sym).cloned().map(Box::new) {
                 value.visit_mut_with(self);
                 *p = Prop::KeyValue(KeyValueProp {
+                    node_id: Default::default(),
                     key: PropName::Ident(i.clone().into()),
                     value,
                 });

--- a/crates/swc_ecma_transforms_optimization/src/json_parse.rs
+++ b/crates/swc_ecma_transforms_optimization/src/json_parse.rs
@@ -74,6 +74,7 @@ impl VisitMut for JsonParse {
                         span: expr.span(),
                         callee: member_expr!(Default::default(), DUMMY_SP, JSON.parse).as_callee(),
                         args: vec![Lit::Str(Str {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             raw: None,
                             value: value.into(),

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -214,7 +214,14 @@ impl VisitMut for Remover {
                 return if value {
                     None
                 } else {
-                    Some(Lit::Bool(Bool { span, value: false }).into())
+                    Some(
+                        Lit::Bool(Bool {
+                            node_id: Default::default(),
+                            span,
+                            value: false,
+                        })
+                        .into(),
+                    )
                 };
             }
 
@@ -281,6 +288,7 @@ impl VisitMut for Remover {
                 span,
                 key,
                 value: Some(expr),
+                ..
             }) if expr.is_undefined(self.expr_ctx)
                 || match **expr {
                     Expr::Unary(UnaryExpr {
@@ -292,6 +300,7 @@ impl VisitMut for Remover {
                 } =>
             {
                 *p = ObjectPatProp::Assign(AssignPatProp {
+                    node_id: Default::default(),
                     span: *span,
                     key: key.take(),
                     value: None,
@@ -390,9 +399,11 @@ impl VisitMut for Remover {
                     test,
                     cons,
                     alt,
+                    ..
                 }) => {
                     if let Stmt::If(IfStmt { alt: Some(..), .. }) = *cons {
                         return IfStmt {
+                            node_id: Default::default(),
                             test,
                             cons: Box::new(
                                 BlockStmt {
@@ -416,7 +427,14 @@ impl VisitMut for Remover {
                         // Preserve effect of the test
                         if !p.is_pure() {
                             if let Some(expr) = ignore_result(test, true, self.expr_ctx) {
-                                stmts.push(ExprStmt { span, expr }.into())
+                                stmts.push(
+                                    ExprStmt {
+                                        node_id: Default::default(),
+                                        span,
+                                        expr,
+                                    }
+                                    .into(),
+                                )
                             }
                         }
 
@@ -437,7 +455,11 @@ impl VisitMut for Remover {
                         }
 
                         if stmts.is_empty() {
-                            return EmptyStmt { span }.into();
+                            return EmptyStmt {
+                                node_id: Default::default(),
+                                span,
+                            }
+                            .into();
                         }
 
                         if cfg!(feature = "debug") {
@@ -465,14 +487,24 @@ impl VisitMut for Remover {
                             self.changed = true;
 
                             return if let Some(expr) = ignore_result(test, true, self.expr_ctx) {
-                                ExprStmt { span, expr }.into()
+                                ExprStmt {
+                                    node_id: Default::default(),
+                                    span,
+                                    expr,
+                                }
+                                .into()
                             } else {
-                                EmptyStmt { span }.into()
+                                EmptyStmt {
+                                    node_id: Default::default(),
+                                    span,
+                                }
+                                .into()
                             };
                         }
                     }
 
                     IfStmt {
+                        node_id: Default::default(),
                         span,
                         test,
                         cons,
@@ -485,14 +517,22 @@ impl VisitMut for Remover {
                     if cfg!(feature = "debug") {
                         debug!("Dropping an empty var declaration");
                     }
-                    EmptyStmt { span: v.span }.into()
+                    EmptyStmt {
+                        node_id: Default::default(),
+                        span: v.span,
+                    }
+                    .into()
                 }
 
                 Stmt::Labeled(LabeledStmt {
                     label, span, body, ..
                 }) if body.is_empty() => {
                     debug!("Dropping an empty label statement: `{}`", label);
-                    EmptyStmt { span }.into()
+                    EmptyStmt {
+                        node_id: Default::default(),
+                        span,
+                    }
+                    .into()
                 }
 
                 Stmt::Labeled(LabeledStmt {
@@ -506,29 +546,53 @@ impl VisitMut for Remover {
                 } =>
                 {
                     debug!("Dropping a label statement with instant break: `{}`", label);
-                    EmptyStmt { span }.into()
+                    EmptyStmt {
+                        node_id: Default::default(),
+                        span,
+                    }
+                    .into()
                 }
 
                 // `1;` -> `;`
                 Stmt::Expr(ExprStmt { span, expr, .. }) => {
                     // Directives
                     if let Expr::Lit(Lit::Str(..)) = &*expr {
-                        return ExprStmt { span, expr }.into();
+                        return ExprStmt {
+                            node_id: Default::default(),
+                            span,
+                            expr,
+                        }
+                        .into();
                     }
 
                     match ignore_result(expr, false, self.expr_ctx) {
-                        Some(e) => ExprStmt { span, expr: e }.into(),
-                        None => EmptyStmt { span: DUMMY_SP }.into(),
+                        Some(e) => ExprStmt {
+                            node_id: Default::default(),
+                            span,
+                            expr: e,
+                        }
+                        .into(),
+                        None => EmptyStmt {
+                            node_id: Default::default(),
+                            span: DUMMY_SP,
+                        }
+                        .into(),
                     }
                 }
 
-                Stmt::Block(BlockStmt { span, stmts, ctxt }) => {
+                Stmt::Block(BlockStmt {
+                    span, stmts, ctxt, ..
+                }) => {
                     if stmts.is_empty() {
                         if cfg!(feature = "debug") {
                             debug!("Drooping an empty block statement");
                         }
 
-                        EmptyStmt { span }.into()
+                        EmptyStmt {
+                            node_id: Default::default(),
+                            span,
+                        }
+                        .into()
                     } else if stmts.len() == 1
                         && !is_block_scoped_stuff(&stmts[0])
                         && stmt_depth(&stmts[0]) <= 1
@@ -541,7 +605,13 @@ impl VisitMut for Remover {
                         v.visit_mut_with(self);
                         v
                     } else {
-                        BlockStmt { span, stmts, ctxt }.into()
+                        BlockStmt {
+                            node_id: Default::default(),
+                            span,
+                            stmts,
+                            ctxt,
+                        }
+                        .into()
                     }
                 }
                 Stmt::Try(s) => {
@@ -550,6 +620,7 @@ impl VisitMut for Remover {
                         block,
                         handler,
                         finalizer,
+                        ..
                     } = *s;
 
                     // Only leave the finally block if try block is empty
@@ -565,7 +636,13 @@ impl VisitMut for Remover {
                             var.map(Box::new)
                                 .map(Decl::from)
                                 .map(Stmt::from)
-                                .unwrap_or_else(|| EmptyStmt { span }.into())
+                                .unwrap_or_else(|| {
+                                    EmptyStmt {
+                                        node_id: Default::default(),
+                                        span,
+                                    }
+                                    .into()
+                                })
                         };
                     }
 
@@ -580,6 +657,7 @@ impl VisitMut for Remover {
                     }
 
                     TryStmt {
+                        node_id: Default::default(),
                         span,
                         block,
                         handler,
@@ -667,8 +745,17 @@ impl VisitMut for Remover {
                             debug!("Removing an empty switch statement");
                         }
                         return match ignore_result(s.discriminant, true, self.expr_ctx) {
-                            Some(expr) => ExprStmt { span: s.span, expr }.into(),
-                            None => EmptyStmt { span: s.span }.into(),
+                            Some(expr) => ExprStmt {
+                                node_id: Default::default(),
+                                span: s.span,
+                                expr,
+                            }
+                            .into(),
+                            None => EmptyStmt {
+                                node_id: Default::default(),
+                                span: s.span,
+                            }
+                            .into(),
                         };
                     }
 
@@ -779,6 +866,7 @@ impl VisitMut for Remover {
                                 })
                                 .flat_map(|stmt| stmt.extract_var_ids())
                                 .map(|i| VarDeclarator {
+                                    node_id: Default::default(),
                                     span: DUMMY_SP,
                                     name: i.into(),
                                     init: None,
@@ -804,11 +892,13 @@ impl VisitMut for Remover {
                                 prepend_stmt(
                                     &mut stmts,
                                     ExprStmt {
+                                        node_id: Default::default(),
                                         span: DUMMY_SP,
                                         expr: if exprs.len() == 1 {
                                             exprs.remove(0)
                                         } else {
                                             SeqExpr {
+                                                node_id: Default::default(),
                                                 span: DUMMY_SP,
                                                 exprs,
                                             }
@@ -842,6 +932,7 @@ impl VisitMut for Remover {
                                     for cons in &case.cons {
                                         vars.extend(cons.extract_var_ids().into_iter().map(
                                             |name| VarDeclarator {
+                                                node_id: Default::default(),
                                                 span: DUMMY_SP,
                                                 name: name.into(),
                                                 init: None,
@@ -986,11 +1077,13 @@ impl VisitMut for Remover {
                                 prepend_stmt(
                                     &mut stmts,
                                     ExprStmt {
+                                        node_id: Default::default(),
                                         span: DUMMY_SP,
                                         expr: if exprs.len() == 1 {
                                             exprs.remove(0)
                                         } else {
                                             SeqExpr {
+                                                node_id: Default::default(),
                                                 span: DUMMY_SP,
                                                 exprs,
                                             }
@@ -1046,6 +1139,7 @@ impl VisitMut for Remover {
                                 .flat_map(|case| extract_var_ids(&case.cons))
                                 .chain(var_ids)
                                 .map(|i| VarDeclarator {
+                                    node_id: Default::default(),
                                     span: i.span,
                                     name: i.into(),
                                     init: None,
@@ -1062,7 +1156,11 @@ impl VisitMut for Remover {
                                 }
                                 .into();
                             }
-                            return EmptyStmt { span: s.span }.into();
+                            return EmptyStmt {
+                                node_id: Default::default(),
+                                span: s.span,
+                            }
+                            .into();
                         }
                     }
 
@@ -1085,7 +1183,11 @@ impl VisitMut for Remover {
                     let body = if let Some(var) = decl {
                         var.into()
                     } else {
-                        EmptyStmt { span: s.span }.into()
+                        EmptyStmt {
+                            node_id: Default::default(),
+                            span: s.span,
+                        }
+                        .into()
                     };
 
                     if s.init.is_some() {
@@ -1106,6 +1208,7 @@ impl VisitMut for Remover {
                             if purity.is_pure() {
                                 WhileStmt {
                                     test: Lit::Bool(Bool {
+                                        node_id: Default::default(),
                                         span: s.test.span(),
                                         value: true,
                                     })
@@ -1119,7 +1222,13 @@ impl VisitMut for Remover {
                         } else {
                             let body = s.body.extract_var_ids_as_var();
                             let body = body.map(Box::new).map(Decl::Var).map(Stmt::Decl);
-                            let body = body.unwrap_or(EmptyStmt { span: s.span }.into());
+                            let body = body.unwrap_or(
+                                EmptyStmt {
+                                    node_id: Default::default(),
+                                    span: s.span,
+                                }
+                                .into(),
+                            );
 
                             if purity.is_pure() {
                                 body
@@ -1145,6 +1254,7 @@ impl VisitMut for Remover {
                         if v {
                             // `for(;;);` is shorter than `do ; while(true);`
                             ForStmt {
+                                node_id: Default::default(),
                                 span: s.span,
                                 init: None,
                                 test: None,
@@ -1204,7 +1314,11 @@ impl VisitMut for Remover {
                             debug!("Dropping a useless variable declaration");
                         }
 
-                        return EmptyStmt { span: v.span }.into();
+                        return EmptyStmt {
+                            node_id: Default::default(),
+                            span: v.span,
+                        }
+                        .into();
                     }
 
                     VarDecl { decls, ..*v }.into()
@@ -1304,6 +1418,7 @@ impl Remover {
                                     Ok(t) => {
                                         let ids = extract_var_ids(&t).into_iter().map(|i| {
                                             VarDeclarator {
+                                                node_id: Default::default(),
                                                 span: i.span,
                                                 name: i.into(),
                                                 init: None,
@@ -1357,7 +1472,13 @@ impl Remover {
 
                             if !is_ok_to_inline_block(&stmts) {
                                 stmts.visit_mut_with(self);
-                                BlockStmt { span, stmts, ctxt }.into()
+                                BlockStmt {
+                                    node_id: Default::default(),
+                                    span,
+                                    stmts,
+                                    ctxt,
+                                }
+                                .into()
                             } else {
                                 new_stmts.extend(
                                     stmts
@@ -1375,6 +1496,7 @@ impl Remover {
                             cons,
                             alt,
                             span,
+                            ..
                         }) => {
                             // check if
                             match test.cast_to_bool(self.expr_ctx) {
@@ -1386,6 +1508,7 @@ impl Remover {
                                         if let Some(expr) = expr {
                                             new_stmts.push(T::from(
                                                 ExprStmt {
+                                                    node_id: Default::default(),
                                                     span: DUMMY_SP,
                                                     expr,
                                                 }
@@ -1414,6 +1537,7 @@ impl Remover {
                                     }
                                 }
                                 _ => IfStmt {
+                                    node_id: Default::default(),
                                     test,
                                     cons,
                                     alt,
@@ -1476,6 +1600,7 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
             left,
             op,
             right,
+            ..
         }) if !op.may_short_circuit() => {
             let left = ignore_result(left, true, ctx);
             let right = ignore_result(right, true, ctx);
@@ -1497,6 +1622,7 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
             left,
             op,
             right,
+            ..
         }) => {
             if op == op!("&&") {
                 let right = if let Some(right) = ignore_result(right, true, ctx) {
@@ -1516,6 +1642,7 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
                 } else {
                     Some(
                         BinExpr {
+                            node_id: Default::default(),
                             span,
                             left,
                             op,
@@ -1540,6 +1667,7 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
                     if let Some(right) = right {
                         Some(
                             BinExpr {
+                                node_id: Default::default(),
                                 span,
                                 left,
                                 op,
@@ -1554,7 +1682,7 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
             }
         }
 
-        Expr::Unary(UnaryExpr { span, op, arg }) => match op {
+        Expr::Unary(UnaryExpr { span, op, arg, .. }) => match op {
             // Don't remove ! from negated iifes.
             op!("!")
                 if match &*arg {
@@ -1565,13 +1693,29 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
                     _ => false,
                 } =>
             {
-                Some(UnaryExpr { span, op, arg }.into())
+                Some(
+                    UnaryExpr {
+                        node_id: Default::default(),
+                        span,
+                        op,
+                        arg,
+                    }
+                    .into(),
+                )
             }
 
             op!("void") | op!(unary, "+") | op!(unary, "-") | op!("!") | op!("~") => {
                 ignore_result(arg, true, ctx)
             }
-            _ => Some(UnaryExpr { span, op, arg }.into()),
+            _ => Some(
+                UnaryExpr {
+                    node_id: Default::default(),
+                    span,
+                    op,
+                    arg,
+                }
+                .into(),
+            ),
         },
 
         Expr::Array(ArrayLit { span, elems, .. }) => {
@@ -1584,14 +1728,28 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
                     Some(v)
                 }
                 None => None,
-                Some(ExprOrSpread { spread: None, expr }) => ignore_result(expr, true, ctx)
-                    .map(|expr| Some(ExprOrSpread { spread: None, expr })),
+                Some(ExprOrSpread {
+                    spread: None, expr, ..
+                }) => ignore_result(expr, true, ctx).map(|expr| {
+                    Some(ExprOrSpread {
+                        node_id: Default::default(),
+                        spread: None,
+                        expr,
+                    })
+                }),
             });
 
             if elems.is_empty() {
                 None
             } else if has_spread {
-                Some(ArrayLit { span, elems }.into())
+                Some(
+                    ArrayLit {
+                        node_id: Default::default(),
+                        span,
+                        elems,
+                    }
+                    .into(),
+                )
             } else {
                 ignore_result(
                     ctx.preserve_effects(
@@ -1626,7 +1784,14 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
                     ctx.preserve_effects(
                         span,
                         Expr::undefined(DUMMY_SP),
-                        once(ObjectLit { span, props }.into()),
+                        once(
+                            ObjectLit {
+                                node_id: Default::default(),
+                                span,
+                                props,
+                            }
+                            .into(),
+                        ),
                     ),
                     true,
                     ctx,
@@ -1641,6 +1806,7 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
             ..
         }) if callee.is_pure_callee(ctx) => ignore_result(
             ArrayLit {
+                node_id: Default::default(),
                 span,
                 elems: args
                     .map(|args| args.into_iter().map(Some).collect())
@@ -1658,6 +1824,7 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
             ..
         }) if callee.is_pure_callee(ctx) => ignore_result(
             ArrayLit {
+                node_id: Default::default(),
                 span,
                 elems: args.into_iter().map(Some).collect(),
             }
@@ -1707,7 +1874,14 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
                 return Some(exprs.pop().unwrap());
             }
 
-            Some(SeqExpr { span, exprs }.into())
+            Some(
+                SeqExpr {
+                    node_id: Default::default(),
+                    span,
+                    exprs,
+                }
+                .into(),
+            )
         }
 
         Expr::Cond(CondExpr {
@@ -1715,12 +1889,14 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
             test,
             cons,
             alt,
+            ..
         }) => {
             let alt = if let Some(alt) = ignore_result(alt, true, ctx) {
                 alt
             } else {
                 return ignore_result(
                     BinExpr {
+                        node_id: Default::default(),
                         span,
                         left: test,
                         op: op!("&&"),
@@ -1737,6 +1913,7 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
             } else {
                 return ignore_result(
                     BinExpr {
+                        node_id: Default::default(),
                         span,
                         left: test,
                         op: op!("||"),
@@ -1750,6 +1927,7 @@ fn ignore_result(e: Box<Expr>, drop_str_lit: bool, ctx: ExprCtx) -> Option<Box<E
 
             Some(
                 CondExpr {
+                    node_id: Default::default(),
                     span,
                     test,
                     cons,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/const_propagation.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/const_propagation.rs
@@ -109,6 +109,7 @@ impl VisitMut for ConstPropagation<'_> {
         if let Prop::Shorthand(i) = p {
             if let Some(expr) = self.scope.find_var(&i.to_id()) {
                 *p = Prop::KeyValue(KeyValueProp {
+                    node_id: Default::default(),
                     key: PropName::Ident(i.take().into()),
                     value: expr.clone(),
                 });

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -908,6 +908,7 @@ impl VisitMut for TreeShaker {
                     Expr::Fn(FnExpr {
                         ident: None,
                         function: f,
+                        ..
                     }) if matches!(
                         &**f,
                         Function {
@@ -1056,7 +1057,11 @@ impl VisitMut for TreeShaker {
                 {
                     debug!("Dropping an import because it's not used");
                     self.changed = true;
-                    *n = EmptyStmt { span: DUMMY_SP }.into();
+                    *n = EmptyStmt {
+                        node_id: Default::default(),
+                        span: DUMMY_SP,
+                    }
+                    .into();
                 }
             }
             _ => {
@@ -1148,10 +1153,15 @@ impl VisitMut for TreeShaker {
                 self.changed = true;
 
                 if exprs.is_empty() {
-                    *s = EmptyStmt { span: DUMMY_SP }.into();
+                    *s = EmptyStmt {
+                        node_id: Default::default(),
+                        span: DUMMY_SP,
+                    }
+                    .into();
                     return;
                 } else {
                     *s = ExprStmt {
+                        node_id: Default::default(),
                         span,
                         expr: Expr::from_exprs(exprs),
                     }
@@ -1162,7 +1172,11 @@ impl VisitMut for TreeShaker {
 
         if let Stmt::Decl(Decl::Var(v)) = s {
             if v.decls.is_empty() {
-                *s = EmptyStmt { span: DUMMY_SP }.into();
+                *s = EmptyStmt {
+                    node_id: Default::default(),
+                    span: DUMMY_SP,
+                }
+                .into();
             }
         }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -159,6 +159,7 @@ impl VisitMut for SimplifyExpr {
                         }
                         _ => {
                             let seq = SeqExpr {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 exprs: vec![0.0.into(), e.take()],
                             };
@@ -255,6 +256,7 @@ impl VisitMut for SimplifyExpr {
                 test,
                 cons,
                 alt,
+                ..
             }) => {
                 if let (p, Known(val)) = test.cast_to_bool(self.expr_ctx) {
                     self.changed = true;
@@ -263,6 +265,7 @@ impl VisitMut for SimplifyExpr {
                     *expr = if p.is_pure() {
                         if expr_value.directness_matters() {
                             SeqExpr {
+                                node_id: Default::default(),
                                 span: *span,
                                 exprs: vec![0.into(), expr_value.take()],
                             }
@@ -272,6 +275,7 @@ impl VisitMut for SimplifyExpr {
                         }
                     } else {
                         SeqExpr {
+                            node_id: Default::default(),
                             span: *span,
                             exprs: vec![test.take(), expr_value.take()],
                         }
@@ -299,11 +303,13 @@ impl VisitMut for SimplifyExpr {
                         Some(ExprOrSpread {
                             spread: Some(..),
                             expr,
+                            ..
                         }) if expr.is_array() => {
                             self.changed = true;
 
                             e.extend(expr.array().unwrap().elems.into_iter().map(|elem| {
                                 Some(elem.unwrap_or_else(|| ExprOrSpread {
+                                    node_id: Default::default(),
                                     spread: None,
                                     expr: Expr::undefined(DUMMY_SP),
                                 }))
@@ -340,6 +346,7 @@ impl VisitMut for SimplifyExpr {
                                     _ => panic!("unable to access unknown nodes"),
                                 }) {
                                     ps.push(PropOrSpread::Spread(SpreadElement {
+                                        node_id: Default::default(),
                                         dot3_token,
                                         expr,
                                     }));
@@ -502,7 +509,7 @@ impl VisitMut for SimplifyExpr {
                 Expr::Lit(_) => {}
 
                 // Flatten array
-                Expr::Array(ArrayLit { span, elems }) => {
+                Expr::Array(ArrayLit { span, elems, .. }) => {
                     let is_simple = elems
                         .iter()
                         .all(|elem| matches!(elem, None | Some(ExprOrSpread { spread: None, .. })));
@@ -510,7 +517,14 @@ impl VisitMut for SimplifyExpr {
                     if is_simple {
                         exprs.extend(elems.into_iter().flatten().map(|e| e.expr));
                     } else {
-                        exprs.push(Box::new(ArrayLit { span, elems }.into()));
+                        exprs.push(Box::new(
+                            ArrayLit {
+                                node_id: Default::default(),
+                                span,
+                                elems,
+                            }
+                            .into(),
+                        ));
                     }
                 }
 
@@ -583,7 +597,16 @@ fn make_bool_expr<I>(ctx: ExprCtx, span: Span, value: bool, orig: I) -> Box<Expr
 where
     I: IntoIterator<Item = Box<Expr>>,
 {
-    ctx.preserve_effects(span, Lit::Bool(Bool { value, span }).into(), orig)
+    ctx.preserve_effects(
+        span,
+        Lit::Bool(Bool {
+            node_id: Default::default(),
+            value,
+            span,
+        })
+        .into(),
+        orig,
+    )
 }
 
 /// Gets the `idx`-th UTF-16 code unit from the given [Wtf8].
@@ -759,6 +782,7 @@ pub fn optimize_member_expr(
                 };
 
                 *expr = Lit::Num(Number {
+                    node_id: Default::default(),
                     value: value.chars().map(|c| c.len_utf16()).sum::<usize>() as _,
                     span: *span,
                     raw: None,
@@ -782,6 +806,7 @@ pub fn optimize_member_expr(
                 value.push(c);
 
                 *expr = Lit::Str(Str {
+                    node_id: Default::default(),
                     raw: None,
                     value: value.into(),
                     span: *span,
@@ -798,7 +823,7 @@ pub fn optimize_member_expr(
         // [1, 2, 3].length
         //
         // [1, 2, 3][0]
-        Expr::Array(ArrayLit { elems, span }) => {
+        Expr::Array(ArrayLit { elems, span, .. }) => {
             // do nothing if spread exists
             let has_spread = elems.iter().any(|elem| {
                 elem.as_ref()
@@ -826,6 +851,7 @@ pub fn optimize_member_expr(
                     *changed = true;
 
                     *expr = Lit::Num(Number {
+                        node_id: Default::default(),
                         value: elems.len() as _,
                         span: *span,
                         raw: None,
@@ -908,7 +934,7 @@ pub fn optimize_member_expr(
         // { foo: true }['foo']
         //
         // { 0.5: true }[0.5]
-        Expr::Object(ObjectLit { props, span }) => {
+        Expr::Object(ObjectLit { props, span, .. }) => {
             // get key
             let key = match op {
                 KnownOp::Index(i) => Atom::from(i.to_string()),
@@ -929,6 +955,7 @@ pub fn optimize_member_expr(
                 v,
                 once(
                     ObjectLit {
+                        node_id: Default::default(),
                         props: props.take(),
                         span: *span,
                     }
@@ -948,6 +975,7 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
         op,
         right,
         span,
+        ..
     } = match expr {
         Expr::Bin(bin) => bin,
         _ => return,
@@ -976,6 +1004,7 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
 
                     let value_expr = if !v.is_nan() {
                         Expr::Lit(Lit::Num(Number {
+                            node_id: Default::default(),
                             value: v,
                             span: *span,
                             raw: None,
@@ -1008,6 +1037,7 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
                     *changed = true;
 
                     *expr = Lit::Str(Str {
+                        node_id: Default::default(),
                         raw: None,
                         value: l.into(),
                         span: *span,
@@ -1035,6 +1065,7 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
                                 value.push_wtf8(&r);
 
                                 *expr = Lit::Str(Str {
+                                    node_id: Default::default(),
                                     raw: None,
                                     value: value.into(),
                                     span: *span,
@@ -1057,6 +1088,7 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
 
                                 let value_expr = if !v.is_nan() {
                                     Lit::Num(Number {
+                                        node_id: Default::default(),
                                         value: v,
                                         span,
                                         raw: None,
@@ -1111,6 +1143,7 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
 
                     if node.directness_matters() {
                         *expr = SeqExpr {
+                            node_id: Default::default(),
                             span: node.span(),
                             exprs: vec![0.into(), node.take()],
                         }
@@ -1122,6 +1155,7 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
                     *changed = true;
 
                     let seq = SeqExpr {
+                        node_id: Default::default(),
                         span: *span,
                         exprs: vec![left.take(), node.take()],
                     };
@@ -1224,12 +1258,14 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
                 left: left_lhs,
                 op: left_op,
                 right: left_rhs,
+                ..
             }) = &mut **left
             {
                 if *left_op == op {
                     if let Known(value) = perform_arithmetic_op(expr_ctx, op, left_rhs, right) {
                         let value_expr = if !value.is_nan() {
                             Lit::Num(Number {
+                                node_id: Default::default(),
                                 value,
                                 span: *span,
                                 raw: None,
@@ -1271,7 +1307,7 @@ pub fn optimize_bin_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool)
 
 /// **NOTE**: This is **NOT** a public API. DO NOT USE.
 pub fn optimize_unary_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool) {
-    let UnaryExpr { op, arg, span } = match expr {
+    let UnaryExpr { op, arg, span, .. } = match expr {
         Expr::Unary(unary) => unary,
         _ => return,
     };
@@ -1319,6 +1355,7 @@ pub fn optimize_unary_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut boo
                 *expr = *expr_ctx.preserve_effects(
                     *span,
                     Lit::Num(Number {
+                        node_id: Default::default(),
                         value: v,
                         span: *span,
                         raw: None,
@@ -1338,6 +1375,7 @@ pub fn optimize_unary_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut boo
             Expr::Lit(Lit::Num(Number { value: f, .. })) => {
                 *changed = true;
                 *expr = Lit::Num(Number {
+                    node_id: Default::default(),
                     value: -f,
                     span: *span,
                     raw: None,
@@ -1358,6 +1396,7 @@ pub fn optimize_unary_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut boo
             *changed = true;
 
             *arg = Lit::Num(Number {
+                node_id: Default::default(),
                 value: 0.0,
                 span: arg.span(),
                 raw: None,
@@ -1370,6 +1409,7 @@ pub fn optimize_unary_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut boo
                 if value.fract() == 0.0 {
                     *changed = true;
                     *expr = Lit::Num(Number {
+                        node_id: Default::default(),
                         span: *span,
                         value: if value < 0.0 {
                             !(value as i32 as u32) as i32 as f64
@@ -1393,7 +1433,7 @@ pub fn optimize_unary_expr(expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut boo
 ///
 /// typeof(6) --> "number"
 fn try_fold_typeof(_expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool) {
-    let UnaryExpr { op, arg, span } = match expr {
+    let UnaryExpr { op, arg, span, .. } = match expr {
         Expr::Unary(unary) => unary,
         _ => return,
     };
@@ -1423,6 +1463,7 @@ fn try_fold_typeof(_expr_ctx: ExprCtx, expr: &mut Expr, changed: &mut bool) {
     *changed = true;
 
     *expr = Lit::Str(Str {
+        node_id: Default::default(),
         span: *span,
         raw: None,
         value: val.into(),
@@ -1676,6 +1717,7 @@ fn perform_abstract_eq_cmp(
                 span,
                 left,
                 &Lit::Num(Number {
+                    node_id: Default::default(),
                     value: rv,
                     span,
                     raw: None,
@@ -1690,6 +1732,7 @@ fn perform_abstract_eq_cmp(
                 expr_ctx,
                 span,
                 &Lit::Num(Number {
+                    node_id: Default::default(),
                     value: lv,
                     span,
                     raw: None,

--- a/crates/swc_ecma_utils/src/constructor.rs
+++ b/crates/swc_ecma_utils/src/constructor.rs
@@ -92,20 +92,24 @@ impl VisitMut for Injector {
 
             *node = if ignore_return_value {
                 SeqExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     exprs: exprs.collect(),
                 }
                 .into()
             } else {
                 let array = ArrayLit {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     elems: exprs.map(ExprOrSpread::from).map(Some).collect(),
                 };
 
                 MemberExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     obj: array.into(),
                     prop: ComputedPropName {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         expr: 0.into(),
                     }

--- a/crates/swc_ecma_utils/src/factory.rs
+++ b/crates/swc_ecma_utils/src/factory.rs
@@ -29,6 +29,7 @@ pub trait ExprFactory: Into<Box<Expr>> {
     /// use swc_ecma_utils::ExprFactory;
     ///
     /// let first = Lit::Num(Number {
+    ///     node_id: Default::default(),
     ///     span: DUMMY_SP,
     ///     value: 0.0,
     ///     raw: None,
@@ -38,6 +39,7 @@ pub trait ExprFactory: Into<Box<Expr>> {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn as_arg(self) -> ExprOrSpread {
         ExprOrSpread {
+            node_id: Default::default(),
             expr: self.into(),
             spread: None,
         }
@@ -48,6 +50,7 @@ pub trait ExprFactory: Into<Box<Expr>> {
     fn into_stmt(self) -> Stmt {
         let expr = self.into();
         ExprStmt {
+            node_id: Default::default(),
             span: expr.span(),
             expr,
         }
@@ -58,6 +61,7 @@ pub trait ExprFactory: Into<Box<Expr>> {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn into_return_stmt(self) -> ReturnStmt {
         ReturnStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             arg: Some(self.into()),
         }
@@ -121,6 +125,7 @@ pub trait ExprFactory: Into<Box<Expr>> {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn into_var_decl(self, kind: VarDeclKind, name: Pat) -> VarDecl {
         let var_declarator = VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name,
             init: Some(self.into()),
@@ -188,7 +193,9 @@ pub trait ExprFactory: Into<Box<Expr>> {
             Expr::Fn(FnExpr {
                 ident: Some(ident),
                 function,
+                ..
             }) => Some(FnDecl {
+                node_id: Default::default(),
                 ident,
                 declare: false,
                 function,
@@ -203,7 +210,9 @@ pub trait ExprFactory: Into<Box<Expr>> {
             Expr::Class(ClassExpr {
                 ident: Some(ident),
                 class,
+                ..
             }) => Some(ClassDecl {
+                node_id: Default::default(),
                 ident,
                 declare: false,
                 class,
@@ -216,7 +225,12 @@ pub trait ExprFactory: Into<Box<Expr>> {
     fn wrap_with_paren(self) -> Expr {
         let expr = self.into();
         let span = expr.span();
-        ParenExpr { expr, span }.into()
+        ParenExpr {
+            node_id: Default::default(),
+            expr,
+            span,
+        }
+        .into()
     }
 
     /// Creates a binary expr `$self === `
@@ -237,6 +251,7 @@ pub trait ExprFactory: Into<Box<Expr>> {
         let right = Box::new(right.into());
 
         BinExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             left: self.into(),
             op,
@@ -251,6 +266,7 @@ pub trait ExprFactory: Into<Box<Expr>> {
         let right = self.into();
 
         AssignExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             left,
             op,
@@ -262,6 +278,7 @@ pub trait ExprFactory: Into<Box<Expr>> {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn make_member(self, prop: IdentName) -> MemberExpr {
         MemberExpr {
+            node_id: Default::default(),
             obj: self.into(),
             span: DUMMY_SP,
             prop: MemberProp::Ident(prop),
@@ -274,9 +291,11 @@ pub trait ExprFactory: Into<Box<Expr>> {
         T: Into<Box<Expr>>,
     {
         MemberExpr {
+            node_id: Default::default(),
             obj: self.into(),
             span: DUMMY_SP,
             prop: MemberProp::Computed(ComputedPropName {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 expr: prop.into(),
             }),
@@ -311,6 +330,7 @@ impl IntoIndirectCall for Callee {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn into_indirect(self) -> Callee {
         SeqExpr {
+            node_id: Default::default(),
             span: DUMMY_SP,
             exprs: vec![0f64.into(), self.expect_expr()],
         }
@@ -326,6 +346,7 @@ impl IntoIndirectCall for TaggedTpl {
         Self {
             tag: Box::new(
                 SeqExpr {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     exprs: vec![0f64.into(), self.tag.take()],
                 }
@@ -340,6 +361,7 @@ pub trait FunctionFactory: Into<Box<Function>> {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn into_fn_expr(self, ident: Option<Ident>) -> FnExpr {
         FnExpr {
+            node_id: Default::default(),
             ident,
             function: self.into(),
         }
@@ -348,6 +370,7 @@ pub trait FunctionFactory: Into<Box<Function>> {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn into_fn_decl(self, ident: Ident) -> FnDecl {
         FnDecl {
+            node_id: Default::default(),
             ident,
             declare: false,
             function: self.into(),
@@ -357,6 +380,7 @@ pub trait FunctionFactory: Into<Box<Function>> {
     #[cfg_attr(not(debug_assertions), inline(always))]
     fn into_method_prop(self, key: PropName) -> MethodProp {
         MethodProp {
+            node_id: Default::default(),
             key,
             function: self.into(),
         }

--- a/crates/swc_ecma_utils/src/function/fn_env_hoister.rs
+++ b/crates/swc_ecma_utils/src/function/fn_env_hoister.rs
@@ -86,14 +86,22 @@ impl FnEnvHoister {
         let mut decls = Vec::with_capacity(3);
         if let Some(this_id) = this {
             decls.push(VarDeclarator {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 name: this_id.into(),
-                init: Some(ThisExpr { span: DUMMY_SP }.into()),
+                init: Some(
+                    ThisExpr {
+                        node_id: Default::default(),
+                        span: DUMMY_SP,
+                    }
+                    .into(),
+                ),
                 definite: false,
             });
         }
         if let Some(id) = args {
             decls.push(VarDeclarator {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 name: id.into(),
                 init: Some(Ident::new_no_ctxt(atom!("arguments"), DUMMY_SP).into()),
@@ -102,10 +110,12 @@ impl FnEnvHoister {
         }
         if let Some(id) = new_target {
             decls.push(VarDeclarator {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 name: id.into(),
                 init: Some(
                     MetaPropExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         kind: MetaPropKind::NewTarget,
                     }
@@ -149,6 +159,7 @@ impl FnEnvHoister {
         let mut decls = Vec::with_capacity(3);
         if let Some(this_id) = &this {
             decls.push(VarDeclarator {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 name: this_id.clone().into(),
                 init: None,
@@ -157,6 +168,7 @@ impl FnEnvHoister {
         }
         if let Some(id) = args {
             decls.push(VarDeclarator {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 name: id.into(),
                 init: Some(Ident::new_no_ctxt(atom!("arguments"), DUMMY_SP).into()),
@@ -165,10 +177,12 @@ impl FnEnvHoister {
         }
         if let Some(id) = new_target {
             decls.push(VarDeclarator {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 name: id.into(),
                 init: Some(
                     MetaPropExpr {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         kind: MetaPropKind::NewTarget,
                     }
@@ -305,6 +319,7 @@ impl VisitMut for FnEnvHoister {
                         .take()
                         .into_iter()
                         .map(|ident| VarDeclarator {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             name: ident.into(),
                             init: None,
@@ -333,6 +348,7 @@ impl VisitMut for FnEnvHoister {
                                 .take()
                                 .into_iter()
                                 .map(|ident| VarDeclarator {
+                                    node_id: Default::default(),
                                     span: DUMMY_SP,
                                     name: ident.into(),
                                     init: None,
@@ -342,6 +358,7 @@ impl VisitMut for FnEnvHoister {
                             ..Default::default()
                         }))),
                         Stmt::Return(ReturnStmt {
+                            node_id: Default::default(),
                             span: e.span(),
                             arg: Some(e.take()),
                         }),
@@ -386,6 +403,7 @@ impl VisitMut for FnEnvHoister {
                 right,
                 span,
                 op,
+                ..
             }) => {
                 let expr = match left {
                     AssignTarget::Simple(e) => e,
@@ -410,6 +428,7 @@ impl VisitMut for FnEnvHoister {
                                     self.extra_ident.push(tmp.clone());
                                     vec![
                                         Expr::Assign(AssignExpr {
+                                            node_id: Default::default(),
                                             span: DUMMY_SP,
                                             left: tmp.clone().into(),
                                             op: op!("="),
@@ -417,6 +436,7 @@ impl VisitMut for FnEnvHoister {
                                         })
                                         .as_arg(),
                                         Expr::Bin(BinExpr {
+                                            node_id: Default::default(),
                                             span: DUMMY_SP,
                                             left: Box::new(Expr::Call(CallExpr {
                                                 span: DUMMY_SP,
@@ -448,6 +468,7 @@ impl VisitMut for FnEnvHoister {
                                     span: *span,
                                     args: vec![(if let Some(op) = op.to_update() {
                                         Box::new(Expr::Bin(BinExpr {
+                                            node_id: Default::default(),
                                             span: DUMMY_SP,
                                             left: Box::new(
                                                 self.super_get(&id.sym, id.span)
@@ -632,16 +653,22 @@ impl VisitMut for InitThis<'_> {
         {
             let span = call_expr.span;
             *expr = ParenExpr {
+                node_id: Default::default(),
                 span,
                 expr: SeqExpr {
+                    node_id: Default::default(),
                     span,
                     exprs: vec![
                         Box::new(Expr::Call(call_expr.take())),
                         Box::new(Expr::Assign(AssignExpr {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             left: self.this_id.clone().into(),
                             op: AssignOp::Assign,
-                            right: Box::new(Expr::This(ThisExpr { span: DUMMY_SP })),
+                            right: Box::new(Expr::This(ThisExpr {
+                                node_id: Default::default(),
+                                span: DUMMY_SP,
+                            })),
                         })),
                     ],
                 }
@@ -661,13 +688,16 @@ fn extend_super(
     decls.extend(update.ident.into_iter().map(|(key, ident)| {
         let value = private_ident!("v");
         VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: ident.into(),
             init: Some(
                 ObjectLit {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     props: vec![
                         Prop::Getter(GetterProp {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             key: PropName::Ident(atom!("_").into()),
                             type_ann: None,
@@ -686,6 +716,7 @@ fn extend_super(
                             }),
                         }),
                         Prop::Setter(SetterProp {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             key: PropName::Ident(atom!("_").into()),
                             this_param: None,
@@ -719,6 +750,7 @@ fn extend_super(
         let value = private_ident!("v");
 
         decls.push(VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: id.into(),
             init: Some(
@@ -727,9 +759,11 @@ fn extend_super(
                     params: vec![prop.clone().into()],
                     body: Box::new(BlockStmtOrExpr::Expr(Box::new(
                         ObjectLit {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             props: vec![
                                 Prop::Getter(GetterProp {
+                                    node_id: Default::default(),
                                     span: DUMMY_SP,
                                     key: PropName::Ident(atom!("_").into()),
                                     type_ann: None,
@@ -747,6 +781,7 @@ fn extend_super(
                                     }),
                                 }),
                                 Prop::Setter(SetterProp {
+                                    node_id: Default::default(),
                                     span: DUMMY_SP,
                                     key: PropName::Ident(atom!("_").into()),
                                     this_param: None,
@@ -781,6 +816,7 @@ fn extend_super(
     }
     decls.extend(get.ident.into_iter().map(|(key, ident)| {
         VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: ident.without_loc().into(),
             init: Some(
@@ -789,7 +825,11 @@ fn extend_super(
                     params: Vec::new(),
                     body: Box::new(BlockStmtOrExpr::Expr(Box::new(
                         SuperPropExpr {
-                            obj: Super { span: DUMMY_SP },
+                            node_id: Default::default(),
+                            obj: Super {
+                                node_id: Default::default(),
+                                span: DUMMY_SP,
+                            },
                             prop: SuperProp::Ident(key.into()),
                             span: DUMMY_SP,
                         }
@@ -805,6 +845,7 @@ fn extend_super(
     if let Some(id) = get.computed {
         let param = private_ident!("_prop");
         decls.push(VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: id.without_loc().into(),
             init: Some(
@@ -813,8 +854,13 @@ fn extend_super(
                     params: vec![param.clone().into()],
                     body: Box::new(BlockStmtOrExpr::Expr(Box::new(
                         SuperPropExpr {
-                            obj: Super { span: DUMMY_SP },
+                            node_id: Default::default(),
+                            obj: Super {
+                                node_id: Default::default(),
+                                span: DUMMY_SP,
+                            },
                             prop: SuperProp::Computed(ComputedPropName {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 expr: Box::new(Expr::Ident(param)),
                             }),
@@ -832,6 +878,7 @@ fn extend_super(
     decls.extend(set.ident.into_iter().map(|(key, ident)| {
         let value = private_ident!("_value");
         VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: ident.without_loc().into(),
             init: Some(
@@ -840,9 +887,14 @@ fn extend_super(
                     params: vec![value.clone().into()],
                     body: Box::new(BlockStmtOrExpr::Expr(Box::new(
                         AssignExpr {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             left: SuperPropExpr {
-                                obj: Super { span: DUMMY_SP },
+                                node_id: Default::default(),
+                                obj: Super {
+                                    node_id: Default::default(),
+                                    span: DUMMY_SP,
+                                },
                                 prop: SuperProp::Ident(key.into()),
                                 span: DUMMY_SP,
                             }
@@ -863,6 +915,7 @@ fn extend_super(
         let prop = private_ident!("_prop");
         let value = private_ident!("_value");
         decls.push(VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: id.without_loc().into(),
             init: Some(
@@ -871,10 +924,16 @@ fn extend_super(
                     params: vec![prop.clone().into(), value.clone().into()],
                     body: Box::new(BlockStmtOrExpr::Expr(Box::new(
                         AssignExpr {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             left: SuperPropExpr {
-                                obj: Super { span: DUMMY_SP },
+                                node_id: Default::default(),
+                                obj: Super {
+                                    node_id: Default::default(),
+                                    span: DUMMY_SP,
+                                },
                                 prop: SuperProp::Computed(ComputedPropName {
+                                    node_id: Default::default(),
                                     span: DUMMY_SP,
                                     expr: Box::new(Expr::Ident(prop)),
                                 }),

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -467,6 +467,7 @@ pub trait StmtExt {
             decls: ids
                 .into_iter()
                 .map(|i| VarDeclarator {
+                    node_id: Default::default(),
                     span: i.span,
                     name: i.into(),
                     init: None,
@@ -1454,6 +1455,7 @@ pub fn prop_name_to_expr(p: PropName) -> Expr {
 pub fn prop_name_to_expr_value(p: PropName) -> Expr {
     match p {
         PropName::Ident(i) => Lit::Str(Str {
+            node_id: Default::default(),
             span: i.span,
             raw: None,
             value: i.sym.into(),
@@ -1472,15 +1474,18 @@ pub fn prop_name_to_member_prop(prop_name: PropName) -> MemberProp {
     match prop_name {
         PropName::Ident(i) => MemberProp::Ident(i),
         PropName::Str(s) => MemberProp::Computed(ComputedPropName {
+            node_id: Default::default(),
             span: DUMMY_SP,
             expr: s.into(),
         }),
         PropName::Num(n) => MemberProp::Computed(ComputedPropName {
+            node_id: Default::default(),
             span: DUMMY_SP,
             expr: n.into(),
         }),
         PropName::Computed(c) => MemberProp::Computed(c),
         PropName::BigInt(b) => MemberProp::Computed(ComputedPropName {
+            node_id: Default::default(),
             span: DUMMY_SP,
             expr: b.into(),
         }),
@@ -1501,9 +1506,11 @@ pub fn default_constructor_with_span(has_super: bool, super_call_span: Span) -> 
         is_optional: false,
         params: if has_super {
             vec![ParamOrTsParamProp::Param(Param {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 decorators: Vec::new(),
                 pat: Pat::Rest(RestPat {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     dot3_token: DUMMY_SP,
                     arg: Box::new(Pat::Ident(quote_ident!("args").into())),
@@ -1517,8 +1524,12 @@ pub fn default_constructor_with_span(has_super: bool, super_call_span: Span) -> 
             stmts: if has_super {
                 vec![CallExpr {
                     span: super_call_span,
-                    callee: Callee::Super(Super { span: DUMMY_SP }),
+                    callee: Callee::Super(Super {
+                        node_id: Default::default(),
+                        span: DUMMY_SP,
+                    }),
                     args: vec![ExprOrSpread {
+                        node_id: Default::default(),
                         spread: Some(DUMMY_SP),
                         expr: Box::new(Expr::Ident(quote_ident!("args").into())),
                     }],
@@ -1551,24 +1562,35 @@ pub fn opt_chain_test(
 ) -> Expr {
     if no_document_all {
         BinExpr {
+            node_id: Default::default(),
             span,
             left,
             op: op!("=="),
-            right: Lit::Null(Null { span: DUMMY_SP }).into(),
+            right: Lit::Null(Null {
+                node_id: Default::default(),
+                span: DUMMY_SP,
+            })
+            .into(),
         }
         .into()
     } else {
         BinExpr {
+            node_id: Default::default(),
             span,
             left: BinExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 left,
                 op: op!("==="),
-                right: Box::new(Expr::Lit(Lit::Null(Null { span: DUMMY_SP }))),
+                right: Box::new(Expr::Lit(Lit::Null(Null {
+                    node_id: Default::default(),
+                    span: DUMMY_SP,
+                }))),
             }
             .into(),
             op: op!("||"),
             right: BinExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 left: right,
                 op: op!("==="),
@@ -1849,7 +1871,12 @@ impl ExprCtx {
         } else {
             exprs.push(val);
 
-            SeqExpr { exprs, span }.into()
+            SeqExpr {
+                node_id: Default::default(),
+                exprs,
+                span,
+            }
+            .into()
         }
     }
 
@@ -1936,7 +1963,7 @@ impl ExprCtx {
                 props.retain(|node| match node {
                     PropOrSpread::Prop(node) => match &**node {
                         Prop::Shorthand(..) => false,
-                        Prop::KeyValue(KeyValueProp { key, value }) => {
+                        Prop::KeyValue(KeyValueProp { key, value, .. }) => {
                             if let PropName::Computed(e) = key {
                                 if e.expr.may_have_side_effects(self) {
                                     return true;
@@ -1969,12 +1996,19 @@ impl ExprCtx {
                 });
 
                 if has_spread {
-                    to.push(ObjectLit { span, props }.into())
+                    to.push(
+                        ObjectLit {
+                            node_id: Default::default(),
+                            span,
+                            props,
+                        }
+                        .into(),
+                    )
                 } else {
                     props.into_iter().for_each(|prop| match prop {
                         PropOrSpread::Prop(node) => match *node {
                             Prop::Shorthand(..) => {}
-                            Prop::KeyValue(KeyValueProp { key, value }) => {
+                            Prop::KeyValue(KeyValueProp { key, value, .. }) => {
                                 if let PropName::Computed(e) = key {
                                     self.extract_side_effects_to(to, *e.expr);
                                 }
@@ -2092,6 +2126,7 @@ impl VisitMut for IdentReplacer<'_> {
                 i.visit_mut_with(self);
                 if i.sym != cloned.sym || i.ctxt != cloned.ctxt {
                     *node = Prop::KeyValue(KeyValueProp {
+                        node_id: Default::default(),
                         key: PropName::Ident(IdentName::new(cloned.sym, cloned.span)),
                         value: i.clone().into(),
                     });
@@ -2183,6 +2218,7 @@ where
             DefaultDecl::Fn(FnExpr {
                 ident: Some(ident),
                 function: f,
+                ..
             }) if f.body.is_some() => {
                 self.add(ident);
             }
@@ -2428,8 +2464,10 @@ impl VisitMut for IdentRenamer<'_> {
                 match p.value.take() {
                     Some(default) => {
                         *i = ObjectPatProp::KeyValue(KeyValuePatProp {
+                            node_id: Default::default(),
                             key: PropName::Ident(orig.clone().into()),
                             value: AssignPat {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 left: p.key.clone().into(),
                                 right: default,
@@ -2439,6 +2477,7 @@ impl VisitMut for IdentRenamer<'_> {
                     }
                     None => {
                         *i = ObjectPatProp::KeyValue(KeyValuePatProp {
+                            node_id: Default::default(),
                             key: PropName::Ident(orig.clone().into()),
                             value: p.key.clone().into(),
                         });
@@ -2459,6 +2498,7 @@ impl VisitMut for IdentRenamer<'_> {
                 i.visit_mut_with(self);
                 if i.sym != cloned.sym || i.ctxt != cloned.ctxt {
                     *node = Prop::KeyValue(KeyValueProp {
+                        node_id: Default::default(),
                         key: PropName::Ident(IdentName::new(cloned.sym, cloned.span)),
                         value: i.clone().into(),
                     });
@@ -2507,6 +2547,7 @@ where
         if let Prop::Shorthand(shorthand) = n {
             if let Some(expr) = self.query.query_ref(shorthand) {
                 *n = KeyValueProp {
+                    node_id: Default::default(),
                     key: shorthand.take().into(),
                     value: expr,
                 }
@@ -2573,6 +2614,7 @@ where
                     .unwrap_or(expr);
 
                 *n = ObjectPatProp::KeyValue(KeyValuePatProp {
+                    node_id: Default::default(),
                     key: PropName::Ident(key.take().into()),
                     value: value.into(),
                 });
@@ -3719,7 +3761,7 @@ fn may_have_side_effects(expr: &Expr, ctx: ExprCtx) -> bool {
         Expr::Object(ObjectLit { props, .. }) => props.iter().any(|node| match node {
             PropOrSpread::Prop(node) => match &**node {
                 Prop::Shorthand(..) => false,
-                Prop::KeyValue(KeyValueProp { key, value }) => {
+                Prop::KeyValue(KeyValueProp { key, value, .. }) => {
                     let k = match key {
                         PropName::Computed(e) => e.expr.may_have_side_effects(ctx),
                         _ => false,
@@ -3870,6 +3912,7 @@ mod ident_usage_finder_parallel_tests {
     fn test_visit_expr_or_spreads() {
         let id = make_id("foo");
         let expr = ExprOrSpread {
+            node_id: Default::default(),
             spread: None,
             expr: Box::new(Expr::Ident(quote_ident!("foo").into())),
         };
@@ -3883,6 +3926,7 @@ mod ident_usage_finder_parallel_tests {
     fn test_visit_module_items() {
         let id = make_id("foo");
         let item = ModuleItem::Stmt(Stmt::Expr(ExprStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             expr: Box::new(Expr::Ident(quote_ident!("foo").into())),
         }));
@@ -3896,6 +3940,7 @@ mod ident_usage_finder_parallel_tests {
     fn test_visit_stmts() {
         let id = make_id("foo");
         let stmt = Stmt::Expr(ExprStmt {
+            node_id: Default::default(),
             span: DUMMY_SP,
             expr: Box::new(Expr::Ident(quote_ident!("foo").into())),
         });
@@ -3909,6 +3954,7 @@ mod ident_usage_finder_parallel_tests {
     fn test_visit_opt_vec_expr_or_spreads() {
         let id = make_id("foo");
         let expr = Some(ExprOrSpread {
+            node_id: Default::default(),
             spread: None,
             expr: Box::new(Expr::Ident(quote_ident!("foo").into())),
         });
@@ -3922,6 +3968,7 @@ mod ident_usage_finder_parallel_tests {
     fn test_visit_var_declarators() {
         let id = make_id("foo");
         let decl = VarDeclarator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             name: Pat::Ident(quote_ident!("foo").into()),
             init: None,

--- a/crates/swc_ecma_utils/src/macros.rs
+++ b/crates/swc_ecma_utils/src/macros.rs
@@ -53,6 +53,7 @@ macro_rules! quote_str {
     };
     ($span:expr, $s:expr) => {{
         $crate::swc_ecma_ast::Str {
+            node_id: Default::default(),
             span: $span,
             raw: None,
             value: $s.into(),
@@ -99,6 +100,7 @@ macro_rules! member_expr {
         let prop = MemberProp::Ident(IdentName::new(stringify!($first).into(), $span));
 
         member_expr!(@EXT, $span, Box::new(Expr::Member(MemberExpr{
+            node_id: Default::default(),
             span: $crate::swc_common::DUMMY_SP,
             obj: $obj,
             prop,
@@ -110,6 +112,7 @@ macro_rules! member_expr {
         let prop = MemberProp::Ident(IdentName::new(stringify!($first).into(), $span));
 
         MemberExpr{
+            node_id: Default::default(),
             span: $crate::swc_common::DUMMY_SP,
             obj: $obj,
             prop,
@@ -137,8 +140,10 @@ mod tests {
         assert_eq!(
             expr,
             Box::new(Expr::Member(MemberExpr {
+                node_id: Default::default(),
                 span,
                 obj: Box::new(Expr::Member(MemberExpr {
+                    node_id: Default::default(),
                     span,
                     obj: member_expr!(Default::default(), Default::default(), Function),
                     prop: MemberProp::Ident(atom!("prototype").into()),

--- a/crates/swc_ecma_visit/src/lib.rs
+++ b/crates/swc_ecma_visit/src/lib.rs
@@ -15,6 +15,61 @@ use swc_visit::{Repeat, Repeated};
 pub use crate::generated::*;
 mod generated;
 
+#[doc(hidden)]
+#[derive(Default)]
+pub struct MaxNodeIdFinder {
+    max: u32,
+}
+
+impl Visit for MaxNodeIdFinder {
+    #[inline]
+    fn visit_node_id(&mut self, node: &NodeId) {
+        if !node.is_dummy() {
+            self.max = self.max.max(node.as_u32());
+        }
+    }
+}
+
+#[doc(hidden)]
+pub struct NodeIdAssigner {
+    next: u32,
+}
+
+impl NodeIdAssigner {
+    #[inline]
+    fn new(current_max: u32) -> Self {
+        Self { next: current_max }
+    }
+}
+
+impl VisitMut for NodeIdAssigner {
+    #[inline]
+    fn visit_mut_node_id(&mut self, node: &mut NodeId) {
+        if node.is_dummy() {
+            self.next = self
+                .next
+                .checked_add(1)
+                .expect("too many AST nodes to assign NodeId");
+            *node = NodeId::from_u32(self.next);
+        }
+    }
+}
+
+/// Assign stable [`NodeId`] values to all AST nodes with a dummy id.
+///
+/// Existing non-dummy ids are preserved so the pass can be rerun after
+/// synthesizing or grafting partial AST fragments.
+pub fn assign_node_ids<N>(node: &mut N)
+where
+    N: VisitWith<MaxNodeIdFinder> + VisitMutWith<NodeIdAssigner>,
+{
+    let mut finder = MaxNodeIdFinder::default();
+    node.visit_with(&mut finder);
+
+    let mut assigner = NodeIdAssigner::new(finder.max);
+    node.visit_mut_with(&mut assigner);
+}
+
 pub fn fold_pass<V>(pass: V) -> FoldPass<V>
 where
     V: Fold,

--- a/crates/swc_ecma_visit/tests/main.rs
+++ b/crates/swc_ecma_visit/tests/main.rs
@@ -9,6 +9,7 @@ fn traverse_lookup() {
         span: DUMMY_SP,
         callee: Callee::Expr(
             AwaitExpr {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 arg: Ident::new_no_ctxt(atom!("foo"), DUMMY_SP).into(),
             }

--- a/crates/swc_estree_compat/src/swcify/class.rs
+++ b/crates/swc_estree_compat/src/swcify/class.rs
@@ -41,6 +41,7 @@ impl Swcify for swc_estree_ast::ClassMethod {
         match self.kind.unwrap_or(ClassMethodKind::Method) {
             ClassMethodKind::Get | ClassMethodKind::Set | ClassMethodKind::Method => {
                 swc_ecma_ast::ClassMethod {
+                    node_id: Default::default(),
                     span: ctx.span(&self.base),
                     key: self.key.swcify(ctx),
                     function: Function {
@@ -98,6 +99,7 @@ impl Swcify for swc_estree_ast::ClassPrivateMethod {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::PrivateMethod {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             key: self.key.swcify(ctx),
             function: Function {
@@ -136,6 +138,7 @@ impl Swcify for swc_estree_ast::ClassProperty {
         let key = self.key.swcify(ctx);
 
         swc_ecma_ast::ClassProp {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             key,
             value: self.value.swcify(ctx),
@@ -158,6 +161,7 @@ impl Swcify for swc_estree_ast::ClassPrivateProperty {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::PrivateProp {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             key: self.key.swcify(ctx),
             value: self.value.swcify(ctx),
@@ -203,6 +207,7 @@ impl Swcify for TSExpressionWithTypeArguments {
         }
         fn swcify_qualified_name(qualified_name: TSQualifiedName, ctx: &Context) -> Box<Expr> {
             MemberExpr {
+                node_id: Default::default(),
                 obj: swcify_expr(*qualified_name.left, ctx),
                 prop: MemberProp::Ident(qualified_name.right.swcify(ctx).into()),
                 span: ctx.span(&qualified_name.base),
@@ -211,6 +216,7 @@ impl Swcify for TSExpressionWithTypeArguments {
         }
 
         TsExprWithTypeArgs {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             expr: swcify_expr(self.expression, ctx),
             type_args: self.type_parameters.swcify(ctx).map(Box::new),

--- a/crates/swc_estree_compat/src/swcify/expr.rs
+++ b/crates/swc_estree_compat/src/swcify/expr.rs
@@ -84,6 +84,7 @@ impl Swcify for ArrayExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ArrayLit {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             elems: self.elements.swcify(ctx),
         }
@@ -95,6 +96,7 @@ impl Swcify for AssignmentExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         AssignExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             op: self.operator.parse().unwrap_or_else(|_| {
                 panic!(
@@ -114,6 +116,7 @@ impl Swcify for BinaryExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         BinExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             op: self.operator.swcify(ctx),
             left: self.left.swcify(ctx),
@@ -127,6 +130,7 @@ impl Swcify for swc_estree_ast::PrivateName {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::PrivateName {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             name: self.id.swcify(ctx).sym.clone(),
         }
@@ -261,15 +265,18 @@ impl Swcify for Arg {
     fn swcify(self, ctx: &Context) -> Self::Output {
         Some(match self {
             Arg::Spread(s) => ExprOrSpread {
+                node_id: Default::default(),
                 spread: Some(ctx.span(&s.base)),
                 expr: s.argument.swcify(ctx),
             },
             Arg::JSXName(e) => ExprOrSpread {
+                node_id: Default::default(),
                 spread: None,
                 expr: e.swcify(ctx).into(),
             },
             Arg::Placeholder(_) => return None,
             Arg::Expr(e) => ExprOrSpread {
+                node_id: Default::default(),
                 spread: None,
                 expr: e.swcify(ctx),
             },
@@ -282,6 +289,7 @@ impl Swcify for ConditionalExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         CondExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             test: self.test.swcify(ctx),
             cons: self.consequent.swcify(ctx),
@@ -295,6 +303,7 @@ impl Swcify for FunctionExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         FnExpr {
+            node_id: Default::default(),
             ident: self.id.swcify(ctx).map(|v| v.into()),
             function: Box::new(Function {
                 params: self.params.swcify(ctx),
@@ -316,7 +325,9 @@ impl Swcify for Identifier {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         BindingIdent {
+            node_id: Default::default(),
             id: Ident {
+                node_id: Default::default(),
                 span: ctx.span(&self.base),
                 sym: self.name,
                 optional: self.optional.unwrap_or(false),
@@ -350,6 +361,7 @@ impl Swcify for LogicalExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         BinExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             op: self.operator.swcify(ctx),
             left: self.left.swcify(ctx),
@@ -364,6 +376,7 @@ impl Swcify for MemberExpression {
     fn swcify(self, ctx: &Context) -> Self::Output {
         match *self.object {
             Expression::Super(s) => SuperPropExpr {
+                node_id: Default::default(),
                 span: ctx.span(&self.base),
                 obj: s.swcify(ctx),
                 prop: match (*self.property, self.computed) {
@@ -371,6 +384,7 @@ impl Swcify for MemberExpression {
                     (MemberExprProp::Expr(e), true) => {
                         let expr = e.swcify(ctx);
                         SuperProp::Computed(ComputedPropName {
+                            node_id: Default::default(),
                             span: expr.span(),
                             expr,
                         })
@@ -380,6 +394,7 @@ impl Swcify for MemberExpression {
             }
             .into(),
             _ => MemberExpr {
+                node_id: Default::default(),
                 span: ctx.span(&self.base),
                 obj: self.object.swcify(ctx),
                 prop: match (*self.property, self.computed) {
@@ -390,6 +405,7 @@ impl Swcify for MemberExpression {
                     (MemberExprProp::Expr(e), true) => {
                         let expr = e.swcify(ctx);
                         MemberProp::Computed(ComputedPropName {
+                            node_id: Default::default(),
                             span: expr.span(),
                             expr,
                         })
@@ -432,6 +448,7 @@ impl Swcify for ObjectExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ObjectLit {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             props: self.properties.swcify(ctx),
         }
@@ -446,6 +463,7 @@ impl Swcify for ObjectExprProp {
             ObjectExprProp::Method(m) => PropOrSpread::Prop(Box::new(Prop::Method(m.swcify(ctx)))),
             ObjectExprProp::Prop(p) => PropOrSpread::Prop(Box::new(Prop::KeyValue(p.swcify(ctx)))),
             ObjectExprProp::Spread(p) => PropOrSpread::Spread(SpreadElement {
+                node_id: Default::default(),
                 // TODO: Use exact span
                 dot3_token: ctx.span(&p.base),
                 expr: p.argument.swcify(ctx),
@@ -459,6 +477,7 @@ impl Swcify for ObjectMethod {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         MethodProp {
+            node_id: Default::default(),
             key: self.key.swcify(ctx),
             function: Box::new(Function {
                 params: self.params.swcify(ctx),
@@ -480,6 +499,7 @@ impl Swcify for swc_estree_ast::Decorator {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::Decorator {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             expr: self.expression.swcify(ctx),
         }
@@ -497,6 +517,7 @@ impl Swcify for ObjectKey {
             ObjectKey::Expr(v) => {
                 let expr = v.swcify(ctx);
                 PropName::Computed(ComputedPropName {
+                    node_id: Default::default(),
                     span: expr.span(),
                     expr,
                 })
@@ -510,6 +531,7 @@ impl Swcify for ObjectProperty {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         KeyValueProp {
+            node_id: Default::default(),
             key: self.key.swcify(ctx),
             value: match self.value {
                 ObjectPropVal::Pattern(pat) => match pat {
@@ -529,6 +551,7 @@ impl Swcify for SequenceExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         SeqExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             exprs: self.expressions.swcify(ctx),
         }
@@ -540,6 +563,7 @@ impl Swcify for ParenthesizedExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ParenExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             expr: self.expression.swcify(ctx),
         }
@@ -551,6 +575,7 @@ impl Swcify for ThisExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ThisExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
         }
     }
@@ -561,6 +586,7 @@ impl Swcify for UnaryExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         UnaryExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             op: self.operator.swcify(ctx),
             arg: self.argument.swcify(ctx),
@@ -606,6 +632,7 @@ impl Swcify for UpdateExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         UpdateExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             op: match self.operator {
                 UpdateExprOp::Increment => {
@@ -654,6 +681,7 @@ impl Swcify for ClassExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ClassExpr {
+            node_id: Default::default(),
             ident: self.id.swcify(ctx).map(|v| v.into()),
             class: Box::new(swc_ecma_ast::Class {
                 span: ctx.span(&self.base),
@@ -678,10 +706,12 @@ impl Swcify for MetaProperty {
         let prop: Ident = self.property.swcify(ctx).into();
         match (&*meta.sym, &*prop.sym) {
             ("new", "target") => MetaPropExpr {
+                node_id: Default::default(),
                 kind: MetaPropKind::NewTarget,
                 span: ctx.span(&self.base),
             },
             ("import", "meta") => MetaPropExpr {
+                node_id: Default::default(),
                 kind: MetaPropKind::NewTarget,
                 span: ctx.span(&self.base),
             },
@@ -695,6 +725,7 @@ impl Swcify for swc_estree_ast::Super {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::Super {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
         }
     }
@@ -730,6 +761,7 @@ impl Swcify for YieldExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         YieldExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             arg: self.argument.swcify(ctx),
             delegate: self.delegate,
@@ -742,6 +774,7 @@ impl Swcify for AwaitExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         AwaitExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             arg: self.argument.swcify(ctx),
         }
@@ -753,6 +786,7 @@ impl Swcify for BabelImport {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         Import {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             // TODO
             phase: Default::default(),
@@ -765,10 +799,12 @@ impl Swcify for OptionalMemberExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         OptChainExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             // TODO: Use correct span.
             optional: self.optional,
             base: Box::new(OptChainBase::Member(MemberExpr {
+                node_id: Default::default(),
                 span: ctx.span(&self.base),
                 obj: self.object.swcify(ctx),
                 prop: match (self.property, self.computed) {
@@ -778,6 +814,7 @@ impl Swcify for OptionalMemberExpression {
                     (OptionalMemberExprProp::Expr(e), true) => {
                         let expr = e.swcify(ctx);
                         MemberProp::Computed(ComputedPropName {
+                            node_id: Default::default(),
                             span: expr.span(),
                             expr,
                         })
@@ -805,6 +842,7 @@ impl Swcify for OptionalCallExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         OptChainExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             optional: self.optional,
             base: Box::new(OptChainBase::Call(OptCall {
@@ -831,6 +869,7 @@ impl Swcify for swc_estree_ast::JSXElement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::JSXElement {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             opening: self.opening_element.swcify(ctx),
             children: self.children.swcify(ctx),
@@ -844,6 +883,7 @@ impl Swcify for swc_estree_ast::JSXOpeningElement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::JSXOpeningElement {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             name: self.name.swcify(ctx),
             attrs: self.attributes.swcify(ctx),
@@ -876,6 +916,7 @@ impl Swcify for JSXMemberExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         JSXMemberExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             obj: self.object.swcify(ctx),
             prop: self.property.swcify(ctx).into(),
@@ -912,6 +953,7 @@ impl Swcify for JSXAttribute {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         JSXAttr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             name: self.name.swcify(ctx),
             value: self.value.swcify(ctx),
@@ -952,6 +994,7 @@ impl Swcify for JSXExpressionContainer {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         JSXExprContainer {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             expr: self.expression.swcify(ctx),
         }
@@ -974,6 +1017,7 @@ impl Swcify for JSXEmptyExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         JSXEmptyExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
         }
     }
@@ -984,6 +1028,7 @@ impl Swcify for JSXSpreadAttribute {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         SpreadElement {
+            node_id: Default::default(),
             dot3_token: ctx.span(&self.base),
             expr: self.argument.swcify(ctx),
         }
@@ -1019,6 +1064,7 @@ impl Swcify for swc_estree_ast::JSXText {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::JSXText {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             value: self.value,
             // TODO fix me
@@ -1032,6 +1078,7 @@ impl Swcify for swc_estree_ast::JSXSpreadChild {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::JSXSpreadChild {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             expr: self.expression.swcify(ctx),
         }
@@ -1043,6 +1090,7 @@ impl Swcify for swc_estree_ast::JSXClosingElement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::JSXClosingElement {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             name: self.name.swcify(ctx),
         }
@@ -1054,6 +1102,7 @@ impl Swcify for swc_estree_ast::JSXFragment {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::JSXFragment {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             opening: self.opening_fragment.swcify(ctx),
             children: self.children.swcify(ctx),
@@ -1067,6 +1116,7 @@ impl Swcify for swc_estree_ast::JSXOpeningFragment {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::JSXOpeningFragment {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
         }
     }
@@ -1077,6 +1127,7 @@ impl Swcify for swc_estree_ast::JSXClosingFragment {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::JSXClosingFragment {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
         }
     }
@@ -1135,6 +1186,7 @@ impl Swcify for TSAsExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         TsAsExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             expr: self.expression.swcify(ctx),
             type_ann: self.type_annotation.swcify(ctx),
@@ -1147,6 +1199,7 @@ impl Swcify for TSTypeAssertion {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         TsTypeAssertion {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             expr: self.expression.swcify(ctx),
             type_ann: self.type_annotation.swcify(ctx),
@@ -1159,6 +1212,7 @@ impl Swcify for TSNonNullExpression {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         TsNonNullExpr {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             expr: self.expression.swcify(ctx),
         }
@@ -1171,11 +1225,13 @@ impl Swcify for ArrayExprEl {
     fn swcify(self, ctx: &Context) -> Self::Output {
         match self {
             ArrayExprEl::Spread(s) => ExprOrSpread {
+                node_id: Default::default(),
                 // TODO: Use correct span
                 spread: Some(ctx.span(&s.base)),
                 expr: s.argument.swcify(ctx),
             },
             ArrayExprEl::Expr(e) => ExprOrSpread {
+                node_id: Default::default(),
                 spread: None,
                 expr: e.swcify(ctx),
             },

--- a/crates/swc_estree_compat/src/swcify/jsx.rs
+++ b/crates/swc_estree_compat/src/swcify/jsx.rs
@@ -7,6 +7,7 @@ impl Swcify for swc_estree_ast::JSXNamespacedName {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::JSXNamespacedName {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             ns: self.namespace.swcify(ctx).into(),
             name: self.name.swcify(ctx).into(),

--- a/crates/swc_estree_compat/src/swcify/lit.rs
+++ b/crates/swc_estree_compat/src/swcify/lit.rs
@@ -30,6 +30,7 @@ impl Swcify for StringLiteral {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         Str {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             value: self.value,
             raw: Some(self.raw),
@@ -42,6 +43,7 @@ impl Swcify for NumberLiteral {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         Number {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             value: self.value,
             // TODO improve me
@@ -55,6 +57,7 @@ impl Swcify for NumericLiteral {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         Number {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             value: self.value,
             // TODO improve me
@@ -68,6 +71,7 @@ impl Swcify for NullLiteral {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         Null {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
         }
     }
@@ -78,6 +82,7 @@ impl Swcify for BooleanLiteral {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         Bool {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             value: self.value,
         }
@@ -89,6 +94,7 @@ impl Swcify for RegExpLiteral {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         Regex {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             exp: self.pattern,
             flags: self.flags,
@@ -101,6 +107,7 @@ impl Swcify for TemplateLiteral {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         Tpl {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             exprs: self.expressions.swcify(ctx),
             quasis: self.quasis.swcify(ctx),
@@ -124,6 +131,7 @@ impl Swcify for TemplateElement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         TplElement {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             tail: self.tail,
             cooked: self.value.cooked,
@@ -137,6 +145,7 @@ impl Swcify for BigIntLiteral {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         BigInt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             value: self
                 .value
@@ -154,6 +163,7 @@ impl Swcify for DecimalLiteral {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         Number {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             value: self
                 .value

--- a/crates/swc_estree_compat/src/swcify/pat.rs
+++ b/crates/swc_estree_compat/src/swcify/pat.rs
@@ -30,6 +30,7 @@ impl Swcify for RestElement {
         let span = ctx.span(&self.base);
 
         RestPat {
+            node_id: Default::default(),
             span,
             dot3_token: span,
             arg: Box::new(self.argument.swcify(ctx)),
@@ -43,6 +44,7 @@ impl Swcify for AssignmentPattern {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         AssignPat {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             left: Box::new(self.left.swcify(ctx)),
             right: self.right.swcify(ctx),
@@ -68,6 +70,7 @@ impl Swcify for ArrayPattern {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ArrayPat {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             elems: self.elements.swcify(ctx),
             optional: false,
@@ -95,6 +98,7 @@ impl Swcify for ObjectPattern {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ObjectPat {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             props: self.properties.swcify(ctx),
             optional: false,
@@ -112,6 +116,7 @@ impl Swcify for ObjectPatternProp {
             ObjectPatternProp::Prop(prop) => {
                 if prop.shorthand {
                     return ObjectPatProp::Assign(AssignPatProp {
+                        node_id: Default::default(),
                         span: ctx.span(&prop.base),
                         key: prop.key.swcify(ctx).expect_ident().into(),
                         value: None,
@@ -121,12 +126,14 @@ impl Swcify for ObjectPatternProp {
                 match prop.value {
                     swc_estree_ast::ObjectPropVal::Pattern(v) => {
                         ObjectPatProp::KeyValue(KeyValuePatProp {
+                            node_id: Default::default(),
                             key: prop.key.swcify(ctx),
                             value: Box::new(v.swcify(ctx)),
                         })
                     }
                     swc_estree_ast::ObjectPropVal::Expr(v) => {
                         ObjectPatProp::Assign(AssignPatProp {
+                            node_id: Default::default(),
                             span: ctx.span(&prop.base),
                             key: prop.key.swcify(ctx).expect_ident().into(),
                             value: Some(v.swcify(ctx)),
@@ -159,6 +166,7 @@ impl Swcify for swc_estree_ast::Param {
                 let pat = v.swcify(ctx);
 
                 swc_ecma_ast::Param {
+                    node_id: Default::default(),
                     span: pat.span(),
                     decorators: Default::default(),
                     pat: pat.into(),
@@ -168,12 +176,14 @@ impl Swcify for swc_estree_ast::Param {
                 let pat = v.swcify(ctx);
 
                 swc_ecma_ast::Param {
+                    node_id: Default::default(),
                     span: pat.span(),
                     decorators: Default::default(),
                     pat,
                 }
             }
             swc_estree_ast::Param::Rest(v) => swc_ecma_ast::Param {
+                node_id: Default::default(),
                 span: ctx.span(&v.base),
                 decorators: v.decorators.swcify(ctx).unwrap_or_default(),
                 pat: v.argument.swcify(ctx),

--- a/crates/swc_estree_compat/src/swcify/stmt.rs
+++ b/crates/swc_estree_compat/src/swcify/stmt.rs
@@ -93,6 +93,7 @@ impl Swcify for BreakStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         BreakStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             label: self.label.swcify(ctx).map(|v| v.into()),
         }
@@ -104,6 +105,7 @@ impl Swcify for ContinueStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ContinueStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             label: self.label.swcify(ctx).map(|v| v.into()),
         }
@@ -115,6 +117,7 @@ impl Swcify for DebuggerStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         DebuggerStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
         }
     }
@@ -125,6 +128,7 @@ impl Swcify for DoWhileStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         DoWhileStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             test: self.test.swcify(ctx),
             body: Box::new(self.body.swcify(ctx).expect_stmt()),
@@ -137,6 +141,7 @@ impl Swcify for EmptyStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         EmptyStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
         }
     }
@@ -147,6 +152,7 @@ impl Swcify for ExpressionStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ExprStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             expr: self.expression.swcify(ctx),
         }
@@ -158,6 +164,7 @@ impl Swcify for ForInStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ForInStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             left: self.left.swcify(ctx),
             right: self.right.swcify(ctx),
@@ -182,6 +189,7 @@ impl Swcify for ForStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ForStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             init: self.init.swcify(ctx),
             test: self.test.swcify(ctx),
@@ -207,6 +215,7 @@ impl Swcify for FunctionDeclaration {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         FnDecl {
+            node_id: Default::default(),
             ident: self.id.swcify(ctx).map(|v| v.into()).unwrap(),
             declare: false,
             function: swc_ecma_ast::Function {
@@ -228,6 +237,7 @@ impl Swcify for IfStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         IfStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             test: self.test.swcify(ctx),
             cons: Box::new(self.consequent.swcify(ctx).expect_stmt()),
@@ -245,6 +255,7 @@ impl Swcify for LabeledStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         LabeledStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             label: self.label.swcify(ctx).into(),
             body: Box::new(self.body.swcify(ctx).expect_stmt()),
@@ -257,6 +268,7 @@ impl Swcify for ReturnStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ReturnStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             arg: self.argument.swcify(ctx),
         }
@@ -268,6 +280,7 @@ impl Swcify for SwitchStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         SwitchStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             discriminant: self.discriminant.swcify(ctx),
             cases: self.cases.swcify(ctx),
@@ -280,6 +293,7 @@ impl Swcify for swc_estree_ast::SwitchCase {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::SwitchCase {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             test: self.test.swcify(ctx),
             cons: self
@@ -297,6 +311,7 @@ impl Swcify for ThrowStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ThrowStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             arg: self.argument.swcify(ctx),
         }
@@ -308,6 +323,7 @@ impl Swcify for TryStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         TryStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             block: self.block.swcify(ctx),
             handler: self.handler.swcify(ctx),
@@ -321,6 +337,7 @@ impl Swcify for swc_estree_ast::CatchClause {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::CatchClause {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             param: self.param.swcify(ctx),
             body: self.body.swcify(ctx),
@@ -363,6 +380,7 @@ impl Swcify for VariableDeclarator {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         VarDeclarator {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             name: self.id.swcify(ctx),
             init: self.init.swcify(ctx),
@@ -376,6 +394,7 @@ impl Swcify for WhileStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         WhileStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             test: self.test.swcify(ctx),
             body: Box::new(self.body.swcify(ctx).expect_stmt()),
@@ -388,6 +407,7 @@ impl Swcify for WithStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         WithStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             obj: self.object.swcify(ctx),
             body: Box::new(self.body.swcify(ctx).expect_stmt()),
@@ -400,6 +420,7 @@ impl Swcify for ClassDeclaration {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ClassDecl {
+            node_id: Default::default(),
             ident: self.id.swcify(ctx).into(),
             declare: self.declare.unwrap_or_default(),
             class: swc_ecma_ast::Class {
@@ -420,6 +441,7 @@ impl Swcify for ExportAllDeclaration {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ExportAll {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             src: self.source.swcify(ctx).into(),
             type_only: self.export_kind == Some(ExportKind::Type),
@@ -436,6 +458,7 @@ impl Swcify for ExportAllDeclaration {
                 })
                 .map(|props| {
                     ObjectLit {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         props,
                     }
@@ -450,6 +473,7 @@ impl Swcify for ImportAttribute {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         KeyValueProp {
+            node_id: Default::default(),
             key: self.key.swcify(ctx),
             value: Lit::Str(self.value.swcify(ctx)).into(),
         }
@@ -475,8 +499,10 @@ impl Swcify for ExportDefaultDeclaration {
             ExportDefaultDeclType::Func(v) => {
                 let d = v.swcify(ctx);
                 ExportDefaultDecl {
+                    node_id: Default::default(),
                     span: ctx.span(&self.base),
                     decl: DefaultDecl::Fn(FnExpr {
+                        node_id: Default::default(),
                         ident: Some(d.ident),
                         function: d.function,
                     }),
@@ -486,8 +512,10 @@ impl Swcify for ExportDefaultDeclaration {
             ExportDefaultDeclType::Class(v) => {
                 let d = v.swcify(ctx);
                 ExportDefaultDecl {
+                    node_id: Default::default(),
                     span: ctx.span(&self.base),
                     decl: DefaultDecl::Class(ClassExpr {
+                        node_id: Default::default(),
                         ident: Some(d.ident),
                         class: d.class,
                     }),
@@ -495,6 +523,7 @@ impl Swcify for ExportDefaultDeclaration {
                 .into()
             }
             ExportDefaultDeclType::Expr(v) => ExportDefaultExpr {
+                node_id: Default::default(),
                 span: ctx.span(&self.base),
                 expr: v.swcify(ctx),
             }
@@ -511,6 +540,7 @@ impl Swcify for ExportNamedDeclaration {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         NamedExport {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             specifiers: self.specifiers.swcify(ctx),
             src: self.source.swcify(ctx).map(Box::new),
@@ -528,6 +558,7 @@ impl Swcify for ExportNamedDeclaration {
                 })
                 .map(|props| {
                     ObjectLit {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         props,
                     }
@@ -560,6 +591,7 @@ impl Swcify for swc_estree_ast::ExportSpecifier {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ExportNamedSpecifier {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             orig: self.local.swcify(ctx),
             exported: Some(self.exported.swcify(ctx)),
@@ -573,6 +605,7 @@ impl Swcify for swc_estree_ast::ExportDefaultSpecifier {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::ExportDefaultSpecifier {
+            node_id: Default::default(),
             exported: self.exported.swcify(ctx).into(),
         }
     }
@@ -583,6 +616,7 @@ impl Swcify for swc_estree_ast::ExportNamespaceSpecifier {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::ExportNamespaceSpecifier {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             name: self.exported.swcify(ctx),
         }
@@ -594,6 +628,7 @@ impl Swcify for ForOfStatement {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ForOfStmt {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             is_await: false,
             left: self.left.swcify(ctx),
@@ -608,6 +643,7 @@ impl Swcify for ImportDeclaration {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ImportDecl {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             specifiers: self.specifiers.swcify(ctx),
             src: self.source.swcify(ctx).into(),
@@ -625,6 +661,7 @@ impl Swcify for ImportDeclaration {
                 })
                 .map(|props| {
                     ObjectLit {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         props,
                     }
@@ -679,6 +716,7 @@ impl Swcify for swc_estree_ast::ImportSpecifier {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ImportNamedSpecifier {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             local: self.local.swcify(ctx).into(),
             imported: Some(self.imported.swcify(ctx)),
@@ -692,6 +730,7 @@ impl Swcify for swc_estree_ast::ImportDefaultSpecifier {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::ImportDefaultSpecifier {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             local: self.local.swcify(ctx).into(),
         }
@@ -703,6 +742,7 @@ impl Swcify for ImportNamespaceSpecifier {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ImportStarAsSpecifier {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             local: self.local.swcify(ctx).into(),
         }
@@ -778,6 +818,7 @@ impl Swcify for DeclareExportAllDeclaration {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         ExportAll {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             src: self.source.swcify(ctx).into(),
             type_only: self.export_kind == Some(ExportKind::Type),

--- a/crates/swc_estree_compat/src/swcify/typescript.rs
+++ b/crates/swc_estree_compat/src/swcify/typescript.rs
@@ -16,6 +16,7 @@ impl Swcify for TSTypeParameterInstantiation {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         TsTypeParamInstantiation {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             params: self.params.swcify(ctx),
         }
@@ -47,6 +48,7 @@ impl Swcify for TSTypeParameterDeclaration {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         TsTypeParamDecl {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             params: self.params.swcify(ctx),
         }
@@ -59,6 +61,7 @@ impl Swcify for TSTypeParameter {
     fn swcify(self, ctx: &Context) -> Self::Output {
         let span = ctx.span(&self.base);
         TsTypeParam {
+            node_id: Default::default(),
             span,
             name: Ident::new_no_ctxt(self.name, span),
             is_in: self.is_in,
@@ -87,6 +90,7 @@ impl Swcify for TSTypeAnnotation {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         TsTypeAnn {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             type_ann: self.type_annotation.swcify(ctx),
         }
@@ -140,6 +144,7 @@ impl Swcify for TSQualifiedName {
 
     fn swcify(self, ctx: &Context) -> Self::Output {
         TsQualifiedName {
+            node_id: Default::default(),
             span: ctx.span(&self.base),
             left: self.left.swcify(ctx),
             right: self.right.swcify(ctx).into(),

--- a/crates/swc_typescript/src/fast_dts/class.rs
+++ b/crates/swc_typescript/src/fast_dts/class.rs
@@ -85,6 +85,7 @@ impl FastDts {
                                 accessibility == Accessibility::Private
                             }) {
                                 class.body.push(ClassMember::ClassProp(ClassProp {
+                                    node_id: Default::default(),
                                     span: method.span,
                                     key: method.key.clone(),
                                     value: None,
@@ -126,9 +127,11 @@ impl FastDts {
                                 accessibility == Accessibility::Private
                             }) {
                                 method.function.params = vec![Param {
+                                    node_id: Default::default(),
                                     span: DUMMY_SP,
                                     decorators: Vec::new(),
                                     pat: Pat::Ident(BindingIdent {
+                                        node_id: Default::default(),
                                         id: atom!("value").into(),
                                         type_ann: None,
                                     }),
@@ -146,9 +149,11 @@ impl FastDts {
 
                             if method.function.params.is_empty() {
                                 method.function.params.push(Param {
+                                    node_id: Default::default(),
                                     span: DUMMY_SP,
                                     decorators: Vec::new(),
                                     pat: Pat::Ident(BindingIdent {
+                                        node_id: Default::default(),
                                         id: atom!("value").into(),
                                         type_ann: None,
                                     }),
@@ -259,9 +264,11 @@ impl FastDts {
             class.body.insert(
                 0,
                 ClassMember::PrivateProp(PrivateProp {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     ctxt: SyntaxContext::empty(),
                     key: PrivateName {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         name: atom!("private"),
                     },
@@ -428,6 +435,7 @@ impl FastDts {
         };
 
         Some(ClassMember::ClassProp(ClassProp {
+            node_id: Default::default(),
             span: DUMMY_SP,
             key: PropName::Ident(ident.into()),
             value: None,

--- a/crates/swc_typescript/src/fast_dts/enum.rs
+++ b/crates/swc_typescript/src/fast_dts/enum.rs
@@ -55,6 +55,7 @@ impl FastDts {
                         let is_neg = v < 0.0;
                         let expr = if v.is_infinite() {
                             Expr::Ident(Ident {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 sym: atom!("Infinity"),
                                 ctxt: SyntaxContext::empty(),
@@ -62,6 +63,7 @@ impl FastDts {
                             })
                         } else {
                             Expr::Lit(Lit::Num(Number {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 value: v,
                                 raw: Some(v.to_string().into()),
@@ -70,6 +72,7 @@ impl FastDts {
 
                         if is_neg {
                             Expr::Unary(UnaryExpr {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 arg: Box::new(expr),
                                 op: UnaryOp::Minus,
@@ -79,6 +82,7 @@ impl FastDts {
                         }
                     }
                     ConstantValue::String(s) => Expr::Lit(Lit::Str(Str {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         value: s.clone().into(),
                         raw: None,

--- a/crates/swc_typescript/src/fast_dts/function.rs
+++ b/crates/swc_typescript/src/fast_dts/function.rs
@@ -177,6 +177,7 @@ impl FastDts {
             if ty.is_ts_fn_or_constructor_type() {
                 ty = Box::new(
                     TsParenthesizedType {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         type_ann: Box::new(*ty),
                     }
@@ -185,6 +186,7 @@ impl FastDts {
             }
             type_ann.type_ann = Box::new(TsType::TsUnionOrIntersectionType(
                 TsUnionOrIntersectionType::TsUnionType(TsUnionType {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     types: vec![ty, ts_keyword_type(TsKeywordTypeKind::TsUndefinedKeyword)],
                 }),

--- a/crates/swc_typescript/src/fast_dts/inferrer.rs
+++ b/crates/swc_typescript/src/fast_dts/inferrer.rs
@@ -156,6 +156,7 @@ impl ReturnTypeInferrer {
         if visitor.return_expr_count > 1 {
             if expr_type.is_ts_fn_or_constructor_type() {
                 expr_type = Box::new(TsType::TsParenthesizedType(TsParenthesizedType {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     type_ann: expr_type,
                 }));
@@ -163,6 +164,7 @@ impl ReturnTypeInferrer {
 
             expr_type = Box::new(TsType::TsUnionOrIntersectionType(
                 TsUnionOrIntersectionType::TsUnionType(TsUnionType {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     types: vec![
                         expr_type,

--- a/crates/swc_typescript/src/fast_dts/mod.rs
+++ b/crates/swc_typescript/src/fast_dts/mod.rs
@@ -156,6 +156,7 @@ impl FastDts {
         if items.is_empty() || (has_non_exported_stmt && !has_export) {
             items.push(ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(
                 NamedExport {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     specifiers: Vec::new(),
                     src: None,
@@ -256,8 +257,10 @@ impl FastDts {
                             kind: VarDeclKind::Const,
                             declare: true,
                             decls: vec![VarDeclarator {
+                                node_id: Default::default(),
                                 span: DUMMY_SP,
                                 name: Pat::Ident(BindingIdent {
+                                    node_id: Default::default(),
                                     id: name_ident.clone(),
                                     type_ann,
                                 }),
@@ -273,6 +276,7 @@ impl FastDts {
                         ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(export)) => items
                             .push(
                                 ExportDefaultExpr {
+                                    node_id: Default::default(),
                                     span: export.span,
                                     expr: name_ident.into(),
                                 }
@@ -281,6 +285,7 @@ impl FastDts {
                         ModuleItem::ModuleDecl(ModuleDecl::TsExportAssignment(export)) => items
                             .push(
                                 TsExportAssignment {
+                                    node_id: Default::default(),
                                     span: export.span,
                                     expr: name_ident.into(),
                                 }

--- a/crates/swc_typescript/src/fast_dts/types.rs
+++ b/crates/swc_typescript/src/fast_dts/types.rs
@@ -84,6 +84,7 @@ impl FastDts {
         return_type.map(|return_type| {
             Box::new(TsType::TsFnOrConstructorType(
                 TsFnOrConstructorType::TsFnType(TsFnType {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     params: self.transform_fn_params_to_ts_type(&function.params),
                     type_params: function.type_params.clone(),
@@ -108,12 +109,14 @@ impl FastDts {
         return_type.map(|return_type| {
             Box::new(TsType::TsFnOrConstructorType(
                 TsFnOrConstructorType::TsFnType(TsFnType {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     params: self.transform_fn_params_to_ts_type(
                         &arrow
                             .params
                             .iter()
                             .map(|pat| Param {
+                                node_id: Default::default(),
                                 span: pat.span(),
                                 decorators: Vec::new(),
                                 pat: pat.clone(),
@@ -180,6 +183,7 @@ impl FastDts {
                         let span = kv.key.span().with_hi(kv.value.span_hi());
                         let key = self.transform_property_name_to_expr(&kv.key);
                         members.push(TsTypeElement::TsPropertySignature(TsPropertySignature {
+                            node_id: Default::default(),
                             span,
                             readonly: is_const,
                             key: Box::new(key),
@@ -216,6 +220,7 @@ impl FastDts {
                         let span = getter.span;
                         let key = self.transform_property_name_to_expr(&getter.key);
                         members.push(TsTypeElement::TsPropertySignature(TsPropertySignature {
+                            node_id: Default::default(),
                             span,
                             readonly: !has_setter,
                             key: Box::new(key),
@@ -253,6 +258,7 @@ impl FastDts {
                         let span = setter.span;
                         let key = self.transform_property_name_to_expr(&setter.key);
                         members.push(TsTypeElement::TsPropertySignature(TsPropertySignature {
+                            node_id: Default::default(),
                             span,
                             readonly: false,
                             key: Box::new(key),
@@ -270,6 +276,7 @@ impl FastDts {
                         if is_const {
                             let key = self.transform_property_name_to_expr(&method.key);
                             members.push(TsTypeElement::TsPropertySignature(TsPropertySignature {
+                                node_id: Default::default(),
                                 span,
                                 readonly: is_const,
                                 key: Box::new(key),
@@ -286,6 +293,7 @@ impl FastDts {
                             let return_type = self.infer_function_return_type(&method.function);
                             let key = self.transform_property_name_to_expr(&method.key);
                             members.push(TsTypeElement::TsMethodSignature(TsMethodSignature {
+                                node_id: Default::default(),
                                 span,
                                 key: Box::new(key),
                                 computed: method.key.is_computed(),
@@ -310,6 +318,7 @@ impl FastDts {
         }
 
         Some(Box::new(TsType::TsTypeLit(TsTypeLit {
+            node_id: Default::default(),
             span: DUMMY_SP,
             members,
         })))
@@ -320,6 +329,7 @@ impl FastDts {
         for elem in &array.elems {
             let Some(elem) = elem else {
                 elements.push(TsTupleElement {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     label: None,
                     ty: ts_keyword_type(TsKeywordTypeKind::TsUndefinedKeyword),
@@ -334,6 +344,7 @@ impl FastDts {
 
             if let Some(type_ann) = self.transform_expr_to_ts_type(&elem.expr) {
                 elements.push(TsTupleElement {
+                    node_id: Default::default(),
                     span: DUMMY_SP,
                     label: None,
                     ty: type_ann,
@@ -344,9 +355,11 @@ impl FastDts {
         }
 
         Some(Box::new(TsType::TsTypeOperator(TsTypeOperator {
+            node_id: Default::default(),
             span: DUMMY_SP,
             op: TsTypeOperatorOp::ReadOnly,
             type_ann: Box::new(TsType::TsTupleType(TsTupleType {
+                node_id: Default::default(),
                 span: DUMMY_SP,
                 elem_types: elements,
             })),
@@ -365,6 +378,7 @@ impl FastDts {
                     let symbol = quote_ident!(ctxt, "Symbol");
 
                     return MemberExpr {
+                        node_id: Default::default(),
                         span: name.span(),
                         obj: symbol.into(),
                         prop: prop.clone(),
@@ -376,6 +390,7 @@ impl FastDts {
                     span,
                     exprs,
                     quasis,
+                    ..
                 }) = computed.expr.as_ref()
                 {
                     if exprs.is_empty() {
@@ -386,6 +401,7 @@ impl FastDts {
                             .clone();
 
                         let str_prop = Str {
+                            node_id: Default::default(),
                             span: *span,
                             value: str_prop,
                             raw: None,
@@ -453,6 +469,7 @@ impl FastDts {
         }
 
         tpl.quasis.first().map(|element| Str {
+            node_id: Default::default(),
             span: DUMMY_SP,
             value: element
                 .cooked

--- a/crates/swc_typescript/src/fast_dts/util/types.rs
+++ b/crates/swc_typescript/src/fast_dts/util/types.rs
@@ -7,6 +7,7 @@ pub fn any_type_ann() -> Box<TsTypeAnn> {
 
 pub fn type_ann(ts_type: Box<TsType>) -> Box<TsTypeAnn> {
     Box::new(TsTypeAnn {
+        node_id: Default::default(),
         span: DUMMY_SP,
         type_ann: ts_type,
     })
@@ -14,6 +15,7 @@ pub fn type_ann(ts_type: Box<TsType>) -> Box<TsTypeAnn> {
 
 pub fn ts_keyword_type(kind: TsKeywordTypeKind) -> Box<TsType> {
     Box::new(TsType::TsKeywordType(TsKeywordType {
+        node_id: Default::default(),
         span: DUMMY_SP,
         kind,
     }))
@@ -21,6 +23,7 @@ pub fn ts_keyword_type(kind: TsKeywordTypeKind) -> Box<TsType> {
 
 pub fn ts_lit_type(lit: TsLit) -> Box<TsType> {
     Box::new(TsType::TsLitType(TsLitType {
+        node_id: Default::default(),
         span: DUMMY_SP,
         lit,
     }))


### PR DESCRIPTION
## Summary
- add `swc_ecma_ast::NodeId` and propagate `node_id` across concrete AST nodes with backward-compatible serde defaults
- add `assign_node_ids` in `swc_ecma_visit` and run it from parser entry points
- add `NodeId`-based scope data and canonical binding analysis, and wire resolver internals to use it
- regenerate visit/hooks outputs and propagate `node_id` through touched parser, utils, transformer, and compatibility code paths

## Testing
- `cargo fmt --all`
- `cargo test -p swc_ecma_ast`
- `cargo test -p swc_ecma_visit`
- `cargo test -p swc_ecma_hooks`
- `cargo test -p swc_ecma_codegen`
- `cargo test -p swc_ecma_utils`
- `cargo test -p swc_ecma_parser`
- `cargo test -p swc_ecma_transforms_base`
- `cargo test -p swc_typescript`
- `cargo test -p swc_ecma_lints`
- `cargo test -p swc_ecma_lexer`
- `cargo test -p swc_ecma_quote_macros`
- `cargo test -p swc_ecma_transformer`
- `cargo test -p swc_ecma_transforms_classes`
- `cargo check -p swc_estree_compat --message-format short`
- `cargo check -p swc_ecma_transforms_optimization --message-format short`

## Known follow-ups
- `cargo clippy --all --all-targets -- -D warnings` is still red because `node_id` propagation is incomplete in downstream transform crates that were not updated in this diff, primarily `swc_ecma_transforms_react`, `swc_ecma_transforms_module`, `swc_ecma_transforms_proposal`, and `swc_ecma_transforms_testing`
- `cargo test -p swc_ecma_transforms_optimization` still fails for the same downstream reason because it compiles those crates as dependencies
- this PR is intentionally opened as draft until the remaining downstream fallout is cleaned up
