### PR TITLE
fix(es/minifier): respect ecma for iife temp vars

### DIFF
--- a/.changeset/respect-ecma-iife-temp-vars.md
+++ b/.changeset/respect-ecma-iife-temp-vars.md
@@ -1,0 +1,7 @@
+---
+swc: patch
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): respect ecma when emitting IIFE temp vars

--- a/crates/swc/tests/fixture/issues-5xxx/5865/output/index.js
+++ b/crates/swc/tests/fixture/issues-5xxx/5865/output/index.js
@@ -1,1 +1,1 @@
-let a;v=(a=r,b=>a.map(t=>{if(t)return t.foo}));
+var a;v=(a=r,b=>a.map(t=>{if(t)return t.foo}));

--- a/crates/swc/tests/fixture/issues-8xxx/8246/output/input.js
+++ b/crates/swc/tests/fixture/issues-8xxx/8246/output/input.js
@@ -1,9 +1,9 @@
 function withLog(t) {
     let e = {};
-    for(let o in t){
-        let n;
-        e[o] = (n = o, function() {
-            return console.log(n + ' invoked'), t[n].apply(this, arguments);
+    for(let n in t){
+        var o;
+        e[n] = (o = n, function() {
+            return console.log(o + ' invoked'), t[o].apply(this, arguments);
         });
     }
     return e;

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -686,7 +686,11 @@ impl Optimizer<'_> {
                             self.prepend_stmts.push(
                                 VarDecl {
                                     span: DUMMY_SP,
-                                    kind: VarDeclKind::Let,
+                                    kind: if self.options.ecma >= EsVersion::Es2015 {
+                                        VarDeclKind::Let
+                                    } else {
+                                        VarDeclKind::Var
+                                    },
                                     declare: Default::default(),
                                     decls: vars,
                                     ..Default::default()

--- a/crates/swc_ecma_minifier/tests/benches-full/terser.js
+++ b/crates/swc_ecma_minifier/tests/benches-full/terser.js
@@ -7449,7 +7449,8 @@
     def_eval(AST_BigInt, function() {
         return supports_bigint ? BigInt(this.value) : this;
     }), def_eval(AST_RegExp, function(compressor) {
-        let source, evaluated = compressor.evaluated_regexps.get(this.value);
+        var source;
+        let evaluated = compressor.evaluated_regexps.get(this.value);
         if (void 0 === evaluated && (source = this.value.source, re_safe_regexp.test(source))) {
             try {
                 let { source, flags } = this.value;
@@ -10108,8 +10109,7 @@
                     }).optimize(compressor);
                     break;
                 case "RegExp":
-                    let source;
-                    var params = [];
+                    var source, params = [];
                     if (self1.args.length >= 1 && self1.args.length <= 2 && self1.args.every((arg)=>{
                         var value = arg.evaluate(compressor);
                         return params.push(value), arg !== value;

--- a/crates/swc_ecma_minifier/tests/fixture/issues/ecma5-iife-temp-var/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/ecma5-iife-temp-var/config.json
@@ -1,0 +1,5 @@
+{
+    "defaults": true,
+    "ecma": 5,
+    "toplevel": false
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/ecma5-iife-temp-var/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/ecma5-iife-temp-var/input.js
@@ -1,0 +1,5 @@
+function run() {
+    return ((value) => value + value)(Math.random());
+}
+
+console.log(run());

--- a/crates/swc_ecma_minifier/tests/fixture/issues/ecma5-iife-temp-var/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/ecma5-iife-temp-var/output.js
@@ -1,0 +1,5 @@
+function run() {
+    var value;
+    return (value = Math.random()) + value;
+}
+console.log(run());

--- a/crates/swc_ecma_minifier/tests/fixture/issues/react-instancesearch/002/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/react-instancesearch/002/output.js
@@ -67,7 +67,7 @@ let isMultiIndexContext = (widget)=>hasMultipleIndices({
                         return {
                             ...request,
                             params: Object.keys(parameters = request.params).map((key)=>{
-                                let value;
+                                var value;
                                 return ((format, ...args)=>{
                                     let i = 0;
                                     return format.replace(/%s/g, ()=>encodeURIComponent(args[i++]));

--- a/crates/swc_ecma_minifier/tests/fixture/issues/react-instancesearch/003/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/react-instancesearch/003/output.js
@@ -83,7 +83,7 @@ let isMultiIndexContext = (widget)=>hasMultipleIndices({
                         return {
                             ...request,
                             params: Object.keys(parameters = request.params).map((key)=>{
-                                let value;
+                                var value;
                                 return ((format, ...args)=>{
                                     let i = 0;
                                     return format.replace(/%s/g, ()=>encodeURIComponent(args[i++]));

--- a/crates/swc_ecma_minifier/tests/fixture/next/47005/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/next/47005/output.js
@@ -5,13 +5,12 @@
     {
         /***/ 9145: /***/ function(m, S, h) {
             "use strict";
-            let E, k;
             /* harmony export */ h.d(S, {
                 /* harmony export */ u: function() {
                     return /* binding */ ei;
                 }
             });
-            /* unused harmony exports TooltipProvider, TooltipWrapper */ /* harmony import */ var R, A = h(7294);
+            /* unused harmony exports TooltipProvider, TooltipWrapper */ /* harmony import */ var E, k, R, A = h(7294);
             /* harmony import */ var O = h(5893);
             var L = Object.create;
             var j = Object.defineProperty;

--- a/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
+++ b/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
@@ -7,7 +7,7 @@
 | lodash.js | 531.35 KiB | 68.92 KiB | 24.60 KiB |
 | moment.js | 169.83 KiB | 57.34 KiB | 18.25 KiB |
 | react.js | 70.45 KiB | 22.45 KiB | 8.04 KiB |
-| terser.js | 1.08 MiB | 446.63 KiB | 120.49 KiB |
+| terser.js | 1.08 MiB | 446.63 KiB | 120.50 KiB |
 | three.js | 1.19 MiB | 630.55 KiB | 154.77 KiB |
 | typescript.js | 10.45 MiB | 3.17 MiB | 840.61 KiB |
 | victory.js | 2.30 MiB | 694.04 KiB | 154.18 KiB |


### PR DESCRIPTION
**Description:**

When compressing arrow IIFEs, the minifier can synthesize temporary variable declarations for extracted parameters. That path always emitted `let`, even when `compress.ecma` was ES5.

This updates the synthesized declaration kind to use `var` below ES2015 and keep `let` for ES2015+, then adds an ES5 fixture covering the arrow IIFE temp-var path. Related snapshots were updated for the same behavior change.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A

**Testing:**

- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo test -p swc_ecma_minifier`
- `cargo clippy --all --all-targets -- -D warnings`