### PR TITLE
docs: clarify untrusted input security model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,14 +30,15 @@ public disclosure when appropriate.
 
 ## Security Model
 
-SWC is a build tool. It is not designed to be a SaaS platform, a multi-tenant
-sandbox, or a security boundary for executing or transforming arbitrary
-untrusted input.
+SWC is a build tool. SWC does not support processing untrusted input and does
+not provide isolation, resource containment, or other sandbox guarantees. It is
+not designed to be a SaaS platform, a multi-tenant sandbox, or a security
+boundary for executing or transforming arbitrary untrusted input.
 
-If you operate SWC in a service that accepts untrusted input, you are
-responsible for validating that input before passing it to SWC and for applying
-appropriate isolation, resource limits, privilege separation, and operational
-controls around the process.
+If you operate SWC in a service that accepts input from untrusted users or
+tenants, you are responsible for validating that input before passing it to SWC
+and for applying appropriate isolation, resource limits, privilege separation,
+and operational controls around the process.
 
 ## Scope
 


### PR DESCRIPTION
**Description:**

Clarifies the `SECURITY.md` security model by explicitly documenting that SWC does not support processing untrusted input and does not provide sandbox, isolation, or resource containment guarantees.

This helps operators understand that services accepting input from untrusted users or tenants must validate that input and apply their own isolation, resource limits, privilege separation, and operational controls before invoking SWC.

Validation: reviewed the rendered Markdown source and confirmed the change is limited to `SECURITY.md`.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.