### PR TITLE
fix(es/parser): Allow return type annotation on Flow constructors

### DIFF
--- a/.changeset/flow-constructor-return-type.md
+++ b/.changeset/flow-constructor-return-type.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): Allow return type annotation on Flow constructors

--- a/crates/swc_ecma_lexer/src/common/parser/class_and_fn.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/class_and_fn.rs
@@ -1047,7 +1047,10 @@ fn parse_class_member_with_is_static<'a, P: Parser<'a>>(
                 let start = p.cur_pos();
                 let type_ann = parse_ts_type_ann(p, true, start)?;
 
-                p.emit_err(type_ann.type_ann.span(), SyntaxError::TS1093);
+                // Flow allows return type annotations on constructors.
+                if !p.syntax().flow() {
+                    p.emit_err(type_ann.type_ann.span(), SyntaxError::TS1093);
+                }
             }
 
             let body: Option<_> =

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -1215,7 +1215,10 @@ impl<I: Tokens> Parser<I> {
                             let start = self.cur_pos();
                             let type_ann = self.parse_ts_type_ann(true, start)?;
 
-                            self.emit_err(type_ann.type_ann.span(), SyntaxError::TS1093);
+                            // Flow allows return type annotations on constructors.
+                            if !self.syntax().flow() {
+                                self.emit_err(type_ann.type_ann.span(), SyntaxError::TS1093);
+                            }
                         }
 
                         let body = self.parse_fn_block_body(

--- a/crates/swc_ecma_parser/tests/flow/issue-11789/input.js
+++ b/crates/swc_ecma_parser/tests/flow/issue-11789/input.js
@@ -1,0 +1,6 @@
+// @flow
+class Foo extends Error {
+  constructor(message: string): void {
+    super(message);
+  }
+}

--- a/crates/swc_ecma_parser/tests/flow/issue-11789/input.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11789/input.js.json
@@ -1,0 +1,147 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 10,
+    "end": 100
+  },
+  "body": [
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 16,
+          "end": 19
+        },
+        "ctxt": 0,
+        "value": "Foo",
+        "optional": false
+      },
+      "declare": false,
+      "span": {
+        "start": 10,
+        "end": 100
+      },
+      "ctxt": 0,
+      "decorators": [],
+      "body": [
+        {
+          "type": "Constructor",
+          "span": {
+            "start": 38,
+            "end": 98
+          },
+          "ctxt": 0,
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 38,
+              "end": 49
+            },
+            "value": "constructor"
+          },
+          "params": [
+            {
+              "type": "Parameter",
+              "span": {
+                "start": 50,
+                "end": 65
+              },
+              "decorators": [],
+              "pat": {
+                "type": "Identifier",
+                "span": {
+                  "start": 50,
+                  "end": 57
+                },
+                "ctxt": 0,
+                "value": "message",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 57,
+                    "end": 65
+                  },
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 59,
+                      "end": 65
+                    },
+                    "kind": "string"
+                  }
+                }
+              }
+            }
+          ],
+          "body": {
+            "type": "BlockStatement",
+            "span": {
+              "start": 73,
+              "end": 98
+            },
+            "ctxt": 0,
+            "stmts": [
+              {
+                "type": "ExpressionStatement",
+                "span": {
+                  "start": 79,
+                  "end": 94
+                },
+                "expression": {
+                  "type": "CallExpression",
+                  "span": {
+                    "start": 79,
+                    "end": 93
+                  },
+                  "ctxt": 0,
+                  "callee": {
+                    "type": "Super",
+                    "span": {
+                      "start": 79,
+                      "end": 84
+                    }
+                  },
+                  "arguments": [
+                    {
+                      "spread": null,
+                      "expression": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 85,
+                          "end": 92
+                        },
+                        "ctxt": 0,
+                        "value": "message",
+                        "optional": false
+                      }
+                    }
+                  ],
+                  "typeArguments": null
+                }
+              }
+            ]
+          },
+          "accessibility": null,
+          "isOptional": false
+        }
+      ],
+      "superClass": {
+        "type": "Identifier",
+        "span": {
+          "start": 28,
+          "end": 33
+        },
+        "ctxt": 0,
+        "value": "Error",
+        "optional": false
+      },
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Description:**

Flow allows explicit return type annotations on class constructors, unlike TypeScript which forbids them (TS1093). This PR skips the TS1093 error emission when parsing in Flow mode.

**BREAKING CHANGE:** No

**Related issue (if exists):** #11789
