### PR TITLE
fix(es/parser): Reject object rest assignment to literals

### DIFF
--- a/.changeset/fix-es-parser-rest-target.md
+++ b/.changeset/fix-es-parser-rest-target.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_es_parser: patch
+---
+
+fix(es/parser): Reject object rest assignment to array or object literals

--- a/crates/swc_es_parser/src/parser.rs
+++ b/crates/swc_es_parser/src/parser.rs
@@ -5513,13 +5513,25 @@ impl<'a> Parser<'a> {
             }
             Some(Expr::Object(object)) => {
                 for (index, prop) in object.props.iter().enumerate() {
-                    if self.is_object_spread_prop(prop) && index + 1 < object.props.len() {
-                        self.errors.push(Error::new(
-                            self.expr_span(prop.value),
-                            Severity::Error,
-                            ErrorCode::InvalidStatement,
-                            "rest element must be the last element",
-                        ));
+                    if self.is_object_spread_prop(prop) {
+                        if index + 1 < object.props.len() {
+                            self.errors.push(Error::new(
+                                self.expr_span(prop.value),
+                                Severity::Error,
+                                ErrorCode::InvalidStatement,
+                                "rest element must be the last element",
+                            ));
+                        }
+
+                        if self.expr_is_array_or_object_literal(prop.value) {
+                            self.errors.push(Error::new(
+                                prop.span,
+                                Severity::Error,
+                                ErrorCode::InvalidAssignTarget,
+                                "Cannot assign to this",
+                            ));
+                            continue;
+                        }
                     }
 
                     self.validate_assignment_target_expr(prop.value);
@@ -5577,6 +5589,16 @@ impl<'a> Parser<'a> {
             &prop.key,
             PropName::Ident(ident) if ident.sym.as_ref() == "__spread__"
         )
+    }
+
+    /// Returns true for array/object literals that cannot be assignment rest
+    /// property targets.
+    fn expr_is_array_or_object_literal(&self, expr: swc_es_ast::ExprId) -> bool {
+        match self.store.expr(expr) {
+            Some(Expr::Array(_) | Expr::Object(_)) => true,
+            Some(Expr::Paren(paren)) => self.expr_is_array_or_object_literal(paren.expr),
+            _ => false,
+        }
     }
 
     fn expr_to_assign_pat(&mut self, expr: swc_es_ast::ExprId) -> swc_es_ast::PatId {

--- a/crates/swc_es_parser/tests/snapshots/ecma_reuse/errors/issue-11543-array/input.js.swc-stderr
+++ b/crates/swc_es_parser/tests/snapshots/ecma_reuse/errors/issue-11543-array/input.js.swc-stderr
@@ -1,0 +1,8 @@
+  x Cannot assign to this
+   ,-[/swc_ecma_parser/tests/errors/issue-11543-array/input.js:1:1]
+ 1 | ({...[]} = {});
+   :   ^^^^^^
+   `----
+
+Advice: 
+  > code: InvalidAssignTarget

--- a/crates/swc_es_parser/tests/snapshots/ecma_reuse/errors/issue-11543/input.js.swc-stderr
+++ b/crates/swc_es_parser/tests/snapshots/ecma_reuse/errors/issue-11543/input.js.swc-stderr
@@ -1,0 +1,8 @@
+  x Cannot assign to this
+   ,-[/swc_ecma_parser/tests/errors/issue-11543/input.js:1:1]
+ 1 | ({...{}} = {});
+   :   ^^^^^^
+   `----
+
+Advice: 
+  > code: InvalidAssignTarget

--- a/crates/swc_es_parser/tests/snapshots/ecma_reuse/typescript/satisfies-precedence/input.ts.json
+++ b/crates/swc_es_parser/tests/snapshots/ecma_reuse/typescript/satisfies-precedence/input.ts.json
@@ -1,0 +1,37 @@
+{
+  "programs": [
+    "Program {\n    span: 1..99,\n    kind: Script,\n    body: [\n        _,\n        _,\n        _,\n    ],\n}"
+  ],
+  "stmts": [
+    "Decl(\n    _,\n)",
+    "Decl(\n    _,\n)",
+    "Expr(\n    ExprStmt {\n        span: 52..68,\n        expr: _,\n    },\n)"
+  ],
+  "decls": [
+    "Var(\n    VarDecl {\n        span: 1..41,\n        kind: Let,\n        declare: false,\n        declarators: [\n            VarDeclarator {\n                span: 1..12,\n                name: _,\n                init: None,\n            },\n            VarDeclarator {\n                span: 1..20,\n                name: _,\n                init: None,\n            },\n            VarDeclarator {\n                span: 1..28,\n                name: _,\n                init: None,\n            },\n            VarDeclarator {\n                span: 1..36,\n                name: _,\n                init: None,\n            },\n        ],\n    },\n)",
+    "TsTypeAlias(\n    TsTypeAliasDecl {\n        span: 37..53,\n        ident: Ident {\n            span: 42..43,\n            sym: \"T\",\n        },\n        declare: false,\n        type_params: [],\n        ty: _,\n    },\n)"
+  ],
+  "pats": [
+    "Ident(\n    Ident {\n        span: 5..6,\n        sym: \"a\",\n    },\n)",
+    "Ident(\n    Ident {\n        span: 13..14,\n        sym: \"b\",\n    },\n)",
+    "Ident(\n    Ident {\n        span: 21..22,\n        sym: \"c\",\n    },\n)",
+    "Ident(\n    Ident {\n        span: 29..30,\n        sym: \"d\",\n    },\n)"
+  ],
+  "exprs": [
+    "Ident(\n    Ident {\n        span: 52..53,\n        sym: \"a\",\n    },\n)",
+    "Ident(\n    Ident {\n        span: 56..57,\n        sym: \"b\",\n    },\n)",
+    "Ident(\n    Ident {\n        span: 60..61,\n        sym: \"c\",\n    },\n)",
+    "Binary(\n    BinaryExpr {\n        span: 58..64,\n        op: Mul,\n        left: _,\n        right: _,\n    },\n)",
+    "Binary(\n    BinaryExpr {\n        span: 54..64,\n        op: Add,\n        left: _,\n        right: _,\n    },\n)",
+    "TsAs(\n    TsAsExpr {\n        span: 62..68,\n        expr: _,\n        ty: _,\n    },\n)"
+  ],
+  "module_decls": [],
+  "functions": [],
+  "classes": [],
+  "class_members": [],
+  "jsx_elements": [],
+  "ts_types": [
+    "Keyword(\n    Any,\n)",
+    "TypeRef(\n    TsTypeRef {\n        span: 65..68,\n        name: Ident {\n            span: 65..68,\n            sym: \"T\",\n        },\n        type_args: [],\n    },\n)"
+  ]
+}


### PR DESCRIPTION
**Description:**

Reject array/object literals used as object rest assignment targets in `swc_es_parser`, matching the `swc_ecma_parser` behavior added for #11543. Also adds the missing reused fixture snapshots needed by `Test - swc_es_parser`.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Closes #11543