### PR TITLE
fix(es/parser): parse mixed Flow anonymous callable params (#11785)

### DIFF
--- a/.changeset/gentle-shirts-know.md
+++ b/.changeset/gentle-shirts-know.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): parse mixed Flow anonymous callable params (#11785)

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2367,6 +2367,27 @@ impl<I: Tokens> Parser<I> {
                 return Ok(true);
             }
         }
+
+        if self.is_flow_syntax()
+            && self
+                .try_parse_ts(|p| p.try_parse_flow_anon_signature_param(0))
+                .is_some()
+        {
+            if self.input().is(Token::Comma) {
+                return Ok(true);
+            }
+
+            if self.input_mut().eat(Token::RParen) && self.input().cur() == Token::Arrow {
+                if self.ctx().contains(Context::DisallowFlowAnonFnType) {
+                    // In arrow return type context, `(T) => U` should bind to
+                    // the outer arrow unless the function type is parenthesized.
+                    return Ok(false);
+                }
+
+                return Ok(true);
+            }
+        }
+
         Ok(false)
     }
 

--- a/crates/swc_ecma_parser/tests/flow/issue-11785-anon-first-callable-param/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/issue-11785-anon-first-callable-param/basic.js
@@ -1,0 +1,8 @@
+type Fn = (() => A, b: B) => C;
+
+type AnimatedProps = {};
+
+type AnimatedPropsMemoHook = (
+  () => AnimatedProps,
+  props: Readonly<{[string]: unknown}>,
+) => AnimatedProps;

