### PR TITLE
Omit empty `export {}` when flow module has only type exports

### DIFF
--- a/.changeset/flow-strip-empty-export.md
+++ b/.changeset/flow-strip-empty-export.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_transforms_typescript: patch
+swc_core: patch
+---
+
+fix(es/transforms/typescript): Omit empty `export {}` when flow module has only type exports

--- a/crates/swc/tests/fixture/issues-11xxx/11808/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-11xxx/11808/input/.swcrc
@@ -1,0 +1,9 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "flow",
+      "requireDirective": true
+    }
+  },
+  "isModule": "unknown"
+}

--- a/crates/swc/tests/fixture/issues-11xxx/11808/input/1.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11808/input/1.js
@@ -1,0 +1,3 @@
+/** @flow strict */
+global.ErrorUtils = {};
+export type ErrorUtilsT = typeof global.ErrorUtils;

--- a/crates/swc/tests/fixture/issues-11xxx/11808/input/2.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11808/input/2.js
@@ -1,0 +1,4 @@
+/** @flow strict */
+import { type ErrorUtilsT } from "error-utils";
+export { type ErrorUtilsT };
+global.ErrorUtils = {};

--- a/crates/swc/tests/fixture/issues-11xxx/11808/input/3.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11808/input/3.js
@@ -1,0 +1,3 @@
+/** @flow strict */
+declare export var ErrorUtilsT: typeof global.ErrorUtils;
+global.ErrorUtils = {};

--- a/crates/swc/tests/fixture/issues-11xxx/11808/output/1.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11808/output/1.js
@@ -1,0 +1,1 @@
+/** @flow strict */ global.ErrorUtils = {};

--- a/crates/swc/tests/fixture/issues-11xxx/11808/output/2.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11808/output/2.js
@@ -1,0 +1,1 @@
+/** @flow strict */ global.ErrorUtils = {};

--- a/crates/swc/tests/fixture/issues-11xxx/11808/output/3.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11808/output/3.js
@@ -1,0 +1,1 @@
+/** @flow strict */ global.ErrorUtils = {};

--- a/crates/swc_ecma_transforms_typescript/src/typescript.rs
+++ b/crates/swc_ecma_transforms_typescript/src/typescript.rs
@@ -8,7 +8,7 @@ use swc_ecma_transforms_react::{parse_expr_for_jsx, JsxDirectives};
 use swc_ecma_visit::{visit_mut_pass, VisitMut, VisitMutWith};
 
 pub use crate::config::*;
