### PR TITLE
Optimize parser token and lexer hot paths

### DIFF
--- a/crates/hstr/src/dynamic.rs
+++ b/crates/hstr/src/dynamic.rs
@@ -62,13 +62,23 @@ pub struct AtomStore {
 
 impl Default for AtomStore {
     fn default() -> Self {
-        Self {
-            data: hashbrown::HashMap::with_capacity_and_hasher(64, BuildEntryHasher::default()),
-        }
+        Self::with_capacity(64)
     }
 }
 
 impl AtomStore {
+    /// Create an atom store with enough capacity for `capacity` non-inline
+    /// atoms before rehashing.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data: hashbrown::HashMap::with_capacity_and_hasher(
+                capacity,
+                BuildEntryHasher::default(),
+            ),
+        }
+    }
+
     #[inline(always)]
     pub fn atom<'a>(&mut self, text: impl Into<Cow<'a, str>>) -> Atom {
         atom_in(self, &text.into())

--- a/crates/swc_atoms/src/lib.rs
+++ b/crates/swc_atoms/src/lib.rs
@@ -311,6 +311,13 @@ pub type StaticString = Atom;
 pub struct AtomStore(hstr::AtomStore);
 
 impl AtomStore {
+    /// Create an atom store with enough capacity for `capacity` non-inline
+    /// atoms before rehashing.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(hstr::AtomStore::with_capacity(capacity))
+    }
+
     #[inline]
     pub fn atom<'a>(&mut self, s: impl Into<Cow<'a, str>>) -> Atom {
         Atom(self.0.atom(s))
@@ -327,6 +334,13 @@ impl AtomStore {
 pub struct AtomStoreCell(UnsafeCell<AtomStore>);
 
 impl AtomStoreCell {
+    /// Create an internally mutable atom store cell with enough capacity for
+    /// `capacity` non-inline atoms before rehashing.
+    #[inline]
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(UnsafeCell::new(AtomStore::with_capacity(capacity)))
+    }
+
     #[inline]
     pub fn atom<'a>(&self, s: impl Into<Cow<'a, str>>) -> Atom {
         // evaluate the into before borrowing (see #8362)

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -69,6 +69,20 @@ static SINGLE_QUOTE_STRING_END_TABLE: SafeByteMatchTable =
 static NOT_ASCII_ID_CONTINUE_TABLE: SafeByteMatchTable =
     safe_byte_match_table!(|b| !(b.is_ascii_alphanumeric() || b == b'_' || b == b'$'));
 
+#[inline]
+fn atom_store_capacity(input_len: usize) -> usize {
+    // Long identifiers and string values are interned in an hstr AtomStore.
+    // Large bundles can create enough non-inline atoms to trigger multiple
+    // hash table rehashes from the default capacity. Use source size as a
+    // conservative hint, while keeping small inputs at the existing default
+    // and capping the hint to avoid over-allocation on very large files.
+    if input_len < 64 * 1024 {
+        return 64;
+    }
+
+    (input_len / 256).clamp(64, 65_536)
+}
+
 #[cfg(feature = "flow")]
 fn flow_pragma_in_comment(comment: &str) -> Option<bool> {
     if comment.contains("@noflow") {
@@ -298,6 +312,7 @@ impl<'a> Lexer<'a> {
         let mut syntax = syntax.into_flags();
         #[cfg(not(feature = "flow"))]
         let syntax = syntax.into_flags();
+        let atom_store_capacity = atom_store_capacity(input.as_str().len());
 
         #[cfg(feature = "flow")]
         {
@@ -320,7 +335,7 @@ impl<'a> Lexer<'a> {
             target,
             errors: Default::default(),
             module_errors: Default::default(),
-            atoms: Default::default(),
+            atoms: Rc::new(AtomStoreCell::with_capacity(atom_store_capacity)),
             token_flags: TokenFlags::empty(),
         }
     }

--- a/crates/swc_ecma_parser/src/lexer/mod.rs
+++ b/crates/swc_ecma_parser/src/lexer/mod.rs
@@ -1911,6 +1911,7 @@ impl<'a> Lexer<'a> {
     }
 
     /// This method is optimized for texts without escape sequences.
+    #[inline(always)]
     fn read_word_as_str_with(&mut self) -> LexResult<(Cow<'a, str>, bool)> {
         debug_assert!(self.cur().is_some());
         let slice_start = self.cur_pos();
@@ -2271,6 +2272,7 @@ impl<'a> Lexer<'a> {
 
     /// This can be used if there's no keyword starting with the first
     /// character.
+    #[inline(always)]
     fn read_ident_unknown(&mut self) -> LexResult<Token> {
         debug_assert!(self.cur().is_some());
 
@@ -2381,7 +2383,11 @@ impl<'a> Lexer<'a> {
         }
     }
 
-    fn read_keyword_with(&mut self, convert: fn(&str) -> Option<Token>) -> LexResult<Token> {
+    #[inline(always)]
+    fn read_keyword_with<F>(&mut self, convert: F) -> LexResult<Token>
+    where
+        F: FnOnce(&str) -> Option<Token>,
+    {
         debug_assert!(self.cur().is_some());
 
         let start = self.cur_pos();
@@ -2408,6 +2414,7 @@ impl<'a> Lexer<'a> {
     /// This is a performant version of [Lexer::read_word_as_str_with] for
     /// reading keywords. We should make sure the first byte is a valid
     /// ASCII.
+    #[inline(always)]
     fn read_keyword_as_str_with(&mut self) -> LexResult<(Cow<'a, str>, bool)> {
         let slice_start = self.cur_pos();
 

--- a/crates/swc_ecma_parser/src/lexer/state.rs
+++ b/crates/swc_ecma_parser/src/lexer/state.rs
@@ -177,6 +177,7 @@ impl crate::input::Tokens for Lexer<'_> {
         self.state.token_value.take()
     }
 
+    #[inline(always)]
     fn first_token(&mut self) -> TokenAndSpan {
         let mut start = self.cur_pos();
         let token = match self.read_shebang() {
@@ -204,6 +205,7 @@ impl crate::input::Tokens for Lexer<'_> {
         self.finish_next_token(self.span(start), token)
     }
 
+    #[inline(always)]
     fn next_token(&mut self) -> TokenAndSpan {
         // `read_next_token` always overwrites this out-parameter before
         // returning, including the regexp path.
@@ -403,6 +405,7 @@ impl Lexer<'_> {
         prefix.as_bytes().last().copied() == Some(b'-')
     }
 
+    #[inline(always)]
     fn read_next_token(&mut self, start: &mut BytePos) -> Result<Token, Error> {
         if let Some(next_regexp) = self.state.next_regexp {
             *start = next_regexp;

--- a/crates/swc_ecma_parser/src/parser/input.rs
+++ b/crates/swc_ecma_parser/src/parser/input.rs
@@ -297,12 +297,14 @@ impl<I: Tokens> Buffer<I> {
         self.set_cur(token);
     }
 
+    #[inline(always)]
     pub fn first_bump(&mut self) {
         let first_token = self.iter.first_token();
         self.prev_span = self.cur.span;
         self.set_cur(first_token);
     }
 
+    #[inline(always)]
     pub fn bump(&mut self) {
         let next = if self.next.is_none() {
             self.iter.next_token()
@@ -317,6 +319,7 @@ impl<I: Tokens> Buffer<I> {
         self.set_cur(next);
     }
 
+    #[inline(always)]
     pub fn expect_word_token_and_bump(&mut self) -> Atom {
         let cur = self.cur();
         let word = if cur == Token::Ident {


### PR DESCRIPTION
## Summary

- Inline hot lexer word/identifier/keyword token paths.
- Make the lexer keyword callback generic over `FnOnce` instead of passing a `fn` pointer.
- Inline hot parser token-buffer bump helpers.
- Pre-size the parser's local atom store for larger inputs to reduce hstr table rehashing during parse.

## Why

Valgrind/Callgrind on the `typescript.js` parse benchmark showed repeated overhead at the lexer/parser token boundary and a smaller but measurable hstr atom-store cost from string/identifier interning. These changes keep the same parser behavior while giving LLVM better visibility into hot token advancement paths and avoiding avoidable atom-store growth work on large bundles.

Measured locally with `scripts/valgrind-callgrind.sh swc parse 1` from the companion benchmark harness:

| Step | Callgrind Ir |
| --- | ---: |
| SWC baseline before lazy source hash | 690,111,316 |
| SWC after lazy source hash | 643,569,691 |
| After lexer inline + generic keyword callback | 628,040,751 |
| After parser buffer inline | 612,471,050 |
| After atom-store capacity hint | 611,103,226 |

Inline-related delta from the lazy-hash baseline before the atom-store change: `-31,098,641 Ir` (`-4.83%`).

Atom-store capacity hint delta from the previous local step: `-1,367,824 Ir` (`-0.22%`). In the same Callgrind profile, `RawTable<(hstr::dynamic::Item, ())>::reserve_rehash` self cost dropped from `1,523,682 Ir` to `506,780 Ir`.

Total local delta from the lazy-hash baseline: `-32,466,465 Ir` (`-5.04%`). Total local delta from the original SWC baseline: `-79,008,090 Ir` (`-11.45%`).

A broader `skip_space` rewrite was also tested and reverted because it regressed Callgrind Ir, so this PR keeps the optimization targeted to measured hot boundaries and atom-store growth.

## Checks

- `cargo test -p swc_ecma_parser --lib`
- Companion benchmark harness: `cargo test`
- Companion benchmark harness: `scripts/valgrind-callgrind.sh swc parse 1`