### PR TITLE
chore: Add changeset skill

### DIFF
--- a/.codex/skills/add-changeset/SKILL.md
+++ b/.codex/skills/add-changeset/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: add-changeset
+description: Create SWC changeset files for pull requests. Use when asked to add a changeset, prepare release notes, decide patch/minor/major bumps, or enumerate changed Rust crates for an SWC PR; the skill requires every publishable Rust crate with a breaking change to be listed as major and every other changed publishable Rust crate to be listed as patch or minor.
+---
+
+# Add Changeset
+
+## Goal
+
+Add one Markdown file under `.changeset/` whose front matter lists every changed publishable Rust crate in the PR.
+
+## Workflow
+
+1. Find the PR base and changed files.
+   - Prefer `gh pr view --json baseRefName,headRefName,body` when the branch has a GitHub PR.
+   - Use `git diff` against the PR merge base; include staged and unstaged local changes when preparing an unpushed PR.
+   - Run `scripts/changed-rust-crates.mjs` from this skill to get a first pass of directly touched Rust crates.
+
+2. Read the code, not only the helper output.
+   - Inspect every changed Rust crate reported by the helper.
+   - Inspect root workspace changes such as `Cargo.toml`, `Cargo.lock`, `rust-toolchain`, `.cargo/`, and release tooling manually; they may affect crates without changing files inside the crate directory.
+   - Ignore non-publishable workspace crates in changeset front matter unless the maintainer explicitly asks otherwise; SWC's release tool skips `publish = false` crates.
+
+3. Classify every changed publishable Rust crate.
+   - Use `major` for every crate whose public API, behavior contract, feature semantics, serialized output, CLI-visible behavior, or documented compatibility is breaking.
+   - Use `minor` for non-breaking new public functionality, new supported syntax, new options, new public exports, or meaningful user-visible capability.
+   - Use `patch` for bug fixes, performance work, refactors, internal-only changes, tests, fixtures, documentation, or dependency bumps that do not add a non-breaking capability.
+   - If a crate has both breaking and non-breaking changes, list it once as `major`.
+
+4. Check `swc_core` exposure explicitly.
+   - If a changed crate's breaking API is re-exported by `swc_core` or exposed through a `swc_core` feature, list `swc_core: major`.
+   - If a changed crate adds non-breaking public API that `swc_core` exposes, list `swc_core: minor`.
+   - If `swc_core` files or feature mappings changed directly and the change is not breaking or additive, list `swc_core: patch`.
+
+5. Write the changeset.
+   - Create a new file at `.changeset/<short-kebab-summary>.md`.
+   - Keep the front matter sorted by crate name unless a maintainer provided another order.
+   - Mention only Rust crate names and bump levels in front matter.
+   - Write a concise summary after the front matter using SWC commit style, such as `fix(es/parser): ...`, `feat(es/parser): ...`, `perf(es/parser): ...`, or `refactor(es/parser): ...`.
+
+## Example
+
+```markdown
+---
+swc_core: minor
+swc_ecma_parser: minor
+---
+
+perf: Optimize es parser comment finalization
+```
+
+## Helper
+
+Run this helper from the repository root:
+
+```bash
+node .codex/skills/add-changeset/scripts/changed-rust-crates.mjs
+```
+
+Useful options:
+
+```bash
+node .codex/skills/add-changeset/scripts/changed-rust-crates.mjs --base origin/main
+node .codex/skills/add-changeset/scripts/changed-rust-crates.mjs --json
+node .codex/skills/add-changeset/scripts/changed-rust-crates.mjs --include-private
+```
+
+Treat the helper as an inventory aid. It does not decide breaking changes, does not understand public API exposure, and cannot fully interpret workspace-level changes.

--- a/.codex/skills/add-changeset/SKILL.md
+++ b/.codex/skills/add-changeset/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: add-changeset
-description: Create SWC changeset files for pull requests. Use when asked to add a changeset, prepare release notes, decide patch/minor/major bumps, or enumerate changed Rust crates for an SWC PR; the skill requires every publishable Rust crate with a breaking change to be listed as major and every other changed publishable Rust crate to be listed as patch or minor.
+description: Create SWC changeset files for pull requests. Use when asked to add a changeset, prepare release notes, decide patch/minor/major bumps, or enumerate changed Rust crates for an SWC PR; the skill requires every publishable Rust crate with a breaking change or a runtime dependency breaking change to be listed as major, every other changed publishable Rust crate to be listed as patch or minor, and swc_core to be listed as at least patch for Rust crate changes.
 ---
 
 # Add Changeset
 
 ## Goal
 
