### PR TITLE
docs: Clarify security scope for npm packages

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -43,7 +43,9 @@ controls around the process.
 
 Security reports are in scope when they affect SWC itself, including:
 
--   Official Rust crates and npm packages
+-   Official Rust crates, in all supported usage
+-   Official npm packages when used as build tools, including CLI and development
+    server integrations
 -   Official bindings and release artifacts
 -   Parser, compiler, bundler, transform, minifier, and code generation behavior
 -   Issues that can cause practical confidentiality, integrity, or availability


### PR DESCRIPTION
**Description:**

Clarifies the security support scope for SWC usage across Rust and npm packages.

- Rust crates are covered for all supported usage.
- npm packages are covered when used as build tools, such as CLI and development server integrations.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.
