### PR TITLE
perf(es/codegen): remove JsWriter last_srcmap cache

### DIFF
--- a/crates/swc_ecma_codegen/src/text_writer/basic_impl.rs
+++ b/crates/swc_ecma_codegen/src/text_writer/basic_impl.rs
@@ -22,7 +22,6 @@ pub struct JsWriter<'a, W: Write> {
     new_line: &'a str,
     srcmap: Option<&'a mut Vec<(BytePos, LineCol)>>,
     srcmap_done: HashSet<(BytePos, u32, u32), FxBuildHasher>,
-    last_srcmap: Option<(BytePos, u32, u32)>,
     /// Used to avoid including whitespaces created by indention.
     pending_srcmap: Option<BytePos>,
     wr: W,
@@ -58,7 +57,6 @@ impl<'a, W: Write> JsWriter<'a, W> {
             wr,
             pending_srcmap: Default::default(),
             srcmap_done: Default::default(),
-            last_srcmap: Default::default(),
             scopes,
             scope_stack: Default::default(),
         }
@@ -173,10 +171,6 @@ impl<'a, W: Write> JsWriter<'a, W> {
 
         if let Some(ref mut srcmap) = self.srcmap {
             let key = (byte_pos, self.line_count as _, self.line_pos as _);
-            if self.last_srcmap == Some(key) {
-                return;
-            }
-
             if self.srcmap_done.insert(key) {
                 let loc = LineCol {
                     line: key.1,
@@ -185,8 +179,6 @@ impl<'a, W: Write> JsWriter<'a, W> {
 
                 srcmap.push((byte_pos, loc));
             }
-
-            self.last_srcmap = Some(key);
         }
     }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

I removed the `last_srcmap` cache because its impact appears to be negligible.

In local A/B walltime benchmarks for `es/codegen/large`, removing `last_srcmap` did not produce a stable regression beyond benchmark noise. 
Since `srcmap_done` still handles source map deduplication, this keeps the writer simpler while preserving behavior.

Let's see what CI/CodSpeed reports for this change.


**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
- #11867