### PR TITLE
perf: Reduce es parser binary expression overhead

### DIFF
--- a/.changeset/reduce-es-parser-binary-overhead.md
+++ b/.changeset/reduce-es-parser-binary-overhead.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_es_parser: patch
+---
+
+perf(es/parser): reduce binary expression parsing overhead

--- a/crates/swc_es_parser/src/lexer.rs
+++ b/crates/swc_es_parser/src/lexer.rs
@@ -305,6 +305,7 @@ impl<'a> Lexer<'a> {
             b'>' => self.gt_like(had_line_break_before),
             b'\'' | b'"' => self.read_string(had_line_break_before),
             b'0'..=b'9' => self.read_number(had_line_break_before),
+            b'$' | b'_' | b'a'..=b'z' | b'A'..=b'Z' => self.read_word(had_line_break_before),
             _ => {
                 if self.is_ident_start()
                     || (self.input.cur_as_ascii() == Some(b'\\') && self.input.peek() == Some(b'u'))

--- a/crates/swc_es_parser/src/parser.rs
+++ b/crates/swc_es_parser/src/parser.rs
@@ -2591,7 +2591,7 @@ impl<'a> Parser<'a> {
     }
 
     fn parse_conditional_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_nullish_expr()?;
+        let mut expr = self.parse_binary_expr(0)?;
 
         if self.cur.kind == TokenKind::Question {
             let start = self.cur.span.lo;
@@ -2604,24 +2604,6 @@ impl<'a> Parser<'a> {
                 test: expr,
                 cons,
                 alt,
-            }));
-        }
-
-        Ok(expr)
-    }
-
-    fn parse_nullish_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_logical_or_expr()?;
-
-        while self.cur.kind == TokenKind::Nullish {
-            let start = self.cur.span.lo;
-            self.bump();
-            let right = self.parse_logical_or_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op: BinaryOp::NullishCoalescing,
-                left: expr,
-                right,
             }));
         }
 
@@ -2678,264 +2660,63 @@ impl<'a> Parser<'a> {
         })))
     }
 
-    fn parse_logical_or_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_logical_and_expr()?;
+    fn parse_binary_expr(&mut self, min_prec: u8) -> PResult<swc_es_ast::ExprId> {
+        let mut left = self.parse_unary_expr()?;
 
-        while self.cur.kind == TokenKind::OrOr {
+        while let Some((op, prec, right_assoc)) = self.current_binary_op() {
+            if prec < min_prec {
+                break;
+            }
+
             let start = self.cur.span.lo;
             self.bump();
-            let right = self.parse_logical_and_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op: BinaryOp::LogicalOr,
-                left: expr,
-                right,
-            }));
-        }
-
-        Ok(expr)
-    }
-
-    fn parse_logical_and_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_bitwise_or_expr()?;
-
-        while self.cur.kind == TokenKind::AndAnd {
-            let start = self.cur.span.lo;
-            self.bump();
-            let right = self.parse_bitwise_or_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op: BinaryOp::LogicalAnd,
-                left: expr,
-                right,
-            }));
-        }
-
-        Ok(expr)
-    }
-
-    fn parse_bitwise_or_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_bitwise_xor_expr()?;
-
-        while self.cur.kind == TokenKind::Pipe {
-            let start = self.cur.span.lo;
-            self.bump();
-            let right = self.parse_bitwise_xor_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op: BinaryOp::BitOr,
-                left: expr,
-                right,
-            }));
-        }
-
-        Ok(expr)
-    }
-
-    fn parse_bitwise_xor_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_bitwise_and_expr()?;
-
-        while self.cur.kind == TokenKind::Caret {
-            let start = self.cur.span.lo;
-            self.bump();
-            let right = self.parse_bitwise_and_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op: BinaryOp::BitXor,
-                left: expr,
-                right,
-            }));
-        }
-
-        Ok(expr)
-    }
-
-    fn parse_bitwise_and_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_equality_expr()?;
-
-        while self.cur.kind == TokenKind::Amp {
-            let start = self.cur.span.lo;
-            self.bump();
-            let right = self.parse_equality_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op: BinaryOp::BitAnd,
-                left: expr,
-                right,
-            }));
-        }
-
-        Ok(expr)
-    }
-
-    fn parse_equality_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_relational_expr()?;
-
-        while matches!(
-            self.cur.kind,
-            TokenKind::EqEq | TokenKind::EqEqEq | TokenKind::NotEq | TokenKind::NotEqEq
-        ) {
-            let start = self.cur.span.lo;
-            let op = match self.cur.kind {
-                TokenKind::EqEq => BinaryOp::EqEq,
-                TokenKind::EqEqEq => BinaryOp::EqEqEq,
-                TokenKind::NotEq => BinaryOp::NotEq,
-                TokenKind::NotEqEq => BinaryOp::NotEqEq,
-                _ => unreachable!(),
-            };
-            self.bump();
-            let right = self.parse_relational_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
+            let right_min_prec = if right_assoc { prec } else { prec + 1 };
+            let right = self.parse_binary_expr(right_min_prec)?;
+            left = self.store.alloc_expr(Expr::Binary(BinaryExpr {
                 span: Span::new_with_checked(start, self.last_pos()),
                 op,
-                left: expr,
+                left,
                 right,
             }));
         }
 