--- a/crates/swc_ecma_parser/tests/flow/issue-11785-anon-first-callable-param/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11785-anon-first-callable-param/basic.js.json
@@ -1,0 +1,369 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 173
+  },
+  "body": [
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 1,
+        "end": 32
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 6,
+          "end": 8
+        },
+        "ctxt": 0,
+        "value": "Fn",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsFunctionType",
+        "span": {
+          "start": 11,
+          "end": 31
+        },
+        "params": [
+          {
+            "type": "Identifier",
+            "span": {
+              "start": 12,
+              "end": 12
+            },
+            "ctxt": 0,
+            "value": "__flow_anon_param_0",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 12,
+                "end": 19
+              },
+              "typeAnnotation": {
+                "type": "TsFunctionType",
+                "span": {
+                  "start": 12,
+                  "end": 19
+                },
+                "params": [],
+                "typeParams": null,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 15,
+                    "end": 19
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 18,
+                      "end": 19
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 18,
+                        "end": 19
+                      },
+                      "ctxt": 0,
+                      "value": "A",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "Identifier",
+            "span": {
+              "start": 21,
+              "end": 22
+            },
+            "ctxt": 0,
+            "value": "b",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 22,
+                "end": 25
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 24,
+                  "end": 25
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 24,
+                    "end": 25
+                  },
+                  "ctxt": 0,
+                  "value": "B",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          }
+        ],
+        "typeParams": null,
+        "typeAnnotation": {
+          "type": "TsTypeAnnotation",
+          "span": {
+            "start": 27,
+            "end": 31
+          },
+          "typeAnnotation": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 30,
+              "end": 31
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 30,
+                "end": 31
+              },
+              "ctxt": 0,
+              "value": "C",
+              "optional": false
+            },
+            "typeParams": null
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 34,
+        "end": 58
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 39,
+          "end": 52
+        },
+        "ctxt": 0,
+        "value": "AnimatedProps",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 55,
+          "end": 57
+        },
+        "members": []
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 60,
+        "end": 173
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 65,
+          "end": 86
+        },
+        "ctxt": 0,
+        "value": "AnimatedPropsMemoHook",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsFunctionType",
+        "span": {
+          "start": 89,
+          "end": 172
+        },
+        "params": [
+          {
+            "type": "Identifier",
+            "span": {
+              "start": 93,
+              "end": 93
+            },
+            "ctxt": 0,
+            "value": "__flow_anon_param_0",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 93,
+                "end": 112
+              },
+              "typeAnnotation": {
+                "type": "TsFunctionType",
+                "span": {
+                  "start": 93,
+                  "end": 112
+                },
+                "params": [],
+                "typeParams": null,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 96,
+                    "end": 112
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 99,
+                      "end": 112
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 99,
+                        "end": 112
+                      },
+                      "ctxt": 0,
+                      "value": "AnimatedProps",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "Identifier",
+            "span": {
+              "start": 116,
+              "end": 121
+            },
+            "ctxt": 0,
+            "value": "props",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 121,
+                "end": 152
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 123,
+                  "end": 152
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 123,
+                    "end": 131
+                  },
+                  "ctxt": 0,
+                  "value": "Readonly",
+                  "optional": false
+                },
+                "typeParams": {
+                  "type": "TsTypeParameterInstantiation",
+                  "span": {
+                    "start": 131,
+                    "end": 152
+                  },
+                  "params": [
+                    {
+                      "type": "TsTypeLiteral",
+                      "span": {
+                        "start": 132,
+                        "end": 151
+                      },
+                      "members": [
+                        {
+                          "type": "TsPropertySignature",
+                          "span": {
+                            "start": 133,
+                            "end": 150
+                          },
+                          "readonly": false,
+                          "key": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 134,
+                              "end": 140
+                            },
+                            "ctxt": 0,
+                            "value": "string",
+                            "optional": false
+                          },
+                          "computed": true,
+                          "optional": false,
+                          "typeAnnotation": {
+                            "type": "TsTypeAnnotation",
+                            "span": {
+                              "start": 141,
+                              "end": 150
+                            },
+                            "typeAnnotation": {
+                              "type": "TsKeywordType",
+                              "span": {
+                                "start": 143,
+                                "end": 150
+                              },
+                              "kind": "unknown"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ],
+        "typeParams": null,
+        "typeAnnotation": {
+          "type": "TsTypeAnnotation",
+          "span": {
+            "start": 156,
+            "end": 172
+          },
+          "typeAnnotation": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 159,
+              "end": 172
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 159,
+                "end": 172
+              },
+              "ctxt": 0,
+              "value": "AnimatedProps",
+              "optional": false
+            },
+            "typeParams": null
+          }
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
## Summary
- fix Flow callable type lookahead for mixed anonymous and named params such as `(() => A, b: B) => C`
- preserve existing Flow AST behavior by synthesizing the first anonymous param and keeping following named params intact
- add a Flow fixture for the minimal repro and the React Native-style multiline case

Closes #11785

## Testing
- `git submodule update --init --recursive`
- `UPDATE=1 RUSTUP_TOOLCHAIN=nightly-2026-03-28 cargo test -p swc_ecma_parser --features flow --test flow spec_tests__flow__issue_11785_anon_first_callable_param__basic_js -- --ignored`
- `RUSTUP_TOOLCHAIN=nightly-2026-03-28 cargo test -p swc_ecma_parser --features flow --test flow spec_tests__flow__issue_11785_anon_first_callable_param__basic_js -- --ignored`
- `RUSTUP_TOOLCHAIN=nightly-2026-03-28 cargo test -p swc_ecma_parser --features flow`
- `RUSTUP_TOOLCHAIN=nightly-2026-03-28 cargo test -p swc_ecma_parser`
- `RUSTUP_TOOLCHAIN=nightly-2026-03-28 cargo fmt --all`
- `RUSTUP_TOOLCHAIN=nightly-2026-03-28 cargo clippy -p swc_ecma_parser --all-targets --features flow -- -D warnings`

## Notes
- `cargo clippy --all --all-targets -- -D warnings` currently fails on an unrelated existing lint in `crates/swc_ecma_minifier/src/compress/pure/bools.rs`.
- The repo-pinned `nightly-2026-04-10` toolchain is partially installed in this environment, so the successful verification above used installed `nightly-2026-03-28`.
