### PR TITLE
perf(es/minifier): reduce minifier profiling hotspots

### DIFF
--- a/.changeset/wet-bobcats-relate.md
+++ b/.changeset/wet-bobcats-relate.md
@@ -1,0 +1,9 @@
+---
+swc_ecma_minifier: patch
+swc_ecma_transforms_base: patch
+swc_ecma_transforms_optimization: patch
+swc_ecma_utils: patch
+swc_core: patch
+---
+
+perf(es/minifier): reduce minifier profiling hotspots

--- a/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
@@ -29,6 +29,15 @@ impl Optimizer<'_> {
         self.eval_global_vars(e);
     }
 
+    #[inline]
+    fn is_declared_ident(&self, i: &Ident) -> bool {
+        self.data
+            .vars
+            .get(&i.to_id())
+            .map(|var| var.flags.contains(VarUsageInfoFlags::DECLARED))
+            .unwrap_or(false)
+    }
+
     fn eval_fn_props(&mut self, e: &mut Expr) -> Option<()> {
         if self
             .ctx
@@ -100,48 +109,55 @@ impl Optimizer<'_> {
             return;
         }
 
-        // We should not convert used-defined `undefined` to `void 0`.
-        if let Expr::Ident(i) = e {
-            if self
-                .data
-                .vars
-                .get(&i.to_id())
-                .map(|var| var.flags.contains(VarUsageInfoFlags::DECLARED))
-                .unwrap_or(false)
-            {
-                return;
+        enum IdentGlobal {
+            Undefined,
+            Infinity,
+        }
+
+        let ident_global = match e {
+            // We should not convert used-defined `undefined` to `void 0`.
+            Expr::Ident(i) if &*i.sym == "undefined" && !self.is_declared_ident(i) => {
+                Some((i.span, IdentGlobal::Undefined))
             }
+            Expr::Ident(i) if &*i.sym == "Infinity" && !self.is_declared_ident(i) => {
+                Some((i.span, IdentGlobal::Infinity))
+            }
+            _ => None,
+        };
+
+        if let Some((span, kind)) = ident_global {
+            match kind {
+                IdentGlobal::Undefined => {
+                    report_change!("evaluate: `undefined` -> `void 0`");
+                    self.changed = true;
+                    *e = *Expr::undefined(span);
+                }
+                IdentGlobal::Infinity => {
+                    report_change!("evaluate: `Infinity` -> `1 / 0`");
+                    self.changed = true;
+                    *e = BinExpr {
+                        span,
+                        op: op!("/"),
+                        left: Lit::Num(Number {
+                            span: DUMMY_SP,
+                            value: 1.0,
+                            raw: None,
+                        })
+                        .into(),
+                        right: Lit::Num(Number {
+                            span: DUMMY_SP,
+                            value: 0.0,
+                            raw: None,
+                        })
+                        .into(),
+                    }
+                    .into();
+                }
+            }
+            return;
         }
 
         match e {
-            Expr::Ident(Ident { span, sym, .. }) if &**sym == "undefined" => {
-                report_change!("evaluate: `undefined` -> `void 0`");
-                self.changed = true;
-                *e = *Expr::undefined(*span);
-            }
-
-            Expr::Ident(Ident { span, sym, .. }) if &**sym == "Infinity" => {
-                report_change!("evaluate: `Infinity` -> `1 / 0`");
-                self.changed = true;
-                *e = BinExpr {
-                    span: *span,
-                    op: op!("/"),
-                    left: Lit::Num(Number {
-                        span: DUMMY_SP,
-                        value: 1.0,
-                        raw: None,
-                    })
-                    .into(),
-                    right: Lit::Num(Number {
-                        span: DUMMY_SP,
-                        value: 0.0,
-                        raw: None,
-                    })
-                    .into(),
-                }
-                .into();
-            }
-
             Expr::Member(MemberExpr {
                 obj,
                 prop: MemberProp::Ident(prop),

--- a/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/evaluate.rs
@@ -25,6 +25,10 @@ impl Optimizer<'_> {
         self.eval_known_static_method_call(e);
     }
 
+    pub(super) fn evaluate_ident(&mut self, e: &mut Expr) {
+        self.eval_global_vars(e);
+    }
+
     fn eval_fn_props(&mut self, e: &mut Expr) -> Option<()> {
         if self
             .ctx

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -1916,7 +1916,7 @@ impl VisitMut for Optimizer<'_> {
         }
 
         // This is not accurate check but avoid some trivial cases.
-        if self.changed {
+        if self.changed && matches!(e, Expr::Bin(..)) {
             self.remove_invalid_bin(e);
         }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -1858,7 +1858,7 @@ impl VisitMut for Optimizer<'_> {
             self.inline(e);
 
             if matches!(e, Expr::Ident(..)) {
-                self.evaluate(e);
+                self.evaluate_ident(e);
 
                 #[cfg(feature = "trace-ast")]
                 tracing::debug!("Output: {}", dump(e, true));

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -1960,7 +1960,15 @@ impl VisitMut for Optimizer<'_> {
             debug_assert_valid(e);
         }
 
-        self.compress_logical_exprs_as_bang_bang(e, false);
+        if matches!(
+            &*e,
+            Expr::Bin(BinExpr {
+                op: op!("&&") | op!("||"),
+                ..
+            })
+        ) {
+            self.compress_logical_exprs_as_bang_bang(e, false);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -629,6 +629,13 @@ impl Optimizer<'_> {
         }
     }
 
+    fn bin_has_direct_invalid_child(e: &Expr) -> bool {
+        matches!(
+            e,
+            Expr::Bin(BinExpr { left, right, .. }) if left.is_invalid() || right.is_invalid()
+        )
+    }
+
     /// Returns [None] if expression is side-effect-free.
     /// If an expression has a side effect, only side effects are returned.
     #[cfg_attr(feature = "debug", tracing::instrument(level = "debug", skip_all))]
@@ -1929,8 +1936,21 @@ impl VisitMut for Optimizer<'_> {
                 debug_assert_valid(e);
             }
 
-            // This is not accurate check but avoid some trivial cases.
-            if self.changed && matches!(e, Expr::Bin(..)) {
+            let should_remove_invalid = match e {
+                Expr::Bin(BinExpr {
+                    op, left, right, ..
+                }) => {
+                    left.is_invalid()
+                        || right.is_invalid()
+                        || self.changed
+                            && matches!(op, op!("&&") | op!("||"))
+                            && (Self::bin_has_direct_invalid_child(left)
+                                || Self::bin_has_direct_invalid_child(right))
+                }
+                _ => false,
+            };
+
+            if should_remove_invalid {
                 self.remove_invalid_bin(e);
             }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -1852,129 +1852,144 @@ impl VisitMut for Optimizer<'_> {
             .entered()
         };
 
-        let ctx = self
-            .ctx
-            .clone()
-            .with(BitCtx::IsExported, false)
-            .with(BitCtx::IsCallee, false);
-        e.visit_mut_children_with(&mut *self.with_ctx(ctx));
+        let is_ident = matches!(e, Expr::Ident(..));
 
-        #[cfg(feature = "trace-ast")]
-        let _tracing = {
-            let s = dump(&*e, true);
-            tracing::span!(
-                tracing::Level::ERROR,
-                "visit_mut_expr_after_children",
-                src = tracing::field::display(&s)
-            )
-            .entered()
-        };
+        if is_ident {
+            self.inline(e);
 
-        match e {
-            Expr::Seq(seq) if seq.exprs.len() == 1 => {
-                let span = seq.span;
-                *e = *seq.exprs[0].take();
-                e.set_span(span);
+            if matches!(e, Expr::Ident(..)) {
+                self.evaluate(e);
+
+                #[cfg(feature = "trace-ast")]
+                tracing::debug!("Output: {}", dump(e, true));
+
+                return;
             }
+        } else {
+            let ctx = self
+                .ctx
+                .clone()
+                .with(BitCtx::IsExported, false)
+                .with(BitCtx::IsCallee, false);
+            e.visit_mut_children_with(&mut *self.with_ctx(ctx));
 
-            Expr::Assign(AssignExpr {
-                op: op!("="),
-                left,
-                right,
-                ..
-            }) => {
-                if let Some(i) = left.as_ident_mut() {
-                    let old = i.to_id();
+            #[cfg(feature = "trace-ast")]
+            let _tracing = {
+                let s = dump(&*e, true);
+                tracing::span!(
+                    tracing::Level::ERROR,
+                    "visit_mut_expr_after_children",
+                    src = tracing::field::display(&s)
+                )
+                .entered()
+            };
 
-                    self.store_var_for_inlining(i, right, false);
-
-                    if i.is_dummy() && self.options.unused {
-                        report_change!("inline: Removed variable ({}, {:?})", old.0, old.1);
-                        self.vars.removed.insert(old.clone());
-                    }
-
-                    if right.is_invalid() {
-                        if let Some(lit) = self
-                            .vars
-                            .lits
-                            .get(&old)
-                            .or_else(|| self.vars.vars_for_inlining.get(&old))
-                        {
-                            *e = (**lit).clone();
-                        }
-                    }
+            match e {
+                Expr::Seq(seq) if seq.exprs.len() == 1 => {
+                    let span = seq.span;
+                    *e = *seq.exprs[0].take();
+                    e.set_span(span);
                 }
 
-                self.lift_seqs_of_assign(e)
+                Expr::Assign(AssignExpr {
+                    op: op!("="),
+                    left,
+                    right,
+                    ..
+                }) => {
+                    if let Some(i) = left.as_ident_mut() {
+                        let old = i.to_id();
+
+                        self.store_var_for_inlining(i, right, false);
+
+                        if i.is_dummy() && self.options.unused {
+                            report_change!("inline: Removed variable ({}, {:?})", old.0, old.1);
+                            self.vars.removed.insert(old.clone());
+                        }
+
+                        if right.is_invalid() {
+                            if let Some(lit) = self
+                                .vars
+                                .lits
+                                .get(&old)
+                                .or_else(|| self.vars.vars_for_inlining.get(&old))
+                            {
+                                *e = (**lit).clone();
+                            }
+                        }
+                    }
+
+                    self.lift_seqs_of_assign(e)
+                }
+
+                _ => {}
             }
 
-            _ => {}
+            if e.is_seq() {
+                debug_assert_valid(e);
+            }
+
+            // This is not accurate check but avoid some trivial cases.
+            if self.changed && matches!(e, Expr::Bin(..)) {
+                self.remove_invalid_bin(e);
+            }
+
+            if e.is_seq() {
+                debug_assert_valid(e);
+            }
+
+            self.optimize_str_access_to_arguments(e);
+
+            if e.is_seq() {
+                debug_assert_valid(e);
+            }
+
+            self.replace_props(e);
+
+            if e.is_seq() {
+                debug_assert_valid(e);
+            }
+
+            self.drop_unused_assignments(e);
+
+            if e.is_seq() {
+                debug_assert_valid(e);
+            }
+
+            self.compress_lits(e);
+
+            if e.is_seq() {
+                debug_assert_valid(e);
+            }
+
+            self.compress_typeofs(e);
+
+            if e.is_seq() {
+                debug_assert_valid(e);
+            }
+
+            self.drop_console(e);
+
+            if e.is_seq() {
+                debug_assert_valid(e);
+            }
+
+            if matches!(
+                &*e,
+                Expr::Bin(BinExpr {
+                    op: op!("&&") | op!("||"),
+                    ..
+                })
+            ) {
+                self.compress_logical_exprs_as_bang_bang(e, false);
+            }
+
+            if e.is_seq() {
+                debug_assert_valid(e);
+            }
+
+            self.inline(e);
         }
-
-        if e.is_seq() {
-            debug_assert_valid(e);
-        }
-
-        // This is not accurate check but avoid some trivial cases.
-        if self.changed && matches!(e, Expr::Bin(..)) {
-            self.remove_invalid_bin(e);
-        }
-
-        if e.is_seq() {
-            debug_assert_valid(e);
-        }
-
-        self.optimize_str_access_to_arguments(e);
-
-        if e.is_seq() {
-            debug_assert_valid(e);
-        }
-
-        self.replace_props(e);
-
-        if e.is_seq() {
-            debug_assert_valid(e);
-        }
-
-        self.drop_unused_assignments(e);
-
-        if e.is_seq() {
-            debug_assert_valid(e);
-        }
-
-        self.compress_lits(e);
-
-        if e.is_seq() {
-            debug_assert_valid(e);
-        }
-
-        self.compress_typeofs(e);
-
-        if e.is_seq() {
-            debug_assert_valid(e);
-        }
-
-        self.drop_console(e);
-
-        if e.is_seq() {
-            debug_assert_valid(e);
-        }
-
-        if matches!(
-            &*e,
-            Expr::Bin(BinExpr {
-                op: op!("&&") | op!("||"),
-                ..
-            })
-        ) {
-            self.compress_logical_exprs_as_bang_bang(e, false);
-        }
-
-        if e.is_seq() {
-            debug_assert_valid(e);
-        }
-
-        self.inline(e);
 
         if e.is_seq() {
             debug_assert_valid(e);

--- a/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
@@ -182,8 +182,24 @@ impl Optimizer<'_> {
             return;
         }
 
-        self.compress_logical_exprs_as_bang_bang(&mut bin.left, true);
-        self.compress_logical_exprs_as_bang_bang(&mut bin.right, true);
+        if matches!(
+            &*bin.left,
+            Expr::Bin(BinExpr {
+                op: op!("&&") | op!("||"),
+                ..
+            })
+        ) {
+            self.compress_logical_exprs_as_bang_bang(&mut bin.left, true);
+        }
+        if matches!(
+            &*bin.right,
+            Expr::Bin(BinExpr {
+                op: op!("&&") | op!("||"),
+                ..
+            })
+        ) {
+            self.compress_logical_exprs_as_bang_bang(&mut bin.right, true);
+        }
 
         let lt = bin.left.get_type(self.ctx.expr_ctx);
         match lt {

--- a/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
@@ -178,14 +178,12 @@ impl Optimizer<'_> {
             _ => return,
         };
 
-        match bin.op {
-            op!("&&") | op!("||") => {
-                self.compress_logical_exprs_as_bang_bang(&mut bin.left, true);
-                self.compress_logical_exprs_as_bang_bang(&mut bin.right, true);
-            }
-
-            _ => {}
+        if !matches!(bin.op, op!("&&") | op!("||")) {
+            return;
         }
+
+        self.compress_logical_exprs_as_bang_bang(&mut bin.left, true);
+        self.compress_logical_exprs_as_bang_bang(&mut bin.right, true);
 
         let lt = bin.left.get_type(self.ctx.expr_ctx);
         match lt {

--- a/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/sequences.rs
@@ -1099,6 +1099,7 @@ impl Optimizer<'_> {
                 Mergable::Drop => return false,
             }
 
+            let e_id = e.to_id();
             let ids_used_by_a_init = match a {
                 Mergable::Var(a) => a.init.as_ref().map(|init| {
                     try_collect_infects_from(
@@ -1140,14 +1141,14 @@ impl Optimizer<'_> {
                     return false;
                 };
 
-                if deps.contains(&(e.to_id(), AccessKind::Reference))
-                    || deps.contains(&(e.to_id(), AccessKind::Call))
-                {
+                if deps.iter().any(|(id, kind)| {
+                    id == &e_id && matches!(kind, AccessKind::Reference | AccessKind::Call)
+                }) {
                     return false;
                 }
             }
 
-            if !self.assignee_skippable_for_seq(a, e) {
+            if !self.assignee_skippable_for_seq(a, &e_id) {
                 return false;
             }
         }
@@ -1461,8 +1462,8 @@ impl Optimizer<'_> {
         }
     }
 
-    fn assignee_skippable_for_seq(&self, a: &Mergable, assignee: &Ident) -> bool {
-        let usgae = if let Some(usage) = self.data.vars.get(&assignee.to_id()) {
+    fn assignee_skippable_for_seq(&self, a: &Mergable, assignee: &Id) -> bool {
+        let usgae = if let Some(usage) = self.data.vars.get(assignee) {
             usage
         } else {
             return false;

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -498,9 +498,19 @@ impl VisitMut for Finalizer<'_> {
     }
 
     fn visit_mut_expr(&mut self, n: &mut Expr) {
+        let can_replace_lit = !self.lits.is_empty();
+        let can_replace_hoisted_prop = !self.hoisted_props.is_empty();
+
+        if !can_replace_lit && !can_replace_hoisted_prop {
+            if !matches!(n, Expr::Ident(..)) {
+                n.visit_mut_children_with(self);
+            }
+            return;
+        }
+
         match n {
             Expr::Ident(i) => {
-                if !self.lits.is_empty() {
+                if can_replace_lit {
                     if let Some(expr) = self.lits.get(&i.to_id()) {
                         *n = *expr.clone();
                     }
@@ -508,7 +518,7 @@ impl VisitMut for Finalizer<'_> {
 
                 return;
             }
-            Expr::Member(e) if !self.hoisted_props.is_empty() => 'a: {
+            Expr::Member(e) if can_replace_hoisted_prop => 'a: {
                 if let Expr::Ident(obj) = &*e.obj {
                     let sym = match &e.prop {
                         MemberProp::Ident(i) => i.sym.borrow(),

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -462,6 +462,10 @@ impl VisitMut for Finalizer<'_> {
     fn visit_mut_bin_expr(&mut self, e: &mut BinExpr) {
         e.visit_mut_children_with(self);
 
+        if self.lits_for_cmp.is_empty() {
+            return;
+        }
+
         match e.op {
             op!("===") | op!("!==") | op!("==") | op!("!=") => {
                 //
@@ -478,6 +482,10 @@ impl VisitMut for Finalizer<'_> {
     fn visit_mut_callee(&mut self, e: &mut Callee) {
         e.visit_mut_children_with(self);
 
+        if self.simple_functions.is_empty() {
+            return;
+        }
+
         if let Callee::Expr(e) = e {
             self.check(e, FinalizerMode::Callee);
         }
@@ -491,13 +499,13 @@ impl VisitMut for Finalizer<'_> {
 
     fn visit_mut_expr(&mut self, n: &mut Expr) {
         match n {
-            Expr::Ident(i) => {
+            Expr::Ident(i) if !self.lits.is_empty() => {
                 if let Some(expr) = self.lits.get(&i.to_id()) {
                     *n = *expr.clone();
                     return;
                 }
             }
-            Expr::Member(e) => 'a: {
+            Expr::Member(e) if !self.hoisted_props.is_empty() => 'a: {
                 if let Expr::Ident(obj) = &*e.obj {
                     let sym = match &e.prop {
                         MemberProp::Ident(i) => i.sym.borrow(),
@@ -536,6 +544,10 @@ impl VisitMut for Finalizer<'_> {
 
     fn visit_mut_member_expr(&mut self, e: &mut MemberExpr) {
         e.visit_mut_children_with(self);
+
+        if self.lits_for_array_access.is_empty() {
+            return;
+        }
 
         if let MemberProp::Computed(prop) = &mut e.prop {
             if let Expr::Lit(Lit::Num(..)) = &*prop.expr {
@@ -591,6 +603,10 @@ impl VisitMut for Finalizer<'_> {
     fn visit_mut_var_declarator(&mut self, n: &mut VarDeclarator) {
         n.visit_mut_children_with(self);
 
+        if self.vars_to_remove.is_empty() {
+            return;
+        }
+
         if n.init.is_none() {
             if let Pat::Ident(i) = &n.name {
                 if self.vars_to_remove.contains(&i.to_id()) {
@@ -608,6 +624,10 @@ impl VisitMut for Finalizer<'_> {
 
     fn visit_mut_prop(&mut self, n: &mut Prop) {
         n.visit_mut_children_with(self);
+
+        if self.lits.is_empty() {
+            return;
+        }
 
         if let Prop::Shorthand(i) = n {
             if let Some(expr) = self.lits.get(&i.to_id()) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -692,11 +692,6 @@ impl VisitMut for NormalMultiReplacer<'_> {
         if self.vars.is_empty() {
             return;
         }
-        e.visit_mut_children_with(self);
-
-        if self.vars.is_empty() {
-            return;
-        }
 
         if let Expr::Ident(i) = e {
             if let Some(new) = self.var(&i.to_id()) {
@@ -705,7 +700,11 @@ impl VisitMut for NormalMultiReplacer<'_> {
 
                 *e = *new;
             }
+
+            return;
         }
+
+        e.visit_mut_children_with(self);
     }
 
     fn visit_mut_module_items(&mut self, items: &mut Vec<ModuleItem>) {

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -499,11 +499,14 @@ impl VisitMut for Finalizer<'_> {
 
     fn visit_mut_expr(&mut self, n: &mut Expr) {
         match n {
-            Expr::Ident(i) if !self.lits.is_empty() => {
-                if let Some(expr) = self.lits.get(&i.to_id()) {
-                    *n = *expr.clone();
-                    return;
+            Expr::Ident(i) => {
+                if !self.lits.is_empty() {
+                    if let Some(expr) = self.lits.get(&i.to_id()) {
+                        *n = *expr.clone();
+                    }
                 }
+
+                return;
             }
             Expr::Member(e) if !self.hoisted_props.is_empty() => 'a: {
                 if let Expr::Ident(obj) = &*e.obj {

--- a/crates/swc_ecma_minifier/src/compress/pure/bools.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/bools.rs
@@ -10,6 +10,20 @@ use crate::{
     util::make_bool,
 };
 
+#[inline(always)]
+pub(super) fn may_make_bool_short(e: &Expr) -> bool {
+    matches!(
+        e,
+        Expr::Cond(..)
+            | Expr::Bin(..)
+            | Expr::Unary(UnaryExpr { op: op!("!"), .. })
+            | Expr::Array(..)
+            | Expr::Call(..)
+            | Expr::Seq(..)
+            | Expr::Assign(..)
+    )
+}
+
 impl Pure<'_> {
     pub(super) fn compress_if_stmt_as_expr(&mut self, s: &mut Stmt) {
         if !self.options.conditionals && !self.options.bools {
@@ -48,9 +62,15 @@ impl Pure<'_> {
     ) {
         match e {
             Expr::Cond(cond) => {
-                self.make_bool_short(&mut cond.test, true, false);
-                self.make_bool_short(&mut cond.cons, in_bool_ctx, ignore_return_value);
-                self.make_bool_short(&mut cond.alt, in_bool_ctx, ignore_return_value);
+                if may_make_bool_short(&cond.test) {
+                    self.make_bool_short(&mut cond.test, true, false);
+                }
+                if may_make_bool_short(&cond.cons) {
+                    self.make_bool_short(&mut cond.cons, in_bool_ctx, ignore_return_value);
+                }
+                if may_make_bool_short(&cond.alt) {
+                    self.make_bool_short(&mut cond.alt, in_bool_ctx, ignore_return_value);
+                }
 
                 if negate_cost(self.expr_ctx, &cond.test, true, false) >= 0 {
                     return;
@@ -66,8 +86,12 @@ impl Pure<'_> {
                 right,
                 ..
             }) => {
-                self.make_bool_short(left, in_bool_ctx, false);
-                self.make_bool_short(right, in_bool_ctx, ignore_return_value);
+                if may_make_bool_short(left) {
+                    self.make_bool_short(left, in_bool_ctx, false);
+                }
+                if may_make_bool_short(right) {
+                    self.make_bool_short(right, in_bool_ctx, ignore_return_value);
+                }
 
                 if in_bool_ctx {
                     match *op {
@@ -103,32 +127,44 @@ impl Pure<'_> {
             }
 
             Expr::Bin(BinExpr { left, right, .. }) => {
-                self.make_bool_short(left, false, false);
-                self.make_bool_short(right, false, false);
+                if may_make_bool_short(left) {
+                    self.make_bool_short(left, false, false);
+                }
+                if may_make_bool_short(right) {
+                    self.make_bool_short(right, false, false);
+                }
                 return;
             }
 
             Expr::Unary(UnaryExpr {
                 op: op!("!"), arg, ..
             }) => {
-                self.make_bool_short(arg, true, ignore_return_value);
+                if may_make_bool_short(arg) {
+                    self.make_bool_short(arg, true, ignore_return_value);
+                }
                 return;
             }
 
             Expr::Array(ArrayLit { elems, .. }) => {
                 for elem in elems.iter_mut().flatten() {
-                    self.make_bool_short(&mut elem.expr, false, false);
+                    if may_make_bool_short(&elem.expr) {
+                        self.make_bool_short(&mut elem.expr, false, false);
+                    }
                 }
                 return;
             }
 
             Expr::Call(CallExpr { callee, args, .. }) => {
                 if let Callee::Expr(callee) = callee {
-                    self.make_bool_short(callee, false, false);
+                    if may_make_bool_short(callee) {
+                        self.make_bool_short(callee, false, false);
+                    }
                 }
 
                 for arg in args {
-                    self.make_bool_short(&mut arg.expr, false, false);
+                    if may_make_bool_short(&arg.expr) {
+                        self.make_bool_short(&mut arg.expr, false, false);
+                    }
                 }
                 return;
             }
@@ -138,13 +174,17 @@ impl Pure<'_> {
                 for (idx, expr) in exprs.iter_mut().enumerate() {
                     let is_last = idx == len - 1;
 
-                    self.make_bool_short(expr, false, !is_last || ignore_return_value);
+                    if may_make_bool_short(expr) {
+                        self.make_bool_short(expr, false, !is_last || ignore_return_value);
+                    }
                 }
                 return;
             }
 
             Expr::Assign(AssignExpr { right, .. }) => {
-                self.make_bool_short(right, false, false);
+                if may_make_bool_short(right) {
+                    self.make_bool_short(right, false, false);
+                }
                 return;
             }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/conds.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/conds.rs
@@ -294,7 +294,6 @@ impl Pure<'_> {
         let lt = bin.left.get_type(self.expr_ctx);
         let rt = bin.right.get_type(self.expr_ctx);
 
-        let _lb = bin.left.as_pure_bool(self.expr_ctx);
         let rb = bin.right.as_pure_bool(self.expr_ctx);
 
         if bin.op == op!("||") {

--- a/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
@@ -197,7 +197,7 @@ impl Pure<'_> {
         }
     }
 
-    pub(super) fn eval_array_method_call(&mut self, e: &mut Expr) {
+    pub(super) fn eval_array_or_fn_method_call(&mut self, e: &mut Expr) {
         if !self.options.evaluate {
             return;
         }
@@ -230,211 +230,169 @@ impl Pure<'_> {
             _ => panic!("unable to access unknown nodes"),
         };
 
-        if let Expr::Member(MemberExpr {
+        let (span, obj, method_name) = if let Expr::Member(MemberExpr {
             span,
             obj,
             prop: MemberProp::Ident(method_name),
         }) = callee
         {
-            if obj.may_have_side_effects(self.expr_ctx) {
-                return;
-            }
+            (*span, obj, method_name)
+        } else {
+            return;
+        };
 
-            let arr = match &mut **obj {
-                Expr::Array(arr) => arr,
-                _ => return,
-            };
+        if obj.may_have_side_effects(self.expr_ctx) {
+            return;
+        }
 
-            let has_spread_elem = arr.elems.iter().any(|s| {
-                matches!(
-                    s,
-                    Some(ExprOrSpread {
-                        spread: Some(..),
-                        ..
-                    })
-                )
-            });
+        match &mut **obj {
+            Expr::Array(arr) => {
+                let has_spread_elem = arr.elems.iter().any(|s| {
+                    matches!(
+                        s,
+                        Some(ExprOrSpread {
+                            spread: Some(..),
+                            ..
+                        })
+                    )
+                });
 
-            // Ignore array
+                // Ignore array
 
-            if &*method_name.sym == "slice" {
-                if has_spread || has_spread_elem {
-                    return;
-                }
-
-                match call.args.len() {
-                    0 => {
-                        self.changed = true;
-                        report_change!("evaluate: Dropping array.slice call");
-                        *e = *obj.take();
+                if &*method_name.sym == "slice" {
+                    if has_spread || has_spread_elem {
+                        return;
                     }
-                    1 => {
-                        if let Value::Known(start) = call.args[0].expr.as_pure_number(self.expr_ctx)
-                        {
-                            if start.is_sign_negative() {
-                                return;
-                            }
 
-                            let start = start.floor() as usize;
-
+                    match call.args.len() {
+                        0 => {
                             self.changed = true;
-                            report_change!("evaluate: Reducing array.slice({}) call", start);
-
-                            if start >= arr.elems.len() {
-                                *e = ArrayLit {
-                                    span: *span,
-                                    elems: Default::default(),
-                                }
-                                .into();
-                                return;
-                            }
-
-                            let elems = arr.elems.drain(start..).collect();
-
-                            *e = ArrayLit { span: *span, elems }.into();
+                            report_change!("evaluate: Dropping array.slice call");
+                            *e = *obj.take();
                         }
-                    }
-                    _ => {
-                        let start = call.args[0].expr.as_pure_number(self.expr_ctx);
-                        let end = call.args[1].expr.as_pure_number(self.expr_ctx);
-                        if let Value::Known(start) = start {
-                            if start.is_sign_negative() {
-                                return;
-                            }
-
-                            let start = start.floor() as usize;
-
-                            if let Value::Known(end) = end {
-                                if end.is_sign_negative() {
+                        1 => {
+                            if let Value::Known(start) =
+                                call.args[0].expr.as_pure_number(self.expr_ctx)
+                            {
+                                if start.is_sign_negative() {
                                     return;
                                 }
 
-                                let end = end.floor() as usize;
-                                let end = end.min(arr.elems.len());
-
-                                if start >= end {
-                                    return;
-                                }
+                                let start = start.floor() as usize;
 
                                 self.changed = true;
-                                report_change!(
-                                    "evaluate: Reducing array.slice({}, {}) call",
-                                    start,
-                                    end
-                                );
+                                report_change!("evaluate: Reducing array.slice({}) call", start);
+
                                 if start >= arr.elems.len() {
                                     *e = ArrayLit {
-                                        span: *span,
+                                        span,
                                         elems: Default::default(),
                                     }
                                     .into();
                                     return;
                                 }
 
-                                let elems = arr.elems.drain(start..end).collect();
+                                let elems = arr.elems.drain(start..).collect();
 
-                                *e = ArrayLit { span: *span, elems }.into();
+                                *e = ArrayLit { span, elems }.into();
+                            }
+                        }
+                        _ => {
+                            let start = call.args[0].expr.as_pure_number(self.expr_ctx);
+                            let end = call.args[1].expr.as_pure_number(self.expr_ctx);
+                            if let Value::Known(start) = start {
+                                if start.is_sign_negative() {
+                                    return;
+                                }
+
+                                let start = start.floor() as usize;
+
+                                if let Value::Known(end) = end {
+                                    if end.is_sign_negative() {
+                                        return;
+                                    }
+
+                                    let end = end.floor() as usize;
+                                    let end = end.min(arr.elems.len());
+
+                                    if start >= end {
+                                        return;
+                                    }
+
+                                    self.changed = true;
+                                    report_change!(
+                                        "evaluate: Reducing array.slice({}, {}) call",
+                                        start,
+                                        end
+                                    );
+                                    if start >= arr.elems.len() {
+                                        *e = ArrayLit {
+                                            span,
+                                            elems: Default::default(),
+                                        }
+                                        .into();
+                                        return;
+                                    }
+
+                                    let elems = arr.elems.drain(start..end).collect();
+
+                                    *e = ArrayLit { span, elems }.into();
+                                }
                             }
                         }
                     }
-                }
-                return;
-            }
-
-            if self.options.unsafe_passes
-                && &*method_name.sym == "toString"
-                && arr.elems.len() == 1
-                && arr.elems[0].is_some()
-            {
-                report_change!("evaluate: Reducing array.toString() call");
-                self.changed = true;
-                *obj = arr.elems[0]
-                    .take()
-                    .map(|elem| elem.expr)
-                    .unwrap_or_else(|| Expr::undefined(*span));
-            }
-        }
-    }
-
-    pub(super) fn eval_fn_method_call(&mut self, e: &mut Expr) {
-        if !self.options.evaluate {
-            return;
-        }
-
-        if self.ctx.intersects(
-            Ctx::IN_DELETE
-                .union(Ctx::IS_UPDATE_ARG)
-                .union(Ctx::IS_LHS_OF_ASSIGN),
-        ) {
-            return;
-        }
-
-        let call = match e {
-            Expr::Call(e) => e,
-            _ => return,
-        };
-
-        let has_spread = call.args.iter().any(|arg| arg.spread.is_some());
-
-        for arg in &call.args {
-            if arg.expr.may_have_side_effects(self.expr_ctx) {
-                return;
-            }
-        }
-
-        let callee = match &mut call.callee {
-            Callee::Super(_) | Callee::Import(_) => return,
-            Callee::Expr(e) => &mut **e,
-            #[cfg(swc_ast_unknown)]
-            _ => panic!("unable to access unknown nodes"),
-        };
-
-        if let Expr::Member(MemberExpr {
-            obj,
-            prop: MemberProp::Ident(method_name),
-            ..
-        }) = callee
-        {
-            if obj.may_have_side_effects(self.expr_ctx) {
-                return;
-            }
-
-            let f = match &mut **obj {
-                Expr::Fn(v) => v,
-                _ => return,
-            };
-
-            if &*method_name.sym == "valueOf" {
-                if has_spread {
                     return;
                 }
 
-                self.changed = true;
-                report_change!("evaluate: Reduced `function.valueOf()` into a function expression");
-
-                *e = *obj.take();
-                return;
+                if self.options.unsafe_passes
+                    && &*method_name.sym == "toString"
+                    && arr.elems.len() == 1
+                    && arr.elems[0].is_some()
+                {
+                    report_change!("evaluate: Reducing array.toString() call");
+                    self.changed = true;
+                    *obj = arr.elems[0]
+                        .take()
+                        .map(|elem| elem.expr)
+                        .unwrap_or_else(|| Expr::undefined(span));
+                }
             }
+            Expr::Fn(f) => {
+                if &*method_name.sym == "valueOf" {
+                    if has_spread {
+                        return;
+                    }
 
-            if self.options.unsafe_passes
-                && &*method_name.sym == "toString"
-                && f.function.params.is_empty()
-                && f.function.body.is_empty()
-            {
-                if has_spread {
+                    self.changed = true;
+                    report_change!(
+                        "evaluate: Reduced `function.valueOf()` into a function expression"
+                    );
+
+                    *e = *obj.take();
                     return;
                 }
 
-                self.changed = true;
-                report_change!("evaluate: Reduced `function.toString()` into a string");
+                if self.options.unsafe_passes
+                    && &*method_name.sym == "toString"
+                    && f.function.params.is_empty()
+                    && f.function.body.is_empty()
+                {
+                    if has_spread {
+                        return;
+                    }
 
-                *e = Str {
-                    span: call.span,
-                    value: atom!("function(){}").into(),
-                    raw: None,
+                    self.changed = true;
+                    report_change!("evaluate: Reduced `function.toString()` into a string");
+
+                    *e = Str {
+                        span: call.span,
+                        value: atom!("function(){}").into(),
+                        raw: None,
+                    }
+                    .into();
                 }
-                .into();
             }
+            _ => {}
         }
     }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/loops.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/loops.rs
@@ -21,7 +21,9 @@ impl Pure<'_> {
         }
 
         if let Some(VarDeclOrExpr::Expr(e)) = init {
-            self.make_bool_short(e, false, true);
+            if super::bools::may_make_bool_short(e) {
+                self.make_bool_short(e, false, true);
+            }
         }
     }
 
@@ -38,7 +40,9 @@ impl Pure<'_> {
                 return;
             }
 
-            self.make_bool_short(e, false, true);
+            if super::bools::may_make_bool_short(e) {
+                self.make_bool_short(e, false, true);
+            }
         }
     }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -321,6 +321,10 @@ impl VisitMut for Pure<'_> {
     fn visit_mut_expr(&mut self, e: &mut Expr) {
         self.handle_known_delete(e);
 
+        if matches!(e, Expr::Ident(..) | Expr::Invalid(..) | Expr::Lit(..)) {
+            return;
+        }
+
         e.visit_mut_children_with(self);
 
         // Expression simplifier

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -439,7 +439,7 @@ impl VisitMut for Pure<'_> {
 
         self.eval_str_addition(e);
 
-        if self.changed {
+        if self.changed && matches!(e, Expr::Seq(..) | Expr::Bin(..)) {
             self.remove_invalid(e);
         }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -97,7 +97,10 @@ impl Repeated for Pure<'_> {
 impl Pure<'_> {
     #[inline(always)]
     fn is_expr_leaf(e: &Expr) -> bool {
-        matches!(e, Expr::Ident(..) | Expr::Invalid(..) | Expr::Lit(..))
+        matches!(
+            e,
+            Expr::Ident(..) | Expr::Invalid(..) | Expr::Lit(..) | Expr::This(..)
+        )
     }
 
     #[inline(always)]

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -443,7 +443,13 @@ impl VisitMut for Pure<'_> {
 
         self.eval_str_addition(e);
 
-        if self.changed && matches!(e, Expr::Seq(..) | Expr::Bin(..)) {
+        let should_remove_invalid = match e {
+            Expr::Seq(seq) => seq.exprs.iter().any(|expr| expr.is_invalid()),
+            Expr::Bin(BinExpr { left, right, .. }) => left.is_invalid() || right.is_invalid(),
+            _ => false,
+        };
+
+        if should_remove_invalid {
             self.remove_invalid(e);
         }
 

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -421,13 +421,17 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.eval_nested_tpl(e);
+        if matches!(e, Expr::Tpl(..)) {
+            self.eval_nested_tpl(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.eval_tpl_as_str(e);
+        if matches!(e, Expr::Tpl(..)) {
+            self.eval_tpl_as_str(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -450,9 +454,13 @@ impl VisitMut for Pure<'_> {
             }
         }
 
-        self.eval_array_spread(e);
+        if matches!(e, Expr::Array(..)) {
+            self.eval_array_spread(e);
+        }
 
-        self.compress_array_join(e);
+        if matches!(e, Expr::Call(..)) {
+            self.compress_array_join(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -464,25 +472,33 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.eval_opt_chain(e);
+        if matches!(e, Expr::OptChain(..)) {
+            self.eval_opt_chain(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.eval_number_call(e);
+        if matches!(e, Expr::Call(..)) {
+            self.eval_number_call(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.eval_arguments_member_access(e);
+        if matches!(e, Expr::Member(..)) {
+            self.eval_arguments_member_access(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.eval_number_method_call(e);
+        if matches!(e, Expr::Call(..)) {
+            self.eval_number_method_call(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -508,7 +524,9 @@ impl VisitMut for Pure<'_> {
         if e.is_seq() {
             debug_assert_valid(e);
         }
-        self.convert_tpl_to_str(e);
+        if matches!(e, Expr::Tpl(..)) {
+            self.convert_tpl_to_str(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -520,7 +538,9 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.compress_useless_deletes(e);
+        if matches!(e, Expr::Unary(..)) {
+            self.compress_useless_deletes(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -544,17 +564,21 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.eval_array_or_fn_method_call(e);
-
-        if e.is_seq() {
-            debug_assert_valid(e);
+        if matches!(e, Expr::Call(..)) {
+            self.eval_array_or_fn_method_call(e);
         }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.eval_str_method_call(e);
+        if e.is_seq() {
+            debug_assert_valid(e);
+        }
+
+        if matches!(e, Expr::Call(..)) {
+            self.eval_str_method_call(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -618,13 +642,17 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.optimize_opt_chain(e);
+        if matches!(e, Expr::OptChain(..)) {
+            self.optimize_opt_chain(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.eval_member_expr(e);
+        if matches!(e, Expr::Member(..)) {
+            self.eval_member_expr(e);
+        }
 
         self.optimize_to_int(e);
     }

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -544,12 +544,11 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.eval_array_method_call(e);
+        self.eval_array_or_fn_method_call(e);
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
-        self.eval_fn_method_call(e);
 
         if e.is_seq() {
             debug_assert_valid(e);

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -95,6 +95,148 @@ impl Repeated for Pure<'_> {
 }
 
 impl Pure<'_> {
+    #[inline(always)]
+    fn is_expr_leaf(e: &Expr) -> bool {
+        matches!(e, Expr::Ident(..) | Expr::Invalid(..) | Expr::Lit(..))
+    }
+
+    #[inline(always)]
+    fn can_simplify_member_expr(e: &MemberExpr) -> bool {
+        matches!(
+            &*e.obj,
+            Expr::Lit(Lit::Str(..)) | Expr::Array(..) | Expr::Object(..)
+        )
+    }
+
+    #[inline(always)]
+    fn can_simplify_bin_expr(e: &BinExpr) -> bool {
+        match e.op {
+            op!("&&") | op!("||") => Self::can_simplify_bin_operand(&e.left),
+
+            op!("instanceof") => {
+                Self::is_known_non_object(&e.left)
+                    || Self::is_known_object(&e.left)
+                        && e.right
+                            .as_ident()
+                            .is_some_and(|ident| &*ident.sym == "Object")
+            }
+
+            op!("<") | op!(">") | op!("<=") | op!(">=") => {
+                Self::can_simplify_bin_operand(&e.left)
+                    || Self::can_simplify_bin_operand(&e.right)
+                    || Self::same_ident(&e.left, &e.right)
+                    || Self::same_typeof_ident(&e.left, &e.right)
+            }
+
+            op!(bin, "+")
+            | op!(bin, "-")
+            | op!("*")
+            | op!("/")
+            | op!("%")
+            | op!("**")
+            | op!("&")
+            | op!("|")
+            | op!("^")
+            | op!("<<")
+            | op!(">>")
+            | op!(">>>")
+            | op!("==")
+            | op!("!=")
+            | op!("===")
+            | op!("!==") => {
+                Self::can_simplify_bin_operand(&e.left)
+                    || Self::can_simplify_bin_operand(&e.right)
+                    || Self::same_typeof_ident(&e.left, &e.right)
+            }
+
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    fn can_simplify_bin_operand(e: &Expr) -> bool {
+        match e {
+            Expr::Lit(..)
+            | Expr::Tpl(..)
+            | Expr::Array(..)
+            | Expr::Object(..)
+            | Expr::Fn(..)
+            | Expr::Class(..)
+            | Expr::New(..)
+            | Expr::Unary(..)
+            | Expr::Seq(..)
+            | Expr::Assign(..)
+            | Expr::Cond(..)
+            | Expr::Bin(..) => true,
+
+            Expr::Member(MemberExpr {
+                obj,
+                prop: MemberProp::Ident(IdentName { sym, .. }),
+                ..
+            }) if &**sym == "length"
+                && matches!(&**obj, Expr::Array(..) | Expr::Lit(Lit::Str(..))) =>
+            {
+                true
+            }
+
+            Expr::Ident(Ident { sym, .. }) => {
+                matches!(&**sym, "undefined" | "Infinity" | "NaN")
+            }
+
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    fn is_known_object(e: &Expr) -> bool {
+        matches!(
+            e,
+            Expr::Array(..) | Expr::Object(..) | Expr::Fn(..) | Expr::Class(..) | Expr::New(..)
+        )
+    }
+
+    #[inline(always)]
+    fn is_known_non_object(e: &Expr) -> bool {
+        match e {
+            Expr::Lit(Lit::Str(..) | Lit::Num(..) | Lit::Null(..) | Lit::Bool(..)) => true,
+            Expr::Ident(Ident { sym, .. }) => {
+                matches!(&**sym, "undefined" | "Infinity" | "NaN")
+            }
+            Expr::Unary(UnaryExpr {
+                op: op!("!") | op!(unary, "-") | op!("void"),
+                arg,
+                ..
+            }) => Self::is_known_non_object(arg),
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    fn same_ident(left: &Expr, right: &Expr) -> bool {
+        left.as_ident()
+            .zip(right.as_ident())
+            .is_some_and(|(left, right)| left.to_id() == right.to_id())
+    }
+
+    #[inline(always)]
+    fn same_typeof_ident(left: &Expr, right: &Expr) -> bool {
+        match (left, right) {
+            (
+                Expr::Unary(UnaryExpr {
+                    op: op!("typeof"),
+                    arg: left,
+                    ..
+                }),
+                Expr::Unary(UnaryExpr {
+                    op: op!("typeof"),
+                    arg: right,
+                    ..
+                }),
+            ) => Self::same_ident(left, right),
+            _ => false,
+        }
+    }
+
     fn handle_stmt_likes<T>(&mut self, stmts: &mut Vec<T>)
     where
         T: ModuleItemExt + Take,
@@ -223,8 +365,12 @@ impl VisitMut for Pure<'_> {
     }
 
     fn visit_mut_bin_expr(&mut self, e: &mut BinExpr) {
-        self.visit_mut_expr(&mut e.left);
-        self.visit_mut_expr(&mut e.right);
+        if !Self::is_expr_leaf(&e.left) {
+            self.visit_mut_expr(&mut e.left);
+        }
+        if !Self::is_expr_leaf(&e.right) {
+            self.visit_mut_expr(&mut e.right);
+        }
 
         self.compress_cmp_with_long_op(e);
 
@@ -264,7 +410,9 @@ impl VisitMut for Pure<'_> {
         self.optimize_arrow_body(body);
 
         if let BlockStmtOrExpr::Expr(e) = body {
-            self.make_bool_short(e, false, false);
+            if self::bools::may_make_bool_short(e) {
+                self.make_bool_short(e, false, false);
+            }
         }
     }
 
@@ -315,15 +463,17 @@ impl VisitMut for Pure<'_> {
             s.body.visit_mut_with(this);
         });
 
-        self.make_bool_short(&mut s.test, true, false);
+        if self::bools::may_make_bool_short(&s.test) {
+            self.make_bool_short(&mut s.test, true, false);
+        }
     }
 
     fn visit_mut_expr(&mut self, e: &mut Expr) {
-        self.handle_known_delete(e);
-
-        if matches!(e, Expr::Ident(..) | Expr::Invalid(..) | Expr::Lit(..)) {
+        if Self::is_expr_leaf(e) {
             return;
         }
+
+        self.handle_known_delete(e);
 
         e.visit_mut_children_with(self);
 
@@ -335,7 +485,7 @@ impl VisitMut for Pure<'_> {
                         .union(Ctx::IS_UPDATE_ARG)
                         .union(Ctx::IS_LHS_OF_ASSIGN)
                         .union(Ctx::IN_OPT_CHAIN),
-                ) =>
+                ) && e.as_member().is_some_and(Self::can_simplify_member_expr) =>
             {
                 let mut changed = false;
                 simplify::expr::optimize_member_expr(
@@ -361,7 +511,7 @@ impl VisitMut for Pure<'_> {
                 }
             }
 
-            Expr::Bin(..) => {
+            Expr::Bin(bin) if Self::can_simplify_bin_expr(bin) => {
                 let mut changed = false;
                 simplify::expr::optimize_bin_expr(self.expr_ctx, e, &mut changed);
 
@@ -370,6 +520,7 @@ impl VisitMut for Pure<'_> {
                     self.changed = true;
                 }
             }
+            Expr::Bin(..) => {}
 
             _ => {}
         }
@@ -443,25 +594,27 @@ impl VisitMut for Pure<'_> {
 
         self.eval_str_addition(e);
 
-        let should_remove_invalid = match e {
-            Expr::Seq(seq) => seq.exprs.iter().any(|expr| expr.is_invalid()),
-            Expr::Bin(BinExpr { left, right, .. }) => left.is_invalid() || right.is_invalid(),
-            _ => false,
-        };
+        match e {
+            Expr::Seq(seq) => {
+                if seq.exprs.iter().any(|expr| expr.is_invalid()) {
+                    self.remove_invalid(e);
+                }
 
-        if should_remove_invalid {
-            self.remove_invalid(e);
-        }
-
-        if let Expr::Seq(seq) = e {
-            if seq.exprs.is_empty() {
-                *e = Invalid { span: DUMMY_SP }.into();
-                return;
+                if let Expr::Seq(seq) = e {
+                    if seq.exprs.is_empty() {
+                        *e = Invalid { span: DUMMY_SP }.into();
+                        return;
+                    }
+                    if seq.exprs.len() == 1 {
+                        self.changed = true;
+                        *e = *seq.exprs.take().into_iter().next().unwrap();
+                    }
+                }
             }
-            if seq.exprs.len() == 1 {
-                self.changed = true;
-                *e = *seq.exprs.take().into_iter().next().unwrap();
+            Expr::Bin(BinExpr { left, right, .. }) if left.is_invalid() || right.is_invalid() => {
+                self.remove_invalid(e);
             }
+            _ => {}
         }
 
         if matches!(e, Expr::Array(..)) {
@@ -689,7 +842,9 @@ impl VisitMut for Pure<'_> {
 
         debug_assert_valid(&s.expr);
 
-        self.make_bool_short(&mut s.expr, false, true);
+        if self::bools::may_make_bool_short(&s.expr) {
+            self.make_bool_short(&mut s.expr, false, true);
+        }
     }
 
     fn visit_mut_exprs(&mut self, nodes: &mut Vec<Box<Expr>>) {
@@ -725,7 +880,9 @@ impl VisitMut for Pure<'_> {
             self.negate_if_terminate(&mut body.stmts, false, true);
         }
 
-        self.make_bool_short(&mut n.right, false, false);
+        if self::bools::may_make_bool_short(&n.right) {
+            self.make_bool_short(&mut n.right, false, false);
+        }
     }
 
     fn visit_mut_for_of_stmt(&mut self, n: &mut ForOfStmt) {
@@ -739,7 +896,9 @@ impl VisitMut for Pure<'_> {
             self.negate_if_terminate(&mut body.stmts, false, true);
         }
 
-        self.make_bool_short(&mut n.right, false, false);
+        if self::bools::may_make_bool_short(&n.right) {
+            self.make_bool_short(&mut n.right, false, false);
+        }
     }
 
     fn visit_mut_for_stmt(&mut self, s: &mut ForStmt) {
@@ -792,13 +951,17 @@ impl VisitMut for Pure<'_> {
 
         self.merge_else_if(s);
 
-        self.make_bool_short(&mut s.test, true, false);
+        if self::bools::may_make_bool_short(&s.test) {
+            self.make_bool_short(&mut s.test, true, false);
+        }
     }
 
     fn visit_mut_key_value_prop(&mut self, p: &mut KeyValueProp) {
         p.visit_mut_children_with(self);
 
-        self.make_bool_short(&mut p.value, false, false);
+        if self::bools::may_make_bool_short(&p.value) {
+            self.make_bool_short(&mut p.value, false, false);
+        }
     }
 
     fn visit_mut_labeled_stmt(&mut self, s: &mut LabeledStmt) {
@@ -941,7 +1104,9 @@ impl VisitMut for Pure<'_> {
         self.drop_undefined_from_return_arg(s);
 
         if let Some(e) = &mut s.arg {
-            self.make_bool_short(e, false, false);
+            if self::bools::may_make_bool_short(e) {
+                self.make_bool_short(e, false, false);
+            }
         }
     }
 
@@ -1197,7 +1362,9 @@ impl VisitMut for Pure<'_> {
     fn visit_mut_throw_stmt(&mut self, s: &mut ThrowStmt) {
         s.visit_mut_children_with(self);
 
-        self.make_bool_short(&mut s.arg, false, false);
+        if self::bools::may_make_bool_short(&s.arg) {
+            self.make_bool_short(&mut s.arg, false, false);
+        }
     }
 
     fn visit_mut_tpl(&mut self, n: &mut Tpl) {
@@ -1267,7 +1434,9 @@ impl VisitMut for Pure<'_> {
         v.visit_mut_children_with(self);
 
         if let Some(init) = &mut v.init {
-            self.make_bool_short(init, false, false);
+            if self::bools::may_make_bool_short(init) {
+                self.make_bool_short(init, false, false);
+            }
         }
     }
 
@@ -1280,7 +1449,9 @@ impl VisitMut for Pure<'_> {
 
         self.optimize_expr_in_bool_ctx(&mut s.test, false);
 
-        self.make_bool_short(&mut s.test, true, false);
+        if self::bools::may_make_bool_short(&s.test) {
+            self.make_bool_short(&mut s.test, true, false);
+        }
     }
 
     /// Noop.

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -539,7 +539,9 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.simplify_assign_expr(e);
+        if matches!(e, Expr::Assign(..)) {
+            self.simplify_assign_expr(e);
+        }
 
         if self.options.unused {
             if let Expr::Unary(UnaryExpr {
@@ -592,7 +594,9 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.eval_str_addition(e);
+        if matches!(e, Expr::Bin(..)) {
+            self.eval_str_addition(e);
+        }
 
         match e {
             Expr::Seq(seq) => {
@@ -629,7 +633,9 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.unsafe_optimize_fn_as_arrow(e);
+        if matches!(e, Expr::Fn(..)) {
+            self.unsafe_optimize_fn_as_arrow(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -667,22 +673,32 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.swap_bin_operands(e);
+        if matches!(e, Expr::Bin(..)) {
+            self.swap_bin_operands(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.drop_logical_operands(e);
+        if matches!(e, Expr::Bin(..)) {
+            self.drop_logical_operands(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.optimize_negate_eq(e);
+        if matches!(e, Expr::Unary(..)) {
+            self.optimize_negate_eq(e);
+        }
 
-        self.lift_minus(e);
-        self.optimize_to_number(e);
+        if matches!(e, Expr::Bin(..)) {
+            self.lift_minus(e);
+        }
+        if matches!(e, Expr::Assign(..) | Expr::Bin(..)) {
+            self.optimize_to_number(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -695,7 +711,9 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.drop_useless_addition_of_str(e);
+        if matches!(e, Expr::Bin(..)) {
+            self.drop_useless_addition_of_str(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -709,19 +727,25 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.remove_useless_logical_rhs(e);
+        if matches!(e, Expr::Bin(..)) {
+            self.remove_useless_logical_rhs(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.handle_negated_seq(e);
+        if matches!(e, Expr::Unary(..)) {
+            self.handle_negated_seq(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.concat_str(e);
+        if matches!(e, Expr::Bin(..)) {
+            self.concat_str(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -747,59 +771,87 @@ impl VisitMut for Pure<'_> {
             debug_assert_valid(e);
         }
 
-        self.optimize_const_cond(e);
+        if matches!(e, Expr::Cond(..)) {
+            self.optimize_const_cond(e);
+        }
 
-        self.compress_conds_as_logical(e);
+        if matches!(e, Expr::Cond(..)) {
+            self.compress_conds_as_logical(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.compress_cond_with_logical_as_logical(e);
+        if matches!(e, Expr::Cond(..)) {
+            self.compress_cond_with_logical_as_logical(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.compress_conds_as_arithmetic(e);
+        if matches!(e, Expr::Cond(..)) {
+            self.compress_conds_as_arithmetic(e);
+        }
 
-        self.eval_logical_expr(e);
+        if matches!(
+            e,
+            Expr::Bin(BinExpr {
+                op: op!("&&") | op!("||"),
+                ..
+            })
+        ) {
+            self.eval_logical_expr(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.lift_seqs_of_bin(e);
+        if matches!(e, Expr::Bin(..)) {
+            self.lift_seqs_of_bin(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.lift_seqs_of_cond_assign(e);
+        if matches!(e, Expr::Assign(..)) {
+            self.lift_seqs_of_cond_assign(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.optimize_nullish_coalescing(e);
+        if matches!(e, Expr::Bin(BinExpr { op: op!("??"), .. })) {
+            self.optimize_nullish_coalescing(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.compress_negated_bin_eq(e);
+        if matches!(e, Expr::Unary(..)) {
+            self.compress_negated_bin_eq(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.compress_useless_cond_expr(e);
+        if matches!(e, Expr::Cond(..)) {
+            self.compress_useless_cond_expr(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
         }
 
-        self.optimize_builtin_object(e);
+        if matches!(e, Expr::Call(..) | Expr::New(..)) {
+            self.optimize_builtin_object(e);
+        }
 
         if e.is_seq() {
             debug_assert_valid(e);
@@ -817,7 +869,9 @@ impl VisitMut for Pure<'_> {
             self.eval_member_expr(e);
         }
 
-        self.optimize_to_int(e);
+        if matches!(e, Expr::Assign(..) | Expr::Bin(..)) {
+            self.optimize_to_int(e);
+        }
     }
 
     fn visit_mut_expr_or_spreads(&mut self, nodes: &mut Vec<ExprOrSpread>) {

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -699,7 +699,10 @@ impl VisitMut for Pure<'_> {
         if matches!(e, Expr::Bin(..)) {
             self.lift_minus(e);
         }
-        if matches!(e, Expr::Assign(..) | Expr::Bin(..)) {
+        if matches!(
+            e,
+            Expr::Assign(AssignExpr { op: op!("="), .. }) | Expr::Bin(BinExpr { op: op!("*"), .. })
+        ) {
             self.optimize_to_number(e);
         }
 
@@ -872,7 +875,16 @@ impl VisitMut for Pure<'_> {
             self.eval_member_expr(e);
         }
 
-        if matches!(e, Expr::Assign(..) | Expr::Bin(..)) {
+        if matches!(
+            e,
+            Expr::Assign(AssignExpr {
+                op: op!("<<=") | op!(">>=") | op!(">>>=") | op!("|=") | op!("^=") | op!("&="),
+                ..
+            }) | Expr::Bin(BinExpr {
+                op: op!("<<") | op!(">>") | op!(">>>") | op!("|") | op!("^") | op!("&"),
+                ..
+            })
+        ) {
             self.optimize_to_int(e);
         }
     }

--- a/crates/swc_ecma_minifier/src/compress/pure/vars.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/vars.rs
@@ -225,7 +225,7 @@ impl Pure<'_> {
             });
 
             // Check for nested variable declartions.
-            let visitor_need_work = if target == VarDeclKind::Var {
+            let visitor_need_work = if !if_need_work && target == VarDeclKind::Var {
                 let mut v = VarWithOutInitCounter {
                     target,
                     need_work: Default::default(),
@@ -313,16 +313,26 @@ impl Visit for VarWithOutInitCounter {
     fn visit_setter_prop(&mut self, _: &SetterProp) {}
 
     fn visit_var_decl(&mut self, v: &VarDecl) {
+        if self.need_work {
+            return;
+        }
+
         v.visit_children_with(self);
+
+        if self.need_work {
+            return;
+        }
 
         if v.kind != self.target {
             return;
         }
 
         let mut found_init = false;
+        let mut all_without_init = true;
         for d in &v.decls {
             if d.init.is_some() {
                 found_init = true;
+                all_without_init = false;
             } else {
                 if found_init {
                     self.need_work = true;
@@ -331,7 +341,7 @@ impl Visit for VarWithOutInitCounter {
             }
         }
 
-        if v.decls.iter().all(|v| v.init.is_none()) {
+        if all_without_init {
             if self.found_var_without_init || self.found_var_with_init {
                 self.need_work = true;
             }
@@ -342,12 +352,30 @@ impl Visit for VarWithOutInitCounter {
     }
 
     fn visit_module_item(&mut self, s: &ModuleItem) {
+        if self.need_work {
+            return;
+        }
+
         if let ModuleItem::Stmt(_) = s {
             s.visit_children_with(self);
         }
     }
 
+    fn visit_module_items(&mut self, items: &[ModuleItem]) {
+        for item in items {
+            if self.need_work {
+                return;
+            }
+
+            item.visit_with(self);
+        }
+    }
+
     fn visit_block_stmt(&mut self, n: &BlockStmt) {
+        if self.need_work {
+            return;
+        }
+
         if self.target != VarDeclKind::Var {
             // noop
             return;
@@ -357,6 +385,16 @@ impl Visit for VarWithOutInitCounter {
     }
 
     fn visit_for_head(&mut self, _: &ForHead) {}
+
+    fn visit_stmts(&mut self, stmts: &[Stmt]) {
+        for stmt in stmts {
+            if self.need_work {
+                return;
+            }
+
+            stmt.visit_with(self);
+        }
+    }
 }
 
 /// Moves all variable without initializer.

--- a/crates/swc_ecma_minifier/src/compress/pure/vars.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/vars.rs
@@ -312,6 +312,28 @@ impl Visit for VarWithOutInitCounter {
 
     fn visit_setter_prop(&mut self, _: &SetterProp) {}
 
+    fn visit_expr(&mut self, e: &Expr) {
+        if self.need_work {
+            return;
+        }
+
+        match e {
+            Expr::Ident(..) | Expr::Invalid(..) | Expr::Lit(..) | Expr::This(..) => {}
+            _ => e.visit_children_with(self),
+        }
+    }
+
+    fn visit_pat(&mut self, n: &Pat) {
+        if self.need_work {
+            return;
+        }
+
+        match n {
+            Pat::Ident(..) => {}
+            _ => n.visit_children_with(self),
+        }
+    }
+
     fn visit_var_decl(&mut self, v: &VarDecl) {
         if self.need_work {
             return;

--- a/crates/swc_ecma_minifier/src/compress/pure/vars.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/vars.rs
@@ -186,6 +186,10 @@ impl Pure<'_> {
             return;
         }
 
+        if stmts.is_empty() || (target != VarDeclKind::Var && stmts.len() < 2) {
+            return;
+        }
+
         {
             let mut need_work = false;
             let mut found_vars_without_init = false;
@@ -304,6 +308,8 @@ impl Visit for VarWithOutInitCounter {
 
     fn visit_arrow_expr(&mut self, _: &ArrowExpr) {}
 
+    fn visit_class(&mut self, _: &Class) {}
+
     fn visit_constructor(&mut self, _: &Constructor) {}
 
     fn visit_function(&mut self, _: &Function) {}
@@ -312,16 +318,7 @@ impl Visit for VarWithOutInitCounter {
 
     fn visit_setter_prop(&mut self, _: &SetterProp) {}
 
-    fn visit_expr(&mut self, e: &Expr) {
-        if self.need_work {
-            return;
-        }
-
-        match e {
-            Expr::Ident(..) | Expr::Invalid(..) | Expr::Lit(..) | Expr::This(..) => {}
-            _ => e.visit_children_with(self),
-        }
-    }
+    fn visit_expr(&mut self, _: &Expr) {}
 
     fn visit_pat(&mut self, n: &Pat) {
         if self.need_work {
@@ -335,12 +332,6 @@ impl Visit for VarWithOutInitCounter {
     }
 
     fn visit_var_decl(&mut self, v: &VarDecl) {
-        if self.need_work {
-            return;
-        }
-
-        v.visit_children_with(self);
-
         if self.need_work {
             return;
         }
@@ -433,6 +424,10 @@ impl VisitMut for VarMover {
     /// Noop
     fn visit_mut_arrow_expr(&mut self, _: &mut ArrowExpr) {}
 
+    fn visit_mut_class(&mut self, _: &mut Class) {}
+
+    fn visit_mut_expr(&mut self, _: &mut Expr) {}
+
     fn visit_mut_block_stmt(&mut self, n: &mut BlockStmt) {
         if self.target != VarDeclKind::Var {
             // noop
@@ -497,8 +492,6 @@ impl VisitMut for VarMover {
     }
 
     fn visit_mut_var_declarators(&mut self, d: &mut Vec<VarDeclarator>) {
-        d.visit_mut_children_with(self);
-
         if self.var_decl_kind != Some(self.target) {
             return;
         }
@@ -556,6 +549,10 @@ impl VisitMut for VarPrepender {
 
     /// Noop
     fn visit_mut_arrow_expr(&mut self, _: &mut ArrowExpr) {}
+
+    fn visit_mut_class(&mut self, _: &mut Class) {}
+
+    fn visit_mut_expr(&mut self, _: &mut Expr) {}
 
     /// Noop
     fn visit_mut_constructor(&mut self, _: &mut Constructor) {}

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -234,56 +234,52 @@ impl Storage for ProgramData {
             let inited = self.initialized_vars.contains(&id);
             match self.vars.entry(id) {
                 Entry::Occupied(mut e) => {
+                    let e = e.get_mut();
+
                     if var_info.flags.contains(VarUsageInfoFlags::INLINE_PREVENTED) {
-                        e.get_mut()
-                            .flags
-                            .insert(VarUsageInfoFlags::INLINE_PREVENTED);
+                        e.flags.insert(VarUsageInfoFlags::INLINE_PREVENTED);
                     }
                     let var_assigned = var_info.assign_count > 0
                         || (var_info.flags.contains(VarUsageInfoFlags::VAR_INITIALIZED)
-                            && !e.get().flags.contains(VarUsageInfoFlags::VAR_INITIALIZED));
+                            && !e.flags.contains(VarUsageInfoFlags::VAR_INITIALIZED));
 
-                    if var_info.assign_count > 0 {
-                        if e.get().initialized() {
-                            e.get_mut().flags.insert(VarUsageInfoFlags::REASSIGNED);
-                        }
+                    if var_info.assign_count > 0 && e.initialized() {
+                        e.flags.insert(VarUsageInfoFlags::REASSIGNED);
                     }
 
                     if var_info.flags.contains(VarUsageInfoFlags::VAR_INITIALIZED) {
                         // If it is inited in some other child scope and also inited in current
                         // scope
-                        if e.get().flags.contains(VarUsageInfoFlags::VAR_INITIALIZED)
-                            || e.get().ref_count > 0
-                        {
-                            e.get_mut().flags.insert(VarUsageInfoFlags::REASSIGNED);
+                        if e.flags.contains(VarUsageInfoFlags::VAR_INITIALIZED) || e.ref_count > 0 {
+                            e.flags.insert(VarUsageInfoFlags::REASSIGNED);
                         } else {
                             // If it is referred outside child scope, it will
                             // be marked as var_initialized false
-                            e.get_mut().flags.insert(VarUsageInfoFlags::VAR_INITIALIZED);
+                            e.flags.insert(VarUsageInfoFlags::VAR_INITIALIZED);
                         }
                     } else {
                         // If it is inited in some other child scope, but referenced in
                         // current child scope
                         if !inited
-                            && e.get().flags.contains(VarUsageInfoFlags::VAR_INITIALIZED)
+                            && e.flags.contains(VarUsageInfoFlags::VAR_INITIALIZED)
                             && var_info.ref_count > 0
                         {
-                            e.get_mut().flags.remove(VarUsageInfoFlags::VAR_INITIALIZED);
-                            e.get_mut().flags.insert(VarUsageInfoFlags::REASSIGNED);
+                            e.flags.remove(VarUsageInfoFlags::VAR_INITIALIZED);
+                            e.flags.insert(VarUsageInfoFlags::REASSIGNED);
                         }
                     }
 
-                    e.get_mut().merged_var_type.merge(var_info.merged_var_type);
+                    e.merged_var_type.merge(var_info.merged_var_type);
 
-                    e.get_mut().ref_count += var_info.ref_count;
-                    e.get_mut().property_mutation_count |= var_info.property_mutation_count;
-                    e.get_mut().declared_count += var_info.declared_count;
-                    e.get_mut().assign_count += var_info.assign_count;
-                    e.get_mut().usage_count += var_info.usage_count;
-                    e.get_mut().infects_to.extend(var_info.infects_to);
-                    e.get_mut().callee_count += var_info.callee_count;
+                    e.ref_count += var_info.ref_count;
+                    e.property_mutation_count |= var_info.property_mutation_count;
+                    e.declared_count += var_info.declared_count;
+                    e.assign_count += var_info.assign_count;
+                    e.usage_count += var_info.usage_count;
+                    e.infects_to.extend(var_info.infects_to);
+                    e.callee_count += var_info.callee_count;
 
-                    e.get_mut().param_count = match (e.get().param_count, var_info.param_count) {
+                    e.param_count = match (e.param_count, var_info.param_count) {
                         (Some(Value::Known(v1)), Some(Value::Known(v2))) if v1 == v2 => {
                             Some(Value::Known(v1))
                         }
@@ -297,11 +293,11 @@ impl Storage for ProgramData {
                     };
 
                     for (k, v) in var_info.accessed_props {
-                        *e.get_mut().accessed_props.entry(k).or_default() += v;
+                        *e.accessed_props.entry(k).or_default() += v;
                     }
 
                     let var_info_flags = var_info.flags;
-                    let e_flags = &mut e.get_mut().flags;
+                    let e_flags = &mut e.flags;
                     *e_flags |= var_info_flags & VarUsageInfoFlags::REASSIGNED;
                     *e_flags |= var_info_flags & VarUsageInfoFlags::HAS_PROPERTY_ACCESS;
                     *e_flags |= var_info_flags & VarUsageInfoFlags::EXPORTED;

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -427,6 +427,10 @@ impl Storage for ProgramData {
             e.usage_count = e.usage_count.saturating_sub(1);
         }
 
+        if e.infects_to.is_empty() {
+            return;
+        }
+
         let mut to_visit: IndexSet<Id, FxBuildHasher> =
             IndexSet::from_iter(e.infects_to.iter().cloned().map(|i| i.0));
 
@@ -542,6 +546,10 @@ impl Storage for ProgramData {
     fn mark_property_mutation(&mut self, id: Id) {
         let e = self.vars.entry(id).or_default();
         e.property_mutation_count += 1;
+
+        if e.infects_to.is_empty() {
+            return;
+        }
 
         let to_mark_mutate = e
             .infects_to

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -428,7 +428,7 @@ impl Storage for ProgramData {
         }
 
         let mut to_visit: IndexSet<Id, FxBuildHasher> =
-            IndexSet::from_iter(e.infects_to.iter().cloned().map(|i| i.0));
+            IndexSet::from_iter(e.infects_to.iter().map(|(id, _)| id.clone()));
 
         let mut idx = 0;
 
@@ -452,7 +452,7 @@ impl Storage for ProgramData {
                     usage.usage_count += 1;
                 }
 
-                to_visit.extend(usage.infects_to.iter().cloned().map(|i| i.0))
+                to_visit.extend(usage.infects_to.iter().map(|(id, _)| id.clone()))
             }
 
             idx += 1;

--- a/crates/swc_ecma_minifier/src/usage_analyzer/alias/mod.rs
+++ b/crates/swc_ecma_minifier/src/usage_analyzer/alias/mod.rs
@@ -366,13 +366,16 @@ impl Visit for InfectionCollector {
     }
 
     fn visit_pat(&mut self, node: &Pat) {
-        node.visit_children_with(self);
-
-        if self.ctx.contains(Ctx::IsPatDecl) {
-            if let Pat::Ident(i) = node {
-                self.add_binding(i)
+        if let Pat::Ident(i) = node {
+            if self.ctx.contains(Ctx::IsPatDecl) {
+                self.add_binding(i);
+            } else {
+                self.add_usage(i.to_id());
             }
+            return;
         }
+
+        node.visit_children_with(self);
     }
 
     fn visit_prop_name(&mut self, n: &PropName) {

--- a/crates/swc_ecma_minifier/src/usage_analyzer/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/usage_analyzer/analyzer/mod.rs
@@ -443,7 +443,7 @@ where
         tracing::instrument(level = "debug", skip_all)
     )]
     fn visit_binding_ident(&mut self, n: &BindingIdent) {
-        self.visit_pat_id(&Ident::from(n));
+        self.visit_pat_id(n);
     }
 
     #[cfg_attr(
@@ -805,8 +805,6 @@ where
             ..self.ctx
         };
 
-        e.visit_children_with(&mut *self.with_ctx(ctx));
-
         if let Expr::Ident(i) = e {
             #[cfg(feature = "tracing-spans")]
             {
@@ -819,7 +817,10 @@ where
             }
 
             self.with_ctx(ctx).report_usage(i);
+            return;
         }
+
+        e.visit_children_with(&mut *self.with_ctx(ctx));
     }
 
     #[cfg_attr(
@@ -1232,7 +1233,7 @@ where
     fn visit_pat(&mut self, n: &Pat) {
         match n {
             Pat::Ident(i) => {
-                i.visit_with(self);
+                self.visit_pat_id(i);
             }
             _ => {
                 let ctx = self

--- a/crates/swc_ecma_minifier/src/util/mod.rs
+++ b/crates/swc_ecma_minifier/src/util/mod.rs
@@ -352,6 +352,15 @@ impl Visit for IdentUsageCollector {
 
     visit_obj_and_computed!();
 
+    fn visit_expr(&mut self, n: &Expr) {
+        if let Expr::Ident(i) = n {
+            self.ids.insert(i.to_id());
+            return;
+        }
+
+        n.visit_children_with(self);
+    }
+
     fn visit_block_stmt_or_expr(&mut self, n: &BlockStmtOrExpr) {
         if self.ignore_nested {
             return;
@@ -413,6 +422,17 @@ impl Visit for CapturedIdCollector {
     noop_visit_type!(fail);
 
     visit_obj_and_computed!();
+
+    fn visit_expr(&mut self, n: &Expr) {
+        if let Expr::Ident(i) = n {
+            if self.is_nested {
+                self.ids.insert(i.to_id());
+            }
+            return;
+        }
+
+        n.visit_children_with(self);
+    }
 
     fn visit_block_stmt_or_expr(&mut self, n: &BlockStmtOrExpr) {
         let old = self.is_nested;

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -239,9 +239,10 @@ impl Scope {
 
             let iter = iter
                 .map(|child| {
-                    use std::collections::HashMap;
-
-                    let mut new_map = HashMap::default();
+                    let mut new_map = FxHashMap::with_capacity_and_hasher(
+                        child.rename_cost(),
+                        Default::default(),
+                    );
                     child.rename_in_mangle_mode(
                         renamer,
                         &mut new_map,

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -242,6 +242,7 @@ where
 
         if R::MANGLE {
             let cost = scope.rename_cost();
+            map.reserve(cost);
             scope.rename_in_mangle_mode(
                 &self.renamer,
                 &mut map,

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -275,11 +275,12 @@ impl<'a> Visit for Dropper<'a> {
     }
 
     fn visit_expr(&mut self, expr: &Expr) {
-        expr.visit_children_with(self);
-
         if let Expr::Ident(i) = expr {
             self.data.drop_usage(&i.to_id());
+            return;
         }
+
+        expr.visit_children_with(self);
     }
 
     fn visit_fn_decl(&mut self, node: &FnDecl) {
@@ -522,11 +523,13 @@ impl Visit for Analyzer<'_> {
         let old_in_var_decl = self.in_var_decl;
 
         self.in_var_decl = false;
-        e.visit_children_with(self);
-
         if let Expr::Ident(i) = e {
             self.add(i.to_id(), false);
+            self.in_var_decl = old_in_var_decl;
+            return;
         }
+
+        e.visit_children_with(self);
 
         self.in_var_decl = old_in_var_decl;
     }
@@ -554,19 +557,21 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_jsx_element_name(&mut self, e: &JSXElementName) {
-        e.visit_children_with(self);
-
         if let JSXElementName::Ident(i) = e {
             self.add(i.to_id(), false);
+            return;
         }
+
+        e.visit_children_with(self);
     }
 
     fn visit_jsx_object(&mut self, e: &JSXObject) {
-        e.visit_children_with(self);
-
         if let JSXObject::Ident(i) = e {
             self.add(i.to_id(), false);
+            return;
         }
+
+        e.visit_children_with(self);
     }
 
     fn visit_arrow_expr(&mut self, n: &ArrowExpr) {
@@ -617,21 +622,23 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_pat(&mut self, p: &Pat) {
-        p.visit_children_with(self);
-
-        if !self.in_var_decl {
-            if let Pat::Ident(i) = p {
+        if let Pat::Ident(i) = p {
+            if !self.in_var_decl {
                 self.add(i.to_id(), true);
             }
+            return;
         }
+
+        p.visit_children_with(self);
     }
 
     fn visit_prop(&mut self, p: &Prop) {
-        p.visit_children_with(self);
-
         if let Prop::Shorthand(i) = p {
             self.add(i.to_id(), false);
+            return;
         }
+
+        p.visit_children_with(self);
     }
 
     fn visit_var_declarator(&mut self, n: &VarDeclarator) {

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2782,11 +2782,49 @@ fn cast_to_bool(expr: &Expr, ctx: ExprCtx) -> (Purity, BoolValue) {
         return (MayBeImpure, Unknown);
     };
 
-    if expr.is_global_ref_to(ctx, "undefined") {
-        return (Pure, Known(false));
+    if let Expr::Ident(i) = expr {
+        if &*i.sym == "NaN" {
+            return (Pure, Known(false));
+        }
+
+        if i.ctxt != ctx.unresolved_ctxt {
+            return (Pure, Unknown);
+        }
+
+        if &*i.sym == "undefined" {
+            return (Pure, Known(false));
+        }
+
+        return if ctx.is_unresolved_ref_safe
+            || matches!(
+                &*i.sym,
+                "Infinity"
+                    | "Math"
+                    | "Object"
+                    | "Array"
+                    | "Date"
+                    | "Promise"
+                    | "Boolean"
+                    | "Number"
+                    | "String"
+                    | "BigInt"
+                    | "Error"
+                    | "RegExp"
+                    | "Function"
+                    | "document"
+            ) {
+            (Pure, Unknown)
+        } else {
+            (MayBeImpure, Unknown)
+        };
     }
-    if expr.is_nan() {
-        return (Pure, Known(false));
+
+    if matches!(expr, Expr::This(..)) {
+        return (Pure, Unknown);
+    }
+
+    if matches!(expr, Expr::Fn(..)) {
+        return (Pure, Known(true));
     }
 
     let val = match expr {

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -3537,10 +3537,6 @@ fn may_have_side_effects(expr: &Expr, ctx: ExprCtx) -> bool {
         return true;
     };
 
-    if expr.is_pure_callee(ctx) {
-        return false;
-    }
-
     match expr {
         Expr::Ident(i) => {
             if ctx.is_unresolved_ref_safe {
@@ -3556,6 +3552,7 @@ fn may_have_side_effects(expr: &Expr, ctx: ExprCtx) -> bool {
                         | "undefined"
                         | "Object"
                         | "Array"
+                        | "Date"
                         | "Promise"
                         | "Boolean"
                         | "Number"
@@ -3593,6 +3590,8 @@ fn may_have_side_effects(expr: &Expr, ctx: ExprCtx) -> bool {
         Expr::Bin(BinExpr { left, right, .. }) => {
             left.may_have_side_effects(ctx) || right.may_have_side_effects(ctx)
         }
+
+        Expr::Member(..) if expr.is_pure_callee(ctx) => false,
 
         Expr::Member(MemberExpr { obj, prop, .. })
             if obj.is_object() || obj.is_fn_expr() || obj.is_arrow() || obj.is_class() =>

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -3404,60 +3404,59 @@ fn get_type(expr: &Expr, ctx: ExprCtx) -> Value<Type> {
     }
 }
 
-fn is_pure_callee(expr: &Expr, ctx: ExprCtx) -> bool {
-    if expr.is_global_ref_to(ctx, "Date") {
-        return true;
-    }
+#[inline(always)]
+fn is_pure_str_method(method: &str) -> bool {
+    matches!(
+        method,
+        "charAt"
+            | "charCodeAt"
+            | "concat"
+            | "endsWith"
+            | "includes"
+            | "indexOf"
+            | "lastIndexOf"
+            | "localeCompare"
+            | "slice"
+            | "split"
+            | "startsWith"
+            | "substr"
+            | "substring"
+            | "toLocaleLowerCase"
+            | "toLocaleUpperCase"
+            | "toLowerCase"
+            | "toString"
+            | "toUpperCase"
+            | "trim"
+            | "trimEnd"
+            | "trimStart"
+    )
+}
 
-    match expr {
-        Expr::Member(MemberExpr {
-            obj,
-            prop: MemberProp::Ident(prop),
-            ..
+#[inline(always)]
+fn is_pure_member_callee(obj: &Expr, prop: &MemberProp, ctx: ExprCtx) -> bool {
+    let MemberProp::Ident(prop) = prop else {
+        return false;
+    };
+
+    match obj {
+        Expr::Ident(Ident {
+            ctxt, sym: math, ..
         }) => {
-            // Some methods of string are pure
-            fn is_pure_str_method(method: &str) -> bool {
-                matches!(
-                    method,
-                    "charAt"
-                        | "charCodeAt"
-                        | "concat"
-                        | "endsWith"
-                        | "includes"
-                        | "indexOf"
-                        | "lastIndexOf"
-                        | "localeCompare"
-                        | "slice"
-                        | "split"
-                        | "startsWith"
-                        | "substr"
-                        | "substring"
-                        | "toLocaleLowerCase"
-                        | "toLocaleUpperCase"
-                        | "toLowerCase"
-                        | "toString"
-                        | "toUpperCase"
-                        | "trim"
-                        | "trimEnd"
-                        | "trimStart"
-                )
-            }
-
-            obj.is_global_ref_to(ctx, "Math")
-                || match &**obj {
-                    // Allow dummy span
-                    Expr::Ident(Ident {
-                        ctxt, sym: math, ..
-                    }) => &**math == "Math" && *ctxt == SyntaxContext::empty(),
-
-                    Expr::Lit(Lit::Str(..)) => is_pure_str_method(&prop.sym),
-                    Expr::Tpl(Tpl { exprs, .. }) if exprs.is_empty() => {
-                        is_pure_str_method(&prop.sym)
-                    }
-
-                    _ => false,
-                }
+            &**math == "Math" && (*ctxt == ctx.unresolved_ctxt || *ctxt == SyntaxContext::empty())
         }
+
+        Expr::Lit(Lit::Str(..)) => is_pure_str_method(&prop.sym),
+        Expr::Tpl(Tpl { exprs, .. }) if exprs.is_empty() => is_pure_str_method(&prop.sym),
+
+        _ => false,
+    }
+}
+
+fn is_pure_callee(expr: &Expr, ctx: ExprCtx) -> bool {
+    match expr {
+        Expr::Ident(i) => i.ctxt == ctx.unresolved_ctxt && &*i.sym == "Date",
+
+        Expr::Member(MemberExpr { obj, prop, .. }) => is_pure_member_callee(obj, prop, ctx),
 
         Expr::Fn(FnExpr { function: f, .. })
             if f.params.iter().all(|p| p.pat.is_ident())
@@ -3591,7 +3590,9 @@ fn may_have_side_effects(expr: &Expr, ctx: ExprCtx) -> bool {
             left.may_have_side_effects(ctx) || right.may_have_side_effects(ctx)
         }
 
-        Expr::Member(..) if expr.is_pure_callee(ctx) => false,
+        Expr::Member(MemberExpr { obj, prop, .. }) if is_pure_member_callee(obj, prop, ctx) => {
+            false
+        }
 
         Expr::Member(MemberExpr { obj, prop, .. })
             if obj.is_object() || obj.is_fn_expr() || obj.is_arrow() || obj.is_class() =>


### PR DESCRIPTION
## Summary

This draft PR contains incremental minifier performance work guided by local callgrind runs on the `swc_ecma_minifier` full benchmark binary.

Current changes:
- Skip empty finalizer replacement-map lookups.
- Avoid eager pure callee checks when member/call shape makes them unnecessary.
- Reserve mangle rename maps from known symbol counts.
- Skip pure boolean rewrites for non-logical expressions.
- Streamline pure member callee checks and share pure method-call evaluation.
- Guard pure-expression evaluation hooks and reuse sequence alias ids.
- Skip no-op invalid cleanup paths and guard logical rewrite calls.
- Skip non-binary invalid cleanup and unused logical bool casts.
- Avoid empty infection propagation, reuse merge entry access, and clone only infection ids when propagating program data.
- Handle replacer identifiers before generic child traversal.
- Return early from Finalizer for leaf identifiers after the literal replacement check.
- Skip redundant var-without-init counter walks once direct statement scanning already knows work is needed, and stop the counter after it finds a result.
- Skip DCE analyzer/dropper child traversal for leaf identifier, JSX identifier, pattern identifier, and shorthand property nodes.
- Skip usage-analysis child traversal for leaf identifiers in usage, alias infection, and local identifier collectors.
- Return early from the pure optimizer for identifier, literal, and invalid leaf expressions.
- Fast-path bare identifiers in the optimizer while preserving identifier inline/evaluate rewrites.
- Skip leaf expression and identifier-pattern traversal in the var-without-init counter.
- Narrow the optimizer identifier fast path to the global-variable evaluation work that can apply to an unchanged identifier.
- Avoid `data.vars` lookups for global identifier evaluation unless the identifier name is a candidate for rewriting.
- Guard invalid cleanup so the pure optimizer only walks sequence/binary expressions with direct invalid children, while the optimizer still catches shallow nested logical invalids.
- Prune additional pure optimizer hot paths: var-without-init visitors avoid expression/class subtrees, boolean shortening is guarded at recursive and call sites, member simplification is limited to literal object shapes, and binary simplification skips shapes that cannot fold.
- Guard pure optimizer expression passes by expression kind, and skip Finalizer expression replacement checks when literal and hoisted-property replacement maps are both empty.
- Treat `this` as a leaf expression in the pure optimizer so it skips the full expression-pass pipeline.
- Fast-path boolean casts for identifiers, `this`, and function expressions before falling back to generic side-effect analysis.
- Narrow numeric pure optimizer guards to the operators handled by the number/int rewrite passes.

## Measurements

Local callgrind instruction counts with `RUST_LOG=off CI=1`:

- `lodash`: `origin/main` `271,951,203` -> current branch `240,324,539` Ir (`11.6295%` reduction).
- Latest step, `lodash`: previous pushed head `6656765043` `240,514,814` -> `4051e8a768` `240,324,539` Ir (`0.0791%` reduction, `190,275` Ir fewer).
- Latest step, `terser`: previous pushed head `6656765043` `624,150,608` -> `4051e8a768` `623,398,377` Ir (`0.1205%` reduction, `752,231` Ir fewer).

Callgrind outputs for the latest step:
- `/tmp/callgrind.lodash.number-op-guards.out`
- `/tmp/callgrind.terser.number-op-guards.out`

CodSpeed/CI notes:
- CI has been restarted for the new head `4051e8a768`.
- On earlier heads in this PR, `Cargo fmt`, `Cargo clippy`, `Benchmark swc_ecma_minifier`, and `Benchmark swc_es_minifier` completed successfully.
- The dependency license failure seen on earlier heads is the existing `rkyv 0.8.13` / `RUSTSEC-2026-0122` issue and is unrelated to this PR; this branch does not touch dependency manifests.

## Validation

- `cargo fmt --all`
- `git submodule update --init --recursive`
- `RUST_LOG=off CI=1 cargo test -p swc_ecma_utils`
- `RUST_LOG=off CI=1 cargo test -p swc_ecma_minifier`
- `(cd crates/swc_ecma_minifier && ./scripts/exec.sh)`
- `cargo clippy --all --all-targets -- -D warnings`

## Breaking change

None.

## Related issue

None.