### PR TITLE
perf: Optimize es parser comment finalization

### DIFF
--- a/.changeset/afraid-rocks-protect.md
+++ b/.changeset/afraid-rocks-protect.md
@@ -1,0 +1,6 @@
+---
+swc_core: minor
+swc_ecma_parser: minor
+---
+
+perf: Optimize es parser comment finalization

--- a/crates/swc_ecma_parser/src/lexer/comments_buffer.rs
+++ b/crates/swc_ecma_parser/src/lexer/comments_buffer.rs
@@ -56,6 +56,12 @@ impl CommentsBuffer {
 
     #[inline(always)]
     pub fn pending_to_comment(&mut self, kind: BufferedCommentKind, pos: BytePos) {
+        // Most tokens have no pending comments; avoid creating an empty drain on
+        // this lexer hot path.
+        if self.pending_leading.is_empty() {
+            return;
+        }
+
         for comment in self.pending_leading.drain(..) {
             let comment = BufferedComment { kind, pos, comment };
             self.comments.push(comment);

--- a/crates/swc_ecma_parser/src/lexer/comments_buffer.rs
+++ b/crates/swc_ecma_parser/src/lexer/comments_buffer.rs
@@ -55,11 +55,23 @@ impl CommentsBuffer {
     }
 
     #[inline(always)]
+    pub fn has_pending(&self) -> bool {
+        !self.pending_leading.is_empty()
+    }
+
+    #[inline(always)]
     pub fn pending_to_comment(&mut self, kind: BufferedCommentKind, pos: BytePos) {
         // Most tokens have no pending comments; avoid creating an empty drain on
         // this lexer hot path.
-        if self.pending_leading.is_empty() {
-            return;
+        match self.pending_leading.len() {
+            0 => return,
+            1 => {
+                let comment = self.pending_leading.pop().unwrap();
+                let comment = BufferedComment { kind, pos, comment };
+                self.comments.push(comment);
+                return;
+            }
+            _ => {}
         }
 
         for comment in self.pending_leading.drain(..) {

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -1918,13 +1918,11 @@ impl<'a> Lexer<'a> {
         // Fast path: try to scan ASCII identifier using byte_search
         if let Some(c) = self.input().cur_as_ascii() {
             if Ident::is_valid_ascii_start(c) {
-                // Advance past first byte
-                self.bump(1); // c is a valid ascii
-
                 // Use byte_search to quickly scan to end of ASCII identifier
                 let next_byte = byte_search! {
                     lexer: self,
                     table: NOT_ASCII_ID_CONTINUE_TABLE,
+                    start_at: 1,
                     handle_eof: {
                         // Reached EOF, entire remainder is identifier
                         let s = unsafe {
@@ -2415,13 +2413,11 @@ impl<'a> Lexer<'a> {
 
         // Fast path: try to scan ASCII identifier using byte_search
         // Performance optimization: check if first char disqualifies as keyword
-        // Advance past first byte
-        self.bump(1);
-
         // Use byte_search to quickly scan to end of ASCII identifier
         let next_byte = byte_search! {
             lexer: self,
             table: NOT_ASCII_ID_CONTINUE_TABLE,
+            start_at: 1,
             handle_eof: {
                 // Reached EOF, entire remainder is identifier
                 let s = unsafe {

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -2383,7 +2383,7 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn read_keyword_with(&mut self, convert: &dyn Fn(&str) -> Option<Token>) -> LexResult<Token> {
+    fn read_keyword_with(&mut self, convert: fn(&str) -> Option<Token>) -> LexResult<Token> {
         debug_assert!(self.cur().is_some());
 
         let start = self.cur_pos();

--- a/crates/swc_ecma_parser/src/lexer/search.rs
+++ b/crates/swc_ecma_parser/src/lexer/search.rs
@@ -98,20 +98,17 @@ macro_rules! byte_search {
         let $byte = 'outer: loop {
             let batch_end = $pos + $crate::lexer::search::SEARCH_BATCH_SIZE;
             let $byte = if batch_end < len {
-                // Safety: `batch_end < len`
-                let batch = unsafe {
-                    std::slice::from_raw_parts(
-                        bytes.add($pos),
-                        $crate::lexer::search::SEARCH_BATCH_SIZE,
-                    )
-                };
                 'inner: loop {
-                    for (i, &byte) in batch.iter().enumerate() {
+                    let mut i = 0;
+                    while i < $crate::lexer::search::SEARCH_BATCH_SIZE {
+                        // Safety: `batch_end < len` and `i < SEARCH_BATCH_SIZE`.
+                        let byte = unsafe { *bytes.add($pos + i) };
                         if $table.matches(byte) {
                             // We find a matched byte, jump out to check with continue_if
                             $pos += i;
                             break 'inner byte;
                         }
+                        i += 1;
                     }
 
                     // We don't find a matched byte in this batch,
@@ -122,14 +119,17 @@ macro_rules! byte_search {
             } else {
                 'inner: loop {
                     // The remaining is shorter than batch size.
-                    let remaining =
-                        unsafe { std::slice::from_raw_parts(bytes.add($pos), len - $pos) };
-                    for (i, &byte) in remaining.iter().enumerate() {
+                    let remaining_len = len - $pos;
+                    let mut i = 0;
+                    while i < remaining_len {
+                        // Safety: `i < remaining_len`.
+                        let byte = unsafe { *bytes.add($pos + i) };
                         if $table.matches(byte) {
                             // We find a matched byte, jump out to check with continue_if
                             $pos += i;
                             break 'inner byte;
                         }
+                        i += 1;
                     }
 
                     // We don't find a matched byte in the remaining,

--- a/crates/swc_ecma_parser/src/lexer/search.rs
+++ b/crates/swc_ecma_parser/src/lexer/search.rs
@@ -37,9 +37,11 @@ impl SafeByteMatchTable {
     #[inline]
     pub const fn use_table(&self) {}
 
-    #[inline]
-    pub const fn matches(&self, b: u8) -> bool {
-        self.0[b as usize]
+    #[inline(always)]
+    pub fn matches(&self, b: u8) -> bool {
+        // Safety: `b` is a byte, so `b as usize` is always within the 256-byte
+        // lookup table.
+        unsafe { *self.0.get_unchecked(b as usize) }
     }
 }
 

--- a/crates/swc_ecma_parser/src/lexer/search.rs
+++ b/crates/swc_ecma_parser/src/lexer/search.rs
@@ -84,15 +84,48 @@ macro_rules! byte_search {
         }
     };
 
+    // Variant for callers that know an initial prefix cannot match and want to
+    // advance the input only once at the end of the search.
+    (
+        lexer: $lexer:ident,
+        table: $table:ident,
+        start_at: $start_at:expr,
+        handle_eof: $eof_handler:expr $(,)?
+    ) => {
+        byte_search! {
+            lexer: $lexer,
+            table: $table,
+            start_at: $start_at,
+            continue_if: (_byte, _pos) false,
+            handle_eof: $eof_handler,
+        }
+    };
+
     // Full version with continue_if support
     (
         lexer: $lexer:ident,
         table: $table:ident,
         continue_if: ($byte:ident, $pos:ident) $should_continue:expr,
         handle_eof: $eof_handler:expr $(,)?
+    ) => {
+        byte_search! {
+            lexer: $lexer,
+            table: $table,
+            start_at: 0,
+            continue_if: ($byte, $pos) $should_continue,
+            handle_eof: $eof_handler,
+        }
+    };
+
+    (
+        lexer: $lexer:ident,
+        table: $table:ident,
+        start_at: $start_at:expr,
+        continue_if: ($byte:ident, $pos:ident) $should_continue:expr,
+        handle_eof: $eof_handler:expr $(,)?
     ) => {{
         $table.use_table();
-        let mut $pos = 0;
+        let mut $pos = $start_at;
         let bytes = $lexer.input().as_str().as_bytes();
         let len = bytes.len();
         let bytes = bytes.as_ptr();

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -416,15 +416,19 @@ impl Lexer<'_> {
 
     #[inline(always)]
     fn finish_next_token(&mut self, span: Span, token: Token) -> TokenAndSpan {
-        if self.comments_buffer.is_some() {
-            if token == Token::Eof {
+        if token == Token::Eof {
+            if self.comments_buffer.is_some() {
                 self.consume_pending_comments();
-            } else {
-                self.comments_buffer
-                    .as_mut()
-                    .unwrap()
-                    .pending_to_comment(BufferedCommentKind::Leading, span.lo);
             }
+        } else if self
+            .comments_buffer
+            .as_ref()
+            .is_some_and(|comments| comments.has_pending())
+        {
+            self.comments_buffer
+                .as_mut()
+                .unwrap()
+                .pending_to_comment(BufferedCommentKind::Leading, span.lo);
         }
 
         self.state.set_token_type(token);

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -41,7 +41,7 @@ pub struct State {
     pub prev_hi: BytePos,
 
     pub(super) token_value: Option<TokenValue>,
-    token_type: Option<Token>,
+    token_type: Token,
 }
 
 pub struct LexerCheckpoint {
@@ -264,7 +264,7 @@ impl crate::input::Tokens for Lexer<'_> {
     }
 
     fn scan_jsx_identifier(&mut self, start: BytePos) -> TokenAndSpan {
-        let token = self.state.token_type.unwrap();
+        let token = self.state.token_type;
         debug_assert!(token.is_word());
         let prefix_end = self.cur_pos();
         let mut v = String::with_capacity(16);
@@ -416,14 +416,19 @@ impl Lexer<'_> {
 
     #[inline(always)]
     fn finish_next_token(&mut self, span: Span, token: Token) -> TokenAndSpan {
-        if token == Token::Eof {
-            self.consume_pending_comments();
-        } else if let Some(comments) = self.comments_buffer.as_mut() {
-            comments.pending_to_comment(BufferedCommentKind::Leading, span.lo);
+        if self.comments_buffer.is_some() {
+            if token == Token::Eof {
+                self.consume_pending_comments();
+            } else {
+                self.comments_buffer
+                    .as_mut()
+                    .unwrap()
+                    .pending_to_comment(BufferedCommentKind::Leading, span.lo);
+            }
         }
 
         self.state.set_token_type(token);
-        self.state.prev_hi = self.last_pos();
+        self.state.prev_hi = span.hi;
         TokenAndSpan {
             token,
             had_line_break: self.state.had_line_break,
@@ -671,7 +676,7 @@ impl State {
             next_regexp: None,
             prev_hi: start_pos,
             token_value: None,
-            token_type: None,
+            token_type: Token::Eof,
         }
     }
 
@@ -683,27 +688,24 @@ impl State {
 impl State {
     #[inline(always)]
     pub fn set_token_type(&mut self, token_type: Token) {
-        self.token_type = Some(token_type);
+        self.token_type = token_type;
     }
 
     #[inline(always)]
-    pub fn token_type(&self) -> Option<Token> {
+    pub fn token_type(&self) -> Token {
         self.token_type
     }
 
     pub fn can_have_trailing_line_comment(&self) -> bool {
-        let Some(t) = self.token_type() else {
-            return true;
-        };
+        let t = self.token_type();
         !t.is_bin_op()
     }
 
     pub fn can_have_trailing_comment(&self) -> bool {
-        self.token_type().is_some_and(|t| {
-            !t.is_keyword()
-                && (t == Token::Semi
-                    || t == Token::LBrace
-                    || t.is_other_and_can_have_trailing_comment())
-        })
+        let t = self.token_type();
+        !t.is_keyword()
+            && (t == Token::Semi
+                || t == Token::LBrace
+                || t.is_other_and_can_have_trailing_comment())
     }
 }

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -205,7 +205,9 @@ impl crate::input::Tokens for Lexer<'_> {
     }
 
     fn next_token(&mut self) -> TokenAndSpan {
-        let mut start = self.cur_pos();
+        // `read_next_token` always overwrites this out-parameter before
+        // returning, including the regexp path.
+        let mut start = BytePos(0);
         let token = match self.read_next_token(&mut start) {
             Ok(res) => res,
             Err(error) => {

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -416,19 +416,17 @@ impl Lexer<'_> {
 
     #[inline(always)]
     fn finish_next_token(&mut self, span: Span, token: Token) -> TokenAndSpan {
-        if token == Token::Eof {
-            if self.comments_buffer.is_some() {
+        if self.comments_buffer.is_some() {
+            if token == Token::Eof {
                 self.consume_pending_comments();
+            } else {
+                let Some(comments_buffer) = self.comments_buffer.as_mut() else {
+                    unreachable!();
+                };
+                if comments_buffer.has_pending() {
+                    comments_buffer.pending_to_comment(BufferedCommentKind::Leading, span.lo);
+                }
             }
-        } else if self
-            .comments_buffer
-            .as_ref()
-            .is_some_and(|comments| comments.has_pending())
-        {
-            self.comments_buffer
-                .as_mut()
-                .unwrap()
-                .pending_to_comment(BufferedCommentKind::Leading, span.lo);
         }
 
         self.state.set_token_type(token);

--- a/crates/swc_ecma_parser/src/lexer/table.rs
+++ b/crates/swc_ecma_parser/src/lexer/table.rs
@@ -56,7 +56,7 @@ const ERR: ByteHandler = |lexer| {
 const IDN: ByteHandler = |lexer| lexer.read_ident_unknown();
 
 const L_A: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "abstract" => Some(Token::Abstract),
         "as" => Some(Token::As),
         "await" => Some(Token::Await),
@@ -70,7 +70,7 @@ const L_A: ByteHandler = |lexer| {
 };
 
 const L_B: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "break" => Some(Token::Break),
         "boolean" => Some(Token::Boolean),
         "bigint" => Some(Token::Bigint),
@@ -79,7 +79,7 @@ const L_B: ByteHandler = |lexer| {
 };
 
 const L_C: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "case" => Some(Token::Case),
         "catch" => Some(Token::Catch),
         "class" => Some(Token::Class),
@@ -90,7 +90,7 @@ const L_C: ByteHandler = |lexer| {
 };
 
 const L_D: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "debugger" => Some(Token::Debugger),
         "default" => Some(Token::Default),
         "delete" => Some(Token::Delete),
@@ -101,7 +101,7 @@ const L_D: ByteHandler = |lexer| {
 };
 
 const L_E: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "else" => Some(Token::Else),
         "enum" => Some(Token::Enum),
         "export" => Some(Token::Export),
@@ -111,7 +111,7 @@ const L_E: ByteHandler = |lexer| {
 };
 
 const L_F: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "false" => Some(Token::False),
         "finally" => Some(Token::Finally),
         "for" => Some(Token::For),
@@ -122,7 +122,7 @@ const L_F: ByteHandler = |lexer| {
 };
 
 const L_G: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "global" => Some(Token::Global),
         "get" => Some(Token::Get),
         _ => None,
@@ -132,7 +132,7 @@ const L_G: ByteHandler = |lexer| {
 const L_H: ByteHandler = IDN;
 
 const L_I: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "if" => Some(Token::If),
         "import" => Some(Token::Import),
         "in" => Some(Token::In),
@@ -149,28 +149,28 @@ const L_I: ByteHandler = |lexer| {
 const L_J: ByteHandler = IDN;
 
 const L_K: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "keyof" => Some(Token::Keyof),
         _ => None,
     })
 };
 
 const L_L: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "let" => Some(Token::Let),
         _ => None,
     })
 };
 
 const L_M: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "meta" => Some(Token::Meta),
         _ => None,
     })
 };
 
 const L_N: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "new" => Some(Token::New),
         "null" => Some(Token::Null),
         "number" => Some(Token::Number),
@@ -181,7 +181,7 @@ const L_N: ByteHandler = |lexer| {
 };
 
 const L_O: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "of" => Some(Token::Of),
         "object" => Some(Token::Object),
         "out" => Some(Token::Out),
@@ -191,7 +191,7 @@ const L_O: ByteHandler = |lexer| {
 };
 
 const L_P: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "public" => Some(Token::Public),
         "package" => Some(Token::Package),
         "protected" => Some(Token::Protected),
@@ -203,7 +203,7 @@ const L_P: ByteHandler = |lexer| {
 const L_Q: ByteHandler = IDN;
 
 const L_R: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "return" => Some(Token::Return),
         "readonly" => Some(Token::Readonly),
         "require" => Some(Token::Require),
@@ -212,7 +212,7 @@ const L_R: ByteHandler = |lexer| {
 };
 
 const L_S: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "super" => Some(Token::Super),
         "static" => Some(Token::Static),
         "switch" => Some(Token::Switch),
@@ -225,7 +225,7 @@ const L_S: ByteHandler = |lexer| {
 };
 
 const L_T: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "this" => Some(Token::This),
         "throw" => Some(Token::Throw),
         "true" => Some(Token::True),
@@ -238,7 +238,7 @@ const L_T: ByteHandler = |lexer| {
 };
 
 const L_U: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "using" => Some(Token::Using),
         "unique" => Some(Token::Unique),
         "undefined" => Some(Token::Undefined),
@@ -248,7 +248,7 @@ const L_U: ByteHandler = |lexer| {
 };
 
 const L_V: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "var" => Some(Token::Var),
         "void" => Some(Token::Void),
         _ => None,
@@ -256,7 +256,7 @@ const L_V: ByteHandler = |lexer| {
 };
 
 const L_W: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "while" => Some(Token::While),
         "with" => Some(Token::With),
         _ => None,
@@ -266,7 +266,7 @@ const L_W: ByteHandler = |lexer| {
 const L_X: ByteHandler = IDN;
 
 const L_Y: ByteHandler = |lexer| {
-    lexer.read_keyword_with(&|s| match s {
+    lexer.read_keyword_with(|s| match s {
         "yield" => Some(Token::Yield),
         _ => None,
     })

--- a/crates/swc_ecma_parser/src/lexer/token.rs
+++ b/crates/swc_ecma_parser/src/lexer/token.rs
@@ -525,6 +525,17 @@ impl Token {
             || (t >= Token::Plus as u8 && t <= Token::Ampersand as u8)
     }
 
+    #[inline(always)]
+    pub const fn needs_unary_expr_prefix_parse(self) -> bool {
+        let t = self as u8;
+        (t >= Token::Bang as u8 && t <= Token::Minus as u8)
+            || (t >= Token::PlusPlus as u8 && t <= Token::MinusMinus as u8)
+            || matches!(
+                self,
+                Token::Lt | Token::Await | Token::Delete | Token::TypeOf | Token::Void
+            )
+    }
+
     pub const fn as_bin_op(self) -> Option<swc_ecma_ast::BinaryOp> {
         match self {
             Token::EqEq => Some(swc_ecma_ast::BinaryOp::EqEq),

--- a/crates/swc_ecma_parser/src/lexer/token.rs
+++ b/crates/swc_ecma_parser/src/lexer/token.rs
@@ -373,7 +373,7 @@ impl<'a> Token {
         buffer.expect_error_token_value()
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn take_word<I: Tokens>(self, buffer: &Buffer<I>) -> Atom {
         if self == Token::Ident {
             let value = buffer.get_token_value();

--- a/crates/swc_ecma_parser/src/lexer/whitespace.rs
+++ b/crates/swc_ecma_parser/src/lexer/whitespace.rs
@@ -157,6 +157,9 @@ impl<'a> Lexer<'a> {
                 Some(v) => v,
                 None => return,
             };
+            if byte > b' ' && byte != b'/' && byte < 0x80 {
+                break;
+            }
 
             let handler = unsafe { *(&BYTE_HANDLERS as *const ByteHandler).offset(byte as isize) };
             if !handler(self) {

--- a/crates/swc_ecma_parser/src/lexer/whitespace.rs
+++ b/crates/swc_ecma_parser/src/lexer/whitespace.rs
@@ -157,7 +157,7 @@ impl<'a> Lexer<'a> {
                 Some(v) => v,
                 None => return,
             };
-            if byte > b' ' && byte != b'/' && byte < 0x80 {
+            if byte.wrapping_sub(b'!') < 0x5f && byte != b'/' {
                 break;
             }
 

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1947,8 +1947,14 @@ impl<I: Tokens> Parser<I> {
     ) -> PResult<(Box<Expr>, Option<u8>)> {
         const PREC_OF_IN: u8 = 7;
 
-        if self.input().syntax().typescript() && !self.input().had_line_break_before_cur() {
-            if PREC_OF_IN > min_prec && self.input().is(Token::As) {
+        // Return left on eof
+        let cur = self.input().cur();
+
+        if (cur == Token::As || cur == Token::Satisfies)
+            && self.input().syntax().typescript()
+            && !self.input().had_line_break_before_cur()
+        {
+            if PREC_OF_IN > min_prec && cur == Token::As {
                 let start = left.span_lo();
                 let expr = left;
                 let node = if peek!(self).is_some_and(|cur| cur == Token::Const) {
@@ -1970,7 +1976,7 @@ impl<I: Tokens> Parser<I> {
                 };
 
                 return self.parse_bin_op_recursively_inner(node, min_prec);
-            } else if self.input().is(Token::Satisfies) {
+            } else if cur == Token::Satisfies {
                 let start = left.span_lo();
                 let expr = left;
                 let node = {
@@ -1987,8 +1993,6 @@ impl<I: Tokens> Parser<I> {
             }
         }
 
-        // Return left on eof
-        let cur = self.input().cur();
         let op = if cur == Token::In && self.ctx().contains(Context::IncludeInExpr) {
             op!("in")
         } else if cur == Token::InstanceOf {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2025,26 +2025,6 @@ impl<I: Tokens> Parser<I> {
                 return Ok(next_left);
             };
 
-            match &*next_left {
-                Expr::Bin(BinExpr {
-                    span,
-                    left,
-                    op: op!("&&"),
-                    ..
-                })
-                | Expr::Bin(BinExpr {
-                    span,
-                    left,
-                    op: op!("||"),
-                    ..
-                }) => {
-                    if let Expr::Bin(BinExpr { op: op!("??"), .. }) = &**left {
-                        self.emit_err(*span, SyntaxError::NullishCoalescingWithLogicalOp);
-                    }
-                }
-                _ => {}
-            }
-
             min_prec = next_prec;
             left = next_left;
         }
@@ -2211,8 +2191,15 @@ impl<I: Tokens> Parser<I> {
             }
         }
 
+        let span = Span::new_with_checked(left.span_lo(), right.span_hi());
+        if (op == op!("&&") || op == op!("||"))
+            && matches!(left.as_ref(), Expr::Bin(BinExpr { op: op!("??"), .. }))
+        {
+            self.emit_err(span, SyntaxError::NullishCoalescingWithLogicalOp);
+        }
+
         let node = BinExpr {
-            span: Span::new_with_checked(left.span_lo(), right.span_hi()),
+            span,
             op,
             left,
             right,

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -519,7 +519,7 @@ impl<I: Tokens> Parser<I> {
                 .into(),
             };
 
-            return self.parse_subscripts(Callee::Expr(call_expr), false, false);
+            return self.parse_subscripts_expr(call_expr, false, false);
         }
         if type_args.is_some() {
             // This fails
@@ -1120,7 +1120,7 @@ impl<I: Tokens> Parser<I> {
         no_call: bool,
         no_computed_member: bool,
     ) -> PResult<Box<Expr>> {
-        let mut expr = match obj {
+        let expr = match obj {
             Callee::Import(import) => {
                 let start = import.span.lo;
                 self.parse_subscript_import_call(start, import)?
@@ -1129,10 +1129,22 @@ impl<I: Tokens> Parser<I> {
                 let start = s.span.lo;
                 self.parse_subscript_super(start, s, no_call)?
             }
-            Callee::Expr(expr) => expr,
+            Callee::Expr(expr) => {
+                return self.parse_subscripts_expr(expr, no_call, no_computed_member);
+            }
             #[cfg(swc_ast_unknown)]
             _ => unreachable!(),
         };
+
+        self.parse_subscripts_expr(expr, no_call, no_computed_member)
+    }
+
+    fn parse_subscripts_expr(
+        &mut self,
+        mut expr: Box<Expr>,
+        no_call: bool,
+        no_computed_member: bool,
+    ) -> PResult<Box<Expr>> {
         let syntax = self.input().syntax();
 
         if !syntax.typescript() {
@@ -1758,7 +1770,7 @@ impl<I: Tokens> Parser<I> {
                         span,
                         kind: MetaPropKind::ImportMeta,
                     };
-                    self.parse_subscripts(Callee::Expr(expr.into()), no_call, false)
+                    self.parse_subscripts_expr(expr.into(), no_call, false)
                 }
                 "defer" => self.parse_dynamic_import_call(start, ImportPhase::Defer),
                 "source" => self.parse_dynamic_import_call(start, ImportPhase::Source),
@@ -1820,7 +1832,7 @@ impl<I: Tokens> Parser<I> {
                         self.emit_err(span, SyntaxError::InvalidNewTarget);
                     }
 
-                    return self.parse_subscripts(Callee::Expr(expr), true, false);
+                    return self.parse_subscripts_expr(expr, true, false);
                 }
 
                 unexpected!(self, "target")
@@ -1882,20 +1894,18 @@ impl<I: Tokens> Parser<I> {
                 // Parsed with 'MemberExpression' production.
                 let args = self.parse_args(false).map(Some)?;
 
-                let new_expr = Callee::Expr(
-                    NewExpr {
-                        span: self.span(start),
-                        callee,
-                        args,
-                        type_args,
-                        ..Default::default()
-                    }
-                    .into(),
-                );
+                let new_expr = NewExpr {
+                    span: self.span(start),
+                    callee,
+                    args,
+                    type_args,
+                    ..Default::default()
+                }
+                .into();
 
                 // We should parse subscripts for MemberExpression.
                 // Because it's left recursive.
-                return self.parse_subscripts(new_expr, true, false);
+                return self.parse_subscripts_expr(new_expr, true, false);
             }
 
             // Parsed with 'NewExpression' production.
@@ -1943,7 +1953,7 @@ impl<I: Tokens> Parser<I> {
             obj
         };
 
-        self.parse_subscripts(Callee::Expr(obj), true, false)
+        self.parse_subscripts_expr(obj, true, false)
     }
 
     /// Parse `NewExpression`.

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1495,12 +1495,13 @@ impl<I: Tokens> Parser<I> {
             debug_assert_eq!(callee.span_lo(), span.lo());
             debug_assert_eq!(prop.span_hi(), span.hi());
 
+            let is_opt_chain = unwrap_ts_non_null(&callee).is_opt_chain();
             let expr = MemberExpr {
                 span,
                 obj: callee,
                 prop,
             };
-            let expr = if unwrap_ts_non_null(&expr.obj).is_opt_chain() {
+            let expr = if is_opt_chain {
                 OptChainExpr {
                     span: self.span(start),
                     optional: false,
@@ -1592,16 +1593,12 @@ impl<I: Tokens> Parser<I> {
                 obj: callee,
                 prop,
             };
-            let expr = if unwrap_ts_non_null(&expr.obj).is_opt_chain() || question_dot {
-                OptChainExpr {
-                    span: self.span(start),
-                    optional: question_dot,
-                    base: Box::new(OptChainBase::Member(expr)),
-                }
-                .into()
-            } else {
-                expr.into()
-            };
+            let expr = OptChainExpr {
+                span: self.span(start),
+                optional: true,
+                base: Box::new(OptChainBase::Member(expr)),
+            }
+            .into();
 
             return Ok((Box::new(expr), true));
         }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1479,6 +1479,41 @@ impl<I: Tokens> Parser<I> {
             return Ok((callee, false));
         }
 
+        if !question_dot && cur == Token::Dot {
+            self.bump();
+            let prop = self.parse_maybe_private_name().map(|e| match e {
+                Either::Left(p) => MemberProp::PrivateName(p),
+                Either::Right(i) => MemberProp::Ident(i),
+            })?;
+            if syntax.flow()
+                && matches!(prop, MemberProp::PrivateName(..))
+                && !self.ctx().contains(Context::InClass)
+            {
+                self.emit_err(self.input().prev_span(), SyntaxError::TS1003);
+            }
+            let span = self.span(callee.span_lo());
+            debug_assert_eq!(callee.span_lo(), span.lo());
+            debug_assert_eq!(prop.span_hi(), span.hi());
+
+            let expr = MemberExpr {
+                span,
+                obj: callee,
+                prop,
+            };
+            let expr = if unwrap_ts_non_null(&expr.obj).is_opt_chain() {
+                OptChainExpr {
+                    span: self.span(start),
+                    optional: false,
+                    base: Box::new(OptChainBase::Member(expr)),
+                }
+                .into()
+            } else {
+                expr.into()
+            };
+
+            return Ok((Box::new(expr), true));
+        }
+
         if !no_computed_member && cur == Token::LBracket {
             self.bump();
             let bracket_lo = self.input().prev_span().lo;
@@ -1537,10 +1572,7 @@ impl<I: Tokens> Parser<I> {
             };
         }
 
-        if question_dot || cur == Token::Dot {
-            if !question_dot {
-                self.bump();
-            }
+        if question_dot {
             let prop = self.parse_maybe_private_name().map(|e| match e {
                 Either::Left(p) => MemberProp::PrivateName(p),
                 Either::Right(i) => MemberProp::Ident(i),

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -170,10 +170,9 @@ impl<I: Tokens> Parser<I> {
             return Err(err);
         }
 
-        let start = self.cur_pos();
         self.state_mut().potential_arrow_start =
             if matches!(cur, Token::Ident | Token::Yield | Token::LParen) || cur.is_known_ident() {
-                start
+                self.cur_pos()
             } else {
                 BytePos::SYNTHESIZED
             };
@@ -191,6 +190,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         if self.input().cur().is_assign_op() {
+            let start = cond.span_lo();
             self.finish_assignment_expr(start, cond)
         } else {
             Ok(cond)

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -535,6 +535,15 @@ impl<I: Tokens> Parser<I> {
 
         self.assert_and_bump(Token::LBracket);
 
+        if self.input().is(Token::RBracket) {
+            expect!(self, Token::RBracket);
+            return Ok(ArrayLit {
+                span: self.span(start),
+                elems: Vec::new(),
+            }
+            .into());
+        }
+
         let mut elems = Vec::with_capacity(8);
 
         while !self.input().is(Token::RBracket) {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1120,10 +1120,15 @@ impl<I: Tokens> Parser<I> {
         no_call: bool,
         no_computed_member: bool,
     ) -> PResult<Box<Expr>> {
-        let start = obj.span().lo;
         let mut expr = match obj {
-            Callee::Import(import) => self.parse_subscript_import_call(start, import)?,
-            Callee::Super(s) => self.parse_subscript_super(start, s, no_call)?,
+            Callee::Import(import) => {
+                let start = import.span.lo;
+                self.parse_subscript_import_call(start, import)?
+            }
+            Callee::Super(s) => {
+                let start = s.span.lo;
+                self.parse_subscript_super(start, s, no_call)?
+            }
             Callee::Expr(expr) => expr,
             #[cfg(swc_ast_unknown)]
             _ => unreachable!(),
@@ -1133,7 +1138,6 @@ impl<I: Tokens> Parser<I> {
         if !syntax.typescript() {
             loop {
                 expr = match self.parse_subscript_without_type_args(
-                    start,
                     expr,
                     no_call,
                     no_computed_member,
@@ -1144,6 +1148,7 @@ impl<I: Tokens> Parser<I> {
                 }
             }
         } else {
+            let start = expr.span_lo();
             loop {
                 expr = match self.parse_subscript(start, expr, no_call, no_computed_member)? {
                     (expr, false) => return Ok(expr),
@@ -1168,7 +1173,6 @@ impl<I: Tokens> Parser<I> {
 
         if !syntax.typescript() {
             return self.parse_subscript_without_type_args(
-                start,
                 callee,
                 no_call,
                 no_computed_member,
@@ -1448,7 +1452,6 @@ impl<I: Tokens> Parser<I> {
     #[inline(always)]
     fn parse_subscript_without_type_args(
         &mut self,
-        start: BytePos,
         callee: Box<Expr>,
         no_call: bool,
         no_computed_member: bool,
@@ -1495,7 +1498,7 @@ impl<I: Tokens> Parser<I> {
             };
             let expr = if is_opt_chain {
                 OptChainExpr {
-                    span: self.span(start),
+                    span,
                     optional: false,
                     base: Box::new(OptChainBase::Member(expr)),
                 }
@@ -1541,6 +1544,7 @@ impl<I: Tokens> Parser<I> {
 
         if cur == Token::LParen && (!no_call || question_dot) {
             let args = self.parse_args(false)?;
+            let start = callee.span_lo();
             let span = self.span(start);
             return if question_dot || unwrap_ts_non_null(&callee).is_opt_chain() {
                 let expr = OptChainExpr {
@@ -1586,7 +1590,7 @@ impl<I: Tokens> Parser<I> {
                 prop,
             };
             let expr = OptChainExpr {
-                span: self.span(start),
+                span,
                 optional: true,
                 base: Box::new(OptChainBase::Member(expr)),
             }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -970,6 +970,11 @@ impl<I: Tokens> Parser<I> {
             let start = p.cur_pos();
             expect!(p, Token::LParen);
 
+            if p.input().is(Token::RParen) {
+                expect!(p, Token::RParen);
+                return Ok(Vec::new());
+            }
+
             let mut first = true;
             let mut expr_or_spreads = Vec::with_capacity(2);
 

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2016,26 +2016,27 @@ impl<I: Tokens> Parser<I> {
     pub(crate) fn parse_bin_op_recursively(
         &mut self,
         mut left: Box<Expr>,
-        mut min_prec: u8,
+        min_prec: u8,
     ) -> PResult<Box<Expr>> {
         loop {
-            let (next_left, next_prec) = self.parse_bin_op_recursively_inner(left, min_prec)?;
+            let (next_left, should_continue) =
+                self.parse_bin_op_recursively_inner(left, min_prec)?;
 
-            let Some(next_prec) = next_prec else {
+            if !should_continue {
                 return Ok(next_left);
-            };
+            }
 
-            min_prec = next_prec;
             left = next_left;
         }
     }
 
-    /// Returns `(left, Some(next_prec))` or `(expr, None)`.
+    /// Returns `(expr, true)` if binary parsing should continue, or `(expr,
+    /// false)`.
     fn parse_bin_op_recursively_inner(
         &mut self,
         left: Box<Expr>,
         min_prec: u8,
-    ) -> PResult<(Box<Expr>, Option<u8>)> {
+    ) -> PResult<(Box<Expr>, bool)> {
         const PREC_OF_IN: u8 = 7;
 
         // Return left on eof
@@ -2090,7 +2091,7 @@ impl<I: Tokens> Parser<I> {
                     return self.parse_bin_op_recursively_inner(node, min_prec);
                 }
             }
-            return Ok((left, None));
+            return Ok((left, false));
         };
 
         let op_prec = op.precedence();
@@ -2105,7 +2106,7 @@ impl<I: Tokens> Parser<I> {
                 );
             }
 
-            return Ok((left, None));
+            return Ok((left, false));
         }
 
         if op == op!("<") && self.syntax().flow() && self.syntax().jsx() {
@@ -2206,7 +2207,7 @@ impl<I: Tokens> Parser<I> {
         }
         .into();
 
-        Ok((node, Some(min_prec)))
+        Ok((node, true))
     }
 
     pub(crate) fn parse_await_expr(

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -341,7 +341,8 @@ impl<I: Tokens> Parser<I> {
         }
 
         let cur = self.input().cur();
-        if cur == Token::PlusPlus || cur == Token::MinusMinus {
+        let cur_kind = cur as u8;
+        if cur_kind >= Token::PlusPlus as u8 && cur_kind <= Token::MinusMinus as u8 {
             // Line terminator isn't allowed here.
             if self.input_mut().had_line_break_before_cur() {
                 return Ok(expr);

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1906,6 +1906,10 @@ impl<I: Tokens> Parser<I> {
         loop {
             let (next_left, next_prec) = self.parse_bin_op_recursively_inner(left, min_prec)?;
 
+            let Some(next_prec) = next_prec else {
+                return Ok(next_left);
+            };
+
             match &*next_left {
                 Expr::Bin(BinExpr {
                     span,
@@ -1926,11 +1930,7 @@ impl<I: Tokens> Parser<I> {
                 _ => {}
             }
 
-            min_prec = match next_prec {
-                Some(v) => v,
-                None => return Ok(next_left),
-            };
-
+            min_prec = next_prec;
             left = next_left;
         }
     }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -42,6 +42,7 @@ impl<I: Tokens> Parser<I> {
 
     /// AssignmentExpression[+In, ?Yield, ?Await]
     /// ...AssignmentExpression[+In, ?Yield, ?Await]
+    #[inline(always)]
     fn parse_expr_or_spread(&mut self) -> PResult<ExprOrSpread> {
         trace_cur!(self, parse_expr_or_spread);
         if self.input().cur() == Token::DotDotDot {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -172,7 +172,7 @@ impl<I: Tokens> Parser<I> {
 
         let start = self.cur_pos();
         self.state_mut().potential_arrow_start =
-            if cur.is_known_ident() || matches!(cur, Token::Ident | Token::Yield | Token::LParen) {
+            if matches!(cur, Token::Ident | Token::Yield | Token::LParen) || cur.is_known_ident() {
                 start
             } else {
                 BytePos::SYNTHESIZED

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1152,6 +1152,22 @@ impl<I: Tokens> Parser<I> {
         mut expr: Box<Expr>,
         no_call: bool,
     ) -> PResult<Box<Expr>> {
+        let cur = self.input().cur();
+        if !matches!(
+            cur,
+            Token::QuestionMark
+                | Token::LBracket
+                | Token::LParen
+                | Token::Dot
+                | Token::TemplateHead
+                | Token::NoSubstitutionTemplateLiteral
+                | Token::BackQuote
+                | Token::Bang
+                | Token::Lt
+        ) {
+            return Ok(expr);
+        }
+
         let syntax = self.input().syntax();
 
         if !syntax.typescript() {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2974,30 +2974,28 @@ impl<I: Tokens> Parser<I> {
                     }
                     .into());
                 }
-            } else if cur == Token::Arrow {
-                if !p.input().had_line_break_before_cur() {
-                    if p.ctx().contains(Context::Strict) && id.is_reserved_in_strict_bind() {
-                        p.emit_strict_mode_err(id.span, SyntaxError::EvalAndArgumentsInStrict)
-                    }
-                    let params = vec![id.into()];
-                    p.bump();
-                    let body = p.parse_fn_block_or_expr_body(
-                        false,
-                        false,
-                        true,
-                        params.is_simple_parameter_list(),
-                    )?;
-
-                    return Ok(ArrowExpr {
-                        span: p.span(start),
-                        body,
-                        params,
-                        is_async: false,
-                        is_generator: false,
-                        ..Default::default()
-                    }
-                    .into());
+            } else if cur == Token::Arrow && !p.input().had_line_break_before_cur() {
+                if p.ctx().contains(Context::Strict) && id.is_reserved_in_strict_bind() {
+                    p.emit_strict_mode_err(id.span, SyntaxError::EvalAndArgumentsInStrict)
                 }
+                let params = vec![id.into()];
+                p.bump();
+                let body = p.parse_fn_block_or_expr_body(
+                    false,
+                    false,
+                    true,
+                    params.is_simple_parameter_list(),
+                )?;
+
+                return Ok(ArrowExpr {
+                    span: p.span(start),
+                    body,
+                    params,
+                    is_async: false,
+                    is_generator: false,
+                    ..Default::default()
+                }
+                .into());
             }
 
             Ok(id.into())

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1447,17 +1447,33 @@ impl<I: Tokens> Parser<I> {
         no_computed_member: bool,
         syntax: SyntaxFlags,
     ) -> PResult<(Box<Expr>, bool)> {
-        let question_dot = if self.input().is(Token::QuestionMark)
-            && peek!(self).is_some_and(|peek| peek == Token::Dot)
-        {
-            self.bump();
-            self.bump();
-            true
-        } else {
-            false
-        };
+        let mut cur = self.input().cur();
+        let question_dot =
+            if cur == Token::QuestionMark && peek!(self).is_some_and(|peek| peek == Token::Dot) {
+                self.bump();
+                self.bump();
+                cur = self.input().cur();
+                true
+            } else {
+                false
+            };
 
-        if !no_computed_member && self.input_mut().eat(Token::LBracket) {
+        if !question_dot
+            && !matches!(
+                cur,
+                Token::LBracket
+                    | Token::LParen
+                    | Token::Dot
+                    | Token::TemplateHead
+                    | Token::NoSubstitutionTemplateLiteral
+                    | Token::BackQuote
+            )
+        {
+            return Ok((callee, false));
+        }
+
+        if !no_computed_member && cur == Token::LBracket {
+            self.bump();
             let bracket_lo = self.input().prev_span().lo;
             let prop = self.allow_in_expr(|p| p.parse_expr())?;
             expect!(self, Token::RBracket);
@@ -1488,7 +1504,7 @@ impl<I: Tokens> Parser<I> {
             return Ok((Box::new(expr), true));
         }
 
-        if self.input.is(Token::LParen) && (!no_call || question_dot) {
+        if cur == Token::LParen && (!no_call || question_dot) {
             let args = self.parse_args(false)?;
             let span = self.span(start);
             return if question_dot || unwrap_ts_non_null(&callee).is_opt_chain() {
@@ -1514,7 +1530,10 @@ impl<I: Tokens> Parser<I> {
             };
         }
 
-        if question_dot || self.input_mut().eat(Token::Dot) {
+        if question_dot || cur == Token::Dot {
+            if !question_dot {
+                self.bump();
+            }
             let prop = self.parse_maybe_private_name().map(|e| match e {
                 Either::Left(p) => MemberProp::PrivateName(p),
                 Either::Right(i) => MemberProp::Ident(i),
@@ -1548,7 +1567,6 @@ impl<I: Tokens> Parser<I> {
             return Ok((Box::new(expr), true));
         }
 
-        let cur = self.input().cur();
         if matches!(
             cur,
             Token::TemplateHead | Token::NoSubstitutionTemplateLiteral | Token::BackQuote

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1896,7 +1896,7 @@ impl<I: Tokens> Parser<I> {
         let obj = self.parse_primary_expr()?;
         return_if_arrow!(self, obj);
 
-        let type_args = if self.syntax().typescript() && self.input().is(Token::Lt) {
+        let type_args = if self.input().is(Token::Lt) && self.syntax().typescript() {
             self.try_parse_ts_type_args()
         } else {
             None

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -44,7 +44,8 @@ impl<I: Tokens> Parser<I> {
     /// ...AssignmentExpression[+In, ?Yield, ?Await]
     fn parse_expr_or_spread(&mut self) -> PResult<ExprOrSpread> {
         trace_cur!(self, parse_expr_or_spread);
-        if self.input_mut().eat(Token::DotDotDot) {
+        if self.input().cur() == Token::DotDotDot {
+            self.bump();
             let start = self.input().prev_span().lo;
             let spread_span = self.span(start);
             let spread = Some(spread_span);

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2796,7 +2796,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         let try_parse_arrow_expr = |p: &mut Self, id: Ident, id_is_async| -> PResult<Box<Expr>> {
-            if can_be_arrow && !p.input().had_line_break_before_cur() {
+            if !p.input().had_line_break_before_cur() {
                 if id_is_async && p.is_ident_ref() {
                     // see https://github.com/tc39/ecma262/issues/2034
                     // ```js
@@ -2890,6 +2890,9 @@ impl<I: Tokens> Parser<I> {
                 !ctx.contains(Context::InGenerator),
                 !ctx.contains(Context::InAsync),
             )?;
+            if !can_be_arrow {
+                return Ok(id.into());
+            }
             try_parse_arrow_expr(self, id, false)
         } else if cur == Token::Hash {
             self.bump(); // consume `#`
@@ -2909,13 +2912,19 @@ impl<I: Tokens> Parser<I> {
                 self.emit_err(self.input().prev_span(), SyntaxError::ArgumentsInClassField)
             };
             let id = Ident::new_no_ctxt(word, self.span(token_start));
+            if !can_be_arrow {
+                return Ok(id.into());
+            }
             try_parse_arrow_expr(self, id, false)
         } else if self.is_ident_ref() {
-            let id_is_async = self.input().cur() == Token::Async;
+            let cur = self.input().cur();
             let token_start = self.input().cur_pos();
             let word = self.input_mut().expect_word_token_and_bump();
             let id = Ident::new_no_ctxt(word, self.span(token_start));
-            try_parse_arrow_expr(self, id, id_is_async)
+            if !can_be_arrow {
+                return Ok(id.into());
+            }
+            try_parse_arrow_expr(self, id, cur == Token::Async)
         } else {
             syntax_error!(self, self.input().cur_span(), SyntaxError::TS1109)
         }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -201,11 +201,10 @@ impl<I: Tokens> Parser<I> {
     pub(super) fn parse_unary_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_unary_expr);
 
-        let token_and_span = self.input().get_cur();
-        let start = token_and_span.span.lo;
-        let cur = token_and_span.token;
+        let cur = self.input().cur();
 
         if cur == Token::Lt && self.input().syntax().typescript() && !self.input().syntax().jsx() {
+            let start = self.input().cur_pos();
             self.bump(); // consume `<`
             return if self.input_mut().eat(Token::Const) {
                 self.expect(Token::Gt)?;
@@ -234,6 +233,7 @@ impl<I: Tokens> Parser<I> {
             }
             return self.parse_jsx_element(true).map(into_expr);
         } else if matches!(cur, Token::PlusPlus | Token::MinusMinus) {
+            let start = self.input().cur_pos();
             // Parse update expression
             let op = if cur == Token::PlusPlus {
                 op!("++")
@@ -261,6 +261,7 @@ impl<I: Tokens> Parser<I> {
             || cur == Token::Tilde
             || cur == Token::Bang
         {
+            let start = self.input().cur_pos();
             // Parse unary expression
             let op = if cur == Token::Delete {
                 op!("delete")
@@ -415,9 +416,8 @@ impl<I: Tokens> Parser<I> {
     pub(crate) fn parse_lhs_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_lhs_expr);
 
-        let token_and_span = self.input().get_cur();
-        let start = token_and_span.span.lo;
-        let cur = token_and_span.token;
+        let start = self.input().cur_pos();
+        let cur = self.input().cur();
 
         // `super()` can't be handled from parse_new_expr()
         if cur == Token::Super {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -915,7 +915,15 @@ impl<I: Tokens> Parser<I> {
             let span = self.span(start);
             Lit::Bool(swc_ecma_ast::Bool { span, value })
         } else if cur == Token::Str {
-            Lit::Str(self.parse_str_lit())
+            let raw = Atom::new(self.input.cur_string());
+            let value = self.input.expect_string_token_value();
+            self.bump();
+
+            Lit::Str(swc_ecma_ast::Str {
+                span: self.span(start),
+                value,
+                raw: Some(raw),
+            })
         } else if cur == Token::Num {
             let raw = Atom::new(self.input.cur_string());
             let value = self.input_mut().expect_number_token_value();

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1729,7 +1729,9 @@ impl<I: Tokens> Parser<I> {
     fn parse_member_expr_or_new_expr_inner(&mut self, is_new_expr: bool) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_member_expr_or_new_expr);
 
-        if self.input_mut().eat(Token::New) {
+        let cur = self.input().cur();
+        if cur == Token::New {
+            self.bump();
             let start = self.input().prev_span().lo;
             if self.input_mut().eat(Token::Dot) {
                 if self.input_mut().eat(Token::Target) {
@@ -1838,13 +1840,15 @@ impl<I: Tokens> Parser<I> {
             .into());
         }
 
-        if self.input_mut().eat(Token::Super) {
+        if cur == Token::Super {
+            self.bump();
             let start = self.input().prev_span().lo;
             let base = Callee::Super(Super {
                 span: self.span(start),
             });
             return self.parse_subscripts(base, true, false);
-        } else if self.input_mut().eat(Token::Import) {
+        } else if cur == Token::Import {
+            self.bump();
             let start = self.input().prev_span().lo;
             return self.parse_dynamic_import_or_import_meta(start, true);
         }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2002,49 +2002,6 @@ impl<I: Tokens> Parser<I> {
         // Return left on eof
         let cur = self.input().cur();
 
-        if (cur == Token::As || cur == Token::Satisfies)
-            && self.input().syntax().typescript()
-            && !self.input().had_line_break_before_cur()
-        {
-            if PREC_OF_IN > min_prec && cur == Token::As {
-                let start = left.span_lo();
-                let expr = left;
-                let node = if peek!(self).is_some_and(|cur| cur == Token::Const) {
-                    self.bump(); // as
-                    self.bump(); // const
-                    TsConstAssertion {
-                        span: self.span(start),
-                        expr,
-                    }
-                    .into()
-                } else {
-                    let type_ann = self.next_then_parse_ts_type()?;
-                    TsAsExpr {
-                        span: self.span(start),
-                        expr,
-                        type_ann,
-                    }
-                    .into()
-                };
-
-                return self.parse_bin_op_recursively_inner(node, min_prec);
-            } else if cur == Token::Satisfies {
-                let start = left.span_lo();
-                let expr = left;
-                let node = {
-                    let type_ann = self.next_then_parse_ts_type()?;
-                    TsSatisfiesExpr {
-                        span: self.span(start),
-                        expr,
-                        type_ann,
-                    }
-                    .into()
-                };
-
-                return self.parse_bin_op_recursively_inner(node, min_prec);
-            }
-        }
-
         let op = if cur == Token::In && self.ctx().contains(Context::IncludeInExpr) {
             op!("in")
         } else if cur == Token::InstanceOf {
@@ -2052,6 +2009,48 @@ impl<I: Tokens> Parser<I> {
         } else if let Some(op) = cur.as_bin_op() {
             op
         } else {
+            if (cur == Token::As || cur == Token::Satisfies)
+                && self.input().syntax().typescript()
+                && !self.input().had_line_break_before_cur()
+            {
+                if PREC_OF_IN > min_prec && cur == Token::As {
+                    let start = left.span_lo();
+                    let expr = left;
+                    let node = if peek!(self).is_some_and(|cur| cur == Token::Const) {
+                        self.bump(); // as
+                        self.bump(); // const
+                        TsConstAssertion {
+                            span: self.span(start),
+                            expr,
+                        }
+                        .into()
+                    } else {
+                        let type_ann = self.next_then_parse_ts_type()?;
+                        TsAsExpr {
+                            span: self.span(start),
+                            expr,
+                            type_ann,
+                        }
+                        .into()
+                    };
+
+                    return self.parse_bin_op_recursively_inner(node, min_prec);
+                } else if cur == Token::Satisfies {
+                    let start = left.span_lo();
+                    let expr = left;
+                    let node = {
+                        let type_ann = self.next_then_parse_ts_type()?;
+                        TsSatisfiesExpr {
+                            span: self.span(start),
+                            expr,
+                            type_ann,
+                        }
+                        .into()
+                    };
+
+                    return self.parse_bin_op_recursively_inner(node, min_prec);
+                }
+            }
             return Ok((left, None));
         };
 

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -420,17 +420,18 @@ impl<I: Tokens> Parser<I> {
     pub(crate) fn parse_lhs_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_lhs_expr);
 
-        let start = self.input().cur_pos();
         let cur = self.input().cur();
 
         // `super()` can't be handled from parse_new_expr()
         if cur == Token::Super {
+            let start = self.input().cur_pos();
             self.bump(); // eat `super`
             let obj = Callee::Super(Super {
                 span: self.span(start),
             });
             return self.parse_subscripts(obj, false, false);
         } else if cur == Token::Import {
+            let start = self.input().cur_pos();
             self.bump(); // eat `import`
             return self.parse_dynamic_import_or_import_meta(start, false);
         }
@@ -474,6 +475,7 @@ impl<I: Tokens> Parser<I> {
         if self.input().is(Token::LParen) {
             // This is parsed using production MemberExpression,
             // which is left-recursive.
+            let start = callee.span_lo();
             let (callee, is_import) = match callee {
                 _ if callee.is_ident_ref_to("import") => (
                     Callee::Import(Import {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -207,126 +207,131 @@ impl<I: Tokens> Parser<I> {
 
         let cur = self.input().cur();
 
-        if cur == Token::Lt && self.input().syntax().typescript() && !self.input().syntax().jsx() {
-            let start = self.input().cur_pos();
-            self.bump(); // consume `<`
-            return if self.input_mut().eat(Token::Const) {
-                self.expect(Token::Gt)?;
-                let expr = self.parse_unary_expr()?;
-                Ok(TsConstAssertion {
-                    span: self.span(start),
-                    expr,
-                }
-                .into())
-            } else {
-                self.parse_ts_type_assertion(start)
-                    .map(Expr::from)
-                    .map(Box::new)
-            };
-        } else if cur == Token::Lt
-            && self.input().syntax().jsx()
-            && self.input_mut().peek().is_some_and(|peek| {
-                peek.is_word() || peek == Token::Gt || peek.should_rescan_into_gt_in_jsx()
-            })
-        {
-            fn into_expr(e: Either<JSXFragment, JSXElement>) -> Box<Expr> {
-                match e {
-                    Either::Left(l) => l.into(),
-                    Either::Right(r) => r.into(),
-                }
-            }
-            return self.parse_jsx_element(true).map(into_expr);
-        } else if matches!(cur, Token::PlusPlus | Token::MinusMinus) {
-            let start = self.input().cur_pos();
-            // Parse update expression
-            let op = if cur == Token::PlusPlus {
-                op!("++")
-            } else {
-                op!("--")
-            };
-            self.bump();
-
-            let arg = self.parse_unary_expr()?;
-            let span = Span::new_with_checked(start, arg.span_hi());
-            self.check_assign_target(&arg, false);
-
-            return Ok(UpdateExpr {
-                span,
-                prefix: true,
-                op,
-                arg,
-            }
-            .into());
-        } else if cur == Token::Delete
-            || cur == Token::Void
-            || cur == Token::TypeOf
-            || cur == Token::Plus
-            || cur == Token::Minus
-            || cur == Token::Tilde
-            || cur == Token::Bang
-        {
-            let start = self.input().cur_pos();
-            // Parse unary expression
-            let op = if cur == Token::Delete {
-                op!("delete")
-            } else if cur == Token::Void {
-                op!("void")
-            } else if cur == Token::TypeOf {
-                op!("typeof")
-            } else if cur == Token::Plus {
-                op!(unary, "+")
-            } else if cur == Token::Minus {
-                op!(unary, "-")
-            } else if cur == Token::Tilde {
-                op!("~")
-            } else {
-                debug_assert!(cur == Token::Bang);
-                op!("!")
-            };
-            self.bump();
-            let arg_start = self.cur_pos() - BytePos(1);
-            let arg = match self.parse_unary_expr() {
-                Ok(expr) => expr,
-                Err(err) => {
-                    self.emit_error(err);
-                    Invalid {
-                        span: Span::new_with_checked(arg_start, arg_start),
+        if cur.needs_unary_expr_prefix_parse() {
+            if cur == Token::Lt
+                && self.input().syntax().typescript()
+                && !self.input().syntax().jsx()
+            {
+                let start = self.input().cur_pos();
+                self.bump(); // consume `<`
+                return if self.input_mut().eat(Token::Const) {
+                    self.expect(Token::Gt)?;
+                    let expr = self.parse_unary_expr()?;
+                    Ok(TsConstAssertion {
+                        span: self.span(start),
+                        expr,
                     }
-                    .into()
-                }
-            };
-
-            if op == op!("delete") {
-                if self.input().syntax().flow()
-                    && matches!(
-                        arg.as_ref(),
-                        Expr::Member(MemberExpr {
-                            prop: MemberProp::PrivateName(..),
-                            ..
-                        })
-                    )
-                {
-                    self.emit_err(arg.span(), SyntaxError::TS1003);
-                }
-
-                // Skip emitting TS1102 in TypeScript mode because it's a semantic error
-                // that should be handled by the type checker, not the parser.
-                // See: https://github.com/swc-project/swc/issues/10558
-                if !self.input().syntax().typescript() {
-                    if let Expr::Ident(ref i) = *arg {
-                        self.emit_strict_mode_err(i.span, SyntaxError::TS1102)
+                    .into())
+                } else {
+                    self.parse_ts_type_assertion(start)
+                        .map(Expr::from)
+                        .map(Box::new)
+                };
+            } else if cur == Token::Lt
+                && self.input().syntax().jsx()
+                && self.input_mut().peek().is_some_and(|peek| {
+                    peek.is_word() || peek == Token::Gt || peek.should_rescan_into_gt_in_jsx()
+                })
+            {
+                fn into_expr(e: Either<JSXFragment, JSXElement>) -> Box<Expr> {
+                    match e {
+                        Either::Left(l) => l.into(),
+                        Either::Right(r) => r.into(),
                     }
                 }
-            }
+                return self.parse_jsx_element(true).map(into_expr);
+            } else if matches!(cur, Token::PlusPlus | Token::MinusMinus) {
+                let start = self.input().cur_pos();
+                // Parse update expression
+                let op = if cur == Token::PlusPlus {
+                    op!("++")
+                } else {
+                    op!("--")
+                };
+                self.bump();
 
-            return Ok(UnaryExpr {
-                span: Span::new_with_checked(start, arg.span_hi()),
-                op,
-                arg,
+                let arg = self.parse_unary_expr()?;
+                let span = Span::new_with_checked(start, arg.span_hi());
+                self.check_assign_target(&arg, false);
+
+                return Ok(UpdateExpr {
+                    span,
+                    prefix: true,
+                    op,
+                    arg,
+                }
+                .into());
+            } else if cur == Token::Delete
+                || cur == Token::Void
+                || cur == Token::TypeOf
+                || cur == Token::Plus
+                || cur == Token::Minus
+                || cur == Token::Tilde
+                || cur == Token::Bang
+            {
+                let start = self.input().cur_pos();
+                // Parse unary expression
+                let op = if cur == Token::Delete {
+                    op!("delete")
+                } else if cur == Token::Void {
+                    op!("void")
+                } else if cur == Token::TypeOf {
+                    op!("typeof")
+                } else if cur == Token::Plus {
+                    op!(unary, "+")
+                } else if cur == Token::Minus {
+                    op!(unary, "-")
+                } else if cur == Token::Tilde {
+                    op!("~")
+                } else {
+                    debug_assert!(cur == Token::Bang);
+                    op!("!")
+                };
+                self.bump();
+                let arg_start = self.cur_pos() - BytePos(1);
+                let arg = match self.parse_unary_expr() {
+                    Ok(expr) => expr,
+                    Err(err) => {
+                        self.emit_error(err);
+                        Invalid {
+                            span: Span::new_with_checked(arg_start, arg_start),
+                        }
+                        .into()
+                    }
+                };
+
+                if op == op!("delete") {
+                    if self.input().syntax().flow()
+                        && matches!(
+                            arg.as_ref(),
+                            Expr::Member(MemberExpr {
+                                prop: MemberProp::PrivateName(..),
+                                ..
+                            })
+                        )
+                    {
+                        self.emit_err(arg.span(), SyntaxError::TS1003);
+                    }
+
+                    // Skip emitting TS1102 in TypeScript mode because it's a semantic error
+                    // that should be handled by the type checker, not the parser.
+                    // See: https://github.com/swc-project/swc/issues/10558
+                    if !self.input().syntax().typescript() {
+                        if let Expr::Ident(ref i) = *arg {
+                            self.emit_strict_mode_err(i.span, SyntaxError::TS1102)
+                        }
+                    }
+                }
+
+                return Ok(UnaryExpr {
+                    span: Span::new_with_checked(start, arg.span_hi()),
+                    op,
+                    arg,
+                }
+                .into());
+            } else if cur == Token::Await {
+                return self.parse_await_expr(None);
             }
-            .into());
-        } else if cur == Token::Await {
-            return self.parse_await_expr(None);
         }
 
         // UpdateExpression

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -182,6 +182,10 @@ impl<I: Tokens> Parser<I> {
 
         return_if_arrow!(self, cond);
 
+        if !self.input().cur().is_assign_op() {
+            return Ok(cond);
+        }
+
         match *cond {
             // if cond is conditional expression but not left-hand-side expression,
             // just return it.
@@ -189,12 +193,8 @@ impl<I: Tokens> Parser<I> {
             _ => {}
         }
 
-        if self.input().cur().is_assign_op() {
-            let start = cond.span_lo();
-            self.finish_assignment_expr(start, cond)
-        } else {
-            Ok(cond)
-        }
+        let start = cond.span_lo();
+        self.finish_assignment_expr(start, cond)
     }
 
     #[allow(dead_code)]

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2822,8 +2822,10 @@ impl<I: Tokens> Parser<I> {
         }
 
         let try_parse_arrow_expr = |p: &mut Self, id: Ident, id_is_async| -> PResult<Box<Expr>> {
-            if !p.input().had_line_break_before_cur() {
-                if id_is_async && p.is_ident_ref() {
+            let cur = p.input().cur();
+
+            if id_is_async && cur.is_word() && !cur.is_reserved(p.ctx()) {
+                if !p.input().had_line_break_before_cur() {
                     // see https://github.com/tc39/ecma262/issues/2034
                     // ```js
                     // for(async of
@@ -2847,7 +2849,7 @@ impl<I: Tokens> Parser<I> {
                         return Ok(id.into());
                     }
 
-                    let token = p.input().cur();
+                    let token = cur;
                     let ident = p.parse_binding_ident(false)?;
                     if p.input().syntax().typescript()
                         && token == Token::As
@@ -2883,11 +2885,14 @@ impl<I: Tokens> Parser<I> {
                         ..Default::default()
                     }
                     .into());
-                } else if p.input_mut().eat(Token::Arrow) {
+                }
+            } else if cur == Token::Arrow {
+                if !p.input().had_line_break_before_cur() {
                     if p.ctx().contains(Context::Strict) && id.is_reserved_in_strict_bind() {
                         p.emit_strict_mode_err(id.span, SyntaxError::EvalAndArgumentsInStrict)
                     }
                     let params = vec![id.into()];
+                    p.bump();
                     let body = p.parse_fn_block_or_expr_body(
                         false,
                         false,

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1715,8 +1715,8 @@ impl<I: Tokens> Parser<I> {
     fn parse_member_expr_or_new_expr_inner(&mut self, is_new_expr: bool) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_member_expr_or_new_expr);
 
-        let start = self.cur_pos();
         if self.input_mut().eat(Token::New) {
+            let start = self.input().prev_span().lo;
             if self.input_mut().eat(Token::Dot) {
                 if self.input_mut().eat(Token::Target) {
                     let span = self.span(start);
@@ -1825,11 +1825,13 @@ impl<I: Tokens> Parser<I> {
         }
 
         if self.input_mut().eat(Token::Super) {
+            let start = self.input().prev_span().lo;
             let base = Callee::Super(Super {
                 span: self.span(start),
             });
             return self.parse_subscripts(base, true, false);
         } else if self.input_mut().eat(Token::Import) {
+            let start = self.input().prev_span().lo;
             return self.parse_dynamic_import_or_import_meta(start, true);
         }
         let obj = self.parse_primary_expr()?;
@@ -1842,6 +1844,7 @@ impl<I: Tokens> Parser<I> {
         };
         let obj = if let Some(type_args) = type_args {
             trace_cur!(self, parse_member_expr_or_new_expr__with_type_args);
+            let start = obj.span_lo();
             TsInstantiation {
                 expr: obj,
                 type_args,

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2016,27 +2016,26 @@ impl<I: Tokens> Parser<I> {
     pub(crate) fn parse_bin_op_recursively(
         &mut self,
         mut left: Box<Expr>,
-        min_prec: u8,
+        mut min_prec: u8,
     ) -> PResult<Box<Expr>> {
         loop {
-            let (next_left, should_continue) =
-                self.parse_bin_op_recursively_inner(left, min_prec)?;
+            let (next_left, next_prec) = self.parse_bin_op_recursively_inner(left, min_prec)?;
 
-            if !should_continue {
+            let Some(next_prec) = next_prec else {
                 return Ok(next_left);
-            }
+            };
 
+            min_prec = next_prec;
             left = next_left;
         }
     }
 
-    /// Returns `(expr, true)` if binary parsing should continue, or `(expr,
-    /// false)`.
+    /// Returns `(left, Some(next_prec))` or `(expr, None)`.
     fn parse_bin_op_recursively_inner(
         &mut self,
         left: Box<Expr>,
         min_prec: u8,
-    ) -> PResult<(Box<Expr>, bool)> {
+    ) -> PResult<(Box<Expr>, Option<u8>)> {
         const PREC_OF_IN: u8 = 7;
 
         // Return left on eof
@@ -2091,7 +2090,7 @@ impl<I: Tokens> Parser<I> {
                     return self.parse_bin_op_recursively_inner(node, min_prec);
                 }
             }
-            return Ok((left, false));
+            return Ok((left, None));
         };
 
         let op_prec = op.precedence();
@@ -2106,7 +2105,7 @@ impl<I: Tokens> Parser<I> {
                 );
             }
 
-            return Ok((left, false));
+            return Ok((left, None));
         }
 
         if op == op!("<") && self.syntax().flow() && self.syntax().jsx() {
@@ -2207,7 +2206,7 @@ impl<I: Tokens> Parser<I> {
         }
         .into();
 
-        Ok((node, true))
+        Ok((node, Some(min_prec)))
     }
 
     pub(crate) fn parse_await_expr(

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -519,7 +519,7 @@ impl<I: Tokens> Parser<I> {
                 .into(),
             };
 
-            return self.parse_subscripts_expr(call_expr, false, false);
+            return self.parse_subscripts_expr::<false>(call_expr, false);
         }
         if type_args.is_some() {
             // This fails
@@ -1130,31 +1130,35 @@ impl<I: Tokens> Parser<I> {
                 self.parse_subscript_super(start, s, no_call)?
             }
             Callee::Expr(expr) => {
-                return self.parse_subscripts_expr(expr, no_call, no_computed_member);
+                return if no_computed_member {
+                    self.parse_subscripts_expr::<true>(expr, no_call)
+                } else {
+                    self.parse_subscripts_expr::<false>(expr, no_call)
+                };
             }
             #[cfg(swc_ast_unknown)]
             _ => unreachable!(),
         };
 
-        self.parse_subscripts_expr(expr, no_call, no_computed_member)
+        if no_computed_member {
+            self.parse_subscripts_expr::<true>(expr, no_call)
+        } else {
+            self.parse_subscripts_expr::<false>(expr, no_call)
+        }
     }
 
-    fn parse_subscripts_expr(
+    fn parse_subscripts_expr<const NO_COMPUTED: bool>(
         &mut self,
         mut expr: Box<Expr>,
         no_call: bool,
-        no_computed_member: bool,
     ) -> PResult<Box<Expr>> {
         let syntax = self.input().syntax();
 
         if !syntax.typescript() {
             loop {
-                expr = match self.parse_subscript_without_type_args(
-                    expr,
-                    no_call,
-                    no_computed_member,
-                    syntax,
-                )? {
+                expr = match self
+                    .parse_subscript_without_type_args::<NO_COMPUTED>(expr, no_call, syntax)?
+                {
                     (expr, false) => return Ok(expr),
                     (expr, true) => expr,
                 }
@@ -1162,7 +1166,7 @@ impl<I: Tokens> Parser<I> {
         } else {
             let start = expr.span_lo();
             loop {
-                expr = match self.parse_subscript(start, expr, no_call, no_computed_member)? {
+                expr = match self.parse_subscript::<NO_COMPUTED>(start, expr, no_call)? {
                     (expr, false) => return Ok(expr),
                     (expr, true) => expr,
                 }
@@ -1172,24 +1176,18 @@ impl<I: Tokens> Parser<I> {
 
     /// returned bool is true if this method should be called again.
     #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
-    fn parse_subscript(
+    fn parse_subscript<const NO_COMPUTED: bool>(
         &mut self,
         start: BytePos,
         mut callee: Box<Expr>,
         no_call: bool,
-        no_computed_member: bool,
     ) -> PResult<(Box<Expr>, bool)> {
         trace_cur!(self, parse_subscript);
 
         let syntax = self.input().syntax();
 
         if !syntax.typescript() {
-            return self.parse_subscript_without_type_args(
-                callee,
-                no_call,
-                no_computed_member,
-                syntax,
-            );
+            return self.parse_subscript_without_type_args::<NO_COMPUTED>(callee, no_call, syntax);
         }
 
         if syntax.typescript() {
@@ -1302,7 +1300,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         // $obj[name()]
-        if !no_computed_member && self.input_mut().eat(Token::LBracket) {
+        if !NO_COMPUTED && self.input_mut().eat(Token::LBracket) {
             let bracket_lo = self.input().prev_span().lo;
             let prop = self.allow_in_expr(|p| p.parse_expr())?;
             expect!(self, Token::RBracket);
@@ -1462,11 +1460,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     #[inline(always)]
-    fn parse_subscript_without_type_args(
+    fn parse_subscript_without_type_args<const NO_COMPUTED: bool>(
         &mut self,
         callee: Box<Expr>,
         no_call: bool,
-        no_computed_member: bool,
         syntax: SyntaxFlags,
     ) -> PResult<(Box<Expr>, bool)> {
         let mut cur = self.input().cur();
@@ -1522,7 +1519,7 @@ impl<I: Tokens> Parser<I> {
             return Ok((Box::new(expr), true));
         }
 
-        if !no_computed_member && cur == Token::LBracket {
+        if !NO_COMPUTED && cur == Token::LBracket {
             self.bump();
             let bracket_lo = self.input().prev_span().lo;
             let prop = self.allow_in_expr(|p| p.parse_expr())?;
@@ -1770,7 +1767,7 @@ impl<I: Tokens> Parser<I> {
                         span,
                         kind: MetaPropKind::ImportMeta,
                     };
-                    self.parse_subscripts_expr(expr.into(), no_call, false)
+                    self.parse_subscripts_expr::<false>(expr.into(), no_call)
                 }
                 "defer" => self.parse_dynamic_import_call(start, ImportPhase::Defer),
                 "source" => self.parse_dynamic_import_call(start, ImportPhase::Source),
@@ -1832,7 +1829,7 @@ impl<I: Tokens> Parser<I> {
                         self.emit_err(span, SyntaxError::InvalidNewTarget);
                     }
 
-                    return self.parse_subscripts_expr(expr, true, false);
+                    return self.parse_subscripts_expr::<false>(expr, true);
                 }
 
                 unexpected!(self, "target")
@@ -1905,7 +1902,7 @@ impl<I: Tokens> Parser<I> {
 
                 // We should parse subscripts for MemberExpression.
                 // Because it's left recursive.
-                return self.parse_subscripts_expr(new_expr, true, false);
+                return self.parse_subscripts_expr::<false>(new_expr, true);
             }
 
             // Parsed with 'NewExpression' production.
@@ -1953,7 +1950,7 @@ impl<I: Tokens> Parser<I> {
             obj
         };
 
-        self.parse_subscripts_expr(obj, true, false)
+        self.parse_subscripts_expr::<false>(obj, true)
     }
 
     /// Parse `NewExpression`.

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2128,15 +2128,17 @@ impl<I: Tokens> Parser<I> {
             return Ok((left, None));
         }
 
-        let left_is_jsx = match left.as_ref() {
-            Expr::JSXElement(..) | Expr::JSXFragment(..) => true,
-            Expr::Paren(ParenExpr { expr, .. }) => {
-                matches!(expr.as_ref(), Expr::JSXElement(..) | Expr::JSXFragment(..))
+        if op == op!("<") && self.syntax().flow() && self.syntax().jsx() {
+            let left_is_jsx = match left.as_ref() {
+                Expr::JSXElement(..) | Expr::JSXFragment(..) => true,
+                Expr::Paren(ParenExpr { expr, .. }) => {
+                    matches!(expr.as_ref(), Expr::JSXElement(..) | Expr::JSXFragment(..))
+                }
+                _ => false,
+            };
+            if left_is_jsx {
+                self.emit_err(self.input().cur_span(), SyntaxError::TS1003);
             }
-            _ => false,
-        };
-        if self.syntax().flow() && self.syntax().jsx() && op == op!("<") && left_is_jsx {
-            self.emit_err(self.input().cur_span(), SyntaxError::TS1003);
         }
 
         self.bump();
@@ -2148,23 +2150,25 @@ impl<I: Tokens> Parser<I> {
                 op_prec
             );
         }
-        match *left {
-            // This is invalid syntax.
-            Expr::Unary { .. } | Expr::Await(..) if op == op!("**") => {
-                // Correct implementation would be returning Ok(left) and
-                // returning "unexpected token '**'" on next.
-                // But it's not useful error message.
+        if op == op!("**") {
+            match *left {
+                // This is invalid syntax.
+                Expr::Unary { .. } | Expr::Await(..) => {
+                    // Correct implementation would be returning Ok(left) and
+                    // returning "unexpected token '**'" on next.
+                    // But it's not useful error message.
 
-                syntax_error!(
-                    self,
-                    SyntaxError::UnaryInExp {
-                        // FIXME: Use display
-                        left: format!("{left:?}"),
-                        left_span: left.span(),
-                    }
-                )
+                    syntax_error!(
+                        self,
+                        SyntaxError::UnaryInExp {
+                            // FIXME: Use display
+                            left: format!("{left:?}"),
+                            left_span: left.span(),
+                        }
+                    )
+                }
+                _ => {}
             }
-            _ => {}
         }
 
         let right = {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -74,7 +74,7 @@ impl<I: Tokens> Parser<I> {
     pub(crate) fn parse_assignment_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_assignment_expr);
 
-        if self.input().syntax().typescript() && self.input().is(Token::JSXTagStart) {
+        if self.input().is(Token::JSXTagStart) && self.input().syntax().typescript() {
             // Note: When the JSX plugin is on, type assertions (`<T> x`) aren't valid
             // syntax.
             let res = self.try_parse_ts(|p| p.parse_assignment_expr_base().map(Some));
@@ -93,12 +93,14 @@ impl<I: Tokens> Parser<I> {
     #[cfg_attr(feature = "tracing-spans", tracing::instrument(skip_all))]
     fn parse_assignment_expr_base(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_assignment_expr_base);
-        let start = self.input().cur_span();
+        let cur = self.input().cur();
+        let syntax = self.input().syntax();
 
-        if self.input().syntax().typescript()
-            && (self.input().cur() == Token::Lt || self.input().cur() == Token::JSXTagStart)
+        if syntax.typescript()
+            && (cur == Token::Lt || cur == Token::JSXTagStart)
             && (peek!(self).is_some_and(|peek| peek.is_word() || peek == Token::JSXName))
         {
+            let start = self.input().cur_span();
             let res = self.do_outside_of_context(Context::WillExpectColonForCond, |p| {
                 p.try_parse_ts(|p| {
                     let type_parameters = p.parse_ts_type_params(false, true)?;
@@ -152,18 +154,16 @@ impl<I: Tokens> Parser<I> {
                 })
             });
             if let Some(res) = res {
-                if self.input().syntax().disallow_ambiguous_jsx_like() {
+                if syntax.disallow_ambiguous_jsx_like() {
                     self.emit_err(start, SyntaxError::ReservedArrowTypeParam);
                 }
                 return Ok(res);
             }
         }
 
-        if self.ctx().contains(Context::InGenerator) && self.input().is(Token::Yield) {
+        if self.ctx().contains(Context::InGenerator) && cur == Token::Yield {
             return self.parse_yield_expr();
         }
-
-        let cur = self.input().cur();
 
         if cur == Token::Error {
             let err = self.input_mut().expect_error_token_and_bump();
@@ -172,9 +172,9 @@ impl<I: Tokens> Parser<I> {
 
         self.state_mut().potential_arrow_start =
             if cur.is_known_ident() || matches!(cur, Token::Ident | Token::Yield | Token::LParen) {
-                Some(self.cur_pos())
+                self.cur_pos()
             } else {
-                None
+                BytePos::SYNTHESIZED
             };
 
         let start = self.cur_pos();
@@ -362,11 +362,7 @@ impl<I: Tokens> Parser<I> {
     pub(super) fn parse_primary_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_primary_expr);
         let start = self.input().cur_pos();
-        let can_be_arrow = self
-            .state
-            .potential_arrow_start
-            .map(|s| s == start)
-            .unwrap_or(false);
+        let can_be_arrow = self.state.potential_arrow_start == start;
         let tok = self.input.cur();
         match tok {
             Token::This => return self.parse_this_expr(start),
@@ -562,7 +558,7 @@ impl<I: Tokens> Parser<I> {
 
     fn at_possible_async(&mut self, expr: &Expr) -> bool {
         // TODO(kdy1): !this.state.containsEsc &&
-        self.state().potential_arrow_start == Some(expr.span_lo()) && expr.is_ident_ref_to("async")
+        self.state().potential_arrow_start == expr.span_lo() && expr.is_ident_ref_to("async")
     }
 
     fn parse_yield_expr(&mut self) -> PResult<Box<Expr>> {
@@ -2057,7 +2053,7 @@ impl<I: Tokens> Parser<I> {
                     .is_some_and(|t| t == Token::LParen || t == Token::Function || t.is_word());
 
             let start = self.cur_pos();
-            self.state_mut().potential_arrow_start = Some(start);
+            self.state_mut().potential_arrow_start = start;
             let modifier_start = start;
 
             let has_modifier = self.eat_any_ts_modifier()?;
@@ -2654,7 +2650,6 @@ impl<I: Tokens> Parser<I> {
         };
 
         let cur = self.input().cur();
-        let token_start = self.input().cur_pos();
 
         if self.is_flow_match_keyword() {
             return self.parse_flow_match_expr(start);
@@ -2753,7 +2748,7 @@ impl<I: Tokens> Parser<I> {
             Ok(id.into())
         };
 
-        if cur == Token::Let || (self.input().syntax().typescript() && cur == Token::Await) {
+        if cur == Token::Let || (cur == Token::Await && self.input().syntax().typescript()) {
             let ctx = self.ctx();
             let id = self.parse_ident(
                 !ctx.contains(Context::InGenerator),
@@ -2772,6 +2767,7 @@ impl<I: Tokens> Parser<I> {
             }
             .into())
         } else if cur == Token::Ident {
+            let token_start = self.input().cur_pos();
             let word = self.input_mut().expect_word_token_and_bump();
             if self.ctx().contains(Context::InClassField) && word == atom!("arguments") {
                 self.emit_err(self.input().prev_span(), SyntaxError::ArgumentsInClassField)
@@ -2780,6 +2776,7 @@ impl<I: Tokens> Parser<I> {
             try_parse_arrow_expr(self, id, false)
         } else if self.is_ident_ref() {
             let id_is_async = self.input().cur() == Token::Async;
+            let token_start = self.input().cur_pos();
             let word = self.input_mut().expect_word_token_and_bump();
             let id = Ident::new_no_ctxt(word, self.span(token_start));
             try_parse_arrow_expr(self, id, id_is_async)

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -335,13 +335,13 @@ impl<I: Tokens> Parser<I> {
             return Ok(expr);
         }
 
-        // Line terminator isn't allowed here.
-        if self.input_mut().had_line_break_before_cur() {
-            return Ok(expr);
-        }
-
         let cur = self.input().cur();
         if cur == Token::PlusPlus || cur == Token::MinusMinus {
+            // Line terminator isn't allowed here.
+            if self.input_mut().had_line_break_before_cur() {
+                return Ok(expr);
+            }
+
             let op = if cur == Token::PlusPlus {
                 op!("++")
             } else {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1762,9 +1762,13 @@ impl<I: Tokens> Parser<I> {
         tracing::instrument(level = "debug", skip_all)
     )]
     fn parse_member_expr_or_new_expr(&mut self, is_new_expr: bool) -> PResult<Box<Expr>> {
-        self.do_inside_of_context(Context::ShouldNotLexLtOrGtAsType, |p| {
-            p.parse_member_expr_or_new_expr_inner(is_new_expr)
-        })
+        if self.ctx().contains(Context::InType) {
+            self.do_inside_of_context(Context::ShouldNotLexLtOrGtAsType, |p| {
+                p.parse_member_expr_or_new_expr_inner(is_new_expr)
+            })
+        } else {
+            self.parse_member_expr_or_new_expr_inner(is_new_expr)
+        }
     }
 
     fn parse_member_expr_or_new_expr_inner(&mut self, is_new_expr: bool) -> PResult<Box<Expr>> {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -161,7 +161,7 @@ impl<I: Tokens> Parser<I> {
             }
         }
 
-        if self.ctx().contains(Context::InGenerator) && cur == Token::Yield {
+        if cur == Token::Yield && self.ctx().contains(Context::InGenerator) {
             return self.parse_yield_expr();
         }
 

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -44,8 +44,8 @@ impl<I: Tokens> Parser<I> {
     /// ...AssignmentExpression[+In, ?Yield, ?Await]
     fn parse_expr_or_spread(&mut self) -> PResult<ExprOrSpread> {
         trace_cur!(self, parse_expr_or_spread);
-        let start = self.input().cur_pos();
         if self.input_mut().eat(Token::DotDotDot) {
+            let start = self.input().prev_span().lo;
             let spread_span = self.span(start);
             let spread = Some(spread_span);
             self.allow_in_expr(Self::parse_assignment_expr)

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -170,14 +170,13 @@ impl<I: Tokens> Parser<I> {
             return Err(err);
         }
 
+        let start = self.cur_pos();
         self.state_mut().potential_arrow_start =
             if cur.is_known_ident() || matches!(cur, Token::Ident | Token::Yield | Token::LParen) {
-                self.cur_pos()
+                start
             } else {
                 BytePos::SYNTHESIZED
             };
-
-        let start = self.cur_pos();
 
         // Try to parse conditional expression.
         let cond = self.parse_cond_expr()?;
@@ -1115,7 +1114,9 @@ impl<I: Tokens> Parser<I> {
     ) -> PResult<(Box<Expr>, bool)> {
         trace_cur!(self, parse_subscript);
 
-        if self.input().syntax().typescript() {
+        let syntax = self.input().syntax();
+
+        if syntax.typescript() {
             if !self.input().had_line_break_before_cur() && self.input().is(Token::Bang) {
                 self.input_mut().set_expr_allowed(false);
                 self.assert_and_bump(Token::Bang);
@@ -1208,7 +1209,7 @@ impl<I: Tokens> Parser<I> {
             }
         }
 
-        let ts_instantiation = if self.syntax().typescript() && self.input().is(Token::Lt) {
+        let ts_instantiation = if syntax.typescript() && self.input().is(Token::Lt) {
             self.try_parse_ts_type_args()
         } else {
             None
@@ -1243,7 +1244,7 @@ impl<I: Tokens> Parser<I> {
                 expr: prop,
             };
 
-            let type_args = if self.syntax().typescript() && self.input().is(Token::Lt) {
+            let type_args = if syntax.typescript() && self.input().is(Token::Lt) {
                 self.try_parse_ts_type_args()
             } else {
                 None
@@ -1278,8 +1279,7 @@ impl<I: Tokens> Parser<I> {
             return Ok((Box::new(expr), true));
         }
 
-        let type_args = if self.syntax().typescript() && self.input().is(Token::Lt) && question_dot
-        {
+        let type_args = if syntax.typescript() && self.input().is(Token::Lt) && question_dot {
             let ret = self.parse_ts_type_args()?;
             self.assert_and_bump(Token::Gt);
             Some(ret)
@@ -1321,7 +1321,7 @@ impl<I: Tokens> Parser<I> {
                 Either::Left(p) => MemberProp::PrivateName(p),
                 Either::Right(i) => MemberProp::Ident(i),
             })?;
-            if self.syntax().flow()
+            if syntax.flow()
                 && matches!(prop, MemberProp::PrivateName(..))
                 && !self.ctx().contains(Context::InClass)
             {
@@ -1331,7 +1331,7 @@ impl<I: Tokens> Parser<I> {
             debug_assert_eq!(callee.span_lo(), span.lo());
             debug_assert_eq!(prop.span_hi(), span.hi());
 
-            let type_args = if self.syntax().typescript() && self.input().is(Token::Lt) {
+            let type_args = if syntax.typescript() && self.input().is(Token::Lt) {
                 self.try_parse_ts_type_args()
             } else {
                 None

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -21,9 +21,9 @@ impl<I: Tokens> Parser<I> {
         trace_cur!(self, parse_expr);
         debug_tracing!(self, "parse_expr");
         let expr = self.parse_assignment_expr()?;
-        let start = expr.span_lo();
 
         if self.input_mut().is(Token::Comma) {
+            let start = expr.span_lo();
             let mut exprs = vec![expr];
 
             while self.input_mut().eat(Token::Comma) {

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1058,12 +1058,11 @@ impl<I: Tokens> Parser<I> {
     fn parse_cond_expr(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_cond_expr);
 
-        let start = self.cur_pos();
-
         let test = self.parse_bin_expr()?;
         return_if_arrow!(self, test);
 
         if self.input_mut().eat(Token::QuestionMark) {
+            let start = test.span_lo();
             let cons = self.do_inside_of_context(
                 Context::InCondExpr
                     .union(Context::WillExpectColonForCond)

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1121,11 +1121,27 @@ impl<I: Tokens> Parser<I> {
             #[cfg(swc_ast_unknown)]
             _ => unreachable!(),
         };
+        let syntax = self.input().syntax();
 
-        loop {
-            expr = match self.parse_subscript(start, expr, no_call, no_computed_member)? {
-                (expr, false) => return Ok(expr),
-                (expr, true) => expr,
+        if !syntax.typescript() {
+            loop {
+                expr = match self.parse_subscript_without_type_args(
+                    start,
+                    expr,
+                    no_call,
+                    no_computed_member,
+                    syntax,
+                )? {
+                    (expr, false) => return Ok(expr),
+                    (expr, true) => expr,
+                }
+            }
+        } else {
+            loop {
+                expr = match self.parse_subscript(start, expr, no_call, no_computed_member)? {
+                    (expr, false) => return Ok(expr),
+                    (expr, true) => expr,
+                }
             }
         }
     }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1455,29 +1455,21 @@ impl<I: Tokens> Parser<I> {
         syntax: SyntaxFlags,
     ) -> PResult<(Box<Expr>, bool)> {
         let mut cur = self.input().cur();
-        let question_dot =
-            if cur == Token::QuestionMark && peek!(self).is_some_and(|peek| peek == Token::Dot) {
+        let question_dot = match cur {
+            Token::QuestionMark if peek!(self).is_some_and(|peek| peek == Token::Dot) => {
                 self.bump();
                 self.bump();
                 cur = self.input().cur();
                 true
-            } else {
-                false
-            };
-
-        if !question_dot
-            && !matches!(
-                cur,
-                Token::LBracket
-                    | Token::LParen
-                    | Token::Dot
-                    | Token::TemplateHead
-                    | Token::NoSubstitutionTemplateLiteral
-                    | Token::BackQuote
-            )
-        {
-            return Ok((callee, false));
-        }
+            }
+            Token::LBracket
+            | Token::LParen
+            | Token::Dot
+            | Token::TemplateHead
+            | Token::NoSubstitutionTemplateLiteral
+            | Token::BackQuote => false,
+            _ => return Ok((callee, false)),
+        };
 
         if !question_dot && cur == Token::Dot {
             self.bump();

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1124,6 +1124,16 @@ impl<I: Tokens> Parser<I> {
 
         let syntax = self.input().syntax();
 
+        if !syntax.typescript() {
+            return self.parse_subscript_without_type_args(
+                start,
+                callee,
+                no_call,
+                no_computed_member,
+                syntax,
+            );
+        }
+
         if syntax.typescript() {
             if !self.input().had_line_break_before_cur() && self.input().is(Token::Bang) {
                 self.input_mut().set_expr_allowed(false);
@@ -1223,22 +1233,15 @@ impl<I: Tokens> Parser<I> {
             None
         };
 
-        let question_dot_token = if self.input().is(Token::QuestionMark)
+        let question_dot = if self.input().is(Token::QuestionMark)
             && peek!(self).is_some_and(|peek| peek == Token::Dot)
         {
-            let start = self.cur_pos();
             self.bump();
-
-            let span = Some(self.span(start));
             self.bump();
-
-            span
+            true
         } else {
-            None
+            false
         };
-
-        // If question_dot_token is Some, then `self.cur == Token::Dot`
-        let question_dot = question_dot_token.is_some();
 
         // $obj[name()]
         if !no_computed_member && self.input_mut().eat(Token::LBracket) {
@@ -1398,6 +1401,130 @@ impl<I: Tokens> Parser<I> {
         }
 
         Ok((expr, false))
+    }
+
+    #[inline(always)]
+    fn parse_subscript_without_type_args(
+        &mut self,
+        start: BytePos,
+        callee: Box<Expr>,
+        no_call: bool,
+        no_computed_member: bool,
+        syntax: SyntaxFlags,
+    ) -> PResult<(Box<Expr>, bool)> {
+        let question_dot = if self.input().is(Token::QuestionMark)
+            && peek!(self).is_some_and(|peek| peek == Token::Dot)
+        {
+            self.bump();
+            self.bump();
+            true
+        } else {
+            false
+        };
+
+        if !no_computed_member && self.input_mut().eat(Token::LBracket) {
+            let bracket_lo = self.input().prev_span().lo;
+            let prop = self.allow_in_expr(|p| p.parse_expr())?;
+            expect!(self, Token::RBracket);
+            let span = Span::new_with_checked(callee.span_lo(), self.input().last_pos());
+            debug_assert_eq!(callee.span_lo(), span.lo());
+            let prop = ComputedPropName {
+                span: Span::new_with_checked(bracket_lo, self.input().last_pos()),
+                expr: prop,
+            };
+
+            let is_opt_chain = unwrap_ts_non_null(&callee).is_opt_chain();
+            let expr = MemberExpr {
+                span,
+                obj: callee,
+                prop: MemberProp::Computed(prop),
+            };
+            let expr = if is_opt_chain || question_dot {
+                OptChainExpr {
+                    span,
+                    optional: question_dot,
+                    base: Box::new(OptChainBase::Member(expr)),
+                }
+                .into()
+            } else {
+                expr.into()
+            };
+
+            return Ok((Box::new(expr), true));
+        }
+
+        if self.input.is(Token::LParen) && (!no_call || question_dot) {
+            let args = self.parse_args(false)?;
+            let span = self.span(start);
+            return if question_dot || unwrap_ts_non_null(&callee).is_opt_chain() {
+                let expr = OptChainExpr {
+                    span,
+                    optional: question_dot,
+                    base: Box::new(OptChainBase::Call(OptCall {
+                        span: self.span(start),
+                        callee,
+                        args,
+                        ..Default::default()
+                    })),
+                };
+                Ok((Box::new(Expr::OptChain(expr)), true))
+            } else {
+                let expr = CallExpr {
+                    span: self.span(start),
+                    callee: Callee::Expr(callee),
+                    args,
+                    ..Default::default()
+                };
+                Ok((Box::new(Expr::Call(expr)), true))
+            };
+        }
+
+        if question_dot || self.input_mut().eat(Token::Dot) {
+            let prop = self.parse_maybe_private_name().map(|e| match e {
+                Either::Left(p) => MemberProp::PrivateName(p),
+                Either::Right(i) => MemberProp::Ident(i),
+            })?;
+            if syntax.flow()
+                && matches!(prop, MemberProp::PrivateName(..))
+                && !self.ctx().contains(Context::InClass)
+            {
+                self.emit_err(self.input().prev_span(), SyntaxError::TS1003);
+            }
+            let span = self.span(callee.span_lo());
+            debug_assert_eq!(callee.span_lo(), span.lo());
+            debug_assert_eq!(prop.span_hi(), span.hi());
+
+            let expr = MemberExpr {
+                span,
+                obj: callee,
+                prop,
+            };
+            let expr = if unwrap_ts_non_null(&expr.obj).is_opt_chain() || question_dot {
+                OptChainExpr {
+                    span: self.span(start),
+                    optional: question_dot,
+                    base: Box::new(OptChainBase::Member(expr)),
+                }
+                .into()
+            } else {
+                expr.into()
+            };
+
+            return Ok((Box::new(expr), true));
+        }
+
+        let cur = self.input().cur();
+        if matches!(
+            cur,
+            Token::TemplateHead | Token::NoSubstitutionTemplateLiteral | Token::BackQuote
+        ) {
+            let tpl = self.do_outside_of_context(Context::WillExpectColonForCond, |p| {
+                p.parse_tagged_tpl(callee, None)
+            })?;
+            return Ok((tpl.into(), true));
+        }
+
+        Ok((callee, false))
     }
 
     /// Section 13.3 ImportCall

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -2914,21 +2914,19 @@ impl<I: Tokens> Parser<I> {
             }
             .into())
         } else if cur == Token::Ident {
-            let token_start = self.input().cur_pos();
             let word = self.input_mut().expect_word_token_and_bump();
             if self.ctx().contains(Context::InClassField) && word == atom!("arguments") {
                 self.emit_err(self.input().prev_span(), SyntaxError::ArgumentsInClassField)
             };
-            let id = Ident::new_no_ctxt(word, self.span(token_start));
+            let id = Ident::new_no_ctxt(word, self.span(start));
             if !can_be_arrow {
                 return Ok(id.into());
             }
             try_parse_arrow_expr(self, id, false)
         } else if self.is_ident_ref() {
             let cur = self.input().cur();
-            let token_start = self.input().cur_pos();
             let word = self.input_mut().expect_word_token_and_bump();
-            let id = Ident::new_no_ctxt(word, self.span(token_start));
+            let id = Ident::new_no_ctxt(word, self.span(start));
             if !can_be_arrow {
                 return Ok(id.into());
             }

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -1991,14 +1991,15 @@ impl<I: Tokens> Parser<I> {
             return Ok((left, None));
         };
 
-        if op.precedence() <= min_prec {
+        let op_prec = op.precedence();
+        if op_prec <= min_prec {
             if cfg!(feature = "debug") {
                 tracing::trace!(
                     "returning {:?} without parsing {:?} because min_prec={}, prec={}",
                     left,
                     op,
                     min_prec,
-                    op.precedence()
+                    op_prec
                 );
             }
 
@@ -2022,7 +2023,7 @@ impl<I: Tokens> Parser<I> {
                 "parsing binary op {:?} min_prec={}, prec={}",
                 op,
                 min_prec,
-                op.precedence()
+                op_prec
             );
         }
         match *left {
@@ -2050,9 +2051,9 @@ impl<I: Tokens> Parser<I> {
                 left_of_right,
                 if op == op!("**") {
                     // exponential operator is right associative
-                    op.precedence() - 1
+                    op_prec - 1
                 } else {
-                    op.precedence()
+                    op_prec
                 },
             )?
         };

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -190,7 +190,11 @@ impl<I: Tokens> Parser<I> {
             _ => {}
         }
 
-        self.finish_assignment_expr(start, cond)
+        if self.input().cur().is_assign_op() {
+            self.finish_assignment_expr(start, cond)
+        } else {
+            Ok(cond)
+        }
     }
 
     #[allow(dead_code)]

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -319,7 +319,11 @@ impl<I: Tokens> Buffer<I> {
 
     pub fn expect_word_token_and_bump(&mut self) -> Atom {
         let cur = self.cur();
-        let word = cur.take_word(self);
+        let word = if cur == Token::Ident {
+            self.expect_word_token_value()
+        } else {
+            cur.take_word(self)
+        };
         self.bump();
         word
     }

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -353,7 +353,7 @@ impl<I: Tokens> Buffer<I> {
 
 impl<I: Tokens> Buffer<I> {
     pub fn had_line_break_before_cur(&self) -> bool {
-        self.get_cur().had_line_break
+        self.cur.had_line_break
     }
 
     /// This returns true on eof.
@@ -438,27 +438,28 @@ impl<I: Tokens> Buffer<I> {
 
     #[inline(always)]
     pub fn is(&self, expected: Token) -> bool {
-        self.cur() == expected
+        self.cur.token == expected
     }
 
     #[inline(always)]
     pub fn eat(&mut self, expected: Token) -> bool {
-        let v = self.is(expected);
-        if v {
+        if self.cur.token == expected {
             self.bump();
+            true
+        } else {
+            false
         }
-        v
     }
 
     /// Returns start of current token.
     #[inline]
     pub fn cur_pos(&self) -> BytePos {
-        self.get_cur().span.lo
+        self.cur.span.lo
     }
 
     #[inline]
     pub fn cur_span(&self) -> Span {
-        self.get_cur().span
+        self.cur.span
     }
 
     #[inline]
@@ -470,7 +471,7 @@ impl<I: Tokens> Buffer<I> {
     /// Returns last byte position of previous token.
     #[inline]
     pub fn last_pos(&self) -> BytePos {
-        self.prev_span().hi
+        self.prev_span.hi
     }
 
     #[inline]

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -304,12 +304,14 @@ impl<I: Tokens> Buffer<I> {
     }
 
     pub fn bump(&mut self) {
-        let next = match self.next.take() {
-            Some(next) => {
-                self.iter.set_token_value(next.value);
-                next.token_and_span
-            }
-            None => self.iter.next_token(),
+        let next = if self.next.is_none() {
+            self.iter.next_token()
+        } else {
+            let Some(next) = self.next.take() else {
+                unreachable!();
+            };
+            self.iter.set_token_value(next.value);
+            next.token_and_span
         };
         self.prev_span = self.cur.span;
         self.set_cur(next);

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -742,83 +742,81 @@ impl<I: Tokens> Parser<I> {
     /// spec: 'PropertyName'
     pub fn parse_prop_name(&mut self) -> PResult<PropName> {
         trace_cur!(self, parse_prop_name);
-        self.do_inside_of_context(Context::InPropertyName, |p| {
-            let start = p.input().cur_pos();
-            let cur = p.input().cur();
-            let v = if cur == Token::Str {
-                PropName::Str(p.parse_str_lit())
-            } else if cur == Token::Num {
-                let token_span = p.input.cur_span();
-                let value = p.input_mut().expect_number_token_value();
-                p.bump();
+        let start = self.input().cur_pos();
+        let cur = self.input().cur();
+        let v = if cur == Token::Str {
+            PropName::Str(self.parse_str_lit())
+        } else if cur == Token::Num {
+            let token_span = self.input.cur_span();
+            let value = self.input_mut().expect_number_token_value();
+            self.bump();
 
-                let raw = p.input.iter.read_string(token_span);
-                PropName::Num(Number {
-                    span: p.span(start),
-                    value,
-                    raw: Some(Atom::new(raw)),
-                })
-            } else if cur == Token::BigInt {
-                let token_span = p.input.cur_span();
-                let value = p.input_mut().expect_bigint_token_value();
-                p.bump();
+            let raw = self.input.iter.read_string(token_span);
+            PropName::Num(Number {
+                span: self.span(start),
+                value,
+                raw: Some(Atom::new(raw)),
+            })
+        } else if cur == Token::BigInt {
+            let token_span = self.input.cur_span();
+            let value = self.input_mut().expect_bigint_token_value();
+            self.bump();
 
-                let raw = p.input.iter.read_string(token_span);
-                PropName::BigInt(BigInt {
-                    span: p.span(start),
-                    value,
-                    raw: Some(Atom::new(raw)),
-                })
-            } else if p.syntax().flow()
-                && cur == Token::At
-                && peek!(p).is_some_and(|peek| peek == Token::At)
-            {
-                p.assert_and_bump(Token::At);
-                p.assert_and_bump(Token::At);
-                if !p.input().cur().is_word() {
-                    unexpected!(p, "identifier");
+            let raw = self.input.iter.read_string(token_span);
+            PropName::BigInt(BigInt {
+                span: self.span(start),
+                value,
+                raw: Some(Atom::new(raw)),
+            })
+        } else if self.syntax().flow()
+            && cur == Token::At
+            && peek!(self).is_some_and(|peek| peek == Token::At)
+        {
+            self.assert_and_bump(Token::At);
+            self.assert_and_bump(Token::At);
+            if !self.input().cur().is_word() {
+                unexpected!(self, "identifier");
+            }
+            let key = self.input_mut().expect_word_token_and_bump();
+            PropName::Str(Str {
+                span: self.span(start),
+                value: format!("@@{key}").into(),
+                raw: None,
+            })
+        } else if cur.is_word() {
+            let w = self.input_mut().expect_word_token_and_bump();
+            PropName::Ident(IdentName::new(w, self.span(start)))
+        } else if cur == Token::LBracket {
+            self.bump();
+            let inner_start = self.input().cur_pos();
+            let mut expr = self.allow_in_expr(Self::parse_assignment_expr)?;
+            if self.syntax().typescript() && self.input().is(Token::Comma) {
+                let mut exprs = vec![expr];
+                while self.input_mut().eat(Token::Comma) {
+                    //
+                    exprs.push(self.allow_in_expr(Self::parse_assignment_expr)?);
                 }
-                let key = p.input_mut().expect_word_token_and_bump();
-                PropName::Str(Str {
-                    span: p.span(start),
-                    value: format!("@@{key}").into(),
-                    raw: None,
-                })
-            } else if cur.is_word() {
-                let w = p.input_mut().expect_word_token_and_bump();
-                PropName::Ident(IdentName::new(w, p.span(start)))
-            } else if cur == Token::LBracket {
-                p.bump();
-                let inner_start = p.input().cur_pos();
-                let mut expr = p.allow_in_expr(Self::parse_assignment_expr)?;
-                if p.syntax().typescript() && p.input().is(Token::Comma) {
-                    let mut exprs = vec![expr];
-                    while p.input_mut().eat(Token::Comma) {
-                        //
-                        exprs.push(p.allow_in_expr(Self::parse_assignment_expr)?);
+                self.emit_err(self.span(inner_start), SyntaxError::TS1171);
+                expr = Box::new(
+                    SeqExpr {
+                        span: self.span(inner_start),
+                        exprs,
                     }
-                    p.emit_err(p.span(inner_start), SyntaxError::TS1171);
-                    expr = Box::new(
-                        SeqExpr {
-                            span: p.span(inner_start),
-                            exprs,
-                        }
-                        .into(),
-                    );
-                }
-                expect!(p, Token::RBracket);
-                PropName::Computed(ComputedPropName {
-                    span: p.span(start),
-                    expr,
-                })
-            } else {
-                unexpected!(
-                    p,
-                    "identifier, string literal, numeric literal or [ for the computed key"
-                )
-            };
-            Ok(v)
-        })
+                    .into(),
+                );
+            }
+            expect!(self, Token::RBracket);
+            PropName::Computed(ComputedPropName {
+                span: self.span(start),
+                expr,
+            })
+        } else {
+            unexpected!(
+                self,
+                "identifier, string literal, numeric literal or [ for the computed key"
+            )
+        };
+        Ok(v)
     }
 
     #[inline]

--- a/crates/swc_ecma_parser/src/parser/state.rs
+++ b/crates/swc_ecma_parser/src/parser/state.rs
@@ -6,13 +6,27 @@ use swc_common::{BytePos, Span};
 
 use crate::{input::Tokens, Parser};
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct State {
     pub labels: Vec<Atom>,
-    /// Start position of an assignment expression.
-    pub potential_arrow_start: Option<BytePos>,
+    /// Start position of an assignment expression that can become an arrow.
+    ///
+    /// `BytePos::SYNTHESIZED` is reserved outside real source positions, so it
+    /// works as the no-potential-arrow sentinel without the extra `Option`
+    /// branch on expression parser hot paths.
+    pub potential_arrow_start: BytePos,
     /// Start position of an AST node and the span of its trailing comma.
     pub trailing_commas: FxHashMap<BytePos, Span>,
+}
+
+impl Default for State {
+    fn default() -> Self {
+        State {
+            labels: Default::default(),
+            potential_arrow_start: BytePos::SYNTHESIZED,
+            trailing_commas: Default::default(),
+        }
+    }
 }
 
 pub struct WithState<'w, I: Tokens> {

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1907,12 +1907,13 @@ impl<I: Tokens> Parser<I> {
                 .map(Stmt::from);
         }
 
+        let top_level = self.ctx().contains(Context::TopLevel);
+
         let cur = self.input().cur();
-        if cur == Token::Ident && self.is_flow_match_keyword() {
+        if self.is_flow_match_keyword() {
             return self.parse_flow_match_stmt(start);
         }
 
-        let top_level = self.ctx().contains(Context::TopLevel);
         if cur == Token::Await && (include_decl || top_level) {
             if top_level {
                 self.mark_found_module_item();
@@ -1937,7 +1938,7 @@ impl<I: Tokens> Parser<I> {
                 return Ok(ExprStmt { span, expr }.into());
             }
         } else if cur == Token::Break || cur == Token::Continue {
-            let is_break = cur == Token::Break;
+            let is_break = self.input().is(Token::Break);
             self.bump();
             let label = if self.eat_general_semi() {
                 None
@@ -2083,7 +2084,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         // Handle async function foo() {}
-        if cur == Token::Async
+        if self.input().is(Token::Async)
             && peek!(self).is_some_and(|peek| peek == Token::Function)
             && !self.input_mut().has_linebreak_between_cur_and_peeked()
         {
@@ -2095,7 +2096,7 @@ impl<I: Tokens> Parser<I> {
         // simply start parsing an expression, and afterwards, if the
         // next token is a colon and the expression was a simple
         // Identifier node, we switch to interpreting it as a label.
-        let expr_token = cur;
+        let expr_token = self.input().cur();
         let expr = self.allow_in_expr(|p| p.parse_expr())?;
 
         let expr = match *expr {

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -130,9 +130,11 @@ impl<I: Tokens> Parser<I> {
         let start = self.cur_pos();
 
         let is_let_or_const = matches!(kind, VarDeclKind::Let | VarDeclKind::Const);
-        let is_typescript = self.input().syntax().typescript();
 
         let mut name = self.parse_binding_pat_or_ident(is_let_or_const)?;
+        let cur = self.input().cur();
+        let is_typescript =
+            matches!(cur, Token::Bang | Token::Colon) && self.input().syntax().typescript();
 
         let definite = if is_typescript {
             match name {

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -130,10 +130,11 @@ impl<I: Tokens> Parser<I> {
         let start = self.cur_pos();
 
         let is_let_or_const = matches!(kind, VarDeclKind::Let | VarDeclKind::Const);
+        let is_typescript = self.input().syntax().typescript();
 
         let mut name = self.parse_binding_pat_or_ident(is_let_or_const)?;
 
-        let definite = if self.input().syntax().typescript() {
+        let definite = if is_typescript {
             match name {
                 Pat::Ident(..) => self.input_mut().eat(Token::Bang),
                 _ => false,
@@ -143,7 +144,7 @@ impl<I: Tokens> Parser<I> {
         };
 
         // Typescript extension
-        if self.input().syntax().typescript() && self.input().is(Token::Colon) {
+        if is_typescript && self.input().is(Token::Colon) {
             let type_annotation = self.try_parse_ts_type_ann()?;
             match name {
                 Pat::Array(ArrayPat {
@@ -2194,28 +2195,31 @@ impl<I: Tokens> Parser<I> {
         };
 
         let parse_stmts = |p: &mut Self, stmts: &mut Vec<Type>| -> PResult<()> {
-            let is_stmt_start = |p: &mut Self| {
-                let cur = p.input().cur();
-                match end {
-                    Some(end) => {
-                        if cur == Token::Eof {
-                            let eof_text = p.input_mut().dump_cur();
-                            p.emit_err(
-                                p.input().cur_span(),
-                                SyntaxError::Expected(format!("{end:?}"), eof_text),
-                            );
-                            false
-                        } else {
-                            cur != end
-                        }
+            if let Some(end) = end {
+                loop {
+                    let cur = p.input().cur();
+                    if cur == Token::Eof {
+                        let eof_text = p.input_mut().dump_cur();
+                        p.emit_err(
+                            p.input().cur_span(),
+                            SyntaxError::Expected(format!("{end:?}"), eof_text),
+                        );
+                        break;
                     }
-                    None => cur != Token::Eof,
+                    if cur == end {
+                        break;
+                    }
+
+                    let stmt = p.parse_stmt_like(true, &handle_import_export)?;
+                    stmts.push(stmt);
                 }
-            };
-            while is_stmt_start(p) {
-                let stmt = p.parse_stmt_like(true, &handle_import_export)?;
-                stmts.push(stmt);
+            } else {
+                while p.input().cur() != Token::Eof {
+                    let stmt = p.parse_stmt_like(true, &handle_import_export)?;
+                    stmts.push(stmt);
+                }
             }
+
             Ok(())
         };
 

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1907,13 +1907,12 @@ impl<I: Tokens> Parser<I> {
                 .map(Stmt::from);
         }
 
-        let top_level = self.ctx().contains(Context::TopLevel);
-
         let cur = self.input().cur();
-        if self.is_flow_match_keyword() {
+        if cur == Token::Ident && self.is_flow_match_keyword() {
             return self.parse_flow_match_stmt(start);
         }
 
+        let top_level = self.ctx().contains(Context::TopLevel);
         if cur == Token::Await && (include_decl || top_level) {
             if top_level {
                 self.mark_found_module_item();
@@ -1938,7 +1937,7 @@ impl<I: Tokens> Parser<I> {
                 return Ok(ExprStmt { span, expr }.into());
             }
         } else if cur == Token::Break || cur == Token::Continue {
-            let is_break = self.input().is(Token::Break);
+            let is_break = cur == Token::Break;
             self.bump();
             let label = if self.eat_general_semi() {
                 None
@@ -2084,7 +2083,7 @@ impl<I: Tokens> Parser<I> {
         }
 
         // Handle async function foo() {}
-        if self.input().is(Token::Async)
+        if cur == Token::Async
             && peek!(self).is_some_and(|peek| peek == Token::Function)
             && !self.input_mut().has_linebreak_between_cur_and_peeked()
         {
@@ -2096,7 +2095,7 @@ impl<I: Tokens> Parser<I> {
         // simply start parsing an expression, and afterwards, if the
         // next token is a colon and the expression was a simple
         // Identifier node, we switch to interpreting it as a label.
-        let expr_token = self.input().cur();
+        let expr_token = cur;
         let expr = self.allow_in_expr(|p| p.parse_expr())?;
 
         let expr = match *expr {

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -97,9 +97,8 @@ impl<I: Tokens> Parser<I> {
     }
 
     fn parse_return_stmt(&mut self) -> PResult<Stmt> {
-        let start = self.cur_pos();
-
         self.assert_and_bump(Token::Return);
+        let start = self.input().prev_span().lo;
 
         let arg = if self.is_general_semi() {
             None

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -1717,7 +1717,7 @@ impl<I: Tokens> Parser<I> {
                     | Token::NoSubstitutionTemplateLiteral
                     | Token::TemplateHead
                     | Token::BackQuote
-            )
+            ) || cur.is_assign_op()
             // these should be type
             // arguments in function
             // call or template, not


### PR DESCRIPTION
**Description:**

Optimize `swc_ecma_parser` parser/lexer hot paths found with callgrind.

This keeps parser behavior intact while reducing repeated work in high-frequency paths:

- skip empty pending-comment drains and empty comment finalization
- reduce token finalization overhead when comments are disabled
- tighten byte-search loops in the lexer
- trim parser buffer token access and avoid taking empty lookahead
- move identifier atoms when bumping instead of cloning them
- inline word and string-literal extraction on hot parser paths
- cache expression syntax flags and reuse current-token positions
- split non-TypeScript subscript parsing to avoid type-argument work on JS/Flow paths
- use function pointers for keyword lookup instead of trait-object callbacks
- cache binary operator precedence within recursive binary parsing
- stop whitespace scanning early for ordinary ASCII token starts
- skip arrow-expression checks for identifier paths that cannot form arrows
- avoid reading token spans on common expression paths
- skip assignment finishing when the current token is not an assignment operator
- skip final nullish/logical mix checks when binary parsing is done
- delay lhs expression start-position reads until spans need them
- check common arrow-start tokens before the wider known-identifier range
- scan ASCII identifier/keyword bodies with a single input bump
- avoid an unused lexer position read before scanning the next token
- delay sequence expression start-position reads until a comma is present
- delay spread expression start-position reads until spread is present
- delay assignment expression start-position reads until arrows or assignments need them
- delay conditional expression start-position reads until a ternary branch is present
- delay member expression start-position reads until `new`, `super`, `import`, or TS type args need them
- reuse primary expression start positions when constructing identifier spans
- skip postfix line-break checks unless `++` or `--` is present
- skip assignment target shape checks unless an assignment operator is present
- skip TypeScript binary `as` / `satisfies` checks unless the current token can use them
- avoid allocating argument vectors for empty call argument lists
- avoid allocating element vectors for empty array literals
- skip arrow line-break checks unless the following token can form an arrow
- dispatch `new`, `super`, and `import` member-expression starts from one token read
- specialize subscript loops for non-TypeScript parsing
- check for `yield` before reading generator context
- dispatch non-TypeScript subscript starts from one token read
- defer TypeScript `as` / `satisfies` parsing until ordinary binary operators are ruled out
- gate prefix-unary parsing by token before checking individual prefix forms
- gate postfix update parsing with the contiguous `++` / `--` token range
- dispatch spread expressions from one token read
- check for `<` before reading syntax for member type arguments
- skip unused property-name context changes
- gate member-expression lex context changes by type mode
- parse ordinary dot subscripts before call and computed subscript checks
- simplify optional dot-subscript wrapping checks
- dispatch subscript starts and optional chaining from one token match
- delay subscript start-position reads until a subscript needs them
- fast-path expression callees in subscript parsing
- specialize computed-subscript parsing by call site
- gate subscript parsing before reading syntax
- gate var declarator TypeScript parsing by token
- gate binary lhs shape checks by operator
- move nullish/logical mix checks into binary parsing
- reuse the bumped return-token span for return statements
- fast-path ordinary array elements and call arguments without spread handling
- inline hot word-token, identifier-name, and binding-identifier parsing
- dispatch lhs/member `new`, `super`, and `import` special tokens with token matches

Latest CodSpeed-style parser callgrind workload:

```text
build:   cargo codspeed build -p swc_ecma_parser --bench parser
command: CODSPEED_CARGO_WORKSPACE_ROOT=$PWD valgrind --tool=callgrind --instr-atstart=no --callgrind-out-file=/tmp/swc-codspeed-parser-match-member-special.callgrind --collect-jumps=no --collect-systime=no target/codspeed/analysis/swc_ecma_parser/parser

baseline: 875,210,708 Ir  (/tmp/swc-codspeed-parser-baseline.callgrind.{2..12}, a236a41749)
current:  852,667,335 Ir  (/tmp/swc-codspeed-parser-match-member-special.callgrind.{2..12}, de7eb7ac21)
delta:    -22,543,373 Ir (-2.576%)
```

Latest incremental local callgrind since reapplying the plain-spread fast path:

```text
baseline: 870,975,340 Ir  (/tmp/swc-codspeed-parser-reapply-plain-spread.callgrind.{2..12}, a27495cabd)
current:  852,667,335 Ir  (/tmp/swc-codspeed-parser-match-member-special.callgrind.{2..12}, de7eb7ac21)
delta:    -18,308,005 Ir (-2.102%)
```

GitHub Benchmark workflow:

```text
de7eb7ac21: run 25829486613 in progress
a27495cabd: run 25828795155 success
```

Earlier local Criterion comparison against `origin/main` for the comment-finalization series:

```text
colors   origin-main2_mean=  4838.951 head5_mean=  4664.744 speedup=   3.60%
angular  origin-main2_mean=5095352.018 head5_mean=3438250.304 speedup=  32.52%
```

Validation:

- `git submodule update --init --recursive`
- `cargo fmt --all --check`
- `cargo test -p swc_ecma_parser --lib`
- `cargo test -p swc_ecma_parser --test js`
- `cargo codspeed build -p swc_ecma_parser --bench parser`
- CodSpeed-style local callgrind with valgrind for parser bench
- Earlier in this branch: `cargo test -p swc_ecma_parser --test jsx` and `cargo test -p swc_ecma_parser --test comments`
- Known unrelated full TypeScript fixture failure: `errors_tests__typescript_errors__type_only_import_specifier__invalid_type_only__input_ts`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.
