### PR TITLE
fix(es/transforms): strip `@flow` and `@noflow` pragma comments

### DIFF
--- a/.changeset/flow-pragma-strip.md
+++ b/.changeset/flow-pragma-strip.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc: patch
+swc_ecma_transforms_typescript: patch
+---
+
+Strip `@flow` and `@noflow` pragma comments when transforming Flow syntax

--- a/.changeset/flow-pragma-strip.md
+++ b/.changeset/flow-pragma-strip.md
@@ -4,4 +4,4 @@ swc: patch
 swc_ecma_transforms_typescript: patch
 ---
 
-Strip `@flow` and `@noflow` pragma comments when transforming Flow syntax
+fix(es/transforms): strip `@flow` and `@noflow` pragma comments when transforming Flow syntax

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -927,6 +927,12 @@ impl Options {
                             ),
                             syntax.typescript() && jsx_enabled,
                         ),
+                        Optional::new(
+                            typescript::flow_pragma_strip::<Option<&dyn Comments>>(
+                                comments.map(|v| v as _),
+                            ),
+                            syntax.flow(),
+                        ),
                     )
                 }),
                 (

--- a/crates/swc_ecma_transforms_typescript/src/flow.rs
+++ b/crates/swc_ecma_transforms_typescript/src/flow.rs
@@ -114,7 +114,8 @@ fn strip_flow_pragma(kind: CommentKind, text: &str) -> Option<String> {
 fn line_has_pragma(line: &str) -> bool {
     let line = line.trim();
     let line = line.trim_start_matches('*').trim_start();
-    starts_with_pragma(line, "@flow") || starts_with_pragma(line, "@noflow")
+
+    is_valid_flow_pragma(line)
 }
 
 /// Walks the body of a block comment, dropping any line that is just a Flow
@@ -138,11 +139,16 @@ fn strip_pragma_lines(text: &str) -> Option<String> {
     }
 }
 
-fn starts_with_pragma(line: &str, pragma: &str) -> bool {
-    match line.strip_prefix(pragma) {
-        Some(rest) => rest.is_empty() || rest.starts_with(|c: char| c.is_whitespace()),
-        None => false,
+fn is_valid_flow_pragma(line: &str) -> bool {
+    if line == "@noflow" {
+        return true;
     }
+
+    let Some(rest) = line.strip_prefix("@flow") else {
+        return false;
+    };
+
+    matches!(rest.trim(), "" | "strict" | "strict-local" | "weak")
 }
 
 /// Returns true when the remaining block comment body has no non-whitespace
@@ -171,6 +177,9 @@ mod tests {
         assert!(!line_has_pragma(" Copyright 2024"));
         assert!(!line_has_pragma(" see @flowtype documentation"));
         assert!(!line_has_pragma(" @flowtype something"));
+        assert!(!line_has_pragma(" @flow migration notes"));
+        assert!(!line_has_pragma(" @flow strictly"));
+        assert!(!line_has_pragma(" @flow strict local"));
         assert!(!line_has_pragma(" @license MIT"));
     }
 

--- a/crates/swc_ecma_transforms_typescript/src/flow.rs
+++ b/crates/swc_ecma_transforms_typescript/src/flow.rs
@@ -1,0 +1,228 @@
+//! Flow-specific post-processing that runs alongside [`crate::typescript`]
+//! when the input was parsed with `swc_ecma_parser::Syntax::Flow`.
+//!
+//! Flow source files opt in to type checking through a leading
+//! `// @flow` (or `/* @flow */`) pragma comment. Once Flow type syntax has
+//! been stripped, the pragma is misleading and should not survive into the
+//! generated JavaScript. This module mirrors the default behavior of
+//! `@babel/plugin-transform-flow-strip-types`, which removes the pragma
+//! unless the consumer explicitly opts out.
+
+use swc_atoms::Atom;
+use swc_common::{
+    comments::{Comment, CommentKind, Comments},
+    BytePos, Spanned,
+};
+use swc_ecma_ast::{Module, Pass, Script};
+use swc_ecma_visit::{visit_mut_pass, VisitMut};
+
+/// Remove `@flow` and `@noflow` pragma comments from the leading comments of
+/// the program.
+///
+/// For line comments that are just a pragma (`// @flow`) the whole comment is
+/// dropped. For block/JSDoc comments with other content, only the pragma
+/// lines are removed so copyright banners and other annotations survive the
+/// transform. If a block comment is reduced to empty whitespace after pragma
+/// removal, it is dropped as well.
+///
+/// The pass visits the module/script span and the first body item because
+/// parsers attach leading comments at either position depending on whether a
+/// shebang or empty prefix is present.
+pub fn flow_pragma_strip<C>(comments: C) -> impl Pass
+where
+    C: Comments,
+{
+    visit_mut_pass(FlowPragmaStrip { comments })
+}
+
+struct FlowPragmaStrip<C>
+where
+    C: Comments,
+{
+    comments: C,
+}
+
+impl<C> FlowPragmaStrip<C>
+where
+    C: Comments,
+{
+    fn strip_at(&self, pos: BytePos) {
+        let Some(existing) = self.comments.take_leading(pos) else {
+            return;
+        };
+
+        let mut kept: Vec<Comment> = Vec::with_capacity(existing.len());
+        for mut cmt in existing {
+            if let Some(new_text) = strip_flow_pragma(cmt.kind, &cmt.text) {
+                if is_empty_comment_body(&new_text) {
+                    continue;
+                }
+                cmt.text = Atom::new(new_text);
+            }
+            kept.push(cmt);
+        }
+
+        if !kept.is_empty() {
+            self.comments.add_leading_comments(pos, kept);
+        }
+    }
+}
+
+impl<C> VisitMut for FlowPragmaStrip<C>
+where
+    C: Comments,
+{
+    fn visit_mut_module(&mut self, n: &mut Module) {
+        self.strip_at(n.span.lo);
+        if let Some(first) = n.body.first() {
+            self.strip_at(first.span_lo());
+        }
+    }
+
+    fn visit_mut_script(&mut self, n: &mut Script) {
+        self.strip_at(n.span.lo);
+        if let Some(first) = n.body.first() {
+            self.strip_at(first.span_lo());
+        }
+    }
+}
+
+/// Remove `@flow` / `@noflow` pragma lines from the comment body.
+///
+/// Returns `Some(new_text)` when the comment contained at least one pragma
+/// line, or `None` when the comment is untouched. Accepted pragma forms
+/// mirror `babel-plugin-transform-flow-strip-types`:
+///  - `@flow`, `@flow strict`, `@flow strict-local`, `@flow weak`
+///  - `@noflow`
+///
+/// For line comments the entire body is dropped when a pragma is detected.
+/// For block/JSDoc comments only the pragma lines are removed, so unrelated
+/// content such as copyright banners is preserved.
+fn strip_flow_pragma(kind: CommentKind, text: &str) -> Option<String> {
+    match kind {
+        CommentKind::Line => {
+            if line_has_pragma(text) {
+                Some(String::new())
+            } else {
+                None
+            }
+        }
+        CommentKind::Block => strip_pragma_lines(text),
+    }
+}
+
+fn line_has_pragma(line: &str) -> bool {
+    let line = line.trim();
+    let line = line.trim_start_matches('*').trim_start();
+    starts_with_pragma(line, "@flow") || starts_with_pragma(line, "@noflow")
+}
+
+/// Walks the body of a block comment, dropping any line that is just a Flow
+/// pragma.
+fn strip_pragma_lines(text: &str) -> Option<String> {
+    let mut stripped = false;
+    let mut out = String::with_capacity(text.len());
+
+    for raw in text.split_inclusive('\n') {
+        if line_has_pragma(raw) {
+            stripped = true;
+            continue;
+        }
+        out.push_str(raw);
+    }
+
+    if stripped {
+        Some(out)
+    } else {
+        None
+    }
+}
+
+fn starts_with_pragma(line: &str, pragma: &str) -> bool {
+    match line.strip_prefix(pragma) {
+        Some(rest) => rest.is_empty() || rest.starts_with(|c: char| c.is_whitespace()),
+        None => false,
+    }
+}
+
+/// Returns true when the remaining block comment body has no non-whitespace
+/// content other than JSDoc `*` decorations. Used to drop comments that have
+/// been reduced to an empty `/** */` by pragma removal.
+fn is_empty_comment_body(text: &str) -> bool {
+    text.lines()
+        .all(|line| line.trim().trim_start_matches('*').trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_common::comments::CommentKind;
+
+    use super::{is_empty_comment_body, line_has_pragma, strip_flow_pragma};
+
+    #[test]
+    fn line_pragma_detection() {
+        assert!(line_has_pragma(" @flow"));
+        assert!(line_has_pragma(" @flow strict"));
+        assert!(line_has_pragma(" @flow strict-local"));
+        assert!(line_has_pragma(" @flow weak"));
+        assert!(line_has_pragma(" @noflow"));
+        assert!(line_has_pragma(" * @flow"));
+
+        assert!(!line_has_pragma(" Copyright 2024"));
+        assert!(!line_has_pragma(" see @flowtype documentation"));
+        assert!(!line_has_pragma(" @flowtype something"));
+        assert!(!line_has_pragma(" @license MIT"));
+    }
+
+    #[test]
+    fn line_comment_fully_stripped() {
+        assert_eq!(
+            strip_flow_pragma(CommentKind::Line, " @flow").as_deref(),
+            Some("")
+        );
+        assert_eq!(
+            strip_flow_pragma(CommentKind::Line, " @flow strict").as_deref(),
+            Some("")
+        );
+        assert_eq!(
+            strip_flow_pragma(CommentKind::Line, " @noflow").as_deref(),
+            Some("")
+        );
+        assert!(strip_flow_pragma(CommentKind::Line, " Copyright 2024").is_none());
+    }
+
+    #[test]
+    fn block_comment_keeps_surrounding_lines() {
+        let input = "*\n * Copyright 2024\n * @flow\n * @format\n ";
+        let out = strip_flow_pragma(CommentKind::Block, input).expect("should strip");
+        assert!(!out.contains("@flow"));
+        assert!(out.contains("Copyright 2024"));
+        assert!(out.contains("@format"));
+    }
+
+    #[test]
+    fn block_comment_becomes_empty() {
+        let input = " @flow ";
+        let out = strip_flow_pragma(CommentKind::Block, input).expect("should strip");
+        assert!(is_empty_comment_body(&out));
+    }
+
+    #[test]
+    fn jsdoc_comment_becomes_empty() {
+        let input = "*\n * @flow\n ";
+        let out = strip_flow_pragma(CommentKind::Block, input).expect("should strip");
+        assert!(is_empty_comment_body(&out));
+    }
+
+    #[test]
+    fn block_comment_without_pragma_untouched() {
+        assert!(strip_flow_pragma(CommentKind::Block, "*\n * @license MIT\n ").is_none());
+    }
+
+    #[test]
+    fn is_empty_comment_body_ignores_jsdoc_stars() {
+        assert!(is_empty_comment_body(""));
+        assert!(is_empty_comment_body("*\n * \n "));
+        assert!(!is_empty_comment_body("*\n * Copyright\n "));
+    }
+}

--- a/crates/swc_ecma_transforms_typescript/src/lib.rs
+++ b/crates/swc_ecma_transforms_typescript/src/lib.rs
@@ -57,7 +57,7 @@
 
 pub use self::{flow::flow_pragma_strip, typescript::*};
 mod config;
-pub mod flow;
+mod flow;
 mod macros;
 mod retain;
 mod semantic;

--- a/crates/swc_ecma_transforms_typescript/src/lib.rs
+++ b/crates/swc_ecma_transforms_typescript/src/lib.rs
@@ -55,8 +55,9 @@
 #![allow(clippy::vec_box)]
 #![allow(clippy::mutable_key_type)]
 
-pub use self::typescript::*;
+pub use self::{flow::flow_pragma_strip, typescript::*};
 mod config;
+pub mod flow;
 mod macros;
 mod retain;
 mod semantic;

--- a/crates/swc_ecma_transforms_typescript/tests/flow_pragma_strip.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/flow_pragma_strip.rs
@@ -23,6 +23,14 @@ fn transform(source: &str) -> String {
         )
         .map_err(|err| err.into_diagnostic(handler).emit())?;
 
+        if !recovered_errors.is_empty() {
+            for err in recovered_errors {
+                err.into_diagnostic(handler).emit();
+            }
+
+            return Err(());
+        }
+
         let unresolved_mark = Mark::new();
         let top_level_mark = Mark::new();
 
@@ -128,6 +136,15 @@ fn preserves_lookalike_comment() {
     assert!(
         output.contains("see @flowtype documentation"),
         "expected @flowtype lookalike comment to be preserved, got: {output}"
+    );
+}
+
+#[test]
+fn preserves_non_directive_flow_text() {
+    let output = transform("// @flow migration notes\nconst value = 1;\n");
+    assert!(
+        output.contains("@flow migration notes"),
+        "expected non-directive @flow text to be preserved, got: {output}"
     );
 }
 

--- a/crates/swc_ecma_transforms_typescript/tests/flow_pragma_strip.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/flow_pragma_strip.rs
@@ -1,0 +1,142 @@
+use swc_common::{comments::SingleThreadedComments, FileName, Mark};
+use swc_ecma_ast::EsVersion;
+use swc_ecma_codegen::to_code_default;
+use swc_ecma_parser::{parse_file_as_program, FlowSyntax, Syntax};
+use swc_ecma_transforms_base::{fixer::fixer, resolver};
+use swc_ecma_transforms_typescript::{flow_pragma_strip, typescript};
+
+fn transform(source: &str) -> String {
+    ::testing::run_test(false, |cm, handler| -> Result<String, ()> {
+        let comments = SingleThreadedComments::default();
+        let fm = cm.new_source_file(
+            FileName::Custom("flow.js".into()).into(),
+            source.to_string(),
+        );
+        let mut recovered_errors = Vec::new();
+
+        let program = parse_file_as_program(
+            &fm,
+            Syntax::Flow(FlowSyntax::default()),
+            EsVersion::latest(),
+            Some(&comments),
+            &mut recovered_errors,
+        )
+        .map_err(|err| err.into_diagnostic(handler).emit())?;
+
+        let unresolved_mark = Mark::new();
+        let top_level_mark = Mark::new();
+
+        let program = program
+            .apply(resolver(unresolved_mark, top_level_mark, false))
+            .apply(typescript::typescript(
+                typescript::Config {
+                    flow_syntax: true,
+                    ..Default::default()
+                },
+                unresolved_mark,
+                top_level_mark,
+            ))
+            .apply(flow_pragma_strip(&comments))
+            .apply(fixer(Some(&comments)));
+
+        Ok(to_code_default(cm.clone(), Some(&comments), &program))
+    })
+    .expect("failed to run flow pragma strip test")
+}
+
+#[test]
+fn strips_line_flow_pragma() {
+    let output = transform("// @flow\nconst value: number = 1;\n");
+    assert!(
+        !output.contains("@flow"),
+        "expected @flow pragma to be stripped, got: {output}"
+    );
+    assert!(output.contains("const value = 1;"));
+}
+
+#[test]
+fn strips_block_flow_pragma() {
+    let output = transform("/* @flow */\nconst value: number = 1;\n");
+    assert!(
+        !output.contains("@flow"),
+        "expected block @flow pragma to be stripped, got: {output}"
+    );
+}
+
+#[test]
+fn strips_jsdoc_flow_pragma() {
+    let output = transform("/**\n * @flow\n */\nconst value: number = 1;\n");
+    assert!(
+        !output.contains("@flow"),
+        "expected JSDoc @flow pragma to be stripped, got: {output}"
+    );
+}
+
+#[test]
+fn strips_flow_strict_pragma() {
+    let output = transform("// @flow strict\nconst value: number = 1;\n");
+    assert!(
+        !output.contains("@flow"),
+        "expected `@flow strict` pragma to be stripped, got: {output}"
+    );
+}
+
+#[test]
+fn strips_noflow_pragma() {
+    let output = transform("// @noflow\nconst value = 1;\n");
+    assert!(
+        !output.contains("@noflow"),
+        "expected @noflow pragma to be stripped, got: {output}"
+    );
+}
+
+#[test]
+fn preserves_unrelated_leading_comment() {
+    let output = transform("// Copyright 2026\n// @flow\nconst value: number = 1;\n");
+    assert!(
+        !output.contains("@flow"),
+        "expected @flow pragma to be stripped, got: {output}"
+    );
+    assert!(
+        output.contains("Copyright 2026"),
+        "expected unrelated comment to be preserved, got: {output}"
+    );
+}
+
+#[test]
+fn preserves_copyright_banner_alongside_pragma() {
+    let source = "/**\n * Copyright 2024 Example Corp\n *\n * @flow\n * @format\n */\nconst \
+                  value: number = 1;\n";
+    let output = transform(source);
+    assert!(
+        !output.contains("@flow"),
+        "expected @flow pragma to be stripped, got: {output}"
+    );
+    assert!(
+        output.contains("Copyright 2024 Example Corp"),
+        "expected copyright banner to be preserved, got: {output}"
+    );
+    assert!(
+        output.contains("@format"),
+        "expected unrelated annotation to be preserved, got: {output}"
+    );
+}
+
+#[test]
+fn preserves_lookalike_comment() {
+    let output = transform("// see @flowtype documentation\nconst value = 1;\n");
+    assert!(
+        output.contains("see @flowtype documentation"),
+        "expected @flowtype lookalike comment to be preserved, got: {output}"
+    );
+}
+
+#[test]
+fn strips_pragma_under_shebang() {
+    let input = "#!/usr/bin/env node\n// @flow\nconst value: number = 1;\n";
+    let output = transform(input);
+    assert!(
+        !output.contains("@flow"),
+        "expected @flow pragma to be stripped under a shebang, got: {output}"
+    );
+}


### PR DESCRIPTION
**Description:** When debugging some other issues I noticed that the flow pragma comments were retained after flow stripping. While technically regular JS can be parsed as flow, it still seems incorrect and I noticed some edge cases where some JS comments caused flow parser to trip up trying to parse them as types. This PR changes this behaviour to strip flow pragma either in its entirety or if multiline only the pragma itself, making it align with the existing [babel transform](https://babeljs.io/repl#?config_lz=N4IgZglgNgpgdgQwLYxALhAJxgBygOgCsBnEAGhB22JgBdS0BtRkeAN3NFoUwHM6GIACYwwCAK5R6ZAARwA9rRkQYMgIxrZCpSoD6SeQCN1a8iANDJMBmKg0Kh8b0gAPa-lqZxMAL4BdMhZibn4AWgAmTmEYAGN5TARaeOIANRhMYgh5OHQQcIAGcIBmUI0zHAgcGCgIOBgABUx5HHliBChcgAsEGIBrEH8KMCh5AHcQAJBieXFMGJgAFQBPKtyLKwGgA&code_lz=PQKhAIChwgZB7ANtCLwAEBmj4HdwDOALgE4CWAxkTMJEA&lineWrap=true&version=7.29.2)

**BREAKING CHANGE:** No.

**Related issue (if exists):** None
