### PR TITLE
fix(es/decorators): scope moved static super rewrite

### DIFF
--- a/crates/swc_ecma_transforms_classes/src/super_field.rs
+++ b/crates/swc_ecma_transforms_classes/src/super_field.rs
@@ -162,6 +162,147 @@ impl VisitMut for SuperFieldAccessFolder<'_> {
     }
 }
 
+/// Rewrites `super` for moved static decorator members without crossing into
+/// nested home-object scopes.
+pub fn rewrite_super_in_moved_static_member(function: &mut Function, class_name: &Ident) {
+    let no_super_class = None;
+    let mut folder = MovedStaticSuperFieldAccessFolder {
+        folder: SuperFieldAccessFolder {
+            class_name,
+            constructor_this_mark: None,
+            is_static: true,
+            folding_constructor: false,
+            in_injected_define_property_call: false,
+            in_nested_scope: false,
+            this_alias_mark: None,
+            constant_super: false,
+            super_class: &no_super_class,
+            in_pat: false,
+        },
+    };
+
+    function.params.visit_mut_with(&mut folder);
+    function.body.visit_mut_with(&mut folder);
+}
+
+struct MovedStaticSuperFieldAccessFolder<'a> {
+    folder: SuperFieldAccessFolder<'a>,
+}
+
+impl VisitMut for MovedStaticSuperFieldAccessFolder<'_> {
+    noop_visit_mut_type!();
+
+    fn visit_mut_class(&mut self, _: &mut Class) {
+        // `super` inside a nested class belongs to that class.
+    }
+
+    fn visit_mut_expr(&mut self, n: &mut Expr) {
+        match n {
+            Expr::This(ThisExpr { span }) if self.folder.in_nested_scope => {
+                *n = quote_ident!(
+                    SyntaxContext::empty().apply_mark(
+                        *self
+                            .folder
+                            .this_alias_mark
+                            .get_or_insert_with(|| Mark::fresh(Mark::root()))
+                    ),
+                    *span,
+                    "_this"
+                )
+                .into();
+            }
+            Expr::Call(CallExpr {
+                callee: Callee::Expr(expr),
+                ..
+            }) if expr.is_ident_ref_to("_define_property") => {
+                let old = self.folder.in_injected_define_property_call;
+                self.folder.in_injected_define_property_call = true;
+                n.visit_mut_children_with(self);
+                self.folder.in_injected_define_property_call = old;
+            }
+            Expr::SuperProp(SuperPropExpr {
+                obj: Super { span: super_token },
+                prop,
+                ..
+            }) => {
+                let super_token = *super_token;
+                prop.visit_mut_children_with(self);
+
+                let prop = prop.take();
+                *n = if self.folder.in_pat {
+                    self.folder.super_to_update_call(super_token, prop).into()
+                } else {
+                    *self.folder.super_to_get_call(super_token, prop)
+                };
+            }
+            Expr::Update(UpdateExpr { arg, .. }) if arg.is_super_prop() => {
+                if let Expr::SuperProp(SuperPropExpr {
+                    obj: Super {
+                        span: super_token, ..
+                    },
+                    prop,
+                    ..
+                }) = &**arg
+                {
+                    *arg = self
+                        .folder
+                        .super_to_update_call(*super_token, prop.clone())
+                        .into();
+                }
+            }
+            Expr::Assign(AssignExpr {
+                ref left,
+                op: op!("="),
+                right,
+                ..
+            }) if is_assign_to_super_prop(left) => {
+                right.visit_mut_with(self);
+                self.folder.visit_mut_super_member_set(n)
+            }
+            Expr::Assign(AssignExpr { left, right, .. }) if is_assign_to_super_prop(left) => {
+                right.visit_mut_with(self);
+                self.folder.visit_mut_super_member_update(n);
+            }
+            Expr::Call(CallExpr {
+                callee: Callee::Expr(callee_expr),
+                args,
+                ..
+            }) if callee_expr.is_super_prop() => {
+                args.visit_mut_children_with(self);
+                self.folder.visit_mut_super_member_call(n);
+            }
+            _ => {
+                n.visit_mut_children_with(self);
+            }
+        }
+    }
+
+    fn visit_mut_function(&mut self, _: &mut Function) {
+        // Nested regular functions have their own `super` binding rules and
+        // should not be rewritten against the moved static member.
+    }
+
+    fn visit_mut_getter_prop(&mut self, n: &mut GetterProp) {
+        n.key.visit_mut_with(self);
+    }
+
+    fn visit_mut_method_prop(&mut self, n: &mut MethodProp) {
+        n.key.visit_mut_with(self);
+    }
+
+    fn visit_mut_pat(&mut self, n: &mut Pat) {
+        let in_pat = self.folder.in_pat;
+        self.folder.in_pat = true;
+        n.visit_mut_children_with(self);
+        self.folder.in_pat = in_pat;
+    }
+
+    fn visit_mut_setter_prop(&mut self, n: &mut SetterProp) {
+        n.key.visit_mut_with(self);
+        n.param.visit_mut_with(self);
+    }
+}
+
 impl SuperFieldAccessFolder<'_> {
     /// # In
     /// ```js

