### PR TITLE
fix(es/parser): align Flow generic arrow JSX disambiguation

### DIFF
--- a/.changeset/twelve-suns-scream.md
+++ b/.changeset/twelve-suns-scream.md
@@ -1,0 +1,7 @@
+---
+swc_ecma_lexer: patch
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(parser): align Flow generic arrow JSX disambiguation

--- a/crates/swc_ecma_lexer/src/common/parser/expr.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/expr.rs
@@ -389,7 +389,10 @@ fn parse_assignment_expr_base<'a, P: Parser<'a>>(p: &mut P) -> PResult<Box<Expr>
                 // looks like JSX.
                 // Valid alternatives: `<T,>() => {}` or `<T extends unknown>() =>
                 // {}`
-                if p.input().syntax().jsx() && type_parameters.params.len() == 1 {
+                if p.input().syntax().jsx()
+                    && !p.input().syntax().flow()
+                    && type_parameters.params.len() == 1
+                {
                     let single_param = &type_parameters.params[0];
                     let has_trailing_comma = type_parameters.span.hi.0 - single_param.span.hi.0 > 1;
                     let dominated_by_jsx = single_param.constraint.is_none()

--- a/crates/swc_ecma_lexer/src/common/parser/typescript.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/typescript.rs
@@ -2877,7 +2877,10 @@ pub fn try_parse_ts_generic_async_arrow_fn<'a, P: Parser<'a>>(
             // In TSX mode, type parameters that could be mistaken for JSX
             // (single param without constraint and no trailing comma) are not
             // allowed.
-            if p.input().syntax().jsx() && type_params.params.len() == 1 {
+            if p.input().syntax().jsx()
+                && !p.input().syntax().flow()
+                && type_params.params.len() == 1
+            {
                 let single_param = &type_params.params[0];
                 let has_trailing_comma = type_params.span.hi.0 - single_param.span.hi.0 > 1;
                 let dominated_by_jsx = single_param.constraint.is_none()

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -5146,7 +5146,10 @@ impl<I: Tokens> Parser<I> {
                 // In TSX mode, type parameters that could be mistaken for JSX
                 // (single param without constraint and no trailing comma) are not
                 // allowed.
-                if p.input().syntax().jsx() && type_params.params.len() == 1 {
+                if p.input().syntax().jsx()
+                    && !p.input().syntax().flow()
+                    && type_params.params.len() == 1
+                {
                     let single_param = &type_params.params[0];
                     let has_trailing_comma = type_params.span.hi.0 - single_param.span.hi.0 > 1;
                     let dominated_by_jsx = single_param.constraint.is_none()

--- a/crates/swc_ecma_parser/tests/flow/issue-11729-arrow-trailing-comma/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/issue-11729-arrow-trailing-comma/basic.js
@@ -5,3 +5,10 @@ const withType = (
 const withTypeParam = <T: {...}>(
   value: T,
 ): T => value;
+
+const genericNoComma = <Generic>(args) => args;
+const genericTrailingComma = <Generic,>(args) => args;
+const genericConstrained = <Generic: mixed>(args) => args;
+const asyncGenericNoComma = async <Generic>(args) => args;
+const asyncGenericTrailingComma = async <Generic,>(args) => args;
+const jsxRollback = <Generic>(args)</Generic>;

--- a/crates/swc_ecma_parser/tests/flow/issue-11729-arrow-trailing-comma/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11729-arrow-trailing-comma/basic.js.json
@@ -2,7 +2,7 @@
   "type": "Script",
   "span": {
     "start": 1,
-    "end": 118
+    "end": 453
   },
   "body": [
     {
@@ -265,6 +265,589 @@
                   "optional": false
                 },
                 "typeParams": null
+              }
+            }
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 120,
+        "end": 167
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 126,
+            "end": 166
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 126,
+              "end": 140
+            },
+            "ctxt": 0,
+            "value": "genericNoComma",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "span": {
+              "start": 143,
+              "end": 166
+            },
+            "ctxt": 0,
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 153,
+                  "end": 157
+                },
+                "ctxt": 0,
+                "value": "args",
+                "optional": false,
+                "typeAnnotation": null
+              }
+            ],
+            "body": {
+              "type": "Identifier",
+              "span": {
+                "start": 162,
+                "end": 166
+              },
+              "ctxt": 0,
+              "value": "args",
+              "optional": false
+            },
+            "async": false,
+            "generator": false,
+            "typeParameters": {
+              "type": "TsTypeParameterDeclaration",
+              "span": {
+                "start": 143,
+                "end": 152
+              },
+              "parameters": [
+                {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 144,
+                    "end": 151
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 144,
+                      "end": 151
+                    },
+                    "ctxt": 0,
+                    "value": "Generic",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "const": false,
+                  "constraint": null,
+                  "default": null
+                }
+              ]
+            },
+            "returnType": null
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 168,
+        "end": 222
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 174,
+            "end": 221
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 174,
+              "end": 194
+            },
+            "ctxt": 0,
+            "value": "genericTrailingComma",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "span": {
+              "start": 197,
+              "end": 221
+            },
+            "ctxt": 0,
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 208,
+                  "end": 212
+                },
+                "ctxt": 0,
+                "value": "args",
+                "optional": false,
+                "typeAnnotation": null
+              }
+            ],
+            "body": {
+              "type": "Identifier",
+              "span": {
+                "start": 217,
+                "end": 221
+              },
+              "ctxt": 0,
+              "value": "args",
+              "optional": false
+            },
+            "async": false,
+            "generator": false,
+            "typeParameters": {
+              "type": "TsTypeParameterDeclaration",
+              "span": {
+                "start": 197,
+                "end": 207
+              },
+              "parameters": [
+                {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 198,
+                    "end": 205
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 198,
+                      "end": 205
+                    },
+                    "ctxt": 0,
+                    "value": "Generic",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "const": false,
+                  "constraint": null,
+                  "default": null
+                }
+              ]
+            },
+            "returnType": null
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 223,
+        "end": 281
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 229,
+            "end": 280
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 229,
+              "end": 247
+            },
+            "ctxt": 0,
+            "value": "genericConstrained",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "span": {
+              "start": 250,
+              "end": 280
+            },
+            "ctxt": 0,
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 267,
+                  "end": 271
+                },
+                "ctxt": 0,
+                "value": "args",
+                "optional": false,
+                "typeAnnotation": null
+              }
+            ],
+            "body": {
+              "type": "Identifier",
+              "span": {
+                "start": 276,
+                "end": 280
+              },
+              "ctxt": 0,
+              "value": "args",
+              "optional": false
+            },
+            "async": false,
+            "generator": false,
+            "typeParameters": {
+              "type": "TsTypeParameterDeclaration",
+              "span": {
+                "start": 250,
+                "end": 266
+              },
+              "parameters": [
+                {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 251,
+                    "end": 265
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 251,
+                      "end": 258
+                    },
+                    "ctxt": 0,
+                    "value": "Generic",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "const": false,
+                  "constraint": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 260,
+                      "end": 265
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 260,
+                        "end": 265
+                      },
+                      "ctxt": 0,
+                      "value": "mixed",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  },
+                  "default": null
+                }
+              ]
+            },
+            "returnType": null
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 282,
+        "end": 340
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 288,
+            "end": 339
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 288,
+              "end": 307
+            },
+            "ctxt": 0,
+            "value": "asyncGenericNoComma",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "span": {
+              "start": 310,
+              "end": 339
+            },
+            "ctxt": 0,
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 326,
+                  "end": 330
+                },
+                "ctxt": 0,
+                "value": "args",
+                "optional": false,
+                "typeAnnotation": null
+              }
+            ],
+            "body": {
+              "type": "Identifier",
+              "span": {
+                "start": 335,
+                "end": 339
+              },
+              "ctxt": 0,
+              "value": "args",
+              "optional": false
+            },
+            "async": true,
+            "generator": false,
+            "typeParameters": {
+              "type": "TsTypeParameterDeclaration",
+              "span": {
+                "start": 316,
+                "end": 325
+              },
+              "parameters": [
+                {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 317,
+                    "end": 324
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 317,
+                      "end": 324
+                    },
+                    "ctxt": 0,
+                    "value": "Generic",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "const": false,
+                  "constraint": null,
+                  "default": null
+                }
+              ]
+            },
+            "returnType": null
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 341,
+        "end": 406
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 347,
+            "end": 405
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 347,
+              "end": 372
+            },
+            "ctxt": 0,
+            "value": "asyncGenericTrailingComma",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "span": {
+              "start": 375,
+              "end": 405
+            },
+            "ctxt": 0,
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 392,
+                  "end": 396
+                },
+                "ctxt": 0,
+                "value": "args",
+                "optional": false,
+                "typeAnnotation": null
+              }
+            ],
+            "body": {
+              "type": "Identifier",
+              "span": {
+                "start": 401,
+                "end": 405
+              },
+              "ctxt": 0,
+              "value": "args",
+              "optional": false
+            },
+            "async": true,
+            "generator": false,
+            "typeParameters": {
+              "type": "TsTypeParameterDeclaration",
+              "span": {
+                "start": 381,
+                "end": 391
+              },
+              "parameters": [
+                {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 382,
+                    "end": 389
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 382,
+                      "end": 389
+                    },
+                    "ctxt": 0,
+                    "value": "Generic",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "const": false,
+                  "constraint": null,
+                  "default": null
+                }
+              ]
+            },
+            "returnType": null
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 407,
+        "end": 453
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 413,
+            "end": 452
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 413,
+              "end": 424
+            },
+            "ctxt": 0,
+            "value": "jsxRollback",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "JSXElement",
+            "span": {
+              "start": 427,
+              "end": 452
+            },
+            "opening": {
+              "type": "JSXOpeningElement",
+              "name": {
+                "type": "Identifier",
+                "span": {
+                  "start": 428,
+                  "end": 435
+                },
+                "ctxt": 0,
+                "value": "Generic",
+                "optional": false
+              },
+              "span": {
+                "start": 427,
+                "end": 436
+              },
+              "attributes": [],
+              "selfClosing": false,
+              "typeArguments": null
+            },
+            "children": [
+              {
+                "type": "JSXText",
+                "span": {
+                  "start": 436,
+                  "end": 442
+                },
+                "value": "(args)",
+                "raw": "(args)"
+              }
+            ],
+            "closing": {
+              "type": "JSXClosingElement",
+              "span": {
+                "start": 442,
+                "end": 452
+              },
+              "name": {
+                "type": "Identifier",
+                "span": {
+                  "start": 444,
+                  "end": 451
+                },
+                "ctxt": 0,
+                "value": "Generic",
+                "optional": false
               }
             }
           },


### PR DESCRIPTION
## Summary
- Align Flow+JSX generic arrow speculative parsing with official Flow parser behavior.
- Allow `<Generic>(args) => args` and `<Generic,>(args) => args` to commit as generic arrows in Flow mode when the full arrow head succeeds.
- Keep rollback behavior for JSX cases like `<Generic>(args)</Generic>`.

## Tests
- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_parser --features flow --test flow -- --ignored`
- `cargo test -p swc_ecma_parser --features flow --test flow -- --ignored`
- `cargo test -p swc_ecma_parser`
- `cargo test -p swc_ecma_lexer`
- `cargo test -p swc_ecma_parser --features flow`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
