### PR TITLE
fix(es/modules): resolve relative symlinked inputs from cwd

### DIFF
--- a/.changeset/fix-relative-symlink-inputs.md
+++ b/.changeset/fix-relative-symlink-inputs.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_module: patch
+---
+
+fix(es/modules): Resolve relative symlinked inputs from cwd

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -329,9 +329,7 @@ where
 
         if base.is_absolute() != target.is_absolute() {
             if !base.is_absolute() {
-                // Relative input filenames are relative to the current process,
-                // while path-mapped targets are resolved from `jsc.baseUrl`.
-                base = Cow::Owned(absolute_path(None, &base)?);
+                base = Cow::Owned(absolute_base_path(self.config.base_dir.as_deref(), &base)?);
             }
 
             if !target.is_absolute() {
@@ -438,4 +436,46 @@ fn absolute_path(base_dir: Option<&Path>, path: &Path) -> io::Result<PathBuf> {
     .clean();
 
     Ok(absolute_path)
+}
+
+fn absolute_base_path(base_dir: Option<&Path>, path: &Path) -> io::Result<PathBuf> {
+    if path.is_absolute() {
+        return Ok(path.to_path_buf().clean());
+    }
+
+    let Some(base_dir) = base_dir else {
+        return absolute_path(None, path);
+    };
+
+    let base_dir_path = base_dir.join(path).clean();
+    let cwd_path = match absolute_path(None, path) {
+        Ok(path) => normalize_path_prefix_like(base_dir, path),
+        Err(_) => return Ok(base_dir_path),
+    };
+
+    // Relative CLI filenames are rooted at the current process directory. Other
+    // API callers commonly pass filenames relative to `jsc.baseUrl`, so keep
+    // that legacy behavior unless the cwd-rooted path is visibly under baseUrl.
+    Ok(if cwd_path.starts_with(base_dir) {
+        cwd_path
+    } else {
+        base_dir_path
+    })
+}
+
+#[cfg(windows)]
+fn normalize_path_prefix_like(reference: &Path, path: PathBuf) -> PathBuf {
+    let reference = reference.as_os_str().to_string_lossy();
+    let path_str = path.as_os_str().to_string_lossy();
+
+    if reference.starts_with(r"\\?\") && !path_str.starts_with(r"\\?\") {
+        PathBuf::from(format!(r"\\?\{}", path_str))
+    } else {
+        path
+    }
+}
+
+#[cfg(not(windows))]
+fn normalize_path_prefix_like(_: &Path, path: PathBuf) -> PathBuf {
+    path
 }

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -448,19 +448,37 @@ fn absolute_base_path(base_dir: Option<&Path>, path: &Path) -> io::Result<PathBu
     };
 
     let base_dir_path = base_dir.join(path).clean();
-    let cwd_path = match absolute_path(None, path) {
-        Ok(path) => normalize_path_prefix_like(base_dir, path),
+    let cwd = match current_dir() {
+        Ok(path) => normalize_path_prefix_like(base_dir, path.clean()),
         Err(_) => return Ok(base_dir_path),
     };
 
+    Ok(absolute_base_path_with_cwd(
+        base_dir,
+        path,
+        &cwd,
+        base_dir_path,
+    ))
+}
+
+fn absolute_base_path_with_cwd(
+    base_dir: &Path,
+    path: &Path,
+    cwd: &Path,
+    base_dir_path: PathBuf,
+) -> PathBuf {
+    let cwd_path = cwd.join(path).clean();
+
     // Relative CLI filenames are rooted at the current process directory. Other
     // API callers commonly pass filenames relative to `jsc.baseUrl`, so keep
-    // that legacy behavior unless the cwd-rooted path is visibly under baseUrl.
-    Ok(if cwd_path.starts_with(base_dir) {
+    // that legacy behavior unless the cwd-rooted path visibly enters baseUrl
+    // from outside it. If cwd is already inside baseUrl, every relative path is
+    // under baseUrl and the interpretation is ambiguous.
+    if cwd_path.starts_with(base_dir) && !cwd.starts_with(base_dir) {
         cwd_path
     } else {
         base_dir_path
-    })
+    }
 }
 
 #[cfg(windows)]
@@ -468,14 +486,77 @@ fn normalize_path_prefix_like(reference: &Path, path: PathBuf) -> PathBuf {
     let reference = reference.as_os_str().to_string_lossy();
     let path_str = path.as_os_str().to_string_lossy();
 
-    if reference.starts_with(r"\\?\") && !path_str.starts_with(r"\\?\") {
-        PathBuf::from(format!(r"\\?\{}", path_str))
-    } else {
-        path
-    }
+    normalize_extended_length_path_prefix(&reference, &path_str)
+        .map(PathBuf::from)
+        .unwrap_or(path)
 }
 
 #[cfg(not(windows))]
 fn normalize_path_prefix_like(_: &Path, path: PathBuf) -> PathBuf {
     path
+}
+
+#[cfg(any(test, windows))]
+fn normalize_extended_length_path_prefix(reference: &str, path: &str) -> Option<String> {
+    if !reference.starts_with(r"\\?\") || path.starts_with(r"\\?\") {
+        return None;
+    }
+
+    if let Some(path) = path.strip_prefix(r"\\") {
+        if path.starts_with(r".\") {
+            return None;
+        }
+
+        return Some(format!(r"\\?\UNC\{path}"));
+    }
+
+    Some(format!(r"\\?\{path}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn absolute_base_path_keeps_base_dir_when_cwd_is_inside_base_dir() {
+        let base_dir = Path::new("/repo");
+        let cwd = Path::new("/repo/packages/app");
+        let path = Path::new("src");
+
+        assert_eq!(
+            absolute_base_path_with_cwd(base_dir, path, cwd, base_dir.join(path).clean()),
+            PathBuf::from("/repo/src")
+        );
+    }
+
+    #[test]
+    fn absolute_base_path_uses_cwd_when_relative_path_enters_base_dir() {
+        let base_dir = Path::new("/repo/bazel-out/foo-app");
+        let cwd = Path::new("/repo");
+        let path = Path::new("bazel-out/foo-app/src");
+
+        assert_eq!(
+            absolute_base_path_with_cwd(base_dir, path, cwd, base_dir.join(path).clean()),
+            PathBuf::from("/repo/bazel-out/foo-app/src")
+        );
+    }
+
+    #[test]
+    fn extended_unc_prefix_uses_canonical_unc_form() {
+        assert_eq!(
+            normalize_extended_length_path_prefix(
+                r"\\?\UNC\server\share\repo",
+                r"\\server\share\repo\src"
+            ),
+            Some(r"\\?\UNC\server\share\repo\src".into())
+        );
+    }
+
+    #[test]
+    fn extended_drive_prefix_preserves_drive_form() {
+        assert_eq!(
+            normalize_extended_length_path_prefix(r"\\?\C:\repo", r"C:\repo\src"),
+            Some(r"\\?\C:\repo\src".into())
+        );
+    }
 }

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -328,8 +328,15 @@ where
         };
 
         if base.is_absolute() != target.is_absolute() {
-            base = Cow::Owned(absolute_path(self.config.base_dir.as_deref(), &base)?);
-            target = absolute_path(self.config.base_dir.as_deref(), &target)?;
+            if !base.is_absolute() {
+                // Relative input filenames are relative to the current process,
+                // while path-mapped targets are resolved from `jsc.baseUrl`.
+                base = Cow::Owned(absolute_path(None, &base)?);
+            }
+
+            if !target.is_absolute() {
+                target = absolute_path(self.config.base_dir.as_deref(), &target)?;
+            }
         }
 
         debug!(

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -328,11 +328,15 @@ where
         };
 
         if base.is_absolute() != target.is_absolute() {
-            if !base.is_absolute() {
+            if base.is_absolute() {
+                base = Cow::Owned(base.to_path_buf().clean());
+            } else {
                 base = Cow::Owned(absolute_base_path(self.config.base_dir.as_deref(), &base)?);
             }
 
-            if !target.is_absolute() {
+            if target.is_absolute() {
+                target = target.clean();
+            } else {
                 target = absolute_path(self.config.base_dir.as_deref(), &target)?;
             }
         }

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -341,6 +341,15 @@ where
             }
         }
 
+        #[cfg(windows)]
+        {
+            (base, target) = normalize_extended_length_path_prefixes(
+                self.config.base_dir.as_deref(),
+                base,
+                target,
+            );
+        }
+
         debug!(
             "Comparing values (after normalizing absoluteness)\nbase={}\ntarget={}",
             base.display(),
@@ -500,9 +509,48 @@ fn normalize_path_prefix_like(_: &Path, path: PathBuf) -> PathBuf {
     path
 }
 
+#[cfg(windows)]
+fn normalize_extended_length_path_prefixes<'a>(
+    base_dir: Option<&Path>,
+    base: Cow<'a, Path>,
+    target: PathBuf,
+) -> (Cow<'a, Path>, PathBuf) {
+    if !base.is_absolute() || !target.is_absolute() {
+        return (base, target);
+    }
+
+    let reference = match base_dir {
+        Some(base_dir) if has_extended_length_path_prefix(base_dir) => Some(base_dir.to_path_buf()),
+        _ if has_extended_length_path_prefix(base.as_ref()) => Some(base.to_path_buf()),
+        _ if has_extended_length_path_prefix(&target) => Some(target.clone()),
+        _ => None,
+    };
+
+    let Some(reference) = reference else {
+        return (base, target);
+    };
+
+    // Windows canonicalization often returns extended-length paths (`\\?\...`).
+    // `pathdiff` treats those as a different prefix from ordinary absolute
+    // paths, so align both sides before calculating a relative import.
+    (
+        Cow::Owned(normalize_path_prefix_like(&reference, base.into_owned())),
+        normalize_path_prefix_like(&reference, target),
+    )
+}
+
+#[cfg(windows)]
+fn has_extended_length_path_prefix(path: &Path) -> bool {
+    path.as_os_str().to_string_lossy().starts_with(r"\\?\")
+}
+
 #[cfg(any(test, windows))]
 fn normalize_extended_length_path_prefix(reference: &str, path: &str) -> Option<String> {
     if !reference.starts_with(r"\\?\") || path.starts_with(r"\\?\") {
+        return None;
+    }
+
+    if !is_windows_absolute_path(path) {
         return None;
     }
 
@@ -515,6 +563,21 @@ fn normalize_extended_length_path_prefix(reference: &str, path: &str) -> Option<
     }
 
     Some(format!(r"\\?\{path}"))
+}
+
+#[cfg(any(test, windows))]
+fn is_windows_absolute_path(path: &str) -> bool {
+    path.starts_with(r"\\") || has_windows_drive_prefix(path)
+}
+
+#[cfg(any(test, windows))]
+fn has_windows_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+
+    bytes.len() >= 3
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && matches!(bytes[2], b'/' | b'\\')
 }
 
 #[cfg(test)]
