### PR TITLE
fix(ts/fast-dts): strip definite assertions in dts

### DIFF
--- a/.changeset/yellow-walls-itch.md
+++ b/.changeset/yellow-walls-itch.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_typescript: patch
+---
+
+fix(typescript): strip definite assertions in dts

--- a/crates/swc_typescript/src/fast_dts/class.rs
+++ b/crates/swc_typescript/src/fast_dts/class.rs
@@ -239,14 +239,14 @@ impl FastDts {
                         .is_some_and(|accessibility| accessibility == Accessibility::Private)
                     {
                         auto_accessor.decorators.clear();
-                        auto_accessor.definite = false;
                         auto_accessor.type_ann = None;
-                        auto_accessor.accessibility =
-                            self.transform_accessibility(auto_accessor.accessibility);
                     }
 
+                    auto_accessor.definite = false;
                     auto_accessor.is_override = false;
                     auto_accessor.value = None;
+                    auto_accessor.accessibility =
+                        self.transform_accessibility(auto_accessor.accessibility);
                     class.body.push(member);
                 }
                 ClassMember::Empty(_) | ClassMember::StaticBlock(_) => {}
@@ -475,6 +475,7 @@ impl FastDts {
         }
 
         prop.declare = false;
+        prop.definite = false;
         prop.decorators.clear();
         prop.accessibility = self.transform_accessibility(prop.accessibility);
     }

--- a/crates/swc_typescript/tests/fixture/class-definite-assignment.snap
+++ b/crates/swc_typescript/tests/fixture/class-definite-assignment.snap
@@ -1,0 +1,15 @@
+```==================== .D.TS ====================
+
+export declare class DefiniteFields {
+    publicField: string;
+    protected protectedField: number;
+    private privateField;
+    readonly readonlyField: string;
+}
+export declare class DefiniteAccessors {
+    accessor publicAccessor: string;
+    protected accessor protectedAccessor: number;
+    private accessor privateAccessor;
+}
+
+

--- a/crates/swc_typescript/tests/fixture/class-definite-assignment.ts
+++ b/crates/swc_typescript/tests/fixture/class-definite-assignment.ts
@@ -1,0 +1,12 @@
+export class DefiniteFields {
+    public publicField!: string;
+    protected protectedField!: number;
+    private privateField!: boolean;
+    readonly readonlyField!: string;
+}
+
+export class DefiniteAccessors {
+    public accessor publicAccessor!: string;
+    protected accessor protectedAccessor!: number;
+    private accessor privateAccessor!: boolean;
+}


### PR DESCRIPTION
**Description:**

This PR aligns isolated declaration emit with tsc for definite assignment assertions on class members. Definite assertions are stripped from class fields and auto-accessors, and public auto-accessor visibility is normalized away in generated d.ts output.

**Related issue (if exists):**

Related to #11850