### PR TITLE
chore(html): add webcontainer fallback for `@swc/html`

### DIFF
--- a/packages/html/binding.js
+++ b/packages/html/binding.js
@@ -341,6 +341,14 @@ if (!nativeBinding || process.env.NAPI_RS_FORCE_WASI) {
     }
 }
 
+if (!nativeBinding && globalThis.process?.versions?.["webcontainer"]) {
+    try {
+        nativeBinding = require("./webcontainer-fallback.cjs");
+    } catch (err) {
+        loadErrors.push(err);
+    }
+}
+
 if (!nativeBinding) {
     if (loadErrors.length > 0) {
         // TODO Link to documentation with potential fixes

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -47,8 +47,8 @@
         "artifacts": "napi artifacts --npm-dir scripts/npm",
         "prepack": "tsc -d && napi prepublish -p scripts/npm --tag-style npm --skip-optional-publish",
         "build:ts": "tsc -d",
-        "build": "(tsc -d || true) && napi build --manifest-path ../../Cargo.toml --platform -p binding_html_node --js ./binding.js --dts ./binding.d.ts --release -o .",
-        "build:dev": "(tsc -d || true) && napi build --manifest-path ../../Cargo.toml --platform -p binding_html_node --js ./binding.js --dts ./binding.d.ts -o .",
+        "build": "(tsc -d || true) && napi build --manifest-path ../../Cargo.toml --platform -p binding_html_node --no-js --dts ./binding.d.ts --release -o .",
+        "build:dev": "(tsc -d || true) && napi build --manifest-path ../../Cargo.toml --platform -p binding_html_node --no-js --dts ./binding.d.ts -o .",
         "test": "echo 'done!'",
         "version": "napi version --npm-dir scripts/npm"
     },

--- a/packages/html/webcontainer-fallback.cjs
+++ b/packages/html/webcontainer-fallback.cjs
@@ -20,4 +20,48 @@ if (!fs.existsSync(bindingEntry)) {
     });
 }
 
-module.exports = require(bindingEntry);
+const wasmBinding = require(bindingEntry);
+
+module.exports.minify = (content, options) => {
+    return wasmBinding.minify(toString(content), toOptions(options));
+};
+
+module.exports.minifyFragment = (content, options) => {
+    return wasmBinding.minifyFragment(toString(content), toOptions(options));
+};
+
+module.exports.minifySync = (content, options) => {
+    return wasmBinding.minifySync(toString(content), toOptions(options));
+};
+
+module.exports.minifyFragmentSync = (content, options) => {
+    return wasmBinding.minifyFragmentSync(toString(content), toOptions(options));
+};
+
+function toString(content) {
+    return Buffer.isBuffer(content) ? content.toString("utf8") : content;
+}
+
+function toOptions(options) {
+    if (options == null) {
+        return {};
+    }
+
+    if (Buffer.isBuffer(options)) {
+        if (options.length === 0) {
+            return {};
+        }
+
+        return JSON.parse(options.toString("utf8"));
+    }
+
+    if (typeof options === "string") {
+        if (options.length === 0) {
+            return {};
+        }
+
+        return JSON.parse(options);
+    }
+
+    return options;
+}

--- a/packages/html/webcontainer-fallback.cjs
+++ b/packages/html/webcontainer-fallback.cjs
@@ -1,0 +1,23 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const childProcess = require("node:child_process");
+
+const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "package.json"), "utf-8")
+);
+const version = pkg.version;
+const baseDir = `/tmp/swc-html-${version}`;
+const bindingEntry = `${baseDir}/node_modules/@swc/html-wasm/wasm.js`;
+
+if (!fs.existsSync(bindingEntry)) {
+    fs.rmSync(baseDir, { recursive: true, force: true });
+    fs.mkdirSync(baseDir, { recursive: true });
+    const bindingPkg = `@swc/html-wasm@${version}`;
+    console.log(`[swc] Downloading ${bindingPkg} on WebContainer...`);
+    childProcess.execFileSync("pnpm", ["i", bindingPkg], {
+        cwd: baseDir,
+        stdio: "inherit",
+    });
+}
+
+module.exports = require(bindingEntry);


### PR DESCRIPTION
**Description:**

- Add `webcontainer-fallback.cjs` to redirect `@swc/html` to `@swc/html-wasm` in the webcontainer environment.
- Set `--no-js` in `@swc/html` build script to avoid  rewrite the binding patch.

**Related issue (if exists):**

closes https://github.com/swc-project/swc/issues/11833