### PR TITLE
perf(parser): reduce ts speculative parse overhead

### DIFF
--- a/crates/swc_ecma_parser/src/lexer/capturing.rs
+++ b/crates/swc_ecma_parser/src/lexer/capturing.rs
@@ -145,16 +145,8 @@ impl<I: Tokens> Tokens for Capturing<I> {
         self.inner.token_flags()
     }
 
-    fn clone_token_value(&self) -> Option<super::TokenValue> {
-        self.inner.clone_token_value()
-    }
-
-    fn take_token_value(&mut self) -> Option<super::TokenValue> {
-        self.inner.take_token_value()
-    }
-
-    fn get_token_value(&self) -> Option<&super::TokenValue> {
-        self.inner.get_token_value()
+    fn token_value(&self, start: swc_common::BytePos) -> Option<&super::TokenValue> {
+        self.inner.token_value(start)
     }
 
     fn first_token(&mut self) -> TokenAndSpan {
@@ -171,10 +163,6 @@ impl<I: Tokens> Tokens for Capturing<I> {
             self.capture(next);
         }
         next
-    }
-
-    fn set_token_value(&mut self, token_value: Option<super::TokenValue>) {
-        self.inner.set_token_value(token_value);
     }
 
     fn scan_jsx_token(&mut self) -> TokenAndSpan {

--- a/crates/swc_ecma_parser/src/lexer/kind.rs
+++ b/crates/swc_ecma_parser/src/lexer/kind.rs
@@ -1,0 +1,1 @@
+pub(crate) type Kind = super::token::Token;

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -26,7 +26,9 @@ use crate::{
         comments_buffer::{BufferedComment, BufferedCommentKind, CommentsBuffer},
         jsx::xhtml,
         number::{parse_integer, LazyInteger},
+        payload_store::PayloadStore,
         search::SafeByteMatchTable,
+        source::Source,
         state::State,
     },
     safe_byte_match_table,
@@ -39,8 +41,11 @@ pub(crate) mod capturing;
 mod char_ext;
 mod comments_buffer;
 mod jsx;
+pub(crate) mod kind;
 mod number;
+mod payload_store;
 pub(crate) mod search;
+mod source;
 mod state;
 mod table;
 pub(crate) mod token;
@@ -210,13 +215,14 @@ pub struct Lexer<'a> {
     comments_buffer: Option<CommentsBuffer>,
 
     pub ctx: Context,
-    input: StringInput<'a>,
+    input: Source<'a>,
     start_pos: BytePos,
 
     state: State,
     token_flags: TokenFlags,
     pub(crate) syntax: SyntaxFlags,
     pub(crate) target: EsVersion,
+    payload_store: PayloadStore,
 
     errors: Vec<Error>,
     module_errors: Vec<Error>,
@@ -226,12 +232,12 @@ pub struct Lexer<'a> {
 
 impl<'a> Lexer<'a> {
     #[inline(always)]
-    fn input(&self) -> &StringInput<'a> {
+    fn input(&self) -> &Source<'a> {
         &self.input
     }
 
     #[inline(always)]
-    fn input_mut(&mut self) -> &mut StringInput<'a> {
+    fn input_mut(&mut self) -> &mut Source<'a> {
         &mut self.input
     }
 
@@ -276,6 +282,11 @@ impl<'a> Lexer<'a> {
     }
 
     #[inline(always)]
+    pub(crate) fn set_token_value(&mut self, token_value: Option<TokenValue>) {
+        self.state.token_value = token_value;
+    }
+
+    #[inline(always)]
     fn atom<'b>(&self, s: impl Into<std::borrow::Cow<'b, str>>) -> swc_atoms::Atom {
         self.atoms.atom(s)
     }
