### PR TITLE
fix(es/jsx): Preserve quoted JSX attribute newlines

### DIFF
--- a/.changeset/selfish-grapes-wait.md
+++ b/.changeset/selfish-grapes-wait.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_react: patch
+---
+
+[codex] Preserve quoted JSX attribute newlines

--- a/crates/swc/tests/fixture/codegen/jsx-1/output/index.js
+++ b/crates/swc/tests/fixture/codegen/jsx-1/output/index.js
@@ -1,5 +1,5 @@
 export default /*#__PURE__*/ React.createElement(A, {
     className: b,
     header: "C",
-    subheader: "D E"
+    subheader: "D\n                E"
 });

--- a/crates/swc/tests/fixture/issues-11xxx/11550/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-11xxx/11550/input/.swcrc
@@ -1,0 +1,19 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "target": "es2024",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": false,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-11xxx/11550/input/index.tsx
+++ b/crates/swc/tests/fixture/issues-11xxx/11550/input/index.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+export default function Hello({}) {
+    return (
+        <div
+            data-anything="bruh
+bruh"
+        >
+            hello
+        </div>
+    );
+}

--- a/crates/swc/tests/fixture/issues-11xxx/11550/output/index.tsx
+++ b/crates/swc/tests/fixture/issues-11xxx/11550/output/index.tsx
@@ -1,0 +1,6 @@
+"use client";
+export default function Hello({}) {
+    return React.createElement("div", {
+        "data-anything": "bruh\nbruh"
+    }, "hello");
+}

--- a/crates/swc/tests/fixture/issues-1xxx/1233/case-1/output/index.js
+++ b/crates/swc/tests/fixture/issues-1xxx/1233/case-1/output/index.js
@@ -1,5 +1,5 @@
 function Component() {
     return /*#__PURE__*/ React.createElement("div", {
-        name: "A B"
+        name: "A\n      B"
     });
 }

--- a/crates/swc/tests/fixture/issues-2xxx/2162/case4/output/index.js
+++ b/crates/swc/tests/fixture/issues-2xxx/2162/case4/output/index.js
@@ -1,5 +1,5 @@
 function test() {
     return /*#__PURE__*/ React.createElement(React.Fragment, null, /*#__PURE__*/ React.createElement(A, {
-        b: "\\ "
+        b: "\\\n            "
     }));
 }

--- a/crates/swc_ecma_parser/tests/typescript/issue-11550/input.tsx
+++ b/crates/swc_ecma_parser/tests/typescript/issue-11550/input.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+export default function Hello({}) {
+    return (
+        <div
+            data-anything="bruh
+bruh"
+        >
+            hello
+        </div>
+    );
+}

