### PR TITLE
fix(deploy): build package ts before Linux GNU binding tests

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -406,6 +406,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Build TypeScript
+        working-directory: ./packages/${{ inputs.package }}
         run: yarn build:ts
       - name: Test bindings
         run: docker run --rm -v $(pwd):/swc -w /swc node:${{ matrix.node }}-slim sh -c 'npm install -f -g yarn@1.22.19 && env DISABLE_PLUGIN_E2E_TESTS=true yarn test:${{ inputs.package }}'


### PR DESCRIPTION
**Description:**

This fixes the `test-linux-x64-gnu-binding` workflow path so the package under test builds its own TypeScript entrypoint before the Docker test step runs.

The failing `Publish minifier@1.15.29-nightly-20260418.1 / Test bindings on Linux-x64-gnu - node@22` job from [run 24609515249](https://github.com/swc-project/swc/actions/runs/24609515249/job/71962047938) failed with:

- `Error: Cannot find module '../index.js'`

That happened because the job was running `yarn build:ts` from the workspace root, which only builds `packages/core`. For `@swc/minifier`, the test suite loads `packages/minifier/index.js`, so the GNU binding test never generated the entrypoint it needed.

This change makes the GNU binding test mirror the package-scoped TypeScript build already used by the other binding jobs by running `yarn build:ts` in `./packages/${{ inputs.package }}`.

Validation used:

- inspected the failing Actions log and confirmed the missing `../index.js` error
- `git submodule update --init --recursive`
- `corepack enable && yarn install --mode=skip-build`
- `(cd packages/minifier && yarn build:ts)`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `(cd packages/minifier && yarn build:dev && yarn test)`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.
