### PR TITLE
fix(es/parser): Fix Flow callable type with unnamed fn-type param

### DIFF
--- a/.changeset/fix-flow-anon-fn-param.md
+++ b/.changeset/fix-flow-anon-fn-param.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): Fix Flow callable type with unnamed function-type parameter followed by additional parameters

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -3201,7 +3201,10 @@ impl<I: Tokens> Parser<I> {
             return Ok(None);
         }
 
-        let ty = self.parse_ts_type()?;
+        // Allow nested anonymous function types (e.g. `() => A` as a
+        // parameter) by clearing the DisallowFlowAnonFnType context.
+        let ty =
+            self.do_outside_of_context(Context::DisallowFlowAnonFnType, Self::parse_ts_type)?;
         if matches!(
             self.input().cur(),
             Token::Colon | Token::QuestionMark | Token::Eq
@@ -3242,7 +3245,10 @@ impl<I: Tokens> Parser<I> {
             } else {
                 None
             };
-            let ty = self.parse_ts_type()?;
+            // Allow nested anonymous function types (e.g. `() => A` as a
+            // parameter) by clearing the DisallowFlowAnonFnType context.
+            let ty =
+                self.do_outside_of_context(Context::DisallowFlowAnonFnType, Self::parse_ts_type)?;
 
             // Named parameters are handled by the regular signature parser.
             if matches!(
@@ -3437,6 +3443,21 @@ impl<I: Tokens> Parser<I> {
                 .map(TsType::from)
                 .map(Box::new);
         }
+
+        // In Flow, callable types can mix unnamed function-type parameters
+        // with named parameters, e.g. `(() => A, b: B) => C`.
+        // `try_parse_flow_anon_fn_type` only handles all-anonymous params and
+        // `is_ts_start_of_fn_type` does not recognize `(` as a valid parameter
+        // start. Fall back to a speculative parse via the regular function type
+        // parser whose binding-list handler supports mixed params.
+        if self.is_flow_syntax() && self.input().is(Token::LParen) {
+            if let Some(fn_type) =
+                self.try_parse_ts(|p| Ok(Some(p.parse_ts_fn_or_constructor_type(true)?)))
+            {
+                return Ok(Box::new(TsType::from(fn_type)));
+            }
+        }
+
         if (self.input().is(Token::Abstract) && peek!(self).is_some_and(|cur| cur == Token::New))
             || self.input().is(Token::New)
         {

--- a/crates/swc_ecma_parser/tests/flow/issue-11785-anon-fn-param/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/issue-11785-anon-fn-param/basic.js
@@ -1,0 +1,11 @@
+// Unnamed function-type parameter followed by additional parameters
+type Fn = (() => A, b: B) => C;
+
+// React Native-style pattern
+type AnimatedPropsMemoHook = (
+  () => AnimatedProps,
+  props: Readonly<{[string]: unknown}>,
+) => AnimatedProps;
+
+// Unnamed function-type parameter as only param (should already work)
+type Fn2 = (() => A) => C;

--- a/crates/swc_ecma_parser/tests/flow/issue-11785-anon-fn-param/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11785-anon-fn-param/basic.js.json
@@ -1,0 +1,447 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 70,
+    "end": 345
+  },
+  "body": [
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 70,
+        "end": 101
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 75,
+          "end": 77
+        },
+        "ctxt": 0,
+        "value": "Fn",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsFunctionType",
+        "span": {
+          "start": 80,
+          "end": 100
+        },
+        "params": [
+          {
+            "type": "Identifier",
+            "span": {
+              "start": 81,
+              "end": 81
+            },
+            "ctxt": 0,
+            "value": "__flow_anon_param_0",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 81,
+                "end": 88
+              },
+              "typeAnnotation": {
+                "type": "TsFunctionType",
+                "span": {
+                  "start": 81,
+                  "end": 88
+                },
+                "params": [],
+                "typeParams": null,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 84,
+                    "end": 88
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 87,
+                      "end": 88
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 87,
+                        "end": 88
+                      },
+                      "ctxt": 0,
+                      "value": "A",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "Identifier",
+            "span": {
+              "start": 90,
+              "end": 91
+            },
+            "ctxt": 0,
+            "value": "b",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 91,
+                "end": 94
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 93,
+                  "end": 94
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 93,
+                    "end": 94
+                  },
+                  "ctxt": 0,
+                  "value": "B",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            }
+          }
+        ],
+        "typeParams": null,
+        "typeAnnotation": {
+          "type": "TsTypeAnnotation",
+          "span": {
+            "start": 96,
+            "end": 100
+          },
+          "typeAnnotation": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 99,
+              "end": 100
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 99,
+                "end": 100
+              },
+              "ctxt": 0,
+              "value": "C",
+              "optional": false
+            },
+            "typeParams": null
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 133,
+        "end": 246
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 138,
+          "end": 159
+        },
+        "ctxt": 0,
+        "value": "AnimatedPropsMemoHook",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsFunctionType",
+        "span": {
+          "start": 162,
+          "end": 245
+        },
+        "params": [
+          {
+            "type": "Identifier",
+            "span": {
+              "start": 166,
+              "end": 166
+            },
+            "ctxt": 0,
+            "value": "__flow_anon_param_0",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 166,
+                "end": 185
+              },
+              "typeAnnotation": {
+                "type": "TsFunctionType",
+                "span": {
+                  "start": 166,
+                  "end": 185
+                },
+                "params": [],
+                "typeParams": null,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 169,
+                    "end": 185
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 172,
+                      "end": 185
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 172,
+                        "end": 185
+                      },
+                      "ctxt": 0,
+                      "value": "AnimatedProps",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                }
+              }
+            }
+          },
+          {
+            "type": "Identifier",
+            "span": {
+              "start": 189,
+              "end": 194
+            },
+            "ctxt": 0,
+            "value": "props",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 194,
+                "end": 225
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 196,
+                  "end": 225
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 196,
+                    "end": 204
+                  },
+                  "ctxt": 0,
+                  "value": "Readonly",
+                  "optional": false
+                },
+                "typeParams": {
+                  "type": "TsTypeParameterInstantiation",
+                  "span": {
+                    "start": 204,
+                    "end": 225
+                  },
+                  "params": [
+                    {
+                      "type": "TsTypeLiteral",
+                      "span": {
+                        "start": 205,
+                        "end": 224
+                      },
+                      "members": [
+                        {
+                          "type": "TsPropertySignature",
+                          "span": {
+                            "start": 206,
+                            "end": 223
+                          },
+                          "readonly": false,
+                          "key": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 207,
+                              "end": 213
+                            },
+                            "ctxt": 0,
+                            "value": "string",
+                            "optional": false
+                          },
+                          "computed": true,
+                          "optional": false,
+                          "typeAnnotation": {
+                            "type": "TsTypeAnnotation",
+                            "span": {
+                              "start": 214,
+                              "end": 223
+                            },
+                            "typeAnnotation": {
+                              "type": "TsKeywordType",
+                              "span": {
+                                "start": 216,
+                                "end": 223
+                              },
+                              "kind": "unknown"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              }
+            }
+          }
+        ],
+        "typeParams": null,
+        "typeAnnotation": {
+          "type": "TsTypeAnnotation",
+          "span": {
+            "start": 229,
+            "end": 245
+          },
+          "typeAnnotation": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 232,
+              "end": 245
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 232,
+                "end": 245
+              },
+              "ctxt": 0,
+              "value": "AnimatedProps",
+              "optional": false
+            },
+            "typeParams": null
+          }
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 319,
+        "end": 345
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 324,
+          "end": 327
+        },
+        "ctxt": 0,
+        "value": "Fn2",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsFunctionType",
+        "span": {
+          "start": 330,
+          "end": 344
+        },
+        "params": [
+          {
+            "type": "Identifier",
+            "span": {
+              "start": 331,
+              "end": 331
+            },
+            "ctxt": 0,
+            "value": "__flow_anon_param_0",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 331,
+                "end": 338
+              },
+              "typeAnnotation": {
+                "type": "TsFunctionType",
+                "span": {
+                  "start": 331,
+                  "end": 338
+                },
+                "params": [],
+                "typeParams": null,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 334,
+                    "end": 338
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 337,
+                      "end": 338
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 337,
+                        "end": 338
+                      },
+                      "ctxt": 0,
+                      "value": "A",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                }
+              }
+            }
+          }
+        ],
+        "typeParams": null,
+        "typeAnnotation": {
+          "type": "TsTypeAnnotation",
+          "span": {
+            "start": 340,
+            "end": 344
+          },
+          "typeAnnotation": {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 343,
+              "end": 344
+            },
+            "typeName": {
+              "type": "Identifier",
+              "span": {
+                "start": 343,
+                "end": 344
+              },
+              "ctxt": 0,
+              "value": "C",
+              "optional": false
+            },
+            "typeParams": null
+          }
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Description:**

When a Flow callable type has an unnamed function-type parameter followed by named parameters (e.g. `(() => A, b: B) => C`), the parser now correctly handles this by falling back to a speculative parse via the regular function type parser, whose binding-list handler supports mixed anonymous and named parameters.

Previously, `try_parse_flow_anon_fn_type` would bail on encountering a named parameter, and `is_ts_start_of_fn_type` would fail because it didn't recognize `(` as a valid function parameter start. The parser would then try to parse `(() => A, ...)` as a parenthesized type and error on the comma.

Also defensively clear `DisallowFlowAnonFnType` context when parsing parameter types in `try_parse_flow_anon_fn_type` and `try_parse_flow_anon_signature_param` so nested anonymous function types like `() => A` are always allowed as parameters.

**BREAKING CHANGE:** No

**Related issue (if exists):** #11785
