### PR TITLE
feat(swc_ecma_minifier, swc_config): add Hash/Eq for options and CachedRegex

### DIFF
--- a/.changeset/hip-terms-notice.md
+++ b/.changeset/hip-terms-notice.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_minifier: major
+---
+
+feat(swc_ecma_minifier, swc_config): add Hash/Eq for options and CachedRegex

--- a/.changeset/quiet-files-heal.md
+++ b/.changeset/quiet-files-heal.md
@@ -1,0 +1,7 @@
+---
+swc_config: patch
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+feat(swc_ecma_minifier, swc_config): add Hash/Eq for options and CachedRegex

--- a/crates/swc_config/src/regex.rs
+++ b/crates/swc_config/src/regex.rs
@@ -32,9 +32,10 @@ impl Deref for CachedRegex {
     }
 }
 
-// Note: PartialEq, Eq, and Hash for CachedRegex should use the pattern string for comparison and hashing,
-// as recommended in https://github.com/rust-lang/regex/issues/670.
-// These traits are implemented below by delegating to the `as_str()` of the internal Regex.
+// Note: PartialEq, Eq, and Hash for CachedRegex should use the pattern string
+// for comparison and hashing, as recommended in https://github.com/rust-lang/regex/issues/670.
+// These traits are implemented below by delegating to the `as_str()` of the
+// internal Regex.
 impl PartialEq for CachedRegex {
     fn eq(&self, other: &Self) -> bool {
         self.regex.as_str() == other.regex.as_str()

--- a/crates/swc_config/src/regex.rs
+++ b/crates/swc_config/src/regex.rs
@@ -1,6 +1,11 @@
 //! Regex cache
 
-use std::{ops::Deref, str::FromStr, sync::Arc};
+use std::{
+    hash::{Hash, Hasher},
+    ops::Deref,
+    str::FromStr,
+    sync::Arc,
+};
 
 pub use anyhow::Error;
 use anyhow::{Context, Result};
@@ -24,6 +29,23 @@ impl Deref for CachedRegex {
 
     fn deref(&self) -> &Self::Target {
         &self.regex
+    }
+}
+
+// Note: PartialEq, Eq, and Hash for CachedRegex should use the pattern string for comparison and hashing,
+// as recommended in https://github.com/rust-lang/regex/issues/670.
+// These traits are implemented below by delegating to the `as_str()` of the internal Regex.
+impl PartialEq for CachedRegex {
+    fn eq(&self, other: &Self) -> bool {
+        self.regex.as_str() == other.regex.as_str()
+    }
+}
+
+impl Eq for CachedRegex {}
+
+impl Hash for CachedRegex {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.regex.as_str().hash(state);
     }
 }
 

--- a/crates/swc_ecma_minifier/src/option/mod.rs
+++ b/crates/swc_ecma_minifier/src/option/mod.rs
@@ -161,7 +161,8 @@ impl Default for CompressExperimentalOptions {
 }
 
 /// Please do not rely on Hash for GlobalDefs.
-/// This implementation uses XOR to combine per-pair hashes, which may lead to hash collisions in some cases.
+/// This implementation uses XOR to combine per-pair hashes, which may lead to
+/// hash collisions in some cases.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
 pub struct GlobalDefs(pub FxHashMap<Box<Expr>, Box<Expr>>);
 
@@ -194,7 +195,8 @@ impl DerefMut for GlobalDefs {
 impl Hash for GlobalDefs {
     fn hash<H: Hasher>(&self, state: &mut H) {
         // Use iteration order-independent hash combination.
-        // Method: Mix all key-value pair hashes with XOR, and include the length for distinction.
+        // Method: Mix all key-value pair hashes with XOR, and include the length for
+        // distinction.
         let mut hash = 0u64;
         for (k, v) in &self.0 {
             // let mut pair_hasher = std::collections::hash_map::DefaultHasher::new();
@@ -204,7 +206,8 @@ impl Hash for GlobalDefs {
             // XOR ensures order independence: a ^ b == b ^ a
             hash ^= pair_hasher.finish();
         }
-        // Mix length to prevent conflicts like `[("a",1),("b",2)]` and `[("a",1),("b",2),("a",1),("b",2)]`
+        // Mix length to prevent conflicts like `[("a",1),("b",2)]` and
+        // `[("a",1),("b",2),("a",1),("b",2)]`
         self.0.len().hash(state);
         hash.hash(state);
     }

--- a/crates/swc_ecma_minifier/src/option/mod.rs
+++ b/crates/swc_ecma_minifier/src/option/mod.rs
@@ -1,9 +1,13 @@
 #![cfg_attr(not(feature = "extra-serde"), allow(unused))]
 
-use std::sync::Arc;
+use std::{
+    hash::{Hash, Hasher},
+    ops::{Deref, DerefMut},
+    sync::Arc,
+};
 
 use parking_lot::RwLock;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHasher};
 use serde::{Deserialize, Serialize};
 use swc_atoms::Atom;
 use swc_common::Mark;
@@ -36,7 +40,7 @@ pub struct ExtraOptions {
     pub mangle_name_cache: Option<Arc<dyn MangleCache>>,
 }
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "extra-serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "extra-serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "extra-serde", serde(deny_unknown_fields))]
@@ -53,14 +57,14 @@ pub struct MinifyOptions {
     pub enclose: bool,
 }
 
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct TopLevelOptions {
     pub functions: bool,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 pub struct MangleOptions {
@@ -98,7 +102,7 @@ pub struct MangleOptions {
     pub disable_char_freq: bool,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize, Merge)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Merge, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 pub struct ManglePropertiesOptions {
     #[serde(default, alias = "reserved")]
@@ -109,7 +113,7 @@ pub struct ManglePropertiesOptions {
     pub regex: Option<CachedRegex>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]
 #[serde(deny_unknown_fields)]
 #[serde(untagged)]
 pub enum PureGetterOption {
@@ -125,7 +129,7 @@ impl Default for PureGetterOption {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
 #[serde(rename_all = "camelCase")]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]
@@ -156,8 +160,58 @@ impl Default for CompressExperimentalOptions {
     }
 }
 
+/// Please do not rely on Hash for GlobalDefs.
+/// This implementation uses XOR to combine per-pair hashes, which may lead to hash collisions in some cases.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct GlobalDefs(pub FxHashMap<Box<Expr>, Box<Expr>>);
+
+impl From<FxHashMap<Box<Expr>, Box<Expr>>> for GlobalDefs {
+    fn from(value: FxHashMap<Box<Expr>, Box<Expr>>) -> Self {
+        GlobalDefs(value)
+    }
+}
+
+impl FromIterator<(Box<Expr>, Box<Expr>)> for GlobalDefs {
+    fn from_iter<T: IntoIterator<Item = (Box<Expr>, Box<Expr>)>>(iter: T) -> Self {
+        GlobalDefs(iter.into_iter().collect())
+    }
+}
+
+impl Deref for GlobalDefs {
+    type Target = FxHashMap<Box<Expr>, Box<Expr>>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for GlobalDefs {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+impl Hash for GlobalDefs {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        // Use iteration order-independent hash combination.
+        // Method: Mix all key-value pair hashes with XOR, and include the length for distinction.
+        let mut hash = 0u64;
+        for (k, v) in &self.0 {
+            // let mut pair_hasher = std::collections::hash_map::DefaultHasher::new();
+            let mut pair_hasher = FxHasher::default();
+            k.hash(&mut pair_hasher);
+            v.hash(&mut pair_hasher);
+            // XOR ensures order independence: a ^ b == b ^ a
+            hash ^= pair_hasher.finish();
+        }
+        // Mix length to prevent conflicts like `[("a",1),("b",2)]` and `[("a",1),("b",2),("a",1),("b",2)]`
+        self.0.len().hash(state);
+        hash.hash(state);
+    }
+}
+
 /// https://terser.org/docs/api-reference.html#compress-options
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "extra-serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "extra-serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "extra-serde", serde(deny_unknown_fields))]
@@ -225,7 +279,7 @@ pub struct CompressOptions {
     /// to remove spans.
     #[cfg_attr(feature = "extra-serde", serde(skip))]
     #[cfg_attr(feature = "extra-serde", serde(alias = "global_defs"))]
-    pub global_defs: FxHashMap<Box<Expr>, Box<Expr>>,
+    pub global_defs: GlobalDefs,
 
     #[cfg_attr(feature = "extra-serde", serde(default))]
     #[cfg_attr(feature = "extra-serde", serde(alias = "hoist_funs"))]


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

I'm a member from [utooland](https://github.com/utooland), a bundler based on turbopack. I'm working on expanding `MinifyType::Minify { mangle: ... }` to `MinifyType::Minify(swc_ecma_minifier::option::MinifyOptions)` for turbopack.

https://github.com/vercel/next.js/blob/38cffffeccbc68e0c256b4fb9aa17e23f3f308f4/turbopack/crates/turbopack-core/src/chunk/chunking_context.rs#L53-L60

<img width="603" height="158" alt="image" src="https://github.com/user-attachments/assets/277a8d07-1e07-4dad-8d8a-46b220f2aeb4" />

But `MinifyOptions` doesn't implement `PartialEq`, `Eq` and `Hash` traits which are required by `TaskInput` trait.

https://github.com/vercel/next.js/blob/38cffffeccbc68e0c256b4fb9aa17e23f3f308f4/turbopack/crates/turbo-tasks/src/task/task_input.rs#L83-L85

<img width="684" height="64" alt="image" src="https://github.com/user-attachments/assets/5a72b20e-6c16-43f7-a4c1-0d51c84242f3" />

So I implement required traits for `MinifyOptions`.

**BREAKING CHANGE:**

In order to implement `Hash` trait for `CompressOptions::global_defs` typed as `FxHashMap`, I added a newtype wrapper with `From<FxHashMap<Box<Expr>, Box<Expr>>>`, `FromIterator<(Box<Expr>, Box<Expr>)>`, `Deref` and `DerefMut` to ease migration, but this may still be a breaking change for code that depended on the field type being `FxHashMap` directly.

**Related issue (if exists):**

https://github.com/utooland/utoo/issues/2741

