### PR TITLE
ci: pass publish docker env explicitly

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -337,9 +337,9 @@ jobs:
           mkdir -p "$HOME/.cargo/git" "$HOME/.cargo/registry"
           docker run --rm \
             -e BUILD_SCRIPT \
-            -e COREPACK_VERSION \
+            -e COREPACK_VERSION="$COREPACK_VERSION" \
             -e PACKAGE \
-            -e PACKAGE_MANAGER \
+            -e PACKAGE_MANAGER="$PACKAGE_MANAGER" \
             -v "$HOME/.cargo/git:/root/.cargo/git" \
             -v "$HOME/.cargo/registry:/root/.cargo/registry" \
             -v "$WORKSPACE:/build" \
@@ -499,9 +499,9 @@ jobs:
           esac
 
           docker run --rm \
-            -e COREPACK_VERSION \
+            -e COREPACK_VERSION="$COREPACK_VERSION" \
             -e PACKAGE \
-            -e PACKAGE_MANAGER \
+            -e PACKAGE_MANAGER="$PACKAGE_MANAGER" \
             -v "$PWD:/swc" \
             -w /swc \
             "$NODE_IMAGE" \
@@ -582,9 +582,9 @@ jobs:
           esac
 
           docker run --rm \
-            -e COREPACK_VERSION \
+            -e COREPACK_VERSION="$COREPACK_VERSION" \
             -e PACKAGE \
-            -e PACKAGE_MANAGER \
+            -e PACKAGE_MANAGER="$PACKAGE_MANAGER" \
             -v "$PWD:/swc" \
             -w /swc \
             "$NODE_IMAGE" \


### PR DESCRIPTION
**Description:**

Fix the follow-up failure in the publish workflow Docker jobs. The previous Corepack update resolved the pnpm signature issue, but the computed packageManager value was passed to Docker as `-e PACKAGE_MANAGER` without exporting it first, so containers failed under `set -u` with `PACKAGE_MANAGER: unbound variable`.

This PR changes the three publish workflow Docker call sites to pass computed values explicitly as `-e COREPACK_VERSION="$COREPACK_VERSION"` and `-e PACKAGE_MANAGER="$PACKAGE_MANAGER"`.

Validation:

- Reproduced the missing `PACKAGE_MANAGER` failure with the old `docker run -e PACKAGE_MANAGER` form.
- Verified explicit `-e PACKAGE_MANAGER="$PACKAGE_MANAGER"` passes `pnpm@10.33.3` into the container.
- Verified Corepack/pnpm preparation on the Debian, Alpine, and Debian aarch64 publish images.
- Ran `git submodule update --init --recursive`.
- Ran `cargo fmt --all`.
- Ran `cargo clippy --all --all-targets -- -D warnings`.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A