### PR TITLE
fix(es/parser): parse empty Flow exact object type

### DIFF
--- a/.changeset/smooth-buckets-hammer.md
+++ b/.changeset/smooth-buckets-hammer.md
@@ -1,0 +1,6 @@
+---
+swc_ecma_parser: patch
+swc_core: patch
+---
+
+fix(es/parser): parse empty Flow exact object type

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -3948,6 +3948,19 @@ impl<I: Tokens> Parser<I> {
         debug_assert!(self.input().syntax().typescript());
 
         expect!(self, Token::LBrace);
+        if self.input().syntax().flow()
+            && self.input().is(Token::LogicalOr)
+            && peek!(self).is_some_and(|peek| peek == Token::RBrace)
+        {
+            // The lexer tokenizes Flow's compact empty exact object delimiter
+            // pair `{||}` as a JavaScript logical-or token. Treat it as the
+            // opening and closing exact-object pipes only in object type
+            // parsing, so ordinary expression tokenization stays unchanged.
+            self.bump();
+            expect!(self, Token::RBrace);
+            return Ok(Vec::new());
+        }
+
         let exact = self.input().syntax().flow() && self.input_mut().eat(Token::Pipe);
         let parse_members = |p: &mut Self| -> PResult<Vec<TsTypeElement>> {
             if exact {

--- a/crates/swc_ecma_parser/tests/flow/exact-object/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/exact-object/basic.js
@@ -1,1 +1,4 @@
+type X = {||};
+const x: React.ComponentType<{||}> = null;
+function f(x: {||}): void {}
 type Box = {| +a: number, ...Other |};

--- a/crates/swc_ecma_parser/tests/flow/exact-object/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/exact-object/basic.js.json
@@ -2,21 +2,223 @@
   "type": "Script",
   "span": {
     "start": 1,
-    "end": 39
+    "end": 126
   },
   "body": [
     {
       "type": "TsTypeAliasDeclaration",
       "span": {
         "start": 1,
-        "end": 39
+        "end": 15
       },
       "declare": false,
       "id": {
         "type": "Identifier",
         "span": {
           "start": 6,
-          "end": 9
+          "end": 7
+        },
+        "ctxt": 0,
+        "value": "X",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 10,
+          "end": 14
+        },
+        "members": []
+      }
+    },
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 16,
+        "end": 58
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 22,
+            "end": 57
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 22,
+              "end": 23
+            },
+            "ctxt": 0,
+            "value": "x",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 23,
+                "end": 50
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 25,
+                  "end": 50
+                },
+                "typeName": {
+                  "type": "TsQualifiedName",
+                  "span": {
+                    "start": 25,
+                    "end": 44
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 25,
+                      "end": 30
+                    },
+                    "ctxt": 0,
+                    "value": "React",
+                    "optional": false
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 31,
+                      "end": 44
+                    },
+                    "value": "ComponentType"
+                  }
+                },
+                "typeParams": {
+                  "type": "TsTypeParameterInstantiation",
+                  "span": {
+                    "start": 44,
+                    "end": 50
+                  },
+                  "params": [
+                    {
+                      "type": "TsTypeLiteral",
+                      "span": {
+                        "start": 45,
+                        "end": 49
+                      },
+                      "members": []
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "init": {
+            "type": "NullLiteral",
+            "span": {
+              "start": 53,
+              "end": 57
+            }
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 68,
+          "end": 69
+        },
+        "ctxt": 0,
+        "value": "f",
+        "optional": false
+      },
+      "declare": false,
+      "params": [
+        {
+          "type": "Parameter",
+          "span": {
+            "start": 70,
+            "end": 77
+          },
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
+            "span": {
+              "start": 70,
+              "end": 71
+            },
+            "ctxt": 0,
+            "value": "x",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 71,
+                "end": 77
+              },
+              "typeAnnotation": {
+                "type": "TsTypeLiteral",
+                "span": {
+                  "start": 73,
+                  "end": 77
+                },
+                "members": []
+              }
+            }
+          }
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 59,
+        "end": 87
+      },
+      "ctxt": 0,
+      "body": {
+        "type": "BlockStatement",
+        "span": {
+          "start": 85,
+          "end": 87
+        },
+        "ctxt": 0,
+        "stmts": []
+      },
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 78,
+          "end": 84
+        },
+        "typeAnnotation": {
+          "type": "TsKeywordType",
+          "span": {
+            "start": 80,
+            "end": 84
+          },
+          "kind": "void"
+        }
+      }
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 88,
+        "end": 126
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 93,
+          "end": 96
         },
         "ctxt": 0,
         "value": "Box",
@@ -26,22 +228,22 @@
       "typeAnnotation": {
         "type": "TsTypeLiteral",
         "span": {
-          "start": 12,
-          "end": 38
+          "start": 99,
+          "end": 125
         },
         "members": [
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 15,
-              "end": 26
+              "start": 102,
+              "end": 113
             },
             "readonly": true,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 16,
-                "end": 17
+                "start": 103,
+                "end": 104
               },
               "ctxt": 0,
               "value": "a",
@@ -52,14 +254,14 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 17,
-                "end": 25
+                "start": 104,
+                "end": 112
               },
               "typeAnnotation": {
                 "type": "TsKeywordType",
                 "span": {
-                  "start": 19,
-                  "end": 25
+                  "start": 106,
+                  "end": 112
                 },
                 "kind": "number"
               }
@@ -68,15 +270,15 @@
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 27,
-              "end": 35
+              "start": 114,
+              "end": 122
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 27,
-                "end": 35
+                "start": 114,
+                "end": 122
               },
               "ctxt": 0,
               "value": "__flow_spread",
@@ -87,20 +289,20 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 27,
-                "end": 35
+                "start": 114,
+                "end": 122
               },
               "typeAnnotation": {
                 "type": "TsTypeReference",
                 "span": {
-                  "start": 30,
-                  "end": 35
+                  "start": 117,
+                  "end": 122
                 },
                 "typeName": {
                   "type": "Identifier",
                   "span": {
-                    "start": 30,
-                    "end": 35
+                    "start": 117,
+                    "end": 122
                   },
                   "ctxt": 0,
                   "value": "Other",


### PR DESCRIPTION
**Description:**

Fixes Flow parsing for empty exact object types like `{||}` by handling the lexer-produced `||` token only in Flow object type parsing. This keeps regular logical-or tokenization unchanged and lets React Native-style type positions parse correctly.

Added fixture coverage for:
- `type X = {||};`
- `React.ComponentType<{||}>`
- `function f(x: {||}): void {}`

Validation:
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo clippy -p swc_ecma_parser --features flow --all-targets -- -D warnings`
- `cargo test -p swc_ecma_parser`
- `cargo test -p swc_ecma_parser --features flow --test flow -- --ignored`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Fixes #11834