### PR TITLE
security: Save CI caches only on main

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -5,6 +5,20 @@ inputs:
     description: "Node version to install"
     required: false
     default: "20"
+  install-dependencies:
+    description: "Install pnpm dependencies after restoring the pnpm cache"
+    required: false
+    default: "true"
+outputs:
+  pnpm-store-path:
+    description: "Resolved pnpm store path"
+    value: ${{ steps.pnpm-store.outputs.path }}
+  pnpm-cache-primary-key:
+    description: "Primary pnpm cache key"
+    value: ${{ steps.restore-pnpm-cache.outputs.cache-primary-key }}
+  pnpm-cache-hit:
+    description: "Whether the primary pnpm cache was restored"
+    value: ${{ steps.restore-pnpm-cache.outputs.cache-hit }}
 
 runs:
   using: "composite"
@@ -20,13 +34,31 @@ runs:
       uses: actions/setup-node@v4
       with:
         node-version: ${{ inputs.node-version }}
-        cache: "pnpm"
-        cache-dependency-path: pnpm-lock.yaml
 
     - name: Enable corepack
       shell: bash
       run: corepack enable
 
+    - name: Get pnpm store path
+      id: pnpm-store
+      shell: bash
+      run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+    - name: Restore pnpm cache
+      id: restore-pnpm-cache
+      uses: actions/cache/restore@v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: pnpm-${{ runner.os }}-${{ runner.arch }}-node-${{ inputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}
+
     - name: Install dependencies
+      if: inputs.install-dependencies == 'true'
       shell: bash
       run: pnpm install --frozen-lockfile
+
+    - name: Save pnpm cache
+      if: inputs.install-dependencies == 'true' && github.ref == 'refs/heads/main' && steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v4
+      with:
+        path: ${{ steps.pnpm-store.outputs.path }}
+        key: ${{ steps.restore-pnpm-cache.outputs.cache-primary-key }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -121,19 +121,9 @@ jobs:
           # toolchain: stable
           # override: true
 
-      - run: corepack enable
-
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Install node dependencies
-        shell: bash
-        run: |
-          corepack enable
-          pnpm install --frozen-lockfile
       # Ensure that all components are compilable.
       - name: Run cargo check for all targets
         run: cargo check --all --all-targets
@@ -154,9 +144,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - shell: bash
-        run: corepack enable
-
       # We explicitly do this to cache properly.
       - uses: actions-rs/toolchain@v1
         with:
@@ -165,17 +152,10 @@ jobs:
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
 
-      - name: Install node dependencies
-        shell: bash
-        run: |
-          corepack enable
-          pnpm install --frozen-lockfile
       - name: Test
         run: |
           (cd bindings/${{ matrix.pkg }} && ./scripts/test.sh)
@@ -230,16 +210,13 @@ jobs:
         with:
           submodules: true
 
-      - run: corepack enable
-        if: matrix.settings.crate != '__noop__'
-
       # Source map format
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
+        id: setup-node
         if: matrix.settings.crate != '__noop__'
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
+          install-dependencies: "false"
 
       # We explicitly do this to cache properly.
       - name: Install Rust
@@ -269,6 +246,13 @@ jobs:
           npm install -g jest@27 mocha || \
           npm install -g jest@27 mocha || true
 
+      - name: Save pnpm cache
+        uses: actions/cache/save@v4
+        if: github.ref == 'refs/heads/main' && matrix.settings.crate != '__noop__' && steps.setup-node.outputs.pnpm-cache-hit != 'true'
+        with:
+          path: ${{ steps.setup-node.outputs.pnpm-store-path }}
+          key: ${{ steps.setup-node.outputs.pnpm-cache-primary-key }}
+
       - name: Configure path (windows)
         shell: bash
         if: runner.os == 'Windows' && matrix.settings.crate != '__noop__'
@@ -288,8 +272,9 @@ jobs:
           mkdir -p .swc-exec-cache
           echo "SWC_ECMA_TESTING_CACHE_DIR=$(pwd)/.swc-exec-cache" >> $GITHUB_ENV
 
-      - name: Cache execution results
-        uses: actions/cache@v3
+      - name: Restore execution cache
+        id: restore-execution-cache
+        uses: actions/cache/restore@v4
         if: matrix.settings.crate != '__noop__' && (matrix.settings.crate == 'swc' || startsWith(matrix.settings.crate, 'swc_ecma_transforms_'))
         with:
           path: |
@@ -370,6 +355,14 @@ jobs:
         run: |
           env RUSTFLAGS="--cfg swc_ast_unknown" cargo check -p ${{ matrix.settings.crate }} --features typescript,react,proposal,optimization,module,compat
 
+      - name: Save execution cache
+        uses: actions/cache/save@v4
+        if: github.ref == 'refs/heads/main' && matrix.settings.crate != '__noop__' && (matrix.settings.crate == 'swc' || startsWith(matrix.settings.crate, 'swc_ecma_transforms_')) && steps.restore-execution-cache.outputs.cache-hit != 'true'
+        with:
+          path: |
+            .swc-exec-cache
+          key: ${{ steps.restore-execution-cache.outputs.cache-primary-key }}
+
   node-test:
     name: Test node bindings - ${{ matrix.os }}
     if: >-
@@ -385,18 +378,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - shell: bash
-        run: corepack enable
-
       # We explicitly do this to cache properly.
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
+        id: setup-node
         with:
           node-version: 18
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
+          install-dependencies: "false"
 
       - name: Set platform name
         run: |
@@ -412,6 +402,12 @@ jobs:
           rustup target add wasm32-wasip1
           corepack enable
           pnpm install --frozen-lockfile
+      - name: Save pnpm cache
+        uses: actions/cache/save@v4
+        if: github.ref == 'refs/heads/main' && steps.setup-node.outputs.pnpm-cache-hit != 'true'
+        with:
+          path: ${{ steps.setup-node.outputs.pnpm-store-path }}
+          key: ${{ steps.setup-node.outputs.pnpm-cache-primary-key }}
       - name: Build
         working-directory: packages/core
         run: |
@@ -430,14 +426,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - shell: bash
-        run: corepack enable
-
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
+        id: setup-node
         with:
           node-version: 20
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
+          install-dependencies: "false"
 
       - name: Set platform name
         run: |
@@ -462,6 +455,13 @@ jobs:
           npm install -g @swc/cli@0.1.56
           npm link
           npm install -g file:$PWD
+
+      - name: Save pnpm cache
+        uses: actions/cache/save@v4
+        if: github.ref == 'refs/heads/main' && steps.setup-node.outputs.pnpm-cache-hit != 'true'
+        with:
+          path: ${{ steps.setup-node.outputs.pnpm-store-path }}
+          key: ${{ steps.setup-node.outputs.pnpm-cache-primary-key }}
 
       - name: Print info
         run: |

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -61,6 +61,7 @@ jobs:
           shared-key: "bench-${{ matrix.crate }}"
           key: "bench-${{ matrix.crate }}"
           cache-all-crates: true
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@v2

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -27,27 +27,25 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Enable corepack shims
-        run: |
-          mkdir -p "$HOME/.local/bin"
-          corepack enable --install-directory "$HOME/.local/bin"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: ./.github/actions/setup-node
+        id: setup-node
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
-
-      - name: Enable corepack
-        run: corepack enable
+          install-dependencies: "false"
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Save pnpm cache
+        uses: actions/cache/save@v4
+        if: github.ref == 'refs/heads/main' && steps.setup-node.outputs.pnpm-cache-hit != 'true'
+        with:
+          path: ${{ steps.setup-node.outputs.pnpm-store-path }}
+          key: ${{ steps.setup-node.outputs.pnpm-cache-primary-key }}
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/devbird.yml
+++ b/.github/workflows/devbird.yml
@@ -69,11 +69,10 @@ jobs:
       - run: corepack enable
 
       # Source map format
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/setup-node
         with:
           node-version: "20"
-          cache: "pnpm"
-          cache-dependency-path: pnpm-lock.yaml
+          install-dependencies: "false"
 
       # We explicitly do this to cache properly.
       - name: Install Rust

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -247,9 +247,19 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: 20
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
           architecture: x64
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: |
+          corepack enable
+          echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Restore pnpm cache
+        id: restore-pnpm-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-${{ runner.os }}-${{ runner.arch }}-node-20-${{ matrix.settings.target }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Output toolchain
         id: toolchain
         shell: bash
@@ -265,13 +275,15 @@ jobs:
         if: ${{ matrix.settings.target == 'armv7-unknown-linux-gnueabihf' || matrix.settings.target == 'powerpc64le-unknown-linux-gnu' || matrix.settings.target == 's390x-unknown-linux-gnu' }}
         with:
           version: 0.15.1
-      - name: Cache cargo registry
-        uses: actions/cache@v4
+      - name: Restore cargo registry
+        id: restore-cargo-registry
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cargo/registry
           key: ${{ matrix.settings.target }}-node@20-cargo-registry-trimmed
-      - name: Cache cargo index
-        uses: actions/cache@v4
+      - name: Restore cargo index
+        id: restore-cargo-index
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cargo/git
           key: ${{ matrix.settings.target }}-node@20-cargo-index-trimmed
@@ -291,6 +303,12 @@ jobs:
           fi
           curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
           echo '/usr/local/cargo/bin' >> $GITHUB_PATH
+      - name: Save pnpm cache
+        if: github.ref == 'refs/heads/main' && steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ steps.restore-pnpm-cache.outputs.cache-primary-key }}
       - name: Setup node x86
         uses: actions/setup-node@v5
         if: matrix.settings.target == 'i686-pc-windows-msvc'
@@ -315,6 +333,18 @@ jobs:
         if: ${{ !matrix.settings.docker }}
         run: ${{ matrix.settings.build }}
         shell: bash
+      - name: Save cargo registry
+        if: github.ref == 'refs/heads/main' && steps.restore-cargo-registry.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ steps.restore-cargo-registry.outputs.cache-primary-key }}
+      - name: Save cargo index
+        if: github.ref == 'refs/heads/main' && matrix.settings.docker && steps.restore-cargo-index.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ~/.cargo/git
+          key: ${{ steps.restore-cargo-index.outputs.cache-primary-key }}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -350,11 +380,27 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
           architecture: x64
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: |
+          corepack enable
+          echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Restore pnpm cache
+        id: restore-pnpm-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-${{ runner.os }}-${{ runner.arch }}-node-${{ matrix.node }}-${{ matrix.settings.target }}-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install dependencies
         run: corepack enable && pnpm install --frozen-lockfile
