### PR TITLE
fix(es/module): add opt-in symlink-preserving resolver

### DIFF
--- a/.changeset/good-lemons-study.md
+++ b/.changeset/good-lemons-study.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_transforms_module: major
+---
+
+fix(es/module): add opt-in symlink-preserving resolver

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6718,6 +6718,7 @@ dependencies = [
  "swc_ecma_transforms_typescript",
  "swc_ecma_utils",
  "swc_ecma_visit",
+ "tempfile",
  "testing",
  "tracing",
 ]

--- a/crates/swc_ecma_transforms_module/Cargo.toml
+++ b/crates/swc_ecma_transforms_module/Cargo.toml
@@ -46,6 +46,7 @@ swc_ecma_visit = { version = "23.0.0", path = "../swc_ecma_visit" }
 [dev-dependencies]
 indexmap   = { workspace = true, features = ["serde"] }
 serde_json = { workspace = true }
+tempfile   = { workspace = true }
 
 swc_ecma_loader = { version = "21.0.0", path = "../swc_ecma_loader", features = [
   "node",

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -94,6 +94,7 @@ where
 {
     resolver: R,
     config: Config,
+    preserve_symlinks: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -118,6 +119,16 @@ where
     R: Resolve,
 {
     pub fn with_config(resolver: R, config: Config) -> Self {
+        Self::with_config_inner(resolver, config, false)
+    }
+
+    /// Creates a resolver that preserves symlink paths when rewriting module
+    /// specifiers.
+    pub fn with_config_preserving_symlinks(resolver: R, config: Config) -> Self {
+        Self::with_config_inner(resolver, config, true)
+    }
+
+    fn with_config_inner(resolver: R, config: Config, preserve_symlinks: bool) -> Self {
         #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
         if let Some(base_dir) = &config.base_dir {
             assert!(
@@ -134,7 +145,11 @@ where
             );
         }
 
-        Self { resolver, config }
+        Self {
+            resolver,
+            config,
+            preserve_symlinks,
+        }
     }
 }
 
@@ -260,12 +275,14 @@ where
             }
         };
 
-        // Bazel uses symlink
-        //
-        // https://github.com/swc-project/swc/issues/8265
-        if let FileName::Real(resolved) = &target.filename {
-            if let Ok(orig) = canonicalize(resolved) {
-                target.filename = FileName::Real(orig);
+        if !self.preserve_symlinks {
+            // Bazel uses symlink
+            //
+            // https://github.com/swc-project/swc/issues/8265
+            if let FileName::Real(resolved) = &target.filename {
+                if let Ok(orig) = canonicalize(resolved) {
+                    target.filename = FileName::Real(orig);
+                }
             }
         }
 

--- a/crates/swc_ecma_transforms_module/tests/path_node.rs
+++ b/crates/swc_ecma_transforms_module/tests/path_node.rs
@@ -1,4 +1,5 @@
 use std::{
+    fs::{create_dir_all, write},
     path::{Path, PathBuf},
     sync::Arc,
 };
@@ -13,6 +14,7 @@ use swc_ecma_transforms_module::{
     rewriter::import_rewriter,
 };
 use swc_ecma_transforms_testing::{test_fixture, FixtureTestConfig};
+use tempfile::tempdir;
 use testing::run_test2;
 
 type TestProvider = NodeImportResolver<NodeModulesResolver>;
@@ -95,24 +97,83 @@ fn paths_resolver(
     rules: Vec<(String, Vec<String>)>,
     resolve_fully: bool,
 ) -> JscPathsProvider {
+    paths_resolver_with_options(base_dir, rules, resolve_fully, false)
+}
+
+fn paths_resolver_with_options(
+    base_dir: &Path,
+    rules: Vec<(String, Vec<String>)>,
+    resolve_fully: bool,
+    preserve_symlinks: bool,
+) -> JscPathsProvider {
     let base_dir = base_dir
         .to_path_buf()
         .canonicalize()
         .expect("failed to canonicalize");
     dbg!(&base_dir);
 
-    NodeImportResolver::with_config(
-        TsConfigResolver::new(
-            NodeModulesResolver::new(swc_ecma_loader::TargetEnv::Node, Default::default(), true),
-            base_dir.clone(),
-            rules,
-        ),
-        swc_ecma_transforms_module::path::Config {
-            base_dir: Some(base_dir),
-            resolve_fully,
-            file_extension: swc_ecma_transforms_module::util::Config::default_js_ext(),
-        },
-    )
+    let resolver = TsConfigResolver::new(
+        NodeModulesResolver::new(swc_ecma_loader::TargetEnv::Node, Default::default(), true),
+        base_dir.clone(),
+        rules,
+    );
+    let config = swc_ecma_transforms_module::path::Config {
+        base_dir: Some(base_dir),
+        resolve_fully,
+        file_extension: swc_ecma_transforms_module::util::Config::default_js_ext(),
+    };
+
+    if preserve_symlinks {
+        NodeImportResolver::with_config_preserving_symlinks(resolver, config)
+    } else {
+        NodeImportResolver::with_config(resolver, config)
+    }
+}
+
+#[test]
+fn symlink_paths_are_preserved_only_when_opted_in() {
+    let sandbox = tempdir().unwrap();
+    let root = sandbox.path();
+
+    create_dir_all(root.join("src")).unwrap();
+    create_dir_all(root.join("shared")).unwrap();
+    create_dir_all(root.join("server")).unwrap();
+
+    write(root.join("src/index.ts"), "import \"../server/source\";\n").unwrap();
+    write(root.join("shared/source.ts"), "export const value = 1;\n").unwrap();
+    create_symlink(
+        &root.join("shared/source.ts"),
+        &root.join("server/source.ts"),
+    );
+
+    let base = FileName::Real(root.join("src/index.ts").canonicalize().unwrap());
+
+    // Keep the original extensionless specifier so the assertion focuses on
+    // symlink preservation instead of extension rewriting.
+    let default_resolver = paths_resolver_with_options(root, Vec::new(), false, false);
+    let preserve_symlinks_resolver = paths_resolver_with_options(root, Vec::new(), false, true);
+
+    let default_resolved = default_resolver
+        .resolve_import(&base, "../server/source")
+        .unwrap();
+    let preserve_symlinks_resolved = preserve_symlinks_resolver
+        .resolve_import(&base, "../server/source")
+        .unwrap();
+
+    assert_eq!(&*default_resolved, "../shared/source");
+    assert_eq!(&*preserve_symlinks_resolved, "../server/source");
+}
+
+fn create_symlink(a: &Path, b: &Path) {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(a, b).unwrap();
+    }
+
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_file(a, b).unwrap();
+    }
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
**Description:**

This adds an opt-in `NodeImportResolver` constructor that preserves symlink paths when rewriting module specifiers.

Today, `NodeImportResolver` always canonicalizes resolved real paths before converting them back into relative import specifiers. That behavior is still useful for the Bazel-related fixes around `jsc.paths`, so this PR keeps it as the default. However, it breaks callers that intentionally preserve symlink locations and need rewritten imports to stay relative to the symlink path instead of the canonicalized real path.

This PR keeps the existing default constructor unchanged and adds a dedicated preserve-symlinks constructor for callers that need `resolve.symlinks: false`-style behavior. It also adds a regression test that creates a symlinked source file and asserts the opt-in boundary explicitly: the default resolver rewrites to the canonical target path, while the new constructor preserves the symlink path.

Validation:
- `git submodule update --init --recursive`
- `cargo test -p swc_ecma_transforms_module`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Closes #11584