### PR TITLE
fix(es/minifier): preserve default parameter object props

### DIFF
--- a/.changeset/preserve-default-parameter-object-props.md
+++ b/.changeset/preserve-default-parameter-object-props.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): Preserve object props used through default parameters

--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -930,6 +930,13 @@ impl Optimizer<'_> {
             return None;
         }
 
+        let accessed_props_count: u32 = usage.accessed_props.values().sum();
+        // Direct uses, such as default-parameter aliases, can read properties
+        // through another binding, so keep the full object in that case.
+        if accessed_props_count < usage.ref_count {
+            return None;
+        }
+
         if usage.flags.intersects(
             VarUsageInfoFlags::INDEXED_WITH_DYNAMIC_KEY
                 .union(VarUsageInfoFlags::USED_AS_REF)

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -12265,6 +12265,51 @@ console.log(getStatusMessage(999).message);
 }
 
 #[test]
+fn issue_11871() {
+    let src = r#"
+var window = {};
+var foo = { min: (items) => items[0] };
+var bar = {};
+var bucketFactory = () => ({
+    utc: (input) => ({
+        diff: () => 0
+    })
+});
+var min = foo;
+var moment = bucketFactory(bar);
+const defaultSpec = {
+    granularities: [
+        {
+            maxDays: 1,
+            displayFormatString: "[Q]Q"
+        }
+    ],
+    other: 1
+};
+
+window.x = {
+    f: (start, end) => ((inputStartDate, inputEndDate, spec = defaultSpec) => {
+        let startDate = moment.utc(inputStartDate);
+        let dayCount = moment.utc(inputEndDate).diff(startDate, "days") + 1;
+        let granularity = spec.granularities
+            .sort((left, right) => left.maxDays - right.maxDays)
+            .find((item) => dayCount <= item.maxDays);
+        return granularity == null ? "" : granularity.displayFormatString;
+    })(start, end) + String(min.min([1, 2]))
+};
+
+console.log(window.x.f(0, 0));
+"#;
+    let config = r#"{
+        "defaults": true,
+        "toplevel": true,
+        "passes": 2
+    }"#;
+
+    run_exec_test(src, config, false);
+}
+
+#[test]
 fn object_freeze_spread_computed_registration() {
     let src = r#"
 const Inner = /*#__PURE__*/ Object.freeze({

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11871/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11871/config.json
@@ -1,0 +1,5 @@
+{
+    "defaults": true,
+    "toplevel": true,
+    "passes": 2
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11871/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11871/input.js
@@ -1,0 +1,32 @@
+var window = {};
+var foo = { min: (items) => items[0] };
+var bar = {};
+var bucketFactory = () => ({
+    utc: (input) => ({
+        diff: () => 0
+    })
+});
+var min = foo;
+var moment = bucketFactory(bar);
+const defaultSpec = {
+    granularities: [
+        {
+            maxDays: 1,
+            displayFormatString: "[Q]Q"
+        }
+    ],
+    other: 1
+};
+
+window.x = {
+    f: (start, end) => ((inputStartDate, inputEndDate, spec = defaultSpec) => {
+        let startDate = moment.utc(inputStartDate);
+        let dayCount = moment.utc(inputEndDate).diff(startDate, "days") + 1;
+        let granularity = spec.granularities
+            .sort((left, right) => left.maxDays - right.maxDays)
+            .find((item) => dayCount <= item.maxDays);
+        return granularity == null ? "" : granularity.displayFormatString;
+    })(start, end) + String(min.min([1, 2]))
+};
+
+console.log(window.x.f(0, 0));

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11871/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11871/output.js
@@ -1,0 +1,18 @@
+var window = {}, moment_utc = (input)=>({
+        diff: ()=>0
+    });
+const defaultSpec = {
+    granularities: [
+        {
+            maxDays: 1,
+            displayFormatString: "[Q]Q"
+        }
+    ],
+    other: 1
+};
+window.x = {
+    f: (start, end)=>((inputStartDate, inputEndDate, spec = defaultSpec)=>{
+            let startDate = moment_utc(inputStartDate), dayCount = moment_utc(inputEndDate).diff(startDate, "days") + 1, granularity = spec.granularities.sort((left, right)=>left.maxDays - right.maxDays).find((item)=>dayCount <= item.maxDays);
+            return null == granularity ? "" : granularity.displayFormatString;
+        })(start, end) + String(1)
+}, console.log(window.x.f(0, 0));


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fixes a SWC minifier regression where `hoist_props` property pruning can reduce a module-scoped object literal to `{}` when the object is used through a default parameter alias. `drop_unused_properties` now keeps the full object when known property reads do not cover every reference, because those direct references can read properties through another binding.

Adds issue 11871 fixture and exec regression coverage for `compress.passes: 2`.

Validated with:
- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_minifier --test compress 11871 -- --ignored`
- `cargo test -p swc_ecma_minifier --test compress 11871 -- --ignored`
- `cargo test -p swc_ecma_minifier --test exec issue_11871`
- `cargo test -p swc_ecma_minifier`
- `./scripts/exec.sh` in `crates/swc_ecma_minifier`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Closes #11871
