### PR TITLE
fix(es/decorators): handle import types in decorator metadata

### DIFF
--- a/.changeset/handle-decorator-import-types.md
+++ b/.changeset/handle-decorator-import-types.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_transforms: patch
+swc_ecma_transforms_proposal: patch
+---
+
+fix(es/decorators): Handle import types in decorator metadata

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/bigint-literal/input.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/bigint-literal/input.ts
@@ -1,0 +1,6 @@
+function dec(target: any, key: string) {}
+
+export class Counter {
+    @dec
+    value!: 1n;
+}

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/bigint-literal/output.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/bigint-literal/output.ts
@@ -1,0 +1,8 @@
+function dec(target: any, key: string) {}
+export class Counter {
+    value!: 1n;
+}
+_ts_decorate([
+    dec,
+    _ts_metadata("design:type", typeof BigInt === "undefined" ? Object : BigInt)
+], Counter.prototype, "value", void 0);

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/constructor/input.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/constructor/input.ts
@@ -1,0 +1,10 @@
+function dec(target: Function) {}
+
+@dec
+export class Channel {
+    constructor(
+        msg: import("./Message").Message,
+        module: import("./Message"),
+        box: import("./Message").Box<import("./Payload").Payload>
+    ) {}
+}

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/constructor/output.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/constructor/output.ts
@@ -1,0 +1,13 @@
+function dec(target: Function) {}
+export class Channel {
+    constructor(msg: import("./Message").Message, module: import("./Message"), box: import("./Message").Box<import("./Payload").Payload>){}
+}
+Channel = _ts_decorate([
+    dec,
+    _ts_metadata("design:type", Function),
+    _ts_metadata("design:paramtypes", [
+        Object,
+        Object,
+        Object
+    ])
+], Channel);

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/method/input.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/method/input.ts
@@ -1,0 +1,10 @@
+function dec(target: any, key: string, descriptor: PropertyDescriptor) {}
+
+export class Channel {
+    @dec
+    send(
+        msg: import("./Message").Message,
+        module: import("./Message"),
+        union: import("./Message").Message | number
+    ): import("./Result").Result {}
+}

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/method/output.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/method/output.ts
@@ -1,0 +1,14 @@
+function dec(target: any, key: string, descriptor: PropertyDescriptor) {}
+export class Channel {
+    send(msg: import("./Message").Message, module: import("./Message"), union: import("./Message").Message | number): import("./Result").Result {}
+}
+_ts_decorate([
+    dec,
+    _ts_metadata("design:type", Function),
+    _ts_metadata("design:paramtypes", [
+        Object,
+        Object,
+        Object
+    ]),
+    _ts_metadata("design:returntype", Object)
+], Channel.prototype, "send", null);

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/property/input.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/property/input.ts
@@ -1,0 +1,21 @@
+function dec(target: any, key: string) {}
+
+export class Channel {
+    @dec
+    msg!: import("./Message").Message;
+
+    @dec
+    module!: import("./Message");
+
+    @dec
+    parenthesized!: (import("./Message").Message);
+
+    @dec
+    generic!: import("./Message").Box<import("./Payload").Payload>;
+
+    @dec
+    union!: import("./Message").Message | string;
+
+    @dec
+    intersection!: import("./Message").Message & { id: string };
+}

--- a/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/property/output.ts
+++ b/crates/swc_ecma_transforms/tests/fixture/legacy-metadata/issues/11915/property/output.ts
@@ -1,0 +1,35 @@
+function dec(target: any, key: string) {}
+export class Channel {
+    msg!: import("./Message").Message;
+    module!: import("./Message");
+    parenthesized!: (import("./Message").Message);
+    generic!: import("./Message").Box<import("./Payload").Payload>;
+    union!: import("./Message").Message | string;
+    intersection!: import("./Message").Message & {
+        id: string;
+    };
+}
+_ts_decorate([
+    dec,
+    _ts_metadata("design:type", Object)
+], Channel.prototype, "msg", void 0);
+_ts_decorate([
+    dec,
+    _ts_metadata("design:type", Object)
+], Channel.prototype, "module", void 0);
+_ts_decorate([
+    dec,
+    _ts_metadata("design:type", Object)
+], Channel.prototype, "parenthesized", void 0);
+_ts_decorate([
+    dec,
+    _ts_metadata("design:type", Object)
+], Channel.prototype, "generic", void 0);
+_ts_decorate([
+    dec,
+    _ts_metadata("design:type", Object)
+], Channel.prototype, "union", void 0);
+_ts_decorate([
+    dec,
+    _ts_metadata("design:type", Object)
+], Channel.prototype, "intersection", void 0);

