### PR TITLE
chore: move swr ecosystem test to todos

### DIFF
--- a/.github/swc-ecosystem-ci/todos/swr.ts
+++ b/.github/swc-ecosystem-ci/todos/swr.ts
@@ -1,6 +1,8 @@
 import { runInRepo } from "../utils.js";
 import { RunOptions } from "../types.js";
 
+// SWR sets pnpm `minimumReleaseAge: 2880` on main, which blocks freshly
+// published SWC nightly packages during the release workflow.
 export async function test(options: RunOptions) {
   await runInRepo({
     ...options,


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Move the SWR ecosystem CI suite from `tests` to `todos`.

SWR now sets `minimumReleaseAge: 2880` in its pnpm workspace configuration, which blocks freshly published SWC nightly packages during the release workflow. Keeping this suite in the passing set currently prevents publish workflows from progressing even when the SWC nightly package itself has been published correctly.

The moved test includes a short comment explaining why it is temporarily tracked as a todo.

Validation:

- `pnpm exec tsc` in `.github/swc-ecosystem-ci`
- `CI_MODE=passing pnpm exec tsx run-all.ts`
- `CI_MODE=ignored pnpm exec tsx run-all.ts`
- `pnpm exec prettier --check .github/swc-ecosystem-ci/todos/swr.ts`
- `cargo fmt --all`
- `git submodule update --init --recursive`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.