### PR TITLE
docs: Document Flow strip support

### DIFF
--- a/.changeset/nine-wombats-obey.md
+++ b/.changeset/nine-wombats-obey.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+swc_ecma_transforms_typescript: patch
+---
+
+[codex] Document Flow strip support

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6831,6 +6831,7 @@ dependencies = [
  "codspeed-criterion-compat",
  "rustc-hash 2.1.1",
  "serde",
+ "serde_json",
  "swc_atoms",
  "swc_common",
  "swc_ecma_ast",

--- a/bindings/binding_core_wasm/src/types.rs
+++ b/bindings/binding_core_wasm/src/types.rs
@@ -708,7 +708,7 @@ export type JscTarget =
   | "es2021"
   | "es2022";
 
-export type ParserConfig = TsParserConfig | EsParserConfig;
+export type ParserConfig = TsParserConfig | EsParserConfig | FlowParserConfig;
 export interface TsParserConfig {
   syntax: "typescript";
   /**
@@ -723,6 +723,38 @@ export interface TsParserConfig {
    * Defaults to `false`
    */
   dynamicImport?: boolean;
+}
+
+export interface FlowParserConfig {
+  syntax: "flow";
+  /**
+   * Defaults to `false`.
+   */
+  jsx?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  all?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  requireDirective?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  enums?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  decorators?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  components?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  patternMatching?: boolean;
 }
 
 export interface EsParserConfig {

--- a/bindings/binding_minifier_wasm/src/types.rs
+++ b/bindings/binding_minifier_wasm/src/types.rs
@@ -709,7 +709,7 @@ export type JscTarget =
   | "es2022"
   | "esnext";
 
-export type ParserConfig = TsParserConfig | EsParserConfig;
+export type ParserConfig = TsParserConfig | EsParserConfig | FlowParserConfig;
 export interface TsParserConfig {
   syntax: "typescript";
   /**
@@ -724,6 +724,38 @@ export interface TsParserConfig {
    * Defaults to `false`
    */
   dynamicImport?: boolean;
+}
+
+export interface FlowParserConfig {
+  syntax: "flow";
+  /**
+   * Defaults to `false`.
+   */
+  jsx?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  all?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  requireDirective?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  enums?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  decorators?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  components?: boolean;
+  /**
+   * Defaults to `false`.
+   */
+  patternMatching?: boolean;
 }
 
 export interface EsParserConfig {

--- a/crates/swc_ecma_parser/src/lib.rs
+++ b/crates/swc_ecma_parser/src/lib.rs
@@ -86,6 +86,38 @@
 //! }
 //! ```
 //!
+//! # Example (flow parser)
+//!
+//! ```
+//! # #[cfg(feature = "flow")] {
+//! use swc_common::{sync::Lrc, FileName, SourceMap};
+//! use swc_ecma_ast::EsVersion;
+//! use swc_ecma_parser::{parse_file_as_program, FlowSyntax, Syntax};
+//!
+//! let cm: Lrc<SourceMap> = Default::default();
+//! let fm = cm.new_source_file(
+//!     FileName::Custom("test.js".into()).into(),
+//!     "// @flow\nconst value: number = 1;",
+//! );
+//! let mut recovered_errors = Vec::new();
+//!
+//! let program = parse_file_as_program(
+//!     &fm,
+//!     Syntax::Flow(FlowSyntax {
+//!         require_directive: true,
+//!         ..Default::default()
+//!     }),
+//!     EsVersion::latest(),
+//!     None,
+//!     &mut recovered_errors,
+//! )
+//! .expect("flow should parse");
+//!
+//! assert!(recovered_errors.is_empty());
+//! let _ = program;
+//! # }
+//! ```
+//!
 //! ## Cargo features
 //!
 //! ### `typescript`

--- a/crates/swc_ecma_transforms_typescript/Cargo.toml
+++ b/crates/swc_ecma_transforms_typescript/Cargo.toml
@@ -3,7 +3,7 @@ authors       = ["강동윤 <kdy1997.dev@gmail.com>"]
 description   = "rust port of babel and closure compiler."
 documentation = "https://rustdoc.swc.rs/swc_ecma_transforms_typescript/"
 edition       = { workspace = true }
-include       = ["Cargo.toml", "src/**/*.rs"]
+include       = ["Cargo.toml", "src/**/*.rs", "examples/**/*.rs"]
 license       = { workspace = true }
 name          = "swc_ecma_transforms_typescript"
 repository    = { workspace = true }
@@ -36,7 +36,8 @@ swc_ecma_visit            = { version = "23.0.0", path = "../swc_ecma_visit" }
 codspeed-criterion-compat = { workspace = true }
 
 swc_ecma_codegen             = { version = "26.0.0", path = "../swc_ecma_codegen" }
-swc_ecma_parser              = { version = "38.0.0", path = "../swc_ecma_parser" }
+serde_json                   = { workspace = true }
+swc_ecma_parser              = { version = "38.0.0", path = "../swc_ecma_parser", features = ["flow"] }
 swc_ecma_transforms_compat   = { version = "47.0.0", path = "../swc_ecma_transforms_compat" }
 swc_ecma_transforms_proposal = { version = "41.0.1", path = "../swc_ecma_transforms_proposal" }
 swc_ecma_transforms_testing  = { version = "45.0.0", path = "../swc_ecma_transforms_testing" }

--- a/crates/swc_ecma_transforms_typescript/examples/flow_to_js.rs
+++ b/crates/swc_ecma_transforms_typescript/examples/flow_to_js.rs
@@ -1,0 +1,72 @@
+//! Usage: cargo run --example flow_to_js path/to/input.js
+//!
+//! This program parses Flow syntax and emits stripped JavaScript to stdout.
+
+use std::{env, path::Path};
+
+use swc_common::{
+    comments::SingleThreadedComments,
+    errors::{ColorConfig, Handler},
+    sync::Lrc,
+    Globals, Mark, SourceMap, GLOBALS,
+};
+use swc_ecma_codegen::to_code_default;
+use swc_ecma_parser::{lexer::Lexer, FlowSyntax, Parser, StringInput, Syntax};
+use swc_ecma_transforms_base::{fixer::fixer, hygiene::hygiene, resolver};
+use swc_ecma_transforms_typescript::typescript;
+
+fn main() {
+    let cm: Lrc<SourceMap> = Default::default();
+    let handler = Handler::with_tty_emitter(ColorConfig::Auto, true, false, Some(cm.clone()));
+
+    let input = env::args()
+        .nth(1)
+        .expect("please provide the path of input flow file");
+
+    let fm = cm
+        .load_file(Path::new(&input))
+        .expect("failed to load input flow file");
+
+    let comments = SingleThreadedComments::default();
+
+    let lexer = Lexer::new(
+        Syntax::Flow(FlowSyntax {
+            jsx: input.ends_with(".jsx"),
+            ..Default::default()
+        }),
+        Default::default(),
+        StringInput::from(&*fm),
+        Some(&comments),
+    );
+
+    let mut parser = Parser::new_from(lexer);
+
+    for e in parser.take_errors() {
+        e.into_diagnostic(&handler).emit();
+    }
+
+    let program = parser
+        .parse_program()
+        .map_err(|e| e.into_diagnostic(&handler).emit())
+        .expect("failed to parse module.");
+
+    let globals = Globals::default();
+    GLOBALS.set(&globals, || {
+        let unresolved_mark = Mark::new();
+        let top_level_mark = Mark::new();
+
+        let program = program.apply(resolver(unresolved_mark, top_level_mark, false));
+        let program = program.apply(typescript::typescript(
+            typescript::Config {
+                flow_syntax: true,
+                ..Default::default()
+            },
+            unresolved_mark,
+            top_level_mark,
+        ));
+        let program = program.apply(hygiene());
+        let program = program.apply(fixer(Some(&comments)));
+
+        println!("{}", to_code_default(cm, Some(&comments), &program));
+    })
+}

--- a/crates/swc_ecma_transforms_typescript/src/config.rs
+++ b/crates/swc_ecma_transforms_typescript/src/config.rs
@@ -35,9 +35,12 @@ pub struct Config {
     #[serde(default)]
     pub ts_enum_is_mutable: bool,
 
-    /// Internal-only hint from the caller that this strip pass is processing
-    /// Flow syntax. Flow-only post-processing must stay disabled for TS/JS to
-    /// avoid extra overhead on the common path.
+    /// Indicates that the input AST was parsed from Flow syntax.
+    ///
+    /// Set this when reusing the strip pass with
+    /// `swc_ecma_parser::Syntax::Flow(...)` so Flow-only post-processing runs
+    /// after type stripping. Leave this disabled for TypeScript and plain
+    /// JavaScript inputs to avoid extra overhead on the common path.
     #[serde(skip)]
     pub flow_syntax: bool,
 }

--- a/crates/swc_ecma_transforms_typescript/src/lib.rs
+++ b/crates/swc_ecma_transforms_typescript/src/lib.rs
@@ -1,3 +1,56 @@
+//! Transforms TypeScript syntax into standard JavaScript.
+//!
+//! Use [`strip`] when the input was parsed as TypeScript.
+//! If the input was parsed with `swc_ecma_parser::Syntax::Flow`, call
+//! [`typescript`] with [`Config`] and set [`Config::flow_syntax`] to `true` so
+//! Flow-specific cleanup runs after stripping type-only syntax.
+//!
+//! ```no_run
+//! use swc_common::{sync::Lrc, FileName, Globals, Mark, SourceMap, GLOBALS};
+//! use swc_ecma_ast::EsVersion;
+//! use swc_ecma_codegen::to_code_default;
+//! use swc_ecma_parser::{parse_file_as_program, FlowSyntax, Syntax};
+//! use swc_ecma_transforms_base::{fixer::fixer, resolver};
+//! use swc_ecma_transforms_typescript::typescript;
+//!
+//! let cm: Lrc<SourceMap> = Default::default();
+//! let fm = cm.new_source_file(
+//!     FileName::Custom("input.js".into()).into(),
+//!     "const value: number = 1;",
+//! );
+//! let mut recovered_errors = Vec::new();
+//!
+//! let program = parse_file_as_program(
+//!     &fm,
+//!     Syntax::Flow(FlowSyntax::default()),
+//!     EsVersion::latest(),
+//!     None,
+//!     &mut recovered_errors,
+//! )
+//! .expect("flow should parse");
+//! assert!(recovered_errors.is_empty());
+//!
+//! GLOBALS.set(&Globals::default(), || {
+//!     let unresolved_mark = Mark::new();
+//!     let top_level_mark = Mark::new();
+//!
+//!     let program = program
+//!         .apply(resolver(unresolved_mark, top_level_mark, false))
+//!         .apply(typescript(
+//!             typescript::Config {
+//!                 flow_syntax: true,
+//!                 ..Default::default()
+//!             },
+//!             unresolved_mark,
+//!             top_level_mark,
+//!         ))
+//!         .apply(fixer(None));
+//!
+//!     let output = to_code_default(cm, None, &program);
+//!     assert_eq!(output, "const value = 1;\n");
+//! });
+//! ```
+
 #![deny(clippy::all)]
 #![allow(clippy::vec_box)]
 #![allow(clippy::mutable_key_type)]

--- a/crates/swc_ecma_transforms_typescript/tests/flow_strip_correctness.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/flow_strip_correctness.rs
@@ -1,0 +1,112 @@
+use std::{fs::File, io::Read, path::PathBuf};
+
+use swc_common::{FileName, Mark};
+use swc_ecma_ast::EsVersion;
+use swc_ecma_codegen::to_code_default;
+use swc_ecma_parser::{parse_file_as_program, EsSyntax, FlowSyntax, Syntax};
+use swc_ecma_transforms_base::{fixer::fixer, resolver};
+use swc_ecma_transforms_typescript::typescript;
+
+#[testing::fixture("../swc_ecma_parser/tests/flow/**/*.js")]
+fn flow_strip_reparses_as_javascript(input: PathBuf) {
+    let is_jsx = input.extension().is_some_and(|ext| ext == "jsx");
+    let config_path = input.parent().unwrap().join("config.json");
+    let flow_syntax = load_flow_syntax(config_path, is_jsx);
+
+    ::testing::run_test(false, |cm, handler| -> Result<(), ()> {
+        let fm = cm.load_file(&input).expect("failed to load flow fixture");
+        let mut recovered_errors = Vec::new();
+
+        let program = parse_file_as_program(
+            &fm,
+            Syntax::Flow(flow_syntax),
+            EsVersion::latest(),
+            None,
+            &mut recovered_errors,
+        )
+        .map_err(|err| err.into_diagnostic(handler).emit())?;
+
+        if !recovered_errors.is_empty() {
+            for recovered in recovered_errors {
+                recovered.into_diagnostic(handler).emit();
+            }
+            return Err(());
+        }
+
+        let unresolved_mark = Mark::new();
+        let top_level_mark = Mark::new();
+
+        let program = program
+            .apply(resolver(unresolved_mark, top_level_mark, false))
+            .apply(typescript::typescript(
+                typescript::Config {
+                    flow_syntax: true,
+                    ..Default::default()
+                },
+                unresolved_mark,
+                top_level_mark,
+            ))
+            .apply(fixer(None));
+
+        let output = to_code_default(cm.clone(), None, &program);
+
+        assert!(
+            !output.contains("__flow_"),
+            "flow synthetic symbols leaked into emitted output for {}",
+            input.display()
+        );
+
+        let output_fm = cm.new_source_file(FileName::Anon.into(), output);
+        let mut js_errors = Vec::new();
+
+        parse_file_as_program(
+            &output_fm,
+            Syntax::Es(EsSyntax {
+                jsx: flow_syntax.jsx,
+                decorators: true,
+                decorators_before_export: true,
+                export_default_from: true,
+                import_attributes: true,
+                allow_super_outside_method: true,
+                auto_accessors: true,
+                explicit_resource_management: true,
+                ..Default::default()
+            }),
+            EsVersion::latest(),
+            None,
+            &mut js_errors,
+        )
+        .map_err(|err| err.into_diagnostic(handler).emit())?;
+
+        if !js_errors.is_empty() {
+            for recovered in js_errors {
+                recovered.into_diagnostic(handler).emit();
+            }
+            return Err(());
+        }
+
+        Ok(())
+    })
+    .expect("failed to run flow strip correctness test");
+}
+
+fn load_flow_syntax(config_path: PathBuf, is_jsx: bool) -> FlowSyntax {
+    let mut flow_syntax = FlowSyntax {
+        jsx: is_jsx,
+        ..Default::default()
+    };
+
+    let mut config = String::new();
+    if File::open(config_path)
+        .ok()
+        .and_then(|mut file| file.read_to_string(&mut config).ok())
+        .is_some()
+    {
+        if let Ok(mut parsed) = serde_json::from_str::<FlowSyntax>(&config) {
+            parsed.jsx |= is_jsx;
+            flow_syntax = parsed;
+        }
+    }
+
+    flow_syntax
+}

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -740,7 +740,7 @@ export type JscTarget =
     | "es2024"
     | "esnext";
 
-export type ParserConfig = TsParserConfig | EsParserConfig;
+export type ParserConfig = TsParserConfig | EsParserConfig | FlowParserConfig;
 export interface TsParserConfig {
     syntax: "typescript";
     /**
@@ -755,6 +755,38 @@ export interface TsParserConfig {
      * @deprecated Always true because it's in ecmascript spec.
      */
     dynamicImport?: boolean;
+}
+
+export interface FlowParserConfig {
+    syntax: "flow";
+    /**
+     * Defaults to `false`.
+     */
+    jsx?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    all?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    requireDirective?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    enums?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    decorators?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    components?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    patternMatching?: boolean;
 }
 
 export interface EsParserConfig {


### PR DESCRIPTION
## Summary

This PR documents the current Flow parse/strip path across the Rust and JS surfaces.

## What Changed

- added a Flow parsing example to `swc_ecma_parser` rustdoc
- documented Flow strip usage in `swc_ecma_transforms_typescript`
- added a `flow_to_js` example and Flow strip correctness coverage
- exposed `FlowParserConfig` in the public parser typings and wasm bindings

## Why

SWC already supports parsing Flow syntax and stripping Flow annotations through the existing TypeScript transform entry point with `flow_syntax: true`, but that path was difficult to discover and not fully represented in the public typings.

## Impact

- Rust users now have crate-level docs and an example showing how to parse Flow and strip it to JavaScript
- JS users can express Flow parser settings through `@swc/types`
- the new fixture-based coverage helps keep the parse -> strip -> reparse flow working

## Validation

- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_parser`
- `cargo test -p swc_ecma_transforms_typescript`
- `(cd packages/types && yarn build)`
- `(cd packages/core && yarn build:ts)`
