### PR TITLE
perf: Optimize Atom equality

### DIFF
--- a/.changeset/optimize-atom-equality.md
+++ b/.changeset/optimize-atom-equality.md
@@ -1,0 +1,7 @@
+---
+hstr: patch
+swc_atoms: patch
+swc_core: patch
+---
+
+perf(atoms): Optimize Atom equality checks

--- a/crates/hstr/src/lib.rs
+++ b/crates/hstr/src/lib.rs
@@ -17,7 +17,7 @@ use once_cell::sync::Lazy;
 
 pub use crate::dynamic::{global_atom_store_gc, AtomStore};
 use crate::{
-    macros::{get_hash, impl_from_alias, partial_eq},
+    macros::{get_hash, impl_from_alias},
     tagged_value::TaggedValue,
 };
 
@@ -297,13 +297,37 @@ impl Atom {
 }
 
 impl PartialEq for Atom {
-    #[inline(never)]
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
-        partial_eq!(self, other);
+        let unsafe_data = self.unsafe_data;
+        let other_unsafe_data = other.unsafe_data;
 
-        // If the store is different, the string may be the same, even though the
-        // `unsafe_data` is different
-        self.as_str() == other.as_str()
+        if unsafe_data == other_unsafe_data {
+            return true;
+        }
+
+        let tag = unsafe_data.tag() & TAG_MASK;
+
+        if tag != (other_unsafe_data.tag() & TAG_MASK) {
+            return false;
+        }
+
+        match tag {
+            // Inline atoms encode both their length and bytes in `unsafe_data`, so
+            // different raw values mean different strings.
+            INLINE_TAG => false,
+            DYNAMIC_TAG => {
+                let this = unsafe { crate::dynamic::deref_from(unsafe_data) };
+                let other = unsafe { crate::dynamic::deref_from(other_unsafe_data) };
+
+                if this.header.header.hash != other.header.header.hash {
+                    return false;
+                }
+
+                this.slice == other.slice
+            }
+            _ => unsafe { debug_unreachable!() },
+        }
     }
 }
 

--- a/crates/hstr/src/macros.rs
+++ b/crates/hstr/src/macros.rs
@@ -18,35 +18,6 @@ macro_rules! get_hash {
     };
 }
 