+      - name: Save pnpm cache
+        if: github.ref == 'refs/heads/main' && steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ steps.restore-pnpm-cache.outputs.cache-primary-key }}
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:
@@ -391,10 +437,26 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: |
+          corepack enable
+          echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Restore pnpm cache
+        id: restore-pnpm-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-${{ runner.os }}-${{ runner.arch }}-node-${{ matrix.node }}-x86_64-unknown-linux-gnu-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install dependencies
         run: corepack enable && pnpm install --frozen-lockfile
+      - name: Save pnpm cache
+        if: github.ref == 'refs/heads/main' && steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ steps.restore-pnpm-cache.outputs.cache-primary-key }}
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:
@@ -430,12 +492,28 @@ jobs:
         uses: actions/setup-node@v5
         with:
           node-version: ${{ matrix.node }}
-          cache: pnpm
-          cache-dependency-path: pnpm-lock.yaml
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: |
+          corepack enable
+          echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+      - name: Restore pnpm cache
+        id: restore-pnpm-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: pnpm-${{ runner.os }}-${{ runner.arch }}-node-${{ matrix.node }}-x86_64-unknown-linux-musl-${{ hashFiles('pnpm-lock.yaml') }}
       - name: Install dependencies
         run: |
           corepack enable
           pnpm install --frozen-lockfile --ignore-scripts --libc=musl
