### PR TITLE
fix(es/react): exclude self-recursive hooks from refresh dependency array

### DIFF
--- a/.changeset/popular-zoos-begin.md
+++ b/.changeset/popular-zoos-begin.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_react: patch
+---
+
+fix(es/react): exclude self-recursive hooks from refresh dependency array

--- a/crates/swc_ecma_transforms_react/src/refresh/hook.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/hook.rs
@@ -238,8 +238,12 @@ impl VisitMut for HookRegister<'_> {
         e.visit_mut_children_with(self);
 
         match e {
-            Expr::Fn(FnExpr { function: f, .. }) if f.body.is_some() => {
-                let sig = collect_hooks(&mut f.body.as_mut().unwrap().stmts, self.cm);
+            Expr::Fn(FnExpr {
+                ident: fn_ident,
+                function: f,
+            }) if f.body.is_some() => {
+                let self_ids = fn_ident.iter().map(|i| i.to_id()).collect::<Vec<_>>();
+                let sig = collect_hooks(&mut f.body.as_mut().unwrap().stmts, self.cm, &self_ids);
 
                 if let Some(HookSig { handle, hooks }) = sig {
                     self.ident.push(handle.clone());
@@ -247,7 +251,7 @@ impl VisitMut for HookRegister<'_> {
                 }
             }
             Expr::Arrow(ArrowExpr { body, .. }) => {
-                let sig = collect_hooks_arrow(body, self.cm);
+                let sig = collect_hooks_arrow(body, self.cm, &[]);
 
                 if let Some(HookSig { handle, hooks }) = sig {
                     self.ident.push(handle.clone());
@@ -271,17 +275,25 @@ impl VisitMut for HookRegister<'_> {
             } = decl
             {
                 match init.as_mut() {
-                    Expr::Fn(FnExpr { function: f, .. }) if f.body.is_some() => {
+                    Expr::Fn(FnExpr {
+                        ident: fn_ident,
+                        function: f,
+                    }) if f.body.is_some() => {
                         f.body.visit_mut_with(self);
+                        let mut self_ids = vec![id.to_id()];
+                        if let Some(fn_ident) = fn_ident {
+                            self_ids.push(fn_ident.to_id());
+                        }
                         if let Some(sig) =
-                            collect_hooks(&mut f.body.as_mut().unwrap().stmts, self.cm)
+                            collect_hooks(&mut f.body.as_mut().unwrap().stmts, self.cm, &self_ids)
                         {
                             self.gen_hook_register_stmt(Ident::from(&*id), sig);
                         }
                     }
                     Expr::Arrow(ArrowExpr { body, .. }) => {
                         body.visit_mut_with(self);
-                        if let Some(sig) = collect_hooks_arrow(body, self.cm) {
+                        let self_ids = [id.to_id()];
+                        if let Some(sig) = collect_hooks_arrow(body, self.cm, &self_ids) {
                             self.gen_hook_register_stmt(Ident::from(&*id), sig);
                         }
                     }
@@ -302,7 +314,10 @@ impl VisitMut for HookRegister<'_> {
                 ident: Some(ident),
                 function: f,
             }) if f.body.is_some() => {
-                if let Some(sig) = collect_hooks(&mut f.body.as_mut().unwrap().stmts, self.cm) {
+                let self_ids = [ident.to_id()];
+                if let Some(sig) =
+                    collect_hooks(&mut f.body.as_mut().unwrap().stmts, self.cm, &self_ids)
+                {
                     self.gen_hook_register_stmt(ident.clone(), sig);
                 }
             }
@@ -314,17 +329,19 @@ impl VisitMut for HookRegister<'_> {
         f.visit_mut_children_with(self);
 
         if let Some(body) = &mut f.function.body {
-            if let Some(sig) = collect_hooks(&mut body.stmts, self.cm) {
+            let self_ids = [f.ident.to_id()];
+            if let Some(sig) = collect_hooks(&mut body.stmts, self.cm, &self_ids) {
                 self.gen_hook_register_stmt(f.ident.clone(), sig);
             }
         }
     }
 }
 
-fn collect_hooks(stmts: &mut Vec<Stmt>, cm: &SourceMap) -> Option<HookSig> {
+fn collect_hooks(stmts: &mut Vec<Stmt>, cm: &SourceMap, self_ids: &[Id]) -> Option<HookSig> {
     let mut hook = HookCollector {
         state: Vec::new(),
         cm,
+        self_ids,
     };
 
     stmts.visit_with(&mut hook);
@@ -339,13 +356,18 @@ fn collect_hooks(stmts: &mut Vec<Stmt>, cm: &SourceMap) -> Option<HookSig> {
     }
 }
 
-fn collect_hooks_arrow(body: &mut BlockStmtOrExpr, cm: &SourceMap) -> Option<HookSig> {
+fn collect_hooks_arrow(
+    body: &mut BlockStmtOrExpr,
+    cm: &SourceMap,
+    self_ids: &[Id],
+) -> Option<HookSig> {
     match body {
-        BlockStmtOrExpr::BlockStmt(block) => collect_hooks(&mut block.stmts, cm),
+        BlockStmtOrExpr::BlockStmt(block) => collect_hooks(&mut block.stmts, cm, self_ids),
         BlockStmtOrExpr::Expr(expr) => {
             let mut hook = HookCollector {
                 state: Vec::new(),
                 cm,
+                self_ids,
             };
 
             expr.visit_with(&mut hook);
@@ -376,6 +398,11 @@ fn collect_hooks_arrow(body: &mut BlockStmtOrExpr, cm: &SourceMap) -> Option<Hoo
 struct HookCollector<'a> {
     state: Vec<Hook>,
     cm: &'a SourceMap,
+    // Bindings of the function being analyzed. Custom hook calls that resolve
+    // to one of these (i.e. recursive self-references) must be excluded from
+    // the dependency array, otherwise react-refresh's runtime
+    // `computeFullKey` enters infinite recursion.
+    self_ids: &'a [Id],
 }
 
 fn is_hook_like(s: &str) -> bool {
@@ -396,6 +423,17 @@ impl HookCollector<'_> {
         let mut hook_call = None;
         let ident = match callee {
             Expr::Ident(ident) => {
+                // Skip recursive references to the function being analyzed.
+                // Including them in the dependency array causes
+                // react-refresh's runtime to recurse infinitely while
+                // computing the signature key.
+                if self
+                    .self_ids
+                    .iter()
+                    .any(|id| id.0 == ident.sym && id.1 == ident.ctxt)
+                {
+                    return None;
+                }
                 hook_call = Some(HookCall::Ident(ident.clone()));
                 Some(&ident.sym)
             }

--- a/crates/swc_ecma_transforms_react/src/refresh/tests.rs
+++ b/crates/swc_ecma_transforms_react/src/refresh/tests.rs
@@ -811,3 +811,83 @@ test!(
     }
 "#
 );
+
+// Recursive custom hooks must not be added to their own dependency
+// array, otherwise react-refresh's runtime `computeFullKey` recurses
+// infinitely. See https://github.com/swc-project/swc/issues/11832.
+test!(
+    module,
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
+        jsx: true,
+        ..Default::default()
+    }),
+    tr,
+    issue_11832_recursive_fn_decl,
+    r#"
+    function useFoo(cond) {
+      const [count, setCount] = useState(0);
+      if (cond) {
+        useFoo(false);
+      }
+      return count;
+    }
+"#
+);
+
+test!(
+    module,
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
+        jsx: true,
+        ..Default::default()
+    }),
+    tr,
+    issue_11832_recursive_var_fn_expr,
+    r#"
+    const useFoo = function (cond) {
+      const [count, setCount] = useState(0);
+      if (cond) {
+        useFoo(false);
+      }
+      return count;
+    };
+"#
+);
+
+test!(
+    module,
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
+        jsx: true,
+        ..Default::default()
+    }),
+    tr,
+    issue_11832_recursive_var_arrow,
+    r#"
+    const useFoo = (cond) => {
+      const [count, setCount] = useState(0);
+      if (cond) {
+        useFoo(false);
+      }
+      return count;
+    };
+"#
+);
+
+test!(
+    module,
+    ::swc_ecma_parser::Syntax::Es(::swc_ecma_parser::EsSyntax {
+        jsx: true,
+        ..Default::default()
+    }),
+    tr,
+    issue_11832_recursive_named_fn_expr,
+    r#"
+    const useFoo = function useInner(cond) {
+      const [count, setCount] = useState(0);
+      if (cond) {
+        useInner(false);
+        useFoo(false);
+      }
+      return count;
+    };
+"#
+);

--- a/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/refresh/tests.rs/issue_11832_recursive_fn_decl.js
+++ b/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/refresh/tests.rs/issue_11832_recursive_fn_decl.js
@@ -1,0 +1,10 @@
+var _s = $RefreshSig$();
+function useFoo(cond) {
+    _s();
+    const [count, setCount] = useState(0);
+    if (cond) {
+        useFoo(false);
+    }
+    return count;
+}
+_s(useFoo, "useState{[count, setCount](0)}");

--- a/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/refresh/tests.rs/issue_11832_recursive_named_fn_expr.js
+++ b/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/refresh/tests.rs/issue_11832_recursive_named_fn_expr.js
@@ -1,0 +1,11 @@
+var _s = $RefreshSig$();
+const useFoo = function useInner(cond) {
+    _s();
+    const [count, setCount] = useState(0);
+    if (cond) {
+        useInner(false);
+        useFoo(false);
+    }
+    return count;
+};
+_s(useFoo, "useState{[count, setCount](0)}");

--- a/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/refresh/tests.rs/issue_11832_recursive_var_arrow.js
+++ b/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/refresh/tests.rs/issue_11832_recursive_var_arrow.js
@@ -1,0 +1,10 @@
+var _s = $RefreshSig$();
+const useFoo = (cond)=>{
+    _s();
+    const [count, setCount] = useState(0);
+    if (cond) {
+        useFoo(false);
+    }
+    return count;
+};
+_s(useFoo, "useState{[count, setCount](0)}");

--- a/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/refresh/tests.rs/issue_11832_recursive_var_fn_expr.js
+++ b/crates/swc_ecma_transforms_react/tests/__swc_snapshots__/src/refresh/tests.rs/issue_11832_recursive_var_fn_expr.js
@@ -1,0 +1,10 @@
+var _s = $RefreshSig$();
+const useFoo = function(cond) {
+    _s();
+    const [count, setCount] = useState(0);
+    if (cond) {
+        useFoo(false);
+    }
+    return count;
+};
+_s(useFoo, "useState{[count, setCount](0)}");


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:** Filter recursive self-references out of the dependency callback emitted by `transform.react.refresh`, matching Babel's `react-refresh/babel` behavior. See related issue below.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:** No

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):** #11832