-Add one Markdown file under `.changeset/` whose front matter lists every changed publishable Rust crate in the PR.
+Add one Markdown file under `.changeset/` whose front matter lists every changed publishable Rust crate in the PR, plus `swc_core` when any Rust crate changes.
 
 ## Workflow
 
@@ -23,6 +23,8 @@ Add one Markdown file under `.changeset/` whose front matter lists every changed
 
 3. Classify every changed publishable Rust crate.
    - Use `major` for every crate whose public API, behavior contract, feature semantics, serialized output, CLI-visible behavior, or documented compatibility is breaking.
+   - Use `major` for a crate when one of its runtime dependencies changed in a breaking way. Check that crate's `[dependencies]`, target-specific runtime dependencies, and relevant `Cargo.lock` changes; do not apply this rule to dev-only or build-only dependencies.
+   - Do not expand `major` through SWC's reverse internal dependency graph just because another crate depends on a breaking crate.
    - Use `minor` for non-breaking new public functionality, new supported syntax, new options, new public exports, or meaningful user-visible capability.
    - Use `patch` for bug fixes, performance work, refactors, internal-only changes, tests, fixtures, documentation, or dependency bumps that do not add a non-breaking capability.
    - If a crate has both breaking and non-breaking changes, list it once as `major`.
@@ -31,6 +33,7 @@ Add one Markdown file under `.changeset/` whose front matter lists every changed
    - If a changed crate's breaking API is re-exported by `swc_core` or exposed through a `swc_core` feature, list `swc_core: major`.
    - If a changed crate adds non-breaking public API that `swc_core` exposes, list `swc_core: minor`.
    - If `swc_core` files or feature mappings changed directly and the change is not breaking or additive, list `swc_core: patch`.
+   - If any publishable Rust crate is listed and no stronger `swc_core` bump is required, include `swc_core: patch` even when `swc_core` files did not change.
 
 5. Write the changeset.
    - Create a new file at `.changeset/<short-kebab-summary>.md`.

--- a/.codex/skills/add-changeset/SKILL.md
+++ b/.codex/skills/add-changeset/SKILL.md
@@ -24,7 +24,7 @@ Add one Markdown file under `.changeset/` whose front matter lists every changed
 3. Classify every changed publishable Rust crate.
    - Use `major` for every crate whose public API, behavior contract, feature semantics, serialized output, CLI-visible behavior, or documented compatibility is breaking.
    - Use `major` for a crate when one of its runtime dependencies changed in a breaking way. Check that crate's `[dependencies]`, target-specific runtime dependencies, and relevant `Cargo.lock` changes; do not apply this rule to dev-only or build-only dependencies.
-   - Do not expand `major` through SWC's reverse internal dependency graph just because another crate depends on a breaking crate.
+   - Do not expand `major` through SWC's reverse internal dependency graph just because another crate depends on a breaking crate; SWC's bump command handles that internal propagation after reading the changeset.
    - Use `minor` for non-breaking new public functionality, new supported syntax, new options, new public exports, or meaningful user-visible capability.
    - Use `patch` for bug fixes, performance work, refactors, internal-only changes, tests, fixtures, documentation, or dependency bumps that do not add a non-breaking capability.
    - If a crate has both breaking and non-breaking changes, list it once as `major`.

--- a/.codex/skills/add-changeset/agents/openai.yaml
+++ b/.codex/skills/add-changeset/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Add Changeset"
+  short_description: "Create complete SWC crate changesets"
+  default_prompt: "Use $add-changeset to add a complete SWC changeset for the current PR."

