### PR TITLE
fix(deploy): Fix musl binding test workflow

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -436,7 +436,7 @@ jobs:
         run: |
           corepack enable
           yarn config set supportedArchitectures.libc "musl"
-          yarn install
+          yarn install --mode=skip-build
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:
@@ -446,6 +446,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Build TypeScript
+        working-directory: ./packages/${{ inputs.package }}
         run: yarn build:ts
       - name: Test bindings
         run: docker run --rm -v $(pwd):/swc -w /swc node:${{ matrix.node }}-alpine sh -c 'npm install -f -g yarn@1.22.19 && env DISABLE_PLUGIN_E2E_TESTS=true yarn test:${{ inputs.package }}'


### PR DESCRIPTION
**Description:**

This updates the `test-linux-x64-musl-binding` job in `publish-npm-package.yml` so the musl binding tests only do the work they actually need.

It fixes two failure modes seen in the `Publish 1.15.28` workflow:
- `node@20` failed during dependency installation because `yarn install` ran unnecessary build scripts and hit a flaky `dprint` postinstall download (`504 Gateway Time-out`)
- `node@22` failed during test execution because the workflow built TypeScript from the workspace root, which only generated `packages/core` outputs and left `packages/minifier/index.js` missing

The workflow change now:
- uses `yarn install --mode=skip-build` in the musl test job to avoid unrelated lifecycle scripts during setup
- runs `yarn build:ts` inside `./packages/${{ inputs.package }}` so the package under test gets its own generated JS entrypoint before the docker test step

This keeps the fix scoped to the failing musl binding test path without changing the other binding jobs.

Validation used:
- disposable clone with `yarn config set supportedArchitectures.libc musl`
- `yarn install --mode=skip-build`
- package-level `yarn build:ts` for `minifier`, `core`, and `html`
- `cargo fmt --all`
- `git submodule update --init --recursive`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.
