### PR TITLE
feat(swc_common): add SourceMapper.map_raw_pos

### DIFF
--- a/.changeset/stale-crews-peel.md
+++ b/.changeset/stale-crews-peel.md
@@ -1,0 +1,7 @@
+---
+swc_common: patch
+swc_ecma_codegen: patch
+swc_core: patch
+---
+
+feat(swc_common): add SourceMapper.map_raw_pos

--- a/crates/swc_common/src/errors/mod.rs
+++ b/crates/swc_common/src/errors/mod.rs
@@ -172,6 +172,14 @@ pub trait SourceMapper: crate::sync::Send + crate::sync::Sync {
     fn call_span_if_macro(&self, sp: Span) -> Span;
     fn doctest_offset_line(&self, line: usize) -> usize;
     fn span_to_snippet(&self, sp: Span) -> Result<String, Box<SpanSnippetError>>;
+    /// This function is called to change the [BytePos] in AST into an unmapped,
+    /// real value.
+    ///
+    /// By default, it returns the raw value because by default, the AST stores
+    /// original values.
+    fn map_raw_pos(&self, raw_pos: BytePos) -> BytePos {
+        raw_pos
+    }
 }
 
 impl CodeSuggestion {

--- a/crates/swc_ecma_codegen/src/comments.rs
+++ b/crates/swc_ecma_codegen/src/comments.rs
@@ -102,7 +102,7 @@ where
             return Ok(());
         }
 
-        if pos.is_pure() {
+        if self.cm.map_raw_pos(pos).is_pure() {
             write_comments!(
                 self,
                 false,


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

#10560 added `Files.map_raw_pos` which can be used to translate BytePos before generating the sourcemap.

The same is also needed in `SourceMapper`, so that the `pos.is_pure()` in `emit_leading_comments` uses the decoded BytePos.

This came up in https://github.com/vercel/next.js/pull/88205 where my BytePos re-encoding mechanism caused `BytePos::PURE` to not codegen the pure comment anymore.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
