### PR TITLE
fix(es/renamer): Avoid duplicate mangled names across eval scope boundaries

### DIFF
--- a/.changeset/renamer-eval-mangle-collision.md
+++ b/.changeset/renamer-eval-mangle-collision.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_base: patch
+---
+
+fix(es/renamer): Avoid duplicate mangled names across eval scope boundaries

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -12349,3 +12349,144 @@ console.log(out.poisoned);
 
     run_default_exec_test(src);
 }
+
+#[test]
+fn issue_11294_eval_mangle_no_collision() {
+    // Regression test for #11294.
+    //
+    // The compressor's scalar replacement rewrites `var x = { ids: [] }; x.ids`
+    // into a synthetic `var x_ids = []` whose binding isn't covered by the
+    // mangler's `eval` bypass. With `eval` present, the top-level map and the
+    // eval-free callback's per-unit map were built with independent reverse
+    // maps, so both reused the same Base54 names and collided. This input both
+    // triggers the scalar replacement (vars inside the `if` block) and contains
+    // `eval`, so a regression reintroduces the collision and breaks runtime.
+    let src = r#"
+var out = function (chart) {
+    var result = "";
+    if (chart.series) {
+        var first = { ids: [] };
+        var second = { ids: [] };
+        chart.series.forEach(function (item) {
+            var id = item.split("-")[2];
+            first.ids.push(id);
+            second.ids.push(id);
+        });
+        result = first.ids.join(",") + "|" + second.ids.join(",");
+    }
+    eval("");
+    return result;
+}({ series: ["a-b-1", "a-b-2", "a-b-3"] });
+console.log(out);
+"#;
+    let config = r#"{
+        "defaults": true,
+        "toplevel": true
+    }"#;
+
+    let expected_output = stdout_of(src).unwrap();
+
+    testing::run_test2(false, |cm, handler| {
+        let _tracing = span!(Level::ERROR, "compress-and-mangle").entered();
+
+        let output = run(
+            cm.clone(),
+            &handler,
+            src,
+            Some(config),
+            Some(MangleOptions {
+                top_level: Some(true),
+                ..Default::default()
+            }),
+        );
+
+        let output = output.expect("Parsing in base test should not fail");
+        let output = print(cm, &[&output], true, false);
+
+        eprintln!(
+            "---- {} -----\n{}",
+            Color::Green.paint("Optimized code"),
+            output
+        );
+
+        let actual_output = stdout_of(&output).expect("failed to execute the optimized code");
+        assert_ne!(actual_output, "");
+
+        assert_eq!(
+            DebugUsingDisplay(&actual_output),
+            DebugUsingDisplay(&expected_output)
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}
+
+#[test]
+fn issue_11294_eval_mangle_no_collision_nested() {
+    // Same root cause as `issue_11294_eval_mangle_no_collision`, but with
+    // nested callbacks (a `forEach` inside another `forEach`), exercising
+    // several levels of per-unit maps that all must avoid the names assigned
+    // by the top-level map under `eval`.
+    let src = r#"
+var out = function (data) {
+    var result = "";
+    if (data.rows) {
+        var collected = { ids: [] };
+        var mirror = { ids: [] };
+        data.rows.forEach(function (row) {
+            row.forEach(function (cell) {
+                var doubled = cell * 2;
+                collected.ids.push(doubled);
+                mirror.ids.push(doubled);
+            });
+        });
+        result = collected.ids.join(",") + "|" + mirror.ids.join(",");
+    }
+    eval("");
+    return result;
+}({ rows: [[1, 2], [3, 4]] });
+console.log(out);
+"#;
+    let config = r#"{
+        "defaults": true,
+        "toplevel": true
+    }"#;
+
+    let expected_output = stdout_of(src).unwrap();
+
+    testing::run_test2(false, |cm, handler| {
+        let _tracing = span!(Level::ERROR, "compress-and-mangle").entered();
+
+        let output = run(
+            cm.clone(),
+            &handler,
+            src,
+            Some(config),
+            Some(MangleOptions {
+                top_level: Some(true),
+                ..Default::default()
+            }),
+        );
+
+        let output = output.expect("Parsing in base test should not fail");
+        let output = print(cm, &[&output], true, false);
+
+        eprintln!(
+            "---- {} -----\n{}",
+            Color::Green.paint("Optimized code"),
+            output
+        );
+
+        let actual_output = stdout_of(&output).expect("failed to execute the optimized code");
+        assert_ne!(actual_output, "");
+
+        assert_eq!(
+            DebugUsingDisplay(&actual_output),
+            DebugUsingDisplay(&expected_output)
+        );
+
+        Ok(())
+    })
+    .unwrap();
+}

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -80,6 +80,7 @@ where
         unresolved: Default::default(),
         previous_cache: Default::default(),
         total_map: None,
+        eval_reserved_targets: Default::default(),
         marker: std::marker::PhantomData::<Atom>,
     })
 }