--- a/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
@@ -5,7 +5,7 @@ use swc_atoms::{atom, Atom};
 use swc_common::{util::take::Take, Mark, Span, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::{helper, helper_expr};
-use swc_ecma_transforms_classes::super_field::SuperFieldAccessFolder;
+use swc_ecma_transforms_classes::super_field::rewrite_super_in_moved_static_member;
 use swc_ecma_utils::{
     alias_ident_for, constructor::inject_after_super, default_constructor_with_span,
     for_each_binding_ident, is_maybe_branch_directive, private_ident, prop_name_to_expr_value,
@@ -163,17 +163,35 @@ impl Visit for CurrentClassNameFinder {
 }
 
 #[derive(Default)]
-struct SuperFinder {
+struct MovedStaticSuperFinder {
     found: bool,
 }
 
-impl Visit for SuperFinder {
+impl Visit for MovedStaticSuperFinder {
     noop_visit_type!();
 
     fn visit_class(&mut self, _: &Class) {
         // `super` inside a nested class belongs to that class and should not
         // affect the decision to rewrite the enclosing moved static
         // member.
+    }
+
+    fn visit_function(&mut self, _: &Function) {
+        // Regular functions do not share the moved static member's `super`
+        // binding and should not trigger the rewrite.
+    }
+
+    fn visit_getter_prop(&mut self, n: &GetterProp) {
+        n.key.visit_with(self);
+    }
+
+    fn visit_method_prop(&mut self, n: &MethodProp) {
+        n.key.visit_with(self);
+    }
+
+    fn visit_setter_prop(&mut self, n: &SetterProp) {
+        n.key.visit_with(self);
+        n.param.visit_with(self);
     }
 
     fn visit_super(&mut self, _: &Super) {
@@ -547,7 +565,7 @@ impl DecoratorPass {
     }
 
     fn expr_uses_super(&self, expr: &Expr) -> bool {
-        let mut v = SuperFinder::default();
+        let mut v = MovedStaticSuperFinder::default();
         expr.visit_with(&mut v);
         v.found
     }
@@ -570,7 +588,7 @@ impl DecoratorPass {
     }
 
     fn stmts_use_super(&self, stmts: &[Stmt]) -> bool {
-        let mut v = SuperFinder::default();
+        let mut v = MovedStaticSuperFinder::default();
         stmts.visit_with(&mut v);
         v.found
     }
@@ -593,8 +611,9 @@ impl DecoratorPass {
     }
 
     fn function_uses_super(&self, function: &Function) -> bool {
-        let mut v = SuperFinder::default();
-        function.visit_with(&mut v);
+        let mut v = MovedStaticSuperFinder::default();
+        function.params.visit_with(&mut v);
+        function.body.visit_with(&mut v);
         v.found
     }
 
@@ -626,21 +645,7 @@ impl DecoratorPass {
     }
 
     fn rewrite_super_for_moved_static_member(&self, function: &mut Function, class_name: &Ident) {
-        let no_super_class = None;
-        let mut folder = SuperFieldAccessFolder {
-            class_name,
-            constructor_this_mark: None,
-            is_static: true,
-            folding_constructor: false,
-            in_nested_scope: false,
-            in_injected_define_property_call: false,
-            this_alias_mark: None,
-            constant_super: false,
-            super_class: &no_super_class,
-            in_pat: false,
-        };
-
-        function.visit_mut_with(&mut folder);
+        rewrite_super_in_moved_static_member(function, class_name);
     }
 
     fn current_class_ref_for_super(&self) -> Option<Ident> {

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/moved-static-super-nested-object-method/exec.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/moved-static-super-nested-object-method/exec.js
@@ -1,0 +1,29 @@
+const dec = () => {};
+
+const otherProto = {
+  id(value) {
+    return `object:${value}`;
+  }
+};
+
+class Base {
+  static id(value) {
+    return `base:${value}`;
+  }
+}
+
+@dec
+class Derived extends Base {
+  static nested = {
+    __proto__: otherProto,
+    getId(value) {
+      return super.id(value);
+    }
+  };
+
+  static callNested(value) {
+    return this.nested.getId(value);
+  }
+}
+
+expect(Derived.callNested("value")).toBe("object:value");

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/moved-static-super-nested-object-method/input.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/moved-static-super-nested-object-method/input.js
@@ -1,0 +1,27 @@
+const dec = () => {};
+
+const otherProto = {
+  id(value) {
+    return `object:${value}`;
+  }
+};
+
+class Base {
+  static id(value) {
+    return `base:${value}`;
+  }
+}
+
+@dec
+class Derived extends Base {
+  static nested = {
+    __proto__: otherProto,
+    getId(value) {
+      return super.id(value);
+    }
+  };
+
+  static callNested(value) {
+    return this.nested.getId(value);
+  }
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/moved-static-super-nested-object-method/options.json
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/moved-static-super-nested-object-method/options.json
@@ -1,0 +1,4 @@
+{
+  "plugins": [["proposal-decorators", { "version": "2023-11" }]],
+  "minNodeVersion": "16.11.0"
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/moved-static-super-nested-object-method/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-misc/moved-static-super-nested-object-method/output.js
@@ -1,0 +1,35 @@
+let _initClass, _Base;
+const dec = ()=>{};
+const otherProto = {
+    id (value) {
+        return `object:${value}`;
+    }
+};
+class Base {
+    static id(value) {
+        return `base:${value}`;
+    }
+}
+_Base = Base;
+let _Derived, _Derived_member;
+new class extends _identity {
+    constructor(){
+        super(_Derived), _initClass(), _Derived_member = _Derived;
+    }
+    static [class Derived extends _Base {
+        static{
+            ({ c: [_Derived, _initClass] } = _apply_decs_2311(this, [
+                dec
+            ], [], 0, void 0, _Base));
+        }
+        static callNested(value) {
+            return this.nested.getId(value);
+        }
+    }];
+    nested = {
+        __proto__: otherProto,
+        getId (value) {
+            return super.id(value);
+        }
+    };
+}();


### PR DESCRIPTION
## Summary
- scope moved-static-member `super` detection to the member's own home-object boundary
- avoid rewriting nested object literal method/getter/setter `super` while still handling lexical arrow-function `super`
- add a regression fixture for a decorated static field containing an object literal method with `super`

## Context
- follow-up for the review feedback on #11781

## Testing
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo test -p swc_ecma_transforms_proposal`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_transforms_proposal --test decorators fixture_tests__decorators__2023_11_misc__moved_static_super_nested_object_method__input_js -- --ignored --nocapture`

## Notes
- the targeted ignored exec fixture still requires `mocha` on `PATH` to run locally