### PR TITLE
fix(parser): support Flow anonymous keyof indexers

### DIFF
--- a/.changeset/weak-icons-smile.md
+++ b/.changeset/weak-icons-smile.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+fix(parser): support Flow anonymous keyof indexers

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2494,6 +2494,13 @@ impl<I: Tokens> Parser<I> {
             return Ok(None);
         }
 
+        // Flow internal slots use a double-bracket form like `[[foo]]`.
+        // Those members are parsed by the regular property/method path, so the
+        // anonymous indexer fast-path must not consume them.
+        if peek!(self).is_some_and(|peek| peek == Token::LBracket) {
+            return Ok(None);
+        }
+
         expect!(self, Token::LBracket);
 
         let key_start = self.cur_pos();

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2480,6 +2480,40 @@ impl<I: Tokens> Parser<I> {
         }))
     }
 
+    /// Flow supports unnamed object indexers like `[keyof T]: V`.
+    fn try_parse_flow_anon_index_signature(
+        &mut self,
+        index_signature_start: BytePos,
+        readonly: bool,
+        is_static: bool,
+    ) -> PResult<Option<TsIndexSignature>> {
+        if !self.input().syntax().flow()
+            || !self.ctx().contains(Context::InType)
+            || self.input().cur() != Token::LBracket
+        {
+            return Ok(None);
+        }
+
+        expect!(self, Token::LBracket);
+
+        let key_start = self.cur_pos();
+        let key_type = self.parse_ts_type()?;
+        expect!(self, Token::RBracket);
+
+        let params = vec![self.make_flow_anon_fn_param(key_start, 0, None, key_type)];
+        let type_ann = Some(self.parse_ts_type_or_type_predicate_ann(Token::Colon)?);
+
+        self.parse_ts_type_member_semicolon()?;
+
+        Ok(Some(TsIndexSignature {
+            span: self.span(index_signature_start),
+            readonly,
+            is_static,
+            params,
+            type_ann,
+        }))
+    }
+
     /// `tsIsExternalModuleReference`
     fn is_ts_external_module_ref(&mut self) -> bool {
         debug_assert!(self.input().syntax().typescript());
@@ -3817,6 +3851,11 @@ impl<I: Tokens> Parser<I> {
 
         let idx = self.try_parse_ts_index_signature(start, readonly, false)?;
         if let Some(idx) = idx {
+            return Ok(idx.into());
+        }
+
+        let flow_anon_idx = self.try_parse_flow_anon_index_signature(start, readonly, false)?;
+        if let Some(idx) = flow_anon_idx {
             return Ok(idx.into());
         }
 

--- a/crates/swc_ecma_parser/tests/flow/issue-11785-anon-first-callable-param/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11785-anon-first-callable-param/basic.js.json
@@ -294,24 +294,34 @@
                       },
                       "members": [
                         {
-                          "type": "TsPropertySignature",
-                          "span": {
-                            "start": 133,
-                            "end": 150
-                          },
-                          "readonly": false,
-                          "key": {
-                            "type": "Identifier",
-                            "span": {
-                              "start": 134,
-                              "end": 140
-                            },
-                            "ctxt": 0,
-                            "value": "string",
-                            "optional": false
-                          },
-                          "computed": true,
-                          "optional": false,
+                          "type": "TsIndexSignature",
+                          "params": [
+                            {
+                              "type": "Identifier",
+                              "span": {
+                                "start": 134,
+                                "end": 134
+                              },
+                              "ctxt": 0,
+                              "value": "__flow_anon_param_0",
+                              "optional": false,
+                              "typeAnnotation": {
+                                "type": "TsTypeAnnotation",
+                                "span": {
+                                  "start": 134,
+                                  "end": 140
+                                },
+                                "typeAnnotation": {
+                                  "type": "TsKeywordType",
+                                  "span": {
+                                    "start": 134,
+                                    "end": 140
+                                  },
+                                  "kind": "string"
+                                }
+                              }
+                            }
+                          ],
                           "typeAnnotation": {
                             "type": "TsTypeAnnotation",
                             "span": {
@@ -326,6 +336,12 @@
                               },
                               "kind": "unknown"
                             }
+                          },
+                          "readonly": false,
+                          "static": false,
+                          "span": {
+                            "start": 133,
+                            "end": 150
                           }
                         }
                       ]

--- a/crates/swc_ecma_parser/tests/flow/issue-11791-keyof-object-indexer/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/issue-11791-keyof-object-indexer/basic.js
@@ -1,0 +1,11 @@
+type Commands<T> = {
+  [keyof T]: (...ReadonlyArray<unknown>) => void,
+};
+
+type UnknownByString = {
+  [string]: unknown,
+};
+
+type NamedIndexer<K, V> = {
+  [key: K]: V,
+};