--- a/crates/swc_ecma_parser/tests/typescript/issue-11550/input.tsx.json
+++ b/crates/swc_ecma_parser/tests/typescript/issue-11550/input.tsx.json
@@ -1,0 +1,180 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 167
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 1,
+        "end": 14
+      },
+      "expression": {
+        "type": "StringLiteral",
+        "span": {
+          "start": 1,
+          "end": 13
+        },
+        "value": "use client",
+        "raw": "\"use client\""
+      }
+    },
+    {
+      "type": "ExportDefaultDeclaration",
+      "span": {
+        "start": 16,
+        "end": 167
+      },
+      "decl": {
+        "type": "FunctionExpression",
+        "identifier": {
+          "type": "Identifier",
+          "span": {
+            "start": 40,
+            "end": 45
+          },
+          "ctxt": 0,
+          "value": "Hello",
+          "optional": false
+        },
+        "params": [
+          {
+            "type": "Parameter",
+            "span": {
+              "start": 46,
+              "end": 48
+            },
+            "decorators": [],
+            "pat": {
+              "type": "ObjectPattern",
+              "span": {
+                "start": 46,
+                "end": 48
+              },
+              "properties": [],
+              "optional": false,
+              "typeAnnotation": null
+            }
+          }
+        ],
+        "decorators": [],
+        "span": {
+          "start": 31,
+          "end": 167
+        },
+        "ctxt": 0,
+        "body": {
+          "type": "BlockStatement",
+          "span": {
+            "start": 50,
+            "end": 167
+          },
+          "ctxt": 0,
+          "stmts": [
+            {
+              "type": "ReturnStatement",
+              "span": {
+                "start": 56,
+                "end": 165
+              },
+              "argument": {
+                "type": "ParenthesisExpression",
+                "span": {
+                  "start": 63,
+                  "end": 164
+                },
+                "expression": {
+                  "type": "JSXElement",
+                  "span": {
+                    "start": 73,
+                    "end": 158
+                  },
+                  "opening": {
+                    "type": "JSXOpeningElement",
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 74,
+                        "end": 77
+                      },
+                      "ctxt": 0,
+                      "value": "div",
+                      "optional": false
+                    },
+                    "span": {
+                      "start": 73,
+                      "end": 125
+                    },
+                    "attributes": [
+                      {
+                        "type": "JSXAttribute",
+                        "span": {
+                          "start": 90,
+                          "end": 115
+                        },
+                        "name": {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 90,
+                            "end": 103
+                          },
+                          "value": "data-anything"
+                        },
+                        "value": {
+                          "type": "StringLiteral",
+                          "span": {
+                            "start": 104,
+                            "end": 115
+                          },
+                          "value": "bruh\nbruh",
+                          "raw": "\"bruh\nbruh\""
+                        }
+                      }
+                    ],
+                    "selfClosing": false,
+                    "typeArguments": null
+                  },
+                  "children": [
+                    {
+                      "type": "JSXText",
+                      "span": {
+                        "start": 125,
+                        "end": 152
+                      },
+                      "value": "\n            hello\n        ",
+                      "raw": "\n            hello\n        "
+                    }
+                  ],
+                  "closing": {
+                    "type": "JSXClosingElement",
+                    "span": {
+                      "start": 152,
+                      "end": 158
+                    },
+                    "name": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 154,
+                        "end": 157
+                      },
+                      "ctxt": 0,
+                      "value": "div",
+                      "optional": false
+                    }
+                  }
+                }
+              }
+            }
+          ]
+        },
+        "generator": false,
+        "async": false,
+        "typeParameters": null,
+        "returnType": null
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -2165,70 +2165,8 @@ fn jsx_attr_value_to_expr(v: JSXAttrValue) -> Option<Box<Expr>> {
 }
 
 fn transform_jsx_attr_str(v: &Wtf8) -> Wtf8Buf {
-    // Fast path: check if transformation is needed
-    let needs_transform = v.code_points().any(|cp| {
-        if let Some(c) = cp.to_char() {
-            matches!(
-                c,
-                '\u{0008}' | '\u{000c}' | '\n' | '\r' | '\t' | '\u{000b}' | '\0'
-            )
-        } else {
-            false
-        }
-    });
-
-    if !needs_transform {
-        return v.to_owned();
-    }
-
-    let single_quote = false;
-    let mut buf = Wtf8Buf::with_capacity(v.len());
-    let mut iter = v.code_points().peekable();
-
-    while let Some(code_point) = iter.next() {
-        if let Some(c) = code_point.to_char() {
-            match c {
-                '\u{0008}' => buf.push_str("\\b"),
-                '\u{000c}' => buf.push_str("\\f"),
-                ' ' => buf.push_char(' '),
-
-                '\n' | '\r' | '\t' => {
-                    buf.push_char(' ');
-
-                    while let Some(next) = iter.peek() {
-                        if next.to_char() == Some(' ') {
-                            iter.next();
-                        } else {
-                            break;
-                        }
-                    }
-                }
-                '\u{000b}' => buf.push_str("\\v"),
-                '\0' => buf.push_str("\\x00"),
-
-                '\'' if single_quote => buf.push_str("\\'"),
-                '"' if !single_quote => buf.push_char('"'),
-
-                '\x01'..='\x0f' | '\x10'..='\x1f' => {
-                    buf.push_char(c);
-                }
-
-                '\x20'..='\x7e' => {
-                    //
-                    buf.push_char(c);
-                }
-                '\u{7f}'..='\u{ff}' => {
-                    buf.push_char(c);
-                }
-
-                _ => {
-                    buf.push_char(c);
-                }
-            }
-        } else {
-            buf.push(code_point);
-        }
-    }
-
-    buf
+    // JSX text whitespace rules do not apply to quoted attribute literals.
+    // The parser already decoded entities and preserved line terminators, so
+    // codegen should receive the original attribute contents unchanged.
+    v.to_owned()
 }

