### PR TITLE
chore: bump cargo-mono to 0.6.7

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -199,7 +199,7 @@ jobs:
       - name: Install cargo-mono
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mono@0.6.5
+          tool: cargo-mono@0.6.7
 
       - name: List crates
         id: list-tests

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install cargo-mono
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-mono@0.6.5
+          tool: cargo-mono@0.6.7
 
       - name: Update constant of swc_core
         run: npx ts-node .github/bot/src/cargo/update-constants.ts


### PR DESCRIPTION
## Summary
- bump the GitHub Actions `cargo-mono` install in CI from `0.6.5` to `0.6.7`
- bump the GitHub Actions `cargo-mono` install in crate publishing from `0.6.5` to `0.6.7`

## Testing
- `git submodule update --init --recursive`
- `cargo mono --version`
- `cargo mono --output json changed --base origin/main`
- `yarn install --immutable`
- `yarn zx ./scripts/github/get-test-matrix.mjs`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`