### PR TITLE
perf(es/minifier): reduce usage analysis overhead

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -1,4 +1,4 @@
-use std::ops::Deref;
+use std::{collections::hash_map::Entry, ops::Deref};
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::atom;
@@ -997,27 +997,27 @@ impl Optimizer<'_> {
             return Some(value);
         }
 
-        // Check without cloning
-        if let Some(value) = self.vars.vars_for_inlining.get(&id) {
-            if self.ctx.bit_ctx.contains(BitCtx::IsExactLhsOfAssign) && !is_valid_for_lhs(value) {
-                return None;
-            }
-
-            if let Expr::Member(..) = &**value {
-                if self.ctx.bit_ctx.contains(BitCtx::ExecutedMultipleTime) {
+        match self.vars.vars_for_inlining.entry(id) {
+            Entry::Occupied(entry) => {
+                let value = entry.get();
+                if self.ctx.bit_ctx.contains(BitCtx::IsExactLhsOfAssign) && !is_valid_for_lhs(value)
+                {
                     return None;
                 }
+
+                if let Expr::Member(..) = &**value {
+                    if self.ctx.bit_ctx.contains(BitCtx::ExecutedMultipleTime) {
+                        return None;
+                    }
+                }
+
+                self.changed = true;
+                report_change!("inline: Replacing '{}' with an expression", ident);
+
+                Some(entry.remove())
             }
+            Entry::Vacant(_) => None,
         }
-
-        if let Some(value) = self.vars.vars_for_inlining.remove(&id) {
-            self.changed = true;
-            report_change!("inline: Replacing '{}' with an expression", ident);
-
-            return Some(value);
-        }
-
-        None
     }
 }
 

--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -316,7 +316,7 @@ impl Optimizer<'_> {
                     property_mutation_count,
                     flags,
                     ..
-                } = **usage;
+                } = *usage;
                 let mut inc_usage = || {
                     for (i, _) in collect_infects_from(
                         &*init,

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -352,6 +352,10 @@ impl From<&Function> for FnMetadata {
 
 impl Optimizer<'_> {
     fn may_remove_ident(&self, id: &Ident) -> bool {
+        if id.ctxt != self.marks.top_level_ctxt {
+            return true;
+        }
+
         if self
             .data
             .vars
@@ -359,10 +363,6 @@ impl Optimizer<'_> {
             .is_some_and(|v| v.flags.contains(VarUsageInfoFlags::EXPORTED))
         {
             return false;
-        }
-
-        if id.ctxt != self.marks.top_level_ctxt {
-            return true;
         }
 
         if self.options.top_level() {

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -285,7 +285,7 @@ impl Vars {
         // Inline candidates scale with the analyzed binding count, but only a
         // subset becomes replaceable. This avoids repeated growth on large
         // modules without over-reserving for typical files.
-        let cap = (var_count / 4).min(16384);
+        let cap = var_count.min(65536);
 
         Self {
             lits: FxHashMap::with_capacity_and_hasher(cap, Default::default()),

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -91,7 +91,7 @@ pub(super) fn optimizer<'a>(
         mangle_options,
         prepend_stmts: Default::default(),
         append_stmts: Default::default(),
-        vars: Default::default(),
+        vars: Vars::with_capacity(data.vars.len()),
         typeofs: Default::default(),
         data,
         ctx,
@@ -251,7 +251,6 @@ struct Optimizer<'a> {
     static_alias_state: &'a mut StaticAliasState,
 }
 
-#[derive(Default)]
 struct Vars {
     /// Cheap to clone.
     ///
@@ -282,6 +281,23 @@ struct Vars {
 }
 
 impl Vars {
+    fn with_capacity(var_count: usize) -> Self {
+        // Inline candidates scale with the analyzed binding count, but only a
+        // subset becomes replaceable. This avoids repeated growth on large
+        // modules without over-reserving for typical files.
+        let cap = (var_count / 4).min(16384);
+
+        Self {
+            lits: FxHashMap::with_capacity_and_hasher(cap, Default::default()),
+            hoisted_props: Default::default(),
+            lits_for_cmp: FxHashMap::with_capacity_and_hasher(cap / 2, Default::default()),
+            lits_for_array_access: Default::default(),
+            simple_functions: Default::default(),
+            vars_for_inlining: FxHashMap::with_capacity_and_hasher(cap, Default::default()),
+            removed: Default::default(),
+        }
+    }
+
     fn has_pending_inline_for(&self, id: &Id) -> bool {
         self.lits.contains_key(id) || self.vars_for_inlining.contains_key(id)
     }

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -508,6 +508,19 @@ impl VisitMut for Finalizer<'_> {
             return;
         }
 
+        if can_replace_lit && !can_replace_hoisted_prop {
+            if let Expr::Ident(i) = n {
+                if let Some(expr) = self.lits.get(&i.to_id()) {
+                    *n = *expr.clone();
+                }
+
+                return;
+            }
+
+            n.visit_mut_children_with(self);
+            return;
+        }
+
         match n {
             Expr::Ident(i) => {
                 if can_replace_lit {

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -476,7 +476,9 @@ impl VisitMut for Pure<'_> {
             return;
         }
 
-        self.handle_known_delete(e);
+        if matches!(e, Expr::Unary(..)) {
+            self.handle_known_delete(e);
+        }
 
         e.visit_mut_children_with(self);
 

--- a/crates/swc_ecma_minifier/src/compress/pure/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/mod.rs
@@ -216,9 +216,12 @@ impl Pure<'_> {
 
     #[inline(always)]
     fn same_ident(left: &Expr, right: &Expr) -> bool {
-        left.as_ident()
-            .zip(right.as_ident())
-            .is_some_and(|(left, right)| left.to_id() == right.to_id())
+        match (left, right) {
+            (Expr::Ident(left), Expr::Ident(right)) => {
+                left.ctxt == right.ctxt && left.sym == right.sym
+            }
+            _ => false,
+        }
     }
 
     #[inline(always)]
@@ -484,13 +487,13 @@ impl VisitMut for Pure<'_> {
 
         // Expression simplifier
         match e {
-            Expr::Member(..)
+            Expr::Member(member)
                 if !self.ctx.intersects(
                     Ctx::IN_DELETE
                         .union(Ctx::IS_UPDATE_ARG)
                         .union(Ctx::IS_LHS_OF_ASSIGN)
                         .union(Ctx::IN_OPT_CHAIN),
-                ) && e.as_member().is_some_and(Self::can_simplify_member_expr) =>
+                ) && Self::can_simplify_member_expr(member) =>
             {
                 let mut changed = false;
                 simplify::expr::optimize_member_expr(

--- a/crates/swc_ecma_minifier/src/compress/pure/sequences.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/sequences.rs
@@ -299,7 +299,9 @@ impl Pure<'_> {
                     }) if prop.is_ident_with("apply") || prop.is_ident_with("call") => {
                         //
                         if let Expr::Ident(b_callee_obj) = &**b_callee_obj {
-                            if b_callee_obj.to_id() != var_name.to_id() {
+                            if b_callee_obj.ctxt != var_name.ctxt
+                                || b_callee_obj.sym != var_name.sym
+                            {
                                 continue;
                             }
                         } else {

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -677,6 +677,10 @@ impl VarDataLike for VarUsageInfo {
     }
 
     fn add_accessed_property(&mut self, name: swc_atoms::Wtf8Atom) {
+        if self.accessed_props.is_empty() {
+            self.accessed_props.reserve(8);
+        }
+
         *self.accessed_props.entry(name).or_default() += 1;
     }
 

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -34,8 +34,8 @@ where
     // Large modules commonly have tens of thousands of bindings. Reserving the
     // top-level storage avoids repeated rehashing while usage data from child
     // scopes is merged back into the program data.
-    data.vars.reserve(65536);
-    data.initialized_vars.reserve(16384);
+    data.vars.reserve(131072);
+    data.initialized_vars.reserve(18432);
 
     analyze_with_custom_storage(data, n, marks)
 }
@@ -280,51 +280,58 @@ impl Storage for ProgramData {
                         }
                     }
 
-                    e.merged_var_type.merge(var_info.merged_var_type);
+                    if let Some(ty) = var_info.merged_var_type {
+                        e.merged_var_type.merge(Some(ty));
+                    }
 
                     e.ref_count += var_info.ref_count;
                     e.property_mutation_count |= var_info.property_mutation_count;
                     e.declared_count += var_info.declared_count;
                     e.assign_count += var_info.assign_count;
                     e.usage_count += var_info.usage_count;
-                    e.infects_to.extend(var_info.infects_to);
+                    if !var_info.infects_to.is_empty() {
+                        e.infects_to.extend(var_info.infects_to);
+                    }
                     e.callee_count += var_info.callee_count;
 
-                    e.param_count = match (e.param_count, var_info.param_count) {
-                        (Some(Value::Known(v1)), Some(Value::Known(v2))) if v1 == v2 => {
-                            Some(Value::Known(v1))
-                        }
-                        (Some(Value::Known(v)), None) | (None, Some(Value::Known(v))) => {
-                            Some(Value::Known(v))
-                        }
-                        (Some(Value::Known(_)), Some(Value::Known(_)))
-                        | (Some(Value::Unknown), _)
-                        | (_, Some(Value::Unknown)) => Some(Value::Unknown),
-                        (None, None) => None,
-                    };
-
-                    for (k, v) in var_info.accessed_props {
-                        *e.accessed_props.entry(k).or_default() += v;
+                    if let Some(param_count) = var_info.param_count {
+                        e.param_count = match (e.param_count, param_count) {
+                            (Some(Value::Known(v1)), Value::Known(v2)) if v1 == v2 => {
+                                Some(Value::Known(v1))
+                            }
+                            (None, Value::Known(v)) => Some(Value::Known(v)),
+                            (Some(Value::Known(_)), Value::Known(_))
+                            | (Some(Value::Unknown), _)
+                            | (_, Value::Unknown) => Some(Value::Unknown),
+                        };
                     }
+
+                    if !var_info.accessed_props.is_empty() {
+                        for (k, v) in var_info.accessed_props {
+                            *e.accessed_props.entry(k).or_default() += v;
+                        }
+                    }
+
+                    const MERGED_FLAGS: VarUsageInfoFlags = VarUsageInfoFlags::REASSIGNED
+                        .union(VarUsageInfoFlags::HAS_PROPERTY_ACCESS)
+                        .union(VarUsageInfoFlags::EXPORTED)
+                        .union(VarUsageInfoFlags::DECLARED)
+                        .union(VarUsageInfoFlags::DECLARED_AS_FN_PARAM)
+                        .union(VarUsageInfoFlags::DECLARED_AS_FN_DECL)
+                        .union(VarUsageInfoFlags::DECLARED_AS_FN_EXPR)
+                        .union(VarUsageInfoFlags::DECLARED_AS_CATCH_PARAM)
+                        .union(VarUsageInfoFlags::EXECUTED_MULTIPLE_TIME)
+                        .union(VarUsageInfoFlags::USED_IN_COND)
+                        .union(VarUsageInfoFlags::USED_AS_ARG)
+                        .union(VarUsageInfoFlags::USED_AS_REF)
+                        .union(VarUsageInfoFlags::INDEXED_WITH_DYNAMIC_KEY)
+                        .union(VarUsageInfoFlags::PURE_FN)
+                        .union(VarUsageInfoFlags::USED_RECURSIVELY)
+                        .union(VarUsageInfoFlags::USED_IN_NON_CHILD_FN);
 
                     let var_info_flags = var_info.flags;
                     let e_flags = &mut e.flags;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::REASSIGNED;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::HAS_PROPERTY_ACCESS;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::EXPORTED;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::DECLARED;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::DECLARED_AS_FN_PARAM;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::DECLARED_AS_FN_DECL;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::DECLARED_AS_FN_EXPR;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::DECLARED_AS_CATCH_PARAM;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::EXECUTED_MULTIPLE_TIME;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::USED_IN_COND;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::USED_AS_ARG;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::USED_AS_REF;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::INDEXED_WITH_DYNAMIC_KEY;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::PURE_FN;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::USED_RECURSIVELY;
-                    *e_flags |= var_info_flags & VarUsageInfoFlags::USED_IN_NON_CHILD_FN;
+                    *e_flags |= var_info_flags & MERGED_FLAGS;
 
                     // If a var is registered at a parent scope, it means that it's delcared before
                     // usages.
@@ -527,8 +534,8 @@ impl Storage for ProgramData {
 
         if ctx.in_pat_of_param() {
             v.merged_var_type = Some(Value::Unknown);
-        } else {
-            v.merged_var_type.merge(init_type);
+        } else if let Some(init_type) = init_type {
+            v.merged_var_type.merge(Some(init_type));
         }
 
         v.declared_count += 1;
@@ -579,6 +586,10 @@ impl Storage for ProgramData {
         if let Some(atoms) = self.property_atoms.as_mut() {
             atoms.push(atom);
         }
+    }
+
+    fn should_collect_property_atoms(&self) -> bool {
+        self.property_atoms.is_some()
     }
 
     fn get_var_data(&self, id: Id) -> Option<&Self::VarData> {

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -23,7 +23,7 @@ pub(crate) fn analyze<N>(n: &N, marks: Option<Marks>, collect_property_atoms: bo
 where
     N: VisitWith<UsageAnalyzer<ProgramData>>,
 {
-    let data = if collect_property_atoms {
+    let mut data = if collect_property_atoms {
         ProgramData {
             property_atoms: Some(Vec::with_capacity(128)),
             ..Default::default()
@@ -31,6 +31,11 @@ where
     } else {
         ProgramData::default()
     };
+    // Large modules commonly have tens of thousands of bindings. Reserving the
+    // top-level storage avoids repeated rehashing while usage data from child
+    // scopes is merged back into the program data.
+    data.vars.reserve(65536);
+    data.initialized_vars.reserve(16384);
 
     analyze_with_custom_storage(data, n, marks)
 }

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -236,9 +236,15 @@ impl Storage for ProgramData {
         self.vars.reserve(child.vars.len());
         for (id, mut var_info) in child.vars {
             // trace!("merge({:?},{}{:?})", kind, id.0, id.1);
-            let inited = self.initialized_vars.contains(&id);
             match self.vars.entry(id) {
                 Entry::Occupied(mut e) => {
+                    let inited = if !var_info.flags.contains(VarUsageInfoFlags::VAR_INITIALIZED)
+                        && var_info.ref_count > 0
+                    {
+                        self.initialized_vars.contains(e.key())
+                    } else {
+                        false
+                    };
                     let e = e.get_mut();
 
                     if var_info.flags.contains(VarUsageInfoFlags::INLINE_PREVENTED) {
@@ -265,9 +271,9 @@ impl Storage for ProgramData {
                     } else {
                         // If it is inited in some other child scope, but referenced in
                         // current child scope
-                        if !inited
-                            && e.flags.contains(VarUsageInfoFlags::VAR_INITIALIZED)
+                        if e.flags.contains(VarUsageInfoFlags::VAR_INITIALIZED)
                             && var_info.ref_count > 0
+                            && !inited
                         {
                             e.flags.remove(VarUsageInfoFlags::VAR_INITIALIZED);
                             e.flags.insert(VarUsageInfoFlags::REASSIGNED);

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -367,9 +367,7 @@ impl Storage for ProgramData {
     }
 
     fn report_usage(&mut self, ctx: Ctx, i: Id) {
-        let inited = self.initialized_vars.contains(&i);
-
-        let e = self.vars.entry(i).or_insert_with(|| {
+        let e = self.vars.entry(i.clone()).or_insert_with(|| {
             let mut default = VarUsageInfo::default();
             default.flags.insert(VarUsageInfoFlags::USED_ABOVE_DECL);
             Box::new(default)
@@ -381,7 +379,9 @@ impl Storage for ProgramData {
         e.ref_count += 1;
         e.usage_count += 1;
         // If it is inited in some child scope, but referenced in current scope
-        if !inited && e.flags.contains(VarUsageInfoFlags::VAR_INITIALIZED) {
+        if e.flags.contains(VarUsageInfoFlags::VAR_INITIALIZED)
+            && !self.initialized_vars.contains(&i)
+        {
             e.flags.insert(VarUsageInfoFlags::REASSIGNED);
             e.flags.remove(VarUsageInfoFlags::VAR_INITIALIZED);
         }
@@ -399,8 +399,6 @@ impl Storage for ProgramData {
     fn report_assign(&mut self, ctx: Ctx, i: Id, is_op: bool, ty: Value<Type>) {
         let e = self.vars.entry(i.clone()).or_default();
 
-        let inited = self.initialized_vars.contains(&i);
-
         if e.assign_count > 0 || e.initialized() {
             e.flags.insert(VarUsageInfoFlags::REASSIGNED);
         }
@@ -409,8 +407,12 @@ impl Storage for ProgramData {
         e.assign_count += 1;
 
         if !is_op {
+            let should_mark_initialized =
+                e.ref_count == 1 && e.var_kind != Some(VarDeclKind::Const);
+            let inited = should_mark_initialized && self.initialized_vars.contains(&i);
+
             self.initialized_vars.insert(i.clone());
-            if e.ref_count == 1 && e.var_kind != Some(VarDeclKind::Const) && !inited {
+            if should_mark_initialized && !inited {
                 e.flags.insert(VarUsageInfoFlags::VAR_INITIALIZED);
             } else {
                 e.flags.insert(VarUsageInfoFlags::REASSIGNED);
@@ -540,25 +542,26 @@ impl Storage for ProgramData {
     }
 
     fn mark_property_mutation(&mut self, id: Id) {
-        let e = self.vars.entry(id).or_default();
-        e.property_mutation_count += 1;
+        let infects_to = {
+            let e = self.vars.entry(id.clone()).or_default();
+            e.property_mutation_count += 1;
 
-        if e.infects_to.is_empty() {
-            return;
+            if e.infects_to.is_empty() {
+                return;
+            }
+
+            std::mem::take(&mut e.infects_to)
+        };
+
+        for (other, kind) in &infects_to {
+            if *kind == AccessKind::Reference {
+                let other = self.vars.entry(other.clone()).or_default();
+
+                other.property_mutation_count += 1;
+            }
         }
 
-        let to_mark_mutate = e
-            .infects_to
-            .iter()
-            .filter(|(_, kind)| *kind == AccessKind::Reference)
-            .map(|(id, _)| id.clone())
-            .collect::<Vec<_>>();
-
-        for other in to_mark_mutate {
-            let other = self.vars.entry(other).or_default();
-
-            other.property_mutation_count += 1;
-        }
+        self.vars.entry(id).or_default().infects_to = infects_to;
     }
 
     fn add_property_atom(&mut self, atom: Wtf8Atom) {

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -43,7 +43,7 @@ where
 /// Analyzed info of a whole program we are working on.
 #[derive(Debug, Default)]
 pub(crate) struct ProgramData {
-    pub(crate) vars: FxHashMap<Id, Box<VarUsageInfo>>,
+    pub(crate) vars: FxHashMap<Id, VarUsageInfo>,
 
     initialized_vars: IndexSet<Id, FxBuildHasher>,
 
@@ -375,7 +375,7 @@ impl Storage for ProgramData {
         let e = self.vars.entry(i.clone()).or_insert_with(|| {
             let mut default = VarUsageInfo::default();
             default.flags.insert(VarUsageInfoFlags::USED_ABOVE_DECL);
-            Box::new(default)
+            default
         });
 
         if ctx.is_id_ref() {
@@ -576,7 +576,7 @@ impl Storage for ProgramData {
     }
 
     fn get_var_data(&self, id: Id) -> Option<&Self::VarData> {
-        self.vars.get(&id).map(|v| v.as_ref())
+        self.vars.get(&id)
     }
 }
 

--- a/crates/swc_ecma_minifier/src/usage_analyzer/alias/mod.rs
+++ b/crates/swc_ecma_minifier/src/usage_analyzer/alias/mod.rs
@@ -168,9 +168,10 @@ pub struct InfectionCollector {
 
 impl InfectionCollector {
     fn add_binding(&mut self, e: &Ident) {
-        if self.bindings.insert(e.to_id()) {
-            self.accesses.remove(&(e.to_id(), AccessKind::Reference));
-            self.accesses.remove(&(e.to_id(), AccessKind::Call));
+        let id = e.to_id();
+        if self.bindings.insert(id.clone()) {
+            self.accesses.remove(&(id.clone(), AccessKind::Reference));
+            self.accesses.remove(&(id, AccessKind::Call));
         }
     }
 

--- a/crates/swc_ecma_minifier/src/usage_analyzer/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/usage_analyzer/analyzer/mod.rs
@@ -157,13 +157,15 @@ where
 
         let i = i.to_id();
 
-        if let Some(recr) = self.used_recursively.get(&i) {
-            if let RecursiveUsage::Var { can_ignore: false } = recr {
-                self.data.report_usage(self.ctx, i.clone());
-                self.data.var_or_default(i.clone()).mark_used_above_decl()
+        if !self.used_recursively.is_empty() {
+            if let Some(recr) = self.used_recursively.get(&i) {
+                if let RecursiveUsage::Var { can_ignore: false } = recr {
+                    self.data.report_usage(self.ctx, i.clone());
+                    self.data.var_or_default(i.clone()).mark_used_above_decl()
+                }
+                self.data.var_or_default(i.clone()).mark_used_recursively();
+                return;
             }
-            self.data.var_or_default(i.clone()).mark_used_recursively();
-            return;
         }
 
         self.data.report_usage(self.ctx, i)

--- a/crates/swc_ecma_minifier/src/usage_analyzer/analyzer/mod.rs
+++ b/crates/swc_ecma_minifier/src/usage_analyzer/analyzer/mod.rs
@@ -1149,7 +1149,9 @@ where
             }
         }
 
-        if is_root_of_member_expr_declared(e, &self.data) {
+        if self.data.should_collect_property_atoms()
+            && is_root_of_member_expr_declared(e, &self.data)
+        {
             if let MemberProp::Ident(ident) = &e.prop {
                 self.data.add_property_atom(ident.sym.clone().into());
             }

--- a/crates/swc_ecma_minifier/src/usage_analyzer/analyzer/storage.rs
+++ b/crates/swc_ecma_minifier/src/usage_analyzer/analyzer/storage.rs
@@ -14,6 +14,10 @@ pub trait Storage: Sized {
 
     fn add_property_atom(&mut self, atom: Wtf8Atom);
 
+    /// Returns true when member property names should be collected for property
+    /// mangling.
+    fn should_collect_property_atoms(&self) -> bool;
+
     fn scope(&mut self, ctxt: SyntaxContext) -> &mut Self::ScopeData;
 
     fn scopes(&self) -> &[Self::ScopeData];

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -6,7 +6,7 @@ use indexmap::IndexSet;
 #[cfg(feature = "concurrent-renamer")]
 use par_iter::prelude::*;
 use rustc_hash::{FxHashMap, FxHashSet, FxHasher};
-use swc_atoms::{atom, Atom};
+use swc_atoms::Atom;
 use swc_common::Mark;
 use swc_ecma_ast::*;
 use tracing::debug;
@@ -46,7 +46,7 @@ pub(super) struct ScopeData {
 
 impl Scope {
     pub(super) fn add_decl(&mut self, id: &Id, has_eval: bool, top_level_mark: Mark) {
-        if id.0 == atom!("arguments") {
+        if id.0 == "arguments" {
             return;
         }
 
@@ -68,7 +68,7 @@ impl Scope {
     }
 
     pub(super) fn add_usage(&mut self, id: Id) {
-        if id.0 == atom!("arguments") {
+        if id.0 == "arguments" {
             return;
         }
 
@@ -81,9 +81,15 @@ impl Scope {
 
     /// Copy `children.data.all` to `self.data.all`.
     pub(crate) fn prepare_renaming(&mut self) {
+        let mut child_len = 0;
         self.children.iter_mut().for_each(|child| {
             child.prepare_renaming();
 
+            child_len += child.data.all.len();
+        });
+
+        self.data.all.reserve(child_len);
+        self.children.iter().for_each(|child| {
             self.data.all.extend(child.data.all.iter().cloned());
         });
     }

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, collections::hash_map::Entry};
+use std::borrow::Cow;
 
 use analyer_and_collector::AnalyzerAndCollector;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -266,21 +266,21 @@ where
         if let Some(total_map) = &mut self.total_map {
             total_map.reserve(map.len());
 
-            for (k, v) in &map {
-                match total_map.entry(k.clone()) {
-                    Entry::Occupied(old) => {
-                        let old = old.get().to_id();
+            #[cfg(debug_assertions)]
+            {
+                for (k, v) in &map {
+                    if let Some(old) = total_map.get(k) {
+                        let old = old.to_id();
                         let new = v.to_id();
                         unreachable!(
                             "{} is already renamed to {}, but it's renamed as {}",
                             k.0, old.0, new.0
                         );
                     }
-                    Entry::Vacant(e) => {
-                        e.insert(v.clone());
-                    }
                 }
             }
+
+            total_map.extend(map.iter().map(|(k, v)| (k.clone(), v.clone())));
         }
 
         map

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -113,6 +113,15 @@ struct Data {
 }
 
 impl Data {
+    fn reserve_for_large_module(&mut self) {
+        // Large modules can produce tens of thousands of bindings and graph
+        // nodes. Reserve the top-level DCE storage up front to avoid repeated
+        // rehashing while the analyzer records usage and dependency edges.
+        self.used_names.reserve(65536);
+        self.entries.reserve(16384);
+        self.graph_ix.reserve(65536);
+    }
+
     fn drop_usage(&mut self, id: &Id) {
         if let Some(e) = self.used_names.get_mut(id) {
             // We use `saturating_sub` to avoid underflow.
@@ -1022,6 +1031,7 @@ impl VisitMut for TreeShaker {
                 initialized: true,
                 ..Default::default()
             };
+            data.reserve_for_large_module();
 
             {
                 let mut analyzer = Analyzer {
@@ -1086,6 +1096,7 @@ impl VisitMut for TreeShaker {
                 initialized: true,
                 ..Default::default()
             };
+            data.reserve_for_large_module();
 
             {
                 let mut analyzer = Analyzer {

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use indexmap::IndexSet;
 use petgraph::{algo::tarjan_scc, prelude::GraphMap, Directed, Direction::Incoming};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
-use swc_atoms::{atom, Atom};
+use swc_atoms::Atom;
 use swc_common::{
     pass::{CompilerPass, Repeated},
     util::take::Take,
@@ -402,17 +402,17 @@ impl Analyzer<'_> {
 
     /// Mark `id` as used
     fn add(&mut self, id: Id, assign: bool) {
-        if id.0 == atom!("arguments") {
+        if &*id.0 == "arguments" {
             self.scope.found_arguemnts = true;
         }
 
         if let Some(f) = &self.cur_fn_id {
-            if id == *f {
+            if id.1 == f.1 && id.0 == f.0 {
                 return;
             }
         }
         if let Some(f) = &self.cur_class_id {
-            if id == *f {
+            if id.1 == f.1 && id.0 == f.0 {
                 return;
             }
         }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -556,8 +556,9 @@ impl Visit for Analyzer<'_> {
             }
             _ => {
                 if let Some(i) = n.left.as_ident() {
-                    self.add(i.to_id(), false);
-                    self.add(i.to_id(), true);
+                    let id = i.to_id();
+                    self.add(id.clone(), false);
+                    self.add(id, true);
                     n.right.visit_with(self);
                 } else {
                     n.visit_children_with(self);

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -704,7 +704,7 @@ impl TreeShaker {
             }
         }
 
-        if self.config.top_retain.contains(&name.0) {
+        if !self.config.top_retain.is_empty() && self.config.top_retain.contains(&name.0) {
             return false;
         }
 
@@ -733,7 +733,7 @@ impl TreeShaker {
             }
         }
 
-        if self.config.top_retain.contains(&name.0) {
+        if !self.config.top_retain.is_empty() && self.config.top_retain.contains(&name.0) {
             return false;
         }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use indexmap::IndexSet;
 use petgraph::{algo::tarjan_scc, prelude::GraphMap, Directed, Direction::Incoming};
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use swc_atoms::Atom;
@@ -109,7 +108,9 @@ struct Data {
     /// Entrypoints.
     entries: FxHashSet<u32>,
 
-    graph_ix: IndexSet<Id, FxBuildHasher>,
+    graph_ix: FxHashMap<Id, u32>,
+    /// Reverse lookup for graph node ids used while subtracting cycles.
+    graph_ids: Vec<Id>,
 }
 
 impl Data {
@@ -120,6 +121,7 @@ impl Data {
         self.used_names.reserve(65536);
         self.entries.reserve(16384);
         self.graph_ix.reserve(65536);
+        self.graph_ids.reserve(65536);
     }
 
     fn drop_usage(&mut self, id: &Id) {
@@ -157,15 +159,18 @@ impl Data {
     }
 
     fn get_node(&self, id: &Id) -> Option<u32> {
-        self.graph_ix.get_index_of(id).map(|ix| ix as _)
+        self.graph_ix.get(id).copied()
     }
 
     fn node(&mut self, id: &Id) -> u32 {
-        self.graph_ix.get_index_of(id).unwrap_or_else(|| {
-            let ix = self.graph_ix.len();
-            self.graph_ix.insert_full(id.clone());
-            ix
-        }) as _
+        if let Some(&ix) = self.graph_ix.get(id) {
+            return ix;
+        }
+
+        let ix = self.graph_ids.len() as u32;
+        self.graph_ids.push(id.clone());
+        self.graph_ix.insert(id.clone(), ix);
+        ix
     }
 
     /// Add an edge to dependency graph
@@ -227,7 +232,7 @@ impl Data {
                         continue;
                     }
 
-                    let id = self.graph_ix.get_index(j as _);
+                    let id = self.graph_ids.get(j as usize);
                     let id = match id {
                         Some(id) => id,
                         None => continue,
@@ -735,9 +740,9 @@ impl TreeShaker {
             }
 
             // Abort if the variable is declared on top level scope.
-            let ix = self.data.graph_ix.get_index_of(&name);
-            if let Some(ix) = ix {
-                if self.data.entries.contains(&(ix as u32)) {
+            let ix = self.data.graph_ix.get(&name);
+            if let Some(&ix) = ix {
+                if self.data.entries.contains(&ix) {
                     return false;
                 }
             }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -320,6 +320,7 @@ struct Analyzer<'a> {
 struct Scope<'a> {
     parent: Option<&'a Scope<'a>>,
     kind: ScopeKind,
+    parent_has_ast_path: bool,
 
     bindings_affected_by_eval: FxHashSet<Id>,
     found_direct_eval: bool,
@@ -359,6 +360,7 @@ impl Analyzer<'_> {
         let child_scope = {
             let child = Scope {
                 parent: Some(&self.scope),
+                parent_has_ast_path: !self.scope.is_ast_path_empty(),
                 ..Default::default()
             };
 
@@ -1244,12 +1246,6 @@ impl VisitMut for TreeShaker {
 impl Scope<'_> {
     /// Returns true if it's not in a function or class.
     fn is_ast_path_empty(&self) -> bool {
-        if !self.ast_path.is_empty() {
-            return false;
-        }
-        match &self.parent {
-            Some(p) => p.is_ast_path_empty(),
-            None => true,
-        }
+        !self.parent_has_ast_path && self.ast_path.is_empty()
     }
 }

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -341,17 +341,15 @@ enum ScopeKind {
 }
 
 impl Analyzer<'_> {
-    fn with_ast_path<F>(&mut self, ids: Vec<Id>, op: F)
+    fn with_ast_path<F>(&mut self, id: Id, op: F)
     where
         F: for<'aa> FnOnce(&mut Analyzer<'aa>),
     {
-        let prev_len = self.scope.ast_path.len();
-
-        self.scope.ast_path.extend(ids);
+        self.scope.ast_path.push(id);
 
         op(self);
 
-        self.scope.ast_path.truncate(prev_len);
+        self.scope.ast_path.pop();
     }
 
     fn with_scope<F>(&mut self, kind: ScopeKind, op: F)
@@ -471,16 +469,17 @@ impl Visit for Analyzer<'_> {
             super_class.visit_with(self);
         }
 
-        self.with_ast_path(vec![n.ident.to_id()], |v| {
+        let id = n.ident.to_id();
+        self.with_ast_path(id.clone(), |v| {
             let old = v.cur_class_id.take();
-            v.cur_class_id = Some(n.ident.to_id());
+            v.cur_class_id = Some(id.clone());
             n.ident.visit_with(v);
             n.class.decorators.visit_with(v);
             n.class.body.visit_with(v);
             v.cur_class_id = old;
 
             if !n.class.decorators.is_empty() {
-                v.add(n.ident.to_id(), false);
+                v.add(id, false);
             }
         })
     }
@@ -599,14 +598,15 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_fn_decl(&mut self, n: &FnDecl) {
-        self.with_ast_path(vec![n.ident.to_id()], |v| {
+        let id = n.ident.to_id();
+        self.with_ast_path(id.clone(), |v| {
             let old = v.cur_fn_id.take();
-            v.cur_fn_id = Some(n.ident.to_id());
+            v.cur_fn_id = Some(id.clone());
             n.visit_children_with(v);
             v.cur_fn_id = old;
 
             if !n.function.decorators.is_empty() {
-                v.add(n.ident.to_id(), false);
+                v.add(id, false);
             }
         })
     }

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -3633,8 +3633,8 @@ fn may_have_side_effects(expr: &Expr, ctx: ExprCtx) -> bool {
                 Expr::Ident(Ident {
                     ctxt, sym: math, ..
                 }) if matches!(prop, MemberProp::Ident(..))
-                    && &**math == "Math"
-                    && (*ctxt == ctx.unresolved_ctxt || *ctxt == SyntaxContext::empty()) =>
+                    && (*ctxt == ctx.unresolved_ctxt || *ctxt == SyntaxContext::empty())
+                    && &**math == "Math" =>
                 {
                     return false;
                 }

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -3480,7 +3480,7 @@ fn is_pure_member_callee(obj: &Expr, prop: &MemberProp, ctx: ExprCtx) -> bool {
         Expr::Ident(Ident {
             ctxt, sym: math, ..
         }) => {
-            &**math == "Math" && (*ctxt == ctx.unresolved_ctxt || *ctxt == SyntaxContext::empty())
+            (*ctxt == ctx.unresolved_ctxt || *ctxt == SyntaxContext::empty()) && &**math == "Math"
         }
 
         Expr::Lit(Lit::Str(..)) => is_pure_str_method(&prop.sym),

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -3628,13 +3628,38 @@ fn may_have_side_effects(expr: &Expr, ctx: ExprCtx) -> bool {
             left.may_have_side_effects(ctx) || right.may_have_side_effects(ctx)
         }
 
-        Expr::Member(MemberExpr { obj, prop, .. }) if is_pure_member_callee(obj, prop, ctx) => {
-            false
-        }
+        Expr::Member(MemberExpr { obj, prop, .. }) => {
+            match &**obj {
+                Expr::Ident(Ident {
+                    ctxt, sym: math, ..
+                }) if matches!(prop, MemberProp::Ident(..))
+                    && &**math == "Math"
+                    && (*ctxt == ctx.unresolved_ctxt || *ctxt == SyntaxContext::empty()) =>
+                {
+                    return false;
+                }
+                Expr::Lit(Lit::Str(..)) => {
+                    if let MemberProp::Ident(prop) = prop {
+                        if is_pure_str_method(&prop.sym) {
+                            return false;
+                        }
+                    }
 
-        Expr::Member(MemberExpr { obj, prop, .. })
-            if obj.is_object() || obj.is_fn_expr() || obj.is_arrow() || obj.is_class() =>
-        {
+                    return true;
+                }
+                Expr::Tpl(Tpl { exprs, .. }) if exprs.is_empty() => {
+                    if let MemberProp::Ident(prop) = prop {
+                        if is_pure_str_method(&prop.sym) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }
+                Expr::Object(_) | Expr::Fn(_) | Expr::Arrow(_) | Expr::Class(_) => {}
+                _ => return true,
+            }
+
             if obj.may_have_side_effects(ctx) {
                 return true;
             }
@@ -3701,7 +3726,6 @@ fn may_have_side_effects(expr: &Expr, ctx: ExprCtx) -> bool {
 
         Expr::Await(_)
         | Expr::Yield(_)
-        | Expr::Member(_)
         | Expr::SuperProp(_)
         | Expr::Update(_)
         | Expr::Assign(_) => true,

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -3069,11 +3069,17 @@ fn cast_to_number(expr: &Expr, ctx: ExprCtx) -> (Purity, Value<f64>) {
 
             return (Pure, num_from_str(&s));
         }
-        Expr::Ident(Ident { sym, ctxt, .. }) => match &**sym {
-            "undefined" | "NaN" if *ctxt == ctx.unresolved_ctxt => f64::NAN,
-            "Infinity" if *ctxt == ctx.unresolved_ctxt => f64::INFINITY,
-            _ => return (Pure, Unknown),
-        },
+        Expr::Ident(Ident { sym, ctxt, .. }) => {
+            if *ctxt != ctx.unresolved_ctxt {
+                return (Pure, Unknown);
+            }
+
+            match &**sym {
+                "undefined" | "NaN" => f64::NAN,
+                "Infinity" => f64::INFINITY,
+                _ => return (Pure, Unknown),
+            }
+        }
         Expr::Unary(UnaryExpr {
             op: op!(unary, "-"),
             arg,
@@ -3193,12 +3199,16 @@ fn as_pure_wtf8(expr: &Expr, ctx: ExprCtx) -> Value<Cow<'_, Wtf8>> {
             // can be converted.
             // unimplemented!("TplLit. as_string()")
         }
-        Expr::Ident(Ident { ref sym, ctxt, .. }) => match &**sym {
-            "undefined" | "Infinity" | "NaN" if ctxt == ctx.unresolved_ctxt => {
-                Known(Cow::Borrowed(Wtf8::from_str(sym)))
+        Expr::Ident(Ident { ref sym, ctxt, .. }) => {
+            if ctxt != ctx.unresolved_ctxt {
+                return Unknown;
             }
-            _ => Unknown,
-        },
+
+            match &**sym {
+                "undefined" | "Infinity" | "NaN" => Known(Cow::Borrowed(Wtf8::from_str(sym))),
+                _ => Unknown,
+            }
+        }
         Expr::Unary(UnaryExpr {
             op: op!("void"), ..
         }) => Known(Cow::Borrowed("undefined".into())),


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Micro-optimization work for the ECMAScript minifier. Current patch reduces usage-analysis, DCE, renamer, and optimizer inline-map overhead on large modules while preserving existing behavior.

## Micro-Optimization Progress

Target benchmark: `swc_ecma_minifier` single-file TypeScript minifier run (`benches/full/typescript.js`)
Measurement mode: `valgrind --tool=callgrind`
Primary metric: `Ir`
Baseline command: `RUST_LOG=off valgrind --tool=callgrind --callgrind-out-file=... target/release/examples/minifier benches/full/typescript.js`

| Commit | Benchmark | Mode | Ir Before | Ir After | Ir Delta | Checks | Notes |
| --- | --- | --- | ---: | ---: | ---: | --- | --- |
| `ceea09e1f8` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,523,555,239` | `-0.62%` | `cargo fmt --all`; `cargo test -p swc_ecma_transforms_optimization`; `cargo test -p swc_ecma_minifier` | Initial progress toward 5%. |
| `38f4f3e7d9` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,498,673,241` | `-1.07%` | `cargo fmt --all`; `cargo test -p swc_ecma_utils`; `cargo test -p swc_ecma_transforms_optimization`; `cargo test -p swc_ecma_minifier`; `crates/swc_ecma_minifier/./scripts/exec.sh`; `cargo clippy --all --all-targets -- -D warnings` | Further progress; target not complete yet. |
| `fb3c8be211` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,490,035,410` | `-1.23%` | `cargo fmt --all`; `cargo test -p swc_ecma_minifier`; `crates/swc_ecma_minifier/./scripts/exec.sh`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Specializes finalizer literal-only traversal; target not complete yet. |
| `ec08f30f6d` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,485,854,488` | `-1.30%` | `cargo test -p swc_ecma_transforms_optimization`; `cargo clippy -p swc_ecma_transforms_optimization --all-targets -- -D warnings` | Caches DCE parent scope path state; target not complete yet. |
| `93d0cbb514` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,485,136,348` | `-1.32%` | `cargo test -p swc_ecma_transforms_optimization`; `cargo clippy -p swc_ecma_transforms_optimization --all-targets -- -D warnings` | Skips empty `top_retain` scans in DCE drop checks; target not complete yet. |
| `1ec437a93e` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,482,169,581` | `-1.37%` | `cargo test -p swc_ecma_utils`; `cargo clippy -p swc_ecma_utils --all-targets -- -D warnings` | Checks `Math.*` side-effect context before atom text; target not complete yet. |
| `fc70244aa0` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,480,340,032` | `-1.40%` | `cargo test -p swc_ecma_utils`; `cargo clippy -p swc_ecma_utils --all-targets -- -D warnings` | Applies the same context-first guard for pure member callees; target not complete yet. |
| `3ffd55bf2a` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,480,276,424` | `-1.40%` | `cargo test -p swc_ecma_utils`; `cargo clippy -p swc_ecma_utils --all-targets -- -D warnings` | Checks identifier contexts before pure number/string casts; target not complete yet. |
| `2b9b9859e3` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,477,865,257` | `-1.45%` | `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Skips delete handling for non-unary expressions; target not complete yet. |
| `1558303f6c` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,463,148,238` | `-1.71%` | `cargo fmt --all`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Checks identifier context before usage-map lookup; target not complete yet. |
| `44316f60d5` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,462,573,553` | `-1.72%` | `cargo fmt --all`; `cargo test -p swc_ecma_transforms_base`; `cargo clippy -p swc_ecma_transforms_base --all-targets -- -D warnings` | Uses release `extend` while accumulating renamer cache updates; target not complete yet. |
| `44b08d8e9f` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,453,904,419` | `-1.88%` | `cargo fmt --all`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Reserves top-level usage-analysis storage for large modules; target not complete yet. |
| `d26e2a8c85` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,429,174,793` | `-2.32%` | `cargo fmt --all`; `cargo test -p swc_ecma_transforms_optimization`; `cargo clippy -p swc_ecma_transforms_optimization --all-targets -- -D warnings` | Reserves DCE analyzer storage for large modules; target not complete yet. |
| `8ba9e3b920` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,417,383,207` | `-2.53%` | `cargo fmt --all`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Reserves optimizer inline maps based on analyzed binding count; target not complete yet. |
| `8056c14022` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,390,205,201` | `-3.02%` | `cargo fmt --all`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Stores `VarUsageInfo` inline in `ProgramData.vars` to avoid per-binding boxes; target not complete yet. |
| `a750dc8391` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,390,134,723` | `-3.02%` | `cargo fmt --all`; `cargo check -p swc_ecma_minifier`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Skips recursive-usage hash lookup when no recursive ids are active; target not complete yet. |
| `7e3d5651fc` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,388,848,817` | `-3.05%` | `cargo fmt --all`; `cargo check -p swc_ecma_minifier`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Compares pure-pass identifiers directly and avoids redundant member downcasts; target not complete yet. |
| `1654ab203e` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,348,517,169` | `-3.77%` | `cargo fmt --all`; `cargo check -p swc_ecma_minifier`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Uses a single occupied-entry lookup when consuming inline variables; target not complete yet. |
| `ff6efc15a6` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,348,385,188` | `-3.78%` | `cargo fmt --all`; `cargo check -p swc_ecma_minifier`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Retunes inline-map reserves after the occupied-entry lookup change; target not complete yet. |
| `0d68d6321c` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,332,892,051` | `-4.06%` | `cargo fmt --all`; `cargo check -p swc_ecma_transforms_base`; `cargo test -p swc_ecma_transforms_base`; `cargo clippy -p swc_ecma_transforms_base --all-targets -- -D warnings`; `cargo check -p swc_ecma_minifier`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Uses string comparison for renamer `arguments` filters and reserves scope identifier storage before merging child scopes; target not complete yet. |
| `d93b793664` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,304,610,408` | `-4.56%` | `cargo fmt --all`; `cargo check -p swc_ecma_minifier`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Defers `initialized_vars` lookups while merging usage data until the branch needs them; target not complete yet. |
| `7e1a9d5ae2` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,302,436,151` | `-4.60%` | `cargo fmt --all`; `cargo test -p swc_ecma_transforms_optimization`; `cargo clippy -p swc_ecma_transforms_optimization --all-targets -- -D warnings`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings` | Reuses computed identifiers in usage tracking and reserves accessed-property storage on first use; target not complete yet. |
| `e2d6f95538` | `examples/minifier benches/full/typescript.js` | Callgrind `Ir` | `5,558,264,214` | `5,263,249,353` | `-5.31%` | `cargo fmt --all`; `cargo test -p swc_ecma_transforms_optimization`; `cargo test -p swc_ecma_minifier`; `cargo clippy -p swc_ecma_transforms_optimization --all-targets -- -D warnings`; `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings`; `cargo clippy --all --all-targets -- -D warnings` | Replaces DCE graph index storage with a direct map plus reverse ids, skips no-op usage-data merges, and avoids property-atom root lookups when collection is disabled. Target reached. |

Local artifacts are under `optimization-artifacts/callgrind/` and are intentionally not committed.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A