-        Ok(expr)
+        Ok(left)
     }
 
-    fn parse_relational_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_shift_expr()?;
+    #[inline]
+    fn current_binary_op(&self) -> Option<(BinaryOp, u8, bool)> {
+        let op = match self.cur.kind {
+            TokenKind::Nullish => (BinaryOp::NullishCoalescing, 1, false),
+            TokenKind::OrOr => (BinaryOp::LogicalOr, 2, false),
+            TokenKind::AndAnd => (BinaryOp::LogicalAnd, 3, false),
+            TokenKind::Pipe => (BinaryOp::BitOr, 4, false),
+            TokenKind::Caret => (BinaryOp::BitXor, 5, false),
+            TokenKind::Amp => (BinaryOp::BitAnd, 6, false),
+            TokenKind::EqEq => (BinaryOp::EqEq, 7, false),
+            TokenKind::EqEqEq => (BinaryOp::EqEqEq, 7, false),
+            TokenKind::NotEq => (BinaryOp::NotEq, 7, false),
+            TokenKind::NotEqEq => (BinaryOp::NotEqEq, 7, false),
+            TokenKind::Lt => (BinaryOp::Lt, 8, false),
+            TokenKind::Gt => (BinaryOp::Gt, 8, false),
+            TokenKind::LtEq => (BinaryOp::LtEq, 8, false),
+            TokenKind::GtEq => (BinaryOp::GtEq, 8, false),
+            TokenKind::Keyword(Keyword::In) if !self.ctx.contains(Context::IN_FOR_HEAD) => {
+                (BinaryOp::In, 8, false)
+            }
+            TokenKind::Keyword(Keyword::InstanceOf) => (BinaryOp::InstanceOf, 8, false),
+            TokenKind::LtLt => (BinaryOp::LShift, 9, false),
+            TokenKind::GtGt => (BinaryOp::RShift, 9, false),
+            TokenKind::GtGtGt => (BinaryOp::ZeroFillRShift, 9, false),
+            TokenKind::Plus => (BinaryOp::Add, 10, false),
+            TokenKind::Minus => (BinaryOp::Sub, 10, false),
+            TokenKind::Star => (BinaryOp::Mul, 11, false),
+            TokenKind::Slash => (BinaryOp::Div, 11, false),
+            TokenKind::Percent => (BinaryOp::Mod, 11, false),
+            TokenKind::StarStar => (BinaryOp::Exp, 12, true),
+            _ => return None,
+        };
 
-        while matches!(
-            self.cur.kind,
-            TokenKind::Lt | TokenKind::Gt | TokenKind::LtEq | TokenKind::GtEq
-        ) {
-            let start = self.cur.span.lo;
-            let op = match self.cur.kind {
-                TokenKind::Lt => BinaryOp::Lt,
-                TokenKind::Gt => BinaryOp::Gt,
-                TokenKind::LtEq => BinaryOp::LtEq,
-                TokenKind::GtEq => BinaryOp::GtEq,
-                _ => unreachable!(),
-            };
-            self.bump();
-            let right = self.parse_shift_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op,
-                left: expr,
-                right,
-            }));
-        }
-
-        while (!self.ctx.contains(Context::IN_FOR_HEAD)
-            && self.cur.kind == TokenKind::Keyword(Keyword::In))
-            || self.cur.kind == TokenKind::Keyword(Keyword::InstanceOf)
-        {
-            let start = self.cur.span.lo;
-            let op = if self.cur.kind == TokenKind::Keyword(Keyword::In) {
-                BinaryOp::In
-            } else {
-                BinaryOp::InstanceOf
-            };
-            self.bump();
-            let right = self.parse_shift_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op,
-                left: expr,
-                right,
-            }));
-        }
-
-        Ok(expr)
-    }
-
-    fn parse_shift_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_additive_expr()?;
-
-        while matches!(
-            self.cur.kind,
-            TokenKind::LtLt | TokenKind::GtGt | TokenKind::GtGtGt
-        ) {
-            let start = self.cur.span.lo;
-            let op = match self.cur.kind {
-                TokenKind::LtLt => BinaryOp::LShift,
-                TokenKind::GtGt => BinaryOp::RShift,
-                TokenKind::GtGtGt => BinaryOp::ZeroFillRShift,
-                _ => unreachable!(),
-            };
-            self.bump();
-            let right = self.parse_additive_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op,
-                left: expr,
-                right,
-            }));
-        }
-
-        Ok(expr)
-    }
-
-    fn parse_additive_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_multiplicative_expr()?;
-
-        while self.cur.kind == TokenKind::Plus || self.cur.kind == TokenKind::Minus {
-            let start = self.cur.span.lo;
-            let op = if self.cur.kind == TokenKind::Plus {
-                BinaryOp::Add
-            } else {
-                BinaryOp::Sub
-            };
-            self.bump();
-            let right = self.parse_multiplicative_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op,
-                left: expr,
-                right,
-            }));
-        }
-
-        Ok(expr)
-    }
-
-    fn parse_multiplicative_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let mut expr = self.parse_exponent_expr()?;
-
-        while matches!(
-            self.cur.kind,
-            TokenKind::Star | TokenKind::Slash | TokenKind::Percent
-        ) {
-            let start = self.cur.span.lo;
-            let op = match self.cur.kind {
-                TokenKind::Star => BinaryOp::Mul,
-                TokenKind::Slash => BinaryOp::Div,
-                TokenKind::Percent => BinaryOp::Mod,
-                _ => unreachable!(),
-            };
-            self.bump();
-            let right = self.parse_exponent_expr()?;
-            expr = self.store.alloc_expr(Expr::Binary(BinaryExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                op,
-                left: expr,
-                right,
-            }));
-        }
-
-        Ok(expr)
-    }
-
-    fn parse_exponent_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
-        let left = self.parse_unary_expr()?;
-        if self.cur.kind != TokenKind::StarStar {
-            return Ok(left);
-        }
-
-        let start = self.cur.span.lo;
-        self.bump();
-        let right = self.parse_exponent_expr()?;
-        Ok(self.store.alloc_expr(Expr::Binary(BinaryExpr {
-            span: Span::new_with_checked(start, self.last_pos()),
-            op: BinaryOp::Exp,
-            left,
-            right,
-        })))
+        Some(op)
     }
 
     fn parse_unary_expr(&mut self) -> PResult<swc_es_ast::ExprId> {

--- a/crates/swc_es_parser/src/parser.rs
+++ b/crates/swc_es_parser/src/parser.rs
@@ -2431,21 +2431,24 @@ impl<'a> Parser<'a> {
 
     fn parse_sequence_expr(&mut self) -> PResult<swc_es_ast::ExprId> {
         let start = self.cur.span.lo;
-        let mut exprs = vec![self.parse_assignment_expr()?];
+        let first = self.parse_assignment_expr()?;
+
+        if self.cur.kind != TokenKind::Comma {
+            return Ok(first);
+        }
+
+        let mut exprs = Vec::with_capacity(2);
+        exprs.push(first);
 
         while self.cur.kind == TokenKind::Comma {
             self.bump();
             exprs.push(self.parse_assignment_expr()?);
         }
 
-        if exprs.len() == 1 {
-            Ok(exprs[0])
-        } else {
-            Ok(self.store.alloc_expr(Expr::Seq(swc_es_ast::SeqExpr {
-                span: Span::new_with_checked(start, self.last_pos()),
-                exprs,
-            })))
-        }
+        Ok(self.store.alloc_expr(Expr::Seq(swc_es_ast::SeqExpr {
+            span: Span::new_with_checked(start, self.last_pos()),
+            exprs,
+        })))
     }
 
     fn parse_assignment_expr(&mut self) -> PResult<swc_es_ast::ExprId> {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Optimizes `swc_es_parser` hot paths seen in CodSpeed parser/transform benchmarks:

- replace the layered binary-expression parser functions with a single precedence-climbing parser
- add a direct ASCII identifier/keyword lexer path before the Unicode identifier fallback

This reduces parser call overhead for expression-heavy inputs and keeps the parser benchmark fixtures on the same syntax surface.

Validation:

- `git submodule update --init --recursive`
- `cargo test -p swc_es_parser`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo codspeed build -p swc_es_parser --bench parser -m simulation`
- `cargo codspeed run -p swc_es_parser --bench parser -m simulation` (local environment executes the suite but does not emit comparison measurements outside CodSpeed)

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.
