### PR TITLE
feat: move swc ast explorer into workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5616,6 +5616,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc-ast-explorer"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "clap 3.2.25",
+ "owo-colors",
+ "regex",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_parser",
+ "swc_error_reporters",
+]
+
+[[package]]
 name = "swc-releaser"
 version = "0.1.0"
 dependencies = [

--- a/crates/swc-ast-explorer/Cargo.toml
+++ b/crates/swc-ast-explorer/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+authors     = ["강동윤 <kdy1997.dev@gmail.com>"]
+description = "Small CLI for printing SWC EcmaScript ASTs"
+edition     = { workspace = true }
+license     = { workspace = true }
+name        = "swc-ast-explorer"
+publish     = false
+repository  = { workspace = true }
+version     = "0.1.0"
+
+[[bin]]
+bench = false
+name  = "swc-ast-explorer"
+path  = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { version = "3", features = ["derive"] }
+owo-colors = { workspace = true }
+regex = { workspace = true }
+swc_common = { version = "21.0.1", path = "../swc_common" }
+swc_ecma_ast = { version = "23.0.0", path = "../swc_ecma_ast" }
+swc_ecma_parser = { version = "39.0.1", path = "../swc_ecma_parser" }
+swc_error_reporters = { version = "23.0.0", path = "../swc_error_reporters" }
+
+[dev-dependencies]
+assert_cmd = { workspace = true }

--- a/crates/swc-ast-explorer/README.md
+++ b/crates/swc-ast-explorer/README.md
@@ -1,0 +1,9 @@
+# swc-ast-explorer
+
+A small binary to print SWC EcmaScript and TypeScript abstract syntax trees.
+
+```shell
+echo "console.log('hello')" | cargo run -p swc-ast-explorer
+```
+
+Use `--spans` to keep span fields in the printed tree.

--- a/crates/swc-ast-explorer/src/args.rs
+++ b/crates/swc-ast-explorer/src/args.rs
@@ -1,0 +1,10 @@
+use clap::Parser;
+
+/// Command line options for the SWC AST explorer.
+#[derive(Debug, Parser)]
+#[clap(author, version, about, long_about = None)]
+pub struct Args {
+    /// Whether to keep Span (location) markers.
+    #[clap(long, value_parser, default_value_t = false)]
+    pub spans: bool,
+}

--- a/crates/swc-ast-explorer/src/format.rs
+++ b/crates/swc-ast-explorer/src/format.rs
@@ -1,0 +1,56 @@
+use std::sync::OnceLock;
+
+use owo_colors::OwoColorize;
+use regex::{NoExpand, Regex};
+use swc_ecma_ast::Program;
+
+static STRUCT_SPAN_FIELD: OnceLock<Regex> = OnceLock::new();
+static RANGE_SPAN_FIELD: OnceLock<Regex> = OnceLock::new();
+static ALTERNATE_WS: OnceLock<Regex> = OnceLock::new();
+static INDENT_WS: OnceLock<Regex> = OnceLock::new();
+
+/// Formats an SWC program using the same tree-like debug output as the
+/// original explorer.
+pub fn format_program(program: &Program, keep_spans: bool) -> String {
+    let print = format!("{program:#?}");
+    let stripped = if keep_spans {
+        print
+    } else {
+        strip_spans(&print)
+    };
+
+    colorize_indentation(&stripped)
+}
+
+fn strip_spans(print: &str) -> String {
+    let print = struct_span_field().replace_all(print, NoExpand(""));
+
+    range_span_field()
+        .replace_all(&print, NoExpand(""))
+        .into_owned()
+}
+
+fn colorize_indentation(print: &str) -> String {
+    let alternate = format!("{}{}", "    ".on_default_color(), "    ".on_black());
+    let alternating = alternate_ws().replace_all(print, NoExpand(&alternate));
+
+    indent_ws()
+        .replace_all(&alternating, NoExpand("  "))
+        .into_owned()
+}
+
+fn struct_span_field() -> &'static Regex {
+    STRUCT_SPAN_FIELD.get_or_init(|| Regex::new(r"(?m)^\s+\w*span\w*: Span \{[^}]*\},\n").unwrap())
+}
+
+fn range_span_field() -> &'static Regex {
+    RANGE_SPAN_FIELD.get_or_init(|| Regex::new(r"(?m)^\s+\w*span\w*: \d+\.\.\d+,\n").unwrap())
+}
+
+fn alternate_ws() -> &'static Regex {
+    ALTERNATE_WS.get_or_init(|| Regex::new(r" {8}").unwrap())
+}
+
+fn indent_ws() -> &'static Regex {
+    INDENT_WS.get_or_init(|| Regex::new(r" {4}").unwrap())
+}

--- a/crates/swc-ast-explorer/src/main.rs
+++ b/crates/swc-ast-explorer/src/main.rs
@@ -1,0 +1,46 @@
+use std::io::{self, Read};
+
+use anyhow::Result;
+use clap::Parser;
+use swc_common::{errors::ColorConfig, sync::Lrc, FileName, Globals, SourceMap, GLOBALS};
+use swc_error_reporters::{
+    handler::{try_with_handler, HandlerOpts},
+    TWithDiagnosticArray,
+};
+
+use crate::{args::Args, format::format_program, parser::parse_source};
+
+mod args;
+mod format;
+mod parser;
+
+fn main() -> Result<()> {
+    let args = Args::parse();
+    let mut contents = String::new();
+    io::stdin().read_to_string(&mut contents)?;
+
+    let cm = Lrc::new(SourceMap::default());
+    let program = parse_stdin(cm, contents).map_err(TWithDiagnosticArray::to_pretty_error)?;
+
+    println!("{}", format_program(&program, args.spans));
+
+    Ok(())
+}
+
+fn parse_stdin(
+    cm: Lrc<SourceMap>,
+    contents: String,
+) -> Result<swc_ecma_ast::Program, TWithDiagnosticArray<anyhow::Error>> {
+    let file = cm.new_source_file(FileName::Anon.into(), contents);
+
+    GLOBALS.set(&Globals::new(), || {
+        try_with_handler(
+            cm,
+            HandlerOpts {
+                color: ColorConfig::Always,
+                skip_filename: false,
+            },
+            |handler| parse_source(&file, handler),
+        )
+    })
+}