@@ -98,6 +99,7 @@ where
         unresolved: Default::default(),
         previous_cache: Default::default(),
         total_map: None,
+        eval_reserved_targets: Default::default(),
         marker: std::marker::PhantomData::<Id>,
     })
 }
@@ -187,6 +189,16 @@ where
     /// [Some] if the [`Renamer::get_cached`] returns [Some].
     total_map: Option<FxHashMap<Id, V>>,
 
+    /// Mangled names assigned by the top-level map when `eval` is present.
+    ///
+    /// With `eval`, the top-level scope and each eval-free nested function are
+    /// renamed in separate `get_map` calls, each with its own fresh
+    /// `ReverseMap`. Without sharing the already-assigned names, a nested
+    /// function could pick a Base54 name already used at the top level,
+    /// producing a collision (#11294). These are fed as reserved symbols to
+    /// the per-unit maps.
+    eval_reserved_targets: FxHashSet<Atom>,
+
     marker: std::marker::PhantomData<V>,
 }
 
@@ -238,6 +250,15 @@ where
             }
         }
 
+        // When `eval` is present, per-unit maps must avoid the names already
+        // assigned by the top-level map, since each map is built with an
+        // independent `ReverseMap`. See #11294.
+        if !top_level && !self.eval_reserved_targets.is_empty() {
+            unresolved
+                .to_mut()
+                .extend(self.eval_reserved_targets.iter().cloned());
+        }
+
         let mut map = FxHashMap::<Id, V>::default();
 
         if R::MANGLE {
@@ -261,6 +282,13 @@ where
                 &self.preserved,
                 &unresolved,
             );
+        }
+
+        // Remember the names assigned at the top level so that per-unit maps
+        // computed for eval-free nested functions can avoid them. Only needed
+        // on the split-map path that `eval` forces. See #11294.
+        if R::MANGLE && top_level && has_eval {
+            self.eval_reserved_targets = map.values().map(|v| v.atom().clone()).collect();
         }
 
         if let Some(total_map) = &mut self.total_map {


### PR DESCRIPTION
**Description:**

`mangle` produces colliding identifiers when `eval` is present in a function, which breaks the program at runtime.

When `eval` exists, the renamer can't mangle the whole program at once: it builds the top-level map first, renames eval-free nested functions per-unit, and applies the top-level map last. Each `get_map` call built its mangle map with a fresh `ReverseMap`, so a per-unit map for a nested function could reuse a Base54 name already assigned by the top-level map.

This becomes observable together with the compressor's scalar replacement, which rewrites `var x = { p: [] }; x.p.push(...)` into a synthetic `var x_p = []; x_p.push(...)`. The synthetic binding isn't covered by the `eval` bypass, so it lands in the top-level map and collides with the names chosen independently for an eval-free callback.

I considered fixing this in the compressor (skipping scalar replacement when `eval` is in scope), but that trades away an optimization and has a wider regression surface. Instead the fix is in the renamer: the rename pass records the names assigned by the top-level map and feeds them as reserved symbols to the per-unit maps, so their encoders skip names already in use. The reserved set is only populated on the `eval` path, so non-eval programs are unaffected.

Verified with two `exec` (runtime) tests that run compress + mangle together and compare stdout — the base repro and a nested-callback variant. Both fail without the fix (the collided output throws at runtime) and pass with it.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Closes #11294