@@ -561,6 +624,14 @@ mod tests {
         assert_eq!(
             normalize_extended_length_path_prefix(r"\\?\C:\repo", r"C:\repo\src"),
             Some(r"\\?\C:\repo\src".into())
+        );
+    }
+
+    #[test]
+    fn extended_drive_prefix_skips_relative_path() {
+        assert_eq!(
+            normalize_extended_length_path_prefix(r"\\?\C:\repo", r"repo\src"),
+            None
         );
     }
 }

--- a/crates/swc_ecma_transforms_module/tests/path_node.rs
+++ b/crates/swc_ecma_transforms_module/tests/path_node.rs
@@ -214,6 +214,67 @@ fn issue_11880_preserve_symlinks_uses_cwd_for_relative_input_filename() {
     assert_eq!(&*resolved, "../../apis/auth");
 }
 
+#[test]
+fn mixed_relative_target_cleans_absolute_base_path() {
+    let cwd = std::env::current_dir().unwrap();
+    let sandbox = tempfile::tempdir_in(&cwd).unwrap();
+    let root = sandbox.path();
+
+    create_dir_all(root.join("bazel-out/foo-app/src")).unwrap();
+    write(
+        root.join("bazel-out/foo-app/src/app.ts"),
+        "import { hello } from '#/apis/auth';\n",
+    )
+    .unwrap();
+
+    let resolver = paths_resolver_with_options(
+        &root.join("bazel-out/foo-app"),
+        vec![("#/apis/*".into(), vec!["../apis/*".into()])],
+        false,
+        true,
+    );
+    let base = root.join("bazel-out/foo-app/src/../src/app.ts");
+
+    let resolved = resolver
+        .resolve_import(&FileName::Real(base), "#/apis/auth")
+        .unwrap();
+
+    assert_eq!(&*resolved, "../../apis/auth");
+}
+
+#[test]
+fn mixed_absolute_target_cleans_target_path() {
+    let cwd = std::env::current_dir().unwrap();
+    let sandbox = tempfile::tempdir_in(&cwd).unwrap();
+    let root = sandbox.path();
+
+    create_dir_all(root.join("bazel-out/foo-app/src")).unwrap();
+    write(
+        root.join("bazel-out/foo-app/src/app.ts"),
+        "import { hello } from '#/apis/auth';\n",
+    )
+    .unwrap();
+
+    let target = root.join("bazel-out/apis/../apis/*").display().to_string();
+    let resolver = paths_resolver_with_options(
+        &root.join("bazel-out/foo-app"),
+        vec![("#/apis/*".into(), vec![target])],
+        false,
+        true,
+    );
+    let relative_input = root
+        .join("bazel-out/foo-app/src/app.ts")
+        .strip_prefix(&cwd)
+        .unwrap()
+        .to_path_buf();
+
+    let resolved = resolver
+        .resolve_import(&FileName::Real(relative_input), "#/apis/auth")
+        .unwrap();
+
+    assert_eq!(&*resolved, "../../apis/auth");
+}
+
 fn create_symlink(a: &Path, b: &Path) {
     #[cfg(unix)]
     {

--- a/crates/swc_ecma_transforms_module/tests/path_node.rs
+++ b/crates/swc_ecma_transforms_module/tests/path_node.rs
@@ -164,6 +164,56 @@ fn symlink_paths_are_preserved_only_when_opted_in() {
     assert_eq!(&*preserve_symlinks_resolved, "../server/source");
 }
 
+#[test]
+fn issue_11880_preserve_symlinks_uses_cwd_for_relative_input_filename() {
+    let cwd = std::env::current_dir().unwrap();
+    let sandbox = tempfile::tempdir_in(&cwd).unwrap();
+    let root = sandbox.path();
+
+    create_dir_all(root.join("apis")).unwrap();
+    create_dir_all(root.join("bazel-out/apis")).unwrap();
+    create_dir_all(root.join("foo-app/src")).unwrap();
+    create_dir_all(root.join("bazel-out/foo-app/src")).unwrap();
+
+    write(
+        root.join("apis/auth.ts"),
+        "export const hello = () => 'hello';\n",
+    )
+    .unwrap();
+    write(
+        root.join("foo-app/src/app.ts"),
+        "import { hello } from '#/apis/auth';\nexport const greet = () => hello();\n",
+    )
+    .unwrap();
+
+    create_symlink(
+        &root.join("apis/auth.ts"),
+        &root.join("bazel-out/apis/auth.ts"),
+    );
+    create_symlink(
+        &root.join("foo-app/src/app.ts"),
+        &root.join("bazel-out/foo-app/src/app.ts"),
+    );
+
+    let resolver = paths_resolver_with_options(
+        &root.join("bazel-out/foo-app"),
+        vec![("#/apis/*".into(), vec!["../apis/*".into()])],
+        false,
+        true,
+    );
+    let relative_input = root
+        .join("bazel-out/foo-app/src/app.ts")
+        .strip_prefix(&cwd)
+        .unwrap()
+        .to_path_buf();
+
+    let resolved = resolver
+        .resolve_import(&FileName::Real(relative_input), "#/apis/auth")
+        .unwrap();
+
+    assert_eq!(&*resolved, "../../apis/auth");
+}
+
 fn create_symlink(a: &Path, b: &Path) {
     #[cfg(unix)]
     {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fixes a `jsc.paths` + `jsc.preserveSymlinks` path rewriting bug when SWC is invoked with a relative input filename. Relative source filenames should be interpreted from the current process directory, while path-mapped targets should continue to resolve from `jsc.baseUrl`.

The bug showed up in Bazel-style symlink layouts where the relative input path was accidentally re-rooted under `jsc.baseUrl`, producing too many `../` segments in emitted CommonJS `require()` paths.

This PR also adds a regression test for issue 11880 using a Bazel-like symlinked layout and verifies that `#/apis/auth` rewrites to `../../apis/auth`.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Fixes #11880

**Validation:**

- `git submodule update --init --recursive`
- `cargo test -p swc_ecma_transforms_module issue_11880`
- `cargo test -p swc_ecma_transforms_module`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
