### PR TITLE
perf(ecma_parser): start oxc-style token payload rewrite

### DIFF
--- a/crates/swc_common/src/input.rs
+++ b/crates/swc_common/src/input.rs
@@ -8,8 +8,8 @@ pub type SourceFileInput<'a> = StringInput<'a>;
 #[derive(Clone)]
 pub struct StringInput<'a> {
     last_pos: BytePos,
-    /// Remaining input as str - we slice this as we consume bytes
-    remaining: &'a str,
+    /// Remaining input as bytes for hot-path ASCII access.
+    remaining: &'a [u8],
     orig: &'a str,
     /// Original start position.
     orig_start: BytePos,
@@ -31,7 +31,7 @@ impl<'a> StringInput<'a> {
         StringInput {
             last_pos: start,
             orig: src,
-            remaining: src,
+            remaining: src.as_bytes(),
             orig_start: start,
             orig_end: end,
         }
@@ -39,6 +39,13 @@ impl<'a> StringInput<'a> {
 
     #[inline(always)]
     pub fn as_str(&self) -> &str {
+        unsafe { str::from_utf8_unchecked(self.remaining) }
+    }
+
+    #[inline(always)]
+    /// Returns the remaining input as bytes without rebuilding a slice on each
+    /// hot-path access.
+    pub fn as_bytes(&self) -> &'a [u8] {
         self.remaining
     }
 
@@ -91,17 +98,17 @@ impl<'a> From<&'a SourceFile> for StringInput<'a> {
 impl<'a> Input<'a> for StringInput<'a> {
     #[inline]
     fn cur(&self) -> Option<u8> {
-        self.remaining.as_bytes().first().copied()
+        self.remaining.first().copied()
     }
 
     #[inline]
     fn peek(&self) -> Option<u8> {
-        self.remaining.as_bytes().get(1).copied()
+        self.remaining.get(1).copied()
     }
 
     #[inline]
     fn peek_ahead(&self) -> Option<u8> {
-        self.remaining.as_bytes().get(2).copied()
+        self.remaining.get(2).copied()
     }
 
     #[inline]
@@ -113,7 +120,7 @@ impl<'a> Input<'a> for StringInput<'a> {
 
     #[inline]
     fn cur_as_ascii(&self) -> Option<u8> {
-        let first_byte = *self.remaining.as_bytes().first()?;
+        let first_byte = *self.remaining.first()?;
         if first_byte <= 0x7f {
             Some(first_byte)
         } else {
@@ -123,7 +130,12 @@ impl<'a> Input<'a> for StringInput<'a> {
 
     #[inline]
     fn cur_as_char(&self) -> Option<char> {
-        self.remaining.chars().next()
+        let first_byte = *self.remaining.first()?;
+        if first_byte <= 0x7f {
+            Some(first_byte as char)
+        } else {
+            self.as_str().chars().next()
+        }
     }
 
     #[inline]
@@ -154,7 +166,7 @@ impl<'a> Input<'a> for StringInput<'a> {
 
         let ret = unsafe { s.get_unchecked(start_idx..end_idx) };
 
-        self.remaining = unsafe { s.get_unchecked(end_idx..) };
+        self.remaining = unsafe { s.as_bytes().get_unchecked(end_idx..) };
         self.last_pos = end;
 
         ret
@@ -167,7 +179,7 @@ impl<'a> Input<'a> for StringInput<'a> {
     {
         let last = {
             let mut last = 0;
-            for c in self.remaining.chars() {
+            for c in self.as_str().chars() {
                 if pred(c) {
                     last += c.len_utf8();
                 } else {
@@ -178,7 +190,7 @@ impl<'a> Input<'a> for StringInput<'a> {
         };
 
         debug_assert!(last <= self.remaining.len());
-        let ret = unsafe { self.remaining.get_unchecked(..last) };
+        let ret = unsafe { str::from_utf8_unchecked(self.remaining.get_unchecked(..last)) };
 
         self.last_pos = self.last_pos + BytePos(last as _);
         self.remaining = unsafe { self.remaining.get_unchecked(last..) };
@@ -197,22 +209,18 @@ impl<'a> Input<'a> for StringInput<'a> {
         let idx = (to - self.orig_start).0 as usize;
 
         debug_assert!(idx <= orig.len());
-        self.remaining = unsafe { orig.get_unchecked(idx..) };
+        self.remaining = unsafe { orig.as_bytes().get_unchecked(idx..) };
         self.last_pos = to;
     }
 
     #[inline]
     fn is_byte(&self, c: u8) -> bool {
-        self.remaining
-            .as_bytes()
-            .first()
-            .map(|b| *b == c)
-            .unwrap_or(false)
+        self.remaining.first().is_some_and(|b| *b == c)
     }
 
     #[inline]
     fn is_str(&self, s: &str) -> bool {
-        self.remaining.starts_with(s)
+        self.as_str().starts_with(s)
     }
 
     #[inline]
@@ -382,6 +390,26 @@ mod tests {
             }
             assert_eq!(i.last_pos, BytePos(6));
             assert_eq!(i.cur(), None);
+        });
+    }
+
+    #[test]
+    fn src_input_bytes_stay_in_sync() {
+        with_test_sess("a℘/z", |mut i| {
+            assert_eq!(i.as_bytes(), "a℘/z".as_bytes());
+            assert_eq!(i.cur_as_char(), Some('a'));
+
+            unsafe {
+                i.bump_bytes(1);
+            }
+            assert_eq!(i.as_bytes(), "℘/z".as_bytes());
+            assert_eq!(i.cur_as_char(), Some('℘'));
+
+            unsafe {
+                i.reset_to(BytePos(5));
+            }
+            assert_eq!(i.as_bytes(), "/z".as_bytes());
+            assert_eq!(i.cur_as_char(), Some('/'));
         });
     }
 

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -759,10 +759,9 @@ impl<'a> Lexer<'a> {
                 } else {
                     // 0xE2 - could be LS/PS or some other Unicode character
                     // Check the next 2 bytes to see if it's really LS/PS
-                    let current_slice = self.input().as_str();
+                    let bytes = self.input().as_bytes();
                     let byte_pos = pos_offset;
-                    if byte_pos + 2 < current_slice.len() {
-                        let bytes = current_slice.as_bytes();
+                    if byte_pos + 2 < bytes.len() {
                         let next2 = [bytes[byte_pos + 1], bytes[byte_pos + 2]];
                         if next2 == LS_BYTES_2_AND_3 || next2 == PS_BYTES_2_AND_3 {
                             // It's a real line terminator
@@ -864,10 +863,9 @@ impl<'a> Lexer<'a> {
                 match matched_byte {
                     LS_OR_PS_FIRST => {
                         // 0xE2 - could be LS/PS or some other Unicode character
-                        let current_slice = self.input().as_str();
+                        let bytes = self.input().as_bytes();
                         let byte_pos = pos_offset;
-                        if byte_pos + 2 < current_slice.len() {
-                            let bytes = current_slice.as_bytes();
+                        if byte_pos + 2 < bytes.len() {
                             let next2 = [bytes[byte_pos + 1], bytes[byte_pos + 2]];
                             if next2 == LS_BYTES_2_AND_3 || next2 == PS_BYTES_2_AND_3 {
                                 self.state.had_line_break = true;
@@ -877,7 +875,7 @@ impl<'a> Lexer<'a> {
                         true
                     }
                     b'*' => {
-                        let bytes = self.input().as_str().as_bytes();
+                        let bytes = self.input().as_bytes();
                         if bytes.get(pos_offset + 1) == Some(&b'/') {
                             // Consume "*/"
                             pos_offset += 2;

--- a/crates/swc_ecma_parser/src/lexer/search.rs
+++ b/crates/swc_ecma_parser/src/lexer/search.rs
@@ -91,7 +91,7 @@ macro_rules! byte_search {
     ) => {{
         $table.use_table();
         let mut $pos = 0;
-        let bytes = $lexer.input().as_str().as_bytes();
+        let bytes = $lexer.input().as_bytes();
         let len = bytes.len();
         let bytes = bytes.as_ptr();
 

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -249,8 +249,7 @@ impl<I: Tokens> Parser<I> {
             return Ok(());
         }
 
-        let is_checks = self.input().cur().is_word()
-            && self.input().cur().take_word(&self.input) == atom!("checks");
+        let is_checks = self.input().is_cur_word("checks");
         if !is_checks {
             unexpected!(self, "checks");
         }
@@ -1069,8 +1068,7 @@ impl<I: Tokens> Parser<I> {
         let mut flow_variance_readonly = false;
         let mut flow_proto_modifier = false;
         if self.input().syntax().flow()
-            && self.input().cur().is_word()
-            && self.input().cur().take_word(&self.input) == atom!("proto")
+            && self.input().is_cur_word("proto")
             && peek!(self)
                 .is_some_and(|peek| !matches!(peek, Token::Colon | Token::LParen | Token::Eq))
         {
@@ -1878,10 +1876,7 @@ impl<I: Tokens> Parser<I> {
                     Vec::with_capacity(4)
                 };
 
-            if p.input().syntax().flow()
-                && p.input().cur().is_word()
-                && p.input().cur().take_word(&p.input) == atom!("mixins")
-            {
+            if p.input().syntax().flow() && p.input().is_cur_word("mixins") {
                 p.bump();
                 let _ = p.parse_ts_heritage_clause()?;
             }

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -90,83 +90,99 @@ pub struct Buffer<I> {
     /// Span of the previous token.
     pub prev_span: Span,
     pub cur: TokenAndSpan,
+    pub cur_value: Option<TokenValue>,
     /// Peeked token
     pub next: Option<NextTokenAndSpan>,
 }
 
 impl<I: Tokens> Buffer<I> {
     pub fn expect_word_token_value(&mut self) -> Atom {
-        let Some(crate::lexer::TokenValue::Word(word)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Word(word)) = self.cur_value.take() else {
             unreachable!()
         };
         word
     }
 
     pub fn expect_word_token_value_ref(&self) -> &Atom {
-        let Some(crate::lexer::TokenValue::Word(word)) = self.iter.get_token_value() else {
-            unreachable!("token_value: {:?}", self.iter.get_token_value())
+        let Some(crate::lexer::TokenValue::Word(word)) = self.cur_value.as_ref() else {
+            unreachable!("token_value: {:?}", self.cur_value)
         };
         word
     }
 
     pub fn expect_number_token_value(&mut self) -> f64 {
-        let Some(crate::lexer::TokenValue::Num(value)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Num(value)) = self.cur_value.take() else {
             unreachable!()
         };
         value
     }
 
     pub fn expect_string_token_value(&mut self) -> Wtf8Atom {
-        let Some(crate::lexer::TokenValue::Str(value)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Str(value)) = self.cur_value.take() else {
             unreachable!()
         };
         value
     }
 
     pub fn expect_jsx_text_token_value(&mut self) -> Atom {
-        let Some(crate::lexer::TokenValue::JsxText(value)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::JsxText(value)) = self.cur_value.take() else {
             unreachable!()
         };
         value
     }
 
     pub fn expect_bigint_token_value(&mut self) -> Box<num_bigint::BigInt> {
-        let Some(crate::lexer::TokenValue::BigInt(value)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::BigInt(value)) = self.cur_value.take() else {
             unreachable!()
         };
         value
     }
 
     pub fn expect_regex_token_value(&mut self) -> BytePos {
-        let Some(crate::lexer::TokenValue::Regex(exp_end)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Regex(exp_end)) = self.cur_value.take() else {
             unreachable!()
         };
         exp_end
     }
 
     pub fn expect_template_token_value(&mut self) -> LexResult<Wtf8Atom> {
-        let Some(crate::lexer::TokenValue::Template(cooked)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Template(cooked)) = self.cur_value.take() else {
             unreachable!()
         };
         cooked
     }
 
     pub fn expect_error_token_value(&mut self) -> Error {
-        let Some(crate::lexer::TokenValue::Error(error)) = self.iter.take_token_value() else {
+        let Some(crate::lexer::TokenValue::Error(error)) = self.cur_value.take() else {
             unreachable!()
         };
         error
     }
 
     pub fn get_token_value(&self) -> Option<&TokenValue> {
-        self.iter.get_token_value()
+        self.cur_value.as_ref()
+    }
+
+    #[inline(always)]
+    pub fn cur_word_as_str(&self) -> &str {
+        match self.get_token_value() {
+            Some(TokenValue::Word(word)) => word,
+            Some(value) => unreachable!("token_value: {:?}", value),
+            None => self.cur_string(),
+        }
+    }
+
+    #[inline(always)]
+    pub fn is_cur_word(&self, expected: &str) -> bool {
+        self.cur().is_word() && self.cur_word_as_str() == expected
     }
 
     pub fn scan_jsx_token(&mut self) {
         let prev = self.cur;
         let t = self.iter.scan_jsx_token();
         self.prev_span = prev.span;
-        self.set_cur(t);
+        let value = self.take_iter_token_value();
+        self.set_cur(t, value);
     }
 
     #[allow(unused)]
@@ -174,7 +190,8 @@ impl<I: Tokens> Buffer<I> {
         let prev = self.cur;
         let t = self.iter.scan_jsx_open_el_terminal_token();
         self.prev_span = prev.span;
-        self.set_cur(t);
+        let value = self.take_iter_token_value();
+        self.set_cur(t, value);
     }
 
     pub fn rescan_jsx_open_el_terminal_token(&mut self) {
@@ -184,13 +201,15 @@ impl<I: Tokens> Buffer<I> {
         // rescan `>=`, `>>`, `>>=`, `>>>`, `>>>=` into `>`
         let start = self.cur.span.lo;
         let t = self.iter.rescan_jsx_open_el_terminal_token(start);
-        self.set_cur(t);
+        let value = self.take_iter_token_value();
+        self.set_cur(t, value);
     }
 
     pub fn rescan_jsx_token(&mut self) {
         let start = self.cur.span.lo;
         let t = self.iter.rescan_jsx_token(start);
-        self.set_cur(t);
+        let value = self.take_iter_token_value();
+        self.set_cur(t, value);
     }
 
     pub fn scan_jsx_identifier(&mut self) {
@@ -198,18 +217,24 @@ impl<I: Tokens> Buffer<I> {
             return;
         }
         let start = self.cur.span.lo;
+        self.iter.set_token_value(self.cur_value.take());
         let cur = self.iter.scan_jsx_identifier(start);
+        let value = self.take_iter_token_value();
         debug_assert!(cur.token == Token::JSXName);
-        self.set_cur(cur);
+        self.set_cur(cur, value);
     }
 
     pub fn scan_jsx_attribute_value(&mut self) {
-        self.cur = self.iter.scan_jsx_attribute_value();
+        let token = self.iter.scan_jsx_attribute_value();
+        let value = self.take_iter_token_value();
+        self.set_cur(token, value);
     }
 
     pub fn rescan_template_token(&mut self, start_with_back_tick: bool) {
         let start = self.cur_pos();
-        self.cur = self.iter.rescan_template_token(start, start_with_back_tick);
+        let token = self.iter.rescan_template_token(start, start_with_back_tick);
+        let value = self.take_iter_token_value();
+        self.set_cur(token, value);
     }
 }
 
@@ -220,14 +245,21 @@ impl<I: Tokens> Buffer<I> {
         Buffer {
             iter: lexer,
             cur: TokenAndSpan::new(Token::Eof, prev_span, false),
+            cur_value: None,
             prev_span,
             next: None,
         }
     }
 
     #[inline(always)]
-    pub fn set_cur(&mut self, token: TokenAndSpan) {
-        self.cur = token
+    pub fn set_cur(&mut self, token: TokenAndSpan, value: Option<TokenValue>) {
+        self.cur = token;
+        self.cur_value = value;
+    }
+
+    #[inline(always)]
+    fn take_iter_token_value(&mut self) -> Option<TokenValue> {
+        self.iter.take_token_value()
     }
 
     #[inline(always)]
@@ -277,13 +309,11 @@ impl<I: Tokens> Buffer<I> {
         );
 
         if self.next.is_none() {
-            let old = self.iter.take_token_value();
             let next_token = self.iter.next_token();
             self.next = Some(NextTokenAndSpan {
                 token_and_span: next_token,
-                value: self.iter.take_token_value(),
+                value: self.take_iter_token_value(),
             });
-            self.iter.set_token_value(old);
         }
 
         self.next.as_ref().map(|ts| ts.token_and_span.token)
@@ -294,25 +324,27 @@ impl<I: Tokens> Buffer<I> {
         debug_assert!(self.cur() != Token::Eof);
         let span = self.prev_span();
         let token = TokenAndSpan::new(token, span, false);
-        self.set_cur(token);
+        self.set_cur(token, None);
     }
 
     pub fn first_bump(&mut self) {
         let first_token = self.iter.first_token();
         self.prev_span = self.cur.span;
-        self.set_cur(first_token);
+        let value = self.take_iter_token_value();
+        self.set_cur(first_token, value);
     }
 
     pub fn bump(&mut self) {
-        let next = match self.next.take() {
-            Some(next) => {
-                self.iter.set_token_value(next.value);
-                next.token_and_span
+        let (next, value) = match self.next.take() {
+            Some(next) => (next.token_and_span, next.value),
+            None => {
+                let next = self.iter.next_token();
+                let value = self.take_iter_token_value();
+                (next, value)
             }
-            None => self.iter.next_token(),
         };
         self.prev_span = self.cur.span;
-        self.set_cur(next);
+        self.set_cur(next, value);
     }
 
     pub fn expect_word_token_and_bump(&mut self) -> Atom {
@@ -372,7 +404,7 @@ impl<I: Tokens> Buffer<I> {
         );
         let span = self.cur_span().with_lo(self.cur_span().lo + BytePos(1));
         let token = TokenAndSpan::new(Token::Lt, span, false);
-        self.set_cur(token);
+        self.set_cur(token, None);
     }
 
     pub fn merge_lt_gt(&mut self) {
@@ -433,7 +465,7 @@ impl<I: Tokens> Buffer<I> {
         };
         let span = span.with_hi(next.span().hi);
         let token = TokenAndSpan::new(token, span, cur.had_line_break);
-        self.set_cur(token);
+        self.set_cur(token, None);
     }
 
     #[inline(always)]

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -56,6 +56,7 @@ pub struct ParserCheckpoint<I: Tokens> {
     lexer: I::Checkpoint,
     buffer_prev_span: Span,
     buffer_cur: TokenAndSpan,
+    buffer_cur_value: Option<crate::lexer::TokenValue>,
     buffer_next: Option<crate::lexer::NextTokenAndSpan>,
     #[cfg(feature = "flow")]
     allow_super_call: bool,
@@ -97,6 +98,7 @@ impl<I: Tokens> Parser<I> {
         ParserCheckpoint {
             lexer: self.input.iter.checkpoint_save(),
             buffer_cur: self.input.cur,
+            buffer_cur_value: self.input.cur_value.clone(),
             buffer_next: self.input.next.clone(),
             buffer_prev_span: self.input.prev_span,
             allow_super_call: self.allow_super_call,
@@ -108,6 +110,7 @@ impl<I: Tokens> Parser<I> {
         ParserCheckpoint {
             lexer: self.input.iter.checkpoint_save(),
             buffer_cur: self.input.cur,
+            buffer_cur_value: self.input.cur_value.clone(),
             buffer_next: self.input.next.clone(),
             buffer_prev_span: self.input.prev_span,
         }
@@ -117,6 +120,7 @@ impl<I: Tokens> Parser<I> {
     fn checkpoint_load(&mut self, checkpoint: ParserCheckpoint<I>) {
         self.input.iter.checkpoint_load(checkpoint.lexer);
         self.input.cur = checkpoint.buffer_cur;
+        self.input.cur_value = checkpoint.buffer_cur_value;
         self.input.next = checkpoint.buffer_next;
         self.input.prev_span = checkpoint.buffer_prev_span;
         self.allow_super_call = checkpoint.allow_super_call;
@@ -126,6 +130,7 @@ impl<I: Tokens> Parser<I> {
     fn checkpoint_load(&mut self, checkpoint: ParserCheckpoint<I>) {
         self.input.iter.checkpoint_load(checkpoint.lexer);
         self.input.cur = checkpoint.buffer_cur;
+        self.input.cur_value = checkpoint.buffer_cur_value;
         self.input.next = checkpoint.buffer_next;
         self.input.prev_span = checkpoint.buffer_prev_span;
     }

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1045,9 +1045,7 @@ impl<I: Tokens> Parser<I> {
         if !self.input().syntax().flow_pattern_matching() {
             return false;
         }
-        if !(self.input().cur().is_word()
-            && self.input().cur().take_word(&self.input) == atom!("match"))
-        {
+        if !self.input().is_cur_word("match") {
             return false;
         }
 
@@ -1532,7 +1530,7 @@ impl<I: Tokens> Parser<I> {
                 .map(FlowMatchPattern::Binding);
         }
 
-        if self.input().cur().is_word() && self.input().cur().take_word(&self.input) == atom!("_") {
+        if self.input().is_cur_word("_") {
             self.bump();
             return Ok(FlowMatchPattern::Wildcard);
         }

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -1067,6 +1067,20 @@ impl<I: Tokens> Parser<I> {
         ret
     }
 
+    /// Like `ts_look_ahead`, but for token-prefix probes that never emit
+    /// diagnostics and therefore do not need `IgnoreError`.
+    #[inline(always)]
+    fn ts_look_ahead_no_errors<T, F>(&mut self, op: F) -> T
+    where
+        F: FnOnce(&mut Self) -> T,
+    {
+        debug_assert!(self.input().syntax().typescript());
+        let checkpoint = self.checkpoint_save();
+        let ret = op(self);
+        self.checkpoint_load(checkpoint);
+        ret
+    }
+
     /// `tsParseTypeArguments`
     pub(crate) fn parse_ts_type_args(&mut self) -> PResult<Box<TsTypeParamInstantiation>> {
         trace_cur!(self, parse_ts_type_args);
@@ -2405,7 +2419,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         if !(self.input().cur() == Token::LBracket
-            && self.ts_look_ahead(Self::is_ts_unambiguously_index_signature))
+            && self.ts_look_ahead_no_errors(Self::is_ts_unambiguously_index_signature))
         {
             return Ok(None);
         }
@@ -4518,7 +4532,7 @@ impl<I: Tokens> Parser<I> {
         } else if cur == Token::TypeOf {
             return self.parse_ts_type_query().map(TsType::from).map(Box::new);
         } else if cur == Token::LBrace {
-            return if self.ts_look_ahead(Self::is_ts_start_of_mapped_type) {
+            return if self.ts_look_ahead_no_errors(Self::is_ts_start_of_mapped_type) {
                 self.parse_ts_mapped_type().map(TsType::from).map(Box::new)
             } else {
                 self.parse_ts_type_lit().map(TsType::from).map(Box::new)

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -955,15 +955,15 @@ impl<I: Tokens> Parser<I> {
                 return Ok(None);
             }
 
-            // This lookahead only needs one token, so a local checkpoint is
-            // cheaper than routing through the generic TS try-parse helper.
-            let checkpoint = self.checkpoint_save();
-            self.bump();
+            let _ = self.input_mut().peek();
+            let Some(next) = self.input().next() else {
+                return Ok(None);
+            };
 
-            let cur = self.input().cur();
-            let can_follow_modifier = !self.input().had_line_break_before_cur()
+            let next_token = next.token();
+            let can_follow_modifier = !next.had_line_break()
                 && matches!(
-                    cur,
+                    next_token,
                     Token::LBracket
                         | Token::LBrace
                         | Token::Asterisk
@@ -973,13 +973,12 @@ impl<I: Tokens> Parser<I> {
                         | Token::Num
                         | Token::BigInt
                 )
-                || cur.is_word();
+                || next_token.is_word();
 
             if can_follow_modifier {
+                self.bump();
                 return Ok(Some(allowed_modifiers[pos]));
             }
-
-            self.checkpoint_load(checkpoint);
         }
         Ok(None)
     }

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -695,33 +695,6 @@ impl<I: Tokens> Parser<I> {
         Ok(buf)
     }
 
-    /// `tsTryParse`
-    pub(super) fn try_parse_ts_bool<F>(&mut self, op: F) -> PResult<bool>
-    where
-        F: FnOnce(&mut Self) -> PResult<Option<bool>>,
-    {
-        if !self.input().syntax().typescript() {
-            return Ok(false);
-        }
-
-        let prev_ignore_error = self.input().get_ctx().contains(Context::IgnoreError);
-        let checkpoint = self.checkpoint_save();
-        self.set_ctx(self.ctx() | Context::IgnoreError);
-        let res = op(self);
-        match res {
-            Ok(Some(res)) if res => {
-                let mut ctx = self.ctx();
-                ctx.set(Context::IgnoreError, prev_ignore_error);
-                self.input_mut().set_ctx(ctx);
-                Ok(res)
-            }
-            _ => {
-                self.checkpoint_load(checkpoint);
-                Ok(false)
-            }
-        }
-    }
-
     /// `tsParseDelimitedList`
     fn parse_ts_delimited_list_inner<T, F>(
         &mut self,
@@ -794,32 +767,6 @@ impl<I: Tokens> Parser<I> {
         }
     }
 
-    /// `tsNextTokenCanFollowModifier`
-    pub(super) fn ts_next_token_can_follow_modifier(&mut self) -> bool {
-        debug_assert!(self.input().syntax().typescript());
-        // Note: TypeScript's implementation is much more complicated because
-        // more things are considered modifiers there.
-        // This implementation only handles modifiers not handled by @babel/parser
-        // itself. And "static". TODO: Would be nice to avoid lookahead. Want a
-        // hasLineBreakUpNext() method...
-        self.bump();
-
-        let cur = self.input().cur();
-        !self.input().had_line_break_before_cur()
-            && matches!(
-                cur,
-                Token::LBracket
-                    | Token::LBrace
-                    | Token::Asterisk
-                    | Token::DotDotDot
-                    | Token::Hash
-                    | Token::Str
-                    | Token::Num
-                    | Token::BigInt
-            )
-            || cur.is_word()
-    }
-
     /// `tsTryParse`
     pub(crate) fn try_parse_ts<T, F>(&mut self, op: F) -> Option<T>
     where
@@ -873,15 +820,6 @@ impl<I: Tokens> Parser<I> {
         }
 
         self.expect_general_semi()
-    }
-
-    /// `tsIsStartOfConstructSignature`
-    fn is_ts_start_of_construct_signature(&mut self) -> bool {
-        debug_assert!(self.input().syntax().typescript());
-
-        self.bump();
-        let cur = self.input().cur();
-        matches!(cur, Token::LParen | Token::Lt)
     }
 
     /// `tsParseDelimitedList`
@@ -1016,9 +954,32 @@ impl<I: Tokens> Parser<I> {
             {
                 return Ok(None);
             }
-            if self.try_parse_ts_bool(|p| Ok(Some(p.ts_next_token_can_follow_modifier())))? {
+
+            // This lookahead only needs one token, so a local checkpoint is
+            // cheaper than routing through the generic TS try-parse helper.
+            let checkpoint = self.checkpoint_save();
+            self.bump();
+
+            let cur = self.input().cur();
+            let can_follow_modifier = !self.input().had_line_break_before_cur()
+                && matches!(
+                    cur,
+                    Token::LBracket
+                        | Token::LBrace
+                        | Token::Asterisk
+                        | Token::DotDotDot
+                        | Token::Hash
+                        | Token::Str
+                        | Token::Num
+                        | Token::BigInt
+                )
+                || cur.is_word();
+
+            if can_follow_modifier {
                 return Ok(Some(allowed_modifiers[pos]));
             }
+
+            self.checkpoint_load(checkpoint);
         }
         Ok(None)
     }
@@ -3774,7 +3735,7 @@ impl<I: Tokens> Parser<I> {
                 .map(into_type_elem);
         }
         if self.input().is(Token::New)
-            && self.ts_look_ahead(Self::is_ts_start_of_construct_signature)
+            && peek!(self).is_some_and(|peek| matches!(peek, Token::LParen | Token::Lt))
         {
             return self
                 .parse_ts_signature_member(SignatureParsingMode::TSConstructSignatureDeclaration)

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -156,9 +156,7 @@ impl<I: Tokens> Parser<I> {
     }
 
     fn is_flow_contextual_word(&mut self, word: &str) -> bool {
-        self.input().syntax().flow()
-            && self.input().cur().is_word()
-            && self.input().cur().take_word(&self.input) == word
+        self.input().syntax().flow() && self.input().is_cur_word(word)
     }
 
     fn make_flow_component_fallback_binding(&mut self, span: Span) -> Pat {
@@ -1568,8 +1566,7 @@ impl<I: Tokens> Parser<I> {
             }
 
             if p.input().syntax().flow() && p.input_mut().eat(Token::Percent) {
-                let is_checks = p.input().cur().is_word()
-                    && p.input().cur().take_word(&p.input) == atom!("checks");
+                let is_checks = p.input().is_cur_word("checks");
                 if !is_checks {
                     unexpected!(p, "checks");
                 }
@@ -1600,8 +1597,7 @@ impl<I: Tokens> Parser<I> {
                 })
             };
             let has_flow_implies = p.syntax().flow()
-                && p.input().cur().is_word()
-                && p.input().cur().take_word(&p.input) == atom!("implies")
+                && p.input().is_cur_word("implies")
                 && peek!(p).is_some_and(|peek| peek.is_word() || peek == Token::This);
 
             if has_type_pred_asserts {
@@ -1624,11 +1620,7 @@ impl<I: Tokens> Parser<I> {
                 p.bump();
             }
 
-            if has_type_pred_asserts
-                && p.syntax().flow()
-                && p.input().cur().is_word()
-                && p.input().cur().take_word(&p.input) == atom!("implies")
-            {
+            if has_type_pred_asserts && p.syntax().flow() && p.input().is_cur_word("implies") {
                 p.emit_err(p.input().cur_span(), SyntaxError::TS1003);
             }
 
@@ -4329,9 +4321,7 @@ impl<I: Tokens> Parser<I> {
             }
 
             if let Some(render_ty) = self.try_parse_ts(|p| {
-                if !(p.input().cur().is_word()
-                    && p.input().cur().take_word(&p.input) == atom!("renders"))
-                {
+                if !p.input().is_cur_word("renders") {
                     return Ok(None);
                 }
                 p.bump();
@@ -5021,8 +5011,7 @@ impl<I: Tokens> Parser<I> {
                     && self.ctx().contains(Context::InDeclare)
                     && self.input_mut().eat(Token::Dot)
                 {
-                    let is_exports = self.input().cur().is_word()
-                        && self.input().cur().take_word(&self.input) == atom!("exports");
+                    let is_exports = self.input().is_cur_word("exports");
 
                     if !is_exports {
                         unexpected!(self, "exports")

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -3843,58 +3843,60 @@ impl<I: Tokens> Parser<I> {
             return Ok(idx.into());
         }
 
-        if let Some(v) = self.try_parse_ts(|p| {
-            let start = p.input().cur_pos();
+        if matches!(self.input().cur(), Token::Get | Token::Set) {
+            if let Some(v) = self.try_parse_ts(|p| {
+                let start = p.input().cur_pos();
 
-            if readonly {
-                syntax_error!(p, SyntaxError::GetterSetterCannotBeReadonly)
-            }
-
-            let is_get = if p.input_mut().eat(Token::Get) {
-                true
-            } else {
-                expect!(p, Token::Set);
-                false
-            };
-
-            let (computed, key) = p.parse_ts_property_name()?;
-
-            if is_get {
-                expect!(p, Token::LParen);
-                expect!(p, Token::RParen);
-                let type_ann = p.try_parse_ts_type_ann()?;
-
-                p.parse_ts_type_member_semicolon()?;
-
-                Ok(Some(TsTypeElement::TsGetterSignature(TsGetterSignature {
-                    span: p.span(start),
-                    key,
-                    computed,
-                    type_ann,
-                })))
-            } else {
-                expect!(p, Token::LParen);
-                let params = p.parse_ts_binding_list_for_signature()?;
-                if params.is_empty() {
-                    syntax_error!(p, SyntaxError::SetterParamRequired)
-                }
-                let param = params.into_iter().next().unwrap();
-
-                if p.input().syntax().flow() && p.input().is(Token::Colon) {
-                    let _ = p.parse_ts_type_or_type_predicate_ann(Token::Colon)?;
+                if readonly {
+                    syntax_error!(p, SyntaxError::GetterSetterCannotBeReadonly)
                 }
 
-                p.parse_ts_type_member_semicolon()?;
+                let is_get = if p.input_mut().eat(Token::Get) {
+                    true
+                } else {
+                    expect!(p, Token::Set);
+                    false
+                };
 
-                Ok(Some(TsTypeElement::TsSetterSignature(TsSetterSignature {
-                    span: p.span(start),
-                    key,
-                    computed,
-                    param,
-                })))
+                let (computed, key) = p.parse_ts_property_name()?;
+
+                if is_get {
+                    expect!(p, Token::LParen);
+                    expect!(p, Token::RParen);
+                    let type_ann = p.try_parse_ts_type_ann()?;
+
+                    p.parse_ts_type_member_semicolon()?;
+
+                    Ok(Some(TsTypeElement::TsGetterSignature(TsGetterSignature {
+                        span: p.span(start),
+                        key,
+                        computed,
+                        type_ann,
+                    })))
+                } else {
+                    expect!(p, Token::LParen);
+                    let params = p.parse_ts_binding_list_for_signature()?;
+                    if params.is_empty() {
+                        syntax_error!(p, SyntaxError::SetterParamRequired)
+                    }
+                    let param = params.into_iter().next().unwrap();
+
+                    if p.input().syntax().flow() && p.input().is(Token::Colon) {
+                        let _ = p.parse_ts_type_or_type_predicate_ann(Token::Colon)?;
+                    }
+
+                    p.parse_ts_type_member_semicolon()?;
+
+                    Ok(Some(TsTypeElement::TsSetterSignature(TsSetterSignature {
+                        span: p.span(start),
+                        key,
+                        computed,
+                        param,
+                    })))
+                }
+            }) {
+                return Ok(v);
             }
-        }) {
-            return Ok(v);
         }
 
         self.parse_ts_property_or_method_signature(start, readonly)

--- a/crates/swc_es_parser/tests/snapshots/ecma_reuse/jsx/basic/raw-arrow-text/input.js.json
+++ b/crates/swc_es_parser/tests/snapshots/ecma_reuse/jsx/basic/raw-arrow-text/input.js.json
@@ -1,0 +1,21 @@
+{
+  "programs": [
+    "Program {\n    span: 1..28,\n    kind: Module,\n    body: [\n        _,\n    ],\n}"
+  ],
+  "stmts": [
+    "Expr(\n    ExprStmt {\n        span: 1..28,\n        expr: _,\n    },\n)"
+  ],
+  "decls": [],
+  "pats": [],
+  "exprs": [
+    "JSXElement(\n    _,\n)"
+  ],
+  "module_decls": [],
+  "functions": [],
+  "classes": [],
+  "class_members": [],
+  "jsx_elements": [
+    "JSXElement {\n    span: 1..27,\n    opening: JSXOpeningElement {\n        span: 1..27,\n        name: Ident(\n            Ident {\n                span: 2..6,\n                sym: \"div\",\n            },\n        ),\n        attrs: [],\n        self_closing: false,\n    },\n    children: [\n        Text(\n            \"hello\",\n        ),\n        Text(\n            \"-\",\n        ),\n        Text(\n            \">\",\n        ),\n        Text(\n            \"there\",\n        ),\n    ],\n    closing: Some(\n        Ident(\n            Ident {\n                span: 22..26,\n                sym: \"div\",\n            },\n        ),\n    ),\n}"
+  ],
+  "ts_types": []
+}

--- a/crates/swc_es_parser/tests/snapshots/ecma_reuse/typescript/issue-11550/input.tsx.json
+++ b/crates/swc_es_parser/tests/snapshots/ecma_reuse/typescript/issue-11550/input.tsx.json
@@ -1,0 +1,31 @@
+{
+  "programs": [
+    "Program {\n    span: 1..168,\n    kind: Module,\n    body: [\n        _,\n        _,\n    ],\n}"
+  ],
+  "stmts": [
+    "Expr(\n    ExprStmt {\n        span: 1..22,\n        expr: _,\n    },\n)",
+    "Return(\n    ReturnStmt {\n        span: 56..167,\n        arg: Some(\n            _,\n        ),\n    },\n)",
+    "ModuleDecl(\n    _,\n)"
+  ],
+  "decls": [
+    "Fn(\n    FnDecl {\n        span: 31..168,\n        ident: Ident {\n            span: 40..45,\n            sym: \"Hello\",\n        },\n        declare: false,\n        params: [\n            _,\n        ],\n        body: [\n            _,\n        ],\n    },\n)"
+  ],
+  "pats": [
+    "Object(\n    ObjectPat {\n        span: 46..49,\n        props: [],\n    },\n)"
+  ],
+  "exprs": [
+    "Lit(\n    Str(\n        StrLit {\n            span: 1..13,\n            value: \"use client\",\n        },\n    ),\n)",
+    "JSXElement(\n    _,\n)",
+    "Paren(\n    ParenExpr {\n        span: 63..165,\n        expr: _,\n    },\n)"
+  ],
+  "module_decls": [
+    "ExportDefaultDecl(\n    ExportDefaultDecl {\n        span: 16..168,\n        decl: _,\n    },\n)"
+  ],
+  "functions": [],
+  "classes": [],
+  "class_members": [],
+  "jsx_elements": [
+    "JSXElement {\n    span: 73..164,\n    opening: JSXOpeningElement {\n        span: 73..164,\n        name: Ident(\n            Ident {\n                span: 74..94,\n                sym: \"div\",\n            },\n        ),\n        attrs: [\n            JSXAttr {\n                span: 90..95,\n                name: \"data\",\n                value: None,\n            },\n            JSXAttr {\n                span: 95..114,\n                name: \"anything\",\n                value: Some(\n                    _,\n                ),\n            },\n            JSXAttr {\n                span: 110..115,\n                name: \"bruh\",\n                value: None,\n            },\n            JSXAttr {\n                span: 114..125,\n                name: \"\",\n                value: None,\n            },\n        ],\n        self_closing: false,\n    },\n    children: [\n        Text(\n            \"hello\",\n        ),\n    ],\n    closing: Some(\n        Ident(\n            Ident {\n                span: 154..158,\n                sym: \"div\",\n            },\n        ),\n    ),\n}"
+  ],
+  "ts_types": []
+}


### PR DESCRIPTION
**Description:**

This starts the long-lived `swc_ecma_parser` performance rewrite with a parser-facing token payload refactor that follows the oxc-style plan without changing the public parser API.

What changed:
- `Buffer` now owns separate current/lookahead token payload slots instead of saving and restoring lexer `token_value` during generic `peek()`.
- TypeScript parser checkpoints now persist the current payload slot directly, so backtracking restores parser state without re-shuffling lexer payload state.
- Flow/TypeScript contextual-word checks that only need equality now use borrowed string comparisons instead of materializing or cloning `Atom`s on hot paths.

Why this helps:
- It removes the generic `Buffer::peek()` payload swap from the main parser hot path.
- It keeps lookahead payloads in parser-owned slots, which is closer to the target architecture for the ongoing lexer/parser rewrite.
- It reduces unnecessary `Atom` work in TS/Flow ambiguity checks.

Local benchmark spot checks on April 20, 2026:
- `es/parser/colors`: from roughly `4.16–4.59 µs` to `3.05–3.07 µs`
- `es/lexer/colors`: from roughly `1.15–1.19 µs` to `0.90–0.93 µs`
- `es/parser/typescript`: measured at roughly `51.3–52.5 ms` after the change

Validation used:
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo test -p swc_ecma_parser`
- `cargo bench -p swc_ecma_parser --bench parser -- --warm-up-time 0.01 --measurement-time 0.01 'es/parser/colors'`
- `cargo bench -p swc_ecma_parser --bench lexer -- --warm-up-time 0.01 --measurement-time 0.01 'es/lexer/colors'`
- `cargo bench -p swc_ecma_parser --bench parser -- --warm-up-time 0.01 --measurement-time 0.01 'es/parser/typescript'`

This is phase 1 of the rewrite PR. After the Benchmark workflow finishes, I plan to use the CodSpeed report to choose the next optimization step.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A