### PR TITLE
fix(swc): preserve plugin error context

### DIFF
--- a/.changeset/plugin-error-context.md
+++ b/.changeset/plugin-error-context.md
@@ -1,5 +1,6 @@
 ---
 swc: patch
+swc_core: patch
 ---
 
 fix(swc): preserve plugin error context in diagnostics

--- a/.changeset/plugin-error-context.md
+++ b/.changeset/plugin-error-context.md
@@ -1,0 +1,5 @@
+---
+swc: patch
+---
+
+fix(swc): preserve plugin error context in diagnostics

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -201,10 +201,8 @@ impl Fold for RustPlugins {
             Ok(program) => program.expect_module(),
             Err(err) => {
                 HANDLER.with(|handler| {
-                    handler.err_with_code(
-                        &format_plugin_error(&err),
-                        DiagnosticId::Error("plugin".into()),
-                    );
+                    handler
+                        .err_with_code(&format!("{err:#}"), DiagnosticId::Error("plugin".into()));
                 });
                 Module::default()
             }
@@ -216,20 +214,13 @@ impl Fold for RustPlugins {
             Ok(program) => program.expect_script(),
             Err(err) => {
                 HANDLER.with(|handler| {
-                    handler.err_with_code(
-                        &format_plugin_error(&err),
-                        DiagnosticId::Error("plugin".into()),
-                    );
+                    handler
+                        .err_with_code(&format!("{err:#}"), DiagnosticId::Error("plugin".into()));
                 });
                 Script::default()
             }
         }
     }
-}
-
-#[cfg(feature = "plugin")]
-fn format_plugin_error(err: &anyhow::Error) -> String {
-    format!("{err:#}")
 }
 
 #[cfg(feature = "plugin")]
@@ -274,16 +265,4 @@ pub(crate) fn compile_wasm_plugins(
     }
 
     Ok(())
-}
-
-#[cfg(all(test, feature = "plugin"))]
-mod tests {
-    use super::format_plugin_error;
-
-    #[test]
-    fn plugin_error_includes_context_chain() {
-        let err = anyhow::anyhow!("root cause").context("outer context");
-
-        assert_eq!(format_plugin_error(&err), "outer context: root cause");
-    }
 }

--- a/crates/swc/src/plugin.rs
+++ b/crates/swc/src/plugin.rs
@@ -201,7 +201,10 @@ impl Fold for RustPlugins {
             Ok(program) => program.expect_module(),
             Err(err) => {
                 HANDLER.with(|handler| {
-                    handler.err_with_code(&err.to_string(), DiagnosticId::Error("plugin".into()));
+                    handler.err_with_code(
+                        &format_plugin_error(&err),
+                        DiagnosticId::Error("plugin".into()),
+                    );
                 });
                 Module::default()
             }
@@ -213,12 +216,20 @@ impl Fold for RustPlugins {
             Ok(program) => program.expect_script(),
             Err(err) => {
                 HANDLER.with(|handler| {
-                    handler.err_with_code(&err.to_string(), DiagnosticId::Error("plugin".into()));
+                    handler.err_with_code(
+                        &format_plugin_error(&err),
+                        DiagnosticId::Error("plugin".into()),
+                    );
                 });
                 Script::default()
             }
         }
     }
+}
+
+#[cfg(feature = "plugin")]
+fn format_plugin_error(err: &anyhow::Error) -> String {
+    format!("{err:#}")
 }
 
 #[cfg(feature = "plugin")]
@@ -263,4 +274,16 @@ pub(crate) fn compile_wasm_plugins(
     }
 
     Ok(())
+}
+
+#[cfg(all(test, feature = "plugin"))]
+mod tests {
+    use super::format_plugin_error;
+
+    #[test]
+    fn plugin_error_includes_context_chain() {
+        let err = anyhow::anyhow!("root cause").context("outer context");
+
+        assert_eq!(format_plugin_error(&err), "outer context: root cause");
+    }
 }


### PR DESCRIPTION
**Description:**

Preserve the full `anyhow` context chain when reporting SWC Wasm plugin transform failures.

Previously plugin errors were reported with `err.to_string()`, which only retained the outermost context. This made ABI/runtime failures hard to diagnose because the diagnostic that reaches consumers such as Rspack could stop at `failed to invoke plugin on ...`.

This now reports plugin errors with `format!("{err:#}")`, so the compact context chain is preserved.

**Error report comparison:**

For a plugin instantiation failure caused by a missing `env.__free` import:

Before:

```text
failed to invoke plugin on 'Some("src/index.jsx")'
```

After:

```text
failed to invoke plugin on 'Some("src/index.jsx")': failed to invoke `@swc/plugin-remove-console` as js transform plugin at @swc/plugin-remove-console: unknown import: `env::__free` has not been defined
```

**BREAKING CHANGE:**

None.

**Related issue (if exists):**
