### PR TITLE
[EXPERIMENT] Add node-id based ECMA semantics

### DIFF
--- a/crates/swc_bundler/src/id.rs
+++ b/crates/swc_bundler/src/id.rs
@@ -6,7 +6,7 @@ use std::{
 use rustc_hash::FxHashMap;
 use swc_atoms::Atom;
 use swc_common::{sync::Lock, FileName, Mark, SyntaxContext, DUMMY_SP};
-use swc_ecma_ast::{Expr, Ident};
+use swc_ecma_ast::{Expr, Ident, NodeId};
 use swc_ecma_utils::ident::IdentLike;
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -91,6 +91,10 @@ impl IdentLike for Id {
 
     fn into_id(self) -> (Atom, SyntaxContext) {
         (self.0, self.1)
+    }
+
+    fn node_id(&self) -> NodeId {
+        NodeId::invalid()
     }
 }
 

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -12,7 +12,7 @@ use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Mark, Span, Spanned, SyntaxContext, DUMMY_SP,
 };
 
-use crate::{typescript::TsTypeAnn, Expr};
+use crate::{typescript::TsTypeAnn, Expr, NodeId};
 
 /// Identifier used as a pattern.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, EqIgnoreSpan, Default)]
@@ -96,6 +96,7 @@ impl From<&'_ BindingIdent> for Ident {
     fn from(bi: &'_ BindingIdent) -> Self {
         Ident {
             span: bi.span,
+            node_id: bi.node_id,
             ctxt: bi.ctxt,
             sym: bi.sym.clone(),
             optional: bi.optional,
@@ -184,6 +185,13 @@ pub struct Ident {
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
     pub span: Span,
 
+    /// Unique id of this identifier occurrence.
+    ///
+    /// This is invalid until a node-id assignment pass runs.
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
+    pub node_id: NodeId,
+
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
     pub ctxt: SyntaxContext,
 
@@ -214,6 +222,7 @@ impl From<(Atom, Span)> for Ident {
     fn from((sym, span): (Atom, Span)) -> Self {
         Ident {
             span,
+            node_id: Default::default(),
             sym,
             ..Default::default()
         }
@@ -479,6 +488,7 @@ impl From<IdentName> for Ident {
     fn from(i: IdentName) -> Self {
         Ident {
             span: i.span,
+            node_id: Default::default(),
             sym: i.sym,
             ..Default::default()
         }
@@ -570,6 +580,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Ident {
 
         Ok(Self {
             span,
+            node_id: Default::default(),
             sym,
             optional,
             ctxt: Default::default(),
@@ -597,6 +608,7 @@ impl Ident {
     pub const fn new(sym: Atom, span: Span, ctxt: SyntaxContext) -> Self {
         Ident {
             span,
+            node_id: NodeId::invalid(),
             ctxt,
             sym,
             optional: false,

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -41,6 +41,7 @@ pub use self::{
         ImportDecl, ImportDefaultSpecifier, ImportNamedSpecifier, ImportPhase, ImportSpecifier,
         ImportStarAsSpecifier, ModuleDecl, ModuleExportName, NamedExport,
     },
+    node_id::NodeId,
     operators::{AssignOp, BinaryOp, UnaryOp, UpdateOp},
     pat::{
         ArrayPat, AssignPat, AssignPatProp, KeyValuePatProp, ObjectPat, ObjectPatProp, Pat, RestPat,
@@ -86,6 +87,7 @@ mod list;
 mod lit;
 mod module;
 mod module_decl;
+mod node_id;
 mod operators;
 mod pat;
 mod prop;

--- a/crates/swc_ecma_ast/src/node_id.rs
+++ b/crates/swc_ecma_ast/src/node_id.rs
@@ -1,0 +1,63 @@
+use swc_common::EqIgnoreSpan;
+
+/// Opaque identifier for an AST node occurrence.
+///
+/// `NodeId(0)` is reserved as an invalid value. Parsers and synthesized AST
+/// constructors intentionally create invalid ids; semantic analysis should
+/// assign fresh ids before using node ids for binding or reference tracking.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-impl", serde(transparent))]
+#[cfg_attr(
+    any(feature = "rkyv-impl"),
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "rkyv-impl", repr(C))]
+#[cfg_attr(
+    feature = "encoding-impl",
+    derive(::swc_common::Encode, ::swc_common::Decode)
+)]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+pub struct NodeId(pub u32);
+
+impl NodeId {
+    /// The reserved invalid node id.
+    pub const INVALID: Self = Self(0);
+
+    /// Returns the reserved invalid node id.
+    #[inline]
+    pub const fn invalid() -> Self {
+        Self::INVALID
+    }
+
+    /// Creates a node id from a raw non-zero id.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `raw == 0`.
+    #[inline]
+    pub const fn new(raw: u32) -> Self {
+        assert!(raw != 0, "NodeId(0) is reserved as invalid");
+        Self(raw)
+    }
+
+    /// Returns the underlying raw id.
+    #[inline]
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+
+    /// Returns true if this id is the reserved invalid value.
+    #[inline]
+    pub const fn is_invalid(self) -> bool {
+        self.0 == 0
+    }
+}
+
+impl EqIgnoreSpan for NodeId {
+    #[inline]
+    fn eq_ignore_span(&self, _: &Self) -> bool {
+        true
+    }
+}

--- a/crates/swc_ecma_hooks/src/generated.rs
+++ b/crates/swc_ecma_hooks/src/generated.rs
@@ -1000,6 +1000,14 @@ pub trait VisitHook<C> {
     #[inline]
     #[allow(unused_variables)]
     fn exit_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `NodeId` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_node_id(&mut self, node: &NodeId, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `NodeId` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_node_id(&mut self, node: &NodeId, ctx: &mut C) {}
     #[doc = "Called when entering a node of type `Null` before visiting its children."]
     #[inline]
     #[allow(unused_variables)]
@@ -3971,6 +3979,18 @@ where
     fn exit_new_expr(&mut self, node: &NewExpr, ctx: &mut C) {
         self.second.exit_new_expr(node, ctx);
         self.first.exit_new_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        self.first.enter_node_id(node, ctx);
+        self.second.enter_node_id(node, ctx);
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        self.second.exit_node_id(node, ctx);
+        self.first.exit_node_id(node, ctx);
     }
 
     #[inline]
@@ -8019,6 +8039,22 @@ where
         match self {
             Self::Left(hook) => hook.exit_new_expr(node, ctx),
             Self::Right(hook) => hook.exit_new_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_node_id(node, ctx),
+            Self::Right(hook) => hook.enter_node_id(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_node_id(node, ctx),
+            Self::Right(hook) => hook.exit_node_id(node, ctx),
         }
     }
 
@@ -12525,6 +12561,20 @@ where
     }
 
     #[inline]
+    fn enter_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_node_id(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &NodeId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_node_id(node, ctx);
+        }
+    }
+
+    #[inline]
     fn enter_null(&mut self, node: &Null, ctx: &mut C) {
         if let Some(hook) = self {
             hook.enter_null(node, ctx);
@@ -15980,6 +16030,14 @@ impl<H: VisitHook<C>, C> Visit for VisitWithHook<H, C> {
         self.hook.exit_new_expr(node, &mut self.context);
     }
 
+    #[doc = "Visits a node of type `NodeId` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_node_id(&mut self, node: &NodeId) {
+        self.hook.enter_node_id(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_node_id(node, &mut self.context);
+    }
+
     #[doc = "Visits a node of type `Null` using the hook's enter and exit methods."]
     #[inline]
     fn visit_null(&mut self, node: &Null) {
@@ -18468,6 +18526,14 @@ pub trait VisitMutHook<C> {
     #[inline]
     #[allow(unused_variables)]
     fn exit_new_expr(&mut self, node: &mut NewExpr, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `NodeId` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `NodeId` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {}
     #[doc = "Called when entering a node of type `Null` before visiting its children."]
     #[inline]
     #[allow(unused_variables)]
@@ -21483,6 +21549,18 @@ where
     fn exit_new_expr(&mut self, node: &mut NewExpr, ctx: &mut C) {
         self.second.exit_new_expr(node, ctx);
         self.first.exit_new_expr(node, ctx);
+    }
+
+    #[inline]
+    fn enter_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        self.first.enter_node_id(node, ctx);
+        self.second.enter_node_id(node, ctx);
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        self.second.exit_node_id(node, ctx);
+        self.first.exit_node_id(node, ctx);
     }
 
     #[inline]
@@ -25567,6 +25645,22 @@ where
         match self {
             Self::Left(hook) => hook.exit_new_expr(node, ctx),
             Self::Right(hook) => hook.exit_new_expr(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_node_id(node, ctx),
+            Self::Right(hook) => hook.enter_node_id(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_node_id(node, ctx),
+            Self::Right(hook) => hook.exit_node_id(node, ctx),
         }
     }
 
@@ -30109,6 +30203,20 @@ where
     }
 
     #[inline]
+    fn enter_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_node_id(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_node_id(&mut self, node: &mut NodeId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_node_id(node, ctx);
+        }
+    }
+
+    #[inline]
     fn enter_null(&mut self, node: &mut Null, ctx: &mut C) {
         if let Some(hook) = self {
             hook.enter_null(node, ctx);
@@ -33590,6 +33698,14 @@ impl<H: VisitMutHook<C>, C> VisitMut for VisitMutWithHook<H, C> {
         self.hook.enter_new_expr(node, &mut self.context);
         node.visit_mut_children_with(self);
         self.hook.exit_new_expr(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `NodeId` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_mut_node_id(&mut self, node: &mut NodeId) {
+        self.hook.enter_node_id(node, &mut self.context);
+        node.visit_mut_children_with(self);
+        self.hook.exit_node_id(node, &mut self.context);
     }
 
     #[doc = "Visits a node of type `Null` using the hook's enter and exit methods."]

--- a/crates/swc_ecma_minifier/src/compress/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/mod.rs
@@ -6,6 +6,7 @@ use std::thread;
 use pretty_assertions::assert_eq;
 use swc_common::pass::{CompilerPass, Repeated};
 use swc_ecma_ast::*;
+use swc_ecma_transforms_base::semantics::assign_node_ids;
 use swc_ecma_visit::VisitMutWith;
 #[cfg(debug_assertions)]
 use swc_ecma_visit::VisitWith;
@@ -87,6 +88,7 @@ impl Compressor<'_> {
         );
 
         if self.options.hoist_vars || self.options.hoist_fns {
+            assign_node_ids(n);
             let data = analyze(&*n, Some(self.marks), false);
 
             let mut v = decl_hoister(
@@ -179,6 +181,7 @@ impl Compressor<'_> {
         {
             let _timer = timer!("apply full optimizer");
 
+            assign_node_ids(n);
             let mut data = analyze(&*n, Some(self.marks), false);
 
             // TODO: reset_opt_flags

--- a/crates/swc_ecma_minifier/src/lib.rs
+++ b/crates/swc_ecma_minifier/src/lib.rs
@@ -42,6 +42,7 @@ use once_cell::sync::Lazy;
 use pass::mangle_names::mangle_names;
 use swc_common::{comments::Comments, pass::Repeated, sync::Lrc, SourceMap, SyntaxContext};
 use swc_ecma_ast::*;
+use swc_ecma_transforms_base::semantics::assign_node_ids;
 use swc_ecma_transforms_optimization::debug_assert_valid;
 use swc_ecma_visit::VisitMutWith;
 use swc_timer::timer;
@@ -104,6 +105,7 @@ pub fn optimize(
     marks.top_level_ctxt = SyntaxContext::empty().apply_mark(extra.top_level_mark);
     marks.unresolved_mark = extra.unresolved_mark;
 
+    assign_node_ids(&mut n);
     debug_assert_valid(&n);
 
     if let Some(defs) = options.compress.as_ref().map(|c| &c.global_defs) {

--- a/crates/swc_ecma_minifier/src/pass/mangle_props.rs
+++ b/crates/swc_ecma_minifier/src/pass/mangle_props.rs
@@ -4,6 +4,7 @@ use once_cell::sync::Lazy;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{Atom, Wtf8Atom};
 use swc_ecma_ast::*;
+use swc_ecma_transforms_base::semantics::assign_node_ids;
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 use crate::{
@@ -123,6 +124,7 @@ pub(crate) fn mangle_properties(
         n: 0,
     };
 
+    assign_node_ids(m);
     let mut data = analyze(&*m, None, true);
 
     for prop in std::mem::take(data.property_atoms.as_mut().unwrap()) {

--- a/crates/swc_ecma_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/swc_ecma_transformer/src/es2016/exponentiation_operator.rs
@@ -287,6 +287,7 @@ fn create_math_pow(left: Box<Expr>, right: Box<Expr>) -> Expr {
             span: DUMMY_SP,
             obj: Box::new(Expr::Ident(Ident {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 ctxt: SyntaxContext::empty(),
                 sym: "Math".into(),
                 optional: false,

--- a/crates/swc_ecma_transforms_base/src/lib.rs
+++ b/crates/swc_ecma_transforms_base/src/lib.rs
@@ -18,5 +18,6 @@ pub mod quote;
 pub mod rename;
 mod resolver;
 pub mod scope;
+pub mod semantics;
 #[cfg(test)]
 mod tests;

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -14,7 +14,10 @@ use self::renamer_concurrent::{Send, Sync};
 #[cfg(not(feature = "concurrent-renamer"))]
 use self::renamer_single::{Send, Sync};
 use self::{analyzer::Analyzer, ops::Operator};
-use crate::hygiene::Config;
+use crate::{
+    hygiene::Config,
+    semantics::{Semantics, SymbolId},
+};
 
 mod analyer_and_collector;
 mod analyzer;
@@ -53,6 +56,7 @@ pub trait Renamer: Send + Sync {
 }
 
 pub type RenameMap = FxHashMap<Id, Atom>;
+pub type SymbolRenameMap<V = Atom> = FxHashMap<SymbolId, V>;
 
 pub fn rename<V: RenamedVariable>(map: &FxHashMap<Id, V>) -> impl '_ + Pass + VisitMut {
     rename_with_config(map, Default::default())
@@ -66,6 +70,24 @@ pub fn rename_with_config<V: RenamedVariable>(
         rename: map,
         config,
         extra: Default::default(),
+    })
+}
+
+/// Renames identifiers using a node-id semantics side table.
+///
+/// `semantics` must be produced from the same AST version as the one being
+/// renamed. If a transform has created or reordered identifier occurrences,
+/// reassign node ids and rebuild semantics before calling this pass.
+pub fn rename_symbols<'a, V>(
+    semantics: &'a Semantics,
+    map: &'a SymbolRenameMap<V>,
+) -> impl 'a + Pass + VisitMut
+where
+    V: RenamedVariable,
+{
+    visit_mut_pass(ops::SymbolOperator {
+        semantics,
+        rename: map,
     })
 }
 

--- a/crates/swc_ecma_transforms_base/src/rename/ops.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/ops.rs
@@ -11,6 +11,7 @@ use crate::{
     hygiene::Config,
     perf::{cpu_count, ParExplode, Parallel, ParallelExt},
     rename::RenamedVariable,
+    semantics::{Semantics, SymbolId},
 };
 
 pub(super) struct Operator<'a, V>
@@ -21,6 +22,14 @@ where
     pub config: Config,
 
     pub extra: Vec<ModuleItem>,
+}
+
+pub(super) struct SymbolOperator<'a, V>
+where
+    V: RenamedVariable,
+{
+    pub semantics: &'a Semantics,
+    pub rename: &'a FxHashMap<SymbolId, V>,
 }
 
 impl<V> Operator<'_, V>
@@ -604,6 +613,38 @@ where
         self.maybe_par(cpu_count() * 100, n, |v, n| {
             n.visit_mut_with(v);
         })
+    }
+}
+
+impl<V> VisitMut for SymbolOperator<'_, V>
+where
+    V: RenamedVariable,
+{
+    noop_visit_mut_type!();
+
+    /// Preserve key of properties.
+    fn visit_mut_assign_pat_prop(&mut self, p: &mut AssignPatProp) {
+        if let Some(value) = &mut p.value {
+            value.visit_mut_children_with(self);
+        }
+    }
+
+    fn visit_mut_ident(&mut self, ident: &mut Ident) {
+        let Some(symbol) = self.semantics.symbol_for_node_id(ident.node_id) else {
+            return;
+        };
+
+        let Some(new_id) = self.rename.get(&symbol) else {
+            return;
+        };
+
+        let new_sym = new_id.atom();
+        if ident.sym.eq(new_sym) {
+            return;
+        }
+
+        ident.ctxt = new_id.ctxt();
+        ident.sym = new_sym.clone();
     }
 }
 

--- a/crates/swc_ecma_transforms_base/src/resolver/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/resolver/mod.rs
@@ -8,7 +8,10 @@ use swc_ecma_visit::{
 };
 use tracing::{debug, span, Level};
 
-use crate::scope::{DeclKind, IdentType, ScopeKind};
+use crate::{
+    scope::{DeclKind, IdentType, ScopeKind},
+    semantics::assign_node_ids,
+};
 
 #[cfg(test)]
 mod tests;
@@ -149,6 +152,7 @@ pub fn resolver(
         in_ts_module: false,
         decl_kind: DeclKind::Lexical,
         strict_mode: false,
+        assign_node_ids: true,
         config: InnerConfig {
             handle_types: typescript,
             unresolved_mark,
@@ -206,6 +210,7 @@ struct Resolver<'a> {
     in_ts_module: bool,
     decl_kind: DeclKind,
     strict_mode: bool,
+    assign_node_ids: bool,
 
     config: InnerConfig,
 }
@@ -230,6 +235,7 @@ impl<'a> Resolver<'a> {
             config,
             decl_kind: DeclKind::Lexical,
             strict_mode: false,
+            assign_node_ids: true,
         }
     }
 
@@ -250,6 +256,7 @@ impl<'a> Resolver<'a> {
             in_ts_module: self.in_ts_module,
             decl_kind: self.decl_kind,
             strict_mode: self.strict_mode,
+            assign_node_ids: false,
         };
 
         op(&mut child);
@@ -376,6 +383,16 @@ impl<'a> Resolver<'a> {
         self.in_type = true;
         i.visit_mut_with(self);
         self.in_type = false;
+    }
+
+    fn assign_node_ids_once<N>(&mut self, node: &mut N)
+    where
+        N: VisitMutWith<crate::semantics::NodeIdAssigner>,
+    {
+        if self.assign_node_ids {
+            assign_node_ids(node);
+            self.assign_node_ids = false;
+        }
     }
 }
 
@@ -524,6 +541,11 @@ impl VisitMut for Resolver<'_> {
 
     // TODO: How should I handle this?
     typed!(visit_mut_ts_namespace_export_decl, TsNamespaceExportDecl);
+
+    fn visit_mut_program(&mut self, program: &mut Program) {
+        self.assign_node_ids_once(program);
+        program.visit_mut_children_with(self);
+    }
 
     fn visit_mut_arrow_expr(&mut self, e: &mut ArrowExpr) {
         self.with_child(ScopeKind::Fn, |child| {
@@ -1060,6 +1082,7 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_module(&mut self, module: &mut Module) {
+        self.assign_node_ids_once(module);
         self.strict_mode = true;
         self.is_module = true;
         module.visit_mut_children_with(self)
@@ -1134,6 +1157,7 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_script(&mut self, script: &mut Script) {
+        self.assign_node_ids_once(script);
         self.strict_mode = script
             .body
             .first()

--- a/crates/swc_ecma_transforms_base/src/semantics.rs
+++ b/crates/swc_ecma_transforms_base/src/semantics.rs
@@ -1,0 +1,1567 @@
+//! Node-id based semantic analysis for `swc_ecma_ast`.
+//!
+//! [`NodeId`] is an occurrence id. It does not identify a binding by itself.
+//! This module assigns fresh occurrence ids, then records the declaration and
+//! reference relationship in a side table keyed by [`NodeId`].
+
+use rustc_hash::FxHashMap;
+use swc_atoms::Atom;
+use swc_ecma_ast::*;
+use swc_ecma_visit::{Visit, VisitMut, VisitMutWith, VisitWith};
+
+macro_rules! define_id {
+    ($name:ident, $doc:literal) => {
+        #[doc = $doc]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        pub struct $name(u32);
+
+        impl $name {
+            #[inline]
+            fn from_index(index: usize) -> Self {
+                Self(index as u32)
+            }
+
+            #[inline]
+            fn index(self) -> usize {
+                self.0 as usize
+            }
+
+            /// Returns the raw id value.
+            #[inline]
+            pub fn as_u32(self) -> u32 {
+                self.0
+            }
+        }
+    };
+}
+
+define_id!(ScopeId, "Opaque identifier of a lexical scope.");
+define_id!(SymbolId, "Opaque identifier of a declared symbol.");
+define_id!(ReferenceId, "Opaque identifier of an identifier reference.");
+
+/// Configuration for node-id based semantic analysis.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SemanticConfig {
+    /// Enables TypeScript type-namespace analysis.
+    pub typescript: bool,
+}
+
+/// Scope category used by semantic analysis.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ScopeKind {
+    /// Program-level scope.
+    Program,
+    /// Function-like scope.
+    Function,
+    /// Lexical block scope.
+    Block,
+    /// Catch clause scope.
+    Catch,
+    /// Class name/body scope.
+    Class,
+}
+
+/// Symbol namespace.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SymbolNamespace {
+    /// JavaScript runtime value namespace.
+    Value,
+    /// TypeScript type namespace.
+    Type,
+}
+
+/// Symbol declaration category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SymbolKind {
+    /// `var`.
+    Var,
+    /// `let`.
+    Let,
+    /// `const`.
+    Const,
+    /// Function declaration or function-expression name.
+    Function,
+    /// Class declaration or class-expression name.
+    Class,
+    /// Function parameter.
+    Param,
+    /// ESM import binding.
+    Import,
+    /// Catch parameter binding.
+    CatchParam,
+    /// TypeScript type alias, interface, or type parameter.
+    Type,
+    /// TypeScript enum binding.
+    Enum,
+    /// TypeScript namespace/module binding.
+    Namespace,
+    /// Explicit resource management binding.
+    Using,
+}
+
+/// Reference usage category.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReferenceKind {
+    /// Read-only reference.
+    Read,
+    /// Write-only reference.
+    Write,
+    /// Read-modify-write reference.
+    ReadWrite,
+}
+
+/// Scope metadata.
+#[derive(Debug, Clone)]
+pub struct ScopeData {
+    /// Scope kind.
+    pub kind: ScopeKind,
+    /// Parent lexical scope.
+    pub parent: Option<ScopeId>,
+    /// Function/program scope containing this scope.
+    pub enclosing_function: ScopeId,
+    /// Parent function/program scope if this scope is itself function-like.
+    pub parent_function: Option<ScopeId>,
+    /// Symbols declared directly in this scope.
+    pub symbols: Vec<SymbolId>,
+}
+
+/// Symbol metadata.
+#[derive(Debug, Clone)]
+pub struct SymbolData {
+    /// Symbol kind.
+    pub kind: SymbolKind,
+    /// Symbol namespace.
+    pub namespace: SymbolNamespace,
+    /// Declaring scope.
+    pub scope: ScopeId,
+    /// Symbol name.
+    pub name: Atom,
+    /// Identifier occurrences that declare this symbol.
+    pub declaration_node_ids: Vec<NodeId>,
+}
+
+/// Reference metadata.
+#[derive(Debug, Clone)]
+pub struct ReferenceData {
+    /// Reference kind.
+    pub kind: ReferenceKind,
+    /// Reference namespace.
+    pub namespace: SymbolNamespace,
+    /// Scope where this reference appears.
+    pub scope: ScopeId,
+    /// Function/program scope containing this reference.
+    pub enclosing_function: ScopeId,
+    /// Referenced name.
+    pub name: Atom,
+    /// Identifier occurrence id.
+    pub node_id: NodeId,
+    /// Resolved symbol, if any.
+    pub symbol: Option<SymbolId>,
+}
+
+/// Complete node-id based semantics result for one AST.
+#[derive(Debug, Default)]
+pub struct Semantics {
+    scopes: Vec<ScopeData>,
+    symbols: Vec<SymbolData>,
+    references: Vec<ReferenceData>,
+    symbol_by_node_id: FxHashMap<NodeId, SymbolId>,
+    reference_by_node_id: FxHashMap<NodeId, ReferenceId>,
+    references_by_symbol: Vec<Vec<ReferenceId>>,
+    unresolved_references: Vec<ReferenceId>,
+}
+
+impl Semantics {
+    /// Returns all scope records.
+    #[inline]
+    pub fn scopes(&self) -> &[ScopeData] {
+        &self.scopes
+    }
+
+    /// Returns all symbol records.
+    #[inline]
+    pub fn symbols(&self) -> &[SymbolData] {
+        &self.symbols
+    }
+
+    /// Returns all reference records.
+    #[inline]
+    pub fn references(&self) -> &[ReferenceData] {
+        &self.references
+    }
+
+    /// Returns a scope by id.
+    #[inline]
+    pub fn scope(&self, id: ScopeId) -> &ScopeData {
+        &self.scopes[id.index()]
+    }
+
+    /// Returns a symbol by id.
+    #[inline]
+    pub fn symbol(&self, id: SymbolId) -> &SymbolData {
+        &self.symbols[id.index()]
+    }
+
+    /// Returns a reference by id.
+    #[inline]
+    pub fn reference(&self, id: ReferenceId) -> &ReferenceData {
+        &self.references[id.index()]
+    }
+
+    /// Returns the symbol declared by or resolved for an identifier occurrence.
+    #[inline]
+    pub fn symbol_for_node_id(&self, node_id: NodeId) -> Option<SymbolId> {
+        self.symbol_by_node_id.get(&node_id).copied()
+    }
+
+    /// Returns the reference record for an identifier occurrence.
+    #[inline]
+    pub fn reference_for_node_id(&self, node_id: NodeId) -> Option<ReferenceId> {
+        self.reference_by_node_id.get(&node_id).copied()
+    }
+
+    /// Returns references attached to a symbol.
+    #[inline]
+    pub fn references_of_symbol(&self, id: SymbolId) -> &[ReferenceId] {
+        self.references_by_symbol
+            .get(id.index())
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+    }
+
+    /// Returns unresolved references.
+    #[inline]
+    pub fn unresolved_references(&self) -> &[ReferenceId] {
+        &self.unresolved_references
+    }
+
+    fn alloc_scope(&mut self, data: ScopeData) -> ScopeId {
+        let id = ScopeId::from_index(self.scopes.len());
+        self.scopes.push(data);
+        id
+    }
+
+    fn alloc_symbol(&mut self, data: SymbolData) -> SymbolId {
+        let id = SymbolId::from_index(self.symbols.len());
+        self.symbols.push(data);
+        self.references_by_symbol.push(Vec::new());
+        id
+    }
+
+    fn alloc_reference(&mut self, data: ReferenceData) -> ReferenceId {
+        let id = ReferenceId::from_index(self.references.len());
+        if !data.node_id.is_invalid() {
+            self.reference_by_node_id.insert(data.node_id, id);
+        }
+
+        if let Some(symbol) = data.symbol {
+            self.symbol_by_node_id.insert(data.node_id, symbol);
+            self.references_by_symbol[symbol.index()].push(id);
+        } else {
+            self.unresolved_references.push(id);
+        }
+
+        self.references.push(data);
+        id
+    }
+}
+
+/// Assigns fresh occurrence ids to every [`Ident`] under `node`.
+///
+/// Existing ids are overwritten. `NodeId(0)` is never assigned.
+pub fn assign_node_ids<N>(node: &mut N)
+where
+    N: VisitMutWith<NodeIdAssigner>,
+{
+    let mut assigner = NodeIdAssigner::default();
+    node.visit_mut_with(&mut assigner);
+}
+
+/// Visitor that assigns fresh occurrence ids to identifiers.
+#[derive(Debug, Default)]
+pub struct NodeIdAssigner {
+    next: u32,
+}
+
+impl NodeIdAssigner {
+    fn next_id(&mut self) -> NodeId {
+        self.next = self
+            .next
+            .checked_add(1)
+            .expect("identifier node id overflowed u32");
+        NodeId::new(self.next)
+    }
+}
+
+impl VisitMut for NodeIdAssigner {
+    fn visit_mut_ident(&mut self, ident: &mut Ident) {
+        ident.node_id = self.next_id();
+    }
+}
+
+/// Assigns fresh node ids and analyzes scopes, symbols, and references.
+pub fn analyze(program: &mut Program, config: SemanticConfig) -> Semantics {
+    assign_node_ids(program);
+    analyze_with_existing_node_ids(program, config)
+}
+
+/// Analyzes scopes, symbols, and references using existing node ids.
+pub fn analyze_with_existing_node_ids(program: &Program, config: SemanticConfig) -> Semantics {
+    let mut semantics = Semantics::default();
+    let mut analyzer = Analyzer::new(config, &mut semantics);
+    program.visit_with(&mut analyzer);
+    semantics
+}
+
+#[derive(Debug)]
+struct ScopeFrame {
+    id: ScopeId,
+    function_scope: ScopeId,
+    decls: FxHashMap<(Atom, SymbolNamespace), SymbolId>,
+}
+
+struct Analyzer<'a> {
+    config: SemanticConfig,
+    semantics: &'a mut Semantics,
+    scope_stack: Vec<ScopeFrame>,
+    namespace: SymbolNamespace,
+}
+
+impl<'a> Analyzer<'a> {
+    fn new(config: SemanticConfig, semantics: &'a mut Semantics) -> Self {
+        Self {
+            config,
+            semantics,
+            scope_stack: Vec::new(),
+            namespace: SymbolNamespace::Value,
+        }
+    }
+
+    fn current_scope(&self) -> ScopeId {
+        self.scope_stack
+            .last()
+            .map(|scope| scope.id)
+            .expect("semantic scope stack should not be empty")
+    }
+
+    fn current_function_scope(&self) -> ScopeId {
+        self.scope_stack
+            .last()
+            .map(|scope| scope.function_scope)
+            .expect("semantic scope stack should not be empty")
+    }
+
+    fn var_scope(&self) -> ScopeId {
+        self.scope_stack
+            .iter()
+            .rev()
+            .find(|scope| {
+                matches!(
+                    self.semantics.scopes[scope.id.index()].kind,
+                    ScopeKind::Program | ScopeKind::Function
+                )
+            })
+            .map(|scope| scope.id)
+            .unwrap_or_else(|| self.current_scope())
+    }
+
+    fn push_scope(&mut self, kind: ScopeKind) -> ScopeId {
+        let parent = self.scope_stack.last().map(|scope| scope.id);
+        let parent_function = parent.and_then(|parent_id| {
+            let parent_scope = &self.semantics.scopes[parent_id.index()];
+            if matches!(kind, ScopeKind::Program | ScopeKind::Function) {
+                Some(parent_scope.enclosing_function)
+            } else {
+                parent_scope.parent_function
+            }
+        });
+        let inherited_function = parent
+            .map(|parent_id| self.semantics.scopes[parent_id.index()].enclosing_function)
+            .unwrap_or_else(|| ScopeId::from_index(0));
+
+        let id = self.semantics.alloc_scope(ScopeData {
+            kind,
+            parent,
+            enclosing_function: inherited_function,
+            parent_function,
+            symbols: Vec::new(),
+        });
+
+        if matches!(kind, ScopeKind::Program | ScopeKind::Function) {
+            self.semantics.scopes[id.index()].enclosing_function = id;
+        }
+
+        let function_scope = self.semantics.scopes[id.index()].enclosing_function;
+        self.scope_stack.push(ScopeFrame {
+            id,
+            function_scope,
+            decls: FxHashMap::default(),
+        });
+        id
+    }
+
+    fn pop_scope(&mut self) {
+        self.scope_stack.pop();
+    }
+
+    fn with_scope<F>(&mut self, kind: ScopeKind, op: F)
+    where
+        F: FnOnce(&mut Self),
+    {
+        self.push_scope(kind);
+        op(self);
+        self.pop_scope();
+    }
+
+    fn with_namespace<F>(&mut self, namespace: SymbolNamespace, op: F)
+    where
+        F: FnOnce(&mut Self),
+    {
+        let old = self.namespace;
+        self.namespace = namespace;
+        op(self);
+        self.namespace = old;
+    }
+
+    fn active_scope_mut(&mut self, id: ScopeId) -> Option<&mut ScopeFrame> {
+        self.scope_stack.iter_mut().find(|scope| scope.id == id)
+    }
+
+    fn find_in_scope(
+        &self,
+        scope: ScopeId,
+        name: &Atom,
+        namespace: SymbolNamespace,
+    ) -> Option<SymbolId> {
+        self.scope_stack
+            .iter()
+            .find(|frame| frame.id == scope)
+            .and_then(|frame| frame.decls.get(&(name.clone(), namespace)).copied())
+    }
+
+    fn declare_ident(
+        &mut self,
+        ident: &Ident,
+        scope: ScopeId,
+        kind: SymbolKind,
+        namespace: SymbolNamespace,
+    ) -> SymbolId {
+        if let Some(symbol) = self.find_in_scope(scope, &ident.sym, namespace) {
+            if !ident.node_id.is_invalid() {
+                self.semantics
+                    .symbol_by_node_id
+                    .insert(ident.node_id, symbol);
+                let data = &mut self.semantics.symbols[symbol.index()];
+                if !data.declaration_node_ids.contains(&ident.node_id) {
+                    data.declaration_node_ids.push(ident.node_id);
+                }
+            }
+            return symbol;
+        }
+
+        let symbol = self.semantics.alloc_symbol(SymbolData {
+            kind,
+            namespace,
+            scope,
+            name: ident.sym.clone(),
+            declaration_node_ids: if ident.node_id.is_invalid() {
+                Vec::new()
+            } else {
+                vec![ident.node_id]
+            },
+        });
+
+        self.semantics.scopes[scope.index()].symbols.push(symbol);
+        if !ident.node_id.is_invalid() {
+            self.semantics
+                .symbol_by_node_id
+                .insert(ident.node_id, symbol);
+        }
+
+        if let Some(frame) = self.active_scope_mut(scope) {
+            frame.decls.insert((ident.sym.clone(), namespace), symbol);
+        }
+
+        symbol
+    }
+
+    fn resolve_symbol(&self, name: &Atom, namespace: SymbolNamespace) -> Option<SymbolId> {
+        for frame in self.scope_stack.iter().rev() {
+            if let Some(symbol) = frame.decls.get(&(name.clone(), namespace)) {
+                return Some(*symbol);
+            }
+        }
+
+        None
+    }
+
+    fn record_reference(&mut self, ident: &Ident, kind: ReferenceKind, namespace: SymbolNamespace) {
+        if ident.node_id.is_invalid() {
+            return;
+        }
+
+        let scope = self.current_scope();
+        let enclosing_function = self.current_function_scope();
+        let symbol = self.resolve_symbol(&ident.sym, namespace);
+
+        self.semantics.alloc_reference(ReferenceData {
+            kind,
+            namespace,
+            scope,
+            enclosing_function,
+            name: ident.sym.clone(),
+            node_id: ident.node_id,
+            symbol,
+        });
+    }
+
+    fn declare_pat(
+        &mut self,
+        pat: &Pat,
+        scope: ScopeId,
+        kind: SymbolKind,
+        namespace: SymbolNamespace,
+    ) {
+        match pat {
+            Pat::Ident(ident) => {
+                self.visit_type_ann_opt(&ident.type_ann);
+                self.declare_ident(&ident.id, scope, kind, namespace);
+            }
+            Pat::Array(array) => {
+                self.visit_type_ann_opt(&array.type_ann);
+                for elem in array.elems.iter().flatten() {
+                    self.declare_pat(elem, scope, kind, namespace);
+                }
+            }
+            Pat::Rest(rest) => {
+                self.visit_type_ann_opt(&rest.type_ann);
+                self.declare_pat(&rest.arg, scope, kind, namespace);
+            }
+            Pat::Object(object) => {
+                self.visit_type_ann_opt(&object.type_ann);
+                for prop in &object.props {
+                    match prop {
+                        ObjectPatProp::KeyValue(prop) => {
+                            self.visit_prop_name(&prop.key);
+                            self.declare_pat(&prop.value, scope, kind, namespace);
+                        }
+                        ObjectPatProp::Assign(prop) => {
+                            self.visit_type_ann_opt(&prop.key.type_ann);
+                            self.declare_ident(&prop.key.id, scope, kind, namespace);
+                            if let Some(value) = &prop.value {
+                                value.visit_with(self);
+                            }
+                        }
+                        ObjectPatProp::Rest(rest) => {
+                            self.declare_pat(&rest.arg, scope, kind, namespace);
+                        }
+                    }
+                }
+            }
+            Pat::Assign(assign) => {
+                self.declare_pat(&assign.left, scope, kind, namespace);
+                assign.right.visit_with(self);
+            }
+            Pat::Expr(expr) => {
+                self.visit_assignment_expr(expr, ReferenceKind::Write);
+            }
+            Pat::Invalid(_) => {}
+        }
+    }
+
+    fn visit_assignment_expr(&mut self, expr: &Expr, kind: ReferenceKind) {
+        match expr {
+            Expr::Ident(ident) => self.record_reference(ident, kind, SymbolNamespace::Value),
+            Expr::Paren(paren) => self.visit_assignment_expr(&paren.expr, kind),
+            Expr::TsAs(expr) => self.visit_assignment_expr(&expr.expr, kind),
+            Expr::TsSatisfies(expr) => self.visit_assignment_expr(&expr.expr, kind),
+            Expr::TsNonNull(expr) => self.visit_assignment_expr(&expr.expr, kind),
+            Expr::TsTypeAssertion(expr) => self.visit_assignment_expr(&expr.expr, kind),
+            Expr::TsInstantiation(expr) => self.visit_assignment_expr(&expr.expr, kind),
+            _ => expr.visit_with(self),
+        }
+    }
+
+    fn visit_assignment_target(&mut self, target: &AssignTarget, kind: ReferenceKind) {
+        match target {
+            AssignTarget::Simple(target) => self.visit_simple_assignment_target(target, kind),
+            AssignTarget::Pat(pat) => self.visit_assignment_target_pat(pat, kind),
+        }
+    }
+
+    fn visit_simple_assignment_target(&mut self, target: &SimpleAssignTarget, kind: ReferenceKind) {
+        match target {
+            SimpleAssignTarget::Ident(ident) => {
+                self.record_reference(&ident.id, kind, SymbolNamespace::Value);
+            }
+            SimpleAssignTarget::Member(member) => member.visit_with(self),
+            SimpleAssignTarget::SuperProp(super_prop) => super_prop.visit_with(self),
+            SimpleAssignTarget::Paren(paren) => self.visit_assignment_expr(&paren.expr, kind),
+            SimpleAssignTarget::OptChain(opt_chain) => opt_chain.visit_with(self),
+            SimpleAssignTarget::TsAs(expr) => self.visit_assignment_expr(&expr.expr, kind),
+            SimpleAssignTarget::TsSatisfies(expr) => self.visit_assignment_expr(&expr.expr, kind),
+            SimpleAssignTarget::TsNonNull(expr) => self.visit_assignment_expr(&expr.expr, kind),
+            SimpleAssignTarget::TsTypeAssertion(expr) => {
+                self.visit_assignment_expr(&expr.expr, kind)
+            }
+            SimpleAssignTarget::TsInstantiation(expr) => {
+                self.visit_assignment_expr(&expr.expr, kind)
+            }
+            SimpleAssignTarget::Invalid(_) => {}
+        }
+    }
+
+    fn visit_assignment_target_pat(&mut self, pat: &AssignTargetPat, kind: ReferenceKind) {
+        match pat {
+            AssignTargetPat::Array(array) => {
+                for elem in array.elems.iter().flatten() {
+                    self.visit_assignment_pat(elem, kind);
+                }
+            }
+            AssignTargetPat::Object(object) => {
+                for prop in &object.props {
+                    match prop {
+                        ObjectPatProp::KeyValue(prop) => {
+                            self.visit_prop_name(&prop.key);
+                            self.visit_assignment_pat(&prop.value, kind);
+                        }
+                        ObjectPatProp::Assign(prop) => {
+                            self.record_reference(&prop.key.id, kind, SymbolNamespace::Value);
+                            if let Some(value) = &prop.value {
+                                value.visit_with(self);
+                            }
+                        }
+                        ObjectPatProp::Rest(rest) => {
+                            self.visit_assignment_pat(&rest.arg, kind);
+                        }
+                    }
+                }
+            }
+            AssignTargetPat::Invalid(_) => {}
+        }
+    }
+
+    fn visit_assignment_pat(&mut self, pat: &Pat, kind: ReferenceKind) {
+        match pat {
+            Pat::Ident(ident) => self.record_reference(&ident.id, kind, SymbolNamespace::Value),
+            Pat::Array(array) => {
+                for elem in array.elems.iter().flatten() {
+                    self.visit_assignment_pat(elem, kind);
+                }
+            }
+            Pat::Rest(rest) => self.visit_assignment_pat(&rest.arg, kind),
+            Pat::Object(object) => {
+                for prop in &object.props {
+                    match prop {
+                        ObjectPatProp::KeyValue(prop) => {
+                            self.visit_prop_name(&prop.key);
+                            self.visit_assignment_pat(&prop.value, kind);
+                        }
+                        ObjectPatProp::Assign(prop) => {
+                            self.record_reference(&prop.key.id, kind, SymbolNamespace::Value);
+                            if let Some(value) = &prop.value {
+                                value.visit_with(self);
+                            }
+                        }
+                        ObjectPatProp::Rest(rest) => {
+                            self.visit_assignment_pat(&rest.arg, kind);
+                        }
+                    }
+                }
+            }
+            Pat::Assign(assign) => {
+                self.visit_assignment_pat(&assign.left, kind);
+                assign.right.visit_with(self);
+            }
+            Pat::Expr(expr) => self.visit_assignment_expr(expr, kind),
+            Pat::Invalid(_) => {}
+        }
+    }
+
+    fn predeclare_module_items(&mut self, items: &[ModuleItem]) {
+        for item in items {
+            match item {
+                ModuleItem::ModuleDecl(decl) => self.predeclare_module_decl(decl),
+                ModuleItem::Stmt(stmt) => self.predeclare_stmt(stmt),
+            }
+        }
+    }
+
+    fn predeclare_stmts(&mut self, stmts: &[Stmt]) {
+        for stmt in stmts {
+            self.predeclare_stmt(stmt);
+        }
+    }
+
+    fn predeclare_stmt(&mut self, stmt: &Stmt) {
+        if let Stmt::Decl(decl) = stmt {
+            self.predeclare_decl(decl);
+        }
+    }
+
+    fn predeclare_module_decl(&mut self, decl: &ModuleDecl) {
+        match decl {
+            ModuleDecl::Import(import) => self.predeclare_import(import),
+            ModuleDecl::ExportDecl(export) => self.predeclare_decl(&export.decl),
+            ModuleDecl::ExportDefaultDecl(export) => self.predeclare_default_decl(&export.decl),
+            ModuleDecl::TsImportEquals(decl) => {
+                let namespace = if decl.is_type_only {
+                    SymbolNamespace::Type
+                } else {
+                    SymbolNamespace::Value
+                };
+                self.declare_ident(
+                    &decl.id,
+                    self.current_scope(),
+                    SymbolKind::Import,
+                    namespace,
+                );
+            }
+            ModuleDecl::TsNamespaceExport(_) => {}
+            ModuleDecl::ExportNamed(_)
+            | ModuleDecl::ExportDefaultExpr(_)
+            | ModuleDecl::ExportAll(_)
+            | ModuleDecl::TsExportAssignment(_) => {}
+        }
+    }
+
+    fn predeclare_default_decl(&mut self, decl: &DefaultDecl) {
+        match decl {
+            DefaultDecl::Fn(function) => {
+                if let Some(ident) = &function.ident {
+                    self.declare_ident(
+                        ident,
+                        self.current_scope(),
+                        SymbolKind::Function,
+                        SymbolNamespace::Value,
+                    );
+                }
+            }
+            DefaultDecl::Class(class) => {
+                if let Some(ident) = &class.ident {
+                    self.declare_ident(
+                        ident,
+                        self.current_scope(),
+                        SymbolKind::Class,
+                        SymbolNamespace::Value,
+                    );
+                }
+            }
+            DefaultDecl::TsInterfaceDecl(decl) => {
+                self.declare_ident(
+                    &decl.id,
+                    self.current_scope(),
+                    SymbolKind::Type,
+                    SymbolNamespace::Type,
+                );
+            }
+        }
+    }
+
+    fn predeclare_decl(&mut self, decl: &Decl) {
+        match decl {
+            Decl::Fn(decl) => {
+                self.declare_ident(
+                    &decl.ident,
+                    self.current_scope(),
+                    SymbolKind::Function,
+                    SymbolNamespace::Value,
+                );
+            }
+            Decl::Class(decl) => {
+                self.declare_ident(
+                    &decl.ident,
+                    self.current_scope(),
+                    SymbolKind::Class,
+                    SymbolNamespace::Value,
+                );
+            }
+            Decl::Var(decl) => self.predeclare_var_decl(decl),
+            Decl::Using(decl) => {
+                for decl in &decl.decls {
+                    self.predeclare_var_declarator(
+                        decl,
+                        self.current_scope(),
+                        SymbolKind::Using,
+                        SymbolNamespace::Value,
+                    );
+                }
+            }
+            Decl::TsInterface(decl) => {
+                self.declare_ident(
+                    &decl.id,
+                    self.current_scope(),
+                    SymbolKind::Type,
+                    SymbolNamespace::Type,
+                );
+            }
+            Decl::TsTypeAlias(decl) => {
+                self.declare_ident(
+                    &decl.id,
+                    self.current_scope(),
+                    SymbolKind::Type,
+                    SymbolNamespace::Type,
+                );
+            }
+            Decl::TsEnum(decl) => {
+                self.declare_ident(
+                    &decl.id,
+                    self.current_scope(),
+                    SymbolKind::Enum,
+                    SymbolNamespace::Value,
+                );
+                if self.config.typescript {
+                    self.declare_ident(
+                        &decl.id,
+                        self.current_scope(),
+                        SymbolKind::Enum,
+                        SymbolNamespace::Type,
+                    );
+                }
+            }
+            Decl::TsModule(decl) => {
+                if let TsModuleName::Ident(id) = &decl.id {
+                    self.declare_ident(
+                        id,
+                        self.current_scope(),
+                        SymbolKind::Namespace,
+                        SymbolNamespace::Value,
+                    );
+                    if self.config.typescript {
+                        self.declare_ident(
+                            id,
+                            self.current_scope(),
+                            SymbolKind::Namespace,
+                            SymbolNamespace::Type,
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    fn predeclare_var_decl(&mut self, decl: &VarDecl) {
+        let scope = if decl.kind == VarDeclKind::Var {
+            self.var_scope()
+        } else {
+            self.current_scope()
+        };
+        let kind = match decl.kind {
+            VarDeclKind::Var => SymbolKind::Var,
+            VarDeclKind::Let => SymbolKind::Let,
+            VarDeclKind::Const => SymbolKind::Const,
+        };
+
+        for decl in &decl.decls {
+            self.predeclare_var_declarator(decl, scope, kind, SymbolNamespace::Value);
+        }
+    }
+
+    fn predeclare_var_declarator(
+        &mut self,
+        decl: &VarDeclarator,
+        scope: ScopeId,
+        kind: SymbolKind,
+        namespace: SymbolNamespace,
+    ) {
+        self.predeclare_pat(&decl.name, scope, kind, namespace);
+    }
+
+    fn predeclare_pat(
+        &mut self,
+        pat: &Pat,
+        scope: ScopeId,
+        kind: SymbolKind,
+        namespace: SymbolNamespace,
+    ) {
+        match pat {
+            Pat::Ident(ident) => {
+                self.declare_ident(&ident.id, scope, kind, namespace);
+            }
+            Pat::Array(array) => {
+                for elem in array.elems.iter().flatten() {
+                    self.predeclare_pat(elem, scope, kind, namespace);
+                }
+            }
+            Pat::Rest(rest) => self.predeclare_pat(&rest.arg, scope, kind, namespace),
+            Pat::Object(object) => {
+                for prop in &object.props {
+                    match prop {
+                        ObjectPatProp::KeyValue(prop) => {
+                            self.predeclare_pat(&prop.value, scope, kind, namespace);
+                        }
+                        ObjectPatProp::Assign(prop) => {
+                            self.declare_ident(&prop.key.id, scope, kind, namespace);
+                        }
+                        ObjectPatProp::Rest(rest) => {
+                            self.predeclare_pat(&rest.arg, scope, kind, namespace);
+                        }
+                    }
+                }
+            }
+            Pat::Assign(assign) => self.predeclare_pat(&assign.left, scope, kind, namespace),
+            Pat::Expr(_) | Pat::Invalid(_) => {}
+        }
+    }
+
+    fn predeclare_import(&mut self, import: &ImportDecl) {
+        for specifier in &import.specifiers {
+            let namespace = match specifier {
+                ImportSpecifier::Named(named) if import.type_only || named.is_type_only => {
+                    SymbolNamespace::Type
+                }
+                _ => SymbolNamespace::Value,
+            };
+
+            self.declare_ident(
+                specifier.local(),
+                self.current_scope(),
+                SymbolKind::Import,
+                namespace,
+            );
+        }
+    }
+
+    fn visit_type_ann_opt(&mut self, type_ann: &Option<Box<TsTypeAnn>>) {
+        if self.config.typescript {
+            self.with_namespace(SymbolNamespace::Type, |analyzer| {
+                type_ann.visit_with(analyzer);
+            });
+        }
+    }
+
+    fn visit_function_like(&mut self, function: &Function, name: Option<&Ident>) {
+        self.with_scope(ScopeKind::Function, |analyzer| {
+            if let Some(name) = name {
+                analyzer.declare_ident(
+                    name,
+                    analyzer.current_scope(),
+                    SymbolKind::Function,
+                    SymbolNamespace::Value,
+                );
+            }
+
+            if analyzer.config.typescript {
+                analyzer.with_namespace(SymbolNamespace::Type, |analyzer| {
+                    function.type_params.visit_with(analyzer);
+                });
+            }
+
+            for param in &function.params {
+                analyzer.declare_pat(
+                    &param.pat,
+                    analyzer.current_scope(),
+                    SymbolKind::Param,
+                    SymbolNamespace::Value,
+                );
+            }
+
+            analyzer.visit_type_ann_opt(&function.return_type);
+
+            if let Some(body) = &function.body {
+                analyzer.predeclare_stmts(&body.stmts);
+                body.stmts.visit_with(analyzer);
+            }
+        });
+    }
+
+    fn visit_class_like(&mut self, class: &Class, name: Option<&Ident>) {
+        class.decorators.visit_with(self);
+        class.super_class.visit_with(self);
+
+        self.with_scope(ScopeKind::Class, |analyzer| {
+            if let Some(name) = name {
+                analyzer.declare_ident(
+                    name,
+                    analyzer.current_scope(),
+                    SymbolKind::Class,
+                    SymbolNamespace::Value,
+                );
+            }
+
+            if analyzer.config.typescript {
+                analyzer.with_namespace(SymbolNamespace::Type, |analyzer| {
+                    class.type_params.visit_with(analyzer);
+                    class.super_type_params.visit_with(analyzer);
+                    class.implements.visit_with(analyzer);
+                });
+            }
+
+            class.body.visit_with(analyzer);
+        });
+    }
+}
+
+impl Visit for Analyzer<'_> {
+    fn visit_program(&mut self, program: &Program) {
+        self.with_scope(ScopeKind::Program, |analyzer| match program {
+            Program::Module(module) => {
+                analyzer.predeclare_module_items(&module.body);
+                module.body.visit_with(analyzer);
+            }
+            Program::Script(script) => {
+                analyzer.predeclare_stmts(&script.body);
+                script.body.visit_with(analyzer);
+            }
+        });
+    }
+
+    fn visit_module(&mut self, module: &Module) {
+        self.predeclare_module_items(&module.body);
+        module.body.visit_with(self);
+    }
+
+    fn visit_script(&mut self, script: &Script) {
+        self.predeclare_stmts(&script.body);
+        script.body.visit_with(self);
+    }
+
+    fn visit_block_stmt(&mut self, block: &BlockStmt) {
+        self.with_scope(ScopeKind::Block, |analyzer| {
+            analyzer.predeclare_stmts(&block.stmts);
+            block.stmts.visit_with(analyzer);
+        });
+    }
+
+    fn visit_catch_clause(&mut self, catch: &CatchClause) {
+        self.with_scope(ScopeKind::Catch, |analyzer| {
+            if let Some(param) = &catch.param {
+                analyzer.declare_pat(
+                    param,
+                    analyzer.current_scope(),
+                    SymbolKind::CatchParam,
+                    SymbolNamespace::Value,
+                );
+            }
+            analyzer.predeclare_stmts(&catch.body.stmts);
+            catch.body.stmts.visit_with(analyzer);
+        });
+    }
+
+    fn visit_fn_decl(&mut self, decl: &FnDecl) {
+        self.declare_ident(
+            &decl.ident,
+            self.current_scope(),
+            SymbolKind::Function,
+            SymbolNamespace::Value,
+        );
+        decl.function.decorators.visit_with(self);
+        self.visit_function_like(&decl.function, None);
+    }
+
+    fn visit_fn_expr(&mut self, expr: &FnExpr) {
+        expr.function.decorators.visit_with(self);
+        self.visit_function_like(&expr.function, expr.ident.as_ref());
+    }
+
+    fn visit_function(&mut self, function: &Function) {
+        function.decorators.visit_with(self);
+        self.visit_function_like(function, None);
+    }
+
+    fn visit_arrow_expr(&mut self, arrow: &ArrowExpr) {
+        self.with_scope(ScopeKind::Function, |analyzer| {
+            if analyzer.config.typescript {
+                analyzer.with_namespace(SymbolNamespace::Type, |analyzer| {
+                    arrow.type_params.visit_with(analyzer);
+                });
+            }
+
+            for param in &arrow.params {
+                analyzer.declare_pat(
+                    param,
+                    analyzer.current_scope(),
+                    SymbolKind::Param,
+                    SymbolNamespace::Value,
+                );
+            }
+
+            analyzer.visit_type_ann_opt(&arrow.return_type);
+
+            match &*arrow.body {
+                BlockStmtOrExpr::BlockStmt(body) => {
+                    analyzer.predeclare_stmts(&body.stmts);
+                    body.stmts.visit_with(analyzer);
+                }
+                BlockStmtOrExpr::Expr(expr) => expr.visit_with(analyzer),
+            }
+        });
+    }
+
+    fn visit_class_decl(&mut self, decl: &ClassDecl) {
+        self.declare_ident(
+            &decl.ident,
+            self.current_scope(),
+            SymbolKind::Class,
+            SymbolNamespace::Value,
+        );
+        self.visit_class_like(&decl.class, None);
+    }
+
+    fn visit_class_expr(&mut self, expr: &ClassExpr) {
+        self.visit_class_like(&expr.class, expr.ident.as_ref());
+    }
+
+    fn visit_class_method(&mut self, method: &ClassMethod) {
+        self.visit_prop_name(&method.key);
+        self.visit_function_like(&method.function, None);
+    }
+
+    fn visit_private_method(&mut self, method: &PrivateMethod) {
+        self.visit_function_like(&method.function, None);
+    }
+
+    fn visit_constructor(&mut self, ctor: &Constructor) {
+        self.with_scope(ScopeKind::Function, |analyzer| {
+            for param in &ctor.params {
+                match param {
+                    ParamOrTsParamProp::Param(param) => {
+                        analyzer.declare_pat(
+                            &param.pat,
+                            analyzer.current_scope(),
+                            SymbolKind::Param,
+                            SymbolNamespace::Value,
+                        );
+                    }
+                    ParamOrTsParamProp::TsParamProp(prop) => prop.visit_with(analyzer),
+                }
+            }
+
+            if let Some(body) = &ctor.body {
+                analyzer.predeclare_stmts(&body.stmts);
+                body.stmts.visit_with(analyzer);
+            }
+        });
+    }
+
+    fn visit_var_decl(&mut self, decl: &VarDecl) {
+        let scope = if decl.kind == VarDeclKind::Var {
+            self.var_scope()
+        } else {
+            self.current_scope()
+        };
+        let kind = match decl.kind {
+            VarDeclKind::Var => SymbolKind::Var,
+            VarDeclKind::Let => SymbolKind::Let,
+            VarDeclKind::Const => SymbolKind::Const,
+        };
+
+        for decl in &decl.decls {
+            self.declare_pat(&decl.name, scope, kind, SymbolNamespace::Value);
+            decl.init.visit_with(self);
+        }
+    }
+
+    fn visit_using_decl(&mut self, decl: &UsingDecl) {
+        for decl in &decl.decls {
+            self.declare_pat(
+                &decl.name,
+                self.current_scope(),
+                SymbolKind::Using,
+                SymbolNamespace::Value,
+            );
+            decl.init.visit_with(self);
+        }
+    }
+
+    fn visit_binding_ident(&mut self, ident: &BindingIdent) {
+        self.visit_type_ann_opt(&ident.type_ann);
+        self.declare_ident(
+            &ident.id,
+            self.current_scope(),
+            SymbolKind::Let,
+            self.namespace,
+        );
+    }
+
+    fn visit_ident(&mut self, ident: &Ident) {
+        self.record_reference(ident, ReferenceKind::Read, self.namespace);
+    }
+
+    fn visit_prop_name(&mut self, name: &PropName) {
+        if let PropName::Computed(computed) = name {
+            computed.expr.visit_with(self);
+        }
+    }
+
+    fn visit_member_prop(&mut self, prop: &MemberProp) {
+        if let MemberProp::Computed(computed) = prop {
+            computed.expr.visit_with(self);
+        }
+    }
+
+    fn visit_super_prop(&mut self, prop: &SuperProp) {
+        if let SuperProp::Computed(computed) = prop {
+            computed.expr.visit_with(self);
+        }
+    }
+
+    fn visit_key_value_pat_prop(&mut self, prop: &KeyValuePatProp) {
+        self.visit_prop_name(&prop.key);
+        prop.value.visit_with(self);
+    }
+
+    fn visit_assign_expr(&mut self, expr: &AssignExpr) {
+        let kind = if expr.op == op!("=") {
+            ReferenceKind::Write
+        } else {
+            ReferenceKind::ReadWrite
+        };
+        self.visit_assignment_target(&expr.left, kind);
+        expr.right.visit_with(self);
+    }
+
+    fn visit_update_expr(&mut self, expr: &UpdateExpr) {
+        self.visit_assignment_expr(&expr.arg, ReferenceKind::ReadWrite);
+    }
+
+    fn visit_for_stmt(&mut self, stmt: &ForStmt) {
+        self.with_scope(ScopeKind::Block, |analyzer| {
+            if let Some(VarDeclOrExpr::VarDecl(decl)) = &stmt.init {
+                analyzer.predeclare_var_decl(decl);
+            }
+            stmt.init.visit_with(analyzer);
+            stmt.test.visit_with(analyzer);
+            stmt.update.visit_with(analyzer);
+            stmt.body.visit_with(analyzer);
+        });
+    }
+
+    fn visit_for_in_stmt(&mut self, stmt: &ForInStmt) {
+        self.with_scope(ScopeKind::Block, |analyzer| {
+            match &stmt.left {
+                ForHead::VarDecl(decl) => {
+                    analyzer.predeclare_var_decl(decl);
+                    decl.visit_with(analyzer);
+                }
+                ForHead::UsingDecl(decl) => decl.visit_with(analyzer),
+                ForHead::Pat(pat) => analyzer.visit_assignment_pat(pat, ReferenceKind::Write),
+            }
+            stmt.right.visit_with(analyzer);
+            stmt.body.visit_with(analyzer);
+        });
+    }
+
+    fn visit_for_of_stmt(&mut self, stmt: &ForOfStmt) {
+        self.with_scope(ScopeKind::Block, |analyzer| {
+            match &stmt.left {
+                ForHead::VarDecl(decl) => {
+                    analyzer.predeclare_var_decl(decl);
+                    decl.visit_with(analyzer);
+                }
+                ForHead::UsingDecl(decl) => decl.visit_with(analyzer),
+                ForHead::Pat(pat) => analyzer.visit_assignment_pat(pat, ReferenceKind::Write),
+            }
+            stmt.right.visit_with(analyzer);
+            stmt.body.visit_with(analyzer);
+        });
+    }
+
+    fn visit_import_decl(&mut self, import: &ImportDecl) {
+        self.predeclare_import(import);
+    }
+
+    fn visit_named_export(&mut self, export: &NamedExport) {
+        if export.src.is_some() {
+            return;
+        }
+
+        let namespace = if export.type_only {
+            SymbolNamespace::Type
+        } else {
+            SymbolNamespace::Value
+        };
+
+        for specifier in &export.specifiers {
+            match specifier {
+                ExportSpecifier::Named(named) => {
+                    let namespace = if named.is_type_only {
+                        SymbolNamespace::Type
+                    } else {
+                        namespace
+                    };
+                    if let ModuleExportName::Ident(orig) = &named.orig {
+                        self.record_reference(orig, ReferenceKind::Read, namespace);
+                    }
+                }
+                ExportSpecifier::Default(default) => {
+                    self.record_reference(&default.exported, ReferenceKind::Read, namespace);
+                }
+                ExportSpecifier::Namespace(_) => {}
+            }
+        }
+    }
+
+    fn visit_export_decl(&mut self, export: &ExportDecl) {
+        export.decl.visit_with(self);
+    }
+
+    fn visit_export_default_decl(&mut self, export: &ExportDefaultDecl) {
+        match &export.decl {
+            DefaultDecl::Fn(function) => {
+                if let Some(ident) = &function.ident {
+                    self.declare_ident(
+                        ident,
+                        self.current_scope(),
+                        SymbolKind::Function,
+                        SymbolNamespace::Value,
+                    );
+                }
+                function.function.decorators.visit_with(self);
+                self.visit_function_like(&function.function, None);
+            }
+            DefaultDecl::Class(class) => {
+                if let Some(ident) = &class.ident {
+                    self.declare_ident(
+                        ident,
+                        self.current_scope(),
+                        SymbolKind::Class,
+                        SymbolNamespace::Value,
+                    );
+                }
+                self.visit_class_like(&class.class, None);
+            }
+            DefaultDecl::TsInterfaceDecl(decl) => decl.visit_with(self),
+        }
+    }
+
+    fn visit_ts_type_ann(&mut self, ann: &TsTypeAnn) {
+        if self.config.typescript {
+            self.with_namespace(SymbolNamespace::Type, |analyzer| {
+                ann.type_ann.visit_with(analyzer);
+            });
+        }
+    }
+
+    fn visit_ts_type_alias_decl(&mut self, decl: &TsTypeAliasDecl) {
+        self.declare_ident(
+            &decl.id,
+            self.current_scope(),
+            SymbolKind::Type,
+            SymbolNamespace::Type,
+        );
+
+        if self.config.typescript {
+            self.with_scope(ScopeKind::Block, |analyzer| {
+                analyzer.with_namespace(SymbolNamespace::Type, |analyzer| {
+                    decl.type_params.visit_with(analyzer);
+                    decl.type_ann.visit_with(analyzer);
+                });
+            });
+        }
+    }
+
+    fn visit_ts_interface_decl(&mut self, decl: &TsInterfaceDecl) {
+        self.declare_ident(
+            &decl.id,
+            self.current_scope(),
+            SymbolKind::Type,
+            SymbolNamespace::Type,
+        );
+
+        if self.config.typescript {
+            self.with_scope(ScopeKind::Block, |analyzer| {
+                analyzer.with_namespace(SymbolNamespace::Type, |analyzer| {
+                    decl.type_params.visit_with(analyzer);
+                    decl.extends.visit_with(analyzer);
+                    decl.body.visit_with(analyzer);
+                });
+            });
+        }
+    }
+
+    fn visit_ts_type_param(&mut self, param: &TsTypeParam) {
+        if !self.config.typescript {
+            return;
+        }
+
+        self.declare_ident(
+            &param.name,
+            self.current_scope(),
+            SymbolKind::Type,
+            SymbolNamespace::Type,
+        );
+
+        self.with_namespace(SymbolNamespace::Type, |analyzer| {
+            param.constraint.visit_with(analyzer);
+            param.default.visit_with(analyzer);
+        });
+    }
+
+    fn visit_ts_entity_name(&mut self, name: &TsEntityName) {
+        if !self.config.typescript {
+            return;
+        }
+
+        match name {
+            TsEntityName::Ident(ident) => {
+                self.record_reference(ident, ReferenceKind::Read, SymbolNamespace::Type);
+            }
+            TsEntityName::TsQualifiedName(qualified) => {
+                qualified.left.visit_with(self);
+            }
+        }
+    }
+
+    fn visit_ts_type_ref(&mut self, type_ref: &TsTypeRef) {
+        if !self.config.typescript {
+            return;
+        }
+
+        self.with_namespace(SymbolNamespace::Type, |analyzer| {
+            type_ref.type_name.visit_with(analyzer);
+            type_ref.type_params.visit_with(analyzer);
+        });
+    }
+
+    fn visit_ts_expr_with_type_args(&mut self, expr: &TsExprWithTypeArgs) {
+        if !self.config.typescript {
+            return;
+        }
+
+        self.with_namespace(SymbolNamespace::Type, |analyzer| {
+            expr.expr.visit_with(analyzer);
+            expr.type_args.visit_with(analyzer);
+        });
+    }
+
+    fn visit_ts_property_signature(&mut self, prop: &TsPropertySignature) {
+        if !self.config.typescript {
+            return;
+        }
+
+        self.with_namespace(SymbolNamespace::Type, |analyzer| {
+            if prop.computed {
+                prop.key.visit_with(analyzer);
+            }
+            prop.type_ann.visit_with(analyzer);
+        });
+    }
+
+    fn visit_ts_getter_signature(&mut self, getter: &TsGetterSignature) {
+        if !self.config.typescript {
+            return;
+        }
+
+        self.with_namespace(SymbolNamespace::Type, |analyzer| {
+            if getter.computed {
+                getter.key.visit_with(analyzer);
+            }
+            getter.type_ann.visit_with(analyzer);
+        });
+    }
+
+    fn visit_ts_setter_signature(&mut self, setter: &TsSetterSignature) {
+        if !self.config.typescript {
+            return;
+        }
+
+        self.with_namespace(SymbolNamespace::Type, |analyzer| {
+            if setter.computed {
+                setter.key.visit_with(analyzer);
+            }
+            setter.param.visit_with(analyzer);
+        });
+    }
+
+    fn visit_ts_method_signature(&mut self, method: &TsMethodSignature) {
+        if !self.config.typescript {
+            return;
+        }
+
+        self.with_scope(ScopeKind::Function, |analyzer| {
+            analyzer.with_namespace(SymbolNamespace::Type, |analyzer| {
+                if method.computed {
+                    method.key.visit_with(analyzer);
+                }
+                method.type_params.visit_with(analyzer);
+                method.params.visit_with(analyzer);
+                method.type_ann.visit_with(analyzer);
+            });
+        });
+    }
+
+    fn visit_ts_enum_decl(&mut self, decl: &TsEnumDecl) {
+        self.declare_ident(
+            &decl.id,
+            self.current_scope(),
+            SymbolKind::Enum,
+            SymbolNamespace::Value,
+        );
+        if self.config.typescript {
+            self.declare_ident(
+                &decl.id,
+                self.current_scope(),
+                SymbolKind::Enum,
+                SymbolNamespace::Type,
+            );
+        }
+
+        self.with_scope(ScopeKind::Block, |analyzer| {
+            for member in &decl.members {
+                if let Some(init) = &member.init {
+                    init.visit_with(analyzer);
+                }
+            }
+        });
+    }
+
+    fn visit_ts_module_decl(&mut self, decl: &TsModuleDecl) {
+        if let TsModuleName::Ident(id) = &decl.id {
+            self.declare_ident(
+                id,
+                self.current_scope(),
+                SymbolKind::Namespace,
+                SymbolNamespace::Value,
+            );
+            if self.config.typescript {
+                self.declare_ident(
+                    id,
+                    self.current_scope(),
+                    SymbolKind::Namespace,
+                    SymbolNamespace::Type,
+                );
+            }
+        }
+
+        self.with_scope(ScopeKind::Block, |analyzer| {
+            decl.body.visit_with(analyzer);
+        });
+    }
+
+    fn visit_ts_namespace_decl(&mut self, decl: &TsNamespaceDecl) {
+        self.declare_ident(
+            &decl.id,
+            self.current_scope(),
+            SymbolKind::Namespace,
+            SymbolNamespace::Value,
+        );
+        if self.config.typescript {
+            self.declare_ident(
+                &decl.id,
+                self.current_scope(),
+                SymbolKind::Namespace,
+                SymbolNamespace::Type,
+            );
+        }
+
+        self.with_scope(ScopeKind::Block, |analyzer| {
+            decl.body.visit_with(analyzer);
+        });
+    }
+
+    fn visit_ts_import_equals_decl(&mut self, decl: &TsImportEqualsDecl) {
+        let namespace = if decl.is_type_only {
+            SymbolNamespace::Type
+        } else {
+            SymbolNamespace::Value
+        };
+        self.declare_ident(
+            &decl.id,
+            self.current_scope(),
+            SymbolKind::Import,
+            namespace,
+        );
+        decl.module_ref.visit_with(self);
+    }
+}

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/catch-param-var/input.js
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/catch-param-var/input.js
@@ -1,0 +1,6 @@
+try {
+    throw error;
+} catch (error) {
+    var lifted = error;
+}
+lifted;

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/catch-param-var/output.txt
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/catch-param-var/output.txt
@@ -1,0 +1,11 @@
+scopes
+  scope#0 Program parent=- fn=0 symbols=[1]
+  scope#1 Block parent=0 fn=0 symbols=[]
+  scope#2 Catch parent=0 fn=0 symbols=[0]
+symbols
+  symbol#0 Value CatchParam error scope=2 decls=[2]
+  symbol#1 Value Var lifted scope=0 decls=[3]
+references
+  reference#0 Value Read error node=1 scope=1 fn=0 symbol=-
+  reference#1 Value Read error node=4 scope=2 fn=0 symbol=0
+  reference#2 Value Read lifted node=5 scope=0 fn=0 symbol=1

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/class-function-expr/input.js
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/class-function-expr/input.js
@@ -1,0 +1,8 @@
+const fn = function named() {
+    return named;
+};
+const cls = class NamedClass {
+    method() {
+        return NamedClass;
+    }
+};

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/class-function-expr/output.txt
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/class-function-expr/output.txt
@@ -1,0 +1,13 @@
+scopes
+  scope#0 Program parent=- fn=0 symbols=[0,1]
+  scope#1 Function parent=0 fn=1 symbols=[2]
+  scope#2 Class parent=0 fn=0 symbols=[3]
+  scope#3 Function parent=2 fn=3 symbols=[]
+symbols
+  symbol#0 Value Const fn scope=0 decls=[1]
+  symbol#1 Value Const cls scope=0 decls=[4]
+  symbol#2 Value Function named scope=1 decls=[2]
+  symbol#3 Value Class NamedClass scope=2 decls=[5]
+references
+  reference#0 Value Read named node=3 scope=1 fn=1 symbol=2
+  reference#1 Value Read NamedClass node=6 scope=3 fn=3 symbol=3

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/imports-exports/input.js
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/imports-exports/input.js
@@ -1,0 +1,6 @@
+import foo, { bar as baz } from "mod";
+const local = foo + baz;
+export { local as renamed };
+export function used() {
+    return local;
+}

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/imports-exports/output.txt
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/imports-exports/output.txt
@@ -1,0 +1,13 @@
+scopes
+  scope#0 Program parent=- fn=0 symbols=[0,1,2,3]
+  scope#1 Function parent=0 fn=1 symbols=[]
+symbols
+  symbol#0 Value Import foo scope=0 decls=[1]
+  symbol#1 Value Import baz scope=0 decls=[2]
+  symbol#2 Value Const local scope=0 decls=[4]
+  symbol#3 Value Function used scope=0 decls=[9]
+references
+  reference#0 Value Read foo node=5 scope=0 fn=0 symbol=0
+  reference#1 Value Read baz node=6 scope=0 fn=0 symbol=1
+  reference#2 Value Read local node=7 scope=0 fn=0 symbol=2
+  reference#3 Value Read local node=10 scope=1 fn=1 symbol=2

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/shadow/input.js
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/shadow/input.js
@@ -1,0 +1,12 @@
+let value = 1;
+{
+    let value = 2;
+    value;
+}
+function outer(param) {
+    var value = param;
+    function inner() {
+        return value;
+    }
+    return inner;
+}

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/shadow/output.txt
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/shadow/output.txt
@@ -1,0 +1,17 @@
+scopes
+  scope#0 Program parent=- fn=0 symbols=[0,1]
+  scope#1 Block parent=0 fn=0 symbols=[2]
+  scope#2 Function parent=0 fn=2 symbols=[3,4,5]
+  scope#3 Function parent=2 fn=3 symbols=[]
+symbols
+  symbol#0 Value Let value scope=0 decls=[1]
+  symbol#1 Value Function outer scope=0 decls=[4]
+  symbol#2 Value Let value scope=1 decls=[2]
+  symbol#3 Value Param param scope=2 decls=[5]
+  symbol#4 Value Var value scope=2 decls=[6]
+  symbol#5 Value Function inner scope=2 decls=[8]
+references
+  reference#0 Value Read value node=3 scope=1 fn=0 symbol=2
+  reference#1 Value Read param node=7 scope=2 fn=2 symbol=3
+  reference#2 Value Read value node=9 scope=3 fn=3 symbol=4
+  reference#3 Value Read inner node=10 scope=2 fn=2 symbol=5

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/ts-type-value/input.ts
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/ts-type-value/input.ts
@@ -1,0 +1,6 @@
+type Box<T> = T;
+const Box = 1;
+let value: Box<number> = Box;
+interface Shape {
+    value: Box<string>;
+}

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/ts-type-value/output.txt
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/ts-type-value/output.txt
@@ -1,0 +1,15 @@
+scopes
+  scope#0 Program parent=- fn=0 symbols=[0,1,2,3]
+  scope#1 Block parent=0 fn=0 symbols=[4]
+  scope#2 Block parent=0 fn=0 symbols=[]
+symbols
+  symbol#0 Type Type Box scope=0 decls=[1]
+  symbol#1 Value Const Box scope=0 decls=[4]
+  symbol#2 Value Let value scope=0 decls=[5]
+  symbol#3 Type Type Shape scope=0 decls=[8]
+  symbol#4 Type Type T scope=1 decls=[2]
+references
+  reference#0 Type Read T node=3 scope=1 fn=0 symbol=4
+  reference#1 Type Read Box node=6 scope=0 fn=0 symbol=0
+  reference#2 Value Read Box node=7 scope=0 fn=0 symbol=1
+  reference#3 Type Read Box node=10 scope=2 fn=0 symbol=0

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/unresolved/input.js
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/unresolved/input.js
@@ -1,0 +1,2 @@
+known + missing;
+let known = 1;

--- a/crates/swc_ecma_transforms_base/tests/node-id-semantics/unresolved/output.txt
+++ b/crates/swc_ecma_transforms_base/tests/node-id-semantics/unresolved/output.txt
@@ -1,0 +1,7 @@
+scopes
+  scope#0 Program parent=- fn=0 symbols=[0]
+symbols
+  symbol#0 Value Let known scope=0 decls=[3]
+references
+  reference#0 Value Read known node=1 scope=0 fn=0 symbol=0
+  reference#1 Value Read missing node=2 scope=0 fn=0 symbol=-

--- a/crates/swc_ecma_transforms_base/tests/semantics.rs
+++ b/crates/swc_ecma_transforms_base/tests/semantics.rs
@@ -1,0 +1,109 @@
+use std::path::{Path, PathBuf};
+
+use swc_ecma_ast::*;
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, StringInput, Syntax, TsSyntax};
+use swc_ecma_transforms_base::semantics::{analyze, SemanticConfig, Semantics};
+use testing::{fixture, run_test2, NormalizedOutput};
+
+fn dump_semantics(semantics: &Semantics) -> String {
+    let mut out = String::new();
+
+    out.push_str("scopes\n");
+    for (idx, scope) in semantics.scopes().iter().enumerate() {
+        let parent = scope
+            .parent
+            .map(|id| id.as_u32().to_string())
+            .unwrap_or_else(|| "-".into());
+        let symbols = scope
+            .symbols
+            .iter()
+            .map(|id| id.as_u32().to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        out.push_str(&format!(
+            "  scope#{idx} {:?} parent={parent} fn={} symbols=[{symbols}]\n",
+            scope.kind,
+            scope.enclosing_function.as_u32()
+        ));
+    }
+
+    out.push_str("symbols\n");
+    for (idx, symbol) in semantics.symbols().iter().enumerate() {
+        let decls = symbol
+            .declaration_node_ids
+            .iter()
+            .map(|id| id.as_u32().to_string())
+            .collect::<Vec<_>>()
+            .join(",");
+
+        out.push_str(&format!(
+            "  symbol#{idx} {:?} {:?} {} scope={} decls=[{decls}]\n",
+            symbol.namespace,
+            symbol.kind,
+            symbol.name,
+            symbol.scope.as_u32()
+        ));
+    }
+
+    out.push_str("references\n");
+    for (idx, reference) in semantics.references().iter().enumerate() {
+        let symbol = reference
+            .symbol
+            .map(|id| id.as_u32().to_string())
+            .unwrap_or_else(|| "-".into());
+
+        out.push_str(&format!(
+            "  reference#{idx} {:?} {:?} {} node={} scope={} fn={} symbol={symbol}\n",
+            reference.namespace,
+            reference.kind,
+            reference.name,
+            reference.node_id.as_u32(),
+            reference.scope.as_u32(),
+            reference.enclosing_function.as_u32()
+        ));
+    }
+
+    out
+}
+
+fn run(input: &Path) {
+    let is_ts = input.extension().filter(|ext| *ext == "ts").is_some();
+    let syntax = if is_ts {
+        Syntax::Typescript(TsSyntax {
+            decorators: true,
+            ..Default::default()
+        })
+    } else {
+        Syntax::Es(EsSyntax {
+            jsx: true,
+            ..Default::default()
+        })
+    };
+
+    let output = input.parent().unwrap().join("output.txt");
+
+    run_test2(false, |cm, handler| {
+        let fm = cm.load_file(input).unwrap();
+        let lexer = Lexer::new(syntax, EsVersion::latest(), StringInput::from(&*fm), None);
+        let mut parser = Parser::new_from(lexer);
+
+        let mut program = parser
+            .parse_program()
+            .map_err(|err| err.into_diagnostic(&handler).emit())?;
+
+        let semantics = analyze(&mut program, SemanticConfig { typescript: is_ts });
+        NormalizedOutput::from(dump_semantics(&semantics))
+            .compare_to_file(&output)
+            .unwrap();
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[fixture("tests/node-id-semantics/**/input.js")]
+#[fixture("tests/node-id-semantics/**/input.ts")]
+fn node_id_semantics(input: PathBuf) {
+    run(&input);
+}

--- a/crates/swc_ecma_utils/src/ident.rs
+++ b/crates/swc_ecma_utils/src/ident.rs
@@ -1,9 +1,10 @@
 use swc_atoms::Atom;
 use swc_common::SyntaxContext;
-use swc_ecma_ast::{unsafe_id_from_ident, BindingIdent, Id, Ident, UnsafeId};
+use swc_ecma_ast::{unsafe_id_from_ident, BindingIdent, Id, Ident, NodeId, UnsafeId};
 
 pub trait IdentLike: Sized + Send + Sync + 'static {
     fn from_ident(i: &Ident) -> Self;
+    fn node_id(&self) -> NodeId;
     fn to_id(&self) -> Id;
     fn into_id(self) -> Id;
 }
@@ -11,6 +12,10 @@ pub trait IdentLike: Sized + Send + Sync + 'static {
 impl IdentLike for Atom {
     fn from_ident(i: &Ident) -> Self {
         i.sym.clone()
+    }
+
+    fn node_id(&self) -> NodeId {
+        NodeId::invalid()
     }
 
     fn to_id(&self) -> Id {
@@ -25,6 +30,10 @@ impl IdentLike for Atom {
 impl IdentLike for BindingIdent {
     fn from_ident(i: &Ident) -> Self {
         i.clone().into()
+    }
+
+    fn node_id(&self) -> NodeId {
+        self.id.node_id
     }
 
     fn to_id(&self) -> Id {
@@ -42,6 +51,10 @@ impl IdentLike for (Atom, SyntaxContext) {
         (i.sym.clone(), i.ctxt)
     }
 
+    fn node_id(&self) -> NodeId {
+        NodeId::invalid()
+    }
+
     #[inline]
     fn to_id(&self) -> Id {
         (self.0.clone(), self.1)
@@ -56,7 +69,12 @@ impl IdentLike for (Atom, SyntaxContext) {
 impl IdentLike for Ident {
     #[inline]
     fn from_ident(i: &Ident) -> Self {
-        Ident::new(i.sym.clone(), i.span, i.ctxt)
+        i.clone()
+    }
+
+    #[inline]
+    fn node_id(&self) -> NodeId {
+        self.node_id
     }
 
     #[inline]
@@ -73,6 +91,10 @@ impl IdentLike for Ident {
 impl IdentLike for UnsafeId {
     fn from_ident(i: &Ident) -> Self {
         unsafe { unsafe_id_from_ident(i) }
+    }
+
+    fn node_id(&self) -> NodeId {
+        NodeId::invalid()
     }
 
     fn to_id(&self) -> Id {

--- a/crates/swc_estree_compat/src/swcify/expr.rs
+++ b/crates/swc_estree_compat/src/swcify/expr.rs
@@ -321,6 +321,7 @@ impl Swcify for Identifier {
                 sym: self.name,
                 optional: self.optional.unwrap_or(false),
                 ctxt: Default::default(),
+                node_id: Default::default(),
             },
             type_ann: self.type_annotation.swcify(ctx).flatten().map(Box::new),
         }

--- a/crates/swc_typescript/src/fast_dts/enum.rs
+++ b/crates/swc_typescript/src/fast_dts/enum.rs
@@ -56,6 +56,7 @@ impl FastDts {
                         let expr = if v.is_infinite() {
                             Expr::Ident(Ident {
                                 span: DUMMY_SP,
+                                node_id: Default::default(),
                                 sym: atom!("Infinity"),
                                 ctxt: SyntaxContext::empty(),
                                 optional: false,


### PR DESCRIPTION
## Summary

- Add `NodeId` to `swc_ecma_ast::Ident` as an occurrence id with `NodeId(0)` reserved as invalid/default.
- Add `swc_ecma_transforms_base::semantics` with fresh node-id assignment plus `ScopeId`, `SymbolId`, and `ReferenceId` side tables.
- Wire resolver entrypoints to assign fresh node ids, add SymbolId-based rename adapter APIs, and expose node-id access through `IdentLike`.
- Assign fresh node ids at minifier analysis entrypoints so the new semantics path can be shared by follow-up internal migrations.

## Notes

This is intentionally experimental. The AST and semantics foundation is in place, but the minifier's internal `ProgramData` variable keys are not fully migrated from legacy `Id` to `SymbolId` yet.

## Test Plan

- `git submodule update --init --recursive`
- `cargo test -p generate-code test_ecmascript -- --nocapture`
- `cargo check -p swc_ecma_ast -p swc_ecma_visit -p swc_ecma_hooks`
- `cargo check -p swc_ecma_transforms_base -p swc_ecma_utils -p swc_ecma_minifier`
- `UPDATE=1 cargo test -p swc_ecma_transforms_base --test semantics -- --ignored`
- `cargo test -p swc_ecma_transforms_base --test semantics -- --ignored`
- `cargo test -p swc_ecma_transforms_base`
- `cargo test -p swc_ecma_utils`
- `cargo test -p swc_ecma_minifier`
- `(cd crates/swc_ecma_minifier && UPDATE=1 ./scripts/test.sh)`
- `(cd crates/swc_ecma_minifier && ./scripts/test.sh)`
- `(cd crates/swc_ecma_minifier && ./scripts/exec.sh)`
- `cargo check -p swc_ecma_transformer -p swc_typescript -p swc_ecma_transforms_module`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_ast -p swc_ecma_visit -p swc_ecma_hooks -p swc_ecma_transformer -p swc_typescript -p swc_estree_compat`
- `cargo test -p swc_bundler --lib`

`cargo test -p swc_bundler ...` with integration tests was attempted, but `swc_bundler --test deno` requires a local `deno` executable and failed with `No such file or directory`.