--- a/.codex/skills/add-changeset/scripts/changed-rust-crates.mjs
+++ b/.codex/skills/add-changeset/scripts/changed-rust-crates.mjs
@@ -1,0 +1,336 @@
+#!/usr/bin/env node
+
+import { spawnSync } from "node:child_process";
+import { relative, sep } from "node:path";
+import { cwd, exit } from "node:process";
+
+const args = parseArgs(process.argv.slice(2));
+
+if (args.help) {
+    printHelp();
+    exit(0);
+}
+
+const repoRoot = run("git", ["rev-parse", "--show-toplevel"]).stdout.trim();
+const head = args.head ?? "HEAD";
+const base = args.base ?? detectBase(head);
+const metadata = JSON.parse(
+    run("cargo", ["metadata", "--format-version", "1", "--no-deps"], {
+        cwd: repoRoot,
+    }).stdout,
+);
+
+const packages = workspacePackages(metadata, repoRoot);
+const changedPaths = collectChangedPaths(base, head);
+const report = buildReport(packages, changedPaths);
+
+if (args.json) {
+    process.stdout.write(
+        `${JSON.stringify(
+            {
+                base,
+                head,
+                publishableCrates: report.publishableCrates,
+                privateCrates: report.privateCrates,
+                workspaceFiles: report.workspaceFiles,
+                unmappedFiles: report.unmappedFiles,
+            },
+            null,
+            2,
+        )}\n`,
+    );
+} else {
+    printReport(base, head, report);
+}
+
+function parseArgs(rawArgs) {
+    const parsed = {
+        base: null,
+        head: null,
+        help: false,
+        includePrivate: false,
+        json: false,
+    };
+
+    for (let i = 0; i < rawArgs.length; i += 1) {
+        const arg = rawArgs[i];
+
+        if (arg === "--help" || arg === "-h") {
+            parsed.help = true;
+        } else if (arg === "--json") {
+            parsed.json = true;
+        } else if (arg === "--include-private") {
+            parsed.includePrivate = true;
+        } else if (arg === "--base") {
+            parsed.base = requireValue(rawArgs, ++i, arg);
+        } else if (arg.startsWith("--base=")) {
+            parsed.base = arg.slice("--base=".length);
+        } else if (arg === "--head") {
+            parsed.head = requireValue(rawArgs, ++i, arg);
+        } else if (arg.startsWith("--head=")) {
+            parsed.head = arg.slice("--head=".length);
+        } else {
+            fail(`Unknown argument: ${arg}`);
+        }
+    }
+
+    return parsed;
+}
+
+function requireValue(rawArgs, index, flag) {
+    const value = rawArgs[index];
+
+    if (!value || value.startsWith("--")) {
+        fail(`Missing value for ${flag}`);
+    }
+
+    return value;
+}
+
+function printHelp() {
+    process.stdout.write(`Usage: changed-rust-crates.mjs [options]
+
+Lists Rust workspace crates touched by the current PR diff.
+
+Options:
+  --base <rev>          Base revision or branch. Defaults to a merge base with origin/main, upstream/main, main, origin/master, or master.
+  --head <rev>          Head revision. Defaults to HEAD.
+  --include-private     Show publish=false workspace crates in the text report.
+  --json                Print machine-readable JSON.
+  -h, --help            Show this help.
+`);
+}
+
+function detectBase(head) {
+    const candidates = [
+        "origin/main",
+        "upstream/main",
+        "main",
+        "origin/master",
+        "master",
+    ];
+
+    for (const candidate of candidates) {
+        const exists = run("git", ["rev-parse", "--verify", candidate], {
+            allowFailure: true,
+        });
+
+        if (!exists.ok) {
+            continue;
+        }
+
+        const mergeBase = run("git", ["merge-base", head, candidate], {
+            allowFailure: true,
+        });
+
+        if (mergeBase.ok && mergeBase.stdout.trim()) {
+            return mergeBase.stdout.trim();
+        }
+    }
+
+    fail("Could not detect a PR base. Pass --base <rev> explicitly.");
+}
+
+function workspacePackages(metadata, repoRoot) {
+    const workspaceMembers = new Set(metadata.workspace_members ?? []);
+
+    return metadata.packages
+        .filter((pkg) => workspaceMembers.has(pkg.id))
+        .map((pkg) => {
+            const manifestPath = normalizePath(relative(repoRoot, pkg.manifest_path));
+            const root = normalizePath(manifestPath.replace(/(^|\/)Cargo\.toml$/, ""));
+
+            return {
+                name: pkg.name,
+                publishable: !Array.isArray(pkg.publish) || pkg.publish.length !== 0,
+                root: root === "" ? "." : root,
+            };
+        })
+        .sort((a, b) => b.root.length - a.root.length);
+}
+
+function collectChangedPaths(base, head) {
+    const paths = new Set();
+    const diffArgs = ["diff", "--name-only", "--diff-filter=ACMRD"];
+
+    addLines(paths, run("git", [...diffArgs, `${base}...${head}`]).stdout);
+
+    if (head === "HEAD") {
+        addLines(paths, run("git", [...diffArgs, "--cached"]).stdout);
+        addLines(paths, run("git", diffArgs).stdout);
+        addLines(
+            paths,
+            run("git", ["ls-files", "--others", "--exclude-standard"]).stdout,
+        );
+    }
+
+    return [...paths].map(normalizePath).sort();
+}
+
+function buildReport(packages, changedPaths) {
+    const publishableByName = new Map();
+    const privateByName = new Map();
+    const workspaceFiles = [];
+    const unmappedFiles = [];
+
+    for (const path of changedPaths) {
+        const pkg = packages.find((candidate) => pathBelongsToPackage(path, candidate));
+
+        if (!pkg) {
+            if (isWorkspaceLevelPath(path)) {
+                workspaceFiles.push(path);
+            } else {
+                unmappedFiles.push(path);
+            }
+
+            continue;
+        }
+
+        const relativePath = pkg.root === "." ? path : path.slice(pkg.root.length + 1);
+        const collection = pkg.publishable ? publishableByName : privateByName;
+        const crate = collection.get(pkg.name) ?? {
+            name: pkg.name,
+            root: pkg.root,
+            paths: [],
+        };
+
+        crate.paths.push(relativePath || "Cargo.toml");
+        collection.set(pkg.name, crate);
+    }
+
+    return {
+        publishableCrates: sortCrates([...publishableByName.values()]),
+        privateCrates: sortCrates([...privateByName.values()]),
+        workspaceFiles,
+        unmappedFiles,
+    };
+}
+
+function pathBelongsToPackage(path, pkg) {
+    if (pkg.root === ".") {
+        return true;
+    }
+
+    return path === pkg.root || path.startsWith(`${pkg.root}/`);
+}
+
+function isWorkspaceLevelPath(path) {
+    return (
+        path === "Cargo.toml" ||
+        path === "Cargo.lock" ||
+        path === "rust-toolchain" ||
+        path.startsWith(".cargo/") ||
+        path.startsWith(".changeset/") ||
+        path.startsWith("tools/swc-releaser/")
+    );
+}
+
+function sortCrates(crates) {
+    return crates
+        .map((crate) => ({
+            ...crate,
+            paths: [...new Set(crate.paths)].sort(),
+        }))
+        .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function printReport(base, head, report) {
+    process.stdout.write(`Base: ${base}\nHead: ${head}\n\n`);
+
+    printCrateSection("Publishable Rust crates touched", report.publishableCrates);
+
+    if (args.includePrivate) {
+        printCrateSection("Private Rust crates touched", report.privateCrates);
+    } else if (report.privateCrates.length > 0) {
+        process.stdout.write(
+            `Private Rust crates touched: ${report.privateCrates.length} (use --include-private to show)\n\n`,
+        );
+    }
+
+    printPathSection(
+        "Workspace-level files requiring manual review",
+        report.workspaceFiles,
+    );
+    printPathSection("Unmapped changed files", report.unmappedFiles);
+
+    if (report.publishableCrates.length > 0) {
+        process.stdout.write("Changeset front matter skeleton:\n---\n");
+
+        for (const crate of report.publishableCrates) {
+            process.stdout.write(`${crate.name}: patch\n`);
+        }
+
+        process.stdout.write("---\n");
+    }
+}
+
+function printCrateSection(title, crates) {
+    process.stdout.write(`${title}:\n`);
+
+    if (crates.length === 0) {
+        process.stdout.write("- none\n\n");
+        return;
+    }
+
+    for (const crate of crates) {
+        const samplePaths = crate.paths.slice(0, 5).join(", ");
+        const suffix = crate.paths.length > 5 ? ", ..." : "";
+        process.stdout.write(`- ${crate.name} (${crate.root}): ${samplePaths}${suffix}\n`);
+    }
+
+    process.stdout.write("\n");
+}
+
+function printPathSection(title, paths) {
+    if (paths.length === 0) {
+        return;
+    }
+
+    process.stdout.write(`${title}:\n`);
+
+    for (const path of paths) {
+        process.stdout.write(`- ${path}\n`);
+    }
+
+    process.stdout.write("\n");
+}
+
+function addLines(target, text) {
+    for (const line of text.split("\n")) {
+        const path = line.trim();
+
+        if (path) {
+            target.add(path);
+        }
+    }
+}
+
+function normalizePath(path) {
+    return path.split(sep).join("/");
+}
+
+function run(command, commandArgs, options = {}) {
+    const result = spawnSync(command, commandArgs, {
+        cwd: options.cwd ?? cwd(),
+        encoding: "utf8",
+    });
+
+    const ok = result.status === 0;
+
+    if (!ok && !options.allowFailure) {
+        fail(
+            `Command failed: ${command} ${commandArgs.join(" ")}\n${result.stderr.trim()}`,
+        );
+    }
+
+    return {
+        ok,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+    };
+}
+
+function fail(message) {
+    process.stderr.write(`${message}\n`);
+    exit(1);
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Adds a repository-local Codex skill for creating SWC changesets.

The skill documents how to enumerate changed publishable Rust crates, classify patch/minor/major bumps, handle runtime dependency breaking changes, and include swc_core as at least patch for Rust crate changes. It also includes a Node.js helper that inventories directly touched Rust crates from the PR diff.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.

Validation:

- node --check .codex/skills/add-changeset/scripts/changed-rust-crates.mjs
- node .codex/skills/add-changeset/scripts/changed-rust-crates.mjs --json
- cargo fmt --all
- cargo clippy --all --all-targets -- -D warnings