-macro_rules! partial_eq {
-    ($self:expr, $other:expr) => {
-        if $self.unsafe_data == $other.unsafe_data {
-            return true;
-        }
-
-        // If one is inline and the other is not, the length is different.
-        // If one is static and the other is not, it's different.
-        if $self.tag() != $other.tag() {
-            return false;
-        }
-
-        if $self.is_dynamic() && $other.is_dynamic() {
-            let te = unsafe { $crate::dynamic::deref_from($self.unsafe_data) };
-            let oe = unsafe { $crate::dynamic::deref_from($other.unsafe_data) };
-
-            if te.header.header.hash != oe.header.header.hash {
-                return false;
-            }
-
-            return te.slice == oe.slice;
-        }
-
-        if $self.get_hash() != $other.get_hash() {
-            return false;
-        }
-    };
-}
-
 macro_rules! impl_from_alias {
     ($ty:ty) => {
         impl $ty {
@@ -68,4 +39,3 @@ macro_rules! impl_from_alias {
 
 pub(crate) use get_hash;
 pub(crate) use impl_from_alias;
-pub(crate) use partial_eq;

--- a/crates/hstr/src/tests.rs
+++ b/crates/hstr/src/tests.rs
@@ -22,6 +22,28 @@ fn store_with_wtf8_atoms(texts: Vec<&Wtf8>) -> (AtomStore, Vec<Wtf8Atom>) {
 }
 
 #[test]
+fn equality_variants() {
+    assert_eq!(Atom::from("inline"), Atom::from("inline"));
+    assert_ne!(Atom::from("inline"), Atom::from("inlinf"));
+
+    let (_, atoms1) = store_with_atoms(vec!["Hello, beautiful world!"]);
+    let (_, atoms2) = store_with_atoms(vec!["Hello, beautiful world!", "Hello, different world!"]);
+    assert_eq!(atoms1[0], atoms2[0]);
+    assert_ne!(atoms1[0], atoms2[1]);
+
+    assert_eq!(Wtf8Atom::from("inline"), Wtf8Atom::from("inline"));
+    assert_ne!(Wtf8Atom::from("inline"), Wtf8Atom::from("inlinf"));
+
+    let (_, atoms1) = store_with_wtf8_atoms(vec![&Wtf8::from_str("Hello, beautiful world!")]);
+    let (_, atoms2) = store_with_wtf8_atoms(vec![
+        &Wtf8::from_str("Hello, beautiful world!"),
+        &Wtf8::from_str("Hello, different world!"),
+    ]);
+    assert_eq!(atoms1[0], atoms2[0]);
+    assert_ne!(atoms1[0], atoms2[1]);
+}
+
+#[test]
 fn simple_usage() {
     // atom
     let (s, atoms) = store_with_atoms(vec!["Hello, world!", "Hello, world!"]);

--- a/crates/hstr/src/wtf8_atom.rs
+++ b/crates/hstr/src/wtf8_atom.rs
@@ -8,7 +8,7 @@ use std::{
 use debug_unreachable::debug_unreachable;
 
 use crate::{
-    macros::{get_hash, impl_from_alias, partial_eq},
+    macros::{get_hash, impl_from_alias},
     tagged_value::TaggedValue,
     wtf8::Wtf8,
     Atom, DYNAMIC_TAG, INLINE_TAG, LEN_MASK, LEN_OFFSET, TAG_MASK,
@@ -242,13 +242,37 @@ impl<'de> serde::de::Deserialize<'de> for Wtf8Atom {
 }
 
 impl PartialEq for Wtf8Atom {
-    #[inline(never)]
+    #[inline]
     fn eq(&self, other: &Self) -> bool {
-        partial_eq!(self, other);
+        let unsafe_data = self.unsafe_data;
+        let other_unsafe_data = other.unsafe_data;
 
-        // If the store is different, the string may be the same, even though the
-        // `unsafe_data` is different
-        self.as_wtf8() == other.as_wtf8()
+        if unsafe_data == other_unsafe_data {
+            return true;
+        }
+
+        let tag = unsafe_data.tag() & TAG_MASK;
+
+        if tag != (other_unsafe_data.tag() & TAG_MASK) {
+            return false;
+        }
+
+        match tag {
+            // Inline atoms encode both their length and bytes in `unsafe_data`, so
+            // different raw values mean different strings.
+            INLINE_TAG => false,
+            DYNAMIC_TAG => {
+                let this = unsafe { crate::dynamic::deref_from(unsafe_data) };
+                let other = unsafe { crate::dynamic::deref_from(other_unsafe_data) };
+
+                if this.header.header.hash != other.header.header.hash {
+                    return false;
+                }
+
+                this.slice == other.slice
+            }
+            _ => unsafe { debug_unreachable!() },
+        }
     }
 }
 
@@ -377,6 +401,7 @@ mod tests {
     use super::*;
     use crate::wtf8::{CodePoint, Wtf8Buf};
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serialize_normal_utf8() {
         let atom = Wtf8Atom::new("Hello, world!");
@@ -384,6 +409,7 @@ mod tests {
         assert_eq!(serialized, "\"Hello, world!\"");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize_normal_utf8() {
         let json = "\"Hello, world!\"";
@@ -391,6 +417,7 @@ mod tests {
         assert_eq!(atom.as_str(), Some("Hello, world!"));
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serialize_unpaired_high_surrogate() {
         // Create a WTF-8 string with an unpaired high surrogate (U+D800)
@@ -403,6 +430,7 @@ mod tests {
         assert_eq!(serialized, "\"\\\\uD800\"");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serialize_unpaired_low_surrogate() {
         // Create a WTF-8 string with an unpaired low surrogate (U+DC00)
@@ -415,6 +443,7 @@ mod tests {
         assert_eq!(serialized, "\"\\\\uDC00\"");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serialize_multiple_surrogates() {
         // Create a WTF-8 string with multiple unpaired surrogates
@@ -430,6 +459,7 @@ mod tests {
         assert_eq!(serialized, "\"Hello \\\\uD800 World \\\\uDC00\"");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_serialize_literal_backslash_u() {
         // Test that literal "\u" in the string gets escaped properly
@@ -439,6 +469,7 @@ mod tests {
         assert_eq!(serialized, "\"\\\\\\\\u0041\"");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize_escaped_backslash_u() {
         // Test deserializing the escaped format for unpaired surrogates
@@ -449,6 +480,7 @@ mod tests {
         assert_eq!(atom.to_string_lossy(), "\u{FFFD}");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize_unpaired_surrogates() {
         let json = "\"\\\\uD800\""; // Use escaped format that matches serialization
@@ -459,6 +491,7 @@ mod tests {
         assert_eq!(atom.to_string_lossy(), "\u{FFFD}");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_round_trip_normal_string() {
         let original = Wtf8Atom::new("Hello, 世界! 🌍");
@@ -467,6 +500,7 @@ mod tests {
         assert_eq!(original.as_str(), deserialized.as_str());
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_round_trip_unpaired_surrogates() {
         // Create a string with unpaired surrogates
@@ -488,6 +522,7 @@ mod tests {
         assert_eq!(original.to_string_lossy(), deserialized.to_string_lossy());
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_round_trip_mixed_content() {
         // Create a complex string with normal text, emojis, and unpaired surrogates
@@ -504,6 +539,7 @@ mod tests {
         assert_eq!(original, deserialized);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_empty_string() {
         let atom = Wtf8Atom::new("");
@@ -514,6 +550,7 @@ mod tests {
         assert_eq!(deserialized.as_str(), Some(""));
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_special_characters() {
         let test_cases = vec![
@@ -533,6 +570,7 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_consecutive_surrogates_not_paired() {
         // Test that consecutive surrogates that don't form a valid pair
@@ -550,6 +588,7 @@ mod tests {
         assert_eq!(atom, deserialized);
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize_incomplete_escape() {
         // Test handling of incomplete escape sequences from our custom format
@@ -560,6 +599,7 @@ mod tests {
         assert_eq!(atom.as_str(), Some("\\u123"));
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_deserialize_invalid_hex() {
         // Test handling of invalid hex in escape sequences from our custom format
@@ -592,6 +632,7 @@ mod tests {
         assert_eq!(err_atom.to_string_lossy(), "\u{FFFD}");
     }
 
+    #[cfg(feature = "serde")]
     #[test]
     fn test_backslash_util_issue_11214() {
         let atom =

--- a/crates/swc_atoms/src/lib.rs
+++ b/crates/swc_atoms/src/lib.rs
@@ -13,7 +13,7 @@ use std::{
     borrow::{Borrow, Cow},
     cell::UnsafeCell,
     fmt::{self, Display, Formatter},
-    hash::Hash,
+    hash::{Hash, Hasher},
     mem::transmute,
     ops::Deref,
     rc::Rc,
@@ -33,10 +33,26 @@ mod wtf8_atom;
 ///
 ///
 /// See [tendril] for more details.
-#[derive(Clone, Default, PartialEq, Eq, Hash)]
+#[derive(Clone, Default)]
 #[cfg_attr(feature = "rkyv-impl", derive(bytecheck::CheckBytes))]
 #[repr(transparent)]
 pub struct Atom(hstr::Atom);
+
+impl PartialEq for Atom {
+    #[inline]
+    fn eq(&self, other: &Self) -> bool {
+        self.0 == other.0
+    }
+}
+
+impl Eq for Atom {}
+
+impl Hash for Atom {
+    #[inline]
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.0.hash(state);
+    }
+}
 
 #[cfg(feature = "encoding-impl")]
 impl cbor4ii::core::enc::Encode for Atom {
@@ -132,6 +148,7 @@ impl Deref for Atom {
 macro_rules! impl_eq {
     ($T:ty) => {
         impl PartialEq<$T> for Atom {
+            #[inline]
             fn eq(&self, other: &$T) -> bool {
                 &**self == &**other
             }
@@ -164,8 +181,9 @@ impl From<Atom> for hstr::Wtf8Atom {
 }
 
 impl PartialEq<str> for Atom {
+    #[inline]
     fn eq(&self, other: &str) -> bool {
-        &**self == other
+        self.0 == *other
     }
 }
 
@@ -260,8 +278,9 @@ macro_rules! lazy_atom {
 }
 
 impl PartialEq<Atom> for str {
+    #[inline]
     fn eq(&self, other: &Atom) -> bool {
-        *self == **other
+        *self == other.0
     }
 }
 
@@ -347,6 +366,30 @@ impl AtomStoreCell {
         // to use an UnsafeCell. Note the borrow here is short lived
         // only to this block.
         unsafe { (*self.0.get()).wtf8_atom(s) }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn equality_variants() {
+        assert_eq!(Atom::from("inline"), Atom::from("inline"));
+        assert_ne!(Atom::from("inline"), Atom::from("inlinf"));
+
+        let mut store = AtomStore::default();
+        let dynamic = store.atom("Hello, beautiful world!");
+        let dynamic_same_store_equal = store.atom("Hello, beautiful world!");
+
+        let mut other_store = AtomStore::default();
+        let dynamic_other_store_equal = other_store.atom("Hello, beautiful world!");
+        let dynamic_different = other_store.atom("Hello, different world!");
+
+        assert_eq!(dynamic, dynamic_same_store_equal);
+        assert_eq!(dynamic, dynamic_other_store_equal);
+        assert_ne!(dynamic, dynamic_different);
+        assert_eq!(dynamic, "Hello, beautiful world!");
     }
 }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

This PR optimizes `Atom` equality checks in `hstr` and `swc_atoms` without adding benchmark files.

Changes:

- Inline the `PartialEq` fast path for `hstr::Atom` and `Wtf8Atom` instead of forcing `#[inline(never)]`.
- Return `false` immediately for non-identical inline atoms, because inline atoms encode both length and bytes in the tagged value.
- Keep dynamic atom equality correct across different `AtomStore`s by preserving the hash + slice fallback.
- Hand-write `swc_atoms::Atom` `PartialEq` / `Hash` wrapper impls and inline wrapper equality helpers.
- Add equality coverage to existing unit tests.

Local CodSpeed simulation was used with a temporary equality benchmark before removing the benchmark from this PR. Representative results:

| Benchmark | Accesses | Δ | Estimated cycles | Δ |
|---|---:|---:|---:|---:|
| `hstr::Atom inline/equal` | 24 → 14 | -41.7% | 549 → 434 | -20.9% |
| `hstr::Atom inline/different` | 40 → 24 | -40.0% | 670 → 549 | -18.1% |
| `hstr::Atom dynamic/same-store/equal` | 24 → 14 | -41.7% | 549 → 434 | -20.9% |
| `hstr::Atom dynamic/other-store/equal` | 73 → 62 | -15.1% | 1438 → 1217 | -15.4% |
| `hstr::Atom dynamic/different` | 37 → 29 | -21.6% | 877 → 764 | -12.9% |
| `swc_atoms::Atom inline/equal` | 24 → 14 | -41.7% | 549 → 434 | -20.9% |
| `swc_atoms::Atom dynamic/other-store/equal` | 73 → 62 | -15.1% | 1753 → 1322 | -24.6% |
| `swc_atoms::Atom dynamic/equal-atom-macro` | 107 → 96 | -10.3% | 2102 → 1566 | -25.5% |

Validation:

- `git submodule update --init --recursive`
- `cargo fmt --all --check`
- `cargo test -p hstr`
- `cargo test -p hstr --features serde`
- `cargo test -p swc_atoms`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

No breaking change.

**Related issue (if exists):**

N/A
