### PR TITLE
fix(bindings/node): Preserve source context for AST transforms

### DIFF
--- a/.changeset/fix-node-ast-source-context.md
+++ b/.changeset/fix-node-ast-source-context.md
@@ -1,0 +1,5 @@
+---
+"@swc/core": patch
+---
+
+fix(core): Preserve source context for AST transform sourcemaps

--- a/.changeset/fix-node-ast-source-context.md
+++ b/.changeset/fix-node-ast-source-context.md
@@ -1,5 +1,0 @@
----
-"@swc/core": patch
----
-
-fix(core): Preserve source context for AST transform sourcemaps

--- a/bindings/binding_core_node/src/ast_context.rs
+++ b/bindings/binding_core_node/src/ast_context.rs
@@ -1,0 +1,233 @@
+use anyhow::{bail, Context, Error};
+use serde::{Deserialize, Serialize};
+use swc_core::{
+    base::Compiler,
+    common::{BytePos, FileName, SourceFile, Span, DUMMY_SP},
+    ecma::{
+        ast::Program,
+        visit::{VisitMut, VisitMutWith},
+    },
+    node::deserialize_json,
+};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgramSourceContext {
+    real_filename: Option<String>,
+    source: String,
+    start_pos: u32,
+    end_pos: u32,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProgramEnvelope {
+    program: Program,
+    source_context: Option<ProgramSourceContext>,
+}
+
+#[derive(Debug)]
+pub enum ProgramInput {
+    Raw(Program),
+    WithContext {
+        program: Program,
+        source_context: ProgramSourceContext,
+    },
+}
+
+pub fn source_context_from_file(fm: &SourceFile) -> ProgramSourceContext {
+    ProgramSourceContext {
+        real_filename: match &*fm.name {
+            FileName::Real(path) => Some(path.display().to_string()),
+            _ => None,
+        },
+        source: fm.src.as_str().to_owned(),
+        start_pos: fm.start_pos.0,
+        end_pos: fm.end_pos.0,
+    }
+}
+
+pub fn serialize_program(program: Program, fm: &SourceFile) -> Result<String, serde_json::Error> {
+    serde_json::to_string(&ProgramEnvelope {
+        program,
+        source_context: Some(source_context_from_file(fm)),
+    })
+}
+
+pub fn deserialize_program_input(json: &str) -> Result<ProgramInput, serde_json::Error> {
+    if let Ok(envelope) = deserialize_json::<ProgramEnvelope>(json) {
+        if let Some(source_context) = envelope.source_context {
+            return Ok(ProgramInput::WithContext {
+                program: envelope.program,
+                source_context,
+            });
+        }
+
+        return Ok(ProgramInput::Raw(envelope.program));
+    }
+
+    deserialize_json(json).map(ProgramInput::Raw)
+}
+
+pub fn prepare_program_with_context(
+    c: &Compiler,
+    mut program: Program,
+    source_context: ProgramSourceContext,
+) -> Result<(swc_core::common::sync::Lrc<SourceFile>, Program), Error> {
+    let fm = c.cm.new_source_file(
+        source_context.file_name().into(),
+        source_context.source.clone(),
+    );
+
+    let expected_len = source_context
+        .end_pos
+        .checked_sub(source_context.start_pos)
+        .context("invalid source context byte range")?;
+
+    if fm.byte_length() != expected_len {
+        bail!(
+            "failed to restore source context because the source length changed while passing AST \
+             between JavaScript and native code"
+        );
+    }
+
+    rebase_program_spans(&mut program, &source_context, &fm)
+        .context("failed to rebase AST spans to restored source context")?;
+
+    Ok((fm, program))
+}
+
+fn rebase_program_spans(
+    program: &mut Program,
+    source_context: &ProgramSourceContext,
+    fm: &SourceFile,
+) -> Result<(), Error> {
+    let old_start = source_context.start_pos;
+    let old_end = source_context.end_pos;
+    let new_start = fm.start_pos.0;
+    let new_end = fm.end_pos.0;
+
+    if old_start > old_end {
+        bail!("invalid source context byte range: {old_start}..{old_end}");
+    }
+
+    program.visit_mut_with(&mut SpanRebaser {
+        old_start,
+        old_end,
+        new_start,
+        new_end,
+    });
+
+    Ok(())
+}
+
+impl ProgramSourceContext {
+    fn file_name(&self) -> FileName {
+        match &self.real_filename {
+            Some(filename) => FileName::Real(filename.into()),
+            None => FileName::Anon,
+        }
+    }
+}
+
+struct SpanRebaser {
+    old_start: u32,
+    old_end: u32,
+    new_start: u32,
+    new_end: u32,
+}
+
+impl SpanRebaser {
+    fn rebase_pos(&self, pos: BytePos) -> Option<BytePos> {
+        if pos.is_dummy() || pos.is_reserved_for_comments() || pos == BytePos::SYNTHESIZED {
+            return Some(pos);
+        }
+
+        if pos.0 < self.old_start || pos.0 > self.old_end {
+            return None;
+        }
+
+        let rebased = self.new_start.checked_add(pos.0 - self.old_start)?;
+        if rebased > self.new_end {
+            return None;
+        }
+
+        Some(BytePos(rebased))
+    }
+
+    fn rebase_span(&self, span: Span) -> Span {
+        if span.is_dummy() {
+            return span;
+        }
+
+        let Some(lo) = self.rebase_pos(span.lo) else {
+            return DUMMY_SP;
+        };
+        let Some(hi) = self.rebase_pos(span.hi) else {
+            return DUMMY_SP;
+        };
+
+        if lo.is_dummy() || hi.is_dummy() {
+            return DUMMY_SP;
+        }
+
+        Span::new_with_checked(lo, hi)
+    }
+}
+
+impl VisitMut for SpanRebaser {
+    fn visit_mut_span(&mut self, span: &mut Span) {
+        *span = self.rebase_span(*span);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rebase_span_into_new_source_range() {
+        let rebaser = SpanRebaser {
+            old_start: 100,
+            old_end: 140,
+            new_start: 1,
+            new_end: 41,
+        };
+
+        let span = rebaser.rebase_span(Span::new(BytePos(110), BytePos(125)));
+
+        assert_eq!(span.lo, BytePos(11));
+        assert_eq!(span.hi, BytePos(26));
+    }
+
+    #[test]
+    fn drops_out_of_range_span() {
+        let rebaser = SpanRebaser {
+            old_start: 100,
+            old_end: 140,
+            new_start: 1,
+            new_end: 41,
+        };
+
+        assert_eq!(
+            rebaser.rebase_span(Span::new(BytePos(90), BytePos(125))),
+            DUMMY_SP
+        );
+    }
+
+    #[test]
+    fn preserves_dummy_and_reserved_spans() {
+        let rebaser = SpanRebaser {
+            old_start: 100,
+            old_end: 140,
+            new_start: 1,
+            new_end: 41,
+        };
+
+        assert_eq!(rebaser.rebase_span(DUMMY_SP), DUMMY_SP);
+        assert_eq!(
+            rebaser.rebase_span(Span::new(BytePos::PURE, BytePos::PURE)),
+            Span::new(BytePos::PURE, BytePos::PURE)
+        );
+    }
+}

--- a/bindings/binding_core_node/src/lib.rs
+++ b/bindings/binding_core_node/src/lib.rs
@@ -16,6 +16,7 @@ use swc_core::{
 
 #[cfg(feature = "plugin")]
 mod analyze;
+mod ast_context;
 mod bundle;
 mod minify;
 mod parse;

--- a/bindings/binding_core_node/src/parse.rs
+++ b/bindings/binding_core_node/src/parse.rs
@@ -11,14 +11,14 @@ use napi::{
 use swc_core::{
     base::{
         config::{ErrorFormat, ParseOptions},
-        Compiler,
+        Compiler, SwcComments,
     },
     common::{comments::Comments, FileName, Mark},
     ecma::{transforms::base::resolver, visit::VisitMutWith},
     node::{deserialize_json, get_deserialized, MapErr},
 };
 
-use crate::{get_compiler, util::try_with};
+use crate::{ast_context::serialize_program, get_fresh_compiler, util::try_with};
 
 // ----- Parsing -----
 
@@ -47,15 +47,16 @@ impl Task for ParseTask {
             .cm
             .new_source_file(self.filename.clone().into(), self.src.clone());
 
+        let local_comments = SwcComments::default();
         let comments = if options.comments {
-            Some(self.c.comments() as &dyn Comments)
+            Some(&local_comments as &dyn Comments)
         } else {
             None
         };
 
         let program = try_with(self.c.cm.clone(), false, ErrorFormat::Normal, |handler| {
             let mut p = self.c.parse_js(
-                fm,
+                fm.clone(),
                 handler,
                 options.target,
                 options.syntax,
@@ -73,7 +74,7 @@ impl Task for ParseTask {
         })
         .convert_err()?;
 
-        let ast_json = serde_json::to_string(&program)?;
+        let ast_json = serialize_program(program, &fm)?;
 
         Ok(ast_json)
     }
@@ -89,7 +90,7 @@ impl Task for ParseFileTask {
     type Output = String;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
-        let program = try_with(self.c.cm.clone(), false, ErrorFormat::Normal, |handler| {
+        let (program, fm) = try_with(self.c.cm.clone(), false, ErrorFormat::Normal, |handler| {
             self.c.run(|| {
                 let options: ParseOptions = deserialize_json(&self.options)?;
 
@@ -99,15 +100,15 @@ impl Task for ParseFileTask {
                     .load_file(&self.path)
                     .context("failed to read module")?;
 
-                let c = self.c.comments().clone();
+                let local_comments = SwcComments::default();
                 let comments = if options.comments {
-                    Some(&c as &dyn Comments)
+                    Some(&local_comments as &dyn Comments)
                 } else {
                     None
                 };
 
                 let mut p = self.c.parse_js(
-                    fm,
+                    fm.clone(),
                     handler,
                     options.target,
                     options.syntax,
@@ -121,12 +122,12 @@ impl Task for ParseFileTask {
                     options.syntax.typescript(),
                 ));
 
-                Ok(p)
+                Ok((p, fm))
             })
         })
         .convert_err()?;
 
-        let ast_json = serde_json::to_string(&program)?;
+        let ast_json = serialize_program(program, &fm)?;
 
         Ok(ast_json)
     }
@@ -152,7 +153,7 @@ pub fn parse(
 ) -> AsyncTask<ParseTask> {
     crate::util::init_default_trace_subscriber();
 
-    let c = get_compiler();
+    let c = get_fresh_compiler();
     let src = stringify(src);
     let options = String::from_utf8_lossy(options.as_ref()).into_owned();
     let filename = if let Some(value) = filename {
@@ -180,7 +181,7 @@ pub fn parse_sync(
 ) -> napi::Result<String> {
     crate::util::init_default_trace_subscriber();
 
-    let c = get_compiler();
+    let c = get_fresh_compiler();
     let src = stringify(src);
     let options: ParseOptions = get_deserialized(&opts)?;
     let filename = if let Some(value) = filename {
@@ -189,18 +190,19 @@ pub fn parse_sync(
         FileName::Anon
     };
 
-    let program = try_with(c.cm.clone(), false, ErrorFormat::Normal, |handler| {
+    let (program, fm) = try_with(c.cm.clone(), false, ErrorFormat::Normal, |handler| {
         c.run(|| {
             let fm = c.cm.new_source_file(filename.into(), src);
 
+            let local_comments = SwcComments::default();
             let comments = if options.comments {
-                Some(c.comments() as &dyn Comments)
+                Some(&local_comments as &dyn Comments)
             } else {
                 None
             };
 
             let mut p = c.parse_js(
-                fm,
+                fm.clone(),
                 handler,
                 options.target,
                 options.syntax,
@@ -214,34 +216,35 @@ pub fn parse_sync(
                 options.syntax.typescript(),
             ));
 
-            Ok(p)
+            Ok((p, fm))
         })
     })
     .convert_err()?;
 
-    Ok(serde_json::to_string(&program)?)
+    Ok(serialize_program(program, &fm)?)
 }
 
 #[napi]
 pub fn parse_file_sync(path: String, opts: Buffer) -> napi::Result<String> {
     crate::util::init_default_trace_subscriber();
-    let c = get_compiler();
+    let c = get_fresh_compiler();
     let options: ParseOptions = get_deserialized(&opts)?;
 
-    let program = {
+    let (program, fm) = {
         try_with(c.cm.clone(), false, ErrorFormat::Normal, |handler| {
             let fm =
                 c.cm.load_file(Path::new(path.as_str()))
                     .expect("failed to read program file");
 
+            let local_comments = SwcComments::default();
             let comments = if options.comments {
-                Some(c.comments() as &dyn Comments)
+                Some(&local_comments as &dyn Comments)
             } else {
                 None
             };
 
             let mut p = c.parse_js(
-                fm,
+                fm.clone(),
                 handler,
                 options.target,
                 options.syntax,
@@ -254,12 +257,12 @@ pub fn parse_file_sync(path: String, opts: Buffer) -> napi::Result<String> {
                 options.syntax.typescript(),
             ));
 
-            Ok(p)
+            Ok((p, fm))
         })
     }
     .convert_err()?;
 
-    Ok(serde_json::to_string(&program)?)
+    Ok(serialize_program(program, &fm)?)
 }
 
 #[napi]
@@ -270,7 +273,7 @@ pub fn parse_file(
 ) -> AsyncTask<ParseFileTask> {
     crate::util::init_default_trace_subscriber();
 
-    let c = get_compiler();
+    let c = get_fresh_compiler();
     let path = PathBuf::from(&path);
     let options = String::from_utf8_lossy(options.as_ref()).into_owned();
 

--- a/bindings/binding_core_node/src/print.rs
+++ b/bindings/binding_core_node/src/print.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Error;
 use napi::{
     bindgen_prelude::{AbortSignal, AsyncTask, Buffer},
     Env, Task,
@@ -14,7 +15,10 @@ use swc_core::{
     node::{deserialize_json, get_deserialized, MapErr},
 };
 
-use crate::get_compiler;
+use crate::{
+    ast_context::{deserialize_program_input, prepare_program_with_context, ProgramInput},
+    get_compiler, get_fresh_compiler,
+};
 
 // ----- Printing -----
 
@@ -24,35 +28,56 @@ pub struct PrintTask {
     pub options: String,
 }
 
+fn compiler_for_program_input(
+    program_input: &ProgramInput,
+    fallback: Arc<Compiler>,
+) -> Arc<Compiler> {
+    match program_input {
+        ProgramInput::WithContext { .. } => get_fresh_compiler(),
+        ProgramInput::Raw(_) => fallback,
+    }
+}
+
+fn prepare_program_for_print(c: &Compiler, program_input: ProgramInput) -> Result<Program, Error> {
+    match program_input {
+        ProgramInput::WithContext {
+            program,
+            source_context,
+        } => prepare_program_with_context(c, program, source_context).map(|(_, program)| program),
+        ProgramInput::Raw(program) => Ok(program),
+    }
+}
+
 #[napi]
 impl Task for PrintTask {
     type JsValue = TransformOutput;
     type Output = TransformOutput;
 
     fn compute(&mut self) -> napi::Result<Self::Output> {
-        let program: Program = deserialize_json(&self.program_json)?;
+        let program_input = deserialize_program_input(&self.program_json)?;
         let options: Options = deserialize_json(&self.options)?;
+        let c = compiler_for_program_input(&program_input, self.c.clone());
+        let program = prepare_program_for_print(&c, program_input).convert_err()?;
 
         GLOBALS.set(&Default::default(), || {
-            self.c
-                .print(
-                    &program,
-                    PrintArgs {
-                        output_path: options.output_path.clone(),
-                        inline_sources_content: true,
-                        source_map: options
-                            .source_maps
-                            .clone()
-                            .unwrap_or(SourceMapsConfig::Bool(false)),
-                        emit_source_map_columns: options.config.emit_source_map_columns.into_bool(),
-                        codegen_config: swc_core::ecma::codegen::Config::default()
-                            .with_target(options.config.jsc.target.unwrap_or(EsVersion::Es2020))
-                            .with_minify(options.config.minify.into_bool()),
-                        source_file_name: Some(&options.filename),
-                        ..Default::default()
-                    },
-                )
-                .convert_err()
+            c.print(
+                &program,
+                PrintArgs {
+                    output_path: options.output_path.clone(),
+                    inline_sources_content: true,
+                    source_map: options
+                        .source_maps
+                        .clone()
+                        .unwrap_or(SourceMapsConfig::Bool(false)),
+                    emit_source_map_columns: options.config.emit_source_map_columns.into_bool(),
+                    codegen_config: swc_core::ecma::codegen::Config::default()
+                        .with_target(options.config.jsc.target.unwrap_or(EsVersion::Es2020))
+                        .with_minify(options.config.minify.into_bool()),
+                    source_file_name: Some(&options.filename),
+                    ..Default::default()
+                },
+            )
+            .convert_err()
         })
     }
 
@@ -88,9 +113,11 @@ pub fn print_sync(program: String, options: Buffer) -> napi::Result<TransformOut
 
     let c = get_compiler();
 
-    let program: Program = deserialize_json(program.as_str())?;
+    let program_input = deserialize_program_input(program.as_str())?;
 
     let options: Options = get_deserialized(&options)?;
+    let c = compiler_for_program_input(&program_input, c);
+    let program = prepare_program_for_print(&c, program_input).convert_err()?;
 
     // Defaults to es3
     let codegen_target = options.codegen_target().unwrap_or_default();

--- a/bindings/binding_core_node/src/transform.rs
+++ b/bindings/binding_core_node/src/transform.rs
@@ -3,7 +3,7 @@ use std::{
     sync::Arc,
 };
 
-use anyhow::Context as _;
+use anyhow::{Context as _, Error};
 use napi::{
     bindgen_prelude::{AbortSignal, AsyncTask, Buffer},
     Env, Task,
@@ -11,13 +11,17 @@ use napi::{
 use path_clean::clean;
 use swc_core::{
     base::{config::Options, Compiler, TransformOutput},
-    common::FileName,
-    ecma::ast::Program,
-    node::{deserialize_json, get_deserialized, MapErr},
+    common::{comments::SingleThreadedComments, errors::Handler, FileName},
+    ecma::ast::noop_pass,
+    node::{get_deserialized, MapErr},
 };
 use tracing::instrument;
 
-use crate::{get_compiler, get_fresh_compiler, util::try_with};
+use crate::{
+    ast_context::{deserialize_program_input, prepare_program_with_context, ProgramInput},
+    get_compiler, get_fresh_compiler,
+    util::try_with,
+};
 
 /// Input to transform
 #[derive(Debug)]
@@ -36,6 +40,43 @@ pub struct TransformTask {
     pub options: Buffer,
 }
 
+fn compiler_for_program_input(
+    program_input: &ProgramInput,
+    fallback: Arc<Compiler>,
+) -> Arc<Compiler> {
+    match program_input {
+        ProgramInput::WithContext { .. } => get_fresh_compiler(),
+        ProgramInput::Raw(_) => fallback,
+    }
+}
+
+fn process_program_input(
+    c: &Compiler,
+    handler: &Handler,
+    program_input: ProgramInput,
+    options: &Options,
+) -> Result<TransformOutput, Error> {
+    match program_input {
+        ProgramInput::WithContext {
+            program,
+            source_context,
+        } => {
+            let (fm, program) = prepare_program_with_context(c, program, source_context)?;
+
+            c.process_js_with_custom_pass(
+                fm,
+                Some(program),
+                handler,
+                options,
+                SingleThreadedComments::default(),
+                |_| noop_pass(),
+                |_| noop_pass(),
+            )
+        }
+        ProgramInput::Raw(program) => c.process_js(handler, program, options),
+    }
+}
+
 #[napi]
 impl Task for TransformTask {
     type JsValue = TransformOutput;
@@ -50,40 +91,50 @@ impl Task for TransformTask {
 
         let error_format = options.experimental.error_format.unwrap_or_default();
 
-        try_with(
-            self.c.cm.clone(),
-            !options.config.error.filename.into_bool(),
-            error_format,
-            |handler| {
-                self.c.run(|| match &self.input {
-                    Input::Program(ref s) => {
-                        let program: Program =
-                            deserialize_json(s).expect("failed to deserialize Program");
-                        // TODO: Source map
-                        self.c.process_js(handler, program, &options)
-                    }
+        match &self.input {
+            Input::Program(s) => {
+                let program_input = deserialize_program_input(s)?;
+                let c = compiler_for_program_input(&program_input, self.c.clone());
 
-                    Input::File(ref path) => {
-                        let fm = self.c.cm.load_file(path).context("failed to load file")?;
-                        self.c.process_js_file(fm, handler, &options)
-                    }
+                try_with(
+                    c.cm.clone(),
+                    !options.config.error.filename.into_bool(),
+                    error_format,
+                    |handler| c.run(|| process_program_input(&c, handler, program_input, &options)),
+                )
+                .convert_err()
+            }
 
-                    Input::Source { src } => {
-                        let fm = self.c.cm.new_source_file(
-                            if options.filename.is_empty() {
-                                FileName::Anon.into()
-                            } else {
-                                FileName::Real(options.filename.clone().into()).into()
-                            },
-                            src.clone(),
-                        );
+            _ => try_with(
+                self.c.cm.clone(),
+                !options.config.error.filename.into_bool(),
+                error_format,
+                |handler| {
+                    self.c.run(|| match &self.input {
+                        Input::Program(_) => unreachable!("Program input is handled above"),
 
-                        self.c.process_js_file(fm, handler, &options)
-                    }
-                })
-            },
-        )
-        .convert_err()
+                        Input::File(ref path) => {
+                            let fm = self.c.cm.load_file(path).context("failed to load file")?;
+                            self.c.process_js_file(fm, handler, &options)
+                        }
+
+                        Input::Source { src } => {
+                            let fm = self.c.cm.new_source_file(
+                                if options.filename.is_empty() {
+                                    FileName::Anon.into()
+                                } else {
+                                    FileName::Real(options.filename.clone().into()).into()
+                                },
+                                src.clone(),
+                            );
+
+                            self.c.process_js_file(fm, handler, &options)
+                        }
+                    })
+                },
+            )
+            .convert_err(),
+        }
     }
 
     fn resolve(&mut self, _env: Env, result: Self::Output) -> napi::Result<Self::JsValue> {
@@ -116,12 +167,6 @@ pub fn transform(
 pub fn transform_sync(s: String, is_module: bool, opts: Buffer) -> napi::Result<TransformOutput> {
     crate::util::init_default_trace_subscriber();
 
-    let c = if is_module {
-        get_compiler()
-    } else {
-        get_fresh_compiler()
-    };
-
     let mut options: Options = get_deserialized(&opts)?;
 
     if !options.filename.is_empty() {
@@ -130,17 +175,26 @@ pub fn transform_sync(s: String, is_module: bool, opts: Buffer) -> napi::Result<
 
     let error_format = options.experimental.error_format.unwrap_or_default();
 
-    try_with(
-        c.cm.clone(),
-        !options.config.error.filename.into_bool(),
-        error_format,
-        |handler| {
-            c.run(|| {
-                if is_module {
-                    let program: Program =
-                        deserialize_json(s.as_str()).context("failed to deserialize Program")?;
-                    c.process_js(handler, program, &options)
-                } else {
+    if is_module {
+        let program_input = deserialize_program_input(s.as_str())?;
+        let c = compiler_for_program_input(&program_input, get_compiler());
+
+        try_with(
+            c.cm.clone(),
+            !options.config.error.filename.into_bool(),
+            error_format,
+            |handler| c.run(|| process_program_input(&c, handler, program_input, &options)),
+        )
+        .convert_err()
+    } else {
+        let c = get_fresh_compiler();
+
+        try_with(
+            c.cm.clone(),
+            !options.config.error.filename.into_bool(),
+            error_format,
+            |handler| {
+                c.run(|| {
                     let fm = c.cm.new_source_file(
                         if options.filename.is_empty() {
                             FileName::Anon.into()
@@ -150,11 +204,11 @@ pub fn transform_sync(s: String, is_module: bool, opts: Buffer) -> napi::Result<
                         s,
                     );
                     c.process_js_file(fm, handler, &options)
-                }
-            })
-        },
-    )
-    .convert_err()
+                })
+            },
+        )
+        .convert_err()
+    }
 }
 
 #[napi]
@@ -186,8 +240,6 @@ pub fn transform_file_sync(
 ) -> napi::Result<TransformOutput> {
     crate::util::init_default_trace_subscriber();
 
-    let c = get_fresh_compiler();
-
     let mut options: Options = get_deserialized(&opts)?;
 
     if !options.filename.is_empty() {
@@ -196,22 +248,31 @@ pub fn transform_file_sync(
 
     let error_format = options.experimental.error_format.unwrap_or_default();
 
-    try_with(
-        c.cm.clone(),
-        !options.config.error.filename.into_bool(),
-        error_format,
-        |handler| {
-            c.run(|| {
-                if is_module {
-                    let program: Program =
-                        deserialize_json(s.as_str()).context("failed to deserialize Program")?;
-                    c.process_js(handler, program, &options)
-                } else {
+    if is_module {
+        let program_input = deserialize_program_input(s.as_str())?;
+        let c = compiler_for_program_input(&program_input, get_compiler());
+
+        try_with(
+            c.cm.clone(),
+            !options.config.error.filename.into_bool(),
+            error_format,
+            |handler| c.run(|| process_program_input(&c, handler, program_input, &options)),
+        )
+        .convert_err()
+    } else {
+        let c = get_fresh_compiler();
+
+        try_with(
+            c.cm.clone(),
+            !options.config.error.filename.into_bool(),
+            error_format,
+            |handler| {
+                c.run(|| {
                     let fm = c.cm.load_file(Path::new(&s)).expect("failed to load file");
                     c.process_js_file(fm, handler, &options)
-                }
-            })
-        },
-    )
-    .convert_err()
+                })
+            },
+        )
+        .convert_err()
+    }
 }

--- a/packages/core/__tests__/transform/sourcemap_test.js
+++ b/packages/core/__tests__/transform/sourcemap_test.js
@@ -3,6 +3,24 @@ const swc = require("../../"),
     sourceMap = require("source-map");
 const path = require("path");
 
+const muiDefaultPropsProvider = `import PropTypes from "prop-types";
+
+const DefaultPropsProvider = {};
+
+DefaultPropsProvider.propTypes /* remove-proptypes */ = {
+  // ┌────────────────────────────── Warning ──────────────────────────────┐
+  // │ These PropTypes are generated from the TypeScript type definitions. │
+  // │ To update them, edit the TypeScript types and run \`pnpm proptypes\`. │
+  // └─────────────────────────────────────────────────────────────────────┘
+  /**
+   * @ignore
+   */
+  children: PropTypes.node,
+};
+
+export { DefaultPropsProvider };
+`;
+
 it("should handle sourcemap correctly", async () => {
     const raw = `
 class Foo extends Array {
@@ -56,6 +74,66 @@ console.log('foo')
     expect(out2.map).toBeTruthy();
     expect(JSON.parse(out2.map).sources).toEqual(["<anon>"]);
     validate(out2.code, out2.map, { "input.js": raw });
+});
+
+it("should keep source context for plugin sourcemaps with multibyte comments", () => {
+    const filename = "DefaultPropsProvider.mjs";
+    const out = swc.transformSync(muiDefaultPropsProvider, {
+        filename,
+        sourceMaps: true,
+        plugin: (m) => ({ ...m }),
+    });
+
+    expect(out.map).toBeTruthy();
+    expect(JSON.parse(out.map).sources).toEqual([filename]);
+    validate(out.code, out.map, { [filename]: muiDefaultPropsProvider });
+});
+
+it("should keep source context for print(parse()) sourcemaps", () => {
+    const filename = "DefaultPropsProvider.mjs";
+    const program = swc.parseSync(
+        muiDefaultPropsProvider,
+        { syntax: "ecmascript" },
+        filename
+    );
+    const out = swc.printSync(program, {
+        filename,
+        sourceMaps: true,
+    });
+
+    expect(out.map).toBeTruthy();
+    expect(JSON.parse(out.map).sources).toEqual([filename]);
+    expect(JSON.stringify(program)).not.toContain("sourceContext");
+    validate(out.code, out.map, { [filename]: muiDefaultPropsProvider });
+});
+
+it("should isolate async plugin source contexts", async () => {
+    const inputs = [
+        muiDefaultPropsProvider,
+        `const emoji = "🙂";\nexport { emoji };\n`,
+    ];
+
+    const outputs = await Promise.all(
+        Array.from({ length: 24 }, (_, index) => {
+            const filename = `input-${index}.mjs`;
+
+            return swc.transform(inputs[index % inputs.length], {
+                filename,
+                sourceMaps: true,
+                plugin: (m) => ({ ...m }),
+            });
+        })
+    );
+
+    outputs.forEach((out, index) => {
+        const filename = `input-${index}.mjs`;
+
+        expect(out.map).toBeTruthy();
+        expect(JSON.parse(out.map).sources).toEqual([filename]);
+        validate(out.code, out.map, {
+            [filename]: inputs[index % inputs.length],
+        });
+    });
 });
 
 it("should handle input sourcemap correctly", async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,6 +42,89 @@ const bindings: typeof import("../binding") = (() => {
     }
 })();
 
+type ProgramSourceContext = {
+    realFilename?: string | null;
+    source: string;
+    startPos: number;
+    endPos: number;
+};
+
+type ProgramEnvelope = {
+    program: Program;
+    sourceContext?: ProgramSourceContext | null;
+};
+
+const programSourceContextKey: unique symbol = Symbol(
+    "@swc/core.programSourceContext"
+);
+
+type ProgramWithSourceContext = Program & {
+    [programSourceContextKey]?: ProgramSourceContext;
+};
+
+function attachProgramSourceContext<T extends Program>(
+    program: T,
+    sourceContext?: ProgramSourceContext | null
+): T {
+    if (!sourceContext || typeof program !== "object" || program === null) {
+        return program;
+    }
+
+    try {
+        Object.defineProperty(program, programSourceContextKey, {
+            configurable: true,
+            enumerable: false,
+            value: sourceContext,
+            writable: true,
+        });
+    } catch (_) {
+        // Frozen user-created ASTs keep the legacy raw Program behavior.
+    }
+
+    return program;
+}
+
+function getProgramSourceContext(
+    program: Program
+): ProgramSourceContext | undefined {
+    return (program as ProgramWithSourceContext)[programSourceContextKey];
+}
+
+function copyProgramSourceContext<T extends Program>(from: Program, to: T): T {
+    return attachProgramSourceContext(to, getProgramSourceContext(from));
+}
+
+function parseProgramJson(json: string): Program {
+    const value = JSON.parse(json) as Program | ProgramEnvelope;
+
+    if (
+        value &&
+        typeof value === "object" &&
+        "program" in value &&
+        value.program
+    ) {
+        return attachProgramSourceContext(
+            value.program,
+            value.sourceContext
+        );
+    }
+
+    return value as Program;
+}
+
+function stringifyProgram(program: Program): string {
+    const sourceContext = getProgramSourceContext(program);
+
+    if (sourceContext) {
+        return JSON.stringify({
+            program,
+            sourceContext,
+        });
+    }
+
+    return JSON.stringify(program);
+}
+
 /**
  * Version of the swc binding.
  */
@@ -111,7 +194,7 @@ export class Compiler {
 
         if (bindings) {
             const res = await bindings.parse(src, toBuffer(options), filename);
-            return JSON.parse(res);
+            return parseProgramJson(res);
         } else if (fallbackBindings) {
             return fallbackBindings.parse(src, options);
         }
@@ -125,7 +208,7 @@ export class Compiler {
         options.syntax = options.syntax || "ecmascript";
 
         if (bindings) {
-            return JSON.parse(
+            return parseProgramJson(
                 bindings.parseSync(src, toBuffer(options), filename)
             );
         } else if (fallbackBindings) {
@@ -154,7 +237,7 @@ export class Compiler {
 
         const res = await bindings.parseFile(path, toBuffer(options));
 
-        return JSON.parse(res);
+        return parseProgramJson(res);
     }
 
     parseFileSync(
@@ -174,7 +257,7 @@ export class Compiler {
             throw new Error("Bindings not found.");
         }
 
-        return JSON.parse(bindings.parseFileSync(path, toBuffer(options)));
+        return parseProgramJson(bindings.parseFileSync(path, toBuffer(options)));
     }
 
     /**
@@ -185,7 +268,7 @@ export class Compiler {
         options = options || {};
 
         if (bindings) {
-            return bindings.print(JSON.stringify(m), toBuffer(options));
+            return bindings.print(stringifyProgram(m), toBuffer(options));
         } else if (fallbackBindings) {
             return fallbackBindings.print(m, options);
         }
@@ -201,7 +284,7 @@ export class Compiler {
         options = options || {};
 
         if (bindings) {
-            return bindings.printSync(JSON.stringify(m), toBuffer(options));
+            return bindings.printSync(stringifyProgram(m), toBuffer(options));
         } else if (fallbackBindings) {
             return fallbackBindings.printSync(m, options);
         }
@@ -230,11 +313,14 @@ export class Compiler {
                             options.filename
                         )
                         : src;
-                return this.transform(plugin(m), newOptions);
+                return this.transform(
+                    copyProgramSourceContext(m, plugin(m)),
+                    newOptions
+                );
             }
 
             return bindings.transform(
-                isModule ? JSON.stringify(src) : src,
+                isModule ? stringifyProgram(src) : src,
                 isModule,
                 toBuffer(newOptions)
             );
@@ -273,11 +359,14 @@ export class Compiler {
                             options.filename
                         )
                         : src;
-                return this.transformSync(plugin(m), newOptions);
+                return this.transformSync(
+                    copyProgramSourceContext(m, plugin(m)),
+                    newOptions
+                );
             }
 
             return bindings.transformSync(
-                isModule ? JSON.stringify(src) : src,
+                isModule ? stringifyProgram(src) : src,
                 isModule,
                 toBuffer(newOptions)
             );
@@ -318,7 +407,10 @@ export class Compiler {
 
         if (plugin) {
             const m = await this.parseFile(path, options?.jsc?.parser);
-            return this.transform(plugin(m), newOptions);
+            return this.transform(
+                copyProgramSourceContext(m, plugin(m)),
+                newOptions
+            );
         }
 
         return bindings.transformFile(path, false, toBuffer(newOptions));
@@ -345,7 +437,10 @@ export class Compiler {
 
         if (plugin) {
             const m = this.parseFileSync(path, options?.jsc?.parser);
-            return this.transformSync(plugin(m), newOptions);
+            return this.transformSync(
+                copyProgramSourceContext(m, plugin(m)),
+                newOptions
+            );
         }
 
         return bindings.transformFileSync(


### PR DESCRIPTION
**Description:**

This fixes the Node `@swc/core` AST handoff path so source maps do not depend on a process-global `Compiler`/`SourceMap` when JavaScript receives a parsed `Program` and later passes it back to `transform` or `print`.

The native parser now returns an internal envelope with the parsed `Program` plus the original source context. The public JS wrapper unwraps it back to the normal AST shape and stores the source context as non-enumerable metadata. When the AST is passed back to native code, the wrapper sends the envelope; native code restores the source file in a fresh compiler and rebases AST spans into that new source map. Legacy raw `Program` JSON input still falls back to the old behavior.

This also stops parser calls from writing comments into the global compiler comment store, and adds regression coverage for the MUI box-drawing comment case, `print(parse(...))`, and concurrent plugin transforms.

Validation:

- `git submodule update --init --recursive`
- `cargo test -p binding_core_node`
- `pnpm --dir packages/core build:dev`
- `pnpm --dir packages/core exec rstest __tests__/transform/sourcemap_test.js`
- `pnpm --dir packages/core test`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Follow-up to #11919. Root cause for the Next.js MUI sourcemap panic originally observed while investigating #11918.
