### PR TITLE
[codex] add node and scope ids

### DIFF
--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -294,6 +294,7 @@ fn downgrade_flow_script_like_module(program: Program) -> Result<Program, Error>
     }
 
     let Module {
+        node_id,
         span,
         body,
         shebang,
@@ -311,6 +312,7 @@ fn downgrade_flow_script_like_module(program: Program) -> Result<Program, Error>
         .collect::<Result<_, Error>>()?;
 
     Ok(Program::Script(Script {
+        node_id,
         span,
         body,
         shebang,

--- a/crates/swc_bundler/src/bundler/chunk/cjs.rs
+++ b/crates/swc_bundler/src/bundler/chunk/cjs.rs
@@ -80,6 +80,7 @@ where
             info.id,
             Module {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 body: vec![stmt],
                 shebang: None,
             },

--- a/crates/swc_bundler/src/bundler/finalize.rs
+++ b/crates/swc_bundler/src/bundler/finalize.rs
@@ -385,6 +385,7 @@ where
 
         Module {
             span: DUMMY_SP,
+            node_id: Default::default(),
             shebang: None,
             body: vec![ModuleItem::Stmt(Stmt::Expr(ExprStmt {
                 span: DUMMY_SP,

--- a/crates/swc_bundler/src/modules/mod.rs
+++ b/crates/swc_bundler/src/modules/mod.rs
@@ -292,6 +292,7 @@ impl Modules {
             cm,
             &Module {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 body: stmts,
                 shebang: None,
             },
@@ -304,6 +305,7 @@ impl From<Modules> for Module {
         // TODO
         Self {
             span: DUMMY_SP,
+            node_id: Default::default(),
             body: modules.into_items(),
             shebang: None,
         }

--- a/crates/swc_bundler/src/modules/sort/mod.rs
+++ b/crates/swc_bundler/src/modules/sort/mod.rs
@@ -45,6 +45,7 @@ impl Modules {
 
         let module = Module {
             span: DUMMY_SP,
+            node_id: Default::default(),
             body: buf,
             shebang: None,
         };

--- a/crates/swc_bundler/src/modules/sort/stmt.rs
+++ b/crates/swc_bundler/src/modules/sort/stmt.rs
@@ -841,6 +841,7 @@ mod tests {
                         "first item",
                         &t.cm,
                         &Module {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             body: vec![module.body[dep].clone()],
                             shebang: None,
@@ -850,6 +851,7 @@ mod tests {
                         "second item",
                         &t.cm,
                         &Module {
+                            node_id: Default::default(),
                             span: DUMMY_SP,
                             body: vec![module.body[i].clone()],
                             shebang: None,

--- a/crates/swc_bundler/src/modules/sort/tests.rs
+++ b/crates/swc_bundler/src/modules/sort/tests.rs
@@ -37,6 +37,7 @@ fn assert_sorted_with_free(src: &[&str], free: &str, res: &str) {
         let sorted = sort_stmts(t.bundler.injected_ctxt, modules, &t.cm);
 
         let actual: Module = drop_span(Module {
+            node_id: Default::default(),
             span: DUMMY_SP,
             body: sorted,
             shebang: None,

--- a/crates/swc_ecma_ast/src/class.rs
+++ b/crates/swc_ecma_ast/src/class.rs
@@ -11,7 +11,7 @@ use crate::{
         Accessibility, TsExprWithTypeArgs, TsIndexSignature, TsTypeAnn, TsTypeParamDecl,
         TsTypeParamInstantiation,
     },
-    BigInt, ComputedPropName, EmptyStmt, Id, Ident, IdentName, Number,
+    BigInt, ComputedPropName, EmptyStmt, Id, Ident, IdentName, NodeId, Number,
 };
 
 #[ast_node]
@@ -22,6 +22,9 @@ pub struct Class {
     pub span: Span,
 
     pub ctxt: SyntaxContext,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
     pub decorators: Vec<Decorator>,
@@ -279,6 +282,9 @@ pub struct Constructor {
     pub span: Span,
 
     pub ctxt: SyntaxContext,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub key: PropName,
 

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -23,7 +23,7 @@ use crate::{
         TsTypeAssertion, TsTypeParamDecl, TsTypeParamInstantiation,
     },
     ArrayPat, BindingIdent, ComputedPropName, Id, IdentName, ImportPhase, Invalid, KeyValueProp,
-    Number, ObjectPat, PropName, Str,
+    NodeId, Number, ObjectPat, PropName, Str,
 };
 
 #[ast_node(no_clone)]
@@ -1080,6 +1080,9 @@ pub struct ArrowExpr {
     pub span: Span,
 
     pub ctxt: SyntaxContext,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub params: Vec<Pat>,
 

--- a/crates/swc_ecma_ast/src/function.rs
+++ b/crates/swc_ecma_ast/src/function.rs
@@ -6,6 +6,7 @@ use crate::{
     pat::Pat,
     stmt::BlockStmt,
     typescript::{TsParamProp, TsTypeAnn, TsTypeParamDecl},
+    NodeId,
 };
 
 /// Common parts of function and method.
@@ -22,6 +23,9 @@ pub struct Function {
     pub span: Span,
 
     pub ctxt: SyntaxContext,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -12,7 +12,7 @@ use swc_common::{
     ast_node, util::take::Take, BytePos, EqIgnoreSpan, Mark, Span, Spanned, SyntaxContext, DUMMY_SP,
 };
 
-use crate::{typescript::TsTypeAnn, Expr};
+use crate::{typescript::TsTypeAnn, BindingId, Expr, ScopeId};
 
 /// Identifier used as a pattern.
 #[derive(Clone, Debug, PartialEq, Eq, Hash, EqIgnoreSpan, Default)]
@@ -97,6 +97,7 @@ impl From<&'_ BindingIdent> for Ident {
         Ident {
             span: bi.span,
             ctxt: bi.ctxt,
+            scope_id: bi.scope_id,
             sym: bi.sym.clone(),
             optional: bi.optional,
         }
@@ -185,7 +186,12 @@ pub struct Ident {
     pub span: Span,
 
     #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
+    #[cfg_attr(feature = "serde-impl", serde(default))]
     pub ctxt: SyntaxContext,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    #[cfg_attr(feature = "__rkyv", rkyv(omit_bounds))]
+    pub scope_id: ScopeId,
 
     #[cfg_attr(feature = "serde-impl", serde(rename = "value"))]
     pub sym: Atom,
@@ -267,6 +273,14 @@ impl Ident {
     /// Creates `Id` using `Atom` and `SyntaxContext` of `self`.
     pub fn to_id(&self) -> Id {
         (self.sym.clone(), self.ctxt)
+    }
+
+    /// Creates an id using the resolver-assigned scope id of `self`.
+    pub fn to_binding_id(&self) -> BindingId {
+        BindingId {
+            sym: self.sym.clone(),
+            scope_id: self.scope_id,
+        }
     }
 
     #[inline]
@@ -573,6 +587,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Ident {
             sym,
             optional,
             ctxt: Default::default(),
+            scope_id: Default::default(),
         })
     }
 }
@@ -598,6 +613,7 @@ impl Ident {
         Ident {
             span,
             ctxt,
+            scope_id: ScopeId::INVALID,
             sym,
             optional: false,
         }

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -12,6 +12,7 @@
 pub use num_bigint::BigInt as BigIntValue;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+use swc_atoms::Atom;
 use swc_common::{ast_node, pass::Either, util::take::Take, EqIgnoreSpan, Span};
 
 pub use self::{
@@ -73,6 +74,112 @@ pub use self::{
         TsUnionOrIntersectionType, TsUnionType,
     },
 };
+
+/// A stable identifier assigned to AST nodes by analysis passes.
+///
+/// `0` means the node has not been assigned an id yet. Parsers and AST
+/// builders should leave this as the default value; passes that need node
+/// identity are responsible for assigning deterministic ids.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, EqIgnoreSpan)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    any(feature = "rkyv-impl"),
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "rkyv-impl", repr(C))]
+#[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-impl", serde(transparent))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(
+    feature = "encoding-impl",
+    derive(::swc_common::Encode, ::swc_common::Decode)
+)]
+pub struct NodeId(pub u32);
+
+impl NodeId {
+    pub const INVALID: Self = Self(0);
+
+    #[inline]
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+
+    #[inline]
+    pub const fn is_invalid(self) -> bool {
+        self.0 == Self::INVALID.0
+    }
+}
+
+/// A stable identifier for lexical/function scopes.
+///
+/// `0` means unassigned, while [`ScopeId::UNRESOLVED`] is used for references
+/// that do not resolve to a binding in the current AST.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, PartialOrd, Ord, Hash, EqIgnoreSpan)]
+#[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
+#[cfg_attr(
+    any(feature = "rkyv-impl"),
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "rkyv-impl", repr(C))]
+#[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde-impl", serde(transparent))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(
+    feature = "encoding-impl",
+    derive(::swc_common::Encode, ::swc_common::Decode)
+)]
+pub struct ScopeId(pub u32);
+
+impl ScopeId {
+    pub const INVALID: Self = Self(0);
+    pub const UNRESOLVED: Self = Self(u32::MAX);
+
+    #[inline]
+    pub const fn from_node_id(node_id: NodeId) -> Self {
+        Self(node_id.0)
+    }
+
+    #[inline]
+    pub const fn as_node_id(self) -> NodeId {
+        NodeId(self.0)
+    }
+
+    #[inline]
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+
+    #[inline]
+    pub const fn is_invalid(self) -> bool {
+        self.0 == Self::INVALID.0
+    }
+
+    #[inline]
+    pub const fn is_unresolved(self) -> bool {
+        self.0 == Self::UNRESOLVED.0
+    }
+}
+
+/// Identifier key based on the resolver-assigned scope id.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash, EqIgnoreSpan)]
+#[cfg_attr(
+    any(feature = "rkyv-impl"),
+    derive(rkyv::Archive, rkyv::Serialize, rkyv::Deserialize)
+)]
+#[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
+#[cfg_attr(feature = "rkyv-impl", repr(C))]
+#[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
+#[cfg_attr(
+    feature = "encoding-impl",
+    derive(::swc_common::Encode, ::swc_common::Decode)
+)]
+pub struct BindingId {
+    pub sym: Atom,
+    pub scope_id: ScopeId,
+}
 
 #[macro_use]
 mod macros;
@@ -508,14 +615,14 @@ mod rkyv_layout_assert {
         };
     }
 
-    assert_size!(ArchivedProgram, 32);
-    assert_size!(ArchivedModule, 28);
-    assert_size!(ArchivedScript, 28);
-    assert_size!(ArchivedModuleItem, 52);
+    assert_size!(ArchivedProgram, 36);
+    assert_size!(ArchivedModule, 32);
+    assert_size!(ArchivedScript, 32);
+    assert_size!(ArchivedModuleItem, 56);
 
     // Class types
     assert_size!(ArchivedAutoAccessor, 96);
-    assert_size!(ArchivedClass, 64);
+    assert_size!(ArchivedClass, 68);
     assert_size!(ArchivedClassMember, 104);
     assert_size!(ArchivedClassMethod, 64);
     assert_size!(ArchivedClassProp, 88);
@@ -525,32 +632,32 @@ mod rkyv_layout_assert {
     assert_size!(ArchivedMethodKind, 1);
     assert_size!(ArchivedPrivateMethod, 36);
     assert_size!(ArchivedPrivateProp, 64);
-    assert_size!(ArchivedStaticBlock, 28);
+    assert_size!(ArchivedStaticBlock, 32);
 
     // Declaration types
-    assert_size!(ArchivedClassDecl, 32);
-    assert_size!(ArchivedDecl, 36);
-    assert_size!(ArchivedFnDecl, 32);
+    assert_size!(ArchivedClassDecl, 36);
+    assert_size!(ArchivedDecl, 40);
+    assert_size!(ArchivedFnDecl, 36);
     assert_size!(ArchivedUsingDecl, 20);
     assert_size!(ArchivedVarDecl, 24);
     assert_size!(ArchivedVarDeclKind, 1);
-    assert_size!(ArchivedVarDeclarator, 56);
+    assert_size!(ArchivedVarDeclarator, 60);
 
     // Expression types
     assert_size!(ArchivedArrayLit, 16);
-    assert_size!(ArchivedArrowExpr, 44);
+    assert_size!(ArchivedArrowExpr, 48);
     assert_size!(ArchivedAssignExpr, 60);
     assert_size!(ArchivedAssignTarget, 44);
     assert_size!(ArchivedAwaitExpr, 12);
     assert_size!(ArchivedBinExpr, 20);
-    assert_size!(ArchivedBlockStmtOrExpr, 24);
+    assert_size!(ArchivedBlockStmtOrExpr, 28);
     assert_size!(ArchivedCallExpr, 44);
     assert_size!(ArchivedCallee, 16);
-    assert_size!(ArchivedClassExpr, 32);
+    assert_size!(ArchivedClassExpr, 36);
     assert_size!(ArchivedCondExpr, 20);
     assert_size!(ArchivedExpr, 64);
     assert_size!(ArchivedExprOrSpread, 16);
-    assert_size!(ArchivedFnExpr, 32);
+    assert_size!(ArchivedFnExpr, 36);
     assert_size!(ArchivedImport, 12);
     assert_size!(ArchivedMemberExpr, 32);
     assert_size!(ArchivedMemberProp, 20);
@@ -577,13 +684,13 @@ mod rkyv_layout_assert {
     assert_size!(ArchivedYieldExpr, 20);
 
     // Function types
-    assert_size!(ArchivedFunction, 72);
-    assert_size!(ArchivedParam, 52);
-    assert_size!(ArchivedParamOrTsParamProp, 60);
+    assert_size!(ArchivedFunction, 80);
+    assert_size!(ArchivedParam, 56);
+    assert_size!(ArchivedParamOrTsParamProp, 64);
 
     // Identifier types
-    assert_size!(ArchivedBindingIdent, 32);
-    assert_size!(ArchivedIdent, 24);
+    assert_size!(ArchivedBindingIdent, 36);
+    assert_size!(ArchivedIdent, 28);
     assert_size!(ArchivedIdentName, 16);
     assert_size!(ArchivedPrivateName, 16);
 
@@ -592,19 +699,19 @@ mod rkyv_layout_assert {
     assert_size!(ArchivedJSXAttrName, 44);
     assert_size!(ArchivedJSXAttrOrSpread, 96);
     assert_size!(ArchivedJSXAttrValue, 36);
-    assert_size!(ArchivedJSXClosingElement, 64);
+    assert_size!(ArchivedJSXClosingElement, 68);
     assert_size!(ArchivedJSXClosingFragment, 8);
-    assert_size!(ArchivedJSXElement, 168);
+    assert_size!(ArchivedJSXElement, 176);
     assert_size!(ArchivedJSXElementChild, 36);
-    assert_size!(ArchivedJSXElementName, 56);
+    assert_size!(ArchivedJSXElementName, 60);
     assert_size!(ArchivedJSXEmptyExpr, 8);
     assert_size!(ArchivedJSXExpr, 12);
     assert_size!(ArchivedJSXExprContainer, 20);
     assert_size!(ArchivedJSXFragment, 32);
-    assert_size!(ArchivedJSXMemberExpr, 52);
+    assert_size!(ArchivedJSXMemberExpr, 56);
     assert_size!(ArchivedJSXNamespacedName, 40);
-    assert_size!(ArchivedJSXObject, 28);
-    assert_size!(ArchivedJSXOpeningElement, 84);
+    assert_size!(ArchivedJSXObject, 32);
+    assert_size!(ArchivedJSXOpeningElement, 88);
     assert_size!(ArchivedJSXOpeningFragment, 8);
     assert_size!(ArchivedJSXSpreadChild, 12);
     assert_size!(ArchivedJSXText, 24);
@@ -619,21 +726,21 @@ mod rkyv_layout_assert {
     assert_size!(ArchivedStr, 28);
 
     // Module declaration types
-    assert_size!(ArchivedDefaultDecl, 36);
+    assert_size!(ArchivedDefaultDecl, 40);
     assert_size!(ArchivedExportAll, 24);
-    assert_size!(ArchivedExportDecl, 44);
-    assert_size!(ArchivedExportDefaultDecl, 44);
+    assert_size!(ArchivedExportDecl, 48);
+    assert_size!(ArchivedExportDefaultDecl, 48);
     assert_size!(ArchivedExportDefaultExpr, 12);
-    assert_size!(ArchivedExportDefaultSpecifier, 24);
+    assert_size!(ArchivedExportDefaultSpecifier, 28);
     assert_size!(ArchivedExportNamedSpecifier, 80);
     assert_size!(ArchivedExportNamespaceSpecifier, 40);
     assert_size!(ArchivedExportSpecifier, 84);
     assert_size!(ArchivedImportDecl, 36);
-    assert_size!(ArchivedImportDefaultSpecifier, 32);
-    assert_size!(ArchivedImportNamedSpecifier, 72);
-    assert_size!(ArchivedImportSpecifier, 76);
-    assert_size!(ArchivedImportStarAsSpecifier, 32);
-    assert_size!(ArchivedModuleDecl, 48);
+    assert_size!(ArchivedImportDefaultSpecifier, 36);
+    assert_size!(ArchivedImportNamedSpecifier, 76);
+    assert_size!(ArchivedImportSpecifier, 80);
+    assert_size!(ArchivedImportStarAsSpecifier, 36);
+    assert_size!(ArchivedModuleDecl, 52);
     assert_size!(ArchivedModuleExportName, 32);
     assert_size!(ArchivedNamedExport, 36);
 
@@ -646,44 +753,44 @@ mod rkyv_layout_assert {
     // Pattern types
     assert_size!(ArchivedArrayPat, 28);
     assert_size!(ArchivedAssignPat, 16);
-    assert_size!(ArchivedAssignPatProp, 48);
+    assert_size!(ArchivedAssignPatProp, 52);
     assert_size!(ArchivedKeyValuePatProp, 48);
     assert_size!(ArchivedObjectPat, 28);
     assert_size!(ArchivedObjectPatProp, 56);
-    assert_size!(ArchivedPat, 36);
+    assert_size!(ArchivedPat, 40);
     assert_size!(ArchivedRestPat, 28);
 
     // Property types
-    assert_size!(ArchivedAssignProp, 36);
+    assert_size!(ArchivedAssignProp, 40);
     assert_size!(ArchivedComputedPropName, 12);
-    assert_size!(ArchivedGetterProp, 80);
+    assert_size!(ArchivedGetterProp, 88);
     assert_size!(ArchivedKeyValueProp, 48);
     assert_size!(ArchivedMethodProp, 48);
-    assert_size!(ArchivedProp, 128);
+    assert_size!(ArchivedProp, 136);
     assert_size!(ArchivedPropName, 40);
-    assert_size!(ArchivedSetterProp, 120);
+    assert_size!(ArchivedSetterProp, 128);
 
     // Statement types
-    assert_size!(ArchivedBlockStmt, 20);
-    assert_size!(ArchivedBreakStmt, 36);
-    assert_size!(ArchivedCatchClause, 68);
-    assert_size!(ArchivedContinueStmt, 36);
+    assert_size!(ArchivedBlockStmt, 24);
+    assert_size!(ArchivedBreakStmt, 40);
+    assert_size!(ArchivedCatchClause, 80);
+    assert_size!(ArchivedContinueStmt, 40);
     assert_size!(ArchivedDebuggerStmt, 8);
     assert_size!(ArchivedDoWhileStmt, 16);
     assert_size!(ArchivedEmptyStmt, 8);
     assert_size!(ArchivedExprStmt, 12);
     assert_size!(ArchivedForHead, 8);
-    assert_size!(ArchivedForInStmt, 24);
-    assert_size!(ArchivedForOfStmt, 28);
-    assert_size!(ArchivedForStmt, 40);
+    assert_size!(ArchivedForInStmt, 28);
+    assert_size!(ArchivedForOfStmt, 32);
+    assert_size!(ArchivedForStmt, 44);
     assert_size!(ArchivedIfStmt, 24);
-    assert_size!(ArchivedLabeledStmt, 36);
+    assert_size!(ArchivedLabeledStmt, 40);
     assert_size!(ArchivedReturnStmt, 16);
-    assert_size!(ArchivedStmt, 44);
+    assert_size!(ArchivedStmt, 48);
     assert_size!(ArchivedSwitchCase, 24);
-    assert_size!(ArchivedSwitchStmt, 20);
+    assert_size!(ArchivedSwitchStmt, 24);
     assert_size!(ArchivedThrowStmt, 12);
-    assert_size!(ArchivedTryStmt, 124);
+    assert_size!(ArchivedTryStmt, 144);
     assert_size!(ArchivedVarDeclOrExpr, 8);
     assert_size!(ArchivedWhileStmt, 16);
     assert_size!(ArchivedWithStmt, 16);
@@ -698,69 +805,69 @@ mod rkyv_layout_assert {
     assert_size!(ArchivedTsConstAssertion, 12);
     assert_size!(ArchivedTsConstructSignatureDecl, 32);
     assert_size!(ArchivedTsConstructorType, 32);
-    assert_size!(ArchivedTsEntityName, 28);
-    assert_size!(ArchivedTsEnumDecl, 44);
+    assert_size!(ArchivedTsEntityName, 32);
+    assert_size!(ArchivedTsEnumDecl, 48);
     assert_size!(ArchivedTsEnumMember, 48);
     assert_size!(ArchivedTsEnumMemberId, 32);
     assert_size!(ArchivedTsExportAssignment, 12);
     assert_size!(ArchivedTsExprWithTypeArgs, 20);
     assert_size!(ArchivedTsExternalModuleRef, 36);
     assert_size!(ArchivedTsFnOrConstructorType, 36);
-    assert_size!(ArchivedTsFnParam, 36);
+    assert_size!(ArchivedTsFnParam, 40);
     assert_size!(ArchivedTsFnType, 28);
     assert_size!(ArchivedTsGetterSignature, 24);
-    assert_size!(ArchivedTsImportEqualsDecl, 76);
-    assert_size!(ArchivedTsImportType, 92);
+    assert_size!(ArchivedTsImportEqualsDecl, 80);
+    assert_size!(ArchivedTsImportType, 96);
     assert_size!(ArchivedTsIndexSignature, 28);
     assert_size!(ArchivedTsIndexedAccessType, 20);
-    assert_size!(ArchivedTsInferType, 60);
+    assert_size!(ArchivedTsInferType, 64);
     assert_size!(ArchivedTsInstantiation, 16);
     assert_size!(ArchivedTsInterfaceBody, 16);
-    assert_size!(ArchivedTsInterfaceDecl, 68);
+    assert_size!(ArchivedTsInterfaceDecl, 72);
     assert_size!(ArchivedTsIntersectionType, 16);
     assert_size!(ArchivedTsKeywordType, 12);
     assert_size!(ArchivedTsKeywordTypeKind, 1);
     assert_size!(ArchivedTsLit, 40);
     assert_size!(ArchivedTsLitType, 48);
-    assert_size!(ArchivedTsMappedType, 84);
+    assert_size!(ArchivedTsMappedType, 88);
     assert_size!(ArchivedTsMethodSignature, 40);
     assert_size!(ArchivedTsModuleBlock, 16);
-    assert_size!(ArchivedTsModuleDecl, 92);
+    assert_size!(ArchivedTsModuleDecl, 96);
     assert_size!(ArchivedTsModuleName, 32);
     assert_size!(ArchivedTsModuleRef, 40);
-    assert_size!(ArchivedTsNamespaceBody, 44);
-    assert_size!(ArchivedTsNamespaceDecl, 40);
-    assert_size!(ArchivedTsNamespaceExportDecl, 32);
+    assert_size!(ArchivedTsNamespaceBody, 48);
+    assert_size!(ArchivedTsNamespaceDecl, 44);
+    assert_size!(ArchivedTsNamespaceExportDecl, 36);
     assert_size!(ArchivedTsNonNullExpr, 12);
     assert_size!(ArchivedTsOptionalType, 12);
-    assert_size!(ArchivedTsParamProp, 56);
-    assert_size!(ArchivedTsParamPropParam, 36);
+    assert_size!(ArchivedTsParamProp, 60);
+    assert_size!(ArchivedTsParamPropParam, 40);
     assert_size!(ArchivedTsParenthesizedType, 12);
     assert_size!(ArchivedTsPropertySignature, 28);
-    assert_size!(ArchivedTsQualifiedName, 52);
+    assert_size!(ArchivedTsQualifiedName, 56);
     assert_size!(ArchivedTsRestType, 12);
     assert_size!(ArchivedTsSatisfiesExpr, 16);
-    assert_size!(ArchivedTsSetterSignature, 52);
+    assert_size!(ArchivedTsSetterSignature, 56);
     assert_size!(ArchivedTsThisType, 8);
-    assert_size!(ArchivedTsThisTypeOrIdent, 28);
+    assert_size!(ArchivedTsThisTypeOrIdent, 32);
     assert_size!(ArchivedTsTplLitType, 24);
-    assert_size!(ArchivedTsTupleElement, 52);
+    assert_size!(ArchivedTsTupleElement, 56);
     assert_size!(ArchivedTsTupleType, 16);
     assert_size!(ArchivedTsType, 120);
-    assert_size!(ArchivedTsTypeAliasDecl, 48);
+    assert_size!(ArchivedTsTypeAliasDecl, 52);
     assert_size!(ArchivedTsTypeAnn, 12);
     assert_size!(ArchivedTsTypeAssertion, 16);
-    assert_size!(ArchivedTsTypeElement, 56);
+    assert_size!(ArchivedTsTypeElement, 60);
     assert_size!(ArchivedTsTypeLit, 16);
     assert_size!(ArchivedTsTypeOperator, 16);
     assert_size!(ArchivedTsTypeOperatorOp, 1);
-    assert_size!(ArchivedTsTypeParam, 52);
+    assert_size!(ArchivedTsTypeParam, 56);
     assert_size!(ArchivedTsTypeParamDecl, 16);
     assert_size!(ArchivedTsTypeParamInstantiation, 16);
-    assert_size!(ArchivedTsTypePredicate, 48);
-    assert_size!(ArchivedTsTypeQuery, 112);
-    assert_size!(ArchivedTsTypeQueryExpr, 96);
-    assert_size!(ArchivedTsTypeRef, 44);
+    assert_size!(ArchivedTsTypePredicate, 52);
+    assert_size!(ArchivedTsTypeQuery, 116);
+    assert_size!(ArchivedTsTypeQueryExpr, 100);
+    assert_size!(ArchivedTsTypeRef, 48);
     assert_size!(ArchivedTsUnionOrIntersectionType, 20);
     assert_size!(ArchivedTsUnionType, 16);
 }

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -2,7 +2,7 @@ use is_macro::Is;
 use swc_atoms::Atom;
 use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 
-use crate::{module_decl::ModuleDecl, stmt::Stmt};
+use crate::{module_decl::ModuleDecl, stmt::Stmt, NodeId};
 
 #[ast_node]
 #[derive(Eq, Hash, Is, EqIgnoreSpan)]
@@ -27,6 +27,9 @@ impl Take for Program {
 pub struct Module {
     pub span: Span,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub body: Vec<ModuleItem>,
 
     #[cfg_attr(feature = "serde-impl", serde(default, rename = "interpreter"))]
@@ -45,6 +48,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Module {
         let body = u.arbitrary()?;
         Ok(Self {
             span,
+            node_id: Default::default(),
             body,
             shebang: None,
         })
@@ -55,6 +59,7 @@ impl Take for Module {
     fn dummy() -> Self {
         Module {
             span: DUMMY_SP,
+            node_id: Default::default(),
             body: Take::dummy(),
             shebang: Take::dummy(),
         }
@@ -66,6 +71,9 @@ impl Take for Module {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Script {
     pub span: Span,
+
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     pub body: Vec<Stmt>,
 
@@ -85,6 +93,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Script {
         let body = u.arbitrary()?;
         Ok(Self {
             span,
+            node_id: Default::default(),
             body,
             shebang: None,
         })
@@ -95,6 +104,7 @@ impl Take for Script {
     fn dummy() -> Self {
         Script {
             span: DUMMY_SP,
+            node_id: Default::default(),
             body: Take::dummy(),
             shebang: Take::dummy(),
         }

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -5,7 +5,7 @@ use crate::{
     decl::{Decl, VarDecl},
     expr::Expr,
     pat::Pat,
-    Ident, Lit, Str, UsingDecl,
+    Ident, Lit, NodeId, Str, UsingDecl,
 };
 
 /// Use when only block statements are allowed.
@@ -19,6 +19,9 @@ pub struct BlockStmt {
 
     pub ctxt: SyntaxContext,
 
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
+
     pub stmts: Vec<Stmt>,
 }
 
@@ -28,6 +31,7 @@ impl Take for BlockStmt {
             span: DUMMY_SP,
             stmts: Vec::new(),
             ctxt: Default::default(),
+            node_id: Default::default(),
         }
     }
 }
@@ -328,6 +332,8 @@ pub struct IfStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SwitchStmt {
     pub span: Span,
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub discriminant: Box<Expr>,
     pub cases: Vec<SwitchCase>,
 }
@@ -392,6 +398,8 @@ pub struct DoWhileStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForStmt {
     pub span: Span,
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
 
     #[cfg_attr(feature = "serde-impl", serde(default))]
     #[cfg_attr(
@@ -423,6 +431,8 @@ pub struct ForStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForInStmt {
     pub span: Span,
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     pub left: ForHead,
     pub right: Box<Expr>,
     pub body: Box<Stmt>,
@@ -434,6 +444,8 @@ pub struct ForInStmt {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForOfStmt {
     pub span: Span,
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     /// Span of the await token.
     ///
     /// es2018
@@ -487,6 +499,8 @@ impl Take for SwitchCase {
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct CatchClause {
     pub span: Span,
+    #[cfg_attr(feature = "serde-impl", serde(default))]
+    pub node_id: NodeId,
     /// es2019
     ///
     /// The param is null if the catch binding is omitted. E.g., try { foo() }

--- a/crates/swc_ecma_ast/tests/node_id.rs
+++ b/crates/swc_ecma_ast/tests/node_id.rs
@@ -1,0 +1,36 @@
+#![cfg(feature = "serde-impl")]
+
+use serde_json::Value;
+use swc_atoms::atom;
+use swc_common::{SyntaxContext, DUMMY_SP};
+use swc_ecma_ast::{Ident, Module, NodeId, ScopeId};
+
+#[test]
+fn module_node_id_serde_defaults_to_invalid() {
+    let module = Module {
+        span: DUMMY_SP,
+        node_id: NodeId(7),
+        body: Vec::new(),
+        shebang: None,
+    };
+
+    let mut value = serde_json::to_value(&module).unwrap();
+    assert_eq!(value["nodeId"], Value::from(7));
+
+    value.as_object_mut().unwrap().remove("nodeId");
+    let module: Module = serde_json::from_value(value).unwrap();
+    assert_eq!(module.node_id, NodeId::INVALID);
+}
+
+#[test]
+fn ident_scope_id_serde_defaults_to_invalid() {
+    let mut ident = Ident::new(atom!("foo"), DUMMY_SP, SyntaxContext::empty());
+    ident.scope_id = ScopeId(11);
+
+    let mut value = serde_json::to_value(&ident).unwrap();
+    assert_eq!(value["scopeId"], Value::from(11));
+
+    value.as_object_mut().unwrap().remove("scopeId");
+    let ident: Ident = serde_json::from_value(value).unwrap();
+    assert_eq!(ident.scope_id, ScopeId::INVALID);
+}

--- a/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
+++ b/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
@@ -346,6 +346,7 @@ impl BlockScoping {
                     stmts.push(
                         SwitchStmt {
                             span: DUMMY_SP,
+                            node_id: Default::default(),
                             discriminant: Box::new(ret.into()),
                             cases: flow_helper
                                 .label

--- a/crates/swc_ecma_compat_es2015/src/destructuring.rs
+++ b/crates/swc_ecma_compat_es2015/src/destructuring.rs
@@ -132,10 +132,16 @@ macro_rules! impl_for_for_stmt {
             for_stmt.left = left;
 
             for_stmt.body = Box::new(Stmt::Block(match &mut *for_stmt.body {
-                Stmt::Block(BlockStmt { span, stmts, ctxt }) => BlockStmt {
+                Stmt::Block(BlockStmt {
+                    span,
+                    stmts,
+                    ctxt,
+                    node_id,
+                }) => BlockStmt {
                     span: *span,
                     stmts: iter::once(stmt).chain(stmts.take()).collect(),
                     ctxt: *ctxt,
+                    node_id: *node_id,
                 },
                 body => BlockStmt {
                     stmts: vec![stmt, body.take()],

--- a/crates/swc_ecma_compat_es2015/src/for_of.rs
+++ b/crates/swc_ecma_compat_es2015/src/for_of.rs
@@ -192,6 +192,7 @@ impl ForOf {
 
             let stmt = ForStmt {
                 span,
+                node_id: Default::default(),
                 init: Some(
                     VarDecl {
                         span: DUMMY_SP,
@@ -317,6 +318,7 @@ impl ForOf {
 
             let stmt = ForStmt {
                 span,
+                node_id: Default::default(),
                 init: Some(
                     VarDecl {
                         kind: VarDeclKind::Var,
@@ -417,6 +419,7 @@ impl ForOf {
 
         let for_stmt = ForStmt {
             span,
+            node_id: Default::default(),
             init: Some(
                 VarDecl {
                     span: DUMMY_SP,
@@ -519,6 +522,7 @@ impl ForOf {
             },
             handler: Some(CatchClause {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 param: Some(quote_ident!("err").into()),
                 // _didIteratorError = true;
                 // _iteratorError = err;

--- a/crates/swc_ecma_compat_es2015/src/generator.rs
+++ b/crates/swc_ecma_compat_es2015/src/generator.rs
@@ -1858,6 +1858,7 @@ impl Generator {
             self.emit_stmt(
                 ForInStmt {
                     span: DUMMY_SP,
+                    node_id: Default::default(),
                     left: ForHead::Pat(key.clone().into()),
                     right: Box::new(obj.clone().into()),
                     body: Box::new(Stmt::Expr(ExprStmt {
@@ -2104,6 +2105,7 @@ impl Generator {
                     self.emit_stmt(
                         SwitchStmt {
                             span: DUMMY_SP,
+                            node_id: Default::default(),
                             discriminant: expression.clone().into(),
                             cases: take(&mut pending_clauses),
                         }
@@ -2973,6 +2975,7 @@ impl Generator {
             let label_expr = self.state.clone().make_member(quote_ident!("label"));
             let switch_stmt = SwitchStmt {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 discriminant: label_expr.into(),
                 cases: clauses,
             };

--- a/crates/swc_ecma_compat_es2015/src/parameters.rs
+++ b/crates/swc_ecma_compat_es2015/src/parameters.rs
@@ -310,6 +310,7 @@ impl Params {
                     unpack_rest = Some(
                         ForStmt {
                             span,
+                            node_id: Default::default(),
                             init: Some(
                                 VarDecl {
                                     kind: VarDeclKind::Var,

--- a/crates/swc_ecma_hooks/src/generated.rs
+++ b/crates/swc_ecma_hooks/src/generated.rs
@@ -153,6 +153,14 @@ pub trait VisitHook<C> {
     #[inline]
     #[allow(unused_variables)]
     fn exit_binary_op(&mut self, node: &BinaryOp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `BindingId` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_binding_id(&mut self, node: &BindingId, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `BindingId` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_binding_id(&mut self, node: &BindingId, ctx: &mut C) {}
     #[doc = "Called when entering a node of type `BindingIdent` before visiting its children."]
     #[inline]
     #[allow(unused_variables)]
@@ -2735,6 +2743,18 @@ where
     fn exit_binary_op(&mut self, node: &BinaryOp, ctx: &mut C) {
         self.second.exit_binary_op(node, ctx);
         self.first.exit_binary_op(node, ctx);
+    }
+
+    #[inline]
+    fn enter_binding_id(&mut self, node: &BindingId, ctx: &mut C) {
+        self.first.enter_binding_id(node, ctx);
+        self.second.enter_binding_id(node, ctx);
+    }
+
+    #[inline]
+    fn exit_binding_id(&mut self, node: &BindingId, ctx: &mut C) {
+        self.second.exit_binding_id(node, ctx);
+        self.first.exit_binding_id(node, ctx);
     }
 
     #[inline]
@@ -6371,6 +6391,22 @@ where
         match self {
             Self::Left(hook) => hook.exit_binary_op(node, ctx),
             Self::Right(hook) => hook.exit_binary_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_binding_id(&mut self, node: &BindingId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_binding_id(node, ctx),
+            Self::Right(hook) => hook.enter_binding_id(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_binding_id(&mut self, node: &BindingId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_binding_id(node, ctx),
+            Self::Right(hook) => hook.exit_binding_id(node, ctx),
         }
     }
 
@@ -11083,6 +11119,20 @@ where
     }
 
     #[inline]
+    fn enter_binding_id(&mut self, node: &BindingId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_binding_id(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_binding_id(&mut self, node: &BindingId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_binding_id(node, ctx);
+        }
+    }
+
+    #[inline]
     fn enter_binding_ident(&mut self, node: &BindingIdent, ctx: &mut C) {
         if let Some(hook) = self {
             hook.enter_binding_ident(node, ctx);
@@ -15134,6 +15184,14 @@ impl<H: VisitHook<C>, C> Visit for VisitWithHook<H, C> {
         self.hook.exit_binary_op(node, &mut self.context);
     }
 
+    #[doc = "Visits a node of type `BindingId` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_binding_id(&mut self, node: &BindingId) {
+        self.hook.enter_binding_id(node, &mut self.context);
+        node.visit_children_with(self);
+        self.hook.exit_binding_id(node, &mut self.context);
+    }
+
     #[doc = "Visits a node of type `BindingIdent` using the hook's enter and exit methods."]
     #[inline]
     fn visit_binding_ident(&mut self, node: &BindingIdent) {
@@ -17611,6 +17669,14 @@ pub trait VisitMutHook<C> {
     #[inline]
     #[allow(unused_variables)]
     fn exit_binary_op(&mut self, node: &mut BinaryOp, ctx: &mut C) {}
+    #[doc = "Called when entering a node of type `BindingId` before visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn enter_binding_id(&mut self, node: &mut BindingId, ctx: &mut C) {}
+    #[doc = "Called when exiting a node of type `BindingId` after visiting its children."]
+    #[inline]
+    #[allow(unused_variables)]
+    fn exit_binding_id(&mut self, node: &mut BindingId, ctx: &mut C) {}
     #[doc = "Called when entering a node of type `BindingIdent` before visiting its children."]
     #[inline]
     #[allow(unused_variables)]
@@ -20239,6 +20305,18 @@ where
     fn exit_binary_op(&mut self, node: &mut BinaryOp, ctx: &mut C) {
         self.second.exit_binary_op(node, ctx);
         self.first.exit_binary_op(node, ctx);
+    }
+
+    #[inline]
+    fn enter_binding_id(&mut self, node: &mut BindingId, ctx: &mut C) {
+        self.first.enter_binding_id(node, ctx);
+        self.second.enter_binding_id(node, ctx);
+    }
+
+    #[inline]
+    fn exit_binding_id(&mut self, node: &mut BindingId, ctx: &mut C) {
+        self.second.exit_binding_id(node, ctx);
+        self.first.exit_binding_id(node, ctx);
     }
 
     #[inline]
@@ -23911,6 +23989,22 @@ where
         match self {
             Self::Left(hook) => hook.exit_binary_op(node, ctx),
             Self::Right(hook) => hook.exit_binary_op(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn enter_binding_id(&mut self, node: &mut BindingId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.enter_binding_id(node, ctx),
+            Self::Right(hook) => hook.enter_binding_id(node, ctx),
+        }
+    }
+
+    #[inline]
+    fn exit_binding_id(&mut self, node: &mut BindingId, ctx: &mut C) {
+        match self {
+            Self::Left(hook) => hook.exit_binding_id(node, ctx),
+            Self::Right(hook) => hook.exit_binding_id(node, ctx),
         }
     }
 
@@ -28659,6 +28753,20 @@ where
     }
 
     #[inline]
+    fn enter_binding_id(&mut self, node: &mut BindingId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.enter_binding_id(node, ctx);
+        }
+    }
+
+    #[inline]
+    fn exit_binding_id(&mut self, node: &mut BindingId, ctx: &mut C) {
+        if let Some(hook) = self {
+            hook.exit_binding_id(node, ctx);
+        }
+    }
+
+    #[inline]
     fn enter_binding_ident(&mut self, node: &mut BindingIdent, ctx: &mut C) {
         if let Some(hook) = self {
             hook.enter_binding_ident(node, ctx);
@@ -32744,6 +32852,14 @@ impl<H: VisitMutHook<C>, C> VisitMut for VisitMutWithHook<H, C> {
         self.hook.enter_binary_op(node, &mut self.context);
         node.visit_mut_children_with(self);
         self.hook.exit_binary_op(node, &mut self.context);
+    }
+
+    #[doc = "Visits a node of type `BindingId` using the hook's enter and exit methods."]
+    #[inline]
+    fn visit_mut_binding_id(&mut self, node: &mut BindingId) {
+        self.hook.enter_binding_id(node, &mut self.context);
+        node.visit_mut_children_with(self);
+        self.hook.exit_binding_id(node, &mut self.context);
     }
 
     #[doc = "Visits a node of type `BindingIdent` using the hook's enter and exit methods."]

--- a/crates/swc_ecma_lexer/src/common/parser/class_and_fn.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/class_and_fn.rs
@@ -323,6 +323,7 @@ where
             is_generator,
             return_type,
             ctxt: Default::default(),
+            node_id: Default::default(),
         }))
     };
 

--- a/crates/swc_ecma_lexer/src/common/parser/stmt.rs
+++ b/crates/swc_ecma_lexer/src/common/parser/stmt.rs
@@ -545,6 +545,7 @@ fn parse_for_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
 
             ForStmt {
                 span,
+                node_id: Default::default(),
                 init,
                 test,
                 update,
@@ -559,6 +560,7 @@ fn parse_for_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
 
             ForInStmt {
                 span,
+                node_id: Default::default(),
                 left,
                 right,
                 body,
@@ -567,6 +569,7 @@ fn parse_for_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
         }
         TempForHead::ForOf { left, right } => ForOfStmt {
             span,
+            node_id: Default::default(),
             is_await: await_token.is_some(),
             left,
             right,
@@ -886,6 +889,7 @@ pub fn parse_block<'a, P: Parser<'a>>(p: &mut P, allow_directives: bool) -> PRes
     let span = p.span(start);
     Ok(BlockStmt {
         span,
+        node_id: Default::default(),
         stmts,
         ctxt: Default::default(),
     })
@@ -906,6 +910,7 @@ fn parse_catch_clause<'a, P: Parser<'a>>(p: &mut P) -> PResult<Option<CatchClaus
         parse_block(p, false)
             .map(|body| CatchClause {
                 span: p.span(start),
+                node_id: Default::default(),
                 param,
                 body,
             })
@@ -999,6 +1004,7 @@ fn parse_switch_stmt<'a, P: Parser<'a>>(p: &mut P) -> PResult<Stmt> {
 
     Ok(SwitchStmt {
         span: p.span(switch_start),
+        node_id: Default::default(),
         discriminant,
         cases,
     }

--- a/crates/swc_ecma_lexer/src/parser/mod.rs
+++ b/crates/swc_ecma_lexer/src/parser/mod.rs
@@ -153,6 +153,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
 
         let ret = parse_stmt_block_body(self, true, None).map(|body| Script {
             span: self.span(start),
+            node_id: Default::default(),
             body,
             shebang,
         })?;
@@ -174,6 +175,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
 
         let ret = parse_stmt_block_body(self, true, None).map(|body| Script {
             span: self.span(start),
+            node_id: Default::default(),
             body,
             shebang,
         })?;
@@ -198,6 +200,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
         let shebang = parse_shebang(self)?;
 
         let ret = parse_module_item_block_body(self, true, None).map(|body| Module {
+            node_id: Default::default(),
             span: self.span(start),
             body,
             shebang,
@@ -239,6 +242,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
         let ret = if has_module_item {
             Program::Module(Module {
                 span: self.span(start),
+                node_id: Default::default(),
                 body,
                 shebang,
             })
@@ -257,6 +261,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
                 .collect();
             Program::Script(Script {
                 span: self.span(start),
+                node_id: Default::default(),
                 body,
                 shebang,
             })
@@ -282,6 +287,7 @@ impl<I: Tokens<TokenAndSpan>> Parser<I> {
 
         let ret = parse_module_item_block_body(self, true, None).map(|body| Module {
             span: self.span(start),
+            node_id: Default::default(),
             body,
             shebang,
         })?;

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -1347,6 +1347,7 @@ impl Optimizer<'_> {
 
         Some(BlockStmt {
             span,
+            node_id: Default::default(),
             ctxt: SyntaxContext::empty().apply_mark(self.marks.fake_block),
             stmts,
         })

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -2688,6 +2688,7 @@ impl VisitMut for Optimizer<'_> {
             let span = s.span();
             *s = BlockStmt {
                 span,
+                node_id: Default::default(),
                 ctxt: SyntaxContext::empty().apply_mark(self.marks.fake_block),
                 stmts: self
                     .prepend_stmts

--- a/crates/swc_ecma_minifier/src/compress/pure/loops.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/loops.rs
@@ -72,6 +72,7 @@ impl Pure<'_> {
                 report_change!("loops: Converting a while loop to a for loop");
                 *s = ForStmt {
                     span: stmt.span,
+                    node_id: Default::default(),
                     init: None,
                     test: Some(stmt.test.take()),
                     update: None,
@@ -87,6 +88,7 @@ impl Pure<'_> {
 
                     *s = ForStmt {
                         span: stmt.span,
+                        node_id: Default::default(),
                         init: None,
                         test: Some(stmt.test.take()),
                         update: None,

--- a/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
+++ b/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
@@ -2,13 +2,13 @@
 | --- | --- | --- | --- |
 | antd.js | 6.38 MiB | 2.06 MiB | 445.45 KiB |
 | d3.js | 542.74 KiB | 261.43 KiB | 85.33 KiB |
-| echarts.js | 3.41 MiB | 977.04 KiB | 314.11 KiB |
+| echarts.js | 3.41 MiB | 977.09 KiB | 314.11 KiB |
 | jquery.js | 280.89 KiB | 87.79 KiB | 30.20 KiB |
 | lodash.js | 531.35 KiB | 68.92 KiB | 24.60 KiB |
 | moment.js | 169.83 KiB | 57.34 KiB | 18.25 KiB |
 | react.js | 70.45 KiB | 22.45 KiB | 8.04 KiB |
 | terser.js | 1.08 MiB | 446.63 KiB | 120.49 KiB |
 | three.js | 1.19 MiB | 630.55 KiB | 154.77 KiB |
-| typescript.js | 10.45 MiB | 3.17 MiB | 840.61 KiB |
+| typescript.js | 10.45 MiB | 3.17 MiB | 840.63 KiB |
 | victory.js | 2.30 MiB | 694.04 KiB | 154.18 KiB |
 | vue.js | 334.13 KiB | 113.56 KiB | 41.80 KiB |

--- a/crates/swc_ecma_parser/src/parser/class_and_fn.rs
+++ b/crates/swc_ecma_parser/src/parser/class_and_fn.rs
@@ -378,6 +378,7 @@ impl<I: Tokens> Parser<I> {
                 is_generator,
                 return_type,
                 ctxt: Default::default(),
+                node_id: Default::default(),
             }))
         };
 

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -224,6 +224,7 @@ impl<I: Tokens> Parser<I> {
 
         let ret = self.parse_stmt_block_body(true, None).map(|body| Script {
             span: self.span(start),
+            node_id: Default::default(),
             body,
             shebang,
         })?;
@@ -248,6 +249,7 @@ impl<I: Tokens> Parser<I> {
 
         let ret = self.parse_stmt_block_body(true, None).map(|body| Script {
             span: self.span(start),
+            node_id: Default::default(),
             body,
             shebang,
         })?;
@@ -275,6 +277,7 @@ impl<I: Tokens> Parser<I> {
             .parse_module_item_block_body(true, None)
             .map(|body| Module {
                 span: self.span(start),
+                node_id: Default::default(),
                 body,
                 shebang,
             })?;
@@ -318,6 +321,7 @@ impl<I: Tokens> Parser<I> {
             }
             Program::Module(Module {
                 span: self.span(start),
+                node_id: Default::default(),
                 body,
                 shebang,
             })
@@ -333,6 +337,7 @@ impl<I: Tokens> Parser<I> {
                 .collect();
             Program::Script(Script {
                 span: self.span(start),
+                node_id: Default::default(),
                 body,
                 shebang,
             })
@@ -360,6 +365,7 @@ impl<I: Tokens> Parser<I> {
             .parse_module_item_block_body(true, None)
             .map(|body| Module {
                 span: self.span(start),
+                node_id: Default::default(),
                 body,
                 shebang,
             })?;

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -569,6 +569,7 @@ impl<I: Tokens> Parser<I> {
 
                 ForStmt {
                     span,
+                    node_id: Default::default(),
                     init,
                     test,
                     update,
@@ -583,6 +584,7 @@ impl<I: Tokens> Parser<I> {
 
                 ForInStmt {
                     span,
+                    node_id: Default::default(),
                     left,
                     right,
                     body,
@@ -599,6 +601,7 @@ impl<I: Tokens> Parser<I> {
 
                 ForOfStmt {
                     span,
+                    node_id: Default::default(),
                     is_await: await_token.is_some(),
                     left,
                     right,
@@ -920,6 +923,7 @@ impl<I: Tokens> Parser<I> {
         let span = self.span(start);
         Ok(BlockStmt {
             span,
+            node_id: Default::default(),
             stmts,
             ctxt: Default::default(),
         })
@@ -940,6 +944,7 @@ impl<I: Tokens> Parser<I> {
             self.parse_block(false)
                 .map(|body| CatchClause {
                     span: self.span(start),
+                    node_id: Default::default(),
                     param,
                     body,
                 })
@@ -1035,6 +1040,7 @@ impl<I: Tokens> Parser<I> {
 
         Ok(SwitchStmt {
             span: self.span(switch_start),
+            node_id: Default::default(),
             discriminant,
             cases,
         }
@@ -1689,6 +1695,7 @@ impl<I: Tokens> Parser<I> {
                 decorators: Vec::new(),
                 body: Some(BlockStmt {
                     span,
+                    node_id: Default::default(),
                     stmts,
                     ctxt: Default::default(),
                 }),
@@ -1697,6 +1704,7 @@ impl<I: Tokens> Parser<I> {
                 type_params: None,
                 return_type: None,
                 ctxt: Default::default(),
+                node_id: Default::default(),
             }),
         }));
 
@@ -1749,6 +1757,7 @@ impl<I: Tokens> Parser<I> {
                 test,
                 cons: Box::new(Stmt::Block(BlockStmt {
                     span,
+                    node_id: Default::default(),
                     stmts: cons_stmts,
                     ctxt: Default::default(),
                 })),
@@ -1788,6 +1797,7 @@ impl<I: Tokens> Parser<I> {
                 let expr = self.allow_in_expr(Self::parse_assignment_expr)?;
                 BlockStmt {
                     span,
+                    node_id: Default::default(),
                     stmts: vec![Stmt::Expr(ExprStmt { span, expr })],
                     ctxt: Default::default(),
                 }
@@ -1811,6 +1821,7 @@ impl<I: Tokens> Parser<I> {
                 test,
                 cons: Box::new(Stmt::Block(BlockStmt {
                     span,
+                    node_id: Default::default(),
                     stmts,
                     ctxt: Default::default(),
                 })),
@@ -1835,6 +1846,7 @@ impl<I: Tokens> Parser<I> {
 
         Ok(Stmt::Block(BlockStmt {
             span,
+            node_id: Default::default(),
             stmts,
             ctxt: Default::default(),
         }))
@@ -2304,6 +2316,7 @@ mod tests {
                     ..Default::default()
                 },
                 handler: Some(CatchClause {
+                    node_id: Default::default(),
                     span,
                     param: Pat::Object(ObjectPat {
                         span,
@@ -2345,6 +2358,7 @@ mod tests {
         assert_eq_ignore_span!(
             stmt("for await (const a of b) ;"),
             Stmt::ForOf(ForOfStmt {
+                node_id: Default::default(),
                 span,
                 is_await: true,
                 left: ForHead::VarDecl(Box::new(VarDecl {

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -466,6 +466,7 @@ impl<I: Tokens> Parser<I> {
                 is_generator: false,
                 return_type,
                 ctxt: Default::default(),
+                node_id: Default::default(),
             }),
         }))
     }
@@ -5239,6 +5240,7 @@ mod tests {
         );
 
         let expected = Module {
+            node_id: Default::default(),
             span: DUMMY_SP,
             shebang: None,
             body: {
@@ -5273,6 +5275,7 @@ mod tests {
         );
 
         let expected = Module {
+            node_id: Default::default(),
             span: DUMMY_SP,
             shebang: None,
             body: {

--- a/crates/swc_ecma_quote_macros/src/ast/class.rs
+++ b/crates/swc_ecma_quote_macros/src/ast/class.rs
@@ -3,6 +3,7 @@ use swc_ecma_ast::*;
 impl_struct!(
     Class,
     [
+        node_id,
         span,
         ctxt,
         decorators,
@@ -17,7 +18,16 @@ impl_struct!(
 
 impl_struct!(
     Constructor,
-    [span, ctxt, key, params, body, accessibility, is_optional]
+    [
+        node_id,
+        span,
+        ctxt,
+        key,
+        params,
+        body,
+        accessibility,
+        is_optional
+    ]
 );
 
 impl_struct!(

--- a/crates/swc_ecma_quote_macros/src/ast/expr.rs
+++ b/crates/swc_ecma_quote_macros/src/ast/expr.rs
@@ -70,6 +70,7 @@ impl_struct!(FnExpr, [ident, function]);
 impl_struct!(
     ArrowExpr,
     [
+        node_id,
         span,
         ctxt,
         params,
@@ -112,6 +113,7 @@ impl_struct!(ParenExpr, [span, expr]);
 impl_struct!(
     Function,
     [
+        node_id,
         ctxt,
         params,
         decorators,

--- a/crates/swc_ecma_quote_macros/src/ast/mod.rs
+++ b/crates/swc_ecma_quote_macros/src/ast/mod.rs
@@ -67,7 +67,7 @@ macro_rules! impl_struct {
             fn to_code(&self, cx: &crate::ctxt::Ctx) -> syn::Expr {
                 let mut builder = crate::builder::Builder::new(stringify!($name));
 
-                let Self { $($v,)* } = self;
+                let Self { $($v,)* .. } = self;
 
                 $(
                     builder.add(
@@ -136,6 +136,20 @@ impl ToCode for Span {
 impl ToCode for SyntaxContext {
     fn to_code(&self, _: &Ctx) -> syn::Expr {
         parse_quote!(swc_core::common::SyntaxContext::empty())
+    }
+}
+
+impl ToCode for NodeId {
+    fn to_code(&self, _: &Ctx) -> syn::Expr {
+        let id = self.as_u32();
+        parse_quote!(swc_core::ecma::ast::NodeId(#id))
+    }
+}
+
+impl ToCode for ScopeId {
+    fn to_code(&self, _: &Ctx) -> syn::Expr {
+        let id = self.as_u32();
+        parse_quote!(swc_core::ecma::ast::ScopeId(#id))
     }
 }
 

--- a/crates/swc_ecma_quote_macros/src/ast/stmt.rs
+++ b/crates/swc_ecma_quote_macros/src/ast/stmt.rs
@@ -9,21 +9,21 @@ impl_enum!(
 );
 
 impl_struct!(EmptyStmt, [span]);
-impl_struct!(BlockStmt, [span, ctxt, stmts]);
+impl_struct!(BlockStmt, [node_id, span, ctxt, stmts]);
 impl_struct!(DebuggerStmt, [span]);
 impl_struct!(WithStmt, [span, obj, body]);
 impl_struct!(LabeledStmt, [span, label, body]);
 impl_struct!(BreakStmt, [span, label]);
 impl_struct!(ContinueStmt, [span, label]);
 impl_struct!(IfStmt, [span, test, cons, alt]);
-impl_struct!(SwitchStmt, [span, discriminant, cases]);
+impl_struct!(SwitchStmt, [node_id, span, discriminant, cases]);
 impl_struct!(ThrowStmt, [span, arg]);
 impl_struct!(TryStmt, [span, block, handler, finalizer]);
 impl_struct!(WhileStmt, [span, test, body]);
 impl_struct!(DoWhileStmt, [span, test, body]);
-impl_struct!(ForStmt, [span, init, test, update, body]);
-impl_struct!(ForInStmt, [span, left, right, body]);
-impl_struct!(ForOfStmt, [span, is_await, left, right, body]);
+impl_struct!(ForStmt, [node_id, span, init, test, update, body]);
+impl_struct!(ForInStmt, [node_id, span, left, right, body]);
+impl_struct!(ForOfStmt, [node_id, span, is_await, left, right, body]);
 impl_struct!(ReturnStmt, [span, arg]);
 impl_struct!(ExprStmt, [span, expr]);
 
@@ -32,4 +32,4 @@ impl_enum!(ForHead, [VarDecl, UsingDecl, Pat]);
 
 impl_struct!(SwitchCase, [span, test, cons]);
 
-impl_struct!(CatchClause, [span, param, body]);
+impl_struct!(CatchClause, [node_id, span, param, body]);

--- a/crates/swc_ecma_transformer/src/es2016/exponentiation_operator.rs
+++ b/crates/swc_ecma_transformer/src/es2016/exponentiation_operator.rs
@@ -289,6 +289,7 @@ fn create_math_pow(left: Box<Expr>, right: Box<Expr>) -> Expr {
                 span: DUMMY_SP,
                 ctxt: SyntaxContext::empty(),
                 sym: "Math".into(),
+                scope_id: Default::default(),
                 optional: false,
             })),
             prop: MemberProp::Ident(IdentName {

--- a/crates/swc_ecma_transformer/src/es2017/async_to_generator.rs
+++ b/crates/swc_ecma_transformer/src/es2017/async_to_generator.rs
@@ -603,6 +603,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
 
         let for_stmt = ForStmt {
             span: s.span,
+            node_id: Default::default(),
             // var _iterator = _async_iterator(lol()), _step;
             init: Some(
                 VarDecl {
@@ -717,6 +718,7 @@ fn handle_await_for(stmt: &mut Stmt, is_async_generator: bool) {
 
         CatchClause {
             span: DUMMY_SP,
+            node_id: Default::default(),
             param: Some(err_param.into()),
             body: BlockStmt {
                 stmts: vec![mark_as_errorred, store_error],

--- a/crates/swc_ecma_transformer/src/es2022/class_static_block.rs
+++ b/crates/swc_ecma_transformer/src/es2022/class_static_block.rs
@@ -148,9 +148,11 @@ impl ClassStaticBlock {
     fn wrap_in_iife(&self, stmts: Vec<Stmt>) -> Expr {
         let arrow = ArrowExpr {
             span: DUMMY_SP,
+            node_id: Default::default(),
             params: vec![],
             body: Box::new(BlockStmtOrExpr::BlockStmt(BlockStmt {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 stmts,
                 ctxt: Default::default(),
             })),

--- a/crates/swc_ecma_transformer/src/es2022/private_property_in_object.rs
+++ b/crates/swc_ecma_transformer/src/es2022/private_property_in_object.rs
@@ -307,6 +307,7 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                 span: DUMMY_SP,
                 callee: ArrowExpr {
                     span: DUMMY_SP,
+                    node_id: Default::default(),
                     params: Default::default(),
                     body: Box::new(BlockStmtOrExpr::BlockStmt(bs)),
                     is_async: false,

--- a/crates/swc_ecma_transforms_base/src/hygiene/tests.rs
+++ b/crates/swc_ecma_transforms_base/src/hygiene/tests.rs
@@ -91,6 +91,7 @@ where
         |tester| {
             Ok(Module {
                 span: DUMMY_SP,
+                node_id: Default::default(),
                 body: op(tester)?.into_iter().map(ModuleItem::Stmt).collect(),
                 shebang: None,
             })

--- a/crates/swc_ecma_transforms_base/src/resolver/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/resolver/mod.rs
@@ -1,3 +1,5 @@
+use std::{cell::Cell, rc::Rc};
+
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::Atom;
 use swc_common::{Mark, SyntaxContext};
@@ -142,7 +144,14 @@ pub fn resolver(
     let _ = SyntaxContext::empty().apply_mark(top_level_mark);
 
     visit_mut_pass(Resolver {
-        current: Scope::new(ScopeKind::Fn, top_level_mark, None),
+        current: Scope::new(
+            ScopeKind::Fn,
+            top_level_mark,
+            ScopeId::from_node_id(NodeId(1)),
+            Some(NodeId(1)),
+            None,
+        ),
+        node_id_generator: NodeIdGenerator::default(),
         ident_type: IdentType::Ref,
         in_type: false,
         is_module: false,
@@ -168,28 +177,108 @@ struct Scope<'a> {
     /// [Mark] of the current scope.
     mark: Mark,
 
+    /// Stable id of the current scope.
+    id: ScopeId,
+
+    /// AST node owning this scope, if the scope has a concrete owner.
+    owner_node_id: Option<NodeId>,
+
     /// All declarations in the scope
-    declared_symbols: FxHashMap<Atom, DeclKind>,
+    declared_symbols: FxHashMap<Atom, ResolvedBinding>,
 
     /// All types declared in the scope
-    declared_types: FxHashSet<Atom>,
+    declared_types: FxHashMap<Atom, ResolvedBinding>,
 }
 
 impl<'a> Scope<'a> {
-    pub fn new(kind: ScopeKind, mark: Mark, parent: Option<&'a Scope<'a>>) -> Self {
+    pub fn new(
+        kind: ScopeKind,
+        mark: Mark,
+        id: ScopeId,
+        owner_node_id: Option<NodeId>,
+        parent: Option<&'a Scope<'a>>,
+    ) -> Self {
         Scope {
             parent,
             kind,
             mark,
+            id,
+            owner_node_id,
             declared_symbols: Default::default(),
             declared_types: Default::default(),
         }
     }
 
-    fn is_declared(&self, symbol: &Atom) -> Option<&DeclKind> {
+    fn is_declared(&self, symbol: &Atom) -> Option<DeclKind> {
         self.declared_symbols
             .get(symbol)
+            .map(|binding| binding.kind)
             .or_else(|| self.parent?.is_declared(symbol))
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResolvedBinding {
+    kind: DeclKind,
+    scope_id: ScopeId,
+    legacy_mark: Mark,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ResolvedRef {
+    scope_id: ScopeId,
+    legacy_mark: Mark,
+}
+
+impl ResolvedRef {
+    fn from_binding(binding: ResolvedBinding, unresolved_mark: Mark) -> Self {
+        let scope_id = if binding.legacy_mark == unresolved_mark {
+            ScopeId::UNRESOLVED
+        } else {
+            binding.scope_id
+        };
+
+        Self {
+            scope_id,
+            legacy_mark: binding.legacy_mark,
+        }
+    }
+
+    fn unresolved(unresolved_mark: Mark) -> Self {
+        Self {
+            scope_id: ScopeId::UNRESOLVED,
+            legacy_mark: unresolved_mark,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct NodeIdGenerator {
+    next: Rc<Cell<u32>>,
+}
+
+impl Default for NodeIdGenerator {
+    fn default() -> Self {
+        Self {
+            // The top-level Module/Script scope is always id 1.
+            next: Rc::new(Cell::new(2)),
+        }
+    }
+}
+
+impl NodeIdGenerator {
+    fn fresh(&self) -> NodeId {
+        let id = self.next.get();
+        self.next.set(id + 1);
+        NodeId(id)
+    }
+
+    fn reserve(&self, id: NodeId) {
+        if id.is_invalid() || id.0 == u32::MAX {
+            return;
+        }
+
+        self.next.set(self.next.get().max(id.0 + 1));
     }
 }
 
@@ -200,6 +289,7 @@ impl<'a> Scope<'a> {
 /// ## Resolving phase
 struct Resolver<'a> {
     current: Scope<'a>,
+    node_id_generator: NodeIdGenerator,
     ident_type: IdentType,
     in_type: bool,
     is_module: bool,
@@ -223,6 +313,7 @@ impl<'a> Resolver<'a> {
     fn new(current: Scope<'a>, config: InnerConfig) -> Self {
         Resolver {
             current,
+            node_id_generator: NodeIdGenerator::default(),
             ident_type: IdentType::Ref,
             in_type: false,
             is_module: false,
@@ -237,12 +328,16 @@ impl<'a> Resolver<'a> {
     where
         F: for<'aa> FnOnce(&mut Resolver<'aa>),
     {
+        let scope_id = ScopeId::from_node_id(self.node_id_generator.fresh());
         let mut child = Resolver {
             current: Scope::new(
                 kind,
                 Mark::fresh(self.config.top_level_mark),
+                scope_id,
+                None,
                 Some(&self.current),
             ),
+            node_id_generator: self.node_id_generator.clone(),
             ident_type: IdentType::Ref,
             config: self.config,
             in_type: self.in_type,
@@ -255,53 +350,124 @@ impl<'a> Resolver<'a> {
         op(&mut child);
     }
 
-    fn visit_mut_stmt_within_child_scope(&mut self, s: &mut Stmt) {
-        self.with_child(ScopeKind::Block, |child| match s {
-            Stmt::Block(s) => {
-                child.mark_block(&mut s.ctxt);
-                s.visit_mut_children_with(child);
-            }
-            _ => s.visit_mut_with(child),
-        });
+    fn with_child_for_node<F>(&self, kind: ScopeKind, owner_node_id: NodeId, op: F)
+    where
+        F: for<'aa> FnOnce(&mut Resolver<'aa>),
+    {
+        self.node_id_generator.reserve(owner_node_id);
+        let mut child = Resolver {
+            current: Scope::new(
+                kind,
+                Mark::fresh(self.config.top_level_mark),
+                ScopeId::from_node_id(owner_node_id),
+                Some(owner_node_id),
+                Some(&self.current),
+            ),
+            node_id_generator: self.node_id_generator.clone(),
+            ident_type: IdentType::Ref,
+            config: self.config,
+            in_type: self.in_type,
+            is_module: self.is_module,
+            in_ts_module: self.in_ts_module,
+            decl_kind: self.decl_kind,
+            strict_mode: self.strict_mode,
+        };
+
+        op(&mut child);
     }
 
-    /// Returns a [Mark] for an identifier reference.
-    fn mark_for_ref(&self, sym: &Atom) -> Option<Mark> {
+    fn ensure_node_id(&self, node_id: &mut NodeId) -> NodeId {
+        if node_id.is_invalid() {
+            *node_id = self.node_id_generator.fresh();
+        } else {
+            self.node_id_generator.reserve(*node_id);
+        }
+
+        *node_id
+    }
+
+    fn use_current_scope_node_id(&mut self, node_id: &mut NodeId) {
+        if node_id.is_invalid() {
+            *node_id = self.current.id.as_node_id();
+            return;
+        }
+
+        self.node_id_generator.reserve(*node_id);
+        self.current.id = ScopeId::from_node_id(*node_id);
+        self.current.owner_node_id = Some(*node_id);
+    }
+
+    fn declare_symbol(&mut self, sym: Atom, kind: DeclKind) {
+        self.current.declared_symbols.insert(
+            sym,
+            ResolvedBinding {
+                kind,
+                scope_id: self.current.id,
+                legacy_mark: self.current.mark,
+            },
+        );
+    }
+
+    fn declare_type(&mut self, sym: Atom) {
+        self.current.declared_types.insert(
+            sym,
+            ResolvedBinding {
+                kind: DeclKind::Type,
+                scope_id: self.current.id,
+                legacy_mark: self.current.mark,
+            },
+        );
+    }
+
+    fn visit_mut_stmt_within_child_scope(&mut self, s: &mut Stmt) {
+        match s {
+            Stmt::Block(s) => {
+                let node_id = self.ensure_node_id(&mut s.node_id);
+                self.with_child_for_node(ScopeKind::Block, node_id, |child| {
+                    child.mark_ctxt(&mut s.ctxt);
+                    s.visit_mut_children_with(child);
+                });
+            }
+            _ => self.with_child(ScopeKind::Block, |child| s.visit_mut_with(child)),
+        }
+    }
+
+    /// Returns the resolved scope and legacy [Mark] for an identifier
+    /// reference.
+    fn mark_for_ref(&self, sym: &Atom) -> Option<ResolvedRef> {
         self.mark_for_ref_inner(sym, false)
     }
 
-    fn mark_for_ref_inner(&self, sym: &Atom, stop_an_fn_scope: bool) -> Option<Mark> {
+    fn mark_for_ref_inner(&self, sym: &Atom, stop_an_fn_scope: bool) -> Option<ResolvedRef> {
         if self.config.handle_types && self.in_type {
-            let mut mark = self.current.mark;
             let mut scope = Some(&self.current);
 
             while let Some(cur) = scope {
                 // if cur.declared_types.contains(sym) ||
                 // cur.hoisted_symbols.borrow().contains(sym) {
-                if cur.declared_types.contains(sym) {
-                    if mark == Mark::root() {
+                if let Some(binding) = cur.declared_types.get(sym) {
+                    if binding.legacy_mark == Mark::root() {
                         break;
                     }
-                    return Some(mark);
+                    return Some(ResolvedRef::from_binding(
+                        *binding,
+                        self.config.unresolved_mark,
+                    ));
                 }
 
                 if cur.kind == ScopeKind::Fn && stop_an_fn_scope {
                     return None;
                 }
 
-                if let Some(parent) = &cur.parent {
-                    mark = parent.mark;
-                }
                 scope = cur.parent;
             }
         }
 
-        let mut mark = self.current.mark;
         let mut scope = Some(&self.current);
 
         while let Some(cur) = scope {
-            if cur.declared_symbols.contains_key(sym) {
-                if mark == Mark::root() {
+            if let Some(binding) = cur.declared_symbols.get(sym) {
+                if binding.legacy_mark == Mark::root() {
                     return None;
                 }
 
@@ -309,11 +475,14 @@ impl<'a> Resolver<'a> {
                     // https://tc39.es/ecma262/multipage/global-object.html#sec-value-properties-of-the-global-object-infinity
                     // non configurable global value
                     "undefined" | "NaN" | "Infinity"
-                        if mark == self.config.top_level_mark && !self.is_module =>
+                        if binding.legacy_mark == self.config.top_level_mark && !self.is_module =>
                     {
-                        Some(self.config.unresolved_mark)
+                        Some(ResolvedRef::unresolved(self.config.unresolved_mark))
                     }
-                    _ => Some(mark),
+                    _ => Some(ResolvedRef::from_binding(
+                        *binding,
+                        self.config.unresolved_mark,
+                    )),
                 };
             }
 
@@ -321,9 +490,6 @@ impl<'a> Resolver<'a> {
                 return None;
             }
 
-            if let Some(parent) = &cur.parent {
-                mark = parent.mark;
-            }
             scope = cur.parent;
         }
 
@@ -344,11 +510,12 @@ impl<'a> Resolver<'a> {
         }
 
         if self.in_type {
-            self.current.declared_types.insert(id.sym.clone());
+            self.declare_type(id.sym.clone());
         } else {
-            self.current.declared_symbols.insert(id.sym.clone(), kind);
+            self.declare_symbol(id.sym.clone(), kind);
         }
 
+        id.scope_id = self.current.id;
         let mark = self.current.mark;
 
         if mark != Mark::root() {
@@ -356,15 +523,23 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    fn mark_block(&mut self, ctxt: &mut SyntaxContext) {
-        if *ctxt != SyntaxContext::empty() {
-            return;
-        }
+    fn mark_block(&mut self, ctxt: &mut SyntaxContext, node_id: &mut NodeId) {
+        self.use_current_scope_node_id(node_id);
 
-        let mark = self.current.mark;
+        debug_assert_eq!(
+            self.current
+                .owner_node_id
+                .map(ScopeId::from_node_id)
+                .unwrap_or(self.current.id),
+            self.current.id
+        );
 
-        if mark != Mark::root() {
-            *ctxt = ctxt.apply_mark(mark)
+        self.mark_ctxt(ctxt);
+    }
+
+    fn mark_ctxt(&self, ctxt: &mut SyntaxContext) {
+        if *ctxt == SyntaxContext::empty() && self.current.mark != Mark::root() {
+            *ctxt = ctxt.apply_mark(self.current.mark)
         }
     }
 
@@ -526,7 +701,8 @@ impl VisitMut for Resolver<'_> {
     typed!(visit_mut_ts_namespace_export_decl, TsNamespaceExportDecl);
 
     fn visit_mut_arrow_expr(&mut self, e: &mut ArrowExpr) {
-        self.with_child(ScopeKind::Fn, |child| {
+        let node_id = self.ensure_node_id(&mut e.node_id);
+        self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
             e.type_params.visit_mut_with(child);
 
             let old = child.ident_type;
@@ -539,7 +715,7 @@ impl VisitMut for Resolver<'_> {
                     .flat_map(find_pat_ids::<_, Id>);
 
                 for id in params {
-                    child.current.declared_symbols.insert(id.0, DeclKind::Param);
+                    child.declare_symbol(id.0, DeclKind::Param);
                 }
             }
             e.params.visit_mut_with(child);
@@ -547,7 +723,8 @@ impl VisitMut for Resolver<'_> {
 
             match &mut *e.body {
                 BlockStmtOrExpr::BlockStmt(s) => {
-                    child.mark_block(&mut s.ctxt);
+                    child.ensure_node_id(&mut s.node_id);
+                    child.mark_ctxt(&mut s.ctxt);
 
                     let old_strict_mode = child.strict_mode;
 
@@ -593,8 +770,9 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_block_stmt(&mut self, block: &mut BlockStmt) {
-        self.with_child(ScopeKind::Block, |child| {
-            child.mark_block(&mut block.ctxt);
+        let node_id = self.ensure_node_id(&mut block.node_id);
+        self.with_child_for_node(ScopeKind::Block, node_id, |child| {
+            child.mark_ctxt(&mut block.ctxt);
             block.visit_mut_children_with(child);
         })
     }
@@ -609,17 +787,21 @@ impl VisitMut for Resolver<'_> {
     fn visit_mut_catch_clause(&mut self, c: &mut CatchClause) {
         // Child folder
 
-        self.with_child(ScopeKind::Fn, |child| {
+        let node_id = self.ensure_node_id(&mut c.node_id);
+        self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
             child.ident_type = IdentType::Binding;
             c.param.visit_mut_with(child);
             child.ident_type = IdentType::Ref;
 
-            child.mark_block(&mut c.body.ctxt);
+            child.ensure_node_id(&mut c.body.node_id);
+            child.mark_ctxt(&mut c.body.ctxt);
             c.body.visit_mut_children_with(child);
         });
     }
 
     fn visit_mut_class(&mut self, c: &mut Class) {
+        self.ensure_node_id(&mut c.node_id);
+
         let old_strict_mode = self.strict_mode;
         self.strict_mode = true;
 
@@ -654,7 +836,8 @@ impl VisitMut for Resolver<'_> {
 
         // Create a child scope. The class name is only accessible within the class.
 
-        self.with_child(ScopeKind::Fn, |child| {
+        let node_id = self.ensure_node_id(&mut n.class.node_id);
+        self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
             child.ident_type = IdentType::Ref;
 
             n.class.visit_mut_with(child);
@@ -666,7 +849,8 @@ impl VisitMut for Resolver<'_> {
 
         n.class.super_class.visit_mut_with(self);
 
-        self.with_child(ScopeKind::Fn, |child| {
+        let node_id = self.ensure_node_id(&mut n.class.node_id);
+        self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
             child.ident_type = IdentType::Binding;
             n.ident.visit_mut_with(child);
             child.ident_type = IdentType::Ref;
@@ -682,7 +866,10 @@ impl VisitMut for Resolver<'_> {
             p.decorators.visit_mut_with(self);
         }
 
-        self.with_child(ScopeKind::Fn, |child| m.function.visit_mut_with(child));
+        let node_id = self.ensure_node_id(&mut m.function.node_id);
+        self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
+            m.function.visit_mut_with(child)
+        });
     }
 
     fn visit_mut_class_prop(&mut self, p: &mut ClassProp) {
@@ -717,7 +904,8 @@ impl VisitMut for Resolver<'_> {
             }
         }
 
-        self.with_child(ScopeKind::Fn, |child| {
+        let node_id = self.ensure_node_id(&mut c.node_id);
+        self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
             let old = child.ident_type;
             child.ident_type = IdentType::Binding;
             {
@@ -733,14 +921,15 @@ impl VisitMut for Resolver<'_> {
                     .flat_map(find_pat_ids::<_, Id>);
 
                 for id in params {
-                    child.current.declared_symbols.insert(id.0, DeclKind::Param);
+                    child.declare_symbol(id.0, DeclKind::Param);
                 }
             }
             c.params.visit_mut_with(child);
             child.ident_type = old;
 
             if let Some(body) = &mut c.body {
-                child.mark_block(&mut body.ctxt);
+                child.ensure_node_id(&mut body.node_id);
+                child.mark_ctxt(&mut body.ctxt);
                 body.visit_mut_children_with(child);
             }
         });
@@ -759,7 +948,8 @@ impl VisitMut for Resolver<'_> {
         match &mut e.decl {
             DefaultDecl::Fn(f) => {
                 if f.ident.is_some() {
-                    self.with_child(ScopeKind::Fn, |child| {
+                    let node_id = self.ensure_node_id(&mut f.function.node_id);
+                    self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
                         f.function.visit_mut_with(child);
                     });
                 } else {
@@ -768,7 +958,10 @@ impl VisitMut for Resolver<'_> {
             }
             DefaultDecl::Class(c) => {
                 // Skip class expression visitor to treat as a declaration.
-                c.class.visit_mut_with(self)
+                let node_id = self.ensure_node_id(&mut c.class.node_id);
+                self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
+                    c.class.visit_mut_with(child)
+                })
             }
             _ => e.visit_mut_children_with(self),
         }
@@ -827,7 +1020,10 @@ impl VisitMut for Resolver<'_> {
         // We don't fold ident as Hoister handles this.
         node.function.decorators.visit_mut_with(self);
 
-        self.with_child(ScopeKind::Fn, |child| node.function.visit_mut_with(child));
+        let node_id = self.ensure_node_id(&mut node.function.node_id);
+        self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
+            node.function.visit_mut_with(child)
+        });
     }
 
     fn visit_mut_fn_expr(&mut self, e: &mut FnExpr) {
@@ -836,19 +1032,22 @@ impl VisitMut for Resolver<'_> {
         if let Some(ident) = &mut e.ident {
             self.with_child(ScopeKind::Fn, |child| {
                 child.modify(ident, DeclKind::Function);
-                child.with_child(ScopeKind::Fn, |child| {
+                let node_id = child.ensure_node_id(&mut e.function.node_id);
+                child.with_child_for_node(ScopeKind::Fn, node_id, |child| {
                     e.function.visit_mut_with(child);
                 });
             });
         } else {
-            self.with_child(ScopeKind::Fn, |child| {
+            let node_id = self.ensure_node_id(&mut e.function.node_id);
+            self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
                 e.function.visit_mut_with(child);
             });
         }
     }
 
     fn visit_mut_for_in_stmt(&mut self, n: &mut ForInStmt) {
-        self.with_child(ScopeKind::Block, |child| {
+        let node_id = self.ensure_node_id(&mut n.node_id);
+        self.with_child_for_node(ScopeKind::Block, node_id, |child| {
             n.left.visit_mut_with(child);
             n.right.visit_mut_with(child);
 
@@ -857,7 +1056,8 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_for_of_stmt(&mut self, n: &mut ForOfStmt) {
-        self.with_child(ScopeKind::Block, |child| {
+        let node_id = self.ensure_node_id(&mut n.node_id);
+        self.with_child_for_node(ScopeKind::Block, node_id, |child| {
             n.left.visit_mut_with(child);
             n.right.visit_mut_with(child);
 
@@ -866,7 +1066,8 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_for_stmt(&mut self, n: &mut ForStmt) {
-        self.with_child(ScopeKind::Block, |child| {
+        let node_id = self.ensure_node_id(&mut n.node_id);
+        self.with_child_for_node(ScopeKind::Block, node_id, |child| {
             child.ident_type = IdentType::Binding;
             n.init.visit_mut_with(child);
             child.ident_type = IdentType::Ref;
@@ -879,7 +1080,7 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_function(&mut self, f: &mut Function) {
-        self.mark_block(&mut f.ctxt);
+        self.mark_block(&mut f.ctxt, &mut f.node_id);
         f.type_params.visit_mut_with(self);
 
         self.ident_type = IdentType::Ref;
@@ -893,7 +1094,7 @@ impl VisitMut for Resolver<'_> {
                 .flat_map(find_pat_ids::<_, Id>);
 
             for id in params {
-                self.current.declared_symbols.insert(id.0, DeclKind::Param);
+                self.declare_symbol(id.0, DeclKind::Param);
             }
         }
         self.ident_type = IdentType::Binding;
@@ -903,7 +1104,8 @@ impl VisitMut for Resolver<'_> {
 
         self.ident_type = IdentType::Ref;
         if let Some(body) = &mut f.body {
-            self.mark_block(&mut body.ctxt);
+            self.ensure_node_id(&mut body.node_id);
+            self.mark_ctxt(&mut body.ctxt);
             let old_strict_mode = self.strict_mode;
             if !self.strict_mode {
                 self.strict_mode = body
@@ -943,6 +1145,7 @@ impl VisitMut for Resolver<'_> {
                 }
 
                 i.ctxt = ctxt;
+                i.scope_id = ScopeId::UNRESOLVED;
 
                 return;
             }
@@ -969,13 +1172,14 @@ impl VisitMut for Resolver<'_> {
                     return;
                 }
 
-                if let Some(mark) = self.mark_for_ref(sym) {
-                    let ctxt = ctxt.apply_mark(mark);
+                if let Some(resolved) = self.mark_for_ref(sym) {
+                    let ctxt = ctxt.apply_mark(resolved.legacy_mark);
 
                     if cfg!(debug_assertions) && LOG {
                         debug!("\t -> {:?}", ctxt);
                     }
                     i.ctxt = ctxt;
+                    i.scope_id = resolved.scope_id;
                 } else {
                     if cfg!(debug_assertions) && LOG {
                         debug!("\t -> Unresolved");
@@ -988,6 +1192,7 @@ impl VisitMut for Resolver<'_> {
                     }
 
                     i.ctxt = ctxt;
+                    i.scope_id = ScopeId::UNRESOLVED;
                     // Support hoisting
                     self.modify(i, self.decl_kind)
                 }
@@ -1012,7 +1217,7 @@ impl VisitMut for Resolver<'_> {
         self.ident_type = IdentType::Binding;
         s.local.visit_mut_with(self);
         if self.config.handle_types {
-            self.current.declared_types.insert(s.local.sym.clone());
+            self.declare_type(s.local.sym.clone());
         }
         self.ident_type = old;
     }
@@ -1056,10 +1261,14 @@ impl VisitMut for Resolver<'_> {
         m.key.visit_mut_with(self);
 
         // Child folder
-        self.with_child(ScopeKind::Fn, |child| m.function.visit_mut_with(child));
+        let node_id = self.ensure_node_id(&mut m.function.node_id);
+        self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
+            m.function.visit_mut_with(child)
+        });
     }
 
     fn visit_mut_module(&mut self, module: &mut Module) {
+        self.use_current_scope_node_id(&mut module.node_id);
         self.strict_mode = true;
         self.is_module = true;
         module.visit_mut_children_with(self)
@@ -1116,7 +1325,10 @@ impl VisitMut for Resolver<'_> {
         {
             // Child folder
 
-            self.with_child(ScopeKind::Fn, |child| m.function.visit_mut_with(child));
+            let node_id = self.ensure_node_id(&mut m.function.node_id);
+            self.with_child_for_node(ScopeKind::Fn, node_id, |child| {
+                m.function.visit_mut_with(child)
+            });
         }
     }
 
@@ -1134,6 +1346,7 @@ impl VisitMut for Resolver<'_> {
     }
 
     fn visit_mut_script(&mut self, script: &mut Script) {
+        self.use_current_scope_node_id(&mut script.node_id);
         self.strict_mode = script
             .body
             .first()
@@ -1194,7 +1407,8 @@ impl VisitMut for Resolver<'_> {
     fn visit_mut_switch_stmt(&mut self, s: &mut SwitchStmt) {
         s.discriminant.visit_mut_with(self);
 
-        self.with_child(ScopeKind::Block, |child| {
+        let node_id = self.ensure_node_id(&mut s.node_id);
+        self.with_child_for_node(ScopeKind::Block, node_id, |child| {
             s.cases.visit_mut_with(child);
         });
     }
@@ -1278,15 +1492,14 @@ impl VisitMut for Resolver<'_> {
             // add the enum member names as declared symbols for this scope
             // Ex. `enum Foo { a, b = a }`
             let member_names = decl.members.iter().filter_map(|m| match &m.id {
-                TsEnumMemberId::Ident(id) => Some((id.sym.clone(), DeclKind::Lexical)),
-                TsEnumMemberId::Str(s) => s
-                    .value
-                    .as_atom()
-                    .map(|atom| (atom.clone(), DeclKind::Lexical)),
+                TsEnumMemberId::Ident(id) => Some(id.sym.clone()),
+                TsEnumMemberId::Str(s) => s.value.as_atom().cloned(),
                 #[cfg(swc_ast_unknown)]
                 _ => None,
             });
-            child.current.declared_symbols.extend(member_names);
+            for member_name in member_names {
+                child.declare_symbol(member_name, DeclKind::Lexical);
+            }
 
             decl.members.visit_mut_with(child);
         });
@@ -1709,10 +1922,7 @@ impl VisitMut for Hoister<'_, '_> {
         self.resolver.modify(&mut node.ident, DeclKind::Lexical);
 
         if self.resolver.config.handle_types {
-            self.resolver
-                .current
-                .declared_types
-                .insert(node.ident.sym.clone());
+            self.resolver.declare_type(node.ident.sym.clone());
         }
     }
 
@@ -1833,10 +2043,7 @@ impl VisitMut for Hoister<'_, '_> {
         self.resolver.modify(&mut n.local, DeclKind::Lexical);
 
         if self.resolver.config.handle_types {
-            self.resolver
-                .current
-                .declared_types
-                .insert(n.local.sym.clone());
+            self.resolver.declare_type(n.local.sym.clone());
         }
     }
 
@@ -1846,10 +2053,7 @@ impl VisitMut for Hoister<'_, '_> {
         self.resolver.modify(&mut n.local, DeclKind::Lexical);
 
         if self.resolver.config.handle_types {
-            self.resolver
-                .current
-                .declared_types
-                .insert(n.local.sym.clone());
+            self.resolver.declare_type(n.local.sym.clone());
         }
     }
 
@@ -1859,10 +2063,7 @@ impl VisitMut for Hoister<'_, '_> {
         self.resolver.modify(&mut n.local, DeclKind::Lexical);
 
         if self.resolver.config.handle_types {
-            self.resolver
-                .current
-                .declared_types
-                .insert(n.local.sym.clone());
+            self.resolver.declare_type(n.local.sym.clone());
         }
     }
 

--- a/crates/swc_ecma_transforms_base/src/resolver/tests.rs
+++ b/crates/swc_ecma_transforms_base/src/resolver/tests.rs
@@ -63,7 +63,7 @@ fn test_mark_for() {
         let mark4 = Mark::fresh(mark3);
 
         let folder1 = Resolver::new(
-            Scope::new(ScopeKind::Block, mark1, None),
+            Scope::new(ScopeKind::Block, mark1, ScopeId(1), Some(NodeId(1)), None),
             InnerConfig {
                 handle_types: true,
                 unresolved_mark: Mark::fresh(Mark::root()),
@@ -71,47 +71,65 @@ fn test_mark_for() {
             },
         );
         let mut folder2 = Resolver::new(
-            Scope::new(ScopeKind::Block, mark2, Some(&folder1.current)),
+            Scope::new(
+                ScopeKind::Block,
+                mark2,
+                ScopeId(2),
+                Some(NodeId(2)),
+                Some(&folder1.current),
+            ),
             InnerConfig {
                 handle_types: true,
                 unresolved_mark: Mark::fresh(Mark::root()),
                 top_level_mark: mark2,
             },
         );
-        folder2
-            .current
-            .declared_symbols
-            .insert(atom!("foo"), DeclKind::Var);
+        folder2.declare_symbol(atom!("foo"), DeclKind::Var);
 
         let mut folder3 = Resolver::new(
-            Scope::new(ScopeKind::Block, mark3, Some(&folder2.current)),
+            Scope::new(
+                ScopeKind::Block,
+                mark3,
+                ScopeId(3),
+                Some(NodeId(3)),
+                Some(&folder2.current),
+            ),
             InnerConfig {
                 handle_types: true,
                 unresolved_mark: Mark::fresh(Mark::root()),
                 top_level_mark: mark3,
             },
         );
-        folder3
-            .current
-            .declared_symbols
-            .insert(atom!("bar"), DeclKind::Var);
-        assert_eq!(folder3.mark_for_ref(&atom!("bar")), Some(mark3));
+        folder3.declare_symbol(atom!("bar"), DeclKind::Var);
+        assert_eq!(
+            folder3.mark_for_ref(&atom!("bar")).map(|v| v.legacy_mark),
+            Some(mark3)
+        );
 
         let mut folder4 = Resolver::new(
-            Scope::new(ScopeKind::Block, mark4, Some(&folder3.current)),
+            Scope::new(
+                ScopeKind::Block,
+                mark4,
+                ScopeId(4),
+                Some(NodeId(4)),
+                Some(&folder3.current),
+            ),
             InnerConfig {
                 handle_types: true,
                 unresolved_mark: Mark::fresh(Mark::root()),
                 top_level_mark: mark4,
             },
         );
-        folder4
-            .current
-            .declared_symbols
-            .insert(atom!("foo"), DeclKind::Var);
+        folder4.declare_symbol(atom!("foo"), DeclKind::Var);
 
-        assert_eq!(folder4.mark_for_ref(&atom!("foo")), Some(mark4));
-        assert_eq!(folder4.mark_for_ref(&atom!("bar")), Some(mark3));
+        assert_eq!(
+            folder4.mark_for_ref(&atom!("foo")).map(|v| v.legacy_mark),
+            Some(mark4)
+        );
+        assert_eq!(
+            folder4.mark_for_ref(&atom!("bar")).map(|v| v.legacy_mark),
+            Some(mark3)
+        );
         Ok(())
     })
     .unwrap();

--- a/crates/swc_ecma_transforms_base/tests/node_id.rs
+++ b/crates/swc_ecma_transforms_base/tests/node_id.rs
@@ -1,0 +1,110 @@
+use swc_common::{Mark, SyntaxContext};
+use swc_ecma_ast::*;
+use swc_ecma_parser::{lexer::Lexer, EsSyntax, Parser, StringInput, Syntax};
+use swc_ecma_transforms_base::resolver;
+use swc_ecma_visit::{Visit, VisitMutWith, VisitWith};
+use testing::run_test2;
+
+fn resolved_program(src: &str) -> Program {
+    run_test2(false, |cm, handler| {
+        let fm = cm.new_source_file(swc_common::FileName::Anon.into(), src.to_string());
+        let lexer = Lexer::new(
+            Syntax::Es(EsSyntax {
+                jsx: true,
+                ..Default::default()
+            }),
+            EsVersion::latest(),
+            StringInput::from(&*fm),
+            None,
+        );
+        let mut parser = Parser::new_from(lexer);
+        let mut program = parser
+            .parse_program()
+            .map_err(|err| err.into_diagnostic(&handler).emit())?;
+
+        program.visit_mut_with(&mut resolver(Mark::new(), Mark::new(), false));
+
+        Ok(program)
+    })
+    .unwrap()
+}
+
+struct Recorder {
+    lines: Vec<String>,
+}
+
+impl Recorder {
+    fn record_node(&mut self, kind: &str, id: NodeId) {
+        self.lines.push(format!("{kind} node={}", id.as_u32()));
+    }
+
+    fn record_ident(&mut self, ident: &Ident) {
+        let ctxt = if ident.ctxt == SyntaxContext::empty() {
+            "empty".to_string()
+        } else {
+            format!("{:?}", ident.ctxt).replace('#', "")
+        };
+
+        self.lines.push(format!(
+            "ident {} scope={} ctxt={ctxt}",
+            ident.sym,
+            ident.scope_id.as_u32()
+        ));
+    }
+}
+
+impl Visit for Recorder {
+    fn visit_module(&mut self, node: &Module) {
+        self.record_node("module", node.node_id);
+        node.visit_children_with(self);
+    }
+
+    fn visit_function(&mut self, node: &Function) {
+        self.record_node("function", node.node_id);
+        node.visit_children_with(self);
+    }
+
+    fn visit_block_stmt(&mut self, node: &BlockStmt) {
+        self.record_node("block", node.node_id);
+        node.visit_children_with(self);
+    }
+
+    fn visit_ident(&mut self, node: &Ident) {
+        self.record_ident(node);
+    }
+}
+
+#[test]
+fn resolver_assigns_stable_node_and_scope_ids() {
+    let program = resolved_program(
+        r#"
+export function outer(a) {
+    let b = a;
+    {
+        let a = b;
+        c(a);
+    }
+}
+"#,
+    );
+
+    let mut recorder = Recorder { lines: Vec::new() };
+    program.visit_with(&mut recorder);
+
+    assert_eq!(
+        recorder.lines.join("\n"),
+        "\
+module node=1
+ident outer scope=1 ctxt=2
+function node=2
+ident a scope=2 ctxt=3
+block node=3
+ident b scope=2 ctxt=3
+ident a scope=2 ctxt=3
+block node=4
+ident a scope=4 ctxt=4
+ident b scope=2 ctxt=3
+ident c scope=4294967295 ctxt=1
+ident a scope=4 ctxt=4"
+    );
+}

--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -267,6 +267,7 @@ impl SystemJs {
             meta.setter_fn_stmts.push(
                 ForInStmt {
                     span: DUMMY_SP,
+                    node_id: Default::default(),
                     left: VarDecl {
                         kind: VarDeclKind::Var,
                         decls: vec![VarDeclarator {

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -307,6 +307,7 @@ pub(crate) fn esm_export() -> Function {
 
     let for_in_stmt: Stmt = ForInStmt {
         span: DUMMY_SP,
+        node_id: Default::default(),
         left: VarDecl {
             decls: vec![VarDeclarator {
                 span: DUMMY_SP,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/branch/mod.rs
@@ -522,7 +522,12 @@ impl VisitMut for Remover {
                     }
                 }
 
-                Stmt::Block(BlockStmt { span, stmts, ctxt }) => {
+                Stmt::Block(BlockStmt {
+                    span,
+                    stmts,
+                    ctxt,
+                    node_id,
+                }) => {
                     if stmts.is_empty() {
                         if cfg!(feature = "debug") {
                             debug!("Drooping an empty block statement");
@@ -541,7 +546,13 @@ impl VisitMut for Remover {
                         v.visit_mut_with(self);
                         v
                     } else {
-                        BlockStmt { span, stmts, ctxt }.into()
+                        BlockStmt {
+                            span,
+                            stmts,
+                            ctxt,
+                            node_id,
+                        }
+                        .into()
                     }
                 }
                 Stmt::Try(s) => {
@@ -1146,6 +1157,7 @@ impl VisitMut for Remover {
                             // `for(;;);` is shorter than `do ; while(true);`
                             ForStmt {
                                 span: s.span,
+                                node_id: Default::default(),
                                 init: None,
                                 test: None,
                                 update: None,
@@ -1349,7 +1361,7 @@ impl Remover {
                             span,
                             mut stmts,
                             ctxt,
-                            ..
+                            node_id,
                         }) => {
                             if stmts.is_empty() {
                                 continue;
@@ -1357,7 +1369,13 @@ impl Remover {
 
                             if !is_ok_to_inline_block(&stmts) {
                                 stmts.visit_mut_with(self);
-                                BlockStmt { span, stmts, ctxt }.into()
+                                BlockStmt {
+                                    span,
+                                    stmts,
+                                    ctxt,
+                                    node_id,
+                                }
+                                .into()
                             } else {
                                 new_stmts.extend(
                                     stmts

--- a/crates/swc_ecma_transforms_proposal/src/explicit_resource_management.rs
+++ b/crates/swc_ecma_transforms_proposal/src/explicit_resource_management.rs
@@ -255,6 +255,7 @@ impl ExplicitResourceManagement {
 
         let catch_clause = CatchClause {
             span: DUMMY_SP,
+            node_id: Default::default(),
             param: Some(Pat::Ident(catch_e.clone().into())),
             body: BlockStmt {
                 span: DUMMY_SP,

--- a/crates/swc_estree_compat/src/swcify/expr.rs
+++ b/crates/swc_estree_compat/src/swcify/expr.rs
@@ -321,6 +321,7 @@ impl Swcify for Identifier {
                 sym: self.name,
                 optional: self.optional.unwrap_or(false),
                 ctxt: Default::default(),
+                scope_id: Default::default(),
             },
             type_ann: self.type_annotation.swcify(ctx).flatten().map(Box::new),
         }

--- a/crates/swc_estree_compat/src/swcify/stmt.rs
+++ b/crates/swc_estree_compat/src/swcify/stmt.rs
@@ -159,6 +159,7 @@ impl Swcify for ForInStatement {
     fn swcify(self, ctx: &Context) -> Self::Output {
         ForInStmt {
             span: ctx.span(&self.base),
+            node_id: Default::default(),
             left: self.left.swcify(ctx),
             right: self.right.swcify(ctx),
             body: Box::new(self.body.swcify(ctx).expect_stmt()),
@@ -183,6 +184,7 @@ impl Swcify for ForStatement {
     fn swcify(self, ctx: &Context) -> Self::Output {
         ForStmt {
             span: ctx.span(&self.base),
+            node_id: Default::default(),
             init: self.init.swcify(ctx),
             test: self.test.swcify(ctx),
             update: self.update.swcify(ctx),
@@ -269,6 +271,7 @@ impl Swcify for SwitchStatement {
     fn swcify(self, ctx: &Context) -> Self::Output {
         SwitchStmt {
             span: ctx.span(&self.base),
+            node_id: Default::default(),
             discriminant: self.discriminant.swcify(ctx),
             cases: self.cases.swcify(ctx),
         }
@@ -322,6 +325,7 @@ impl Swcify for swc_estree_ast::CatchClause {
     fn swcify(self, ctx: &Context) -> Self::Output {
         swc_ecma_ast::CatchClause {
             span: ctx.span(&self.base),
+            node_id: Default::default(),
             param: self.param.swcify(ctx),
             body: self.body.swcify(ctx),
         }
@@ -595,6 +599,7 @@ impl Swcify for ForOfStatement {
     fn swcify(self, ctx: &Context) -> Self::Output {
         ForOfStmt {
             span: ctx.span(&self.base),
+            node_id: Default::default(),
             is_await: false,
             left: self.left.swcify(ctx),
             right: self.right.swcify(ctx),

--- a/crates/swc_node_bundler/src/loaders/json.rs
+++ b/crates/swc_node_bundler/src/loaders/json.rs
@@ -34,6 +34,7 @@ pub(super) fn load_json_as_module(fm: &Arc<SourceFile>) -> Result<Module, Error>
     .into();
 
     Ok(Module {
+        node_id: Default::default(),
         span: DUMMY_SP,
         body: vec![export],
         shebang: None,

--- a/crates/swc_node_bundler/src/loaders/swc.rs
+++ b/crates/swc_node_bundler/src/loaders/swc.rs
@@ -95,6 +95,7 @@ impl SwcLoader {
                 return Ok(ModuleData {
                     fm,
                     module: Module {
+                        node_id: Default::default(),
                         span: DUMMY_SP,
                         body: Default::default(),
                         shebang: Default::default(),

--- a/crates/swc_typescript/src/fast_dts/enum.rs
+++ b/crates/swc_typescript/src/fast_dts/enum.rs
@@ -58,6 +58,7 @@ impl FastDts {
                                 span: DUMMY_SP,
                                 sym: atom!("Infinity"),
                                 ctxt: SyntaxContext::empty(),
+                                scope_id: Default::default(),
                                 optional: false,
                             })
                         } else {

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1302,6 +1302,10 @@ export interface Span {
     ctxt: number;
 }
 
+export type NodeId = number;
+
+export type ScopeId = number;
+
 export interface Node {
     type: string;
 }
@@ -1315,6 +1319,8 @@ export interface HasDecorator {
 }
 
 export interface Class extends HasSpan, HasDecorator {
+    nodeId: NodeId;
+
     body: ClassMember[];
 
     superClass?: Expression;
@@ -1379,6 +1385,8 @@ export interface Param extends Node, HasSpan, HasDecorator {
 
 export interface Constructor extends Node, HasSpan {
     type: "Constructor";
+
+    nodeId: NodeId;
 
     key: PropertyName;
 
@@ -1528,6 +1536,8 @@ export interface Identifier extends ExpressionBase {
     type: "Identifier";
 
     value: string;
+
+    scopeId: ScopeId;
 
     /// TypeScript only. Used in case of an optional parameter.
     optional: boolean;
@@ -1696,6 +1706,8 @@ export interface SequenceExpression extends ExpressionBase {
 export interface ArrowFunctionExpression extends ExpressionBase {
     type: "ArrowFunctionExpression";
 
+    nodeId: NodeId;
+
     params: Pattern[];
 
     body: BlockStatement | Expression;
@@ -1762,6 +1774,8 @@ export interface ParenthesisExpression extends ExpressionBase {
 }
 
 export interface Fn extends HasSpan, HasDecorator {
+    nodeId: NodeId;
+
     params: Param[];
 
     body?: BlockStatement;
@@ -2106,11 +2120,15 @@ export type Program = Module | Script;
 export interface Module extends Node, HasSpan, HasInterpreter {
     type: "Module";
 
+    nodeId: NodeId;
+
     body: ModuleItem[];
 }
 
 export interface Script extends Node, HasSpan, HasInterpreter {
     type: "Script";
+
+    nodeId: NodeId;
 
     body: Statement[];
 }
@@ -2185,6 +2203,7 @@ export type Pattern =
 export interface BindingIdentifier extends PatternBase {
     type: "Identifier";
     value: string;
+    scopeId: ScopeId;
     optional: boolean;
 }
 
@@ -2304,6 +2323,8 @@ export interface ComputedPropName extends Node, HasSpan {
 export interface BlockStatement extends Node, HasSpan {
     type: "BlockStatement";
 
+    nodeId: NodeId;
+
     stmts: Statement[];
 }
 
@@ -2384,6 +2405,8 @@ export interface IfStatement extends Node, HasSpan {
 export interface SwitchStatement extends Node, HasSpan {
     type: "SwitchStatement";
 
+    nodeId: NodeId;
+
     discriminant: Expression;
     cases: SwitchCase[];
 }
@@ -2419,6 +2442,8 @@ export interface DoWhileStatement extends Node, HasSpan {
 export interface ForStatement extends Node, HasSpan {
     type: "ForStatement";
 
+    nodeId: NodeId;
+
     init?: VariableDeclaration | Expression;
     test?: Expression;
     update?: Expression;
@@ -2428,6 +2453,8 @@ export interface ForStatement extends Node, HasSpan {
 export interface ForInStatement extends Node, HasSpan {
     type: "ForInStatement";
 
+    nodeId: NodeId;
+
     left: VariableDeclaration | Pattern;
     right: Expression;
     body: Statement;
@@ -2435,6 +2462,8 @@ export interface ForInStatement extends Node, HasSpan {
 
 export interface ForOfStatement extends Node, HasSpan {
     type: "ForOfStatement";
+
+    nodeId: NodeId;
 
     /**
      *  Span of the await token.
@@ -2459,6 +2488,8 @@ export interface SwitchCase extends Node, HasSpan {
 
 export interface CatchClause extends Node, HasSpan {
     type: "CatchClause";
+
+    nodeId: NodeId;
 
     /**
      * The param is `undefined` if the catch binding is omitted. E.g., `try { foo() } catch {}`

--- a/tools/generate-code/src/main.rs
+++ b/tools/generate-code/src/main.rs
@@ -200,6 +200,8 @@ fn test_ecmascript() {
             "EncodeBigInt".into(),
             "EsVersion".into(),
             "FnPass".into(),
+            "NodeId".into(),
+            "ScopeId".into(),
         ],
     )
     .unwrap();
@@ -212,6 +214,8 @@ fn test_ecmascript() {
             "EncodeBigInt".into(),
             "EsVersion".into(),
             "FnPass".into(),
+            "NodeId".into(),
+            "ScopeId".into(),
         ],
     )
     .unwrap();


### PR DESCRIPTION
**Description:**

Adds public `NodeId`, `ScopeId`, and `BindingId` types to `swc_ecma_ast`, adds `node_id` fields to scope-owning AST nodes, and adds `scope_id` to `Ident`. The resolver now assigns deterministic node/scope ids and records binding/reference scope ids while preserving the existing `SyntaxContext` projection for downstream compatibility.

This also updates serde defaults and camelCase schema output, rkyv/encoding coverage, generated visit/hooks code, TypeScript public types, parser/transformer construction sites, and focused node/scope id tests.

Validation:

- `git submodule update --init --recursive`
- `cargo test -p generate-code test_ecmascript -- --nocapture`
- `cargo check --all --all-targets`
- `cargo test -p swc_ecma_ast --features serde-impl`
- `cargo test -p swc_ecma_visit`
- `cargo test -p swc_ecma_transforms_base`
- `cargo test -p swc_ecma_minifier`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo check -p swc_ecma_ast --features rkyv-impl`
- `cargo check -p swc_ecma_ast --features encoding-impl`

**BREAKING CHANGE:**

Direct construction or exhaustive pattern matching of the affected AST structs must account for the new `node_id` and `scope_id` fields. Existing serde JSON without these fields continues to deserialize with default ids.

**Related issue (if exists):**

N/A
