### PR TITLE
fix(ci): update rand lockfile entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,7 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0acb89ccf798a28683f00089d0630dfaceec087234eae0d308c05ddeaa941b40"
 dependencies = [
  "ambient-authority",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2625,7 +2625,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "par-iter",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv 0.8.13",
  "rustc-hash 2.1.1",
  "serde",
@@ -4178,7 +4178,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -4464,7 +4464,7 @@ dependencies = [
  "bit-vec",
  "bitflags 2.10.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
@@ -4600,9 +4600,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -4611,9 +4611,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -8849,7 +8849,7 @@ dependencies = [
  "petgraph",
  "pin-project",
  "pin-utils",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rkyv 0.8.13",
  "rusty_pool",
  "semver",
@@ -9214,7 +9214,7 @@ dependencies = [
  "libc",
  "once_cell",
  "path-clean 1.0.1",
- "rand 0.8.5",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",


### PR DESCRIPTION
**Description:**

Updates Cargo.lock so cargo-deny no longer reports RUSTSEC-2026-0097 for rand. This moves rand 0.8.5 to 0.8.6 and rand 0.9.2 to 0.9.4, staying within the existing semver-compatible dependency ranges.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

CI failure: https://github.com/swc-project/swc/actions/runs/24973953736/job/73122070650