### PR TITLE
docs: update agent guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,3 +74,4 @@
 ## Compatibility rule
 
 -   Do not use unstable, nightly only features of rustc.
+-   Respect the project's MSRV. Do not rely on Rust language features or standard library APIs newer than the MSRV unless the change intentionally raises the MSRV.

--- a/crates/swc_ecma_minifier/AGENTS.md
+++ b/crates/swc_ecma_minifier/AGENTS.md
@@ -7,6 +7,7 @@
 
 ### Fixture Test Addition Guide
 
-- Preferred fixture roots in this crate: tests/fixture, tests/terser, tests/mangle, tests/pass-1, tests/pass-default, tests/full, tests/projects, benches/full.
+- Preferred fixture roots in this crate: tests/fixture, tests/mangle, tests/pass-1, tests/pass-default, tests/full, tests/projects, benches/full.
+- Do not add new regression coverage to tests/terser. Use SWC-owned fixtures such as tests/fixture/issues instead.
 - Update generated fixture outputs with: UPDATE=1 cargo test -p swc_ecma_minifier.
 - Verify without UPDATE before finishing: cargo test -p swc_ecma_minifier.


### PR DESCRIPTION
**Description:**

Adds agent guidance requested from PR review feedback:

- Respect the project MSRV when writing Rust code.
- Keep new swc_ecma_minifier regression coverage out of tests/terser and prefer SWC-owned fixtures such as tests/fixture/issues.

This is documentation-only and helps future automated edits choose the right compatibility and fixture behavior.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Refs https://github.com/swc-project/swc/pull/11830#issuecomment-4363859988