--- a/crates/swc_ecma_transforms_react/src/jsx/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/tests.rs
@@ -1155,6 +1155,22 @@ fn jsx_text() {
 }
 
 #[test]
+fn jsx_attr_str_preserves_line_terminators() {
+    let cases = [
+        ("bruh\nbruh", "bruh\nbruh"),
+        ("bruh\rbruh", "bruh\rbruh"),
+        ("bruh\r\nbruh", "bruh\r\nbruh"),
+    ];
+
+    for (input, expected) in cases {
+        assert_eq!(
+            transform_jsx_attr_str(Wtf8::from_str(input)),
+            Wtf8Buf::from_str(expected)
+        );
+    }
+}
+
+#[test]
 fn jsx_text_with_raw_entity_whitespace_matrix() {
     fn convert(value: &str, raw: &str) -> String {
         let value: Atom = value.into();

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/react-automatic/should-preserve-line-breaks-in-quoted-jsx-attributes/input.js
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/react-automatic/should-preserve-line-breaks-in-quoted-jsx-attributes/input.js
@@ -1,0 +1,2 @@
+<button data-anything="bruh
+bruh">Button</button>;

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/react-automatic/should-preserve-line-breaks-in-quoted-jsx-attributes/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/react-automatic/should-preserve-line-breaks-in-quoted-jsx-attributes/output.mjs
@@ -1,0 +1,5 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+/*#__PURE__*/ _jsx("button", {
+    "data-anything": "bruh\nbruh",
+    children: "Button"
+});

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/react/should-preserve-line-breaks-in-quoted-jsx-attributes/input.js
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/react/should-preserve-line-breaks-in-quoted-jsx-attributes/input.js
@@ -1,0 +1,2 @@
+<button data-anything="bruh
+bruh">Button</button>;

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/react/should-preserve-line-breaks-in-quoted-jsx-attributes/output.js
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/react/should-preserve-line-breaks-in-quoted-jsx-attributes/output.js
@@ -1,0 +1,3 @@
+/*#__PURE__*/ React.createElement("button", {
+    "data-anything": "bruh\nbruh"
+}, "Button");

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/vercel/1/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/vercel/1/output.mjs
@@ -1,5 +1,5 @@
 export default /*#__PURE__*/ React.createElement(A, {
     className: b,
     header: "C",
-    subheader: "D E"
+    subheader: "D\n                E"
 });


### PR DESCRIPTION
## Summary
- preserve line terminators in quoted JSX attribute literals instead of folding them like JSX text
- add parser, React transform, and end-to-end regressions for issue #11550

## Why
`transform_jsx_attr_str` was normalizing quoted JSX attribute strings with JSX text whitespace rules, even though the parser already preserved the original line terminators. That changed `"bruh\nbruh"` into `"bruh bruh"` and could cause downstream hydration mismatches.

## Impact
Quoted JSX attributes like `data-anything="bruh\nbruh"` now compile to JS strings that preserve the embedded newline, matching Babel/TypeScript behavior.

## Validation
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo test -p swc_ecma_parser`
- `cargo test -p swc_ecma_transforms_react`
- `cargo test -p swc_ecma_parser --test typescript issue_11550 -- --ignored`
- `cargo test -p swc_ecma_transforms_react preserve_line_breaks_in_quoted_jsx_attributes -- --ignored`
- `cargo test -p swc --test projects issues_11xxx__11550 -- --ignored`
- `cargo clippy --all --all-targets -- -D warnings`

## Notes
- `cargo test -p swc` still hits existing `source_map` test failures in this environment because the Node module `sourcemap-validator` is not installed.

Fixes #11550