### PR TITLE
perf(hstr): trim atom hash and benchmark hashset lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2632,8 +2632,8 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "hstr"
 version = "3.0.5"
 dependencies = [
+ "codspeed-criterion-compat",
  "compact_str",
- "criterion",
  "hashbrown 0.14.5",
  "kstring",
  "new_debug_unreachable",

--- a/crates/hstr/Cargo.toml
+++ b/crates/hstr/Cargo.toml
@@ -28,16 +28,16 @@ triomphe              = { workspace = true }
 
 
 [dev-dependencies]
-compact_str  = { workspace = true }
-criterion    = { workspace = true }
-kstring      = { workspace = true }
-num_cpus     = { workspace = true }
-par-iter     = { workspace = true }
-rand         = { workspace = true }
-serde_json   = { workspace = true }
-smartstring  = { workspace = true }
-smol_str     = { workspace = true }
-string_cache = { workspace = true }
+codspeed-criterion-compat = { workspace = true }
+compact_str               = { workspace = true }
+kstring                   = { workspace = true }
+num_cpus                  = { workspace = true }
+par-iter                  = { workspace = true }
+rand                      = { workspace = true }
+serde_json                = { workspace = true }
+smartstring               = { workspace = true }
+smol_str                  = { workspace = true }
+string_cache              = { workspace = true }
 
 swc_malloc = { version = "1.2.5", path = "../swc_malloc" }
 

--- a/crates/hstr/benches/libs.rs
+++ b/crates/hstr/benches/libs.rs
@@ -175,73 +175,67 @@ fn bench_hash_operation(c: &mut Criterion) {
     {
         for len in length {
             group.bench_with_input(BenchmarkId::new("hstr", len), &len, |b, _| {
-                let mut for_fairness = vec![];
                 let mut store = hstr::AtomStore::default();
-                b.iter_batched(
+                b.iter_batched_ref(
                     || prepare(len, &mut |s| store.atom(s)),
                     |(map, keys)| {
-                        for key in &keys {
+                        for key in keys.iter() {
                             black_box(map.contains(key));
                         }
-                        for_fairness.extend(map);
-                        for_fairness.extend(keys);
                     },
                     BatchSize::SmallInput,
                 );
             });
             group.bench_with_input(BenchmarkId::new("string_cache", len), &len, |b, _| {
-                let mut for_fairness = vec![];
-                b.iter_batched(
+                b.iter_batched_ref(
                     || prepare(len, &mut string_cache::DefaultAtom::from),
                     |(map, keys)| {
-                        for key in &keys {
+                        for key in keys.iter() {
                             black_box(map.contains(key));
                         }
-                        for_fairness.extend(map);
-                        for_fairness.extend(keys);
                     },
                     BatchSize::SmallInput,
                 );
             });
             group.bench_with_input(BenchmarkId::new("compact_str", len), &len, |b, _| {
-                b.iter_batched(
+                b.iter_batched_ref(
                     || prepare(len, &mut CompactString::from),
                     |(map, keys)| {
-                        for key in keys {
-                            black_box(map.contains(&key));
+                        for key in keys.iter() {
+                            black_box(map.contains(key));
                         }
                     },
                     BatchSize::SmallInput,
                 );
             });
             group.bench_with_input(BenchmarkId::new("smartstring", len), &len, |b, _| {
-                b.iter_batched(
+                b.iter_batched_ref(
                     || prepare(len, &mut SmartString::<LazyCompact>::from),
                     |(map, keys)| {
-                        for key in keys {
-                            black_box(map.contains(&key));
+                        for key in keys.iter() {
+                            black_box(map.contains(key));
                         }
                     },
                     BatchSize::SmallInput,
                 );
             });
             group.bench_with_input(BenchmarkId::new("smol_str", len), &len, |b, _| {
-                b.iter_batched(
+                b.iter_batched_ref(
                     || prepare(len, &mut smol_str::SmolStr::from),
                     |(map, keys)| {
-                        for key in keys {
-                            black_box(map.contains(&key));
+                        for key in keys.iter() {
+                            black_box(map.contains(key));
                         }
                     },
                     BatchSize::SmallInput,
                 );
             });
             group.bench_with_input(BenchmarkId::new("kstring", len), &len, |b, _| {
-                b.iter_batched(
+                b.iter_batched_ref(
                     || prepare(len, &mut kstring::KString::from),
                     |(map, keys)| {
-                        for key in keys {
-                            black_box(map.contains(&key));
+                        for key in keys.iter() {
+                            black_box(map.contains(key));
                         }
                     },
                     BatchSize::SmallInput,

--- a/crates/hstr/benches/libs.rs
+++ b/crates/hstr/benches/libs.rs
@@ -2,12 +2,12 @@
 
 extern crate swc_malloc;
 
-#[macro_use]
-extern crate criterion;
 use std::{hash::Hash, mem::forget};
 
+use codspeed_criterion_compat::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion,
+};
 use compact_str::CompactString;
-use criterion::{black_box, BatchSize, BenchmarkId, Criterion};
 use par_iter::prelude::*;
 use rand::distributions::{Alphanumeric, DistString};
 use rustc_hash::FxHashSet;

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -213,7 +213,7 @@ impl Storage for &'_ mut AtomStore {
 #[inline(always)]
 fn calc_hash(text: &[u8]) -> u64 {
     let mut hasher = FxHasher::default();
-    hasher.write(text);
+    text.hash(&mut hasher);
     hasher.finish()
 }
 

--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -213,7 +213,7 @@ impl Storage for &'_ mut AtomStore {
 #[inline(always)]
 fn calc_hash(text: &[u8]) -> u64 {
     let mut hasher = FxHasher::default();
-    text.hash(&mut hasher);
+    hasher.write(text);
     hasher.finish()
 }
 

--- a/crates/hstr/src/lib.rs
+++ b/crates/hstr/src/lib.rs
@@ -297,13 +297,9 @@ impl Atom {
 }
 
 impl PartialEq for Atom {
-    #[inline(never)]
+    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         partial_eq!(self, other);
-
-        // If the store is different, the string may be the same, even though the
-        // `unsafe_data` is different
-        self.as_str() == other.as_str()
     }
 }
 

--- a/crates/hstr/src/macros.rs
+++ b/crates/hstr/src/macros.rs
@@ -24,13 +24,16 @@ macro_rules! partial_eq {
             return true;
         }
 
+        let self_tag = $self.tag();
+        let other_tag = $other.tag();
+
         // If one is inline and the other is not, the length is different.
         // If one is static and the other is not, it's different.
-        if $self.tag() != $other.tag() {
+        if self_tag != other_tag {
             return false;
         }
 
-        if $self.is_dynamic() && $other.is_dynamic() {
+        if self_tag == DYNAMIC_TAG {
             let te = unsafe { $crate::dynamic::deref_from($self.unsafe_data) };
             let oe = unsafe { $crate::dynamic::deref_from($other.unsafe_data) };
 

--- a/crates/hstr/src/macros.rs
+++ b/crates/hstr/src/macros.rs
@@ -20,12 +20,15 @@ macro_rules! get_hash {
 
 macro_rules! partial_eq {
     ($self:expr, $other:expr) => {
-        if $self.unsafe_data == $other.unsafe_data {
+        let self_data = $self.unsafe_data;
+        let other_data = $other.unsafe_data;
+
+        if self_data == other_data {
             return true;
         }
 
-        let self_tag = $self.tag();
-        let other_tag = $other.tag();
+        let self_tag = self_data.tag() & TAG_MASK;
+        let other_tag = other_data.tag() & TAG_MASK;
 
         // If one is inline and the other is not, the length is different.
         // If one is static and the other is not, it's different.
@@ -34,8 +37,8 @@ macro_rules! partial_eq {
         }
 
         if self_tag == DYNAMIC_TAG {
-            let te = unsafe { $crate::dynamic::deref_from($self.unsafe_data) };
-            let oe = unsafe { $crate::dynamic::deref_from($other.unsafe_data) };
+            let te = unsafe { $crate::dynamic::deref_from(self_data) };
+            let oe = unsafe { $crate::dynamic::deref_from(other_data) };
 
             if te.header.header.hash != oe.header.header.hash {
                 return false;
@@ -44,9 +47,8 @@ macro_rules! partial_eq {
             return te.slice == oe.slice;
         }
 
-        if $self.get_hash() != $other.get_hash() {
-            return false;
-        }
+        // Inline atoms compare equal only if their raw tagged value matched above.
+        return false;
     };
 }
 

--- a/crates/hstr/src/tagged_value.rs
+++ b/crates/hstr/src/tagged_value.rs
@@ -36,11 +36,20 @@ type RawTaggedNonZeroValue = std::ptr::NonNull<()>;
 
 pub(crate) const MAX_INLINE_LEN: usize = std::mem::size_of::<TaggedValue>() - 1;
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug)]
 #[repr(transparent)]
 pub(crate) struct TaggedValue {
     value: RawTaggedNonZeroValue,
 }
+
+impl PartialEq for TaggedValue {
+    #[inline(always)]
+    fn eq(&self, other: &Self) -> bool {
+        self.get_value() == other.get_value()
+    }
+}
+
+impl Eq for TaggedValue {}
 
 impl TaggedValue {
     #[inline(always)]

--- a/crates/hstr/src/tagged_value.rs
+++ b/crates/hstr/src/tagged_value.rs
@@ -101,14 +101,32 @@ impl TaggedValue {
             feature = "atom_size_64",
             feature = "atom_size_128"
         )))]
-        unsafe {
-            std::mem::transmute(Some(self.value))
+        {
+            self.value.as_ptr() as _
         }
     }
 
     #[inline(always)]
     fn get_value(&self) -> RawTaggedValue {
-        unsafe { std::mem::transmute(Some(self.value)) }
+        #[cfg(any(
+            target_pointer_width = "32",
+            target_pointer_width = "16",
+            feature = "atom_size_64",
+            feature = "atom_size_128"
+        ))]
+        unsafe {
+            std::mem::transmute(Some(self.value))
+        }
+
+        #[cfg(not(any(
+            target_pointer_width = "32",
+            target_pointer_width = "16",
+            feature = "atom_size_64",
+            feature = "atom_size_128"
+        )))]
+        {
+            self.value.as_ptr() as _
+        }
     }
 
     #[inline(always)]

--- a/crates/hstr/src/wtf8_atom.rs
+++ b/crates/hstr/src/wtf8_atom.rs
@@ -242,13 +242,9 @@ impl<'de> serde::de::Deserialize<'de> for Wtf8Atom {
 }
 
 impl PartialEq for Wtf8Atom {
-    #[inline(never)]
+    #[inline(always)]
     fn eq(&self, other: &Self) -> bool {
         partial_eq!(self, other);
-
-        // If the store is different, the string may be the same, even though the
-        // `unsafe_data` is different
-        self.as_wtf8() == other.as_wtf8()
     }
 }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Draft hstr micro-optimization investigation. CodSpeed/Callgrind simulation is the source of truth for this PR; Criterion wall-time is not used for the acceptance metric.

The original `calc_hash` change in `03e0a131a0` regressed the measured simulation region, so the current head reverts that product-code change. The current product-code optimization keeps the dynamic atom hash path intact and instead tightens the equality hot path: `Atom`/`Wtf8Atom` equality is inlined, `TaggedValue` equality compares the raw tagged value directly, and `partial_eq!` avoids the redundant fallback after the current dynamic/inline tag cases have been resolved.

This PR also includes a benchmark harness correction for the HashSet group: it uses `iter_batched_ref` so setup and drop/keep-alive costs are outside the measured region and the benchmark measures the lookup loop consistently for every library. That benchmark-scope correction is listed separately below and is not counted as product-code speedup.

## Micro-Optimization Progress

Target benchmark: `single-thread/HashSet/hstr/10000`
Measurement mode: CodSpeed/Callgrind simulation, measured benchmark region
Primary metric: `Ir`, with `accesses` and `estimated_cycles` tracked from the same Callgrind events
Baseline command: local `codspeed run -m simulation --profile-folder <dir> -- cargo codspeed run --bench libs -m simulation 'single-thread/HashSet'`

| Commit | Benchmark | Mode | Ir Before | Ir After | Ir Delta | Accesses Before | Accesses After | Accesses Delta | Estimated Cycles Before | Estimated Cycles After | Estimated Cycles Delta | Checks | Notes |
| --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
| `03e0a131a0` | `single-thread/HashSet/hstr/10000` | CodSpeed/Callgrind simulation | 4,939,194 | 4,956,885 | +17,691 (+0.358%) | 7,413,610 | 7,434,365 | +20,755 (+0.280%) | 21,894,280 | 21,933,745 | +39,465 (+0.180%) | CI passed for hstr benchmark | Not a simulation improvement; superseded by current head. |
| `caf9244729` | `single-thread/HashSet/hstr/10000` | CodSpeed/Callgrind simulation | 4,939,194 | 4,898,269 | -40,925 (-0.829%) | 7,413,610 | 7,371,354 | -42,256 (-0.570%) | 21,894,280 | 21,863,064 | -31,216 (-0.143%) | `cargo fmt --all`; `cargo test -p hstr --features serde`; `cargo clippy -p hstr --all-targets --features serde -- -D warnings`; `cargo clippy --all --all-targets -- -D warnings` | Product-code improvement from avoiding repeated atom tag extraction and using direct pointer casts in the default `TaggedValue` representation. This did not meet a 5% product-code target. |
| `e8a21e83e8` | `single-thread/HashSet/hstr/10000` | CodSpeed/Callgrind simulation | 4,898,269 | 3,984,583 | -913,686 (-18.653%) | 7,371,354 | 4,701,453 | -2,669,901 (-36.220%) | 21,863,064 | 17,408,473 | -4,454,591 (-20.375%) | `cargo fmt --all`; `cargo clippy -p hstr --all-targets --features serde -- -D warnings`; `cargo codspeed build -p hstr --bench libs -m simulation` | Benchmark-scope correction: moves HashSet setup/drop/keep-alive work out of the measured region for all libraries. This is not counted as product-code speedup. |
| `9472db84ff` | `single-thread/HashSet/hstr/10000` | CodSpeed/Callgrind simulation | 4,025,411 | 3,794,702 | -230,709 (-5.731%) | 4,744,054 | 4,387,796 | -356,258 (-7.510%) | 17,457,889 | 17,108,326 | -349,563 (-2.002%) | `cargo fmt --all`; `cargo test -p hstr --features serde`; `cargo clippy -p hstr --all-targets --features serde -- -D warnings`; `cargo clippy --all --all-targets -- -D warnings`; local CodSpeed simulation | Product-code delta only, using the corrected HashSet measured region for both before and after. The same run shows `single-thread/HashSet/hstr/1000` at -5.006% Ir and no hstr benchmark Ir regressions in the measured hstr cases. |

Notes:

- The final product-code baseline for `9472db84ff` is the corrected HashSet measured region with the benchmark harness fix kept and the product-code changes reverted locally. This separates hstr runtime improvement from benchmark measurement correction.
- A full-process direct Callgrind run for `03e0a131a0` showed `Ir` decreasing by 528,959 (`0.014853%`), but that includes Criterion harness/setup/random-data work and is not the metric used for this PR.
- Local simulation required porting the hstr bench harness to `codspeed_criterion_compat` to get measured-region Callgrind dumps. The harness change is included in this PR so local CodSpeed simulation and CI measure the same benchmark region.
- Additional attempted product-code candidates, including direct raw `ThinArc` header hash reads, storing the dynamic pointer at the hash field, full tag-byte comparison, `write_u32`/`write_usize` hashing, `FxHasher` preimage hashing, and accessor inlining, did not improve the simulation metric and were not kept.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.
