### PR TITLE
fix(es/minifier): preserve args at call sites of destructured bindings

### DIFF
--- a/.changeset/swc-args-destructure-fix.md
+++ b/.changeset/swc-args-destructure-fix.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): mark destructured `let`/`const` bindings as having unknown param count

--- a/crates/swc_ecma_minifier/src/usage_analyzer/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/usage_analyzer/analyzer/mod.rs
@@ -1513,6 +1513,16 @@ where
                         .var_or_default(var.id.to_id())
                         .store_param_count(Value::Unknown),
                 }
+            } else if !matches!(&decl.name, Pat::Ident(_)) {
+                // Destructuring binding (object/array/rest pattern). The
+                // bound identifiers are read from runtime properties or
+                // elements, so we cannot statically determine the arity
+                // of any callable that reaches them.
+                for id in find_pat_ids::<_, Id>(&decl.name) {
+                    self.data
+                        .var_or_default(id)
+                        .store_param_count(Value::Unknown);
+                }
             }
         }
     }

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11829/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11829/config.json
@@ -1,0 +1,12 @@
+{
+    "unused": true,
+    "reduce_vars": false,
+    "reduce_funcs": false,
+    "inline": false,
+    "evaluate": false,
+    "collapse_vars": false,
+    "side_effects": false,
+    "keep_fargs": true,
+    "passes": 1,
+    "toplevel": false
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11829/destructure-decl-stale-arity/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11829/destructure-decl-stale-arity/input.js
@@ -1,0 +1,7 @@
+function run(opts) {
+    let { match } = opts;
+    if (!match) match = () => true;
+    return match("hello", "world");
+}
+
+console.log(run({ match: (a, b) => a + " " + b }));

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11829/destructure-decl-stale-arity/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11829/destructure-decl-stale-arity/output.js
@@ -1,0 +1,8 @@
+function run(opts) {
+    let { match } = opts;
+    if (!match) match = ()=>true;
+    return match("hello", "world");
+}
+console.log(run({
+    match: (a, b)=>a + " " + b
+}));


### PR DESCRIPTION
I ran into this issue using Slate, getting different results during next dev and next build/start, traced back to this issue. In Slate this surfaces by breaking `Editor.nodes(editor, { match: <fn> })` between next dev/prod whenever a function predicate is passed to match.

The core issue is that destructured bindings which are later assigned to a function have a param_count of 0 rather than unknown.

**Description:**

`visit_var_decl` only records `param_count` for `let x = init` style declarators. Destructuring patterns (`let { x } = init`, `let [x] = init`, etc.) fall outside the existing `if let (Pat::Ident(var), Some(init)) = ...` guard with no fallback, so `x.param_count` stays at the default `None`. A later assignment to a known-arity arrow then sets `param_count` via the merge rule `(None, Known(N)) => Some(Known(N))`, and `ignore_unused_args_of_call` (added in #11645) trims arguments at every call site of `x` accordingly.

Minimal repro:

```js
function run(opts) {
    let { match } = opts;
    if (!match) match = () => true;
    return match(\"hello\", \"world\");
}

console.log(run({ match: (a, b) => a + \" \" + b }));
```

- Source result: `\"hello world\"`
- Minified result on current `main`: `\"undefined undefined\"` (call site becomes `match()`)

**Fix:**

Mirror what `report_assign_pat` already does for runtime destructuring assignments: when the binding is anything other than a plain `Pat::Ident`, mark every bound identifier as having an unknown param count.

```rust
} else if !matches!(&decl.name, Pat::Ident(_)) {
    // Destructuring binding (object/array/rest pattern). The
    // bound identifiers are read from runtime properties or
    // elements, so we cannot statically determine the arity
    // of any callable that reaches them.
    for id in find_pat_ids::<_, Id>(&decl.name) {
        self.data
            .var_or_default(id)
            .store_param_count(Value::Unknown);
    }
}
```

**Tests:**

- New fixture at `tests/fixture/issues/11829/destructure-decl-stale-arity/` exercises the exact pattern above with the same `config.json` used by the #11645 fixtures (`unused: true`, `keep_fargs: true`).
- The new test FAILS on `main` with diff `match(\"hello\", \"world\")` → `match()` and PASSES with this fix applied.
- All 10 sibling tests under `tests/fixture/issues/11645/` still pass — including `logical-and-assign-stale-arity`, `child-scope-reassign-merge`, `for-of-rebind-arity` and the eval/with-stmt safety tests.
- Full \`cargo test --test compress\`: 2855 passed; 0 failed; 27 ignored.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Closes #11829.