@@ -313,11 +324,12 @@ impl<'a> Lexer<'a> {
             comments,
             comments_buffer: comments.is_some().then(CommentsBuffer::new),
             ctx: Default::default(),
-            input,
+            input: Source::new(input),
             start_pos,
             state: State::new(start_pos),
             syntax,
             target,
+            payload_store: Default::default(),
             errors: Default::default(),
             module_errors: Default::default(),
             atoms: Default::default(),

--- a/crates/swc_ecma_parser/src/lexer/payload_store.rs
+++ b/crates/swc_ecma_parser/src/lexer/payload_store.rs
@@ -1,0 +1,53 @@
+use rustc_hash::FxHashMap;
+use swc_common::BytePos;
+
+use super::token::TokenValue;
+
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct PayloadStoreCheckpoint {
+    len: usize,
+}
+
+/// Stores token payloads outside the parser cursor so lookahead and TS
+/// backtracking only need to restore byte positions and store lengths.
+#[derive(Clone, Debug, Default)]
+pub(crate) struct PayloadStore {
+    order: Vec<BytePos>,
+    values: FxHashMap<BytePos, TokenValue>,
+}
+
+impl PayloadStore {
+    #[inline(always)]
+    pub(crate) fn checkpoint_save(&self) -> PayloadStoreCheckpoint {
+        PayloadStoreCheckpoint {
+            len: self.order.len(),
+        }
+    }
+
+    pub(crate) fn checkpoint_load(&mut self, checkpoint: PayloadStoreCheckpoint) {
+        while self.order.len() > checkpoint.len {
+            let key = self.order.pop().expect("payload checkpoint underflow");
+            self.values.remove(&key);
+        }
+    }
+
+    pub(crate) fn clear_at_or_after(&mut self, pos: BytePos) {
+        while self.order.last().is_some_and(|last| *last >= pos) {
+            let key = self.order.pop().expect("payload order should not be empty");
+            self.values.remove(&key);
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn insert(&mut self, pos: BytePos, value: TokenValue) {
+        let replaced = self.values.insert(pos, value);
+        if replaced.is_none() {
+            self.order.push(pos);
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn get(&self, pos: BytePos) -> Option<&TokenValue> {
+        self.values.get(&pos)
+    }
+}

--- a/crates/swc_ecma_parser/src/lexer/source.rs
+++ b/crates/swc_ecma_parser/src/lexer/source.rs
@@ -1,0 +1,133 @@
+use swc_common::{
+    input::{Input, StringInput},
+    BytePos,
+};
+
+/// Thin wrapper around `StringInput` that exposes a byte-position checkpoint
+/// API compatible with the parser/lexer backtracking paths.
+#[derive(Clone)]
+pub(crate) struct Source<'a> {
+    input: StringInput<'a>,
+}
+
+impl<'a> Source<'a> {
+    #[inline(always)]
+    pub(crate) fn new(input: StringInput<'a>) -> Self {
+        Self { input }
+    }
+
+    #[inline(always)]
+    pub(crate) fn checkpoint_save(&self) -> BytePos {
+        self.input.last_pos()
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn checkpoint_load(&mut self, checkpoint: BytePos) {
+        self.input.reset_to(checkpoint);
+    }
+
+    #[inline(always)]
+    pub(crate) fn as_str(&self) -> &str {
+        self.input.as_str()
+    }
+
+    #[inline(always)]
+    pub(crate) fn start_pos(&self) -> BytePos {
+        self.input.start_pos()
+    }
+
+    #[inline(always)]
+    pub(crate) fn end_pos(&self) -> BytePos {
+        self.input.end_pos()
+    }
+
+    #[inline(always)]
+    pub(crate) fn last_pos(&self) -> BytePos {
+        self.input.last_pos()
+    }
+
+    #[inline(always)]
+    pub(crate) unsafe fn slice_str(&self, start: BytePos, end: BytePos) -> &'a str {
+        self.input.slice_str(start, end)
+    }
+}
+
+impl<'a> Input<'a> for Source<'a> {
+    #[inline(always)]
+    fn cur(&self) -> Option<u8> {
+        self.input.cur()
+    }
+
+    #[inline(always)]
+    fn peek(&self) -> Option<u8> {
+        self.input.peek()
+    }
+
+    #[inline(always)]
+    fn peek_ahead(&self) -> Option<u8> {
+        self.input.peek_ahead()
+    }
+
+    #[inline(always)]
+    unsafe fn bump_bytes(&mut self, n: usize) {
+        self.input.bump_bytes(n);
+    }
+
+    #[inline(always)]
+    fn cur_as_ascii(&self) -> Option<u8> {
+        self.input.cur_as_ascii()
+    }
+
+    #[inline(always)]
+    fn cur_as_char(&self) -> Option<char> {
+        self.input.cur_as_char()
+    }
+
+    #[inline(always)]
+    fn is_at_start(&self) -> bool {
+        self.input.is_at_start()
+    }
+
+    #[inline(always)]
+    fn cur_pos(&self) -> BytePos {
+        self.input.cur_pos()
+    }
+
+    #[inline(always)]
+    fn last_pos(&self) -> BytePos {
+        self.input.last_pos()
+    }
+
+    #[inline(always)]
+    unsafe fn slice(&mut self, start: BytePos, end: BytePos) -> &'a str {
+        self.input.slice(start, end)
+    }
+
+    #[inline(always)]
+    fn uncons_while<F>(&mut self, pred: F) -> &'a str
+    where
+        F: FnMut(char) -> bool,
+    {
+        self.input.uncons_while(pred)
+    }
+
+    #[inline(always)]
+    unsafe fn reset_to(&mut self, to: BytePos) {
+        self.input.reset_to(to);
+    }
+
+    #[inline(always)]
+    fn is_byte(&self, c: u8) -> bool {
+        self.input.is_byte(c)
+    }
+
+    #[inline(always)]
+    fn is_str(&self, s: &str) -> bool {
+        self.input.is_str(s)
+    }
+
+    #[inline(always)]
+    unsafe fn eat_byte(&mut self, c: u8) -> bool {
+        self.input.eat_byte(c)
+    }
+}

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -12,6 +12,7 @@ use crate::{
     lexer::{
         char_ext::CharExt,
         comments_buffer::{BufferedCommentKind, CommentsBufferCheckpoint},
+        payload_store::PayloadStoreCheckpoint,
         search::SafeByteMatchTable,
         token::{Token, TokenAndSpan, TokenValue},
         LexResult,
@@ -46,9 +47,10 @@ pub struct State {
 
 pub struct LexerCheckpoint {
     comments_buffer: CommentsBufferCheckpoint,
+    payload_store: PayloadStoreCheckpoint,
     state: State,
     ctx: Context,
-    input_last_pos: BytePos,
+    input_checkpoint: BytePos,
 }
 
 impl crate::input::Tokens for Lexer<'_> {
@@ -58,7 +60,8 @@ impl crate::input::Tokens for Lexer<'_> {
         LexerCheckpoint {
             state: self.state.clone(),
             ctx: self.ctx,
-            input_last_pos: self.input.last_pos(),
+            input_checkpoint: self.input.checkpoint_save(),
+            payload_store: self.payload_store.checkpoint_save(),
             comments_buffer: self
                 .comments_buffer
                 .as_ref()
@@ -70,7 +73,8 @@ impl crate::input::Tokens for Lexer<'_> {
     fn checkpoint_load(&mut self, checkpoint: LexerCheckpoint) {
         self.state = checkpoint.state;
         self.ctx = checkpoint.ctx;
-        unsafe { self.input.reset_to(checkpoint.input_last_pos) };
+        self.payload_store.checkpoint_load(checkpoint.payload_store);
+        unsafe { self.input.checkpoint_load(checkpoint.input_checkpoint) };
         if let Some(comments_buffer) = self.comments_buffer.as_mut() {
             comments_buffer.checkpoint_load(checkpoint.comments_buffer);
         }
@@ -161,20 +165,8 @@ impl crate::input::Tokens for Lexer<'_> {
         self.token_flags
     }
 
-    fn clone_token_value(&self) -> Option<TokenValue> {
-        self.state.token_value.clone()
-    }
-
-    fn get_token_value(&self) -> Option<&TokenValue> {
-        self.state.token_value.as_ref()
-    }
-
-    fn set_token_value(&mut self, token_value: Option<TokenValue>) {
-        self.state.token_value = token_value;
-    }
-
-    fn take_token_value(&mut self) -> Option<TokenValue> {
-        self.state.token_value.take()
+    fn token_value(&self, start: BytePos) -> Option<&TokenValue> {
+        self.payload_store.get(start)
     }
 
     fn first_token(&mut self) -> TokenAndSpan {
@@ -286,9 +278,9 @@ impl crate::input::Tokens for Lexer<'_> {
                 };
                 value.reserve(prefix.len() + v.len());
                 value.push_str(prefix);
-            } else if let Some(TokenValue::Word(prefix)) = self.state.token_value.take() {
+            } else if let Some(TokenValue::Word(prefix)) = self.payload_store.get(start) {
                 value.reserve(prefix.len() + v.len());
-                value.push_str(&prefix);
+                value.push_str(prefix);
             } else {
                 let prefix = unsafe {
                     // Safety: start and end are valid position because we got them from
@@ -307,15 +299,16 @@ impl crate::input::Tokens for Lexer<'_> {
                 self.input_slice_str(start, prefix_end)
             };
             self.atom(prefix)
-        } else if let Some(TokenValue::Word(value)) = self.state.token_value.take() {
-            value
+        } else if let Some(TokenValue::Word(value)) = self.payload_store.get(start) {
+            value.clone()
         } else {
             unreachable!(
                 "`token_value` should be a word, but got: {:?}",
-                self.state.token_value
+                self.payload_store.get(start)
             )
         };
         self.state.set_token_value(TokenValue::Word(v));
+        self.store_token_value_for_span(start);
         TokenAndSpan {
             token: Token::JSXName,
             had_line_break: self.state.had_line_break,
@@ -349,9 +342,12 @@ impl crate::input::Tokens for Lexer<'_> {
                     }
                 };
                 debug_assert!(self
-                    .get_token_value()
+                    .state
+                    .token_value
+                    .as_ref()
                     .is_some_and(|t| matches!(t, TokenValue::Str { .. })));
                 debug_assert!(token == Token::Str);
+                self.store_token_value_for_span(start);
                 TokenAndSpan {
                     token,
                     had_line_break: self.state.had_line_break,
@@ -367,6 +363,7 @@ impl crate::input::Tokens for Lexer<'_> {
         start: BytePos,
         start_with_back_tick: bool,
     ) -> TokenAndSpan {
+        self.payload_store.clear_at_or_after(start);
         unsafe { self.input.reset_to(start) };
         let res = self.scan_template_token(start, start_with_back_tick);
         let token = match res.map_err(|e| {
@@ -387,6 +384,14 @@ impl crate::input::Tokens for Lexer<'_> {
 }
 
 impl Lexer<'_> {
+    #[inline(always)]
+    fn store_token_value_for_span(&mut self, start: BytePos) {
+        self.payload_store.clear_at_or_after(start);
+        if let Some(token_value) = self.state.token_value.take() {
+            self.payload_store.insert(start, token_value);
+        }
+    }
+
     #[inline]
     fn jsx_text_allows_raw_gt(&self, start: BytePos, pos: BytePos) -> bool {
         let prefix = unsafe {
@@ -416,6 +421,7 @@ impl Lexer<'_> {
 
     #[inline(always)]
     fn finish_next_token(&mut self, span: Span, token: Token) -> TokenAndSpan {
+        self.store_token_value_for_span(span.lo);
         if token == Token::Eof {
             self.consume_pending_comments();
         } else if let Some(comments) = self.comments_buffer.as_mut() {

--- a/crates/swc_ecma_parser/src/lexer/token.rs
+++ b/crates/swc_ecma_parser/src/lexer/token.rs
@@ -882,10 +882,9 @@ impl TokenAndSpan {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Copy)]
 pub struct NextTokenAndSpan {
     pub token_and_span: TokenAndSpan,
-    pub value: Option<TokenValue>,
 }
 
 impl NextTokenAndSpan {

--- a/crates/swc_ecma_parser/src/parser/cursor.rs
+++ b/crates/swc_ecma_parser/src/parser/cursor.rs
@@ -1,0 +1,35 @@
+use swc_common::Span;
+
+use super::input::{Buffer, Tokens};
+use crate::lexer::{NextTokenAndSpan, TokenAndSpan};
+
+/// Snapshot of the parser cursor state used by speculative TS parses.
+#[derive(Clone)]
+pub(crate) struct CursorCheckpoint<I: Tokens> {
+    lexer: I::Checkpoint,
+    prev_span: Span,
+    cur: TokenAndSpan,
+    next: Option<NextTokenAndSpan>,
+}
+
+impl<I: Tokens> Buffer<I> {
+    #[inline(always)]
+    pub(crate) fn checkpoint_save(&self) -> CursorCheckpoint<I> {
+        CursorCheckpoint {
+            lexer: self.iter.checkpoint_save(),
+            prev_span: self.prev_span,
+            cur: self.cur,
+            next: self.next,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn checkpoint_load(&mut self, checkpoint: CursorCheckpoint<I>) {
+        self.iter.checkpoint_load(checkpoint.lexer);
+        self.prev_span = checkpoint.prev_span;
+        self.cur = checkpoint.cur;
+        self.next = checkpoint.next;
+    }
+}
+
+pub(crate) type Cursor<I> = Buffer<I>;

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -4,7 +4,7 @@ use swc_ecma_ast::EsVersion;
 
 use crate::{
     error::Error,
-    lexer::{LexResult, NextTokenAndSpan, Token, TokenAndSpan, TokenFlags, TokenValue},
+    lexer::{kind::Kind, LexResult, NextTokenAndSpan, Token, TokenAndSpan, TokenFlags, TokenValue},
     syntax::SyntaxFlags,
     Context,
 };
@@ -57,10 +57,7 @@ pub trait Tokens: Clone {
     fn update_token_flags(&mut self, f: impl FnOnce(&mut TokenFlags));
     fn token_flags(&self) -> TokenFlags;
 
-    fn clone_token_value(&self) -> Option<TokenValue>;
-    fn take_token_value(&mut self) -> Option<TokenValue>;
-    fn get_token_value(&self) -> Option<&TokenValue>;
-    fn set_token_value(&mut self, token_value: Option<TokenValue>);
+    fn token_value(&self, start: BytePos) -> Option<&TokenValue>;
 
     /// Returns the first token in the file.
     ///
@@ -96,70 +93,70 @@ pub struct Buffer<I> {
 
 impl<I: Tokens> Buffer<I> {
     pub fn expect_word_token_value(&mut self) -> Atom {
-        let Some(crate::lexer::TokenValue::Word(word)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Word(word)) = self.get_token_value() else {
             unreachable!()
         };
-        word
+        word.clone()
     }
 
     pub fn expect_word_token_value_ref(&self) -> &Atom {
-        let Some(crate::lexer::TokenValue::Word(word)) = self.iter.get_token_value() else {
-            unreachable!("token_value: {:?}", self.iter.get_token_value())
+        let Some(crate::lexer::TokenValue::Word(word)) = self.get_token_value() else {
+            unreachable!("token_value: {:?}", self.get_token_value())
         };
         word
     }
 
     pub fn expect_number_token_value(&mut self) -> f64 {
-        let Some(crate::lexer::TokenValue::Num(value)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Num(value)) = self.get_token_value() else {
             unreachable!()
         };
-        value
+        *value
     }
 
     pub fn expect_string_token_value(&mut self) -> Wtf8Atom {
-        let Some(crate::lexer::TokenValue::Str(value)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Str(value)) = self.get_token_value() else {
             unreachable!()
         };
-        value
+        value.clone()
     }
 
     pub fn expect_jsx_text_token_value(&mut self) -> Atom {
-        let Some(crate::lexer::TokenValue::JsxText(value)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::JsxText(value)) = self.get_token_value() else {
             unreachable!()
         };
-        value
+        value.clone()
     }
 
     pub fn expect_bigint_token_value(&mut self) -> Box<num_bigint::BigInt> {
-        let Some(crate::lexer::TokenValue::BigInt(value)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::BigInt(value)) = self.get_token_value() else {
             unreachable!()
         };
-        value
+        value.clone()
     }
 
     pub fn expect_regex_token_value(&mut self) -> BytePos {
-        let Some(crate::lexer::TokenValue::Regex(exp_end)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Regex(exp_end)) = self.get_token_value() else {
             unreachable!()
         };
-        exp_end
+        *exp_end
     }
 
     pub fn expect_template_token_value(&mut self) -> LexResult<Wtf8Atom> {
-        let Some(crate::lexer::TokenValue::Template(cooked)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Template(cooked)) = self.get_token_value() else {
             unreachable!()
         };
-        cooked
+        cooked.clone()
     }
 
     pub fn expect_error_token_value(&mut self) -> Error {
-        let Some(crate::lexer::TokenValue::Error(error)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Error(error)) = self.get_token_value() else {
             unreachable!()
         };
-        error
+        error.clone()
     }
 
     pub fn get_token_value(&self) -> Option<&TokenValue> {
-        self.iter.get_token_value()
+        self.iter.token_value(self.cur.span.lo)
     }
 
     pub fn scan_jsx_token(&mut self) {
@@ -270,20 +267,17 @@ impl<I: Tokens> Buffer<I> {
         &mut self.iter
     }
 
-    pub fn peek(&mut self) -> Option<Token> {
+    pub fn peek(&mut self) -> Option<Kind> {
         debug_assert!(
             self.cur.token != Token::Eof,
             "parser should not call peek() without knowing current token"
         );
 
         if self.next.is_none() {
-            let old = self.iter.take_token_value();
             let next_token = self.iter.next_token();
             self.next = Some(NextTokenAndSpan {
                 token_and_span: next_token,
-                value: self.iter.take_token_value(),
             });
-            self.iter.set_token_value(old);
         }
 
         self.next.as_ref().map(|ts| ts.token_and_span.token)
@@ -305,10 +299,7 @@ impl<I: Tokens> Buffer<I> {
 
     pub fn bump(&mut self) {
         let next = match self.next.take() {
-            Some(next) => {
-                self.iter.set_token_value(next.value);
-                next.token_and_span
-            }
+            Some(next) => next.token_and_span,
             None => self.iter.next_token(),
         };
         self.prev_span = self.cur.span;

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -6,13 +6,11 @@ use swc_atoms::Atom;
 use swc_common::{comments::Comments, input::StringInput, BytePos, Span, Spanned};
 use swc_ecma_ast::*;
 
-#[cfg(feature = "typescript")]
-use crate::lexer::TokenAndSpan;
 use crate::{
     error::SyntaxError,
-    input::Buffer,
     lexer::Token,
     parser::{
+        cursor::Cursor,
         input::Tokens,
         state::{State, WithState},
         util::ExprExt,
@@ -30,6 +28,7 @@ use crate::error::Error;
 #[macro_use]
 mod macros;
 mod class_and_fn;
+mod cursor;
 mod expr;
 mod ident;
 pub mod input;
@@ -53,10 +52,7 @@ pub type PResult<T> = Result<T, crate::error::Error>;
 
 #[cfg(feature = "typescript")]
 pub struct ParserCheckpoint<I: Tokens> {
-    lexer: I::Checkpoint,
-    buffer_prev_span: Span,
-    buffer_cur: TokenAndSpan,
-    buffer_next: Option<crate::lexer::NextTokenAndSpan>,
+    cursor: cursor::CursorCheckpoint<I>,
     #[cfg(feature = "flow")]
     allow_super_call: bool,
 }
@@ -65,7 +61,7 @@ pub struct ParserCheckpoint<I: Tokens> {
 #[derive(Clone)]
 pub struct Parser<I: self::input::Tokens> {
     state: State,
-    input: self::input::Buffer<I>,
+    input: Cursor<I>,
     found_module_item: bool,
     #[cfg(feature = "flow")]
     allow_super_call: bool,
@@ -73,12 +69,12 @@ pub struct Parser<I: self::input::Tokens> {
 
 impl<I: Tokens> Parser<I> {
     #[inline(always)]
-    pub fn input(&self) -> &Buffer<I> {
+    pub fn input(&self) -> &Cursor<I> {
         &self.input
     }
 
     #[inline(always)]
-    pub fn input_mut(&mut self) -> &mut Buffer<I> {
+    pub fn input_mut(&mut self) -> &mut Cursor<I> {
         &mut self.input
     }
 
@@ -95,10 +91,7 @@ impl<I: Tokens> Parser<I> {
     #[cfg(all(feature = "typescript", feature = "flow"))]
     fn checkpoint_save(&self) -> ParserCheckpoint<I> {
         ParserCheckpoint {
-            lexer: self.input.iter.checkpoint_save(),
-            buffer_cur: self.input.cur,
-            buffer_next: self.input.next.clone(),
-            buffer_prev_span: self.input.prev_span,
+            cursor: self.input.checkpoint_save(),
             allow_super_call: self.allow_super_call,
         }
     }
@@ -106,28 +99,19 @@ impl<I: Tokens> Parser<I> {
     #[cfg(all(feature = "typescript", not(feature = "flow")))]
     fn checkpoint_save(&self) -> ParserCheckpoint<I> {
         ParserCheckpoint {
-            lexer: self.input.iter.checkpoint_save(),
-            buffer_cur: self.input.cur,
-            buffer_next: self.input.next.clone(),
-            buffer_prev_span: self.input.prev_span,
+            cursor: self.input.checkpoint_save(),
         }
     }
 
     #[cfg(all(feature = "typescript", feature = "flow"))]
     fn checkpoint_load(&mut self, checkpoint: ParserCheckpoint<I>) {
-        self.input.iter.checkpoint_load(checkpoint.lexer);
-        self.input.cur = checkpoint.buffer_cur;
-        self.input.next = checkpoint.buffer_next;
-        self.input.prev_span = checkpoint.buffer_prev_span;
+        self.input.checkpoint_load(checkpoint.cursor);
         self.allow_super_call = checkpoint.allow_super_call;
     }
 
     #[cfg(all(feature = "typescript", not(feature = "flow")))]
     fn checkpoint_load(&mut self, checkpoint: ParserCheckpoint<I>) {
-        self.input.iter.checkpoint_load(checkpoint.lexer);
-        self.input.cur = checkpoint.buffer_cur;
-        self.input.next = checkpoint.buffer_next;
-        self.input.prev_span = checkpoint.buffer_prev_span;
+        self.input.checkpoint_load(checkpoint.cursor);
     }
 
     #[cfg(feature = "flow")]
@@ -187,7 +171,7 @@ impl<I: Tokens> Parser<I> {
         let start_pos = input.start_pos();
         let mut p = Parser {
             state: Default::default(),
-            input: crate::parser::input::Buffer::new(input),
+            input: Cursor::new(input),
             found_module_item: false,
             #[cfg(feature = "flow")]
             allow_super_call: false,

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -50,6 +50,18 @@ enum FlowEnumMemberKind {
     Invalid,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TsInstantiationFastPath {
+    Candidate,
+    NonCandidate,
+    Unknown,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum TsInstantiationVirtualFollow {
+    Token(Token),
+}
+
 /// Mark as declare
 fn make_decl_declare(mut decl: Decl) -> Decl {
     match decl {
@@ -119,6 +131,149 @@ enum FlowComponentParam {
 }
 
 impl<I: Tokens> Parser<I> {
+    fn ts_is_invalid_instantiation_expr_follower(token: Token) -> bool {
+        matches!(
+            token,
+            Token::Lt
+                | Token::Gt
+                | Token::Eq
+                | Token::RShift
+                | Token::GtEq
+                | Token::Plus
+                | Token::Minus
+                | Token::LParen
+                | Token::NoSubstitutionTemplateLiteral
+                | Token::TemplateHead
+                | Token::BackQuote
+        )
+    }
+
+    fn ts_classify_instantiation_fast_path(
+        &mut self,
+        follow: Option<TsInstantiationVirtualFollow>,
+    ) -> TsInstantiationFastPath {
+        if let Some(TsInstantiationVirtualFollow::Token(token)) = follow {
+            return if Self::ts_is_invalid_instantiation_expr_follower(token) {
+                TsInstantiationFastPath::NonCandidate
+            } else {
+                TsInstantiationFastPath::Unknown
+            };
+        }
+
+        let cur = self.input().cur();
+        if Self::ts_is_invalid_instantiation_expr_follower(cur) {
+            return TsInstantiationFastPath::NonCandidate;
+        }
+
+        if self.input().had_line_break_before_cur() || cur.is_bin_op() || !self.is_start_of_expr() {
+            TsInstantiationFastPath::Candidate
+        } else {
+            TsInstantiationFastPath::NonCandidate
+        }
+    }
+
+    fn ts_scan_instantiation_type_args_fast_path(&mut self) -> TsInstantiationFastPath {
+        debug_assert!(self.input().syntax().typescript());
+        debug_assert!(self.input().is(Token::Lt));
+
+        self.assert_and_bump(Token::Lt);
+
+        let mut depth = 1usize;
+
+        loop {
+            let virtual_follow = match self.input().cur() {
+                Token::Lt => {
+                    depth += 1;
+                    self.bump();
+                    None
+                }
+                // `<<` may be nested generic openers or a shift operator. Let the full
+                // speculative parser disambiguate that case.
+                Token::LShift => return TsInstantiationFastPath::Unknown,
+                Token::Gt => {
+                    depth -= 1;
+                    self.bump();
+                    if depth == 0 {
+                        return self.ts_classify_instantiation_fast_path(None);
+                    }
+                    None
+                }
+                Token::RShift => match depth {
+                    0 => return TsInstantiationFastPath::Unknown,
+                    1 => Some(TsInstantiationVirtualFollow::Token(Token::Gt)),
+                    _ => {
+                        depth -= 2;
+                        self.bump();
+                        if depth == 0 {
+                            return self.ts_classify_instantiation_fast_path(None);
+                        }
+                        None
+                    }
+                },
+                Token::GtEq => match depth {
+                    0 => return TsInstantiationFastPath::Unknown,
+                    1 => Some(TsInstantiationVirtualFollow::Token(Token::Eq)),
+                    _ => return TsInstantiationFastPath::Unknown,
+                },
+                Token::RShiftEq => match depth {
+                    0 => return TsInstantiationFastPath::Unknown,
+                    1 => Some(TsInstantiationVirtualFollow::Token(Token::GtEq)),
+                    2 => Some(TsInstantiationVirtualFollow::Token(Token::Eq)),
+                    _ => return TsInstantiationFastPath::Unknown,
+                },
+                Token::ZeroFillRShift => match depth {
+                    0 => return TsInstantiationFastPath::Unknown,
+                    1 => Some(TsInstantiationVirtualFollow::Token(Token::RShift)),
+                    2 => Some(TsInstantiationVirtualFollow::Token(Token::Gt)),
+                    _ => {
+                        depth -= 3;
+                        self.bump();
+                        if depth == 0 {
+                            return self.ts_classify_instantiation_fast_path(None);
+                        }
+                        None
+                    }
+                },
+                Token::ZeroFillRShiftEq => match depth {
+                    0 => return TsInstantiationFastPath::Unknown,
+                    1 => Some(TsInstantiationVirtualFollow::Token(Token::RShiftEq)),
+                    2 => Some(TsInstantiationVirtualFollow::Token(Token::GtEq)),
+                    3 => Some(TsInstantiationVirtualFollow::Token(Token::Eq)),
+                    _ => return TsInstantiationFastPath::Unknown,
+                },
+                Token::Eof => return TsInstantiationFastPath::NonCandidate,
+                _ => {
+                    self.bump();
+                    None
+                }
+            };
+
+            if let Some(virtual_follow) = virtual_follow {
+                return self.ts_classify_instantiation_fast_path(Some(virtual_follow));
+            }
+        }
+    }
+
+    fn ts_try_fast_path_instantiation_type_args(&mut self) -> TsInstantiationFastPath {
+        debug_assert!(self.input().syntax().typescript());
+        debug_assert!(self.input().is(Token::Lt));
+
+        self.do_outside_of_context(Context::ShouldNotLexLtOrGtAsType, |p| {
+            let checkpoint = p.checkpoint_save();
+            let prev_ignore_error = p.input().get_ctx().contains(Context::IgnoreError);
+            p.set_ctx(p.ctx() | Context::IgnoreError);
+
+            let result = p.ts_scan_instantiation_type_args_fast_path();
+
+            p.checkpoint_load(checkpoint);
+            let mut ctx = p.ctx();
+            ctx.set(Context::IgnoreError, prev_ignore_error);
+            p.input_mut().set_ctx(ctx);
+
+            result
+        })
+    }
+
     fn make_flow_any_keyword_type(&mut self, start: BytePos) -> Box<TsType> {
         Box::new(TsType::TsKeywordType(TsKeywordType {
             span: self.span(start),
@@ -1700,6 +1855,14 @@ impl<I: Tokens> Parser<I> {
         trace_cur!(self, try_parse_ts_type_args);
         debug_assert!(self.input().syntax().typescript());
 
+        if !self.input().syntax().jsx()
+            && self.input().is(Token::Lt)
+            && self.ts_try_fast_path_instantiation_type_args()
+                == TsInstantiationFastPath::NonCandidate
+        {
+            return None;
+        }
+
         self.try_parse_ts(|p| {
             let type_args = p.parse_ts_type_args()?;
             p.assert_and_bump(Token::Gt);
@@ -1734,6 +1897,47 @@ impl<I: Tokens> Parser<I> {
                 Ok(None)
             }
         })
+    }
+
+    fn parse_ts_generic_async_arrow_fn_head(
+        &mut self,
+    ) -> PResult<Option<(Box<TsTypeParamDecl>, Vec<Pat>, Option<Box<TsTypeAnn>>)>> {
+        debug_assert!(self.input().syntax().typescript());
+
+        let cur = self.input().cur();
+        if cur != Token::Lt && cur != Token::JSXTagStart {
+            return Ok(None);
+        }
+
+        let type_params = self.parse_ts_type_params(false, false)?;
+
+        // In TSX mode, type parameters that could be mistaken for JSX
+        // (single param without constraint and no trailing comma) are not
+        // allowed.
+        if self.input().syntax().jsx() && type_params.params.len() == 1 {
+            let single_param = &type_params.params[0];
+            let has_trailing_comma = type_params.span.hi.0 - single_param.span.hi.0 > 1;
+            let dominated_by_jsx = single_param.constraint.is_none()
+                && single_param.default.is_none()
+                && !has_trailing_comma;
+
+            if dominated_by_jsx {
+                return Ok(None);
+            }
+        }
+
+        // Don't use overloaded parseFunctionParams which would look for "<" again.
+        expect!(self, Token::LParen);
+        let params: Vec<Pat> = self
+            .parse_formal_params()?
+            .into_iter()
+            .map(|p| p.pat)
+            .collect();
+        expect!(self, Token::RParen);
+        let return_type = self.try_parse_ts_type_or_type_predicate_ann()?;
+        expect!(self, Token::Arrow);
+
+        Ok(Some((type_params, params, return_type)))
     }
 
     /// `tsTryParseType`
@@ -5138,47 +5342,11 @@ impl<I: Tokens> Parser<I> {
             return Ok(Default::default());
         }
 
-        let cur = self.input().cur();
-        let res = if cur == Token::Lt || cur == Token::JSXTagStart {
-            self.try_parse_ts(|p| {
-                let type_params = p.parse_ts_type_params(false, false)?;
-
-                // In TSX mode, type parameters that could be mistaken for JSX
-                // (single param without constraint and no trailing comma) are not
-                // allowed.
-                if p.input().syntax().jsx() && type_params.params.len() == 1 {
-                    let single_param = &type_params.params[0];
-                    let has_trailing_comma = type_params.span.hi.0 - single_param.span.hi.0 > 1;
-                    let dominated_by_jsx = single_param.constraint.is_none()
-                        && single_param.default.is_none()
-                        && !has_trailing_comma;
-
-                    if dominated_by_jsx {
-                        return Ok(None);
-                    }
-                }
-
-                // Don't use overloaded parseFunctionParams which would look for "<" again.
-                expect!(p, Token::LParen);
-                let params: Vec<Pat> = p
-                    .parse_formal_params()?
-                    .into_iter()
-                    .map(|p| p.pat)
-                    .collect();
-                expect!(p, Token::RParen);
-                let return_type = p.try_parse_ts_type_or_type_predicate_ann()?;
-                expect!(p, Token::Arrow);
-
-                Ok(Some((type_params, params, return_type)))
-            })
-        } else {
-            None
-        };
-
-        let (type_params, params, return_type) = match res {
-            Some(v) => v,
-            None => return Ok(None),
-        };
+        let (type_params, params, return_type) =
+            match self.parse_ts_generic_async_arrow_fn_head()? {
+                Some(v) => v,
+                None => return Ok(None),
+            };
 
         self.do_inside_of_context(Context::InAsync, |p| {
             p.do_outside_of_context(Context::InGenerator, |p| {

--- a/crates/swc_ecma_parser/tests/typescript.rs
+++ b/crates/swc_ecma_parser/tests/typescript.rs
@@ -71,6 +71,8 @@ fn shifted(file: PathBuf) {
 #[testing::fixture("tests/typescript/**/*.cts")]
 #[testing::fixture("tests/typescript/**/*.tsx")]
 fn spec(file: PathBuf) {
+    // Keep the glob broad so parser fast-path regressions can land as focused
+    // fixtures.
     let output = file.parent().unwrap().join(format!(
         "{}.json",
         file.file_name().unwrap().to_string_lossy()

--- a/crates/swc_ecma_parser/tests/typescript/fast-paths/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/fast-paths/input.ts
@@ -1,0 +1,5 @@
+async<T>();
+foo.bar<T>();
+foo[bar]<T>();
+foo<T>?.();
+foo<T> + 1;

--- a/crates/swc_ecma_parser/tests/typescript/fast-paths/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/fast-paths/input.ts.json
@@ -1,0 +1,337 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 65
+  },
+  "body": [
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 1,
+        "end": 12
+      },
+      "expression": {
+        "type": "CallExpression",
+        "span": {
+          "start": 1,
+          "end": 11
+        },
+        "ctxt": 0,
+        "callee": {
+          "type": "Identifier",
+          "span": {
+            "start": 1,
+            "end": 6
+          },
+          "ctxt": 0,
+          "value": "async",
+          "optional": false
+        },
+        "arguments": [],
+        "typeArguments": {
+          "type": "TsTypeParameterInstantiation",
+          "span": {
+            "start": 6,
+            "end": 9
+          },
+          "params": [
+            {
+              "type": "TsTypeReference",
+              "span": {
+                "start": 7,
+                "end": 8
+              },
+              "typeName": {
+                "type": "Identifier",
+                "span": {
+                  "start": 7,
+                  "end": 8
+                },
+                "ctxt": 0,
+                "value": "T",
+                "optional": false
+              },
+              "typeParams": null
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 13,
+        "end": 26
+      },
+      "expression": {
+        "type": "CallExpression",
+        "span": {
+          "start": 13,
+          "end": 25
+        },
+        "ctxt": 0,
+        "callee": {
+          "type": "MemberExpression",
+          "span": {
+            "start": 13,
+            "end": 20
+          },
+          "object": {
+            "type": "Identifier",
+            "span": {
+              "start": 13,
+              "end": 16
+            },
+            "ctxt": 0,
+            "value": "foo",
+            "optional": false
+          },
+          "property": {
+            "type": "Identifier",
+            "span": {
+              "start": 17,
+              "end": 20
+            },
+            "value": "bar"
+          }
+        },
+        "arguments": [],
+        "typeArguments": {
+          "type": "TsTypeParameterInstantiation",
+          "span": {
+            "start": 20,
+            "end": 23
+          },
+          "params": [
+            {
+              "type": "TsTypeReference",
+              "span": {
+                "start": 21,
+                "end": 22
+              },
+              "typeName": {
+                "type": "Identifier",
+                "span": {
+                  "start": 21,
+                  "end": 22
+                },
+                "ctxt": 0,
+                "value": "T",
+                "optional": false
+              },
+              "typeParams": null
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 27,
+        "end": 41
+      },
+      "expression": {
+        "type": "CallExpression",
+        "span": {
+          "start": 27,
+          "end": 40
+        },
+        "ctxt": 0,
+        "callee": {
+          "type": "MemberExpression",
+          "span": {
+            "start": 27,
+            "end": 35
+          },
+          "object": {
+            "type": "Identifier",
+            "span": {
+              "start": 27,
+              "end": 30
+            },
+            "ctxt": 0,
+            "value": "foo",
+            "optional": false
+          },
+          "property": {
+            "type": "Computed",
+            "span": {
+              "start": 30,
+              "end": 35
+            },
+            "expression": {
+              "type": "Identifier",
+              "span": {
+                "start": 31,
+                "end": 34
+              },
+              "ctxt": 0,
+              "value": "bar",
+              "optional": false
+            }
+          }
+        },
+        "arguments": [],
+        "typeArguments": {
+          "type": "TsTypeParameterInstantiation",
+          "span": {
+            "start": 35,
+            "end": 38
+          },
+          "params": [
+            {
+              "type": "TsTypeReference",
+              "span": {
+                "start": 36,
+                "end": 37
+              },
+              "typeName": {
+                "type": "Identifier",
+                "span": {
+                  "start": 36,
+                  "end": 37
+                },
+                "ctxt": 0,
+                "value": "T",
+                "optional": false
+              },
+              "typeParams": null
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 42,
+        "end": 53
+      },
+      "expression": {
+        "type": "OptionalChainingExpression",
+        "span": {
+          "start": 42,
+          "end": 52
+        },
+        "optional": true,
+        "base": {
+          "type": "CallExpression",
+          "span": {
+            "start": 42,
+            "end": 52
+          },
+          "ctxt": 0,
+          "callee": {
+            "type": "TsInstantiation",
+            "span": {
+              "start": 42,
+              "end": 48
+            },
+            "expression": {
+              "type": "Identifier",
+              "span": {
+                "start": 42,
+                "end": 45
+              },
+              "ctxt": 0,
+              "value": "foo",
+              "optional": false
+            },
+            "typeArguments": {
+              "type": "TsTypeParameterInstantiation",
+              "span": {
+                "start": 45,
+                "end": 48
+              },
+              "params": [
+                {
+                  "type": "TsTypeReference",
+                  "span": {
+                    "start": 46,
+                    "end": 47
+                  },
+                  "typeName": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 46,
+                      "end": 47
+                    },
+                    "ctxt": 0,
+                    "value": "T",
+                    "optional": false
+                  },
+                  "typeParams": null
+                }
+              ]
+            }
+          },
+          "arguments": [],
+          "typeArguments": null
+        }
+      }
+    },
+    {
+      "type": "ExpressionStatement",
+      "span": {
+        "start": 54,
+        "end": 65
+      },
+      "expression": {
+        "type": "BinaryExpression",
+        "span": {
+          "start": 54,
+          "end": 64
+        },
+        "operator": ">",
+        "left": {
+          "type": "BinaryExpression",
+          "span": {
+            "start": 54,
+            "end": 59
+          },
+          "operator": "<",
+          "left": {
+            "type": "Identifier",
+            "span": {
+              "start": 54,
+              "end": 57
+            },
+            "ctxt": 0,
+            "value": "foo",
+            "optional": false
+          },
+          "right": {
+            "type": "Identifier",
+            "span": {
+              "start": 58,
+              "end": 59
+            },
+            "ctxt": 0,
+            "value": "T",
+            "optional": false
+          }
+        },
+        "right": {
+          "type": "UnaryExpression",
+          "span": {
+            "start": 61,
+            "end": 64
+          },
+          "operator": "+",
+          "argument": {
+            "type": "NumericLiteral",
+            "span": {
+              "start": 63,
+              "end": 64
+            },
+            "value": 1.0,
+            "raw": "1"
+          }
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/typescript/fast-paths/input.tsx
+++ b/crates/swc_ecma_parser/tests/typescript/fast-paths/input.tsx
@@ -1,0 +1,2 @@
+const comma = async <T,>() => <div />;
+const constrained = async <T extends unknown>() => <div />;

--- a/crates/swc_ecma_parser/tests/typescript/fast-paths/input.tsx.json
+++ b/crates/swc_ecma_parser/tests/typescript/fast-paths/input.tsx.json
@@ -1,0 +1,223 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 99
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 1,
+        "end": 39
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 7,
+            "end": 38
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 7,
+              "end": 12
+            },
+            "ctxt": 0,
+            "value": "comma",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "span": {
+              "start": 15,
+              "end": 38
+            },
+            "ctxt": 0,
+            "params": [],
+            "body": {
+              "type": "JSXElement",
+              "span": {
+                "start": 31,
+                "end": 38
+              },
+              "opening": {
+                "type": "JSXOpeningElement",
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 32,
+                    "end": 35
+                  },
+                  "ctxt": 0,
+                  "value": "div",
+                  "optional": false
+                },
+                "span": {
+                  "start": 31,
+                  "end": 38
+                },
+                "attributes": [],
+                "selfClosing": true,
+                "typeArguments": null
+              },
+              "children": [],
+              "closing": null
+            },
+            "async": true,
+            "generator": false,
+            "typeParameters": {
+              "type": "TsTypeParameterDeclaration",
+              "span": {
+                "start": 21,
+                "end": 25
+              },
+              "parameters": [
+                {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 22,
+                    "end": 23
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 22,
+                      "end": 23
+                    },
+                    "ctxt": 0,
+                    "value": "T",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "const": false,
+                  "constraint": null,
+                  "default": null
+                }
+              ]
+            },
+            "returnType": null
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 40,
+        "end": 99
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 46,
+            "end": 98
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 46,
+              "end": 57
+            },
+            "ctxt": 0,
+            "value": "constrained",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "span": {
+              "start": 60,
+              "end": 98
+            },
+            "ctxt": 0,
+            "params": [],
+            "body": {
+              "type": "JSXElement",
+              "span": {
+                "start": 91,
+                "end": 98
+              },
+              "opening": {
+                "type": "JSXOpeningElement",
+                "name": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 92,
+                    "end": 95
+                  },
+                  "ctxt": 0,
+                  "value": "div",
+                  "optional": false
+                },
+                "span": {
+                  "start": 91,
+                  "end": 98
+                },
+                "attributes": [],
+                "selfClosing": true,
+                "typeArguments": null
+              },
+              "children": [],
+              "closing": null
+            },
+            "async": true,
+            "generator": false,
+            "typeParameters": {
+              "type": "TsTypeParameterDeclaration",
+              "span": {
+                "start": 66,
+                "end": 85
+              },
+              "parameters": [
+                {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 67,
+                    "end": 84
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 67,
+                      "end": 68
+                    },
+                    "ctxt": 0,
+                    "value": "T",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "const": false,
+                  "constraint": {
+                    "type": "TsKeywordType",
+                    "span": {
+                      "start": 77,
+                      "end": 84
+                    },
+                    "kind": "unknown"
+                  },
+                  "default": null
+                }
+              ]
+            },
+            "returnType": null
+          },
+          "definite": false
+        }
+      ]
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Description:**

This PR continues the `swc_ecma_parser` parser-core re-architecture by cutting TypeScript speculative parse overhead on the hot path without changing the public parser API.

- decouple token payload storage from cursor checkpoints so speculative parse no longer shuffles token payload ownership during backtracking
- add cursor-based checkpoint helpers and use them to reduce parser state restore work in TypeScript speculation
- split generic async arrow parsing into head detection plus committed parse to avoid nested `try_parse_ts` round-trips
- add a token-level fast reject for instantiation expression type arguments in non-JSX TypeScript while preserving the existing TSX ambiguity behavior
- extend the fixture suite with generic async arrow and instantiation-expression edge cases, including member/computed access and optional chaining

Validation:

- `cargo fmt --all`
- `cargo test -p swc_ecma_parser --test js`
- `cargo test -p swc_ecma_parser --test jsx`
- `cargo test -p swc_ecma_parser --test typescript`
- `cargo test -p swc_ecma_parser --test errors`
- `cargo test -p swc_ecma_parser --test comments`
- `cargo test -p swc_ecma_parser --test span`
- `cargo test -p swc_ecma_parser`
- `cargo clippy -p swc_ecma_parser --all-targets -- -D warnings`
- `cargo run --example perf --quiet`

Perf notes:

- `es/parser/cal-com` improved from roughly `9.22-11.34ms` on the baseline run to `8.74-8.97ms`
- `es/parser/typescript` stayed effectively neutral at roughly `68.5-82.7ms` baseline vs `68.9-82.2ms` current

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A