--- a/crates/swc-ast-explorer/src/parser.rs
+++ b/crates/swc-ast-explorer/src/parser.rs
@@ -1,0 +1,32 @@
+use anyhow::{anyhow, bail, Result};
+use swc_common::{errors::Handler, SourceFile};
+use swc_ecma_ast::{EsVersion, Program};
+use swc_ecma_parser::{parse_file_as_program, Syntax, TsSyntax};
+
+/// Parses a source file as JavaScript, TypeScript, or TSX and returns the SWC
+/// program tree. Recovered parser errors are treated as fatal so the CLI does
+/// not print partial ASTs for invalid input.
+pub fn parse_source(file: &SourceFile, handler: &Handler) -> Result<Program> {
+    let syntax = Syntax::Typescript(TsSyntax {
+        tsx: true,
+        ..Default::default()
+    });
+    let mut errors = Vec::new();
+    let program = parse_file_as_program(file, syntax, EsVersion::latest(), None, &mut errors)
+        .map_err(|err| {
+            err.into_diagnostic(handler).emit();
+            anyhow!("Syntax Error")
+        })?;
+
+    let mut has_recovered_error = false;
+    for err in errors {
+        err.into_diagnostic(handler).emit();
+        has_recovered_error = true;
+    }
+
+    if has_recovered_error {
+        bail!("Syntax Error");
+    }
+
+    Ok(program)
+}

--- a/crates/swc-ast-explorer/tests/fixtures.rs
+++ b/crates/swc-ast-explorer/tests/fixtures.rs
@@ -1,0 +1,73 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::Result;
+use assert_cmd::{cargo::cargo_bin_cmd, Command};
+
+fn fixture(name: &str) -> Result<String> {
+    Ok(fs::read_to_string(fixture_path(name))?)
+}
+
+fn fixture_path(name: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(name)
+}
+
+fn explorer() -> Command {
+    cargo_bin_cmd!("swc-ast-explorer")
+}
+
+#[test]
+fn prints_typescript_tsx_ast() -> Result<()> {
+    let assert = explorer()
+        .write_stdin(fixture("basic.tsx")?)
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+
+    assert!(stdout.contains("TsTypeAnn"), "{stdout}");
+    assert!(stdout.contains("JSXElement"), "{stdout}");
+
+    Ok(())
+}
+
+#[test]
+fn strips_spans_by_default() -> Result<()> {
+    let assert = explorer()
+        .write_stdin(fixture("span.ts")?)
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+
+    assert!(!stdout.contains("span:"), "{stdout}");
+
+    Ok(())
+}
+
+#[test]
+fn keeps_spans_when_requested() -> Result<()> {
+    let assert = explorer()
+        .arg("--spans")
+        .write_stdin(fixture("span.ts")?)
+        .assert()
+        .success();
+    let stdout = String::from_utf8(assert.get_output().stdout.clone())?;
+
+    assert!(stdout.contains("span:"), "{stdout}");
+
+    Ok(())
+}
+
+#[test]
+fn reports_invalid_input() -> Result<()> {
+    let assert = explorer()
+        .write_stdin(fixture("invalid.ts")?)
+        .assert()
+        .failure();
+    let stderr = String::from_utf8(assert.get_output().stderr.clone())?;
+
+    assert!(stderr.contains("Syntax Error"), "{stderr}");
+
+    Ok(())
+}

--- a/crates/swc-ast-explorer/tests/fixtures/basic.tsx
+++ b/crates/swc-ast-explorer/tests/fixtures/basic.tsx
@@ -1,0 +1,9 @@
+type Message = {
+    value: string;
+};
+
+const message: Message = {
+    value: "hello",
+};
+
+export const view = <span>{message.value}</span>;

--- a/crates/swc-ast-explorer/tests/fixtures/invalid.ts
+++ b/crates/swc-ast-explorer/tests/fixtures/invalid.ts
@@ -1,0 +1,1 @@
+const value: = ;

--- a/crates/swc-ast-explorer/tests/fixtures/span.ts
+++ b/crates/swc-ast-explorer/tests/fixtures/span.ts
@@ -1,0 +1,1 @@
+const value: number = 1;


### PR DESCRIPTION
**Description:**

Moves the `swc-ast-explorer` binary crate from the Next.js repository into the SWC workspace as `crates/swc-ast-explorer`.

This keeps the crate private with `publish = false`, uses the SWC workspace Apache-2.0 metadata, parses stdin directly with `swc_ecma_parser`, and preserves the original CLI behavior for default span stripping and `--spans` output.

Verification:

- `git submodule update --init --recursive`
- `cargo test -p swc-ast-explorer`
- `cargo fmt --all`
- `cargo clippy -p swc-ast-explorer --all-targets -- -D warnings`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.
