### PR TITLE
feat(swc_cli): Implement all features for `swc_cli`

### DIFF
--- a/.changeset/itchy-worms-divide.md
+++ b/.changeset/itchy-worms-divide.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_cli_impl: patch
+---
+
+feat(swc_cli): Implement all features for `swc_cli`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5805,7 +5805,6 @@ dependencies = [
  "par-iter",
  "path-absolutize",
  "pathdiff",
- "relative-path",
  "serde_json",
  "swc_core",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,7 +363,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2257,6 +2257,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,6 +3021,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd5b3eaf1a28b758ac0faa5a4254e8ab2705605496f1b1f3fbbc3988ad73d199"
+dependencies = [
+ "bitflags 2.10.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "insta"
 version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3163,6 +3192,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b558af6b49fd918e970471374e7a798b2c9bbcda624a210ffa3901ee5614bc8e"
 dependencies = [
  "serde_json",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -3613,6 +3662,7 @@ checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
 dependencies = [
  "hermit-abi 0.3.9",
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.52.0",
 ]
@@ -3770,6 +3820,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a9da8c9922c35a1033d76f7272dfc2e7ee20392083d75aeea6ced23c6266578"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.10.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.10.0",
 ]
 
 [[package]]
@@ -5723,9 +5800,11 @@ dependencies = [
  "assert_fs",
  "clap 3.2.25",
  "glob",
+ "notify",
  "par-core",
  "par-iter",
  "path-absolutize",
+ "pathdiff",
  "relative-path",
  "serde_json",
  "swc_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ napi-derive               = { version = "3", default-features = false }
 new_debug_unreachable     = "1.0.6"
 nom                       = "7.1.3"
 ntest                     = "0.7.2"
+notify                    = "8.0.0"
 num-bigint                = "0.4.3"
 num_cpus                  = "1.13.1"
 once_cell                 = "1.19.0"

--- a/crates/swc_cli_impl/Cargo.toml
+++ b/crates/swc_cli_impl/Cargo.toml
@@ -33,7 +33,6 @@ par-core           = { workspace = true, features = ["chili"] }
 par-iter           = { workspace = true }
 path-absolutize    = { workspace = true, features = ["once_cell_cache"] }
 pathdiff           = { workspace = true }
-relative-path      = { workspace = true }
 serde_json         = { workspace = true, features = ["unbounded_depth"] }
 tracing            = { workspace = true }
 tracing-chrome     = { workspace = true }

--- a/crates/swc_cli_impl/Cargo.toml
+++ b/crates/swc_cli_impl/Cargo.toml
@@ -28,9 +28,11 @@ plugin = [
 anyhow             = { workspace = true }
 clap               = { version = "3.2.25", features = ["derive", "wrap_help"] }
 glob               = { workspace = true }
+notify             = { workspace = true }
 par-core           = { workspace = true, features = ["chili"] }
 par-iter           = { workspace = true }
 path-absolutize    = { workspace = true, features = ["once_cell_cache"] }
+pathdiff           = { workspace = true }
 relative-path      = { workspace = true }
 serde_json         = { workspace = true, features = ["unbounded_depth"] }
 tracing            = { workspace = true }

--- a/crates/swc_cli_impl/src/commands/compile.rs
+++ b/crates/swc_cli_impl/src/commands/compile.rs
@@ -1,16 +1,21 @@
 use std::{
+    collections::BTreeSet,
     fs::{self, File},
-    io::{self, IsTerminal, Read, Write},
+    io::{self, ErrorKind, IsTerminal, Read, Write},
     path::{Component, Path, PathBuf},
     sync::Arc,
 };
 
-use anyhow::Context;
+mod paths;
+mod watch;
+
+use anyhow::{bail, Context};
 use clap::Parser;
-use glob::glob;
+use glob::Pattern;
 use par_iter::prelude::*;
 use path_absolutize::Absolutize;
-use relative_path::RelativePath;
+use pathdiff::diff_paths;
+use paths::resolve_output_path;
 use swc_core::{
     base::{
         config::{
@@ -18,12 +23,11 @@ use swc_core::{
         },
         try_with_handler, Compiler, HandlerOpts, TransformOutput,
     },
-    common::{
-        errors::ColorConfig, sync::Lazy, FileName, FilePathMapping, SourceFile, SourceMap, GLOBALS,
-    },
+    common::{errors::ColorConfig, FileName, FilePathMapping, SourceFile, SourceMap, GLOBALS},
     trace_macro::swc_trace,
 };
 use walkdir::WalkDir;
+use watch::FileWatcher;
 
 use crate::util::trace::init_trace;
 
@@ -88,6 +92,14 @@ pub struct CompileOptions {
     #[clap(long, group = "output")]
     out_dir: Option<PathBuf>,
 
+    /// When compiling to a directory, copy over non-compilable files.
+    #[clap(long)]
+    copy_files: bool,
+
+    /// Remove the leading directory from emitted output paths.
+    #[clap(long)]
+    strip_leading_paths: bool,
+
     /// Specify specific file extensions to compile.
     #[clap(long)]
     extensions: Option<Vec<String>>,
@@ -97,7 +109,7 @@ pub struct CompileOptions {
     files: Vec<PathBuf>,
 
     /// Use a specific extension for the output files
-    #[clap(long, default_value_t= String::from("js"))]
+    #[clap(long, default_value_t = String::from("js"))]
     out_file_extension: String,
 
     /// Enable experimental trace profiling
@@ -109,12 +121,35 @@ pub struct CompileOptions {
     /// `trace-{unix epoch time}.json` will be used by default.
     #[clap(group = "experimental_trace", long)]
     trace_out_file: Option<String>,
-    /*Flags legacy @swc/cli supports, might need some thoughts if we need support same.
-     *log_watch_compilation: bool,
-     *copy_files: bool,
-     *include_dotfiles: bool,
-     *only: Option<String>,
-     *no_swcrc: bool, */
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum InputOrigin {
+    Explicit,
+    Discovered,
+}
+
+struct InputFile {
+    path: PathBuf,
+    origin: InputOrigin,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum OutputEntryKind {
+    Compile,
+    Copy,
+}
+
+struct OutputEntry {
+    path: PathBuf,
+    kind: OutputEntryKind,
+}
+
+struct InputContext {
+    options: Options,
+    fm: Arc<SourceFile>,
+    compiler: Arc<Compiler>,
+    file_path: PathBuf,
 }
 
 fn parse_config(s: &str) -> Result<Config, serde_json::Error> {
@@ -132,152 +167,81 @@ fn parse_root_mode(s: &str) -> Result<RootMode, String> {
     }
 }
 
-static COMPILER: Lazy<Arc<Compiler>> = Lazy::new(|| {
-    let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
-
-    Arc::new(Compiler::new(cm))
-});
-
 /// List of file extensions supported by default.
 static DEFAULT_EXTENSIONS: &[&str] = &["js", "jsx", "es6", "es", "mjs", "ts", "tsx", "cts", "mts"];
 
-/// Infer list of files to be transformed from cli arguments.
-/// If given input is a directory, it'll traverse it and collect all supported
-/// files.
+fn new_compiler() -> Arc<Compiler> {
+    let cm = Arc::new(SourceMap::new(FilePathMapping::empty()));
+    Arc::new(Compiler::new(cm))
+}
+
+fn parse_ignore_pattern(ignore_pattern: Option<&str>) -> anyhow::Result<Option<Pattern>> {
+    ignore_pattern
+        .map(|ignore_pattern| Pattern::new(ignore_pattern).context("invalid --ignore pattern"))
+        .transpose()
+}
+
+fn is_compilable_extension(file_path: &Path, extensions: &[String]) -> bool {
+    let extension = match file_path.extension().and_then(|ext| ext.to_str()) {
+        Some(extension) => extension,
+        None => return false,
+    };
+
+    extensions
+        .iter()
+        .map(|value| value.trim_start_matches('.'))
+        .any(|value| value == extension)
+}
+
+fn is_ignored_path(path: &Path, ignore_pattern: Option<&Pattern>, cwd: &Path) -> bool {
+    let Some(ignore_pattern) = ignore_pattern else {
+        return false;
+    };
+
+    ignore_pattern.matches_path(path)
+        || diff_paths(path, cwd)
+            .as_ref()
+            .map(|relative_path| ignore_pattern.matches_path(relative_path))
+            .unwrap_or(false)
+}
+
+/// Infer list of files from cli arguments.
 #[tracing::instrument(level = "info", skip_all)]
-fn get_files_list(
+fn collect_input_files(
     raw_files_input: &[PathBuf],
-    extensions: &[String],
-    ignore_pattern: Option<&str>,
-    _include_dotfiles: bool,
-) -> anyhow::Result<Vec<PathBuf>> {
-    let input_dir = raw_files_input.iter().find(|p| p.is_dir());
+    ignore_pattern: Option<&Pattern>,
+) -> anyhow::Result<Vec<InputFile>> {
+    let input_dir = raw_files_input.iter().find(|path| path.is_dir());
+    let cwd = std::env::current_dir()?;
 
     let files = if let Some(input_dir) = input_dir {
         if raw_files_input.len() > 1 {
-            return Err(anyhow::anyhow!(
-                "Cannot specify multiple files when using a directory as input"
-            ));
+            bail!("Cannot specify multiple files when using a directory as input");
         }
 
         WalkDir::new(input_dir)
             .into_iter()
-            .filter_map(|e| e.ok())
-            .map(|e| e.into_path())
-            .filter(|e| e.is_file())
-            .filter(|e| {
-                extensions
-                    .iter()
-                    .any(|ext| e.extension().map(|v| v == &**ext).unwrap_or(false))
+            .filter_map(|entry| entry.ok())
+            .map(|entry| entry.into_path())
+            .filter(|path| path.is_file())
+            .filter(|path| !is_ignored_path(path, ignore_pattern, &cwd))
+            .map(|path| InputFile {
+                path,
+                origin: InputOrigin::Discovered,
             })
             .collect()
     } else {
-        raw_files_input.to_owned()
+        raw_files_input
+            .iter()
+            .filter(|path| !is_ignored_path(path, ignore_pattern, &cwd))
+            .map(|path| InputFile {
+                path: path.clone(),
+                origin: InputOrigin::Explicit,
+            })
+            .collect()
     };
-
-    if let Some(ignore_pattern) = ignore_pattern {
-        let pattern: Vec<PathBuf> = glob(ignore_pattern)?.filter_map(|p| p.ok()).collect();
-
-        return Ok(files
-            .into_iter()
-            .filter(|file_path| !pattern.iter().any(|p| p.eq(file_path)))
-            .collect());
-    }
 
     Ok(files)
-}
-
-/// Calculate full, absolute path to the file to emit.
-/// Currently this is quite naive calculation based on assumption input file's
-/// path and output dir are relative to the same directory.
-fn resolve_output_file_path(
-    out_dir: &Path,
-    file_path: &Path,
-    file_extension: PathBuf,
-) -> anyhow::Result<PathBuf> {
-    let default = PathBuf::from(".");
-    let base = file_path.parent().unwrap_or(&default).display().to_string();
-
-    let dist_absolute_path = out_dir.absolutize()?;
-
-    // These are possible combinations between input to output dir.
-    // cwd: /c/github/swc
-    //
-    // Input
-    // 1. Relative to cwd                   : ./crates/swc/tests/serde/a.js
-    // 2. Relative to cwd, traverse up      : ../repo/some/dir/b.js
-    // 3. Absolute path, relative to cwd: /c/github/swc/crates/swc/tests/serde/a.js
-    // 4. Absolute path, not relative to cwd: /c/github/repo/some/dir/b.js
-    //
-    // OutDir
-    // a. Relative to cwd: ./dist
-    // b. Relative to cwd, traverse up: ../outer_dist
-    // c. Absolute path: /c/github/swc/dist
-    // d. Absolute path, not relative to cwd: /c/github/outer_dist
-    //
-    // It is unclear how to calculate output path when either input or output is not
-    // relative to cwd (2,4 and b,d) and it is UB for now.
-    let base = RelativePath::new(&*base);
-    let output_path = base.to_logical_path(dist_absolute_path).join(
-        // Custom output file extension is not supported yet
-        file_path
-            .with_extension(file_extension)
-            .file_name()
-            .expect("Filename should be available"),
-    );
-
-    Ok(output_path)
-}
-
-fn emit_output(
-    mut output: TransformOutput,
-    out_dir: &Option<PathBuf>,
-    file_path: &Path,
-    file_extension: PathBuf,
-) -> anyhow::Result<()> {
-    if let Some(out_dir) = out_dir {
-        let output_file_path = resolve_output_file_path(out_dir, file_path, file_extension)?;
-        let output_dir = output_file_path
-            .parent()
-            .expect("Parent should be available");
-
-        if !output_dir.as_os_str().is_empty() && !output_dir.is_dir() {
-            fs::create_dir_all(output_dir)?;
-        }
-
-        if let Some(ref source_map) = output.map {
-            let source_map_path = output_file_path.with_extension("js.map");
-
-            output.code.push_str("\n//# sourceMappingURL=");
-            output
-                .code
-                .push_str(&source_map_path.file_name().unwrap().to_string_lossy());
-
-            fs::write(source_map_path, source_map)?;
-        }
-
-        fs::write(&output_file_path, &output.code)?;
-
-        if let Some(extra) = &output.output {
-            let mut extra: serde_json::Map<String, serde_json::Value> =
-                serde_json::from_str(extra).context("failed to parse extra output")?;
-
-            if let Some(dts_code) = extra.remove("__swc_isolated_declarations__") {
-                let dts_file_path = output_file_path.with_extension("d.ts");
-                fs::write(dts_file_path, dts_code.as_str().unwrap())?;
-            }
-        }
-    } else {
-        let source_map = if let Some(ref source_map) = output.map {
-            &**source_map
-        } else {
-            ""
-        };
-
-        eprintln!("{}", file_path.display());
-        println!("{}\n{}", output.code, source_map,);
-    };
-    Ok(())
 }
 
 fn collect_stdin_input() -> Option<String> {
@@ -296,12 +260,93 @@ fn collect_stdin_input() -> Option<String> {
     }
 }
 
-struct InputContext {
-    options: Options,
-    fm: Arc<SourceFile>,
+fn execute_transform(
     compiler: Arc<Compiler>,
-    file_path: PathBuf,
-    file_extension: PathBuf,
+    fm: Arc<SourceFile>,
+    options: Options,
+) -> anyhow::Result<TransformOutput> {
+    let color = ColorConfig::Always;
+    let skip_filename = false;
+
+    try_with_handler(
+        compiler.cm.clone(),
+        HandlerOpts {
+            color,
+            skip_filename,
+        },
+        |handler| {
+            GLOBALS.set(&Default::default(), || {
+                compiler.process_js_file(fm, handler, &options)
+            })
+        },
+    )
+    .map_err(|error| error.to_pretty_error())
+}
+
+fn resolve_source_map_path(output_file_path: &Path) -> PathBuf {
+    let extension = match output_file_path.extension() {
+        Some(extension) => format!("{}.map", extension.to_string_lossy()),
+        None => String::from("map"),
+    };
+
+    output_file_path.with_extension(extension)
+}
+
+fn resolve_declaration_path(output_file_path: &Path) -> PathBuf {
+    output_file_path.with_extension("d.ts")
+}
+
+fn remove_file_if_exists(path: &Path) -> anyhow::Result<()> {
+    match fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error.into()),
+    }
+}
+
+fn emit_directory_output(
+    mut output: TransformOutput,
+    output_file_path: &Path,
+) -> anyhow::Result<()> {
+    let output_dir = output_file_path
+        .parent()
+        .expect("Parent should be available");
+
+    if !output_dir.as_os_str().is_empty() && !output_dir.is_dir() {
+        fs::create_dir_all(output_dir)?;
+    }
+
+    if let Some(ref source_map) = output.map {
+        let source_map_path = resolve_source_map_path(output_file_path);
+
+        output.code.push_str("\n//# sourceMappingURL=");
+        output
+            .code
+            .push_str(&source_map_path.file_name().unwrap().to_string_lossy());
+
+        fs::write(source_map_path, source_map)?;
+    }
+
+    fs::write(output_file_path, &output.code)?;
+
+    if let Some(extra) = &output.output {
+        let mut extra: serde_json::Map<String, serde_json::Value> =
+            serde_json::from_str(extra).context("failed to parse extra output")?;
+
+        if let Some(dts_code) = extra.remove("__swc_isolated_declarations__") {
+            let declaration_path = resolve_declaration_path(output_file_path);
+            fs::write(declaration_path, dts_code.as_str().unwrap())?;
+        }
+    }
+
+    Ok(())
+}
+
+fn emit_stdout_output(file_path: &Path, output: TransformOutput) {
+    let source_map = output.map.as_deref().unwrap_or("");
+
+    eprintln!("{}", file_path.display());
+    println!("{}\n{}", output.code, source_map);
 }
 
 #[swc_trace]
@@ -322,18 +367,16 @@ impl CompileOptions {
             options.config.jsc.experimental.plugins.map(|plugins| {
                 plugins
                     .into_iter()
-                    .map(|p| {
-                        // if the path starts with . or .., then turn it into an absolute path using
-                        // the current working directory as the base
-                        let path = Path::new(&p.0);
+                    .map(|plugin| {
+                        let path = Path::new(&plugin.0);
                         PluginConfig(
                             match path.components().next() {
                                 Some(Component::CurDir) | Some(Component::ParentDir) => {
                                     path.absolutize().unwrap().display().to_string()
                                 }
-                                _ => p.0,
+                                _ => plugin.0,
                             },
-                            p.1,
+                            plugin.1,
                         )
                     })
                     .collect()
@@ -369,47 +412,118 @@ impl CompileOptions {
         Ok(options)
     }
 
-    /// Create canonical list of inputs to be processed across stdin / single
-    /// file / multiple files.
-    fn collect_inputs(&self) -> anyhow::Result<Vec<InputContext>> {
-        let compiler = COMPILER.clone();
+    fn validate(&self) -> anyhow::Result<()> {
+        if self.watch && self.out_file.is_none() && self.out_dir.is_none() {
+            bail!("--watch requires --out-file or --out-dir");
+        }
 
+        if self.watch && self.files.is_empty() {
+            bail!("--watch requires input files");
+        }
+
+        if self.copy_files && self.out_dir.is_none() {
+            bail!("--copy-files requires --out-dir");
+        }
+
+        if self.strip_leading_paths && self.out_dir.is_none() {
+            bail!("--strip-leading-paths requires --out-dir");
+        }
+
+        Ok(())
+    }
+
+    fn included_extensions(&self) -> Vec<String> {
+        self.extensions.clone().unwrap_or_else(|| {
+            DEFAULT_EXTENSIONS
+                .iter()
+                .map(|value| value.to_string())
+                .collect()
+        })
+    }
+
+    fn has_directory_input(&self) -> bool {
+        self.files.iter().any(|path| path.is_dir())
+    }
+
+    fn collect_compile_file_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
+        let ignore_pattern = parse_ignore_pattern(self.ignore.as_deref())?;
+        let inputs = collect_input_files(&self.files, ignore_pattern.as_ref())?;
+
+        if self.has_directory_input() {
+            let extensions = self.included_extensions();
+
+            Ok(inputs
+                .into_iter()
+                .filter(|input| is_compilable_extension(&input.path, &extensions))
+                .map(|input| input.path)
+                .collect())
+        } else {
+            Ok(inputs.into_iter().map(|input| input.path).collect())
+        }
+    }
+
+    fn classify_output_entry(&self, input: InputFile) -> Option<OutputEntry> {
+        if is_compilable_extension(&input.path, &self.included_extensions()) {
+            return Some(OutputEntry {
+                path: input.path,
+                kind: OutputEntryKind::Compile,
+            });
+        }
+
+        if self.copy_files {
+            return Some(OutputEntry {
+                path: input.path,
+                kind: OutputEntryKind::Copy,
+            });
+        }
+
+        if input.origin == InputOrigin::Explicit {
+            return Some(OutputEntry {
+                path: input.path,
+                kind: OutputEntryKind::Compile,
+            });
+        }
+
+        None
+    }
+
+    fn collect_output_dir_entries(&self) -> anyhow::Result<Vec<OutputEntry>> {
+        let ignore_pattern = parse_ignore_pattern(self.ignore.as_deref())?;
+        let inputs = collect_input_files(&self.files, ignore_pattern.as_ref())?;
+
+        Ok(inputs
+            .into_iter()
+            .filter_map(|input| self.classify_output_entry(input))
+            .collect())
+    }
+
+    fn collect_inputs(&self, compiler: Arc<Compiler>) -> anyhow::Result<Vec<InputContext>> {
         if !self.files.is_empty() {
-            let included_extensions = if let Some(extensions) = &self.extensions {
-                extensions.clone()
-            } else {
-                DEFAULT_EXTENSIONS.iter().map(|v| v.to_string()).collect()
-            };
+            return self
+                .collect_compile_file_paths()?
+                .into_iter()
+                .map(|file_path| {
+                    self.build_transform_options(&Some(file_path.as_path()))
+                        .and_then(|options| {
+                            let fm = compiler
+                                .cm
+                                .load_file(&file_path)
+                                .context(format!("Failed to open file {}", file_path.display()))?;
 
-            return get_files_list(
-                &self.files,
-                &included_extensions,
-                self.ignore.as_deref(),
-                false,
-            )?
-            .iter()
-            .map(|file_path| {
-                self.build_transform_options(&Some(file_path))
-                    .and_then(|options| {
-                        let fm = compiler
-                            .cm
-                            .load_file(file_path)
-                            .context(format!("Failed to open file {}", file_path.display()));
-                        fm.map(|fm| InputContext {
-                            options,
-                            fm,
-                            compiler: compiler.clone(),
-                            file_path: file_path.to_path_buf(),
-                            file_extension: self.out_file_extension.clone().into(),
+                            Ok(InputContext {
+                                options,
+                                fm,
+                                compiler: compiler.clone(),
+                                file_path,
+                            })
                         })
-                    })
-            })
-            .collect::<anyhow::Result<Vec<InputContext>>>();
+                })
+                .collect();
         }
 
         let stdin_input = collect_stdin_input();
         if stdin_input.is_some() && !self.files.is_empty() {
-            anyhow::bail!("Cannot specify inputs from stdin and files at the same time");
+            bail!("Cannot specify inputs from stdin and files at the same time");
         }
 
         if let Some(stdin_input) = stdin_input {
@@ -432,146 +546,385 @@ impl CompileOptions {
                     .filename
                     .clone()
                     .unwrap_or_else(|| PathBuf::from("unknown")),
-                file_extension: self.out_file_extension.clone().into(),
             }]);
         }
 
-        anyhow::bail!("Input is empty");
+        bail!("Input is empty");
     }
 
-    fn execute_inner(&self) -> anyhow::Result<()> {
-        let inputs = self.collect_inputs()?;
+    fn transform_path(
+        &self,
+        compiler: Arc<Compiler>,
+        file_path: &Path,
+    ) -> anyhow::Result<TransformOutput> {
+        let options = self.build_transform_options(&Some(file_path))?;
+        let fm = compiler
+            .cm
+            .load_file(file_path)
+            .context(format!("Failed to open file {}", file_path.display()))?;
 
-        let execute = |compiler: Arc<Compiler>, fm: Arc<SourceFile>, options: Options| {
-            let color = ColorConfig::Always;
-            let skip_filename = false;
+        execute_transform(compiler, fm, options)
+    }
 
-            try_with_handler(
-                compiler.cm.clone(),
-                HandlerOpts {
-                    color,
-                    skip_filename,
-                },
-                |handler| {
-                    GLOBALS.set(&Default::default(), || {
-                        compiler.process_js_file(fm, handler, &options)
-                    })
-                },
-            )
-            .map_err(|e| e.to_pretty_error())
-        };
+    fn emit_output_dir_entry(
+        &self,
+        compiler: Arc<Compiler>,
+        out_dir: &Path,
+        entry: &OutputEntry,
+    ) -> anyhow::Result<()> {
+        match entry.kind {
+            OutputEntryKind::Compile => {
+                let output = self.transform_path(compiler, &entry.path)?;
+                let output_file_path = resolve_output_path(
+                    out_dir,
+                    &self.files,
+                    &entry.path,
+                    Some(&self.out_file_extension),
+                    self.strip_leading_paths,
+                )?;
 
-        if let Some(single_out_file) = self.out_file.as_ref() {
-            let result: anyhow::Result<Vec<TransformOutput>> = inputs
-                .into_par_iter()
-                .map(
-                    |InputContext {
-                         compiler,
-                         fm,
-                         options,
-                         ..
-                     }| execute(compiler, fm, options),
-                )
-                .collect();
-
-            let parent = single_out_file
-                .parent()
-                .expect("Parent should be available");
-            if !parent.as_os_str().is_empty() {
-                fs::create_dir_all(parent)?;
+                emit_directory_output(output, &output_file_path)
             }
-            let mut buf = File::create(single_out_file)?;
-            let mut buf_srcmap = None;
-            let mut buf_dts = None;
-            let mut source_map_path = None;
+            OutputEntryKind::Copy => {
+                let output_file_path = resolve_output_path(
+                    out_dir,
+                    &self.files,
+                    &entry.path,
+                    None,
+                    self.strip_leading_paths,
+                )?;
+                let output_dir = output_file_path
+                    .parent()
+                    .expect("Parent should be available");
 
-            // write all transformed files to single output buf
-            for r in result?.iter() {
-                if let Some(src_map) = r.map.as_ref() {
-                    if buf_srcmap.is_none() {
-                        let map_out_file = if let Some(source_map_target) = &self.source_map_target
-                        {
-                            source_map_path = Some(source_map_target.clone());
-                            source_map_target.into()
-                        } else {
-                            let map_out_file = single_out_file.with_extension(format!(
-                                "{}map",
-                                if let Some(ext) = single_out_file.extension() {
-                                    format!("{}.", ext.to_string_lossy())
-                                } else {
-                                    "".to_string()
-                                }
-                            ));
-
-                            // Get the filename of the source map, as the source map will
-                            // be created in the same directory next to the output.
-                            source_map_path = Some(
-                                map_out_file
-                                    .file_name()
-                                    .unwrap()
-                                    .to_string_lossy()
-                                    .to_string(),
-                            );
-                            map_out_file
-                        };
-                        buf_srcmap = Some(File::create(map_out_file)?);
-                    }
-
-                    buf_srcmap
-                        .as_ref()
-                        .expect("Srcmap buffer should be available")
-                        .write(src_map.as_bytes())
-                        .and(Ok(()))?;
+                if !output_dir.as_os_str().is_empty() && !output_dir.is_dir() {
+                    fs::create_dir_all(output_dir)?;
                 }
 
-                if let Some(extra) = &r.output {
-                    let mut extra: serde_json::Map<String, serde_json::Value> =
-                        serde_json::from_str(extra).context("failed to parse extra output")?;
+                fs::copy(&entry.path, output_file_path)
+                    .with_context(|| format!("Failed to copy {}", entry.path.display()))?;
 
-                    if let Some(dts_code) = extra.remove("__swc_isolated_declarations__") {
-                        if buf_dts.is_none() {
-                            let dts_file_path = single_out_file.with_extension("d.ts");
-                            buf_dts = Some(File::create(dts_file_path)?);
-                        }
-
-                        let dts_code = dts_code.as_str().expect("dts code should be string");
-                        buf_dts
-                            .as_ref()
-                            .expect("dts buffer should be available")
-                            .write(dts_code.as_bytes())
-                            .and(Ok(()))?;
-                    }
-                }
-
-                buf.write(r.code.as_bytes()).and(Ok(()))?;
+                Ok(())
             }
+        }
+    }
 
-            if let Some(source_map_path) = source_map_path {
-                buf.write_all(b"\n//# sourceMappingURL=")?;
-                buf.write_all(source_map_path.as_bytes())?;
-            }
+    fn remove_output_dir_entry(&self, out_dir: &Path, entry: &OutputEntry) -> anyhow::Result<()> {
+        let output_file_path = resolve_output_path(
+            out_dir,
+            &self.files,
+            &entry.path,
+            match entry.kind {
+                OutputEntryKind::Compile => Some(&self.out_file_extension),
+                OutputEntryKind::Copy => None,
+            },
+            self.strip_leading_paths,
+        )?;
 
-            buf.flush()
-                .context("Failed to write output into single file")
-        } else {
-            inputs.into_par_iter().try_for_each(
+        remove_file_if_exists(&output_file_path)?;
+
+        if entry.kind == OutputEntryKind::Compile {
+            remove_file_if_exists(&resolve_source_map_path(&output_file_path))?;
+            remove_file_if_exists(&resolve_declaration_path(&output_file_path))?;
+        }
+
+        Ok(())
+    }
+
+    fn execute_out_file_once(&self, single_out_file: &Path) -> anyhow::Result<()> {
+        let compiler = new_compiler();
+        let inputs = self.collect_inputs(compiler)?;
+
+        let result: anyhow::Result<Vec<TransformOutput>> = inputs
+            .into_par_iter()
+            .map(
                 |InputContext {
                      compiler,
                      fm,
                      options,
-                     file_path,
-                     file_extension,
-                 }| {
-                    let result = execute(compiler, fm, options);
-
-                    match result {
-                        Ok(output) => {
-                            emit_output(output, &self.out_dir, &file_path, file_extension)
-                        }
-                        Err(e) => Err(e),
-                    }
-                },
+                     ..
+                 }| execute_transform(compiler, fm, options),
             )
+            .collect();
+
+        let parent = single_out_file
+            .parent()
+            .expect("Parent should be available");
+        if !parent.as_os_str().is_empty() {
+            fs::create_dir_all(parent)?;
+        }
+
+        let mut buf = File::create(single_out_file)?;
+        let mut buf_srcmap = None;
+        let mut buf_dts = None;
+        let mut source_map_path = None;
+
+        for output in result?.iter() {
+            if let Some(src_map) = output.map.as_ref() {
+                if buf_srcmap.is_none() {
+                    let map_out_file = if let Some(source_map_target) = &self.source_map_target {
+                        source_map_path = Some(source_map_target.clone());
+                        PathBuf::from(source_map_target)
+                    } else {
+                        let map_out_file = resolve_source_map_path(single_out_file);
+
+                        source_map_path = Some(
+                            map_out_file
+                                .file_name()
+                                .unwrap()
+                                .to_string_lossy()
+                                .to_string(),
+                        );
+                        map_out_file
+                    };
+
+                    buf_srcmap = Some(File::create(map_out_file)?);
+                }
+
+                buf_srcmap
+                    .as_ref()
+                    .expect("Srcmap buffer should be available")
+                    .write(src_map.as_bytes())
+                    .and(Ok(()))?;
+            }
+
+            if let Some(extra) = &output.output {
+                let mut extra: serde_json::Map<String, serde_json::Value> =
+                    serde_json::from_str(extra).context("failed to parse extra output")?;
+
+                if let Some(dts_code) = extra.remove("__swc_isolated_declarations__") {
+                    if buf_dts.is_none() {
+                        let dts_file_path = single_out_file.with_extension("d.ts");
+                        buf_dts = Some(File::create(dts_file_path)?);
+                    }
+
+                    let dts_code = dts_code.as_str().expect("dts code should be string");
+                    buf_dts
+                        .as_ref()
+                        .expect("dts buffer should be available")
+                        .write(dts_code.as_bytes())
+                        .and(Ok(()))?;
+                }
+            }
+
+            buf.write(output.code.as_bytes()).and(Ok(()))?;
+        }
+
+        if let Some(source_map_path) = source_map_path {
+            buf.write_all(b"\n//# sourceMappingURL=")?;
+            buf.write_all(source_map_path.as_bytes())?;
+        }
+
+        buf.flush()
+            .context("Failed to write output into single file")
+    }
+
+    fn execute_out_dir_once(&self, out_dir: &Path) -> anyhow::Result<()> {
+        let entries = self.collect_output_dir_entries()?;
+        let compiler = new_compiler();
+
+        entries
+            .into_par_iter()
+            .try_for_each(|entry| self.emit_output_dir_entry(compiler.clone(), out_dir, &entry))
+    }
+
+    fn execute_stdout_once(&self) -> anyhow::Result<()> {
+        let compiler = new_compiler();
+        let inputs = self.collect_inputs(compiler)?;
+
+        inputs.into_par_iter().try_for_each(
+            |InputContext {
+                 compiler,
+                 fm,
+                 options,
+                 file_path,
+                 ..
+             }| {
+                let output = execute_transform(compiler, fm, options)?;
+                emit_stdout_output(&file_path, output);
+                Ok(())
+            },
+        )
+    }
+
+    fn execute_once(&self) -> anyhow::Result<()> {
+        if let Some(single_out_file) = self.out_file.as_ref() {
+            self.execute_out_file_once(single_out_file)
+        } else if let Some(out_dir) = self.out_dir.as_ref() {
+            self.execute_out_dir_once(out_dir)
+        } else {
+            self.execute_stdout_once()
+        }
+    }
+
+    fn is_explicit_input_path(&self, file_path: &Path) -> bool {
+        let Ok(file_path) = file_path.absolutize().map(|path| path.into_owned()) else {
+            return false;
+        };
+
+        self.files
+            .iter()
+            .filter(|path| !path.is_dir())
+            .filter_map(|path| path.absolutize().ok().map(|path| path.into_owned()))
+            .any(|path| path == file_path)
+    }
+
+    fn is_relevant_input_path(&self, file_path: &Path) -> bool {
+        let Ok(file_path) = file_path.absolutize().map(|path| path.into_owned()) else {
+            return false;
+        };
+
+        self.files.iter().any(|input| {
+            let Ok(input) = input.absolutize().map(|path| path.into_owned()) else {
+                return false;
+            };
+
+            if input.is_dir() {
+                file_path.starts_with(&input)
+            } else {
+                file_path == input
+            }
+        })
+    }
+
+    fn classify_watch_output_entry(&self, file_path: &Path) -> Option<OutputEntry> {
+        let origin = if self.is_explicit_input_path(file_path) {
+            InputOrigin::Explicit
+        } else {
+            InputOrigin::Discovered
+        };
+
+        self.classify_output_entry(InputFile {
+            path: file_path.to_path_buf(),
+            origin,
+        })
+    }
+
+    fn process_out_dir_watch_batch(
+        &self,
+        out_dir: &Path,
+        changed_paths: Vec<PathBuf>,
+        removed_paths: Vec<PathBuf>,
+        ignore_pattern: Option<&Pattern>,
+    ) {
+        let relevant_removed: BTreeSet<_> = removed_paths
+            .into_iter()
+            .filter(|path| {
+                self.is_relevant_input_path(path)
+                    && !is_ignored_path(path, ignore_pattern, &std::env::current_dir().unwrap())
+            })
+            .collect();
+
+        for path in relevant_removed {
+            if let Some(entry) = self.classify_watch_output_entry(&path) {
+                if let Err(error) = self.remove_output_dir_entry(out_dir, &entry) {
+                    eprintln!("{error:#}");
+                }
+            }
+        }
+
+        let relevant_changed: BTreeSet<_> = changed_paths
+            .into_iter()
+            .filter(|path| {
+                path.is_file()
+                    && self.is_relevant_input_path(path)
+                    && !is_ignored_path(path, ignore_pattern, &std::env::current_dir().unwrap())
+            })
+            .collect();
+
+        let compiler = new_compiler();
+
+        for path in relevant_changed {
+            if let Some(entry) = self.classify_watch_output_entry(&path) {
+                if let Err(error) = self.emit_output_dir_entry(compiler.clone(), out_dir, &entry) {
+                    eprintln!("{error:#}");
+                }
+            }
+        }
+    }
+
+    fn should_rebuild_out_file(&self, file_path: &Path, ignore_pattern: Option<&Pattern>) -> bool {
+        if !self.is_relevant_input_path(file_path) {
+            return false;
+        }
+
+        let cwd = match std::env::current_dir() {
+            Ok(cwd) => cwd,
+            Err(_) => return false,
+        };
+
+        if is_ignored_path(file_path, ignore_pattern, &cwd) {
+            return false;
+        }
+
+        if self.has_directory_input() {
+            is_compilable_extension(file_path, &self.included_extensions())
+        } else {
+            true
+        }
+    }
+
+    fn remove_out_file_outputs(&self, single_out_file: &Path) -> anyhow::Result<()> {
+        remove_file_if_exists(single_out_file)?;
+        remove_file_if_exists(&resolve_source_map_path(single_out_file))?;
+        remove_file_if_exists(&single_out_file.with_extension("d.ts"))?;
+        Ok(())
+    }
+
+    fn watch_out_dir(&self, out_dir: &Path) -> anyhow::Result<()> {
+        let ignore_pattern = parse_ignore_pattern(self.ignore.as_deref())?;
+        let watcher = FileWatcher::new(&self.files)?;
+
+        if let Err(error) = self.execute_out_dir_once(out_dir) {
+            eprintln!("{error:#}");
+        }
+
+        loop {
+            let changes = watcher.recv_changes()?;
+            self.process_out_dir_watch_batch(
+                out_dir,
+                changes.changed,
+                changes.removed,
+                ignore_pattern.as_ref(),
+            );
+        }
+    }
+
+    fn watch_out_file(&self, single_out_file: &Path) -> anyhow::Result<()> {
+        let ignore_pattern = parse_ignore_pattern(self.ignore.as_deref())?;
+        let watcher = FileWatcher::new(&self.files)?;
+
+        if let Err(error) = self.execute_out_file_once(single_out_file) {
+            eprintln!("{error:#}");
+        }
+
+        loop {
+            let changes = watcher.recv_changes()?;
+            let should_rebuild = changes
+                .changed
+                .iter()
+                .chain(changes.removed.iter())
+                .any(|path| self.should_rebuild_out_file(path, ignore_pattern.as_ref()));
+
+            if !should_rebuild {
+                continue;
+            }
+
+            match self.collect_compile_file_paths() {
+                Ok(files) if files.is_empty() => {
+                    if let Err(error) = self.remove_out_file_outputs(single_out_file) {
+                        eprintln!("{error:#}");
+                    }
+                }
+                Ok(_) => {
+                    // Rebuild the full bundle so the concatenation order and
+                    // source map output stay consistent with one-shot mode.
+                    if let Err(error) = self.execute_out_file_once(single_out_file) {
+                        eprintln!("{error:#}");
+                    }
+                }
+                Err(error) => eprintln!("{error:#}"),
+            }
         }
     }
 }
@@ -579,19 +932,31 @@ impl CompileOptions {
 #[swc_trace]
 impl super::CommandRunner for CompileOptions {
     fn execute(&self) -> anyhow::Result<()> {
+        self.validate()?;
+
         let guard = if self.experimental_trace {
             init_trace(&self.trace_out_file)
         } else {
             None
         };
 
-        let ret = self.execute_inner();
+        let result = if self.watch {
+            if let Some(out_dir) = self.out_dir.as_ref() {
+                self.watch_out_dir(out_dir)
+            } else if let Some(out_file) = self.out_file.as_ref() {
+                self.watch_out_file(out_file)
+            } else {
+                bail!("--watch requires --out-file or --out-dir");
+            }
+        } else {
+            self.execute_once()
+        };
 
         if let Some(guard) = guard {
             guard.flush();
             drop(guard);
         }
 
-        ret
+        result
     }
 }

--- a/crates/swc_cli_impl/src/commands/compile.rs
+++ b/crates/swc_cli_impl/src/commands/compile.rs
@@ -205,14 +205,43 @@ fn is_ignored_path(path: &Path, ignore_pattern: Option<&Pattern>, cwd: &Path) ->
             .unwrap_or(false)
 }
 
+fn absolutize_path(path: &Path) -> anyhow::Result<PathBuf> {
+    Ok(path.absolutize()?.into_owned())
+}
+
+fn is_same_or_nested_path(path: &Path, base_path: &Path) -> bool {
+    let Ok(path) = absolutize_path(path) else {
+        return false;
+    };
+
+    path.starts_with(base_path)
+}
+
+fn is_exact_path(path: &Path, expected_paths: &BTreeSet<PathBuf>) -> bool {
+    let Ok(path) = absolutize_path(path) else {
+        return false;
+    };
+
+    expected_paths.contains(&path)
+}
+
+fn collect_absolute_paths(paths: &[PathBuf]) -> BTreeSet<PathBuf> {
+    paths
+        .iter()
+        .filter_map(|path| absolutize_path(path).ok())
+        .collect()
+}
+
 /// Infer list of files from cli arguments.
 #[tracing::instrument(level = "info", skip_all)]
 fn collect_input_files(
     raw_files_input: &[PathBuf],
     ignore_pattern: Option<&Pattern>,
+    excluded_dir: Option<&Path>,
 ) -> anyhow::Result<Vec<InputFile>> {
     let input_dir = raw_files_input.iter().find(|path| path.is_dir());
     let cwd = std::env::current_dir()?;
+    let excluded_dir = excluded_dir.map(absolutize_path).transpose()?;
 
     let files = if let Some(input_dir) = input_dir {
         if raw_files_input.len() > 1 {
@@ -221,6 +250,14 @@ fn collect_input_files(
 
         WalkDir::new(input_dir)
             .into_iter()
+            .filter_entry(|entry| {
+                // Avoid descending into generated output when --out-dir is
+                // nested inside the watched or compiled input tree.
+                !excluded_dir
+                    .as_deref()
+                    .map(|excluded_dir| is_same_or_nested_path(entry.path(), excluded_dir))
+                    .unwrap_or(false)
+            })
             .filter_map(|entry| entry.ok())
             .map(|entry| entry.into_path())
             .filter(|path| path.is_file())
@@ -233,6 +270,12 @@ fn collect_input_files(
     } else {
         raw_files_input
             .iter()
+            .filter(|path| {
+                !excluded_dir
+                    .as_deref()
+                    .map(|excluded_dir| is_same_or_nested_path(path, excluded_dir))
+                    .unwrap_or(false)
+            })
             .filter(|path| !is_ignored_path(path, ignore_pattern, &cwd))
             .map(|path| InputFile {
                 path: path.clone(),
@@ -445,25 +488,54 @@ impl CompileOptions {
         self.files.iter().any(|path| path.is_dir())
     }
 
-    fn collect_compile_file_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
+    fn collect_compile_file_paths_inner(
+        &self,
+        existing_only: bool,
+        excluded_files: &[PathBuf],
+    ) -> anyhow::Result<Vec<PathBuf>> {
         let ignore_pattern = parse_ignore_pattern(self.ignore.as_deref())?;
-        let inputs = collect_input_files(&self.files, ignore_pattern.as_ref())?;
+        let inputs = collect_input_files(&self.files, ignore_pattern.as_ref(), None)?;
+        let excluded_files = collect_absolute_paths(excluded_files);
+
+        let is_input_path_enabled = |path: &Path| {
+            (!existing_only || path.is_file()) && !is_exact_path(path, &excluded_files)
+        };
 
         if self.has_directory_input() {
             let extensions = self.included_extensions();
 
             Ok(inputs
                 .into_iter()
+                .filter(|input| is_input_path_enabled(&input.path))
                 .filter(|input| is_compilable_extension(&input.path, &extensions))
                 .map(|input| input.path)
                 .collect())
         } else {
-            Ok(inputs.into_iter().map(|input| input.path).collect())
+            Ok(inputs
+                .into_iter()
+                .filter(|input| is_input_path_enabled(&input.path))
+                .map(|input| input.path)
+                .collect())
         }
     }
 
-    fn classify_output_entry(&self, input: InputFile) -> Option<OutputEntry> {
-        if is_compilable_extension(&input.path, &self.included_extensions()) {
+    fn collect_compile_file_paths(&self) -> anyhow::Result<Vec<PathBuf>> {
+        self.collect_compile_file_paths_inner(false, &[])
+    }
+
+    fn collect_existing_compile_file_paths(
+        &self,
+        excluded_files: &[PathBuf],
+    ) -> anyhow::Result<Vec<PathBuf>> {
+        self.collect_compile_file_paths_inner(true, excluded_files)
+    }
+
+    fn classify_output_entry(
+        &self,
+        input: InputFile,
+        extensions: &[String],
+    ) -> Option<OutputEntry> {
+        if is_compilable_extension(&input.path, extensions) {
             return Some(OutputEntry {
                 path: input.path,
                 kind: OutputEntryKind::Compile,
@@ -487,38 +559,46 @@ impl CompileOptions {
         None
     }
 
-    fn collect_output_dir_entries(&self) -> anyhow::Result<Vec<OutputEntry>> {
+    fn collect_output_dir_entries(&self, out_dir: &Path) -> anyhow::Result<Vec<OutputEntry>> {
         let ignore_pattern = parse_ignore_pattern(self.ignore.as_deref())?;
-        let inputs = collect_input_files(&self.files, ignore_pattern.as_ref())?;
+        let inputs = collect_input_files(&self.files, ignore_pattern.as_ref(), Some(out_dir))?;
+        let extensions = self.included_extensions();
 
         Ok(inputs
             .into_iter()
-            .filter_map(|input| self.classify_output_entry(input))
+            .filter_map(|input| self.classify_output_entry(input, &extensions))
             .collect())
+    }
+
+    fn collect_file_inputs(
+        &self,
+        compiler: Arc<Compiler>,
+        file_paths: Vec<PathBuf>,
+    ) -> anyhow::Result<Vec<InputContext>> {
+        file_paths
+            .into_iter()
+            .map(|file_path| {
+                self.build_transform_options(&Some(file_path.as_path()))
+                    .and_then(|options| {
+                        let fm = compiler
+                            .cm
+                            .load_file(&file_path)
+                            .context(format!("Failed to open file {}", file_path.display()))?;
+
+                        Ok(InputContext {
+                            options,
+                            fm,
+                            compiler: compiler.clone(),
+                            file_path,
+                        })
+                    })
+            })
+            .collect()
     }
 
     fn collect_inputs(&self, compiler: Arc<Compiler>) -> anyhow::Result<Vec<InputContext>> {
         if !self.files.is_empty() {
-            return self
-                .collect_compile_file_paths()?
-                .into_iter()
-                .map(|file_path| {
-                    self.build_transform_options(&Some(file_path.as_path()))
-                        .and_then(|options| {
-                            let fm = compiler
-                                .cm
-                                .load_file(&file_path)
-                                .context(format!("Failed to open file {}", file_path.display()))?;
-
-                            Ok(InputContext {
-                                options,
-                                fm,
-                                compiler: compiler.clone(),
-                                file_path,
-                            })
-                        })
-                })
-                .collect();
+            return self.collect_file_inputs(compiler, self.collect_compile_file_paths()?);
         }
 
         let stdin_input = collect_stdin_input();
@@ -631,10 +711,11 @@ impl CompileOptions {
         Ok(())
     }
 
-    fn execute_out_file_once(&self, single_out_file: &Path) -> anyhow::Result<()> {
-        let compiler = new_compiler();
-        let inputs = self.collect_inputs(compiler)?;
-
+    fn execute_out_file_with_inputs(
+        &self,
+        single_out_file: &Path,
+        inputs: Vec<InputContext>,
+    ) -> anyhow::Result<()> {
         let result: anyhow::Result<Vec<TransformOutput>> = inputs
             .into_par_iter()
             .map(
@@ -719,8 +800,40 @@ impl CompileOptions {
             .context("Failed to write output into single file")
     }
 
+    fn execute_out_file_once(&self, single_out_file: &Path) -> anyhow::Result<()> {
+        let compiler = new_compiler();
+        let inputs = self.collect_inputs(compiler)?;
+
+        self.execute_out_file_with_inputs(single_out_file, inputs)
+    }
+
+    fn execute_existing_out_file_paths(
+        &self,
+        single_out_file: &Path,
+        file_paths: Vec<PathBuf>,
+    ) -> anyhow::Result<()> {
+        if file_paths.is_empty() {
+            return self.remove_out_file_outputs(single_out_file);
+        }
+
+        let compiler = new_compiler();
+        let inputs = self.collect_file_inputs(compiler, file_paths)?;
+
+        self.execute_out_file_with_inputs(single_out_file, inputs)
+    }
+
+    fn execute_existing_out_file_once(&self, single_out_file: &Path) -> anyhow::Result<()> {
+        let output_files = self.out_file_output_paths(single_out_file);
+        // Watch mode rebuilds from files that still exist, so deleting one
+        // explicit input removes it from the next bundle instead of failing the
+        // whole rebuild.
+        let file_paths = self.collect_existing_compile_file_paths(&output_files)?;
+
+        self.execute_existing_out_file_paths(single_out_file, file_paths)
+    }
+
     fn execute_out_dir_once(&self, out_dir: &Path) -> anyhow::Result<()> {
-        let entries = self.collect_output_dir_entries()?;
+        let entries = self.collect_output_dir_entries(out_dir)?;
         let compiler = new_compiler();
 
         entries
@@ -787,17 +900,24 @@ impl CompileOptions {
         })
     }
 
-    fn classify_watch_output_entry(&self, file_path: &Path) -> Option<OutputEntry> {
+    fn classify_watch_output_entry(
+        &self,
+        file_path: &Path,
+        extensions: &[String],
+    ) -> Option<OutputEntry> {
         let origin = if self.is_explicit_input_path(file_path) {
             InputOrigin::Explicit
         } else {
             InputOrigin::Discovered
         };
 
-        self.classify_output_entry(InputFile {
-            path: file_path.to_path_buf(),
-            origin,
-        })
+        self.classify_output_entry(
+            InputFile {
+                path: file_path.to_path_buf(),
+                origin,
+            },
+            extensions,
+        )
     }
 
     fn process_out_dir_watch_batch(
@@ -807,16 +927,33 @@ impl CompileOptions {
         removed_paths: Vec<PathBuf>,
         ignore_pattern: Option<&Pattern>,
     ) {
+        let cwd = match std::env::current_dir() {
+            Ok(cwd) => cwd,
+            Err(error) => {
+                tracing::warn!(error = %error, "failed to read current directory for watch batch");
+                return;
+            }
+        };
+        let output_dir = match absolutize_path(out_dir) {
+            Ok(output_dir) => output_dir,
+            Err(error) => {
+                tracing::warn!(error = %error, "failed to resolve output directory for watch batch");
+                return;
+            }
+        };
+        let extensions = self.included_extensions();
+
         let relevant_removed: BTreeSet<_> = removed_paths
             .into_iter()
             .filter(|path| {
                 self.is_relevant_input_path(path)
-                    && !is_ignored_path(path, ignore_pattern, &std::env::current_dir().unwrap())
+                    && !is_same_or_nested_path(path, &output_dir)
+                    && !is_ignored_path(path, ignore_pattern, &cwd)
             })
             .collect();
 
         for path in relevant_removed {
-            if let Some(entry) = self.classify_watch_output_entry(&path) {
+            if let Some(entry) = self.classify_watch_output_entry(&path, &extensions) {
                 if let Err(error) = self.remove_output_dir_entry(out_dir, &entry) {
                     eprintln!("{error:#}");
                 }
@@ -828,14 +965,15 @@ impl CompileOptions {
             .filter(|path| {
                 path.is_file()
                     && self.is_relevant_input_path(path)
-                    && !is_ignored_path(path, ignore_pattern, &std::env::current_dir().unwrap())
+                    && !is_same_or_nested_path(path, &output_dir)
+                    && !is_ignored_path(path, ignore_pattern, &cwd)
             })
             .collect();
 
         let compiler = new_compiler();
 
         for path in relevant_changed {
-            if let Some(entry) = self.classify_watch_output_entry(&path) {
+            if let Some(entry) = self.classify_watch_output_entry(&path, &extensions) {
                 if let Err(error) = self.emit_output_dir_entry(compiler.clone(), out_dir, &entry) {
                     eprintln!("{error:#}");
                 }
@@ -843,30 +981,54 @@ impl CompileOptions {
         }
     }
 
-    fn should_rebuild_out_file(&self, file_path: &Path, ignore_pattern: Option<&Pattern>) -> bool {
+    fn should_rebuild_out_file(
+        &self,
+        file_path: &Path,
+        ignore_pattern: Option<&Pattern>,
+        cwd: &Path,
+        extensions: &[String],
+        output_files: &BTreeSet<PathBuf>,
+    ) -> bool {
+        if is_exact_path(file_path, output_files) {
+            return false;
+        }
+
         if !self.is_relevant_input_path(file_path) {
             return false;
         }
 
-        let cwd = match std::env::current_dir() {
-            Ok(cwd) => cwd,
-            Err(_) => return false,
-        };
-
-        if is_ignored_path(file_path, ignore_pattern, &cwd) {
+        if is_ignored_path(file_path, ignore_pattern, cwd) {
             return false;
         }
 
         if self.has_directory_input() {
-            is_compilable_extension(file_path, &self.included_extensions())
+            is_compilable_extension(file_path, extensions)
         } else {
             true
         }
     }
 
+    fn out_file_output_paths(&self, single_out_file: &Path) -> Vec<PathBuf> {
+        let mut paths = vec![
+            single_out_file.to_path_buf(),
+            single_out_file.with_extension("d.ts"),
+        ];
+
+        if let Some(source_map_target) = &self.source_map_target {
+            paths.push(PathBuf::from(source_map_target));
+        } else {
+            paths.push(resolve_source_map_path(single_out_file));
+        }
+
+        paths
+    }
+
     fn remove_out_file_outputs(&self, single_out_file: &Path) -> anyhow::Result<()> {
         remove_file_if_exists(single_out_file)?;
         remove_file_if_exists(&resolve_source_map_path(single_out_file))?;
+        if let Some(source_map_target) = &self.source_map_target {
+            remove_file_if_exists(Path::new(source_map_target))?;
+        }
         remove_file_if_exists(&single_out_file.with_extension("d.ts"))?;
         Ok(())
     }
@@ -894,32 +1056,49 @@ impl CompileOptions {
         let ignore_pattern = parse_ignore_pattern(self.ignore.as_deref())?;
         let watcher = FileWatcher::new(&self.files)?;
 
-        if let Err(error) = self.execute_out_file_once(single_out_file) {
+        if let Err(error) = self.execute_existing_out_file_once(single_out_file) {
             eprintln!("{error:#}");
         }
 
+        let output_files = self.out_file_output_paths(single_out_file);
+        let output_files = collect_absolute_paths(&output_files);
+        let extensions = self.included_extensions();
+
         loop {
             let changes = watcher.recv_changes()?;
+            let cwd = match std::env::current_dir() {
+                Ok(cwd) => cwd,
+                Err(error) => {
+                    tracing::warn!(error = %error, "failed to read current directory for watch batch");
+                    continue;
+                }
+            };
             let should_rebuild = changes
                 .changed
                 .iter()
                 .chain(changes.removed.iter())
-                .any(|path| self.should_rebuild_out_file(path, ignore_pattern.as_ref()));
+                .any(|path| {
+                    self.should_rebuild_out_file(
+                        path,
+                        ignore_pattern.as_ref(),
+                        &cwd,
+                        &extensions,
+                        &output_files,
+                    )
+                });
 
             if !should_rebuild {
                 continue;
             }
 
-            match self.collect_compile_file_paths() {
-                Ok(files) if files.is_empty() => {
-                    if let Err(error) = self.remove_out_file_outputs(single_out_file) {
-                        eprintln!("{error:#}");
-                    }
-                }
-                Ok(_) => {
+            match self
+                .collect_existing_compile_file_paths(&self.out_file_output_paths(single_out_file))
+            {
+                Ok(files) => {
                     // Rebuild the full bundle so the concatenation order and
                     // source map output stay consistent with one-shot mode.
-                    if let Err(error) = self.execute_out_file_once(single_out_file) {
+                    if let Err(error) = self.execute_existing_out_file_paths(single_out_file, files)
+                    {
                         eprintln!("{error:#}");
                     }
                 }

--- a/crates/swc_cli_impl/src/commands/compile.rs
+++ b/crates/swc_cli_impl/src/commands/compile.rs
@@ -152,6 +152,51 @@ struct InputContext {
     file_path: PathBuf,
 }
 
+/// Input path roles captured when watch mode starts.
+///
+/// Removal events are delivered after filesystem state changes, so directory
+/// inputs must not be classified with `Path::is_dir()` while processing each
+/// event.
+struct WatchInputPaths {
+    files: BTreeSet<PathBuf>,
+    directories: Vec<PathBuf>,
+}
+
+impl WatchInputPaths {
+    fn new(raw_inputs: &[PathBuf]) -> anyhow::Result<Self> {
+        let mut files = BTreeSet::new();
+        let mut directories = Vec::new();
+
+        for input in raw_inputs {
+            let input = absolutize_path(input)?;
+
+            if input.is_dir() {
+                directories.push(input);
+            } else {
+                files.insert(input);
+            }
+        }
+
+        Ok(Self { files, directories })
+    }
+
+    fn contains(&self, file_path: &Path) -> bool {
+        let Ok(file_path) = absolutize_path(file_path) else {
+            return false;
+        };
+
+        self.files.contains(&file_path)
+            || self
+                .directories
+                .iter()
+                .any(|input_dir| file_path.starts_with(input_dir))
+    }
+
+    fn is_explicit_file(&self, file_path: &Path) -> bool {
+        is_exact_path(file_path, &self.files)
+    }
+}
+
 fn parse_config(s: &str) -> Result<Config, serde_json::Error> {
     serde_json::from_str(s)
 }
@@ -345,6 +390,14 @@ fn remove_file_if_exists(path: &Path) -> anyhow::Result<()> {
         Err(error) if error.kind() == ErrorKind::NotFound => Ok(()),
         Err(error) => Err(error.into()),
     }
+}
+
+fn remove_dir_if_exists(path: &Path) -> anyhow::Result<()> {
+    if path.is_dir() {
+        fs::remove_dir_all(path)?;
+    }
+
+    Ok(())
 }
 
 fn emit_directory_output(
@@ -711,6 +764,18 @@ impl CompileOptions {
         Ok(())
     }
 
+    fn remove_output_dir_tree(&self, out_dir: &Path, input_dir: &Path) -> anyhow::Result<()> {
+        let output_dir_path = resolve_output_path(
+            out_dir,
+            &self.files,
+            input_dir,
+            None,
+            self.strip_leading_paths,
+        )?;
+
+        remove_dir_if_exists(&output_dir_path)
+    }
+
     fn execute_out_file_with_inputs(
         &self,
         single_out_file: &Path,
@@ -870,42 +935,13 @@ impl CompileOptions {
         }
     }
 
-    fn is_explicit_input_path(&self, file_path: &Path) -> bool {
-        let Ok(file_path) = file_path.absolutize().map(|path| path.into_owned()) else {
-            return false;
-        };
-
-        self.files
-            .iter()
-            .filter(|path| !path.is_dir())
-            .filter_map(|path| path.absolutize().ok().map(|path| path.into_owned()))
-            .any(|path| path == file_path)
-    }
-
-    fn is_relevant_input_path(&self, file_path: &Path) -> bool {
-        let Ok(file_path) = file_path.absolutize().map(|path| path.into_owned()) else {
-            return false;
-        };
-
-        self.files.iter().any(|input| {
-            let Ok(input) = input.absolutize().map(|path| path.into_owned()) else {
-                return false;
-            };
-
-            if input.is_dir() {
-                file_path.starts_with(&input)
-            } else {
-                file_path == input
-            }
-        })
-    }
-
     fn classify_watch_output_entry(
         &self,
         file_path: &Path,
         extensions: &[String],
+        watch_inputs: &WatchInputPaths,
     ) -> Option<OutputEntry> {
-        let origin = if self.is_explicit_input_path(file_path) {
+        let origin = if watch_inputs.is_explicit_file(file_path) {
             InputOrigin::Explicit
         } else {
             InputOrigin::Discovered
@@ -925,7 +961,9 @@ impl CompileOptions {
         out_dir: &Path,
         changed_paths: Vec<PathBuf>,
         removed_paths: Vec<PathBuf>,
+        removed_directories: Vec<PathBuf>,
         ignore_pattern: Option<&Pattern>,
+        watch_inputs: &WatchInputPaths,
     ) {
         let cwd = match std::env::current_dir() {
             Ok(cwd) => cwd,
@@ -946,17 +984,33 @@ impl CompileOptions {
         let relevant_removed: BTreeSet<_> = removed_paths
             .into_iter()
             .filter(|path| {
-                self.is_relevant_input_path(path)
+                watch_inputs.contains(path)
                     && !is_same_or_nested_path(path, &output_dir)
                     && !is_ignored_path(path, ignore_pattern, &cwd)
             })
             .collect();
 
         for path in relevant_removed {
-            if let Some(entry) = self.classify_watch_output_entry(&path, &extensions) {
+            if let Some(entry) = self.classify_watch_output_entry(&path, &extensions, watch_inputs)
+            {
                 if let Err(error) = self.remove_output_dir_entry(out_dir, &entry) {
                     eprintln!("{error:#}");
                 }
+            }
+        }
+
+        let relevant_removed_directories: BTreeSet<_> = removed_directories
+            .into_iter()
+            .filter(|path| {
+                watch_inputs.contains(path)
+                    && !is_same_or_nested_path(path, &output_dir)
+                    && !is_ignored_path(path, ignore_pattern, &cwd)
+            })
+            .collect();
+
+        for path in relevant_removed_directories {
+            if let Err(error) = self.remove_output_dir_tree(out_dir, &path) {
+                eprintln!("{error:#}");
             }
         }
 
@@ -964,7 +1018,7 @@ impl CompileOptions {
             .into_iter()
             .filter(|path| {
                 path.is_file()
-                    && self.is_relevant_input_path(path)
+                    && watch_inputs.contains(path)
                     && !is_same_or_nested_path(path, &output_dir)
                     && !is_ignored_path(path, ignore_pattern, &cwd)
             })
@@ -973,7 +1027,8 @@ impl CompileOptions {
         let compiler = new_compiler();
 
         for path in relevant_changed {
-            if let Some(entry) = self.classify_watch_output_entry(&path, &extensions) {
+            if let Some(entry) = self.classify_watch_output_entry(&path, &extensions, watch_inputs)
+            {
                 if let Err(error) = self.emit_output_dir_entry(compiler.clone(), out_dir, &entry) {
                     eprintln!("{error:#}");
                 }
@@ -988,12 +1043,13 @@ impl CompileOptions {
         cwd: &Path,
         extensions: &[String],
         output_files: &BTreeSet<PathBuf>,
+        watch_inputs: &WatchInputPaths,
     ) -> bool {
         if is_exact_path(file_path, output_files) {
             return false;
         }
 
-        if !self.is_relevant_input_path(file_path) {
+        if !watch_inputs.contains(file_path) {
             return false;
         }
 
@@ -1006,6 +1062,19 @@ impl CompileOptions {
         } else {
             true
         }
+    }
+
+    fn should_rebuild_removed_input_dir_out_file(
+        &self,
+        file_path: &Path,
+        ignore_pattern: Option<&Pattern>,
+        cwd: &Path,
+        output_files: &BTreeSet<PathBuf>,
+        watch_inputs: &WatchInputPaths,
+    ) -> bool {
+        !is_exact_path(file_path, output_files)
+            && watch_inputs.contains(file_path)
+            && !is_ignored_path(file_path, ignore_pattern, cwd)
     }
 
     fn out_file_output_paths(&self, single_out_file: &Path) -> Vec<PathBuf> {
@@ -1036,6 +1105,7 @@ impl CompileOptions {
     fn watch_out_dir(&self, out_dir: &Path) -> anyhow::Result<()> {
         let ignore_pattern = parse_ignore_pattern(self.ignore.as_deref())?;
         let watcher = FileWatcher::new(&self.files)?;
+        let watch_inputs = WatchInputPaths::new(&self.files)?;
 
         if let Err(error) = self.execute_out_dir_once(out_dir) {
             eprintln!("{error:#}");
@@ -1047,7 +1117,9 @@ impl CompileOptions {
                 out_dir,
                 changes.changed,
                 changes.removed,
+                changes.removed_directories,
                 ignore_pattern.as_ref(),
+                &watch_inputs,
             );
         }
     }
@@ -1055,6 +1127,7 @@ impl CompileOptions {
     fn watch_out_file(&self, single_out_file: &Path) -> anyhow::Result<()> {
         let ignore_pattern = parse_ignore_pattern(self.ignore.as_deref())?;
         let watcher = FileWatcher::new(&self.files)?;
+        let watch_inputs = WatchInputPaths::new(&self.files)?;
 
         if let Err(error) = self.execute_existing_out_file_once(single_out_file) {
             eprintln!("{error:#}");
@@ -1084,6 +1157,16 @@ impl CompileOptions {
                         &cwd,
                         &extensions,
                         &output_files,
+                        &watch_inputs,
+                    )
+                })
+                || changes.removed_directories.iter().any(|path| {
+                    self.should_rebuild_removed_input_dir_out_file(
+                        path,
+                        ignore_pattern.as_ref(),
+                        &cwd,
+                        &output_files,
+                        &watch_inputs,
                     )
                 });
 

--- a/crates/swc_cli_impl/src/commands/compile/paths.rs
+++ b/crates/swc_cli_impl/src/commands/compile/paths.rs
@@ -1,0 +1,160 @@
+use std::path::{Component, Path, PathBuf};
+
+use anyhow::Context;
+use path_absolutize::Absolutize;
+use pathdiff::diff_paths;
+
+/// Resolve the output path for a compiled file or copied asset under `out_dir`.
+pub fn resolve_output_path(
+    out_dir: &Path,
+    raw_inputs: &[PathBuf],
+    file_path: &Path,
+    file_extension: Option<&str>,
+    strip_leading_paths: bool,
+) -> anyhow::Result<PathBuf> {
+    let out_dir = out_dir.absolutize()?.into_owned();
+    let mut relative_path =
+        resolve_relative_output_path(raw_inputs, file_path, strip_leading_paths)?;
+
+    if let Some(file_extension) = file_extension {
+        relative_path.set_extension(file_extension);
+    }
+
+    Ok(out_dir.join(relative_path))
+}
+
+fn resolve_relative_output_path(
+    raw_inputs: &[PathBuf],
+    file_path: &Path,
+    strip_leading_paths: bool,
+) -> anyhow::Result<PathBuf> {
+    let file_path = file_path.absolutize()?.into_owned();
+
+    if let Some(relative_to_input_dir) = resolve_relative_to_input_dir(raw_inputs, &file_path)? {
+        return Ok(finalize_relative_path(
+            &file_path,
+            relative_to_input_dir,
+            strip_leading_paths,
+        ));
+    }
+
+    let cwd = std::env::current_dir()?;
+    let cwd_relative = diff_paths(&file_path, &cwd).with_context(|| {
+        format!(
+            "failed to make {} relative to {}",
+            file_path.display(),
+            cwd.display()
+        )
+    })?;
+
+    // Absolute inputs outside the current working directory should not recreate
+    // the host filesystem under `out_dir`.
+    let base_path = if file_path.is_absolute() && starts_with_parent_component(&cwd_relative) {
+        fallback_relative_path(&file_path)?
+    } else {
+        cwd_relative
+    };
+
+    Ok(finalize_relative_path(
+        &file_path,
+        base_path,
+        strip_leading_paths,
+    ))
+}
+
+fn resolve_relative_to_input_dir(
+    raw_inputs: &[PathBuf],
+    file_path: &Path,
+) -> anyhow::Result<Option<PathBuf>> {
+    let input_dir = match raw_inputs.iter().find(|path| path.is_dir()) {
+        Some(input_dir) => input_dir,
+        None => return Ok(None),
+    };
+
+    let input_dir = input_dir.absolutize()?.into_owned();
+    let stripped = match file_path.strip_prefix(&input_dir) {
+        Ok(stripped) => stripped,
+        Err(_) => return Ok(None),
+    };
+
+    let mut relative_path = PathBuf::new();
+
+    if let Some(dir_name) = input_dir.file_name() {
+        relative_path.push(dir_name);
+    }
+
+    if !stripped.as_os_str().is_empty() {
+        relative_path.push(stripped);
+    }
+
+    Ok(Some(relative_path))
+}
+
+fn finalize_relative_path(
+    file_path: &Path,
+    base_path: PathBuf,
+    strip_leading_paths: bool,
+) -> PathBuf {
+    let mut relative_path = sanitize_relative_path(base_path, strip_leading_paths);
+
+    if relative_path.as_os_str().is_empty() {
+        relative_path = fallback_file_name(file_path);
+    }
+
+    relative_path
+}
+
+fn sanitize_relative_path(path: PathBuf, strip_leading_paths: bool) -> PathBuf {
+    let mut sanitized = PathBuf::new();
+    let mut stripped_first_component = !strip_leading_paths;
+
+    for component in path.components() {
+        match component {
+            Component::Normal(component) => {
+                if !stripped_first_component {
+                    stripped_first_component = true;
+                    continue;
+                }
+
+                sanitized.push(component);
+            }
+            Component::CurDir
+            | Component::ParentDir
+            | Component::RootDir
+            | Component::Prefix(_) => {
+                // Ignore non-normal components so output paths cannot escape
+                // the destination directory or recreate
+                // host-specific prefixes.
+            }
+        }
+    }
+
+    sanitized
+}
+
+fn fallback_relative_path(file_path: &Path) -> anyhow::Result<PathBuf> {
+    let mut path = PathBuf::new();
+
+    if let Some(parent_name) = file_path.parent().and_then(Path::file_name) {
+        path.push(parent_name);
+    }
+
+    path.push(
+        file_path
+            .file_name()
+            .context("Filename should be available for output path fallback")?,
+    );
+
+    Ok(path)
+}
+
+fn fallback_file_name(file_path: &Path) -> PathBuf {
+    file_path
+        .file_name()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from("unknown"))
+}
+
+fn starts_with_parent_component(path: &Path) -> bool {
+    matches!(path.components().next(), Some(Component::ParentDir))
+}

--- a/crates/swc_cli_impl/src/commands/compile/paths.rs
+++ b/crates/swc_cli_impl/src/commands/compile/paths.rs
@@ -77,10 +77,13 @@ fn resolve_relative_to_input_dir(
         Err(_) => return Ok(None),
     };
 
+    let cwd = std::env::current_dir()?.absolutize()?.into_owned();
     let mut relative_path = PathBuf::new();
 
-    if let Some(dir_name) = input_dir.file_name() {
-        relative_path.push(dir_name);
+    if input_dir != cwd {
+        if let Some(dir_name) = input_dir.file_name() {
+            relative_path.push(dir_name);
+        }
     }
 
     if !stripped.as_os_str().is_empty() {

--- a/crates/swc_cli_impl/src/commands/compile/watch.rs
+++ b/crates/swc_cli_impl/src/commands/compile/watch.rs
@@ -1,0 +1,113 @@
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::mpsc::{channel, Receiver},
+};
+
+use anyhow::Context;
+use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use path_absolutize::Absolutize;
+
+pub struct FileWatcher {
+    _watcher: RecommendedWatcher,
+    receiver: Receiver<notify::Result<Event>>,
+}
+
+pub struct PathChanges {
+    pub changed: Vec<PathBuf>,
+    pub removed: Vec<PathBuf>,
+}
+
+impl FileWatcher {
+    pub fn new(raw_inputs: &[PathBuf]) -> anyhow::Result<Self> {
+        let (sender, receiver) = channel();
+        let mut watcher = RecommendedWatcher::new(
+            move |event| {
+                let _ = sender.send(event);
+            },
+            Config::default(),
+        )?;
+
+        for (path, recursive_mode) in collect_watch_roots(raw_inputs)? {
+            watcher
+                .watch(&path, recursive_mode)
+                .with_context(|| format!("failed to watch {}", path.display()))?;
+        }
+
+        Ok(Self {
+            _watcher: watcher,
+            receiver,
+        })
+    }
+
+    pub fn recv_changes(&self) -> anyhow::Result<PathChanges> {
+        loop {
+            let event = self
+                .receiver
+                .recv()
+                .context("watch channel unexpectedly closed")??;
+
+            if let Some(changes) = translate_event(event) {
+                return Ok(changes);
+            }
+        }
+    }
+}
+
+fn collect_watch_roots(raw_inputs: &[PathBuf]) -> anyhow::Result<HashMap<PathBuf, RecursiveMode>> {
+    let mut roots = HashMap::new();
+
+    for input in raw_inputs {
+        let input = input.absolutize()?.into_owned();
+        let (root, recursive_mode) = if input.is_dir() {
+            (input, RecursiveMode::Recursive)
+        } else {
+            (
+                input
+                    .parent()
+                    .map(PathBuf::from)
+                    .unwrap_or_else(|| PathBuf::from(".")),
+                RecursiveMode::NonRecursive,
+            )
+        };
+
+        match roots.get_mut(&root) {
+            Some(existing_mode) => {
+                if *existing_mode == RecursiveMode::NonRecursive
+                    && recursive_mode == RecursiveMode::Recursive
+                {
+                    *existing_mode = RecursiveMode::Recursive;
+                }
+            }
+            None => {
+                roots.insert(root, recursive_mode);
+            }
+        }
+    }
+
+    Ok(roots)
+}
+
+fn translate_event(event: Event) -> Option<PathChanges> {
+    match event.kind {
+        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
+            let mut changed = Vec::new();
+            let mut removed = Vec::new();
+
+            for path in event.paths {
+                if path.exists() {
+                    changed.push(path);
+                } else {
+                    removed.push(path);
+                }
+            }
+
+            if changed.is_empty() && removed.is_empty() {
+                None
+            } else {
+                Some(PathChanges { changed, removed })
+            }
+        }
+        _ => None,
+    }
+}

--- a/crates/swc_cli_impl/src/commands/compile/watch.rs
+++ b/crates/swc_cli_impl/src/commands/compile/watch.rs
@@ -5,7 +5,10 @@ use std::{
 };
 
 use anyhow::Context;
-use notify::{Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{
+    event::{ModifyKind, RemoveKind},
+    Config, Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher,
+};
 use path_absolutize::Absolutize;
 
 pub struct FileWatcher {
@@ -16,6 +19,7 @@ pub struct FileWatcher {
 pub struct PathChanges {
     pub changed: Vec<PathBuf>,
     pub removed: Vec<PathBuf>,
+    pub removed_directories: Vec<PathBuf>,
 }
 
 impl FileWatcher {
@@ -97,7 +101,31 @@ fn collect_watch_roots(raw_inputs: &[PathBuf]) -> anyhow::Result<HashMap<PathBuf
 
 fn translate_event(event: Event) -> Option<PathChanges> {
     match event.kind {
-        EventKind::Create(_) | EventKind::Modify(_) | EventKind::Remove(_) => {
+        EventKind::Modify(ModifyKind::Name(_)) => {
+            let mut changed = Vec::new();
+            let mut removed = Vec::new();
+            let mut removed_directories = Vec::new();
+
+            for path in event.paths {
+                if path.exists() {
+                    changed.push(path);
+                } else {
+                    removed_directories.push(path.clone());
+                    removed.push(path);
+                }
+            }
+
+            if changed.is_empty() && removed.is_empty() {
+                None
+            } else {
+                Some(PathChanges {
+                    changed,
+                    removed,
+                    removed_directories,
+                })
+            }
+        }
+        EventKind::Create(_) | EventKind::Modify(_) => {
             let mut changed = Vec::new();
             let mut removed = Vec::new();
 
@@ -112,7 +140,29 @@ fn translate_event(event: Event) -> Option<PathChanges> {
             if changed.is_empty() && removed.is_empty() {
                 None
             } else {
-                Some(PathChanges { changed, removed })
+                Some(PathChanges {
+                    changed,
+                    removed,
+                    removed_directories: Vec::new(),
+                })
+            }
+        }
+        EventKind::Remove(remove_kind) => {
+            let removed = event.paths;
+            let removed_directories = if remove_kind == RemoveKind::Folder {
+                removed.clone()
+            } else {
+                Vec::new()
+            };
+
+            if removed.is_empty() {
+                None
+            } else {
+                Some(PathChanges {
+                    changed: Vec::new(),
+                    removed,
+                    removed_directories,
+                })
             }
         }
         _ => None,

--- a/crates/swc_cli_impl/src/commands/compile/watch.rs
+++ b/crates/swc_cli_impl/src/commands/compile/watch.rs
@@ -42,10 +42,17 @@ impl FileWatcher {
 
     pub fn recv_changes(&self) -> anyhow::Result<PathChanges> {
         loop {
-            let event = self
+            let event = match self
                 .receiver
                 .recv()
-                .context("watch channel unexpectedly closed")??;
+                .context("watch channel unexpectedly closed")?
+            {
+                Ok(event) => event,
+                Err(error) => {
+                    tracing::warn!(error = %error, "file watcher emitted a recoverable error");
+                    continue;
+                }
+            };
 
             if let Some(changes) = translate_event(event) {
                 return Ok(changes);

--- a/crates/swc_cli_impl/tests/issues.rs
+++ b/crates/swc_cli_impl/tests/issues.rs
@@ -1,10 +1,12 @@
 use std::{
     fs::{self, create_dir_all, hard_link},
     path::Path,
-    process::{Command, Stdio},
+    process::{Child, Command, Stdio},
+    thread::sleep,
+    time::{Duration, Instant},
 };
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use assert_cmd::prelude::*;
 use assert_fs::TempDir;
 
@@ -12,6 +14,46 @@ fn cli() -> Result<Command> {
     let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("swc"));
     cmd.stderr(Stdio::inherit());
     Ok(cmd)
+}
+
+struct ChildGuard {
+    child: Child,
+}
+
+impl ChildGuard {
+    fn try_wait(&mut self) -> Result<Option<std::process::ExitStatus>> {
+        Ok(self.child.try_wait()?)
+    }
+}
+
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn spawn_watch_command(cmd: &mut Command) -> Result<ChildGuard> {
+    let child = cmd.stdout(Stdio::null()).stdin(Stdio::null()).spawn()?;
+
+    Ok(ChildGuard { child })
+}
+
+fn wait_for<F>(message: &str, mut check: F) -> Result<()>
+where
+    F: FnMut() -> Result<bool>,
+{
+    let deadline = Instant::now() + Duration::from_secs(10);
+
+    while Instant::now() < deadline {
+        if check()? {
+            return Ok(());
+        }
+
+        sleep(Duration::from_millis(50));
+    }
+
+    bail!("Timed out while waiting for {message}")
 }
 
 #[test]
@@ -253,6 +295,294 @@ const value: string = "ok";
         !output.contains(": string"),
         "Flow variable type annotation should be stripped. Got: {output}"
     );
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_out_dir_preserves_leading_directory() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src"))?;
+    fs::write(
+        sandbox.path().join("src/index.ts"),
+        "export const value = 1;\n",
+    )?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--out-dir")
+        .arg("dist")
+        .arg("src");
+
+    cmd.assert().success();
+
+    assert!(
+        sandbox.path().join("dist/src/index.js").exists(),
+        "Expected output at dist/src/index.js"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_strip_leading_paths_flattens_output() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src"))?;
+    fs::write(
+        sandbox.path().join("src/index.ts"),
+        "export const value = 1;\n",
+    )?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--out-dir")
+        .arg("dist")
+        .arg("--strip-leading-paths")
+        .arg("src");
+
+    cmd.assert().success();
+
+    assert!(
+        sandbox.path().join("dist/index.js").exists(),
+        "Expected output at dist/index.js"
+    );
+    assert!(
+        !sandbox.path().join("dist/src/index.js").exists(),
+        "Did not expect output at dist/src/index.js"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_absolute_directory_input_is_normalized() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src"))?;
+    fs::write(
+        sandbox.path().join("src/index.ts"),
+        "export const value = 1;\n",
+    )?;
+
+    let out_dir = sandbox.path().join("dist");
+    let absolute_input = sandbox.path().join("src").canonicalize()?;
+
+    let mut cmd = cli()?;
+    cmd.arg("compile")
+        .arg("--out-dir")
+        .arg(&out_dir)
+        .arg(&absolute_input);
+
+    cmd.assert().success();
+
+    assert!(
+        out_dir.join("src/index.js").exists(),
+        "Expected absolute directory input to emit dist/src/index.js"
+    );
+    assert!(
+        !out_dir.join("var").exists(),
+        "Absolute input should not recreate host paths under out-dir"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_copy_files_copies_non_compilable_assets() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src"))?;
+    fs::write(
+        sandbox.path().join("src/index.ts"),
+        "export const value = 1;\n",
+    )?;
+    fs::write(sandbox.path().join("src/data.json"), "{\"ok\":true}\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--out-dir")
+        .arg("dist")
+        .arg("--copy-files")
+        .arg("src");
+
+    cmd.assert().success();
+
+    let copied = fs::read_to_string(sandbox.path().join("dist/src/data.json"))?;
+    assert_eq!(copied, "{\"ok\":true}\n");
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_watch_out_dir_updates_and_removes_outputs() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src"))?;
+
+    let source_path = sandbox.path().join("src/index.ts");
+    let output_path = sandbox.path().join("dist/src/index.js");
+
+    fs::write(&source_path, "export const value = 1;\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--watch")
+        .arg("--out-dir")
+        .arg("dist")
+        .arg("src");
+
+    let mut child = spawn_watch_command(&mut cmd)?;
+
+    wait_for("initial watch output", || Ok(output_path.exists()))?;
+    wait_for("watch process to stay alive", || {
+        Ok(child.try_wait()?.is_none())
+    })?;
+
+    let initial = fs::read_to_string(&output_path)?;
+    assert!(initial.contains('1'));
+
+    fs::write(&source_path, "export const value = 2;\n")?;
+    wait_for("updated watch output", || {
+        Ok(fs::read_to_string(&output_path)
+            .map(|content| content.contains('2'))
+            .unwrap_or(false))
+    })?;
+
+    fs::remove_file(&source_path)?;
+    wait_for("compiled output removal after deleting source", || {
+        Ok(!output_path.exists())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_copy_files_watch_adds_updates_and_removes_assets() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src"))?;
+
+    fs::write(
+        sandbox.path().join("src/index.ts"),
+        "export const value = 1;\n",
+    )?;
+    let asset_path = sandbox.path().join("src/data.json");
+    let copied_path = sandbox.path().join("dist/src/data.json");
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--watch")
+        .arg("--out-dir")
+        .arg("dist")
+        .arg("--copy-files")
+        .arg("src");
+
+    let mut child = spawn_watch_command(&mut cmd)?;
+
+    wait_for("initial watch compilation", || {
+        Ok(sandbox.path().join("dist/src/index.js").exists())
+    })?;
+    wait_for("watch process to stay alive", || {
+        Ok(child.try_wait()?.is_none())
+    })?;
+
+    fs::write(&asset_path, "{\"version\":1}\n")?;
+    wait_for("copied asset creation", || Ok(copied_path.exists()))?;
+
+    let copied = fs::read_to_string(&copied_path)?;
+    assert_eq!(copied, "{\"version\":1}\n");
+
+    fs::write(&asset_path, "{\"version\":2}\n")?;
+    wait_for("copied asset update", || {
+        Ok(fs::read_to_string(&copied_path)
+            .map(|content| content.contains("\"version\":2"))
+            .unwrap_or(false))
+    })?;
+
+    fs::remove_file(&asset_path)?;
+    wait_for("copied asset removal", || Ok(!copied_path.exists()))?;
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_watch_out_file_rebuilds_single_output() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    let source_path = sandbox.path().join("input.ts");
+    let output_path = sandbox.path().join("output.js");
+
+    fs::write(&source_path, "export const value = 1;\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--watch")
+        .arg("--out-file")
+        .arg("output.js")
+        .arg("input.ts");
+
+    let mut child = spawn_watch_command(&mut cmd)?;
+
+    wait_for("initial out-file watch output", || Ok(output_path.exists()))?;
+    wait_for("watch process to stay alive", || {
+        Ok(child.try_wait()?.is_none())
+    })?;
+
+    fs::write(&source_path, "export const value = 2;\n")?;
+    wait_for("rebuilt out-file output", || {
+        Ok(fs::read_to_string(&output_path)
+            .map(|content| content.contains('2'))
+            .unwrap_or(false))
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_watch_requires_output() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    fs::write(sandbox.path().join("input.ts"), "export const value = 1;\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--watch")
+        .arg("input.ts");
+
+    cmd.assert().failure();
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_copy_files_requires_out_dir() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    fs::write(sandbox.path().join("input.json"), "{\"ok\":true}\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--copy-files")
+        .arg("input.json");
+
+    cmd.assert().failure();
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_strip_leading_paths_requires_out_dir() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    fs::write(sandbox.path().join("input.ts"), "export const value = 1;\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--strip-leading-paths")
+        .arg("input.ts");
+
+    cmd.assert().failure();
 
     Ok(())
 }

--- a/crates/swc_cli_impl/tests/issues.rs
+++ b/crates/swc_cli_impl/tests/issues.rs
@@ -389,6 +389,122 @@ fn issue_4017_absolute_directory_input_is_normalized() -> Result<()> {
 }
 
 #[test]
+fn issue_4017_current_directory_input_is_relative_to_cwd() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src"))?;
+    fs::write(
+        sandbox.path().join("src/index.ts"),
+        "export const value = 1;\n",
+    )?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--out-dir")
+        .arg("dist")
+        .arg(".");
+
+    cmd.assert().success();
+
+    assert!(
+        sandbox.path().join("dist/src/index.js").exists(),
+        "Expected current-directory input to emit dist/src/index.js"
+    );
+
+    let cwd_name = sandbox
+        .path()
+        .file_name()
+        .expect("temporary directory should have a name");
+    assert!(
+        !sandbox
+            .path()
+            .join("dist")
+            .join(cwd_name)
+            .join("src/index.js")
+            .exists(),
+        "Current-directory input should not prefix output paths with the cwd name"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_absolute_current_directory_input_is_relative_to_cwd() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src"))?;
+    fs::write(
+        sandbox.path().join("src/index.ts"),
+        "export const value = 1;\n",
+    )?;
+
+    let absolute_input = sandbox.path().canonicalize()?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--out-dir")
+        .arg("dist")
+        .arg(&absolute_input);
+
+    cmd.assert().success();
+
+    assert!(
+        sandbox.path().join("dist/src/index.js").exists(),
+        "Expected absolute cwd input to emit dist/src/index.js"
+    );
+
+    let cwd_name = sandbox
+        .path()
+        .file_name()
+        .expect("temporary directory should have a name");
+    assert!(
+        !sandbox
+            .path()
+            .join("dist")
+            .join(cwd_name)
+            .join("src/index.js")
+            .exists(),
+        "Absolute cwd input should not prefix output paths with the cwd name"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_out_dir_inside_input_is_excluded_from_scan() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src/dist"))?;
+    fs::write(
+        sandbox.path().join("src/index.ts"),
+        "export const value = 1;\n",
+    )?;
+    fs::write(
+        sandbox.path().join("src/dist/stale.ts"),
+        "export const stale = true;\n",
+    )?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--out-dir")
+        .arg("src/dist")
+        .arg("src");
+
+    cmd.assert().success();
+
+    assert!(
+        sandbox.path().join("src/dist/src/index.js").exists(),
+        "Expected source output under nested out-dir"
+    );
+    assert!(
+        !sandbox.path().join("src/dist/src/dist/stale.js").exists(),
+        "Output directory contents should not be treated as fresh inputs"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn issue_4017_copy_files_copies_non_compilable_assets() -> Result<()> {
     let sandbox = TempDir::new()?;
     create_dir_all(sandbox.path().join("src"))?;
@@ -453,6 +569,45 @@ fn issue_4017_watch_out_dir_updates_and_removes_outputs() -> Result<()> {
     wait_for("compiled output removal after deleting source", || {
         Ok(!output_path.exists())
     })?;
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_watch_out_dir_ignores_generated_output_changes() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src"))?;
+
+    let source_path = sandbox.path().join("src/index.ts");
+    let output_path = sandbox.path().join("src/dist/src/index.js");
+    let nested_output_path = sandbox.path().join("src/dist/src/dist/src/index.js");
+
+    fs::write(&source_path, "export const value = 1;\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--watch")
+        .arg("--out-dir")
+        .arg("src/dist")
+        .arg("src");
+
+    let mut child = spawn_watch_command(&mut cmd)?;
+
+    wait_for("initial nested out-dir watch output", || {
+        Ok(output_path.exists())
+    })?;
+    wait_for("watch process to stay alive", || {
+        Ok(child.try_wait()?.is_none())
+    })?;
+
+    fs::write(&output_path, "const generated = 1;\n")?;
+    sleep(Duration::from_millis(1000));
+
+    assert!(
+        !nested_output_path.exists(),
+        "Generated output changes should not create nested output files"
+    );
 
     Ok(())
 }
@@ -535,6 +690,86 @@ fn issue_4017_watch_out_file_rebuilds_single_output() -> Result<()> {
             .map(|content| content.contains('2'))
             .unwrap_or(false))
     })?;
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_watch_out_file_drops_deleted_explicit_inputs() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    let keep_path = sandbox.path().join("keep.ts");
+    let removed_path = sandbox.path().join("removed.ts");
+    let output_path = sandbox.path().join("bundle.js");
+
+    fs::write(&keep_path, "export const keep = 1;\n")?;
+    fs::write(&removed_path, "export const removed = 2;\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--watch")
+        .arg("--out-file")
+        .arg("bundle.js")
+        .arg("keep.ts")
+        .arg("removed.ts");
+
+    let mut child = spawn_watch_command(&mut cmd)?;
+
+    wait_for("initial bundle with both explicit inputs", || {
+        Ok(fs::read_to_string(&output_path)
+            .map(|content| content.contains("keep") && content.contains("removed"))
+            .unwrap_or(false))
+    })?;
+    wait_for("watch process to stay alive", || {
+        Ok(child.try_wait()?.is_none())
+    })?;
+
+    fs::remove_file(&removed_path)?;
+
+    wait_for("bundle rebuild without deleted explicit input", || {
+        Ok(fs::read_to_string(&output_path)
+            .map(|content| content.contains("keep") && !content.contains("removed"))
+            .unwrap_or(false))
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_watch_out_file_ignores_generated_output_changes() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    create_dir_all(sandbox.path().join("src"))?;
+
+    let source_path = sandbox.path().join("src/input.ts");
+    let output_path = sandbox.path().join("src/bundle.js");
+
+    fs::write(&source_path, "export const value = 1;\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--watch")
+        .arg("--out-file")
+        .arg("src/bundle.js")
+        .arg("src");
+
+    let mut child = spawn_watch_command(&mut cmd)?;
+
+    wait_for("initial in-tree out-file watch output", || {
+        Ok(output_path.exists())
+    })?;
+    wait_for("watch process to stay alive", || {
+        Ok(child.try_wait()?.is_none())
+    })?;
+
+    fs::write(&output_path, "const generated = 1;\n")?;
+    sleep(Duration::from_millis(1000));
+
+    let output = fs::read_to_string(&output_path)?;
+    assert_eq!(
+        output, "const generated = 1;\n",
+        "Generated out-file changes should not trigger a rebuild"
+    );
 
     Ok(())
 }

--- a/crates/swc_cli_impl/tests/issues.rs
+++ b/crates/swc_cli_impl/tests/issues.rs
@@ -574,6 +574,75 @@ fn issue_4017_watch_out_dir_updates_and_removes_outputs() -> Result<()> {
 }
 
 #[test]
+fn issue_4017_watch_out_dir_removes_outputs_after_input_dir_deleted() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    let input_dir = sandbox.path().join("src");
+    create_dir_all(input_dir.join("nested"))?;
+
+    let source_path = input_dir.join("nested/index.ts");
+    let output_path = sandbox.path().join("dist/src/nested/index.js");
+
+    fs::write(&source_path, "export const value = 1;\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--watch")
+        .arg("--out-dir")
+        .arg("dist")
+        .arg("src");
+
+    let mut child = spawn_watch_command(&mut cmd)?;
+
+    wait_for("initial nested watch output", || Ok(output_path.exists()))?;
+    wait_for("watch process to stay alive", || {
+        Ok(child.try_wait()?.is_none())
+    })?;
+
+    fs::remove_dir_all(&input_dir)?;
+    wait_for("compiled output removal after deleting input dir", || {
+        Ok(!output_path.exists())
+    })?;
+
+    Ok(())
+}
+
+#[test]
+fn issue_4017_watch_out_dir_removes_outputs_after_input_dir_renamed() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    let input_dir = sandbox.path().join("src");
+    let renamed_dir = sandbox.path().join("renamed");
+    create_dir_all(input_dir.join("nested"))?;
+
+    let source_path = input_dir.join("nested/index.ts");
+    let output_path = sandbox.path().join("dist/src/nested/index.js");
+
+    fs::write(&source_path, "export const value = 1;\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--watch")
+        .arg("--out-dir")
+        .arg("dist")
+        .arg("src");
+
+    let mut child = spawn_watch_command(&mut cmd)?;
+
+    wait_for("initial nested watch output", || Ok(output_path.exists()))?;
+    wait_for("watch process to stay alive", || {
+        Ok(child.try_wait()?.is_none())
+    })?;
+
+    fs::rename(&input_dir, renamed_dir)?;
+    wait_for("compiled output removal after renaming input dir", || {
+        Ok(!output_path.exists())
+    })?;
+
+    Ok(())
+}
+
+#[test]
 fn issue_4017_watch_out_dir_ignores_generated_output_changes() -> Result<()> {
     let sandbox = TempDir::new()?;
     create_dir_all(sandbox.path().join("src"))?;


### PR DESCRIPTION
## Summary
- add real long-running `swc compile --watch` support with incremental `--out-dir` updates and `--out-file` rebuilds
- add `--copy-files` and `--strip-leading-paths` to the Rust CLI
- normalize `--out-dir` path resolution, including absolute inputs, and cover the regressions with issue tests

## Why
Issue #4017 called out a few gaps in the Rust CLI compared to the older behavior: `--watch` was exposed but did not actually keep running, compatibility flags for copying files and stripping leading paths were missing, and `out-dir` path handling regressed for some inputs. This keeps the current default `dist/src/...` layout while restoring the requested compatibility options and watch behavior.

## Validation
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo test -p swc_cli_impl`
- `cargo clippy --all --all-targets -- -D warnings`

Fixes #4017