--- a/crates/swc_ecma_parser/tests/flow/issue-11791-keyof-object-indexer/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11791-keyof-object-indexer/basic.js.json
@@ -1,0 +1,447 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 171
+  },
+  "body": [
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 1,
+        "end": 74
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 6,
+          "end": 14
+        },
+        "ctxt": 0,
+        "value": "Commands",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 14,
+          "end": 17
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 15,
+              "end": 16
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 15,
+                "end": 16
+              },
+              "ctxt": 0,
+              "value": "T",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "const": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 20,
+          "end": 73
+        },
+        "members": [
+          {
+            "type": "TsIndexSignature",
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 25,
+                  "end": 25
+                },
+                "ctxt": 0,
+                "value": "__flow_anon_param_0",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 25,
+                    "end": 32
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeOperator",
+                    "span": {
+                      "start": 25,
+                      "end": 32
+                    },
+                    "op": "keyof",
+                    "typeAnnotation": {
+                      "type": "TsTypeReference",
+                      "span": {
+                        "start": 31,
+                        "end": 32
+                      },
+                      "typeName": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 31,
+                          "end": 32
+                        },
+                        "ctxt": 0,
+                        "value": "T",
+                        "optional": false
+                      },
+                      "typeParams": null
+                    }
+                  }
+                }
+              }
+            ],
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 33,
+                "end": 70
+              },
+              "typeAnnotation": {
+                "type": "TsFunctionType",
+                "span": {
+                  "start": 35,
+                  "end": 70
+                },
+                "params": [
+                  {
+                    "type": "RestElement",
+                    "span": {
+                      "start": 36,
+                      "end": 61
+                    },
+                    "rest": {
+                      "start": 36,
+                      "end": 39
+                    },
+                    "argument": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 36,
+                        "end": 36
+                      },
+                      "ctxt": 0,
+                      "value": "__flow_anon_param_0",
+                      "optional": false,
+                      "typeAnnotation": {
+                        "type": "TsTypeAnnotation",
+                        "span": {
+                          "start": 39,
+                          "end": 61
+                        },
+                        "typeAnnotation": {
+                          "type": "TsTypeReference",
+                          "span": {
+                            "start": 39,
+                            "end": 61
+                          },
+                          "typeName": {
+                            "type": "Identifier",
+                            "span": {
+                              "start": 39,
+                              "end": 52
+                            },
+                            "ctxt": 0,
+                            "value": "ReadonlyArray",
+                            "optional": false
+                          },
+                          "typeParams": {
+                            "type": "TsTypeParameterInstantiation",
+                            "span": {
+                              "start": 52,
+                              "end": 61
+                            },
+                            "params": [
+                              {
+                                "type": "TsKeywordType",
+                                "span": {
+                                  "start": 53,
+                                  "end": 60
+                                },
+                                "kind": "unknown"
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    },
+                    "typeAnnotation": null
+                  }
+                ],
+                "typeParams": null,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 63,
+                    "end": 70
+                  },
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 66,
+                      "end": 70
+                    },
+                    "kind": "void"
+                  }
+                }
+              }
+            },
+            "readonly": false,
+            "static": false,
+            "span": {
+              "start": 24,
+              "end": 71
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 76,
+        "end": 124
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 81,
+          "end": 96
+        },
+        "ctxt": 0,
+        "value": "UnknownByString",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 99,
+          "end": 123
+        },
+        "members": [
+          {
+            "type": "TsIndexSignature",
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 104,
+                  "end": 104
+                },
+                "ctxt": 0,
+                "value": "__flow_anon_param_0",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 104,
+                    "end": 110
+                  },
+                  "typeAnnotation": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 104,
+                      "end": 110
+                    },
+                    "kind": "string"
+                  }
+                }
+              }
+            ],
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 111,
+                "end": 120
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 113,
+                  "end": 120
+                },
+                "kind": "unknown"
+              }
+            },
+            "readonly": false,
+            "static": false,
+            "span": {
+              "start": 103,
+              "end": 121
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 126,
+        "end": 171
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 131,
+          "end": 143
+        },
+        "ctxt": 0,
+        "value": "NamedIndexer",
+        "optional": false
+      },
+      "typeParams": {
+        "type": "TsTypeParameterDeclaration",
+        "span": {
+          "start": 143,
+          "end": 149
+        },
+        "parameters": [
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 144,
+              "end": 145
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 144,
+                "end": 145
+              },
+              "ctxt": 0,
+              "value": "K",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "const": false,
+            "constraint": null,
+            "default": null
+          },
+          {
+            "type": "TsTypeParameter",
+            "span": {
+              "start": 147,
+              "end": 148
+            },
+            "name": {
+              "type": "Identifier",
+              "span": {
+                "start": 147,
+                "end": 148
+              },
+              "ctxt": 0,
+              "value": "V",
+              "optional": false
+            },
+            "in": false,
+            "out": false,
+            "const": false,
+            "constraint": null,
+            "default": null
+          }
+        ]
+      },
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 152,
+          "end": 170
+        },
+        "members": [
+          {
+            "type": "TsIndexSignature",
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 157,
+                  "end": 163
+                },
+                "ctxt": 0,
+                "value": "key",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 160,
+                    "end": 163
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 162,
+                      "end": 163
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 162,
+                        "end": 163
+                      },
+                      "ctxt": 0,
+                      "value": "K",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                }
+              }
+            ],
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 164,
+                "end": 167
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 166,
+                  "end": 167
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 166,
+                    "end": 167
+                  },
+                  "ctxt": 0,
+                  "value": "V",
+                  "optional": false
+                },
+                "typeParams": null
+              }
+            },
+            "readonly": false,
+            "static": false,
+            "span": {
+              "start": 156,
+              "end": 168
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
## Summary
- parse unnamed Flow object indexers like `{[keyof T]: V}`
- normalize unnamed Flow indexers to anonymous `TsIndexSignature` nodes
- add a dedicated issue #11791 Flow fixture and update existing unnamed indexer snapshots

## Testing
- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_parser --features flow --test flow -- --ignored`
- `cargo test -p swc_ecma_parser`
- `cargo test -p swc_ecma_parser --features flow --test flow -- --ignored`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

Fixes #11791