### PR TITLE
fix(minifier): preserve frozen spread registry keys

### DIFF
--- a/.changeset/spotty-plants-call.md
+++ b/.changeset/spotty-plants-call.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_minifier: patch
+swc_core: patch
+---
+
+fix(minifier): preserve frozen spread registry keys

--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -946,6 +946,15 @@ impl Optimizer<'_> {
 
         let usage = self.data.vars.get(&name.to_id())?;
 
+        // Property pruning is only safe when every property read is reflected in
+        // accessed_props. Some reduced computed reads only leave the coarser
+        // HAS_PROPERTY_ACCESS marker, so keep the whole object in that case.
+        if usage.flags.contains(VarUsageInfoFlags::HAS_PROPERTY_ACCESS)
+            && usage.accessed_props.is_empty()
+        {
+            return None;
+        }
+
         if usage.flags.intersects(
             VarUsageInfoFlags::INDEXED_WITH_DYNAMIC_KEY
                 .union(VarUsageInfoFlags::USED_AS_REF)

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -284,7 +284,54 @@ impl Pure<'_> {
     }
 
     pub(super) fn eval_spread_object(&mut self, e: &mut ObjectLit) {
-        fn should_skip(p: &PropOrSpread, expr_ctx: ExprCtx) -> bool {
+        fn is_proto_key(key: &PropName) -> bool {
+            match key {
+                PropName::Ident(i) => &*i.sym == "__proto__",
+                PropName::Str(s) => s.value.as_str() == Some("__proto__"),
+                _ => false,
+            }
+        }
+
+        fn can_flatten_spread_expr(expr: &Expr, expr_ctx: ExprCtx) -> bool {
+            match expr {
+                Expr::Object(ObjectLit { props, .. }) => {
+                    props.iter().all(|p| can_flatten_spread_prop(p, expr_ctx))
+                }
+                Expr::Lit(Lit::Null(_)) => true,
+                _ => false,
+            }
+        }
+
+        fn can_flatten_spread_prop(p: &PropOrSpread, expr_ctx: ExprCtx) -> bool {
+            match p {
+                PropOrSpread::Prop(p) => match &**p {
+                    Prop::KeyValue(KeyValueProp { key, value, .. }) => {
+                        !key.is_computed()
+                            && !is_proto_key(key)
+                            && !value.may_have_side_effects(expr_ctx)
+                    }
+                    Prop::Assign(AssignProp { key, value, .. }) => {
+                        key.sym != *"__proto__" && !value.may_have_side_effects(expr_ctx)
+                    }
+                    Prop::Shorthand(i) => i.sym != *"__proto__",
+
+                    // Moving methods between object literals can change their
+                    // [[HomeObject]], which matters for `super`.
+                    Prop::Method(..) | Prop::Getter(..) | Prop::Setter(..) => false,
+
+                    #[cfg(swc_ast_unknown)]
+                    _ => false,
+                },
+
+                PropOrSpread::Spread(SpreadElement { expr, .. }) => {
+                    can_flatten_spread_expr(expr, expr_ctx)
+                }
+                #[cfg(swc_ast_unknown)]
+                _ => panic!("unable to access unknown nodes"),
+            }
+        }
+
+        fn should_skip_target_prop(p: &PropOrSpread, expr_ctx: ExprCtx) -> bool {
             match p {
                 PropOrSpread::Prop(p) => match &**p {
                     Prop::KeyValue(KeyValueProp { key, value, .. }) => {
@@ -299,9 +346,7 @@ impl Pure<'_> {
                 },
 
                 PropOrSpread::Spread(SpreadElement { expr, .. }) => match &**expr {
-                    Expr::Object(ObjectLit { props, .. }) => {
-                        props.iter().any(|p| should_skip(p, expr_ctx))
-                    }
+                    Expr::Object(..) => !can_flatten_spread_expr(expr, expr_ctx),
                     _ => false,
                 },
                 #[cfg(swc_ast_unknown)]
@@ -309,10 +354,12 @@ impl Pure<'_> {
             }
         }
 
-        if e.props.iter().any(|p| should_skip(p, self.expr_ctx))
+        if e.props
+            .iter()
+            .any(|p| should_skip_target_prop(p, self.expr_ctx))
             || !e.props.iter().any(|p| match p {
                 PropOrSpread::Spread(SpreadElement { expr, .. }) => {
-                    expr.is_object() || expr.is_null()
+                    can_flatten_spread_expr(expr, self.expr_ctx)
                 }
                 _ => false,
             })
@@ -325,7 +372,7 @@ impl Pure<'_> {
         for prop in e.props.take() {
             match prop {
                 PropOrSpread::Spread(SpreadElement { expr, .. })
-                    if expr.is_object() || expr.is_null() =>
+                    if can_flatten_spread_expr(&expr, self.expr_ctx) =>
                 {
                     match *expr {
                         Expr::Object(ObjectLit { props, .. }) => {
@@ -347,6 +394,8 @@ impl Pure<'_> {
         }
 
         e.props = new_props;
+        self.changed = true;
+        report_change!("evaluate: Folded object spread from a plain object literal");
     }
 
     /// `foo(...[1, 2])`` => `foo(1, 2)`

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -12096,3 +12096,44 @@ console.log(getStatusMessage(999).message);
 "#;
     run_default_exec_test(src);
 }
+
+#[test]
+fn object_freeze_spread_computed_registration() {
+    let src = r#"
+const Inner = /*#__PURE__*/ Object.freeze({
+  FocalTweet: "FocalTweet"
+});
+const Outer = /*#__PURE__*/ Object.freeze({
+  ...Inner,
+  Tweet: "Tweet"
+});
+const handlers = {
+  [Outer.Tweet]: "tweetHandler",
+  [Outer.FocalTweet]: "focalTweetHandler"
+};
+
+console.log(Outer.FocalTweet);
+console.log(handlers.FocalTweet);
+console.log(Object.prototype.hasOwnProperty.call(handlers, "undefined"));
+"#;
+    let config = r#"{
+        "defaults": true,
+        "toplevel": true,
+        "passes": 3
+    }"#;
+
+    run_exec_test(src, config, false);
+}
+
+#[test]
+fn object_spread_proto_key_is_not_flattened() {
+    let src = r#"
+const proto = { poisoned: true };
+const out = { ...{ __proto__: proto } };
+
+console.log(Object.getPrototypeOf(out) === Object.prototype);
+console.log(out.poisoned);
+"#;
+
+    run_default_exec_test(src);
+}


### PR DESCRIPTION
**Description:**

Fixes a minifier regression where frozen registry objects assembled through object spread can lose keys that are later used through computed property registration sites. The object spread folder now only flattens direct plain object literal spreads with safe data properties, leaving Object.freeze calls, identifiers, accessors, computed keys, methods, and semantic-sensitive keys opaque. Property-level pruning also backs off when property access was observed but the accessed key set is incomplete.

Added exec coverage for `Inner = Object.freeze({ FocalTweet: "FocalTweet" })`, `Outer = Object.freeze({ ...Inner, Tweet: "Tweet" })`, and computed handler registrations so `Outer.FocalTweet` and `handlers.FocalTweet` survive while `handlers.undefined` is absent. Also added a `__proto__` spread semantic guard.

Verification:

- `git submodule update --init --recursive`
- `cargo test -p swc_ecma_minifier --test exec object_freeze_spread_computed_registration -- --nocapture`
- `cargo test -p swc_ecma_minifier --test exec object_spread_proto_key_is_not_flattened -- --nocapture`
- `cargo test -p swc_ecma_minifier`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A
