### PR TITLE
ci: make minifier test path explicit

### DIFF
--- a/packages/minifier/package.json
+++ b/packages/minifier/package.json
@@ -53,7 +53,7 @@
         "build:wasm": "npm-run-all \"pack -- build ../../bindings/binding_minifier_wasm --scope swc {1} -t {2}\" --",
         "build": "tsc -d && napi build --platform --js ./src/binding.js --dts ./src/binding.d.ts --manifest-path ../../Cargo.toml -p binding_minifier_node --output-dir . --release",
         "build:dev": "tsc -d && napi build --platform --js ./src/binding.js --dts ./src/binding.d.ts --manifest-path ../../Cargo.toml -p binding_minifier_node --output-dir .",
-        "test": "node --test tests/*.test.cjs",
+        "test": "node --test tests/extract-comments.test.cjs",
         "version": "napi version --npm-dir scripts/npm"
     },
     "funding": {


### PR DESCRIPTION
**Description:**

Fixes the remaining `Publish 1.15.38` failure in the `@swc/minifier` Windows Node 20 binding test.

The test script used `node --test tests/*.test.cjs`. On Windows Node 20 that glob is passed literally, so Node failed with `Could not find ... tests\*.test.cjs`. The workflow is now already running in `packages/minifier`; this PR makes the test path explicit instead of relying on glob expansion.

Validation:

- Reconfirmed run `26296803105` has only one failing job: `minifier` Windows x64 on Node 20.
- Confirmed the failed log runs in `D:\a\swc\swc\packages\minifier` and fails on the literal glob.
- Ran `pnpm --dir packages/minifier build:dev`.
- Ran `pnpm --dir packages/minifier test`.
- Ran `git submodule update --init --recursive`.
- Ran `cargo fmt --all`.
- Ran `cargo clippy --all --all-targets -- -D warnings`.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.
