### PR TITLE
fix(plugin): avoid importing __free from env

### DIFF
--- a/.changeset/light-eagles-wish.md
+++ b/.changeset/light-eagles-wish.md
@@ -1,0 +1,7 @@
+---
+swc_common: major
+---
+
+fix(plugin): avoid importing __free from env
+
+Bumping swc_common to republish all crates

--- a/crates/swc_plugin_proxy/src/memory_interop/read_returned_result_from_host.rs
+++ b/crates/swc_plugin_proxy/src/memory_interop/read_returned_result_from_host.rs
@@ -6,7 +6,9 @@ use swc_common::plugin::serialized::PluginSerializedBytes;
 pub struct AllocatedBytesPtr(pub u32, pub u32);
 
 #[cfg(target_arch = "wasm32")]
-#[link(wasm_import_module = "env")]
+// `__free` is linked from `swc_core::plugin::memory`, which re-exports the
+// allocator shim from `swc_plugin::allocation`. It must stay a linked plugin
+// symbol instead of being modeled as an `env` host import.
 extern "C" {
     fn __free(ptr: *mut u8, size: i32) -> i32;
 }

--- a/crates/swc_plugin_runner/src/imported_fn/mod.rs
+++ b/crates/swc_plugin_runner/src/imported_fn/mod.rs
@@ -131,14 +131,6 @@ pub(crate) fn build_import_object(
         }
     }
 
-    // Guest proxies drop host-returned buffers through an imported `env::__free`.
-    // Route that import back to the instance's exported allocator shim.
-    let free_bytes = runtime::Func::from_fn(move |caller, [ptr, size]| {
-        [caller
-            .free(ptr as u32, size as u32)
-            .expect("should be able to free plugin memory") as i32]
-    });
-
     // core_diagnostics
     define!(fn set_plugin_core_pkg_diagnostics(env diagnostics_env, bytes_ptr, bytes_ptr_len));
 
@@ -195,7 +187,6 @@ pub(crate) fn build_import_object(
     define!(fn span_to_source_proxy(env source_map_host_env, span_lo, span_hi, allocated_ret_ptr) -> i32);
 
     [
-        ("__free", free_bytes),
         (
             "__set_transform_plugin_core_pkg_diagnostics",
             set_plugin_core_pkg_diagnostics,


### PR DESCRIPTION
**Description:**

- Treat `__free` in plugin memory interop as the linked allocator symbol from `swc_plugin::allocation`, not an `env` host import.
- Stop injecting `env::__free` from the Wasm plugin runtime import object.
- This fixes the regression from swc-project/swc#11783 where `__free` was accidentally treated like a dynamic host import.

**Related issue:**

Related to swc-project/swc#11783.

 - Closes https://github.com/swc-project/swc/issues/11907