### PR TITLE
[codex] Fix Flow type-only modules in script transforms

### DIFF
--- a/.changeset/popular-zoos-begin.md
+++ b/.changeset/popular-zoos-begin.md
@@ -1,0 +1,6 @@
+---
+swc: major
+swc_ecma_transforms_typescript: patch
+---
+
+[codex] Fix Flow type-only modules in script transforms

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -263,7 +263,7 @@ impl Options {
         &self,
         cm: &Arc<SourceMap>,
         base: &FileName,
-        parse: impl FnOnce(Syntax, EsVersion, IsModule) -> Result<Program, Error>,
+        parse: impl FnOnce(Syntax, EsVersion, IsModule) -> Result<(Program, bool), Error>,
         output_path: Option<&Path>,
         source_root: Option<String>,
         source_file_name: Option<String>,
@@ -332,7 +332,7 @@ impl Options {
 
         let syntax = syntax.unwrap_or_default();
 
-        let mut program = parse(syntax, es_version, is_module)?;
+        let (mut program, flow_strip_script_like_module) = parse(syntax, es_version, is_module)?;
 
         let mut transform = transform.into_inner().unwrap_or_default();
 
@@ -352,7 +352,7 @@ impl Options {
             syntax.typescript(),
         ));
 
-        let default_top_level = program.is_module();
+        let default_top_level = program.is_module() && !flow_strip_script_like_module;
 
         js_minify = js_minify.map(|mut c| {
             let compress = c
@@ -981,6 +981,7 @@ impl Options {
                 .into_bool(),
             emit_source_map_scopes: experimental.emit_source_map_scopes.into_bool(),
             codegen_inline_script,
+            flow_strip_script_like_module,
             emit_isolated_dts: experimental.emit_isolated_dts.into_bool(),
             unresolved_mark,
             #[cfg(feature = "module")]
@@ -1296,6 +1297,7 @@ pub struct BuiltInput<P: Pass> {
     pub emit_assert_for_import_attributes: bool,
     pub emit_source_map_scopes: bool,
     pub codegen_inline_script: bool,
+    pub flow_strip_script_like_module: bool,
 
     pub emit_isolated_dts: bool,
     pub unresolved_mark: Mark,
@@ -1333,6 +1335,7 @@ where
             emit_assert_for_import_attributes: self.emit_assert_for_import_attributes,
             emit_source_map_scopes: self.emit_source_map_scopes,
             codegen_inline_script: self.codegen_inline_script,
+            flow_strip_script_like_module: self.flow_strip_script_like_module,
             emit_isolated_dts: self.emit_isolated_dts,
             unresolved_mark: self.unresolved_mark,
             #[cfg(feature = "module")]

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -129,19 +129,24 @@ use jsonc_parser::{parse_to_serde_value, ParseOptions};
 use once_cell::sync::Lazy;
 use serde_json::error::Category;
 use swc_common::{
-    comments::Comments, errors::Handler, sync::Lrc, FileName, Mark, SourceFile, SourceMap, Spanned,
-    GLOBALS,
+    comments::Comments, errors::Handler, sync::Lrc, FileName, Mark, SourceFile, SourceMap, Span,
+    Spanned, GLOBALS,
 };
 pub use swc_compiler_base::{PrintArgs, TransformOutput};
 pub use swc_config::types::{BoolConfig, BoolOr, BoolOrDataConfig};
-use swc_ecma_ast::{noop_pass, EsVersion, Pass, Program};
+use swc_ecma_ast::{
+    noop_pass, Decl, DefaultDecl, EsVersion, Module, ModuleDecl, ModuleItem, Pass, Program, Script,
+    TsNamespaceBody,
+};
 use swc_ecma_codegen::Node;
 #[cfg(feature = "module")]
 use swc_ecma_loader::resolvers::{
     lru::CachingResolver, node::NodeModulesResolver, tsc::TsConfigResolver,
 };
 use swc_ecma_minifier::option::{MangleCache, MinifyOptions, TopLevelOptions};
-use swc_ecma_parser::{EsSyntax, Syntax};
+use swc_ecma_parser::{
+    error::SyntaxError, parse_file_as_program, parse_file_as_script, EsSyntax, Syntax,
+};
 use swc_ecma_transforms::{
     fixer,
     helpers::{self, Helpers},
@@ -214,6 +219,181 @@ pub mod resolver {
 type SwcImportResolver = Arc<
     NodeImportResolver<CachingResolver<TsConfigResolver<CachingResolver<NodeModulesResolver>>>>,
 >;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FlowScriptLikeModuleKind {
+    Script,
+    TypeOnlyModule,
+    RuntimeModule(Span),
+}
+
+fn emit_parser_recoverable_errors(
+    handler: &Handler,
+    errors: Vec<swc_ecma_parser::error::Error>,
+) -> Result<(), Error> {
+    if errors.is_empty() {
+        return Ok(());
+    }
+
+    for error in errors {
+        error.into_diagnostic(handler).emit();
+    }
+
+    Err(Error::msg("Syntax Error"))
+}
+
+fn classify_flow_script_like_module(program: &Program) -> FlowScriptLikeModuleKind {
+    let Program::Module(module) = program else {
+        return FlowScriptLikeModuleKind::Script;
+    };
+
+    classify_flow_script_like_module_body(module)
+}
+
+fn classify_flow_script_like_module_body(module: &Module) -> FlowScriptLikeModuleKind {
+    let mut saw_module_decl = false;
+
+    for module_item in &module.body {
+        let Some(module_decl) = module_item.as_module_decl() else {
+            continue;
+        };
+
+        saw_module_decl = true;
+
+        if is_runtime_module_decl(module_decl) {
+            return FlowScriptLikeModuleKind::RuntimeModule(module_item.span());
+        }
+    }
+
+    if saw_module_decl {
+        FlowScriptLikeModuleKind::TypeOnlyModule
+    } else {
+        let span = module
+            .body
+            .first()
+            .map(Spanned::span)
+            .unwrap_or(module.span);
+        FlowScriptLikeModuleKind::RuntimeModule(span)
+    }
+}
+
+fn downgrade_flow_script_like_module(program: Program) -> Result<Program, Error> {
+    let Program::Module(module) = program else {
+        return Ok(program);
+    };
+
+    if module
+        .body
+        .iter()
+        .any(|module_item| matches!(module_item, ModuleItem::ModuleDecl(..)))
+    {
+        bail!(
+            "failed to downgrade Flow type-only module to script because module declarations \
+             remain after stripping"
+        );
+    }
+
+    let Module {
+        span,
+        body,
+        shebang,
+    } = module;
+
+    let body = body
+        .into_iter()
+        .map(|module_item| match module_item {
+            ModuleItem::Stmt(stmt) => Ok(stmt),
+            ModuleItem::ModuleDecl(..) => bail!(
+                "failed to downgrade Flow type-only module to script because module declarations \
+                 remain after stripping"
+            ),
+        })
+        .collect::<Result<_, Error>>()?;
+
+    Ok(Program::Script(Script {
+        span,
+        body,
+        shebang,
+    }))
+}
+
+fn is_runtime_module_decl(module_decl: &ModuleDecl) -> bool {
+    match module_decl {
+        ModuleDecl::Import(import_decl) => !import_decl.type_only,
+        ModuleDecl::ExportDecl(export_decl) => is_runtime_decl(&export_decl.decl),
+        ModuleDecl::ExportNamed(named_export) => !named_export.type_only,
+        ModuleDecl::ExportDefaultDecl(export_default_decl) => {
+            is_runtime_default_decl(&export_default_decl.decl)
+        }
+        ModuleDecl::ExportDefaultExpr(..) => true,
+        ModuleDecl::ExportAll(export_all) => !export_all.type_only,
+        ModuleDecl::TsImportEquals(ts_import_equals_decl) => !ts_import_equals_decl.is_type_only,
+        ModuleDecl::TsExportAssignment(..) => true,
+        ModuleDecl::TsNamespaceExport(..) => false,
+    }
+}
+
+fn is_runtime_decl(decl: &Decl) -> bool {
+    if is_declare_decl(decl) {
+        return false;
+    }
+
+    match decl {
+        Decl::TsInterface(..) | Decl::TsTypeAlias(..) => false,
+        Decl::Fn(function_decl) => function_decl.function.body.is_some(),
+        Decl::Class(..) | Decl::Var(..) | Decl::Using(..) | Decl::TsEnum(..) => true,
+        Decl::TsModule(ts_module_decl) => ts_module_decl
+            .body
+            .as_ref()
+            .map(is_runtime_namespace_body)
+            .unwrap_or_default(),
+    }
+}
+
+fn is_runtime_default_decl(default_decl: &DefaultDecl) -> bool {
+    match default_decl {
+        DefaultDecl::Class(..) => true,
+        DefaultDecl::Fn(function_expr) => function_expr.function.body.is_some(),
+        DefaultDecl::TsInterfaceDecl(..) => false,
+    }
+}
+
+fn is_runtime_namespace_body(namespace_body: &TsNamespaceBody) -> bool {
+    match namespace_body {
+        TsNamespaceBody::TsModuleBlock(ts_module_block) => {
+            ts_module_block
+                .body
+                .iter()
+                .any(|module_item| match module_item {
+                    ModuleItem::Stmt(stmt) => is_runtime_stmt(stmt),
+                    ModuleItem::ModuleDecl(module_decl) => is_runtime_module_decl(module_decl),
+                })
+        }
+        TsNamespaceBody::TsNamespaceDecl(ts_namespace_decl) => {
+            is_runtime_namespace_body(&ts_namespace_decl.body)
+        }
+    }
+}
+
+fn is_runtime_stmt(stmt: &swc_ecma_ast::Stmt) -> bool {
+    match stmt {
+        swc_ecma_ast::Stmt::Empty(..) => false,
+        swc_ecma_ast::Stmt::Decl(decl) => is_runtime_decl(decl),
+        _ => true,
+    }
+}
+
+fn is_declare_decl(decl: &Decl) -> bool {
+    match decl {
+        Decl::Class(class_decl) => class_decl.declare,
+        Decl::Fn(function_decl) => function_decl.declare,
+        Decl::Var(var_decl) => var_decl.declare,
+        Decl::Using(..) => false,
+        Decl::TsInterface(..) | Decl::TsTypeAlias(..) => true,
+        Decl::TsEnum(ts_enum_decl) => ts_enum_decl.declare,
+        Decl::TsModule(ts_module_decl) => ts_module_decl.declare || ts_module_decl.global,
+    }
+}
 
 /// All methods accept [Handler], which is a storage for errors.
 ///
@@ -444,6 +624,66 @@ impl Compiler {
         )
     }
 
+    fn parse_js_as_transform_input(
+        &self,
+        fm: Arc<SourceFile>,
+        handler: &Handler,
+        target: EsVersion,
+        syntax: Syntax,
+        is_module: IsModule,
+        comments: Option<&dyn Comments>,
+    ) -> Result<(Program, bool), Error> {
+        if !syntax.flow() {
+            return self
+                .parse_js(fm, handler, target, syntax, is_module, comments)
+                .map(|program| (program, false));
+        }
+
+        if matches!(is_module, IsModule::Bool(false)) {
+            let mut errors = Vec::new();
+            match parse_file_as_script(&fm, syntax, target, comments, &mut errors) {
+                Ok(script) => {
+                    emit_parser_recoverable_errors(handler, errors)?;
+                    return Ok((Program::Script(script), false));
+                }
+                Err(err) if matches!(err.kind(), SyntaxError::ImportExportInScript) => {}
+                Err(err) => {
+                    emit_parser_recoverable_errors(handler, errors)?;
+                    err.into_diagnostic(handler).emit();
+                    return Err(Error::msg("Syntax Error"));
+                }
+            }
+
+            let mut errors = Vec::new();
+            let program = parse_file_as_program(&fm, syntax, target, comments, &mut errors)
+                .map_err(|err| {
+                    err.into_diagnostic(handler).emit();
+                    Error::msg("Syntax Error")
+                })?;
+
+            emit_parser_recoverable_errors(handler, errors)?;
+
+            match classify_flow_script_like_module(&program) {
+                FlowScriptLikeModuleKind::Script => Ok((program, false)),
+                FlowScriptLikeModuleKind::TypeOnlyModule => Ok((program, true)),
+                FlowScriptLikeModuleKind::RuntimeModule(span) => {
+                    handler
+                        .struct_span_err(span, &SyntaxError::ImportExportInScript.msg())
+                        .emit();
+                    Err(Error::msg("Syntax Error"))
+                }
+            }
+        } else {
+            let program = self.parse_js(fm, handler, target, syntax, is_module, comments)?;
+            let flow_strip_script_like_module = matches!(
+                classify_flow_script_like_module(&program),
+                FlowScriptLikeModuleKind::TypeOnlyModule
+            ) && matches!(is_module, IsModule::Unknown);
+
+            Ok((program, flow_strip_script_like_module))
+        }
+    }
+
     /// Converts ast node to source string and sourcemap.
     ///
     ///
@@ -629,8 +869,8 @@ impl Compiler {
                 &self.cm,
                 name,
                 move |syntax, target, is_module| match program {
-                    Some(v) => Ok(v),
-                    _ => self.parse_js(
+                    Some(v) => Ok((v, false)),
+                    _ => self.parse_js_as_transform_input(
                         fm.clone(),
                         handler,
                         target,
@@ -1070,6 +1310,12 @@ impl Compiler {
                     })
                 })
             });
+
+            let program = if config.flow_strip_script_like_module {
+                downgrade_flow_script_like_module(program)?
+            } else {
+                program
+            };
 
             if let Some(comments) = &config.comments {
                 swc_compiler_base::minify_file_comments(

--- a/crates/swc_ecma_transforms_typescript/src/typescript.rs
+++ b/crates/swc_ecma_transforms_typescript/src/typescript.rs
@@ -8,7 +8,7 @@ use swc_ecma_transforms_react::{parse_expr_for_jsx, JsxDirectives};
 use swc_ecma_visit::{visit_mut_pass, VisitMut, VisitMutWith};
 
 pub use crate::config::*;
-use crate::{semantic::analyze_program, transform::transform};
+use crate::{retain::IsConcrete, semantic::analyze_program, transform::transform};
 
 macro_rules! static_str {
     ($s:expr) => {
@@ -77,7 +77,14 @@ impl TypeScript {
         n.body
             .iter()
             .rev()
-            .find(|m| m.is_es_module_decl())
+            .find(|module_item| {
+                module_item.as_module_decl().is_some_and(|module_decl| {
+                    match self.config.flow_syntax {
+                        true => module_decl.is_runtime_esm_decl(),
+                        false => module_decl.is_es_module_decl(),
+                    }
+                })
+            })
             .map(Spanned::span)
     }
 
@@ -98,6 +105,7 @@ impl TypeScript {
 
 trait EsModuleDecl {
     fn is_es_module_decl(&self) -> bool;
+    fn is_runtime_esm_decl(&self) -> bool;
 }
 
 impl EsModuleDecl for ModuleDecl {
@@ -119,12 +127,21 @@ impl EsModuleDecl for ModuleDecl {
             _ => panic!("unable to access unknown nodes"),
         }
     }
+
+    fn is_runtime_esm_decl(&self) -> bool {
+        self.is_es_module_decl() && self.is_concrete()
+    }
 }
 
 impl EsModuleDecl for ModuleItem {
     fn is_es_module_decl(&self) -> bool {
         self.as_module_decl()
             .is_some_and(ModuleDecl::is_es_module_decl)
+    }
+
+    fn is_runtime_esm_decl(&self) -> bool {
+        self.as_module_decl()
+            .is_some_and(ModuleDecl::is_runtime_esm_decl)
     }
 }
 

--- a/crates/swc_ecma_transforms_typescript/tests/flow_strip_correctness.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/flow_strip_correctness.rs
@@ -1,6 +1,6 @@
 use std::{fs::File, io::Read, path::PathBuf};
 
-use swc_common::{FileName, Mark};
+use swc_common::{errors::Handler, sync::Lrc, FileName, Mark, SourceFile, SourceMap};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_codegen::to_code_default;
 use swc_ecma_parser::{parse_file_as_program, EsSyntax, FlowSyntax, Syntax};
@@ -15,40 +15,7 @@ fn flow_strip_reparses_as_javascript(input: PathBuf) {
 
     ::testing::run_test(false, |cm, handler| -> Result<(), ()> {
         let fm = cm.load_file(&input).expect("failed to load flow fixture");
-        let mut recovered_errors = Vec::new();
-
-        let program = parse_file_as_program(
-            &fm,
-            Syntax::Flow(flow_syntax),
-            EsVersion::latest(),
-            None,
-            &mut recovered_errors,
-        )
-        .map_err(|err| err.into_diagnostic(handler).emit())?;
-
-        if !recovered_errors.is_empty() {
-            for recovered in recovered_errors {
-                recovered.into_diagnostic(handler).emit();
-            }
-            return Err(());
-        }
-
-        let unresolved_mark = Mark::new();
-        let top_level_mark = Mark::new();
-
-        let program = program
-            .apply(resolver(unresolved_mark, top_level_mark, false))
-            .apply(typescript::typescript(
-                typescript::Config {
-                    flow_syntax: true,
-                    ..Default::default()
-                },
-                unresolved_mark,
-                top_level_mark,
-            ))
-            .apply(fixer(None));
-
-        let output = to_code_default(cm.clone(), None, &program);
+        let output = strip_flow_program(cm.clone(), handler, fm, flow_syntax)?;
 
         assert!(
             !output.contains("__flow_"),
@@ -56,38 +23,123 @@ fn flow_strip_reparses_as_javascript(input: PathBuf) {
             input.display()
         );
 
-        let output_fm = cm.new_source_file(FileName::Anon.into(), output);
-        let mut js_errors = Vec::new();
-
-        parse_file_as_program(
-            &output_fm,
-            Syntax::Es(EsSyntax {
-                jsx: flow_syntax.jsx,
-                decorators: true,
-                decorators_before_export: true,
-                export_default_from: true,
-                import_attributes: true,
-                allow_super_outside_method: true,
-                auto_accessors: true,
-                explicit_resource_management: true,
-                ..Default::default()
-            }),
-            EsVersion::latest(),
-            None,
-            &mut js_errors,
-        )
-        .map_err(|err| err.into_diagnostic(handler).emit())?;
-
-        if !js_errors.is_empty() {
-            for recovered in js_errors {
-                recovered.into_diagnostic(handler).emit();
-            }
-            return Err(());
-        }
+        assert_reparses_as_javascript(cm.clone(), handler, output, flow_syntax)?;
 
         Ok(())
     })
     .expect("failed to run flow strip correctness test");
+}
+
+#[test]
+fn issue_11808_does_not_restore_empty_export_for_flow_type_only_module() {
+    ::testing::run_test(false, |cm, handler| -> Result<(), ()> {
+        let flow_syntax = FlowSyntax {
+            require_directive: true,
+            ..Default::default()
+        };
+        let fm = cm.new_source_file(
+            FileName::Custom("issue-11808.js".into()).into(),
+            "/** @flow strict */\nglobal.ErrorUtils = {};\nexport type ErrorUtilsT = typeof \
+             global.ErrorUtils;\n",
+        );
+
+        let output = strip_flow_program(cm.clone(), handler, fm, flow_syntax)?;
+
+        assert!(
+            output.contains("global.ErrorUtils = {};"),
+            "expected runtime assignment to remain in stripped output, got: {output}"
+        );
+        assert!(
+            !output.contains("export {"),
+            "expected Flow type-only export to be removed without restoring `export {{}}`, got: \
+             {output}"
+        );
+
+        assert_reparses_as_javascript(cm.clone(), handler, output, flow_syntax)?;
+
+        Ok(())
+    })
+    .expect("failed to run flow strip issue-11808 test");
+}
+
+fn strip_flow_program(
+    cm: Lrc<SourceMap>,
+    handler: &Handler,
+    fm: Lrc<SourceFile>,
+    flow_syntax: FlowSyntax,
+) -> Result<String, ()> {
+    let mut recovered_errors = Vec::new();
+
+    let program = parse_file_as_program(
+        &fm,
+        Syntax::Flow(flow_syntax),
+        EsVersion::latest(),
+        None,
+        &mut recovered_errors,
+    )
+    .map_err(|err| err.into_diagnostic(handler).emit())?;
+
+    if !recovered_errors.is_empty() {
+        for recovered in recovered_errors {
+            recovered.into_diagnostic(handler).emit();
+        }
+        return Err(());
+    }
+
+    let unresolved_mark = Mark::new();
+    let top_level_mark = Mark::new();
+
+    let program = program
+        .apply(resolver(unresolved_mark, top_level_mark, false))
+        .apply(typescript::typescript(
+            typescript::Config {
+                flow_syntax: true,
+                ..Default::default()
+            },
+            unresolved_mark,
+            top_level_mark,
+        ))
+        .apply(fixer(None));
+
+    Ok(to_code_default(cm, None, &program))
+}
+
+fn assert_reparses_as_javascript(
+    cm: Lrc<SourceMap>,
+    handler: &Handler,
+    output: String,
+    flow_syntax: FlowSyntax,
+) -> Result<(), ()> {
+    let output_fm = cm.new_source_file(FileName::Anon.into(), output);
+    let mut js_errors = Vec::new();
+
+    parse_file_as_program(
+        &output_fm,
+        Syntax::Es(EsSyntax {
+            jsx: flow_syntax.jsx,
+            decorators: true,
+            decorators_before_export: true,
+            export_default_from: true,
+            import_attributes: true,
+            allow_super_outside_method: true,
+            auto_accessors: true,
+            explicit_resource_management: true,
+            ..Default::default()
+        }),
+        EsVersion::latest(),
+        None,
+        &mut js_errors,
+    )
+    .map_err(|err| err.into_diagnostic(handler).emit())?;
+
+    if !js_errors.is_empty() {
+        for recovered in js_errors {
+            recovered.into_diagnostic(handler).emit();
+        }
+        return Err(());
+    }
+
+    Ok(())
 }
 
 fn load_flow_syntax(config_path: PathBuf, is_jsx: bool) -> FlowSyntax {

--- a/packages/core/__tests__/transform/api_test.js
+++ b/packages/core/__tests__/transform/api_test.js
@@ -140,11 +140,73 @@ it("should respect isModule = false", async () => {
     expect(out.code.trim()).toEqual(`var five = 005;`);
 });
 
+it("should strip Flow type-only exports without restoring empty exports in isModule = unknown", () => {
+    const out = swc.transformSync(
+        `/** @flow strict */
+global.ErrorUtils = {};
+export type ErrorUtilsT = typeof global.ErrorUtils;
+`,
+        {
+            isModule: "unknown",
+            jsc: {
+                parser: {
+                    syntax: "flow",
+                    requireDirective: true,
+                },
+            },
+        }
+    );
+
+    expect(out.code).toContain("global.ErrorUtils = {};");
+    expect(out.code).not.toMatch(/export\s*\{\s*\}/);
+});
+
+it("should strip Flow type-only exports in isModule = false transform mode", () => {
+    const out = swc.transformSync(
+        `/** @flow strict */
+global.ErrorUtils = {};
+export type ErrorUtilsT = typeof global.ErrorUtils;
+`,
+        {
+            isModule: false,
+            jsc: {
+                parser: {
+                    syntax: "flow",
+                    requireDirective: true,
+                },
+            },
+        }
+    );
+
+    expect(out.code).toContain("global.ErrorUtils = {};");
+    expect(out.code).not.toMatch(/export\s*\{\s*\}/);
+});
+
 it("should respect isModule = true", async () => {
     const f = () =>
         swc.transformSync(`const five = 005`, {
             isModule: true,
         });
+    expect(f).toThrowError(/Syntax Error/);
+});
+
+it("should reject runtime Flow exports in isModule = false transform mode", () => {
+    const f = () =>
+        swc.transformSync(
+            `/** @flow */
+export const x = 1;
+`,
+            {
+                isModule: false,
+                jsc: {
+                    parser: {
+                        syntax: "flow",
+                        requireDirective: true,
+                    },
+                },
+            }
+        );
+
     expect(f).toThrowError(/Syntax Error/);
 });
 


### PR DESCRIPTION
**Description:**

- Root cause: Flow inputs that were only considered modules because of type-only `import`/`export` syntax kept module semantics after stripping, which either restored a synthetic `export {}` in `isModule: "unknown"` mode or rejected `isModule: false` transforms before the strip pass could run.
- What changed:
  - `swc_ecma_transforms_typescript` now restores empty exports for Flow only when the original module contained a runtime ESM declaration.
  - The transform pipeline now has a Flow-only fallback for `isModule: false` that accepts type-only module syntax, strips it, and downgrades the result back to script output.
  - Runtime Flow imports/exports in explicit script mode still throw the existing syntax error.
  - Added Rust and JS API regressions for the reported `export type` case and a negative runtime-export case.
- Impact: Flow polyfill/script-style inputs with type-only exports now stay script-like after transform, while direct parser strictness remains unchanged.
- Validation:
  - `cargo fmt --all`
  - `cargo clippy --all --all-targets -- -D warnings`
  - `cargo test -p swc_ecma_transforms_typescript`
  - `yarn build:dev` (in `packages/core`)
  - `yarn test` (in `packages/core`)
  - `cargo test -p swc` still has a pre-existing unrelated failure in `tests/source_map.rs::issue_622`.

**Related issue (if exists):**

- Closes #11808
