### PR TITLE
fix(swc_common): Fix sourcemap panic for multibyte mapping positions

### DIFF
--- a/.changeset/fix-sourcemap-multibyte-mapping.md
+++ b/.changeset/fix-sourcemap-multibyte-mapping.md
@@ -1,0 +1,6 @@
+---
+swc_common: patch
+swc_core: patch
+---
+
+fix(common): Clamp sourcemap mappings inside UTF-8 characters

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1244,6 +1244,35 @@ fn calc_utf16_offset(file: &SourceFile, bpos: BytePos, state: &mut ByteToCharPos
     total_extra_bytes
 }
 
+/// Source map producers can occasionally point a generated mapping at a byte
+/// inside a UTF-8 character. Source map columns are character-based, so treat
+/// that mapping as pointing at the character start before calculating columns.
+#[cfg(feature = "sourcemap")]
+fn normalize_sourcemap_pos(file: &SourceFile, pos: BytePos) -> BytePos {
+    let mbcs = &file.analyze().multibyte_chars;
+    if mbcs.is_empty() {
+        return pos;
+    }
+
+    let index = match mbcs.binary_search_by(|mbc| mbc.pos.cmp(&pos)) {
+        Ok(_) | Err(0) => return pos,
+        Err(index) => index - 1,
+    };
+    let mbc = &mbcs[index];
+    let mbc_end = mbc.pos + BytePos(mbc.bytes as u32);
+
+    if pos < mbc_end {
+        debug!(
+            "clamping sourcemap byte position inside multibyte char: bpos = {:?}, mbc.pos = {:?}, \
+             mbc.bytes = {:?}",
+            pos, mbc.pos, mbc.bytes
+        );
+        return mbc.pos;
+    }
+
+    pos
+}
+
 pub trait Files {
     /// This function is called to change the [BytePos] in AST into an unmapped,
     /// real value.
@@ -1367,6 +1396,7 @@ pub fn build_source_map(
             continue;
         }
 
+        let pos = normalize_sourcemap_pos(f, pos);
         let emit_columns = config.emit_columns(&f.name);
 
         if !emit_columns && lc.line == prev_dst_line {
@@ -1836,6 +1866,42 @@ mod tests {
 
             assert_eq!(actual, cpos.to_u32());
         }
+    }
+
+    #[cfg(feature = "sourcemap")]
+    #[test]
+    fn source_map_clamps_mappings_inside_multibyte_chars() {
+        let input = "// ┌\nconst emoji = '💩';\n";
+        let sm = SourceMap::new(FilePathMapping::empty());
+        let file = sm.new_source_file(Lrc::new(PathBuf::from("multibyte.js").into()), input);
+
+        let box_drawing_start = input.find('┌').unwrap() as u32;
+        let emoji_start = input.find('💩').unwrap() as u32;
+        let mappings = [
+            (
+                file.start_pos + BytePos(box_drawing_start + 1),
+                LineCol { line: 0, col: 0 },
+            ),
+            (
+                file.start_pos + BytePos(emoji_start + 2),
+                LineCol { line: 1, col: 0 },
+            ),
+        ];
+
+        let map = sm.build_source_map(&mappings, None, DefaultSourceMapGenConfig);
+        let tokens = map
+            .tokens()
+            .map(|token| {
+                (
+                    token.get_dst_line(),
+                    token.get_dst_col(),
+                    token.get_src_line(),
+                    token.get_src_col(),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(tokens, vec![(0, 0, 0, 3), (1, 0, 1, 15)]);
     }
 
     #[test]


### PR DESCRIPTION
**Description:**

This makes source map generation robust when a raw mapping points inside a UTF-8 multibyte character. The builder now normalizes such positions to the start of the character before calculating UTF-16 source columns, so assertion-enabled builds do not panic on mappings like the MUI box-drawing comment case seen in Next.js CI.

The existing `calc_utf16_offset` assertions are kept intact; only the source map builder input is normalized. The regression test covers both a 3-byte box-drawing character and a 4-byte emoji interior byte position, and verifies that emitted source columns point at the character start.

Validation:

- `git submodule update --init --recursive`
- `cargo test -p swc_common --features sourcemap source_map_clamps_mappings_inside_multibyte_chars`
- `cargo test -p swc_common source_map`
- `cargo test -p swc_common`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- Next.js PR 94157 scratch checkout: rebuilt assertion native with patched `swc_common 21.0.1`, then `material-ui.test.ts` dev-webpack e2e passed without the `BytePos(658)` panic.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A
