### PR TITLE
chore: bump cargo-mono to 0.6.9

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Install cargo-mono
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
         with:
-          tool: cargo-mono@0.6.7
+          tool: cargo-mono@0.6.9
 
       - name: List crates
         id: list-tests

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Install cargo-mono
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
         with:
-          tool: cargo-mono@0.6.7
+          tool: cargo-mono@0.6.9
 
       - name: Update constant of swc_core
         run: npx ts-node .github/bot/src/cargo/update-constants.ts


### PR DESCRIPTION
**Description:**

Update `cargo-mono` in CI and crate publishing workflows from `0.6.7` to `0.6.9`, the latest crates.io release. This keeps test matrix generation and crate publishing on the current cargo-mono release.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.

**Validation:**

- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`