--- a/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorators/legacy/metadata.rs
@@ -368,6 +368,16 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
         }
     }
 
+    fn serialize_bigint_type() -> Expr {
+        CondExpr {
+            span: DUMMY_SP,
+            test: check_object_existed(quote_ident!("BigInt").into()),
+            cons: quote_ident!("Object").into(),
+            alt: quote_ident!("BigInt").into(),
+        }
+        .into()
+    }
+
     fn serialize_type_ref(class_name: &str, ty: &TsTypeRef) -> Expr {
         match &ty.type_name {
             // We should omit references to self (class) since it will throw a ReferenceError at
@@ -517,21 +527,14 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
                 ..
             }) => quote_ident!("Number").into(),
 
-            TsType::TsKeywordType(TsKeywordType {
+            TsType::TsLitType(TsLitType {
+                lit: TsLit::BigInt(..),
+                ..
+            })
+            | TsType::TsKeywordType(TsKeywordType {
                 kind: TsKeywordTypeKind::TsBigIntKeyword,
                 ..
-            }) => CondExpr {
-                span: DUMMY_SP,
-                test: check_object_existed(quote_ident!("BigInt").into()),
-                cons: quote_ident!("Object").into(),
-                alt: quote_ident!("BigInt").into(),
-            }
-            .into(),
-
-            TsType::TsLitType(ty) => {
-                // TODO: Proper error reporting
-                panic!("Bad type for decoration: {ty:?}");
-            }
+            }) => serialize_bigint_type(),
 
             TsType::TsKeywordType(TsKeywordType {
                 kind: TsKeywordTypeKind::TsSymbolKeyword,
@@ -551,7 +554,8 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
                 kind: TsKeywordTypeKind::TsUnknownKeyword,
                 ..
             })
-            | TsType::TsThisType(..) => quote_ident!("Object").into(),
+            | TsType::TsThisType(..)
+            | TsType::TsImportType(_) => quote_ident!("Object").into(),
 
             TsType::TsUnionOrIntersectionType(ty) => match ty {
                 TsUnionOrIntersectionType::TsUnionType(ty) => {
@@ -570,7 +574,7 @@ fn serialize_type(class_name: Option<&Ident>, param: Option<&TsTypeAnn>) -> Expr
 
             TsType::TsTypeRef(ty) => serialize_type_ref(class_name, ty),
 
-            _ => panic!("Bad type for decorator: {ty:?}"),
+            _ => quote_ident!("Object").into(),
         }
     }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fixes a legacy decorator metadata panic when a decorated TypeScript member uses an inline import type such as `import("./Message").Message`.

The metadata serializer now treats `TsImportType` as an unresolvable transpile-only type and emits `Object`, matching TypeScript's runtime metadata behavior. The catch-all serializer path also falls back to `Object` instead of panicking on well-formed TS type nodes, and bigint literal metadata now follows the existing `BigInt` constructor fallback.

Added legacy metadata fixtures for import types on properties, methods, constructors, parenthesized/generic/union/intersection forms, and bigint literal metadata.

Validation:
- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_transforms --all-features --test decorators legacy_metadata_tests__fixture__legacy_metadata__issues__11915 -- --include-ignored`
- `cargo test -p swc_ecma_transforms --all-features --test decorators legacy_metadata_tests__fixture__legacy_metadata__issues__11915 -- --include-ignored`
- `cargo test -p swc_ecma_transforms --all-features --test decorators legacy_metadata_tests -- --include-ignored`
- `cargo test -p swc_ecma_transforms_proposal`
- `cargo test -p swc_ecma_transforms`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

Note: `cargo test -p swc_ecma_transforms --all-features` was also attempted locally, but exec tests requiring `mocha` could not run because `mocha` is not installed on PATH in this environment.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Closes #11915
