### PR TITLE
refactor(plugin): remove explicit env wasm import module

### DIFF
--- a/.changeset/remove-explicit-env-import-module.md
+++ b/.changeset/remove-explicit-env-import-module.md
@@ -1,0 +1,10 @@
+---
+swc_cli_impl: patch
+swc_common: patch
+swc_core: patch
+swc_plugin_macro: patch
+swc_plugin_proxy: patch
+swc_transform_common: patch
+---
+
+refactor(plugin): Remove explicit wasm env import module annotations

--- a/crates/swc_cli_impl/src/commands/plugin.rs
+++ b/crates/swc_cli_impl/src/commands/plugin.rs
@@ -194,7 +194,11 @@ build-wasm32 = "build --target wasm32-unknown-unknown"
 
 [target.'cfg(target_arch = "wasm32")']
 rustflags = [
-  "--cfg=swc_ast_unknown"
+  "--cfg=swc_ast_unknown",
+  # Keep host-provided plugin ABI functions as wasm imports without requiring
+  # every extern block to specify a wasm import module.
+  "-C",
+  "link-arg=--import-undefined",
 ]
 "#
             .as_bytes(),

--- a/crates/swc_common/src/syntax_pos.rs
+++ b/crates/swc_common/src/syntax_pos.rs
@@ -497,7 +497,6 @@ pub struct MultiSpan {
     span_labels: Vec<PrimarySpanLabel>,
 }
 
-#[cfg_attr(target_arch = "wasm32", link(wasm_import_module = "env"))]
 extern "C" {
     fn __span_dummy_with_cmt_proxy() -> u32;
 }

--- a/crates/swc_common/src/syntax_pos/hygiene.rs
+++ b/crates/swc_common/src/syntax_pos/hygiene.rs
@@ -119,7 +119,6 @@ pub struct MutableMarkContext(pub u32, pub u32, pub u32);
 // List of proxy calls injected by the host in the plugin's runtime context.
 // When related calls being executed inside of the plugin, it'll call these
 // proxies instead which'll call actual host fn.
-#[cfg_attr(target_arch = "wasm32", link(wasm_import_module = "env"))]
 extern "C" {
     // Instead of trying to copy-serialize `Mark`, this fn directly consume
     // inner raw value as well as fn and let each context constructs struct

--- a/crates/swc_plugin_backend_tests/tests/fixture/.cargo/config.toml
+++ b/crates/swc_plugin_backend_tests/tests/fixture/.cargo/config.toml
@@ -1,4 +1,8 @@
 [target.'cfg(target_arch = "wasm32")']
 rustflags = [
-  "--cfg=swc_ast_unknown"
+  "--cfg=swc_ast_unknown",
+  # Keep host-provided plugin ABI functions as wasm imports without requiring
+  # every extern block to specify a wasm import module.
+  "-C",
+  "link-arg=--import-undefined",
 ]

--- a/crates/swc_plugin_macro/src/lib.rs
+++ b/crates/swc_plugin_macro/src/lib.rs
@@ -31,7 +31,6 @@ fn handle_func(func: ItemFn, ast_type: Ident) -> TokenStream {
         // Declaration for imported function from swc host.
         // Refer swc_plugin_runner for the actual implementation.
         #[cfg(target_arch = "wasm32")] // Allow testing
-        #[link(wasm_import_module = "env")]
         extern "C" {
             fn __set_transform_result(bytes_ptr: u32, bytes_ptr_len: u32);
             fn __set_transform_plugin_core_pkg_diagnostics(bytes_ptr: u32, bytes_ptr_len: u32);

--- a/crates/swc_plugin_proxy/src/comments/plugin_comments_proxy.rs
+++ b/crates/swc_plugin_proxy/src/comments/plugin_comments_proxy.rs
@@ -14,7 +14,6 @@ use swc_trace_macro::swc_trace;
 use crate::memory_interop::read_returned_result_from_host;
 
 #[cfg(target_arch = "wasm32")]
-#[link(wasm_import_module = "env")]
 extern "C" {
     fn __copy_comment_to_host_env(bytes_ptr: u32, bytes_ptr_len: u32);
     fn __add_leading_comment_proxy(byte_pos: u32);

--- a/crates/swc_plugin_proxy/src/memory_interop/read_returned_result_from_host.rs
+++ b/crates/swc_plugin_proxy/src/memory_interop/read_returned_result_from_host.rs
@@ -6,7 +6,6 @@ use swc_common::plugin::serialized::PluginSerializedBytes;
 pub struct AllocatedBytesPtr(pub u32, pub u32);
 
 #[cfg(target_arch = "wasm32")]
-#[link(wasm_import_module = "env")]
 extern "C" {
     fn __free(ptr: *mut u8, size: i32) -> i32;
 }

--- a/crates/swc_plugin_proxy/src/metadata/transform_plugin_metadata.rs
+++ b/crates/swc_plugin_proxy/src/metadata/transform_plugin_metadata.rs
@@ -31,7 +31,6 @@ pub struct TransformPluginProgramMetadata {
 }
 
 #[cfg(target_arch = "wasm32")] // Allow testing
-#[link(wasm_import_module = "env")]
 extern "C" {
     fn __copy_context_key_to_host_env(bytes_ptr: u32, bytes_ptr_len: u32);
     fn __get_transform_plugin_config(allocated_ret_ptr: u32) -> u32;

--- a/crates/swc_plugin_proxy/src/source_map/plugin_source_map_proxy.rs
+++ b/crates/swc_plugin_proxy/src/source_map/plugin_source_map_proxy.rs
@@ -23,7 +23,6 @@ use swc_trace_macro::swc_trace;
 use crate::memory_interop::read_returned_result_from_host;
 
 #[cfg(target_arch = "wasm32")]
-#[link(wasm_import_module = "env")]
 extern "C" {
     fn __lookup_char_pos_source_map_proxy(
         byte_pos: u32,

--- a/crates/swc_transform_common/Cargo.toml
+++ b/crates/swc_transform_common/Cargo.toml
@@ -13,7 +13,7 @@ all-features = true
 rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
-plugin-mode = []
+plugin-mode = ["swc_common/plugin-mode"]
 
 [dependencies]
 rustc-hash = { workspace = true }

--- a/crates/swc_transform_common/src/output.rs
+++ b/crates/swc_transform_common/src/output.rs
@@ -21,7 +21,6 @@ pub fn capture<Ret>(f: impl FnOnce() -> Ret) -> (Ret, FxHashMap<String, String>)
 }
 
 #[cfg(all(feature = "plugin-mode", target_arch = "wasm32"))]
-#[link(wasm_import_module = "env")]
 extern "C" {
     fn __emit_output(output_ptr: u32, output_len: u32);
 }


### PR DESCRIPTION
**Description:**

Remove explicit `wasm_import_module = "env"` annotations from wasm plugin host imports. Host-provided plugin ABI functions are now kept as wasm imports through plugin build config using `-C link-arg=--import-undefined`, and `swc_transform_common/plugin-mode` now enables `swc_common/plugin-mode` for direct plugin-mode wasm checks.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.

**Verification:**

- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_common`
- `cargo test -p swc_plugin_proxy`
- `cargo test -p swc_plugin_macro`
- `cargo test -p swc_transform_common`
- `cargo test -p swc_cli_impl`
- `cargo check -p swc_common --features plugin-mode --target wasm32-unknown-unknown`
- `cargo check -p swc_plugin_proxy --features plugin-mode --target wasm32-unknown-unknown`
- `cargo check -p swc_transform_common --features plugin-mode --target wasm32-unknown-unknown`
- `cargo test -p swc_plugin_backend_tests --release`
