### PR TITLE
fix(es/compat): rewrite this in destructuring defaults

### DIFF
--- a/.changeset/rewrite-this-destructuring-defaults.md
+++ b/.changeset/rewrite-this-destructuring-defaults.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_transformer: patch
+swc_ecma_transforms_compat: patch
+---
+
+fix(es2017): rewrite `this` in destructuring defaults for async class-field arrows

--- a/crates/swc_ecma_transformer/src/es2017/async_to_generator.rs
+++ b/crates/swc_ecma_transformer/src/es2017/async_to_generator.rs
@@ -933,6 +933,9 @@ fn replace_this_in_stmt(stmt: &mut Stmt, this_var: &Ident) {
         Stmt::Try(try_stmt) => {
             replace_this_in_stmts(&mut try_stmt.block.stmts, this_var);
             if let Some(handler) = &mut try_stmt.handler {
+                if let Some(param) = &mut handler.param {
+                    replace_this_in_pat_inner(param, this_var);
+                }
                 replace_this_in_stmts(&mut handler.body.stmts, this_var);
             }
             if let Some(finalizer) = &mut try_stmt.finalizer {
@@ -952,9 +955,7 @@ fn replace_this_in_stmt(stmt: &mut Stmt, this_var: &Ident) {
                 match init {
                     VarDeclOrExpr::VarDecl(var_decl) => {
                         for decl in &mut var_decl.decls {
-                            if let Some(init) = &mut decl.init {
-                                replace_this_in_expr(init, this_var);
-                            }
+                            replace_this_in_var_declarator(decl, this_var);
                         }
                     }
                     VarDeclOrExpr::Expr(expr) => {
@@ -976,16 +977,17 @@ fn replace_this_in_stmt(stmt: &mut Stmt, this_var: &Ident) {
             match &mut for_in.left {
                 ForHead::VarDecl(var_decl) => {
                     for decl in &mut var_decl.decls {
-                        if let Some(init) = &mut decl.init {
-                            replace_this_in_expr(init, this_var);
-                        }
+                        replace_this_in_var_declarator(decl, this_var);
                     }
                 }
-                ForHead::Pat(_pat) => {
-                    // Patterns in for-in don't need traversal as they're
-                    // binding patterns
+                ForHead::Pat(pat) => {
+                    replace_this_in_pat_inner(pat, this_var);
                 }
-                ForHead::UsingDecl(_) => {}
+                ForHead::UsingDecl(using_decl) => {
+                    for decl in &mut using_decl.decls {
+                        replace_this_in_var_declarator(decl, this_var);
+                    }
+                }
                 #[cfg(swc_ast_unknown)]
                 _ => {}
             }
@@ -996,16 +998,17 @@ fn replace_this_in_stmt(stmt: &mut Stmt, this_var: &Ident) {
             match &mut for_of.left {
                 ForHead::VarDecl(var_decl) => {
                     for decl in &mut var_decl.decls {
-                        if let Some(init) = &mut decl.init {
-                            replace_this_in_expr(init, this_var);
-                        }
+                        replace_this_in_var_declarator(decl, this_var);
                     }
                 }
-                ForHead::Pat(_pat) => {
-                    // Patterns in for-of don't need traversal as they're
-                    // binding patterns
+                ForHead::Pat(pat) => {
+                    replace_this_in_pat_inner(pat, this_var);
                 }
-                ForHead::UsingDecl(_) => {}
+                ForHead::UsingDecl(using_decl) => {
+                    for decl in &mut using_decl.decls {
+                        replace_this_in_var_declarator(decl, this_var);
+                    }
+                }
                 #[cfg(swc_ast_unknown)]
                 _ => {}
             }
@@ -1018,7 +1021,6 @@ fn replace_this_in_stmt(stmt: &mut Stmt, this_var: &Ident) {
         Stmt::Decl(decl) => match decl {
             Decl::Class(_)
             | Decl::Fn(_)
-            | Decl::Using(_)
             | Decl::TsInterface(_)
             | Decl::TsTypeAlias(_)
             | Decl::TsEnum(_)
@@ -1027,9 +1029,12 @@ fn replace_this_in_stmt(stmt: &mut Stmt, this_var: &Ident) {
             }
             Decl::Var(var_decl) => {
                 for decl in &mut var_decl.decls {
-                    if let Some(init) = &mut decl.init {
-                        replace_this_in_expr(init, this_var);
-                    }
+                    replace_this_in_var_declarator(decl, this_var);
+                }
+            }
+            Decl::Using(using_decl) => {
+                for decl in &mut using_decl.decls {
+                    replace_this_in_var_declarator(decl, this_var);
                 }
             }
             #[cfg(swc_ast_unknown)]
@@ -1252,6 +1257,15 @@ fn replace_this_in_opt_chain_base(base: &mut OptChainBase, this_var: &Ident) {
     }
 }
 
+/// Replaces `this` in variable declarator initializers and binding-pattern
+/// default values after an async arrow body is moved into a generator function.
+fn replace_this_in_var_declarator(decl: &mut VarDeclarator, this_var: &Ident) {
+    replace_this_in_pat_inner(&mut decl.name, this_var);
+    if let Some(init) = &mut decl.init {
+        replace_this_in_expr(init, this_var);
+    }
+}
+
 fn replace_this_in_pat(pat: &mut AssignTargetPat, this_var: &Ident) {
     match pat {
         AssignTargetPat::Array(array) => {
@@ -1323,8 +1337,11 @@ fn replace_this_in_pat_inner(pat: &mut Pat, this_var: &Ident) {
         Pat::Rest(rest) => {
             replace_this_in_pat_inner(&mut rest.arg, this_var);
         }
+        Pat::Expr(expr) => {
+            replace_this_in_expr(expr, this_var);
+        }
         // Don't need to traverse these as they're just identifiers or invalid
-        Pat::Ident(_) | Pat::Invalid(_) | Pat::Expr(_) => {}
+        Pat::Ident(_) | Pat::Invalid(_) => {}
         #[cfg(swc_ast_unknown)]
         _ => {}
     }

--- a/crates/swc_ecma_transforms_compat/tests/async-to-generator/this-in-destructuring-default-class-field/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/async-to-generator/this-in-destructuring-default-class-field/input.js
@@ -1,0 +1,14 @@
+class Base {
+    setState(value) {
+        return value;
+    }
+}
+
+class Derived extends Base {
+    state = { value: 1 };
+
+    method = async (param) => {
+        const { state = this.state } = param;
+        return this.setState(state);
+    };
+}

--- a/crates/swc_ecma_transforms_compat/tests/async-to-generator/this-in-destructuring-default-class-field/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/async-to-generator/this-in-destructuring-default-class-field/output.js
@@ -1,0 +1,16 @@
+class Base {
+    setState(value) {
+        return value;
+    }
+}
+class Derived extends Base {
+    constructor(...args){
+        var _this;
+        super(...args), _this = this, _define_property(this, "state", {
+            value: 1
+        }), _define_property(this, "method", (param)=>_async_to_generator(function*() {
+                const { state = _this.state } = param;
+                return _this.setState(state);
+            })());
+    }
+}

--- a/crates/swc_ecma_transforms_compat/tests/es2017_async_to_generator.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2017_async_to_generator.rs
@@ -12,7 +12,7 @@ use swc_ecma_transforms_compat::{
     es2017::async_to_generator,
     es2022::class_properties,
 };
-use swc_ecma_transforms_testing::{compare_stdout, test, test_exec};
+use swc_ecma_transforms_testing::{compare_stdout, test, test_exec, test_fixture};
 use swc_ecma_visit::{fold_pass, Fold, FoldWith};
 
 struct ParenRemover;
@@ -2102,6 +2102,26 @@ class Foo extends Bar {
 }
 "#
 );
+
+#[testing::fixture("tests/async-to-generator/**/input.js")]
+fn fixture(input: PathBuf) {
+    test_fixture(
+        Default::default(),
+        &|_| {
+            let unresolved_mark = Mark::new();
+            let top_level_mark = Mark::new();
+
+            (
+                resolver(unresolved_mark, top_level_mark, false),
+                class_properties(Default::default(), unresolved_mark),
+                async_to_generator(Default::default(), unresolved_mark),
+            )
+        },
+        &input,
+        &input.with_file_name("output.js"),
+        Default::default(),
+    );
+}
 
 #[testing::fixture("tests/async-to-generator/**/exec.js")]
 fn exec(input: PathBuf) {


### PR DESCRIPTION
## Summary

Fix async-to-generator so `this` inside destructuring defaults in async arrow class fields is rewritten to the hoisted `_this` binding.

## Origin issue case

Repro playground case: https://play.swc.rs/?version=1.15.40&code=H4sIAAAAAAAAA61Uy27bMBC8%2BysWvkRCa6Up0IuNBGgSt02bxkWc9Box0spmI5EuScU2DAP9iH5hv6RDKrLzQk7RxTC5Ozs7O9yd2jJZZ2Tmdga0u0uGRUmVzuuSLQnTXlI0HH%2BPB%2BSm4UQsKXVTaVO65kxXCE1rlXMhFecp7R8gzui57QBw%2FxU%2Fj2fnGaWGZ6XI%2BMpzuJLqihczAy71hP79%2BdtSk8rKnElQzqBcZ642Uk3wrxB16UgXJJRHFHapMvQKxnR0%2BnE8pk8nw9Nj5CP3eHh%2B8nN4TFkprCVp6Wx0AZHmRjrHipymNLBIEw91Xqsg0XUtyxyQThYC4uXScObKJc2lm1KqdM6pT0UbBlJnHJIuljMegoXxUAGNf9fItHQ4uvhCUF3ZQpsKc8mcvOW%2BjyHqbW96oZWe070JKzbCafM0JnTSQ%2BEZgx%2FQiSJOJgn9slnihJmw61OX7ft3ex%2B68auPsBHyUMB3qw6RZTd2wnG0iGkFQTAkRYsBrTvrThuLsfICauf383wS7SPnVpQ192mP1gOcg%2B7h5ed%2B44EkRHknBIGf9wFilrb1TNQ7oI2TSTgytXKy4hjQFbupzlGzMUw0E0ZUsXe7J0SUaWUdCLXUtgxojb8hfBAi79psAloBQiSeWOjBX5FWTCdj4Jo7%2BzzwXbAd4ND2RqrRzSOl6N4HWFB0Rpf9tl2tgBp8rmANvPxAomLlCEJsy42%2BvSD5Y12eSGIfiPGSBPFg0xDY9vwHh5RFD2NQfmjti3FSq%2Ba%2B01QtatUcVkIqUPD1m%2Br6xlObC%2BlI8RwSRXHSUI5COR%2BlS05KPYm6dwIRwjZB%2Fv0cdN%2FS1%2FHoLPHrUE1ksYz0TdxOa9UNinT7e2sAOrN80L55UB9u3hJYrTcQa6%2Fa8w4twhLY9wMRmOxWyk2RDX%2Bg38O%2BUxlOjs5G%2Fl3E%2Fad9mLhRnTLhsil2QXyPvQdmv5Oi7vnwx%2Fno%2BPIIyzDIwUloz9PFylKiYnpDXawO%2FDBIWCsmHDfTxtAyHCS8kO4I2w%2BK7IWimHQzsEHnP2LBffKLBgAA&config=H4sIAAAAAAAAA02OSQ7CMAxF95yiyrqRgAUL7sAJEAsrdUtRJtkuoqp6dzJQIIvI%2Fnn5esuuSUc92KhzszQqAjFSnXn2Aq80KzQO2NAYRbUZzmEPlrFZ025DYPxLaqUL3WSxNskcsfTwSX2BkS8bIjThJ0X%2FzH%2FKkiFv7NRl5qqEwHMfyGlIakZL0AN6JJBA2ev3biww60ghIsmIrG7tVihAAwpXL3On4IrZ4bhPZgXK9%2FoGBgwLNRgBAAA%3D

## Root cause

When the async arrow body is moved into a generator function, the constructor-context `this` rewrite only walked initializer expressions. It skipped binding-pattern defaults inside variable declarators, so nested `this` references survived and became `undefined` at runtime.

## Validation

- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo test -p swc_ecma_transformer`
- `cargo test -p swc_ecma_transforms_compat`
- `cargo clippy --all --all-targets -- -D warnings`