### PR TITLE
revert(swc_common): Revert sourcemap multibyte mapping clamp

### DIFF
--- a/.changeset/fix-sourcemap-multibyte-mapping.md
+++ b/.changeset/fix-sourcemap-multibyte-mapping.md
@@ -1,6 +1,0 @@
----
-swc_common: patch
-swc_core: patch
----
-
-fix(common): Clamp sourcemap mappings inside UTF-8 characters

--- a/.changeset/revert-sourcemap-multibyte-clamp.md
+++ b/.changeset/revert-sourcemap-multibyte-clamp.md
@@ -1,0 +1,6 @@
+---
+swc_common: patch
+swc_core: patch
+---
+
+fix(common): Revert sourcemap multibyte mapping clamp

--- a/crates/swc_common/src/source_map.rs
+++ b/crates/swc_common/src/source_map.rs
@@ -1244,35 +1244,6 @@ fn calc_utf16_offset(file: &SourceFile, bpos: BytePos, state: &mut ByteToCharPos
     total_extra_bytes
 }
 
-/// Source map producers can occasionally point a generated mapping at a byte
-/// inside a UTF-8 character. Source map columns are character-based, so treat
-/// that mapping as pointing at the character start before calculating columns.
-#[cfg(feature = "sourcemap")]
-fn normalize_sourcemap_pos(file: &SourceFile, pos: BytePos) -> BytePos {
-    let mbcs = &file.analyze().multibyte_chars;
-    if mbcs.is_empty() {
-        return pos;
-    }
-
-    let index = match mbcs.binary_search_by(|mbc| mbc.pos.cmp(&pos)) {
-        Ok(_) | Err(0) => return pos,
-        Err(index) => index - 1,
-    };
-    let mbc = &mbcs[index];
-    let mbc_end = mbc.pos + BytePos(mbc.bytes as u32);
-
-    if pos < mbc_end {
-        debug!(
-            "clamping sourcemap byte position inside multibyte char: bpos = {:?}, mbc.pos = {:?}, \
-             mbc.bytes = {:?}",
-            pos, mbc.pos, mbc.bytes
-        );
-        return mbc.pos;
-    }
-
-    pos
-}
-
 pub trait Files {
     /// This function is called to change the [BytePos] in AST into an unmapped,
     /// real value.
@@ -1396,7 +1367,6 @@ pub fn build_source_map(
             continue;
         }
 
-        let pos = normalize_sourcemap_pos(f, pos);
         let emit_columns = config.emit_columns(&f.name);
 
         if !emit_columns && lc.line == prev_dst_line {
@@ -1866,42 +1836,6 @@ mod tests {
 
             assert_eq!(actual, cpos.to_u32());
         }
-    }
-
-    #[cfg(feature = "sourcemap")]
-    #[test]
-    fn source_map_clamps_mappings_inside_multibyte_chars() {
-        let input = "// ┌\nconst emoji = '💩';\n";
-        let sm = SourceMap::new(FilePathMapping::empty());
-        let file = sm.new_source_file(Lrc::new(PathBuf::from("multibyte.js").into()), input);
-
-        let box_drawing_start = input.find('┌').unwrap() as u32;
-        let emoji_start = input.find('💩').unwrap() as u32;
-        let mappings = [
-            (
-                file.start_pos + BytePos(box_drawing_start + 1),
-                LineCol { line: 0, col: 0 },
-            ),
-            (
-                file.start_pos + BytePos(emoji_start + 2),
-                LineCol { line: 1, col: 0 },
-            ),
-        ];
-
-        let map = sm.build_source_map(&mappings, None, DefaultSourceMapGenConfig);
-        let tokens = map
-            .tokens()
-            .map(|token| {
-                (
-                    token.get_dst_line(),
-                    token.get_dst_col(),
-                    token.get_src_line(),
-                    token.get_src_col(),
-                )
-            })
-            .collect::<Vec<_>>();
-
-        assert_eq!(tokens, vec![(0, 0, 0, 3), (1, 0, 1, 15)]);
     }
 
     #[test]


### PR DESCRIPTION
**Description:**

Reverts #11918 because the source map builder clamp is not the correct fix for the Next.js/MUI source map panic. This removes the `normalize_sourcemap_pos` helper, its use in `build_source_map`, and the regression test added by that PR, restoring the previous source map assertion behavior.

This PR also replaces the original changeset with a revert changeset for `swc_common` and `swc_core`.

Validation:

- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo test -p swc_common`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Reverts #11918
