### PR TITLE
perf(ecma): reduce transformer compat overhead

### DIFF
--- a/.changeset/optimize-ecma-transformer-compat.md
+++ b/.changeset/optimize-ecma-transformer-compat.md
@@ -1,0 +1,15 @@
+---
+swc_core: patch
+swc_ecma_compat_common: patch
+swc_ecma_compat_es2015: patch
+swc_ecma_compat_es2016: patch
+swc_ecma_compat_es2017: patch
+swc_ecma_compat_es2018: patch
+swc_ecma_compat_es2019: patch
+swc_ecma_compat_es2020: patch
+swc_ecma_compat_es2021: patch
+swc_ecma_compat_es2022: patch
+swc_ecma_transformer: minor
+---
+
+perf(ecma): reduce transformer compat overhead

--- a/crates/swc_ecma_compat_common/src/regexp.rs
+++ b/crates/swc_ecma_compat_common/src/regexp.rs
@@ -1,19 +1,17 @@
 use swc_ecma_ast::Pass;
 
 pub fn regexp(config: Config) -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
+    let mut options = swc_ecma_transformer::RegExpOptions::default();
+    options.dot_all_regex = config.dot_all_regex;
+    options.has_indices = config.has_indices;
+    options.lookbehind_assertion = config.lookbehind_assertion;
+    options.named_capturing_groups_regex = config.named_capturing_groups_regex;
+    options.sticky_regex = config.sticky_regex;
+    options.unicode_property_regex = config.unicode_property_regex;
+    options.unicode_regex = config.unicode_regex;
+    options.unicode_sets_regex = config.unicode_sets_regex;
 
-    let t = &mut options.env.regexp;
-    t.dot_all_regex = config.dot_all_regex;
-    t.has_indices = config.has_indices;
-    t.lookbehind_assertion = config.lookbehind_assertion;
-    t.named_capturing_groups_regex = config.named_capturing_groups_regex;
-    t.sticky_regex = config.sticky_regex;
-    t.unicode_property_regex = config.unicode_property_regex;
-    t.unicode_regex = config.unicode_regex;
-    t.unicode_sets_regex = config.unicode_sets_regex;
-
-    options.into_pass()
+    swc_ecma_transformer::regexp_pass(options)
 }
 
 #[derive(Default, Clone, Copy)]

--- a/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
+++ b/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
@@ -50,8 +50,8 @@ enum ScopeKind {
     Loop {
         lexical_var: Vec<Id>,
         args: Vec<Id>,
-        /// Produced by identifier reference and consumed by for-of/in loop.
-        used: Vec<Id>,
+        /// Set by identifier references and consumed by for-of/in loop.
+        has_used: bool,
         /// Map of original identifier to modified syntax context
         mutated: FxHashMap<Id, SyntaxContext>,
     },
@@ -64,7 +64,7 @@ impl ScopeKind {
         ScopeKind::Loop {
             lexical_var: Vec::new(),
             args: Vec::new(),
-            used: Vec::new(),
+            has_used: false,
             mutated: Default::default(),
         }
     }
@@ -94,7 +94,7 @@ impl BlockScoping {
         }
     }
 