-use crate::{semantic::analyze_program, transform::transform};
+use crate::{retain::IsConcrete, semantic::analyze_program, transform::transform};
 
 macro_rules! static_str {
     ($s:expr) => {
@@ -74,10 +74,17 @@ impl TypeScript {
             return None;
         }
 
+        // Flow strips type-only syntax without preserving module context: if the
+        // only module declarations are type-only (e.g. `export type`), the result
+        // should be a plain script. TypeScript keeps the placeholder to match
+        // `tsc`, which emits `export {}` so downstream module transforms still
+        // treat the file as a module.
+        let keep_type_only = !self.config.flow_syntax;
+
         n.body
             .iter()
             .rev()
-            .find(|m| m.is_es_module_decl())
+            .find(|m| m.is_es_module_decl() && (keep_type_only || m.is_concrete()))
             .map(Spanned::span)
     }
 

--- a/crates/swc_ecma_transforms_typescript/src/typescript.rs
+++ b/crates/swc_ecma_transforms_typescript/src/typescript.rs
@@ -84,11 +84,7 @@ impl TypeScript {
             .rev()
             .find(|m| {
                 m.is_es_module_decl()
-                    && if self.config.flow_syntax {
-                        Self::flow_module_item_has_runtime_semantics(m)
-                    } else {
-                        m.is_concrete()
-                    }
+                    && (!self.config.flow_syntax || Self::flow_module_item_has_runtime_semantics(m))
             })
             .map(Spanned::span)
     }

--- a/crates/swc_ecma_transforms_typescript/src/typescript.rs
+++ b/crates/swc_ecma_transforms_typescript/src/typescript.rs
@@ -79,13 +79,82 @@ impl TypeScript {
         // should be a plain script. TypeScript keeps the placeholder to match
         // `tsc`, which emits `export {}` so downstream module transforms still
         // treat the file as a module.
-        let keep_type_only = !self.config.flow_syntax;
-
         n.body
             .iter()
             .rev()
-            .find(|m| m.is_es_module_decl() && (keep_type_only || m.is_concrete()))
+            .find(|m| {
+                m.is_es_module_decl()
+                    && if self.config.flow_syntax {
+                        Self::flow_module_item_has_runtime_semantics(m)
+                    } else {
+                        m.is_concrete()
+                    }
+            })
             .map(Spanned::span)
+    }
+
+    fn flow_module_item_has_runtime_semantics(item: &ModuleItem) -> bool {
+        let Some(module_decl) = item.as_module_decl() else {
+            return false;
+        };
+
+        match module_decl {
+            ModuleDecl::Import(import_decl) => {
+                !import_decl.type_only
+                    && (import_decl.specifiers.is_empty()
+                        || import_decl
+                            .specifiers
+                            .iter()
+                            .any(|specifier| match specifier {
+                                ImportSpecifier::Named(named) => !named.is_type_only,
+                                ImportSpecifier::Default(..) | ImportSpecifier::Namespace(..) => {
+                                    true
+                                }
+                                #[cfg(swc_ast_unknown)]
+                                _ => panic!("unable to access unknown nodes"),
+                            }))
+            }
+            ModuleDecl::ExportDecl(export_decl) => !Self::decl_is_declare(&export_decl.decl),
+            ModuleDecl::ExportNamed(named_export) => {
+                !named_export.type_only
+                    && (named_export.specifiers.is_empty()
+                        || named_export
+                            .specifiers
+                            .iter()
+                            .any(|specifier| match specifier {
+                                ExportSpecifier::Named(named) => !named.is_type_only,
+                                ExportSpecifier::Default(..) | ExportSpecifier::Namespace(..) => {
+                                    true
+                                }
+                                #[cfg(swc_ast_unknown)]
+                                _ => panic!("unable to access unknown nodes"),
+                            }))
+            }
+            ModuleDecl::ExportDefaultDecl(export_default_decl) => {
+                export_default_decl.decl.is_concrete()
+            }
+            ModuleDecl::ExportDefaultExpr(..) => true,
+            ModuleDecl::ExportAll(export_all) => !export_all.type_only,
+            ModuleDecl::TsImportEquals(ts_import_equals) => !ts_import_equals.is_type_only,
+            ModuleDecl::TsExportAssignment(..) => true,
+            ModuleDecl::TsNamespaceExport(..) => false,
+            #[cfg(swc_ast_unknown)]
+            _ => panic!("unable to access unknown nodes"),
+        }
+    }
+
+    fn decl_is_declare(decl: &Decl) -> bool {
+        match decl {
+            Decl::Class(class_decl) => class_decl.declare,
+            Decl::Fn(function_decl) => function_decl.declare,
+            Decl::Var(var_decl) => var_decl.declare,
+            Decl::Using(..) => false,
+            Decl::TsInterface(..) | Decl::TsTypeAlias(..) => true,
+            Decl::TsEnum(ts_enum_decl) => ts_enum_decl.declare,
+            Decl::TsModule(ts_module_decl) => ts_module_decl.declare || ts_module_decl.global,
+            #[cfg(swc_ast_unknown)]
+            _ => panic!("unable to access unknown nodes"),
+        }
     }
 
     fn restore_esm_ctx(n: &mut Module, span: Span) {


### PR DESCRIPTION
**Description:**

I'm having some issues with react-native polyfills as described in https://github.com/swc-project/swc/issues/11808 where an empty `export {}` is emitted in a file that only exports types. While this seems consistent with how TSC behaves, it's not consistent with the babel flow stripper as far as I can tell from their [Babel online REPL](https://babeljs.io/repl#?config_lz=N4IgZglgNgpgdgQwLYxALhAJxgBygOgCsBnEAGhB22JgBdS0BtRkeAN3NFoUwHM6GIACYwwCAK5R6ZAARwA9rRkQYMgIxrZCpSoD6SeQCN1a8iANDJMBmKg0Kh8b0gAPa-lqZxMAL4BdMhZibn4AWgAmTmEYAGN5TARaeOIANRhMYgh5OHQQcIAGcIBmUI0zHAgcGCgIOBgABUx5HHliBChcgAsEGIBrEH8KMCh5AHcQAJBieXFMGJgAFQBPKtyLKwGgA&code_lz=PQKhAIAEDMBsHsDu4DOAXATgSwMZvCMAFADmCARgIawB0AohhvBgKppawrgC84A3gF8A3EQCmADwAOzfGgCek0eAZNW7TgBUe4eYvjRwZeFVormbDihFA&lineWrap=true&version=7.29.2). 

So this PR simply strips the empty `export {}` when a Flow module only has type exports. 

**BREAKING CHANGE:** I don't think so, I kept existing behavior for TS. 

**Related issue (if exists):** https://github.com/swc-project/swc/issues/11808
