### PR TITLE
fix(encoding)!: Fix incorrect fields count

### DIFF
--- a/.changeset/fix-encoding-ignored-field-count.md
+++ b/.changeset/fix-encoding-ignored-field-count.md
@@ -1,0 +1,6 @@
+---
+ast_node: major
+swc_core: major
+---
+
+fix(encoding): Correct field counts for ignored fields

--- a/crates/ast_node/src/encoding/decode.rs
+++ b/crates/ast_node/src/encoding/decode.rs
@@ -40,7 +40,11 @@ pub fn expand(DeriveInput { ident, data, .. }: DeriveInput) -> syn::ItemImpl {
                 syn::parse_quote! { #ident ( #(#names),* ) }
             };
 
-            let count = data.fields.len();
+            let count = data
+                .fields
+                .iter()
+                .filter(|field| !is_ignore(&field.attrs))
+                .count();
             let head: Option<syn::Stmt> = (count != 1).then(|| {
                 syn::parse_quote! {
                     let len = <cbor4ii::core::types::Array<()>>::len(reader)?.unwrap();
@@ -193,7 +197,7 @@ pub fn expand(DeriveInput { ident, data, .. }: DeriveInput) -> syn::ItemImpl {
                                     }
                                 })
                                 .collect::<Vec<_>>();
-                            let count = field.fields.len();
+                            let count = names.len();
 
                             let stmt = field.fields.iter()
                                 .zip(names.iter())

--- a/crates/ast_node/src/encoding/encode.rs
+++ b/crates/ast_node/src/encoding/encode.rs
@@ -28,8 +28,9 @@ pub fn expand(DeriveInput { ident, data, .. }: DeriveInput) -> syn::ItemImpl {
                             cbor4ii::core::enc::Encode::encode(&#fieldpath, writer)?;
                         },
                     }
-                });
-            let count = data.fields.len();
+                })
+                .collect::<Vec<_>>();
+            let count = fields.len();
             let head: Option<syn::Stmt> = (count != 1).then(|| {
                 syn::parse_quote! {
                     <cbor4ii::core::types::Array<()>>::bounded(#count, writer)?;


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Currently, our `encoding` mod does not correctly handle the `ignore` attr when get fields count.

**BREAKING CHANGE:**

This doesn't cause a problem now because both encode and decode use wrong count. However, it's important to note that this fix will result in a breaking change.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