-    fn mark_as_used(&mut self, i: Id) {
+    fn mark_as_used(&mut self, i: &Ident) {
         // Only consider the variable used in a non-ScopeKind::Loop, which means it is
         // captured in a closure
         for scope in self
@@ -104,11 +104,16 @@ impl BlockScoping {
             .skip_while(|scope| matches!(scope, ScopeKind::Loop { .. }))
         {
             if let ScopeKind::Loop {
-                lexical_var, used, ..
+                lexical_var,
+                has_used,
+                ..
             } = scope
             {
-                if lexical_var.contains(&i) {
-                    used.push(i);
+                if lexical_var
+                    .iter()
+                    .any(|(sym, ctxt)| sym == &i.sym && *ctxt == i.ctxt)
+                {
+                    *has_used = true;
                     return;
                 }
             }
@@ -127,12 +132,12 @@ impl BlockScoping {
 
         if let Some(ScopeKind::Loop {
             args,
-            used,
+            has_used,
             mutated,
             ..
         }) = self.scope.pop()
         {
-            if used.is_empty() {
+            if !has_used {
                 return;
             }
 
@@ -470,7 +475,7 @@ impl VisitMut for BlockScoping {
         let kind = ScopeKind::Loop {
             lexical_var,
             args,
-            used: Vec::new(),
+            has_used: false,
             mutated: Default::default(),
         };
 
@@ -496,7 +501,7 @@ impl VisitMut for BlockScoping {
         let kind = ScopeKind::Loop {
             lexical_var: vars,
             args,
-            used: Vec::new(),
+            has_used: false,
             mutated: Default::default(),
         };
 
@@ -522,7 +527,7 @@ impl VisitMut for BlockScoping {
         let kind = ScopeKind::Loop {
             lexical_var,
             args,
-            used: Vec::new(),
+            has_used: false,
             mutated: Default::default(),
         };
         self.visit_mut_with_scope(kind, &mut node.body);
@@ -542,8 +547,7 @@ impl VisitMut for BlockScoping {
     }
 
     fn visit_mut_ident(&mut self, node: &mut Ident) {
-        let id = node.to_id();
-        self.mark_as_used(id);
+        self.mark_as_used(node);
     }
 
     fn visit_mut_module_items(&mut self, stmts: &mut Vec<ModuleItem>) {

--- a/crates/swc_ecma_compat_es2015/src/block_scoping/vars.rs
+++ b/crates/swc_ecma_compat_es2015/src/block_scoping/vars.rs
@@ -38,9 +38,14 @@ struct ParentScope<'a> {
 
 #[swc_trace]
 impl BlockScopedVars {
-    fn add_usage(&mut self, id: Id) {
-        if !self.scope.usages.contains(&id) {
-            self.scope.usages.push(id);
+    fn add_usage(&mut self, ident: &Ident) {
+        if !self
+            .scope
+            .usages
+            .iter()
+            .any(|(sym, ctxt)| sym == &ident.sym && *ctxt == ident.ctxt)
+        {
+            self.scope.usages.push(ident.to_id());
         }
     }
 
@@ -264,7 +269,7 @@ impl VisitMut for BlockScopedVars {
         if let Some(kind) = self.var_decl_kind {
             self.scope.vars.insert(n.key.to_id(), kind);
         } else if !self.is_param {
-            self.add_usage(n.key.to_id())
+            self.add_usage(&n.key.id)
         }
     }
 
@@ -272,7 +277,7 @@ impl VisitMut for BlockScopedVars {
         if let Some(kind) = self.var_decl_kind {
             self.scope.vars.insert(i.to_id(), kind);
         } else if !self.is_param {
-            self.add_usage(i.to_id())
+            self.add_usage(&i.id)
         }
     }
 
@@ -312,7 +317,7 @@ impl VisitMut for BlockScopedVars {
         n.visit_mut_children_with(self);
 
         if let Expr::Ident(i) = n {
-            self.add_usage(i.to_id());
+            self.add_usage(i);
         }
 
         self.var_decl_kind = old_var_decl_kind;
@@ -430,7 +435,7 @@ impl VisitMut for BlockScopedVars {
         n.visit_mut_children_with(self);
 
         if let Prop::Shorthand(i) = n {
-            self.add_usage(i.to_id());
+            self.add_usage(i);
         }
     }
 

--- a/crates/swc_ecma_compat_es2015/src/classes/mod.rs
+++ b/crates/swc_ecma_compat_es2015/src/classes/mod.rs
@@ -14,7 +14,7 @@ use swc_ecma_utils::{
     ExprFactory, ModuleItemLike, StmtLike,
 };
 use swc_ecma_visit::{
-    noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith,
+    noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitMutWith, VisitWith,
 };
 use swc_trace_macro::swc_trace;
 
@@ -976,6 +976,30 @@ struct ClassFinder {
 
 impl Visit for ClassFinder {
     noop_visit_type!(fail);
+
+    fn visit_module_item(&mut self, node: &ModuleItem) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
+
+    fn visit_stmt(&mut self, node: &Stmt) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
+
+    fn visit_expr(&mut self, node: &Expr) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
 
     fn visit_class(&mut self, _: &Class) {
         self.found = true

--- a/crates/swc_ecma_compat_es2015/src/destructuring.rs
+++ b/crates/swc_ecma_compat_es2015/src/destructuring.rs
@@ -1348,15 +1348,46 @@ struct DestructuringVisitor {
 impl Visit for DestructuringVisitor {
     noop_visit_type!(fail);
 
+    fn visit_module_item(&mut self, node: &ModuleItem) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
+
+    fn visit_stmt(&mut self, node: &Stmt) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
+
+    fn visit_expr(&mut self, node: &Expr) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
+
     fn visit_assign_target_pat(&mut self, _: &AssignTargetPat) {
         self.found = true;
     }
 
     fn visit_pat(&mut self, node: &Pat) {
-        node.visit_children_with(self);
+        if self.found {
+            return;
+        }
+
         match *node {
             Pat::Ident(..) => {}
             _ => self.found = true,
+        }
+
+        if !self.found {
+            node.visit_children_with(self);
         }
     }
 }

--- a/crates/swc_ecma_compat_es2015/src/duplicate_keys.rs
+++ b/crates/swc_ecma_compat_es2015/src/duplicate_keys.rs
@@ -1,7 +1,5 @@
 use swc_ecma_ast::Pass;
 
 pub fn duplicate_keys() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2015.duplicate_keys = true;
-    options.into_pass()
+    swc_ecma_transformer::es2015_duplicate_keys()
 }

--- a/crates/swc_ecma_compat_es2015/src/function_name.rs
+++ b/crates/swc_ecma_compat_es2015/src/function_name.rs
@@ -18,7 +18,5 @@ use swc_ecma_ast::Pass;
 /// var Foo = (class Foo {});
 /// ```
 pub fn function_name() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2015.function_name = true;
-    options.into_pass()
+    swc_ecma_transformer::es2015_function_name()
 }

--- a/crates/swc_ecma_compat_es2015/src/instanceof.rs
+++ b/crates/swc_ecma_compat_es2015/src/instanceof.rs
@@ -26,9 +26,7 @@ use swc_ecma_ast::Pass;
 /// _instanceof(foo, Bar);
 /// ```
 pub fn instance_of() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2015.instanceof = true;
-    options.into_pass()
+    swc_ecma_transformer::es2015_instanceof()
 }
 
 #[cfg(test)]

--- a/crates/swc_ecma_compat_es2015/src/lib.rs
+++ b/crates/swc_ecma_compat_es2015/src/lib.rs
@@ -48,13 +48,6 @@ pub fn es2015<C>(unresolved_mark: Mark, comments: Option<C>, c: Config) -> impl 
 where
     C: Comments + Clone,
 {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.regexp.sticky_regex = true;
-    options.env.es2015.shorthand = true;
-    options.env.es2015.instanceof = true;
-    options.env.es2015.duplicate_keys = true;
-    options.env.es2015.typeof_symbol = true;
-
     (
         (
             block_scoped_functions(),
@@ -81,7 +74,7 @@ where
             block_scoping(unresolved_mark),
             generator::generator(unresolved_mark, comments.clone()),
         ),
-        options.into_pass(),
+        swc_ecma_transformer::es2015_runtime_transforms(),
     )
 }
 

--- a/crates/swc_ecma_compat_es2015/src/shorthand_property.rs
+++ b/crates/swc_ecma_compat_es2015/src/shorthand_property.rs
@@ -35,7 +35,5 @@ use swc_ecma_ast::Pass;
 /// };
 /// ```
 pub fn shorthand() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2015.shorthand = true;
-    options.into_pass()
+    swc_ecma_transformer::es2015_shorthand()
 }

--- a/crates/swc_ecma_compat_es2015/src/sticky_regex.rs
+++ b/crates/swc_ecma_compat_es2015/src/sticky_regex.rs
@@ -15,7 +15,5 @@ use swc_ecma_ast::Pass;
 /// new RegExp("o+", "y")
 /// ```
 pub fn sticky_regex() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.regexp.sticky_regex = true;
-    options.into_pass()
+    swc_ecma_transformer::es2015_sticky_regex()
 }

--- a/crates/swc_ecma_compat_es2015/src/typeof_symbol.rs
+++ b/crates/swc_ecma_compat_es2015/src/typeof_symbol.rs
@@ -5,9 +5,7 @@ pub fn typeof_symbol(c: Config) -> impl Pass {
     if c.loose {
         None
     } else {
-        let mut options = swc_ecma_transformer::Options::default();
-        options.env.es2015.typeof_symbol = true;
-        Some(options.into_pass())
+        Some(swc_ecma_transformer::es2015_typeof_symbol())
     }
 }
 

--- a/crates/swc_ecma_compat_es2016/src/exponentiation.rs
+++ b/crates/swc_ecma_compat_es2016/src/exponentiation.rs
@@ -20,9 +20,7 @@ use swc_ecma_ast::*;
 /// x = Math.pow(x, 3);
 /// ```
 pub fn exponentiation() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2016.exponentiation_operator = true;
-    options.into_pass()
+    swc_ecma_transformer::es2016_exponentiation()
 }
 
 #[cfg(test)]

--- a/crates/swc_ecma_compat_es2017/src/async_to_generator.rs
+++ b/crates/swc_ecma_compat_es2017/src/async_to_generator.rs
@@ -23,13 +23,10 @@ use swc_ecma_ast::*;
 /// });
 /// ```
 pub fn async_to_generator(c: Config, unresolved_mark: Mark) -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-
-    options.unresolved_ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
-    options.assumptions.ignore_function_length = c.ignore_function_length;
-    options.env.es2017.async_to_generator = true;
-
-    options.into_pass()
+    swc_ecma_transformer::es2017_async_to_generator(
+        SyntaxContext::empty().apply_mark(unresolved_mark),
+        c.ignore_function_length,
+    )
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]

--- a/crates/swc_ecma_compat_es2018/src/lib.rs
+++ b/crates/swc_ecma_compat_es2018/src/lib.rs
@@ -3,29 +3,25 @@
 
 use serde::Deserialize;
 use swc_ecma_ast::Pass;
+use swc_ecma_transforms_base::assumptions::Assumptions;
 
 pub use self::object_rest_spread::object_rest_spread;
 
 pub mod object_rest_spread;
 
 pub fn es2018(config: Config) -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
+    let mut regexp_options = swc_ecma_transformer::RegExpOptions::default();
+    regexp_options.dot_all_regex = true;
+    regexp_options.lookbehind_assertion = true;
+    regexp_options.named_capturing_groups_regex = true;
+    regexp_options.unicode_property_regex = true;
 
-    {
-        options.env.regexp.dot_all_regex = true;
-        options.env.regexp.lookbehind_assertion = true;
-        options.env.regexp.named_capturing_groups_regex = true;
-        options.env.regexp.unicode_property_regex = true;
-    }
+    let mut assumptions = Assumptions::default();
+    assumptions.object_rest_no_symbols = config.object_rest_spread.no_symbol;
+    assumptions.set_spread_properties = config.object_rest_spread.set_property;
+    assumptions.pure_getters = config.object_rest_spread.pure_getters;
 
-    {
-        options.env.es2018.object_rest_spread = true;
-        options.assumptions.object_rest_no_symbols = config.object_rest_spread.no_symbol;
-        options.assumptions.set_spread_properties = config.object_rest_spread.set_property;
-        options.assumptions.pure_getters = config.object_rest_spread.pure_getters;
-    }
-
-    options.into_pass()
+    swc_ecma_transformer::es2018_runtime_transforms(assumptions, regexp_options)
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]

--- a/crates/swc_ecma_compat_es2018/src/object_rest_spread.rs
+++ b/crates/swc_ecma_compat_es2018/src/object_rest_spread.rs
@@ -1,19 +1,18 @@
 use serde::Deserialize;
 use swc_ecma_ast::Pass;
+use swc_ecma_transforms_base::assumptions::Assumptions;
 
 // TODO: currently swc behaves like babel with
 // `ignoreFunctionLength` on
 
 /// `@babel/plugin-proposal-object-rest-spread`
 pub fn object_rest_spread(config: Config) -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
+    let mut assumptions = Assumptions::default();
+    assumptions.object_rest_no_symbols = config.no_symbol;
+    assumptions.set_spread_properties = config.set_property;
+    assumptions.pure_getters = config.pure_getters;
 
-    options.assumptions.object_rest_no_symbols = config.no_symbol;
-    options.assumptions.set_spread_properties = config.set_property;
-    options.assumptions.pure_getters = config.pure_getters;
-    options.env.es2018.object_rest_spread = true;
-
-    options.into_pass()
+    swc_ecma_transformer::es2018_object_rest_spread(assumptions)
 }
 
 #[derive(Debug, Clone, Copy, Default, Deserialize)]

--- a/crates/swc_ecma_compat_es2019/src/optional_catch_binding.rs
+++ b/crates/swc_ecma_compat_es2019/src/optional_catch_binding.rs
@@ -1,9 +1,7 @@
 use swc_ecma_ast::*;
 
 pub fn optional_catch_binding() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2019.optional_catch_binding = true;
-    options.into_pass()
+    swc_ecma_transformer::es2019_optional_catch_binding()
 }
 
 #[cfg(test)]

--- a/crates/swc_ecma_compat_es2020/src/export_namespace_from.rs
+++ b/crates/swc_ecma_compat_es2020/src/export_namespace_from.rs
@@ -1,7 +1,5 @@
 use swc_ecma_ast::Pass;
 
 pub fn export_namespace_from() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2020.export_namespace_from = true;
-    options.into_pass()
+    swc_ecma_transformer::es2020_export_namespace_from()
 }

--- a/crates/swc_ecma_compat_es2020/src/lib.rs
+++ b/crates/swc_ecma_compat_es2020/src/lib.rs
@@ -1,5 +1,5 @@
 use serde::Deserialize;
-use swc_common::{Mark, SyntaxContext};
+use swc_common::Mark;
 use swc_ecma_ast::Pass;
 
 pub use self::{
@@ -12,15 +12,9 @@ pub mod nullish_coalescing;
 pub mod optional_chaining;
 
 pub fn es2020(config: Config, unresolved_mark: Mark) -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.unresolved_ctxt = SyntaxContext::empty().apply_mark(unresolved_mark);
-    options.assumptions.no_document_all = config.nullish_coalescing.no_document_all;
-    options.env.es2020.nullish_coalescing = true;
-    options.env.es2020.export_namespace_from = true;
-
     (
         optional_chaining(config.optional_chaining, unresolved_mark),
-        options.into_pass(),
+        swc_ecma_transformer::es2020_runtime_transforms(config.nullish_coalescing.no_document_all),
     )
 }
 

--- a/crates/swc_ecma_compat_es2020/src/nullish_coalescing.rs
+++ b/crates/swc_ecma_compat_es2020/src/nullish_coalescing.rs
@@ -13,8 +13,5 @@ pub struct Config {
 ///
 /// This is now a thin wrapper around the Compiler implementation.
 pub fn nullish_coalescing(c: Config) -> impl Pass + 'static {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2020.nullish_coalescing = true;
-    options.assumptions.no_document_all = c.no_document_all;
-    options.into_pass()
+    swc_ecma_transformer::es2020_nullish_coalescing(c.no_document_all)
 }

--- a/crates/swc_ecma_compat_es2021/src/logical_assignments.rs
+++ b/crates/swc_ecma_compat_es2021/src/logical_assignments.rs
@@ -7,7 +7,5 @@ use swc_ecma_ast::Pass;
 /// - ES2020 nullish coalescing (to transform the ?? operator generated from
 ///   ??=)
 pub fn logical_assignments() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2021.logical_assignment_operators = true;
-    options.into_pass()
+    swc_ecma_transformer::es2021_logical_assignments()
 }

--- a/crates/swc_ecma_compat_es2022/src/class_properties/mod.rs
+++ b/crates/swc_ecma_compat_es2022/src/class_properties/mod.rs
@@ -427,74 +427,71 @@ impl ClassProperties {
         mut class: Box<Class>,
     ) -> (ClassDecl, ClassExtra) {
         // Create one mark per class
-        let private = Private {
-            mark: Mark::fresh(Mark::root()),
-            class_name: class_ident.clone(),
-            ident: {
-                let mut private_map = FxHashMap::default();
+        let mut private_map = FxHashMap::default();
 
-                for member in class.body.iter() {
-                    match member {
-                        ClassMember::PrivateMethod(method) => {
-                            if let Some(kind) = private_map.get_mut(&method.key.name) {
-                                if dup_private_method(kind, method) {
-                                    let error =
-                                        format!("duplicate private name #{}.", method.key.name);
-                                    HANDLER.with(|handler| {
-                                        handler.struct_span_err(method.key.span, &error).emit()
-                                    });
-                                } else {
-                                    match method.kind {
-                                        MethodKind::Getter => kind.has_getter = true,
-                                        MethodKind::Setter => kind.has_setter = true,
-                                        MethodKind::Method => unreachable!(),
-                                        #[cfg(swc_ast_unknown)]
-                                        _ => panic!("unable to access unknown nodes"),
-                                    }
-                                }
-                            } else {
-                                private_map.insert(
-                                    method.key.name.clone(),
-                                    PrivateKind {
-                                        is_method: true,
-                                        is_static: method.is_static,
-                                        has_getter: method.kind == MethodKind::Getter,
-                                        has_setter: method.kind == MethodKind::Setter,
-                                    },
-                                );
+        for member in class.body.iter() {
+            match member {
+                ClassMember::PrivateMethod(method) => {
+                    if let Some(kind) = private_map.get_mut(&method.key.name) {
+                        if dup_private_method(kind, method) {
+                            let error = format!("duplicate private name #{}.", method.key.name);
+                            HANDLER.with(|handler| {
+                                handler.struct_span_err(method.key.span, &error).emit()
+                            });
+                        } else {
+                            match method.kind {
+                                MethodKind::Getter => kind.has_getter = true,
+                                MethodKind::Setter => kind.has_setter = true,
+                                MethodKind::Method => unreachable!(),
+                                #[cfg(swc_ast_unknown)]
+                                _ => panic!("unable to access unknown nodes"),
                             }
                         }
+                    } else {
+                        private_map.insert(
+                            method.key.name.clone(),
+                            PrivateKind {
+                                is_method: true,
+                                is_static: method.is_static,
+                                has_getter: method.kind == MethodKind::Getter,
+                                has_setter: method.kind == MethodKind::Setter,
+                            },
+                        );
+                    }
+                }
 
-                        ClassMember::PrivateProp(prop) => {
-                            if private_map.contains_key(&prop.key.name) {
-                                let error = format!("duplicate private name #{}.", prop.key.name);
-                                HANDLER.with(|handler| {
-                                    handler.struct_span_err(prop.key.span, &error).emit()
-                                });
-                            } else {
-                                private_map.insert(
-                                    prop.key.name.clone(),
-                                    PrivateKind {
-                                        is_method: false,
-                                        is_static: prop.is_static,
-                                        has_getter: false,
-                                        has_setter: false,
-                                    },
-                                );
-                            };
-                        }
-
-                        ClassMember::AutoAccessor(_) => {
-                            // AutoAccessor is preserved as-is, no private field
-                            // registration needed
-                        }
-
-                        _ => (),
+                ClassMember::PrivateProp(prop) => {
+                    if private_map.contains_key(&prop.key.name) {
+                        let error = format!("duplicate private name #{}.", prop.key.name);
+                        HANDLER
+                            .with(|handler| handler.struct_span_err(prop.key.span, &error).emit());
+                    } else {
+                        private_map.insert(
+                            prop.key.name.clone(),
+                            PrivateKind {
+                                is_method: false,
+                                is_static: prop.is_static,
+                                has_getter: false,
+                                has_setter: false,
+                            },
+                        );
                     };
                 }
 
-                private_map
-            },
+                ClassMember::AutoAccessor(_) => {
+                    // AutoAccessor is preserved as-is, no private field
+                    // registration needed
+                }
+
+                _ => (),
+            };
+        }
+
+        let has_private_bindings = !private_map.is_empty();
+        let private = Private {
+            mark: Mark::fresh(Mark::root()),
+            class_name: class_ident.clone(),
+            ident: private_map,
         };
 
         self.private.push(private);
@@ -515,9 +512,13 @@ impl ClassProperties {
         let mut used_key_names = Vec::new();
         let mut super_ident = None;
 
-        class.body.visit_mut_with(&mut BrandCheckHandler {
-            private: &self.private,
-        });
+        let should_visit_private = has_private_bindings || contains_private_name(&class.body);
+
+        if should_visit_private {
+            class.body.visit_mut_with(&mut BrandCheckHandler {
+                private: &self.private,
+            });
+        }
 
         let should_create_vars_for_method_names = class.body.iter().any(|m| match m {
             ClassMember::Constructor(_)
@@ -967,25 +968,29 @@ impl ClassProperties {
             members.push(ClassMember::Constructor(c));
         }
 
-        private_method_fn_decls.visit_mut_with(&mut PrivateAccessVisitor {
-            private: &self.private,
-            vars: Vec::new(),
-            private_access_type: Default::default(),
-            c: self.c,
-            unresolved_mark: self.unresolved_mark,
-        });
+        if should_visit_private {
+            private_method_fn_decls.visit_mut_with(&mut PrivateAccessVisitor {
+                private: &self.private,
+                vars: Vec::new(),
+                private_access_type: Default::default(),
+                c: self.c,
+                unresolved_mark: self.unresolved_mark,
+            });
+        }
 
         let mut extra_stmts = extra_inits.into_init_static(class_ident.clone());
 
         extra_stmts.extend(private_method_fn_decls);
 
-        members.visit_mut_with(&mut PrivateAccessVisitor {
-            private: &self.private,
-            vars: Vec::new(),
-            private_access_type: Default::default(),
-            c: self.c,
-            unresolved_mark: self.unresolved_mark,
-        });
+        if should_visit_private {
+            members.visit_mut_with(&mut PrivateAccessVisitor {
+                private: &self.private,
+                vars: Vec::new(),
+                private_access_type: Default::default(),
+                c: self.c,
+                unresolved_mark: self.unresolved_mark,
+            });
+        }
 
         self.private.pop();
 
@@ -1060,6 +1065,27 @@ impl ClassProperties {
         } else {
             None
         }
+    }
+}
+
+fn contains_private_name<N>(node: &N) -> bool
+where
+    N: VisitWith<PrivateNameFinder>,
+{
+    let mut finder = PrivateNameFinder { found: false };
+    node.visit_with(&mut finder);
+    finder.found
+}
+
+struct PrivateNameFinder {
+    found: bool,
+}
+
+impl Visit for PrivateNameFinder {
+    noop_visit_type!(fail);
+
+    fn visit_private_name(&mut self, _: &PrivateName) {
+        self.found = true;
     }
 }
 

--- a/crates/swc_ecma_compat_es2022/src/class_properties/mod.rs
+++ b/crates/swc_ecma_compat_es2022/src/class_properties/mod.rs
@@ -1098,6 +1098,38 @@ struct ShouldWork {
 impl Visit for ShouldWork {
     noop_visit_type!(fail);
 
+    fn visit_module_item(&mut self, node: &ModuleItem) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
+
+    fn visit_stmt(&mut self, node: &Stmt) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
+
+    fn visit_expr(&mut self, node: &Expr) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
+
+    fn visit_class_member(&mut self, node: &ClassMember) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
+
     fn visit_class_method(&mut self, _: &ClassMethod) {
         self.found = true;
     }

--- a/crates/swc_ecma_compat_es2022/src/lib.rs
+++ b/crates/swc_ecma_compat_es2022/src/lib.rs
@@ -14,22 +14,15 @@ pub mod private_in_object;
 pub mod static_blocks;
 
 pub fn es2022(config: Config, unresolved_mark: Mark) -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-
-    {
-        let t = &mut options.env.regexp;
-        t.dot_all_regex = true;
-        t.has_indices = true;
-        t.lookbehind_assertion = true;
-        t.named_capturing_groups_regex = true;
-        t.unicode_property_regex = true;
-    }
-
-    options.env.es2022.class_static_block = true;
-    options.env.es2022.private_property_in_object = true;
+    let mut regexp_options = swc_ecma_transformer::RegExpOptions::default();
+    regexp_options.dot_all_regex = true;
+    regexp_options.has_indices = true;
+    regexp_options.lookbehind_assertion = true;
+    regexp_options.named_capturing_groups_regex = true;
+    regexp_options.unicode_property_regex = true;
 
     (
-        options.into_pass(),
+        swc_ecma_transformer::es2022_runtime_transforms(regexp_options),
         class_properties(config.class_properties, unresolved_mark),
     )
 }

--- a/crates/swc_ecma_compat_es2022/src/private_in_object.rs
+++ b/crates/swc_ecma_compat_es2022/src/private_in_object.rs
@@ -2,7 +2,5 @@ use swc_ecma_ast::Pass;
 
 /// https://github.com/tc39/proposal-private-fields-in-in
 pub fn private_in_object() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2022.private_property_in_object = true;
-    options.into_pass()
+    swc_ecma_transformer::es2022_private_in_object()
 }

--- a/crates/swc_ecma_compat_es2022/src/static_blocks.rs
+++ b/crates/swc_ecma_compat_es2022/src/static_blocks.rs
@@ -1,7 +1,5 @@
 use swc_ecma_ast::*;
 
 pub fn static_blocks() -> impl Pass {
-    let mut options = swc_ecma_transformer::Options::default();
-    options.env.es2022.class_static_block = true;
-    options.into_pass()
+    swc_ecma_transformer::es2022_static_blocks()
 }

--- a/crates/swc_ecma_transformer/src/common/var_declarations.rs
+++ b/crates/swc_ecma_transformer/src/common/var_declarations.rs
@@ -54,6 +54,8 @@ impl VisitMutHook<TraverseCtx> for VarDeclarations {
                 declarations: None,
             }),
             BlockStmtOrExpr::BlockStmt(_) => None,
+            #[cfg(swc_ast_unknown)]
+            _ => None,
         });
     }
 
@@ -84,6 +86,8 @@ impl VisitMutHook<TraverseCtx> for VarDeclarations {
                 });
             }
             BlockStmtOrExpr::BlockStmt(block) => Self::insert_arrow_declarations(block, stmts),
+            #[cfg(swc_ast_unknown)]
+            _ => {}
         }
     }
 

--- a/crates/swc_ecma_transformer/src/common/var_declarations.rs
+++ b/crates/swc_ecma_transformer/src/common/var_declarations.rs
@@ -17,6 +17,8 @@
 //! ctx.var_declarations.insert_let(ident, Some(init), ctx);
 //! ```
 
+use std::{mem, ptr};
+
 use swc_common::{util::take::Take, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_hooks::VisitMutHook;
@@ -28,21 +30,82 @@ use crate::TraverseCtx;
 /// requested that.
 ///
 /// Must run after all other transforms.
+#[derive(Debug, Default)]
+pub struct VarDeclarations {
+    arrow_exprs: Vec<Option<ArrowExprScope>>,
+}
+
 #[derive(Debug)]
-pub struct VarDeclarations;
+struct ArrowExprScope {
+    /// The `BlockStmtOrExpr` for an expression-bodied arrow. Starting the scope
+    /// here keeps generated temps out of params while still catching body
+    /// transforms that queue declarations in `enter_expr`.
+    body: *const BlockStmtOrExpr,
+    started: bool,
+    declarations: Option<(Option<Stmt>, Option<Stmt>)>,
+}
 
 impl VisitMutHook<TraverseCtx> for VarDeclarations {
-    fn enter_arrow_expr(&mut self, node: &mut ArrowExpr, ctx: &mut TraverseCtx) {
-        if matches!(&*node.body, BlockStmtOrExpr::Expr(_)) {
-            ctx.var_declarations.record_entering_stmts();
-        }
+    fn enter_arrow_expr(&mut self, node: &mut ArrowExpr, _ctx: &mut TraverseCtx) {
+        self.arrow_exprs.push(match &mut *node.body {
+            BlockStmtOrExpr::Expr(_) => Some(ArrowExprScope {
+                body: &*node.body,
+                started: false,
+                declarations: None,
+            }),
+            BlockStmtOrExpr::BlockStmt(_) => None,
+        });
     }
 
     fn exit_arrow_expr(&mut self, node: &mut ArrowExpr, ctx: &mut TraverseCtx) {
-        if let BlockStmtOrExpr::Expr(expr) = &mut *node.body {
-            if let Some(block) = ctx.var_declarations.take_arrow_expr_block(expr) {
-                *node.body = BlockStmtOrExpr::BlockStmt(block);
+        let Some(mut scope) = self.arrow_exprs.pop().flatten() else {
+            return;
+        };
+
+        if scope.started {
+            scope.declarations = ctx.var_declarations.get_var_statement();
+        }
+
+        let Some(mut stmts) = Self::declaration_stmts(scope.declarations) else {
+            return;
+        };
+
+        match &mut *node.body {
+            BlockStmtOrExpr::Expr(expr) => {
+                stmts.push(Stmt::Return(ReturnStmt {
+                    span: DUMMY_SP,
+                    arg: Some(expr.take()),
+                }));
+
+                *node.body = BlockStmtOrExpr::BlockStmt(BlockStmt {
+                    span: DUMMY_SP,
+                    stmts,
+                    ..Default::default()
+                });
             }
+            BlockStmtOrExpr::BlockStmt(block) => Self::insert_arrow_declarations(block, stmts),
+        }
+    }
+
+    fn enter_block_stmt_or_expr(&mut self, node: &mut BlockStmtOrExpr, ctx: &mut TraverseCtx) {
+        let Some(Some(scope)) = self.arrow_exprs.last_mut() else {
+            return;
+        };
+
+        if !scope.started && ptr::eq(scope.body, node) {
+            ctx.var_declarations.record_entering_stmts();
+            scope.started = true;
+        }
+    }
+
+    fn exit_block_stmt_or_expr(&mut self, node: &mut BlockStmtOrExpr, ctx: &mut TraverseCtx) {
+        let Some(Some(scope)) = self.arrow_exprs.last_mut() else {
+            return;
+        };
+
+        if scope.started && ptr::eq(scope.body, node) {
+            scope.declarations = ctx.var_declarations.get_var_statement();
+            scope.started = false;
         }
     }
 
@@ -60,6 +123,48 @@ impl VisitMutHook<TraverseCtx> for VarDeclarations {
 
     fn exit_module_items(&mut self, items: &mut Vec<ModuleItem>, ctx: &mut TraverseCtx) {
         ctx.var_declarations.insert_into_module_items(items);
+    }
+}
+
+impl VarDeclarations {
+    fn declaration_stmts(declarations: Option<(Option<Stmt>, Option<Stmt>)>) -> Option<Vec<Stmt>> {
+        let (var_statement, let_statement) = declarations?;
+        let mut stmts = Vec::with_capacity(2);
+
+        match (var_statement, let_statement) {
+            (Some(var_statement), Some(let_statement)) => {
+                stmts.push(var_statement);
+                stmts.push(let_statement);
+            }
+            (Some(statement), None) | (None, Some(statement)) => {
+                stmts.push(statement);
+            }
+            (None, None) => return None,
+        }
+
+        Some(stmts)
+    }
+
+    fn insert_arrow_declarations(block: &mut BlockStmt, declarations: Vec<Stmt>) {
+        if declarations.is_empty() {
+            return;
+        }
+
+        if matches!(
+            block.stmts.last(),
+            Some(Stmt::Return(ReturnStmt { span: DUMMY_SP, .. }))
+        ) {
+            let return_stmt = block.stmts.pop().unwrap();
+            block.stmts.extend(declarations);
+            block.stmts.push(return_stmt);
+            return;
+        }
+
+        let original = mem::take(&mut block.stmts);
+        let mut stmts = Vec::with_capacity(declarations.len() + original.len());
+        stmts.extend(declarations);
+        stmts.extend(original);
+        block.stmts = stmts;
     }
 }
 
@@ -202,36 +307,6 @@ impl VarDeclarationsStore {
             new_items.append(items);
             *items = new_items;
         }
-    }
-
-    fn take_arrow_expr_block(&mut self, expr: &mut Box<Expr>) -> Option<BlockStmt> {
-        if let Some((var_statement, let_statement)) = self.get_var_statement() {
-            let mut stmts = Vec::with_capacity(3);
-
-            match (var_statement, let_statement) {
-                (Some(var_statement), Some(let_statement)) => {
-                    stmts.push(var_statement);
-                    stmts.push(let_statement);
-                }
-                (Some(statement), None) | (None, Some(statement)) => {
-                    stmts.push(statement);
-                }
-                (None, None) => return None,
-            }
-
-            stmts.push(Stmt::Return(ReturnStmt {
-                span: DUMMY_SP,
-                arg: Some(expr.take()),
-            }));
-
-            return Some(BlockStmt {
-                span: DUMMY_SP,
-                stmts,
-                ..Default::default()
-            });
-        }
-
-        None
     }
 
     #[inline]

--- a/crates/swc_ecma_transformer/src/common/var_declarations.rs
+++ b/crates/swc_ecma_transformer/src/common/var_declarations.rs
@@ -17,7 +17,7 @@
 //! ctx.var_declarations.insert_let(ident, Some(init), ctx);
 //! ```
 
-use swc_common::DUMMY_SP;
+use swc_common::{util::take::Take, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_hooks::VisitMutHook;
 
@@ -32,6 +32,20 @@ use crate::TraverseCtx;
 pub struct VarDeclarations;
 
 impl VisitMutHook<TraverseCtx> for VarDeclarations {
+    fn enter_arrow_expr(&mut self, node: &mut ArrowExpr, ctx: &mut TraverseCtx) {
+        if matches!(&*node.body, BlockStmtOrExpr::Expr(_)) {
+            ctx.var_declarations.record_entering_stmts();
+        }
+    }
+
+    fn exit_arrow_expr(&mut self, node: &mut ArrowExpr, ctx: &mut TraverseCtx) {
+        if let BlockStmtOrExpr::Expr(expr) = &mut *node.body {
+            if let Some(block) = ctx.var_declarations.take_arrow_expr_block(expr) {
+                *node.body = BlockStmtOrExpr::BlockStmt(block);
+            }
+        }
+    }
+
     fn enter_stmts(&mut self, _stmts: &mut Vec<Stmt>, ctx: &mut TraverseCtx) {
         ctx.var_declarations.record_entering_stmts();
     }
@@ -188,6 +202,36 @@ impl VarDeclarationsStore {
             new_items.append(items);
             *items = new_items;
         }
+    }
+
+    fn take_arrow_expr_block(&mut self, expr: &mut Box<Expr>) -> Option<BlockStmt> {
+        if let Some((var_statement, let_statement)) = self.get_var_statement() {
+            let mut stmts = Vec::with_capacity(3);
+
+            match (var_statement, let_statement) {
+                (Some(var_statement), Some(let_statement)) => {
+                    stmts.push(var_statement);
+                    stmts.push(let_statement);
+                }
+                (Some(statement), None) | (None, Some(statement)) => {
+                    stmts.push(statement);
+                }
+                (None, None) => return None,
+            }
+
+            stmts.push(Stmt::Return(ReturnStmt {
+                span: DUMMY_SP,
+                arg: Some(expr.take()),
+            }));
+
+            return Some(BlockStmt {
+                span: DUMMY_SP,
+                stmts,
+                ..Default::default()
+            });
+        }
+
+        None
     }
 
     #[inline]

--- a/crates/swc_ecma_transformer/src/es2015/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2015/mod.rs
@@ -5,12 +5,12 @@ use crate::{
     TraverseCtx,
 };
 
-mod duplicate_keys;
-mod function_name;
-mod instanceof;
-mod shorthand;
+pub(crate) mod duplicate_keys;
+pub(crate) mod function_name;
+pub(crate) mod instanceof;
+pub(crate) mod shorthand;
 mod sticky_regex;
-mod typeof_symbol;
+pub(crate) mod typeof_symbol;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]

--- a/crates/swc_ecma_transformer/src/es2016/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2016/mod.rs
@@ -2,7 +2,7 @@ use swc_ecma_hooks::VisitMutHook;
 
 use crate::TraverseCtx;
 
-mod exponentiation_operator;
+pub(crate) mod exponentiation_operator;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]

--- a/crates/swc_ecma_transformer/src/es2017/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2017/mod.rs
@@ -1,4 +1,4 @@
-mod async_to_generator;
+pub(crate) mod async_to_generator;
 
 use swc_common::SyntaxContext;
 use swc_ecma_hooks::VisitMutHook;

--- a/crates/swc_ecma_transformer/src/es2018/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2018/mod.rs
@@ -3,7 +3,7 @@ use swc_ecma_transforms_base::assumptions::Assumptions;
 
 use crate::TraverseCtx;
 
-mod object_rest_spread;
+pub(crate) mod object_rest_spread;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]

--- a/crates/swc_ecma_transformer/src/es2019/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2019/mod.rs
@@ -2,7 +2,7 @@ use swc_ecma_hooks::VisitMutHook;
 
 use crate::TraverseCtx;
 
-mod optional_catch_binding;
+pub(crate) mod optional_catch_binding;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]

--- a/crates/swc_ecma_transformer/src/es2019/optional_catch_binding.rs
+++ b/crates/swc_ecma_transformer/src/es2019/optional_catch_binding.rs
@@ -1,6 +1,7 @@
 use swc_ecma_ast::*;
 use swc_ecma_hooks::VisitMutHook;
 use swc_ecma_utils::private_ident;
+use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
 
 use crate::TraverseCtx;
 
@@ -8,14 +9,33 @@ pub fn hook() -> impl VisitMutHook<TraverseCtx> {
     OptionalCatchBindingPass {}
 }
 
+pub(crate) fn pass() -> impl Pass {
+    visit_mut_pass(OptionalCatchBindingPass {})
+}
+
 struct OptionalCatchBindingPass {}
 
-impl VisitMutHook<TraverseCtx> for OptionalCatchBindingPass {
-    fn enter_catch_clause(&mut self, node: &mut CatchClause, _: &mut TraverseCtx) {
+impl OptionalCatchBindingPass {
+    fn transform_catch_clause(&mut self, node: &mut CatchClause) {
         if node.param.is_none() {
             // TODO: Do not use private_ident! here.
             // All private identifiers should be tracked using TraverseCtx.
             node.param = Some(Pat::Ident(private_ident!("unused").into()));
         }
+    }
+}
+
+impl VisitMutHook<TraverseCtx> for OptionalCatchBindingPass {
+    fn enter_catch_clause(&mut self, node: &mut CatchClause, _: &mut TraverseCtx) {
+        self.transform_catch_clause(node);
+    }
+}
+
+impl VisitMut for OptionalCatchBindingPass {
+    noop_visit_mut_type!(fail);
+
+    fn visit_mut_catch_clause(&mut self, node: &mut CatchClause) {
+        self.transform_catch_clause(node);
+        node.body.visit_mut_with(self);
     }
 }

--- a/crates/swc_ecma_transformer/src/es2020/export_namespace_from.rs
+++ b/crates/swc_ecma_transformer/src/es2020/export_namespace_from.rs
@@ -1,11 +1,16 @@
 use swc_ecma_ast::*;
 use swc_ecma_hooks::VisitMutHook;
 use swc_ecma_utils::private_ident;
+use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut};
 
 use crate::{utils::normalize_module_export_name, TraverseCtx};
 
 pub fn hook() -> impl VisitMutHook<TraverseCtx> {
     ExportNamespaceFromPass
+}
+
+pub(crate) fn pass() -> impl Pass {
+    visit_mut_pass(ExportNamespaceFromPass)
 }
 
 struct ExportNamespaceFromPass;
@@ -123,6 +128,18 @@ impl ExportNamespaceFromPass {
 
 impl VisitMutHook<TraverseCtx> for ExportNamespaceFromPass {
     fn exit_program(&mut self, node: &mut Program, _: &mut TraverseCtx) {
+        let Program::Module(module) = node else {
+            return;
+        };
+
+        self.transform_export_namespace_from(&mut module.body);
+    }
+}
+
+impl VisitMut for ExportNamespaceFromPass {
+    noop_visit_mut_type!(fail);
+
+    fn visit_mut_program(&mut self, node: &mut Program) {
         let Program::Module(module) = node else {
             return;
         };

--- a/crates/swc_ecma_transformer/src/es2020/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2020/mod.rs
@@ -6,8 +6,8 @@ use crate::{
     TraverseCtx,
 };
 
-mod export_namespace_from;
-mod nullish_coalescing;
+pub(crate) mod export_namespace_from;
+pub(crate) mod nullish_coalescing;
 mod optional_chaining;
 
 #[derive(Debug, Default)]

--- a/crates/swc_ecma_transformer/src/es2021/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2021/mod.rs
@@ -1,4 +1,4 @@
-mod logical_assignment_operators;
+pub(crate) mod logical_assignment_operators;
 
 use swc_ecma_hooks::VisitMutHook;
 

--- a/crates/swc_ecma_transformer/src/es2022/mod.rs
+++ b/crates/swc_ecma_transformer/src/es2022/mod.rs
@@ -6,8 +6,8 @@ use crate::{
 };
 
 mod class_properties;
-mod class_static_block;
-mod private_property_in_object;
+pub(crate) mod class_static_block;
+pub(crate) mod private_property_in_object;
 
 #[derive(Debug, Default)]
 #[non_exhaustive]

--- a/crates/swc_ecma_transformer/src/es2022/private_property_in_object.rs
+++ b/crates/swc_ecma_transformer/src/es2022/private_property_in_object.rs
@@ -38,14 +38,34 @@ use rustc_hash::FxHashSet;
 use swc_atoms::Atom;
 use swc_common::{util::take::Take, Mark, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_hooks::VisitMutHook;
+use swc_ecma_hooks::{VisitMutHook, VisitMutWithHook};
 use swc_ecma_utils::{default_constructor_with_span, private_ident, quote_ident, ExprFactory};
-use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitMutWith, VisitWith};
 
 use crate::TraverseCtx;
 
 pub fn hook() -> impl VisitMutHook<TraverseCtx> {
     PrivatePropertyInObjectPass::default()
+}
+
+pub(crate) fn pass() -> impl Pass {
+    PrivatePropertyInObjectFastPass
+}
+
+struct PrivatePropertyInObjectFastPass;
+
+impl Pass for PrivatePropertyInObjectFastPass {
+    fn process(&mut self, program: &mut Program) {
+        let mut finder = PrivateInFinder { found: false };
+        program.visit_with(&mut finder);
+
+        if finder.found {
+            program.visit_mut_with(&mut VisitMutWithHook {
+                hook: PrivatePropertyInObjectPass::default(),
+                context: TraverseCtx::default(),
+            });
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -551,6 +571,35 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
             }
             .into(),
         );
+    }
+}
+
+struct PrivateInFinder {
+    found: bool,
+}
+
+impl Visit for PrivateInFinder {
+    noop_visit_type!(fail);
+
+    fn visit_expr(&mut self, node: &Expr) {
+        if self.found {
+            return;
+        }
+
+        node.visit_children_with(self);
+    }
+
+    fn visit_bin_expr(&mut self, node: &BinExpr) {
+        if self.found {
+            return;
+        }
+
+        if node.op == op!("in") && node.left.is_private_name() {
+            self.found = true;
+            return;
+        }
+
+        node.visit_children_with(self);
     }
 }
 

--- a/crates/swc_ecma_transformer/src/hook_utils.rs
+++ b/crates/swc_ecma_transformer/src/hook_utils.rs
@@ -42,6 +42,12 @@ where
 
     chained_method!(enter_block_stmt, exit_block_stmt, BlockStmt);
 
+    chained_method!(
+        enter_block_stmt_or_expr,
+        exit_block_stmt_or_expr,
+        BlockStmtOrExpr
+    );
+
     chained_method!(enter_module_item, exit_module_item, ModuleItem);
 
     chained_method!(enter_module_items, exit_module_items, Vec<ModuleItem>);

--- a/crates/swc_ecma_transformer/src/lib.rs
+++ b/crates/swc_ecma_transformer/src/lib.rs
@@ -199,10 +199,10 @@ pub fn es2015_duplicate_keys() -> impl Pass {
 }
 
 pub fn es2015_sticky_regex() -> impl Pass {
-    let mut regexp_options = crate::regexp::RegExpOptions::default();
-    regexp_options.sticky_regex = true;
-
-    regexp_pass(regexp_options)
+    regexp_pass(crate::regexp::RegExpOptions {
+        sticky_regex: true,
+        ..Default::default()
+    })
 }
 
 pub fn es2015_instanceof() -> impl Pass {
@@ -214,16 +214,16 @@ pub fn es2015_typeof_symbol() -> impl Pass {
 }
 
 pub fn es2015_runtime_transforms() -> impl Pass {
-    let mut regexp_options = crate::regexp::RegExpOptions::default();
-    regexp_options.sticky_regex = true;
-
     hook_pass(
         HookBuilder::new(NoopHook)
             .chain(crate::es2015::shorthand::hook())
             .chain(crate::es2015::duplicate_keys::hook())
             .chain(crate::es2015::instanceof::hook())
             .chain(crate::es2015::typeof_symbol::hook())
-            .chain_optional(crate::regexp::hook(regexp_options))
+            .chain_optional(crate::regexp::hook(crate::regexp::RegExpOptions {
+                sticky_regex: true,
+                ..Default::default()
+            }))
             .build(),
     )
 }

--- a/crates/swc_ecma_transformer/src/lib.rs
+++ b/crates/swc_ecma_transformer/src/lib.rs
@@ -2,6 +2,7 @@
 
 use swc_ecma_ast::*;
 use swc_ecma_hooks::{VisitMutHook, VisitMutWithHook};
+use swc_ecma_transforms_base::assumptions::Assumptions;
 use swc_ecma_visit::visit_mut_pass;
 
 use crate::hook_utils::{HookBuilder, NoopHook};
@@ -84,6 +85,133 @@ pub fn hook_pass<H: VisitMutHook<TraverseCtx>>(hook: H) -> impl Pass {
     let ctx = TraverseCtx::default();
 
     visit_mut_pass(VisitMutWithHook { hook, context: ctx })
+}
+
+fn hook_pass_with_var_declarations<H: VisitMutHook<TraverseCtx>>(hook: H) -> impl Pass {
+    hook_pass(
+        HookBuilder::new(hook)
+            .chain(common::VarDeclarations)
+            .build(),
+    )
+}
+
+pub fn es2022_static_blocks() -> impl Pass {
+    hook_pass(crate::es2022::class_static_block::hook())
+}
+
+pub fn es2022_private_in_object() -> impl Pass {
+    hook_pass(crate::es2022::private_property_in_object::hook())
+}
+
+pub fn es2022_runtime_transforms(regexp_options: crate::regexp::RegExpOptions) -> impl Pass {
+    hook_pass(
+        HookBuilder::new(NoopHook)
+            .chain(crate::es2022::class_static_block::hook())
+            .chain(crate::es2022::private_property_in_object::hook())
+            .chain_optional(crate::regexp::hook(regexp_options))
+            .build(),
+    )
+}
+
+pub fn es2021_logical_assignments() -> impl Pass {
+    hook_pass_with_var_declarations(crate::es2021::logical_assignment_operators::hook())
+}
+
+pub fn es2020_export_namespace_from() -> impl Pass {
+    hook_pass(crate::es2020::export_namespace_from::hook())
+}
+
+pub fn es2020_nullish_coalescing(no_document_all: bool) -> impl Pass {
+    hook_pass_with_var_declarations(crate::es2020::nullish_coalescing::hook(no_document_all))
+}
+
+pub fn es2020_runtime_transforms(no_document_all: bool) -> impl Pass {
+    hook_pass_with_var_declarations(
+        HookBuilder::new(NoopHook)
+            .chain(crate::es2020::export_namespace_from::hook())
+            .chain(crate::es2020::nullish_coalescing::hook(no_document_all))
+            .build(),
+    )
+}
+
+pub fn es2019_optional_catch_binding() -> impl Pass {
+    hook_pass(crate::es2019::optional_catch_binding::hook())
+}
+
+pub fn es2018_object_rest_spread(assumptions: Assumptions) -> impl Pass {
+    hook_pass_with_var_declarations(crate::es2018::object_rest_spread::hook(assumptions))
+}
+
+pub fn es2018_runtime_transforms(
+    assumptions: Assumptions,
+    regexp_options: crate::regexp::RegExpOptions,
+) -> impl Pass {
+    hook_pass_with_var_declarations(
+        HookBuilder::new(NoopHook)
+            .chain(crate::es2018::object_rest_spread::hook(assumptions))
+            .chain_optional(crate::regexp::hook(regexp_options))
+            .build(),
+    )
+}
+
+pub fn es2017_async_to_generator(
+    unresolved_ctxt: swc_common::SyntaxContext,
+    ignore_function_length: bool,
+) -> impl Pass {
+    hook_pass(crate::es2017::async_to_generator::hook(
+        unresolved_ctxt,
+        ignore_function_length,
+    ))
+}
+
+pub fn es2016_exponentiation() -> impl Pass {
+    hook_pass_with_var_declarations(crate::es2016::exponentiation_operator::hook())
+}
+
+pub fn es2015_shorthand() -> impl Pass {
+    hook_pass(crate::es2015::shorthand::hook())
+}
+
+pub fn es2015_function_name() -> impl Pass {
+    hook_pass(crate::es2015::function_name::hook())
+}
+
+pub fn es2015_duplicate_keys() -> impl Pass {
+    hook_pass(crate::es2015::duplicate_keys::hook())
+}
+
+pub fn es2015_sticky_regex() -> impl Pass {
+    let mut regexp_options = crate::regexp::RegExpOptions::default();
+    regexp_options.sticky_regex = true;
+
+    regexp_pass(regexp_options)
+}
+
+pub fn es2015_instanceof() -> impl Pass {
+    hook_pass(crate::es2015::instanceof::hook())
+}
+
+pub fn es2015_typeof_symbol() -> impl Pass {
+    hook_pass(crate::es2015::typeof_symbol::hook())
+}
+
+pub fn es2015_runtime_transforms() -> impl Pass {
+    let mut regexp_options = crate::regexp::RegExpOptions::default();
+    regexp_options.sticky_regex = true;
+
+    hook_pass(
+        HookBuilder::new(NoopHook)
+            .chain(crate::es2015::shorthand::hook())
+            .chain(crate::es2015::duplicate_keys::hook())
+            .chain(crate::es2015::instanceof::hook())
+            .chain(crate::es2015::typeof_symbol::hook())
+            .chain_optional(crate::regexp::hook(regexp_options))
+            .build(),
+    )
+}
+
+pub fn regexp_pass(options: crate::regexp::RegExpOptions) -> impl Pass {
+    hook_pass(crate::regexp::hook(options))
 }
 
 impl Options {

--- a/crates/swc_ecma_transformer/src/lib.rs
+++ b/crates/swc_ecma_transformer/src/lib.rs
@@ -73,7 +73,7 @@ pub fn transform_hook(options: Options) -> impl VisitMutHook<TraverseCtx> {
     // declarations. Most transformer passes do not need it, and keeping it in
     // the hook chain for those passes only pushes/pops empty declaration scopes.
     let hook = hook.chain(if needs_var_declarations {
-        Some(common::VarDeclarations)
+        Some(common::VarDeclarations::default())
     } else {
         None
     });
@@ -90,7 +90,7 @@ pub fn hook_pass<H: VisitMutHook<TraverseCtx>>(hook: H) -> impl Pass {
 fn hook_pass_with_var_declarations<H: VisitMutHook<TraverseCtx>>(hook: H) -> impl Pass {
     hook_pass(
         HookBuilder::new(hook)
-            .chain(common::VarDeclarations)
+            .chain(common::VarDeclarations::default())
             .build(),
     )
 }

--- a/crates/swc_ecma_transformer/src/lib.rs
+++ b/crates/swc_ecma_transformer/src/lib.rs
@@ -95,6 +95,22 @@ fn hook_pass_with_var_declarations<H: VisitMutHook<TraverseCtx>>(hook: H) -> imp
     )
 }
 
+struct OptionalPass<P> {
+    pass: P,
+    enabled: bool,
+}
+
+impl<P> Pass for OptionalPass<P>
+where
+    P: Pass,
+{
+    fn process(&mut self, program: &mut Program) {
+        if self.enabled {
+            self.pass.process(program);
+        }
+    }
+}
+
 pub fn es2022_static_blocks() -> impl Pass {
     hook_pass(crate::es2022::class_static_block::hook())
 }
@@ -118,7 +134,7 @@ pub fn es2021_logical_assignments() -> impl Pass {
 }
 
 pub fn es2020_export_namespace_from() -> impl Pass {
-    hook_pass(crate::es2020::export_namespace_from::hook())
+    crate::es2020::export_namespace_from::pass()
 }
 
 pub fn es2020_nullish_coalescing(no_document_all: bool) -> impl Pass {
@@ -135,7 +151,7 @@ pub fn es2020_runtime_transforms(no_document_all: bool) -> impl Pass {
 }
 
 pub fn es2019_optional_catch_binding() -> impl Pass {
-    hook_pass(crate::es2019::optional_catch_binding::hook())
+    crate::es2019::optional_catch_binding::pass()
 }
 
 pub fn es2018_object_rest_spread(assumptions: Assumptions) -> impl Pass {
@@ -211,7 +227,12 @@ pub fn es2015_runtime_transforms() -> impl Pass {
 }
 
 pub fn regexp_pass(options: crate::regexp::RegExpOptions) -> impl Pass {
-    hook_pass(crate::regexp::hook(options))
+    let enabled = options.is_enabled();
+
+    OptionalPass {
+        pass: crate::regexp::pass(options),
+        enabled,
+    }
 }
 
 impl Options {

--- a/crates/swc_ecma_transformer/src/lib.rs
+++ b/crates/swc_ecma_transformer/src/lib.rs
@@ -116,16 +116,18 @@ pub fn es2022_static_blocks() -> impl Pass {
 }
 
 pub fn es2022_private_in_object() -> impl Pass {
-    hook_pass(crate::es2022::private_property_in_object::hook())
+    crate::es2022::private_property_in_object::pass()
 }
 
 pub fn es2022_runtime_transforms(regexp_options: crate::regexp::RegExpOptions) -> impl Pass {
-    hook_pass(
-        HookBuilder::new(NoopHook)
-            .chain(crate::es2022::class_static_block::hook())
-            .chain(crate::es2022::private_property_in_object::hook())
-            .chain_optional(crate::regexp::hook(regexp_options))
-            .build(),
+    (
+        hook_pass(
+            HookBuilder::new(NoopHook)
+                .chain(crate::es2022::class_static_block::hook())
+                .chain_optional(crate::regexp::hook(regexp_options))
+                .build(),
+        ),
+        crate::es2022::private_property_in_object::pass(),
     )
 }
 

--- a/crates/swc_ecma_transformer/src/lib.rs
+++ b/crates/swc_ecma_transformer/src/lib.rs
@@ -37,6 +37,11 @@ pub struct TraverseCtx {
 }
 
 pub fn transform_hook(options: Options) -> impl VisitMutHook<TraverseCtx> {
+    let needs_var_declarations = options.env.es2021.logical_assignment_operators
+        || options.env.es2020.nullish_coalescing
+        || options.env.es2018.object_rest_spread
+        || options.env.es2016.exponentiation_operator;
+
     let hook = HookBuilder::new(NoopHook);
 
     let hook = hook.chain_optional(options.typescript.map(crate::typescript::hook));
@@ -63,13 +68,14 @@ pub fn transform_hook(options: Options) -> impl VisitMutHook<TraverseCtx> {
     #[cfg(feature = "es3")]
     let hook = hook.chain(crate::es3::hook(options.env.es3));
 
-    // VarDeclarations must run after all other transforms to collect all variable
-    // declarations
-    let hook = hook.chain(common::VarDeclarations);
-
-    // Statement injector must be the last to process all injected statements
-    // because exit_stmts must be called after all statements are injected
-    let hook = hook.chain(common::StmtInjector::default());
+    // VarDeclarations must run after all transforms that may queue generated
+    // declarations. Most transformer passes do not need it, and keeping it in
+    // the hook chain for those passes only pushes/pops empty declaration scopes.
+    let hook = hook.chain(if needs_var_declarations {
+        Some(common::VarDeclarations)
+    } else {
+        None
+    });
 
     hook.build()
 }

--- a/crates/swc_ecma_transformer/src/regexp.rs
+++ b/crates/swc_ecma_transformer/src/regexp.rs
@@ -9,6 +9,7 @@ use swc_ecma_regexp::{
 };
 use swc_ecma_transforms_base::helper;
 use swc_ecma_utils::{quote_ident, ExprFactory};
+use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
 
 use crate::TraverseCtx;
 
@@ -62,6 +63,10 @@ pub(crate) fn hook(options: RegExpOptions) -> Option<impl VisitMutHook<TraverseC
     } else {
         None
     }
+}
+
+pub(crate) fn pass(options: RegExpOptions) -> impl Pass {
+    visit_mut_pass(RegexpPass { options })
 }
 
 struct RegexpPass {
@@ -216,6 +221,21 @@ impl RegexpPass {
 
 impl VisitMutHook<TraverseCtx> for RegexpPass {
     fn exit_expr(&mut self, expr: &mut Expr, _: &mut TraverseCtx) {
+        self.transform_expr(expr);
+    }
+}
+
+impl VisitMut for RegexpPass {
+    noop_visit_mut_type!(fail);
+
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        expr.visit_mut_children_with(self);
+        self.transform_expr(expr);
+    }
+}
+
+impl RegexpPass {
+    fn transform_expr(&mut self, expr: &mut Expr) {
         match expr {
             Expr::Lit(Lit::Regex(regex)) => {
                 // Try named groups transform first


### PR DESCRIPTION
**Description:**

Optimizes ECMA transformer/compat benchmark hot paths from CodSpeed/Callgrind data without touching `swc_es_*` crates.

Changes:
- Reduce ES2015 block-scoping `Id` cloning in captured-loop and usage tracking.
- Skip unused common hook state and avoid building full `Options::into_pass()` pipelines for one-off compat wrappers.
- Route simple compat wrappers through direct visitors/passes for optional catch binding, export namespace, and standalone regexp.
- Stop syntax detectors after the first match.
- Skip ES2022 private visitors and `#x in obj` handling when the input has no relevant private syntax.
- Keep the final direct sticky-regexp options initialization clippy-clean.
- Scope generated var declarations inside concise arrow bodies without restoring the full statement injector hot path.

CodSpeed / Callgrind IR data (`swc_ecma_transforms_typescript` `compat`, `RUST_LOG=off`, `valgrind-3.26.0.codspeed`):

| Step | Aggregate Ir | Delta vs baseline | Notes |
| --- | ---: | ---: | --- |
| Baseline (`753b222fbf`) | 19,480,917 | - | `origin/main` at branch point |
| After `1d18dbff51` | 19,476,707 | -4,210 (-0.02%) | Avoid storing captured loop ids |
| After `eeebf21b6d` | 19,470,908 | -10,009 (-0.05%) | Avoid duplicate usage id clones |
| After `6d333edb06` | 19,076,175 | -404,742 (-2.08%) | Skip unused common hooks |
| After `eb84fd4900` | 18,281,590 | -1,199,327 (-6.16%) | Use direct passes for compat wrappers |
| After `80a43c44db` | 18,277,381 | -1,203,536 (-6.18%) | Use direct visitors for simple passes |
| After `5511f03a5f` | 17,886,208 | -1,594,709 (-8.19%) | Skip private visitors without private names |
| After `d46a268034` | 17,791,558 | -1,689,359 (-8.67%) | Stop syntax detectors after a match |
| After `073fbd0455` | 17,499,239 | -1,981,678 (-10.17%) | Skip private-in pass without brand checks |
| After `1d43d588f3` | 17,499,239 | -1,981,678 (-10.17%) | Clippy-only cleanup |
| Final (`dfd6421122`) | 17,516,274 | -1,964,643 (-10.08%) | Balance concise-arrow temp scopes after body rewrites |

Measured and reverted experiments:
- `block_scoping/vars.rs` `FxHashMap`/`FxHashSet` rewrite: `17,794,158 Ir`, slower than the preceding result.
- Runtime regexp split with a scanner fast path: `17,970,703 Ir`, slower than the preceding result.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.

Verification:
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_compat_common`
- `PATH="$(pwd)/node_modules/.bin:$PATH" cargo test -p swc_ecma_compat_es2015`
- `cargo test -p swc_ecma_compat_es2016`
- `cargo test -p swc_ecma_compat_es2017`
- `cargo test -p swc_ecma_compat_es2018`
- `cargo test -p swc_ecma_compat_es2019`
- `cargo test -p swc_ecma_compat_es2020`
- `cargo test -p swc_ecma_compat_es2021`
- `cargo test -p swc_ecma_compat_es2022`
- `cargo test -p swc_ecma_transformer`
- `cargo test -p swc --test projects`
- `CI=1 DIFF=0 RUST_LOG=off cargo test -p swc fixture____swc_ecma_parser__tests__tsc__objectRest_ts`
- `cargo test -p swc --test projects fixture_tests__fixture__issues_7xxx__7977__input`
- `cargo test -p swc --test projects fixture_tests__fixture__issues_9xxx__9110__input`
- `cargo clippy -p swc_ecma_transformer --all-targets -- -D warnings`
- `env RUSTFLAGS="--cfg swc_ast_unknown" cargo check -p swc_ecma_transforms --features typescript,react,proposal,optimization,module,compat`
- `cargo codspeed build -p swc_ecma_transforms_typescript --bench compat`
- `CODSPEED_CARGO_WORKSPACE_ROOT="$(pwd)" RUST_LOG=off valgrind --tool=callgrind --callgrind-out-file=target/codspeed/swc_ecma_transforms_typescript_compat.ci-fix-block-scope.callgrind.out target/codspeed/analysis/swc_ecma_transforms_typescript/compat`

Note: `swc_ecma_compat_es2015` has two exec tests that require `mocha` on `PATH`; I installed the locked JS dependencies with `pnpm install --frozen-lockfile` and reran the full crate test with `node_modules/.bin` on `PATH`.

