### PR TITLE
fix(es/minifier): fold unary bool nullish coalescing

### DIFF
--- a/.changeset/unlucky-vans-occur.md
+++ b/.changeset/unlucky-vans-occur.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): fold unary bool nullish coalescing

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -2493,6 +2493,13 @@ impl Pure<'_> {
                 self.changed = true;
                 *e = l.take();
             }
+            Expr::Unary(UnaryExpr {
+                op: op!("!"), arg, ..
+            }) if matches!(&**arg, Expr::Lit(Lit::Num(..))) => {
+                report_change!("Removing rhs of ?? as lhs cannot be null nor undefined");
+                self.changed = true;
+                *e = l.take();
+            }
             _ => {}
         }
     }

--- a/crates/swc_ecma_minifier/tests/terser/compress/nullish/simplify_nullish_coalescing/input.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/nullish/simplify_nullish_coalescing/input.js
@@ -1,5 +1,9 @@
 const y = id("one");
 const is_null = null;
 const not_null = "two";
+const folded_true = false ? 0 : true;
+const folded_false = false ? 1 : false;
 console.log(is_null ?? y);
 console.log(not_null ?? y);
+console.log(folded_true ?? y);
+console.log(folded_false ?? y);

--- a/crates/swc_ecma_minifier/tests/terser/compress/nullish/simplify_nullish_coalescing/output.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/nullish/simplify_nullish_coalescing/output.js
@@ -1,2 +1,4 @@
 console.log(id("one"));
 console.log("two");
+console.log(!0);
+console.log(!1);

--- a/crates/swc_ecma_minifier/tests/terser/compress/nullish/simplify_nullish_coalescing/output.mangleOnly.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/nullish/simplify_nullish_coalescing/output.mangleOnly.js
@@ -1,5 +1,9 @@
 const o = id("one");
-const n = null;
-const l = "two";
-console.log(n ?? o);
+const l = null;
+const s = "two";
+const n = false ? 0 : true;
+const c = false ? 1 : false;
 console.log(l ?? o);
+console.log(s ?? o);
+console.log(n ?? o);
+console.log(c ?? o);

--- a/crates/swc_ecma_minifier/tests/terser/compress/nullish/simplify_nullish_coalescing/output.terser.js
+++ b/crates/swc_ecma_minifier/tests/terser/compress/nullish/simplify_nullish_coalescing/output.terser.js
@@ -1,3 +1,5 @@
 const y = id("one");
 console.log(y);
 console.log("two");
+console.log(!0 ?? y);
+console.log(!1 ?? y);


### PR DESCRIPTION
## Summary

- fold nullish coalescing when the lhs is a unary boolean expression like `!0` or `!1`
- add coverage for booleans produced by previous compression passes before `??` simplification

## Test

`cargo test -p swc_ecma_minifier --test compress simplify_nullish_coalescing -- --nocapture`