+      - name: Save pnpm cache
+        if: github.ref == 'refs/heads/main' && steps.restore-pnpm-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ steps.restore-pnpm-cache.outputs.cache-primary-key }}
       - name: Download artifacts
         uses: actions/download-artifact@v5
         with:
@@ -691,8 +769,9 @@ jobs:
         with:
           node-version: 20
 
-      - name: Cache
-        uses: actions/cache@v4
+      - name: Restore cargo cache
+        id: restore-cargo-cache
+        uses: actions/cache/restore@v4
         with:
           path: |
             ~/.cargo/
@@ -716,6 +795,14 @@ jobs:
         if: ${{ matrix.settings.build }}
         run: |
           ${{ matrix.settings.build }}
+
+      - name: Save cargo cache
+        if: github.ref == 'refs/heads/main' && steps.restore-cargo-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.cargo/
+          key: ${{ steps.restore-cargo-cache.outputs.cache-primary-key }}
 
       # Ensure npm 11.5.1 or later is installed
       - name: Update npm


### PR DESCRIPTION
**Description:**

PR, merge queue, and non-main manual CI runs can still restore existing caches, but they can no longer create new cache entries. This replaces built-in pnpm caching with explicit restore/save steps, gates every cache save on `refs/heads/main`, and applies the same policy to Rust and execution caches used by CI/release workflows.

This reduces the risk of untrusted or branch-specific CI poisoning shared caches while keeping cache restore behavior available for PR performance.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.

Validation:

- `go run github.com/rhysd/actionlint/cmd/actionlint@latest ...` with existing unrelated workflow warnings ignored
- YAML parse check for local composite actions
- Cache policy check ensuring every cache save is gated to `refs/heads/main`
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
