### PR TITLE
fix(minifier): preserve unsafe object spreads

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -15,7 +15,7 @@ use super::Pure;
 use crate::{
     compress::{
         pure::{strings::convert_str_value_to_tpl_raw, Ctx},
-        util::is_pure_undefined,
+        util::{contains_super, is_pure_undefined},
     },
     usage_analyzer::util::is_global_var_with_pure_property_access,
 };
@@ -284,6 +284,43 @@ impl Pure<'_> {
     }
 
     pub(super) fn eval_spread_object(&mut self, e: &mut ObjectLit) {
+        fn is_proto_key(key: &PropName) -> bool {
+            match key {
+                PropName::Ident(i) => i.sym == "__proto__",
+                PropName::Str(s) => &*s.value == "__proto__",
+                _ => false,
+            }
+        }
+
+        fn should_skip_spread_source_prop(p: &PropOrSpread, expr_ctx: ExprCtx) -> bool {
+            match p {
+                PropOrSpread::Prop(p) => match &**p {
+                    Prop::KeyValue(KeyValueProp { key, value, .. }) => {
+                        key.is_computed()
+                            || is_proto_key(key)
+                            || value.may_have_side_effects(expr_ctx)
+                    }
+                    Prop::Assign(AssignProp { value, .. }) => value.may_have_side_effects(expr_ctx),
+                    Prop::Method(method) => {
+                        method.key.is_computed() || contains_super(&method.function.body)
+                    }
+
+                    Prop::Getter(..) | Prop::Setter(..) => true,
+
+                    _ => false,
+                },
+
+                PropOrSpread::Spread(SpreadElement { expr, .. }) => match &**expr {
+                    Expr::Object(ObjectLit { props, .. }) => props
+                        .iter()
+                        .any(|p| should_skip_spread_source_prop(p, expr_ctx)),
+                    _ => false,
+                },
+                #[cfg(swc_ast_unknown)]
+                _ => panic!("unable to access unknown nodes"),
+            }
+        }
+
         fn should_skip(p: &PropOrSpread, expr_ctx: ExprCtx) -> bool {
             match p {
                 PropOrSpread::Prop(p) => match &**p {
@@ -299,9 +336,9 @@ impl Pure<'_> {
                 },
 
                 PropOrSpread::Spread(SpreadElement { expr, .. }) => match &**expr {
-                    Expr::Object(ObjectLit { props, .. }) => {
-                        props.iter().any(|p| should_skip(p, expr_ctx))
-                    }
+                    Expr::Object(ObjectLit { props, .. }) => props
+                        .iter()
+                        .any(|p| should_skip_spread_source_prop(p, expr_ctx)),
                     _ => false,
                 },
                 #[cfg(swc_ast_unknown)]

--- a/crates/swc_ecma_minifier/tests/fixture/issues/object-spread-frozen-key/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/object-spread-frozen-key/config.json
@@ -1,0 +1,5 @@
+{
+    "defaults": true,
+    "module": false,
+    "toplevel": true
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/object-spread-frozen-key/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/object-spread-frozen-key/input.js
@@ -1,0 +1,23 @@
+const assert = require("assert");
+
+let leaked = false;
+const proto = {
+    get Leaked() {
+        leaked = true;
+        return "bad";
+    },
+};
+
+const Keys = Object.freeze({
+    ...{ __proto__: proto },
+    FocalTweet: "focal_tweet",
+});
+
+const handler = () => "handled";
+const handlers = {
+    [Keys.FocalTweet]: handler,
+};
+
+assert.strictEqual(Keys.Leaked, undefined);
+assert.strictEqual(leaked, false);
+assert.strictEqual(handlers[Keys.FocalTweet](), "handled");

--- a/crates/swc_ecma_minifier/tests/fixture/issues/object-spread-frozen-key/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/object-spread-frozen-key/output.js
@@ -1,0 +1,15 @@
+const assert = require("assert");
+let leaked = !1;
+const Keys = Object.freeze({
+    ...{
+        __proto__: {
+            get Leaked () {
+                return leaked = !0, "bad";
+            }
+        }
+    },
+    FocalTweet: "focal_tweet"
+}), handlers = {
+    [Keys.FocalTweet]: ()=>"handled"
+};
+assert.strictEqual(Keys.Leaked, void 0), assert.strictEqual(leaked, !1), assert.strictEqual(handlers[Keys.FocalTweet](), "handled");


### PR DESCRIPTION
## Summary
- Prevent object spread folding from flattening spread sources that are not semantically plain data objects.
- Treat `__proto__`, computed keys, accessors, impure values, and methods containing `super` as unsafe spread barriers.
- Add a regression fixture that keeps the frozen `"focal_tweet"` source literal while preserving computed-property registration behavior.

## Test Plan
- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_minifier --test compress custom_fixture_tests__fixture__issues__object_spread_frozen_key__input_js -- --ignored`
- `cargo test -p swc_ecma_minifier --test compress custom_fixture_tests__fixture__issues__object_spread_frozen_key__input_js -- --ignored`
- `(cd crates/swc_ecma_minifier && ./scripts/exec.sh)`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_minifier`
- `node crates/swc_ecma_minifier/tests/fixture/issues/object-spread-frozen-key/output.js`
