### PR TITLE
fix(es/fixer): preserve new tagged template callee parens

### DIFF
--- a/.changeset/preserve-new-tagged-template-parens.md
+++ b/.changeset/preserve-new-tagged-template-parens.md
@@ -1,0 +1,7 @@
+---
+swc: patch
+swc_core: patch
+swc_ecma_transforms_base: patch
+---
+
+fix(es): Preserve parentheses for tagged template new callees

--- a/crates/swc/tests/fixture/issues-11xxx/11921/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-11xxx/11921/input/.swcrc
@@ -1,0 +1,19 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "ecmascript",
+            "jsx": false
+        },
+        "target": "es2024",
+        "loose": false,
+        "minify": {
+            "compress": false,
+            "mangle": false
+        }
+    },
+    "module": {
+        "type": "es6"
+    },
+    "minify": false,
+    "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-11xxx/11921/input/index.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11921/input/index.js
@@ -1,2 +1,12 @@
 const foo = () => (args) => class A {};
 new (foo()`bar`)();
+
+const taggedObject = () => (args) => ({
+    bar: (args) => class B {},
+});
+new ((taggedObject()`a`).bar`b`)();
+
+function Foo() {
+    return (args) => class C {};
+}
+new ((new Foo)`bar`)();

--- a/crates/swc/tests/fixture/issues-11xxx/11921/input/index.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11921/input/index.js
@@ -6,6 +6,9 @@ const taggedObject = () => (args) => ({
 });
 new ((taggedObject()`a`).bar`b`)();
 
+const nestedTag = () => (args) => (args) => class D {};
+new (nestedTag()`a``b`)();
+
 function Foo() {
     return (args) => class C {};
 }

--- a/crates/swc/tests/fixture/issues-11xxx/11921/input/index.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11921/input/index.js
@@ -1,0 +1,2 @@
+const foo = () => (args) => class A {};
+new (foo()`bar`)();

--- a/crates/swc/tests/fixture/issues-11xxx/11921/output/index.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11921/output/index.js
@@ -6,8 +6,11 @@ const taggedObject = ()=>(args)=>({
                 }
         });
 new (taggedObject()`a`.bar`b`)();
+const nestedTag = ()=>(args)=>(args)=>class D {
+            };
+new (nestedTag()`a``b`)();
 function Foo() {
     return (args)=>class C {
         };
 }
-new (new Foo`bar`)();
+new (new Foo)`bar`();

--- a/crates/swc/tests/fixture/issues-11xxx/11921/output/index.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11921/output/index.js
@@ -1,0 +1,3 @@
+const foo = ()=>(args)=>class A {
+        };
+new (foo()`bar`)();

--- a/crates/swc/tests/fixture/issues-11xxx/11921/output/index.js
+++ b/crates/swc/tests/fixture/issues-11xxx/11921/output/index.js
@@ -1,3 +1,13 @@
 const foo = ()=>(args)=>class A {
         };
 new (foo()`bar`)();
+const taggedObject = ()=>(args)=>({
+            bar: (args)=>class B {
+                }
+        });
+new (taggedObject()`a`.bar`b`)();
+function Foo() {
+    return (args)=>class C {
+        };
+}
+new (new Foo`bar`)();

--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -617,6 +617,11 @@ impl VisitMut for Fixer<'_> {
         self.ctx = Context::Callee { is_new: true };
         node.callee.visit_mut_with(self);
         match *node.callee {
+            // `new foo()`bar`() constructs `foo`, while `new (foo()`bar`)()`
+            // constructs the class returned by the tagged template expression.
+            Expr::TaggedTpl(TaggedTpl { ref tag, .. }) if matches!(**tag, Expr::Call(..)) => {
+                self.wrap(&mut node.callee)
+            }
             Expr::Call(..)
             | Expr::Await(..)
             | Expr::Yield(..)

--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -71,6 +71,22 @@ enum Context {
 }
 
 impl Fixer<'_> {
+    fn should_wrap_tagged_tpl_new_callee(tag: &Expr) -> bool {
+        match tag {
+            Expr::Call(..) | Expr::New(..) => true,
+            Expr::Member(MemberExpr { obj, .. }) => Self::member_tag_starts_with_tagged_tpl(obj),
+            _ => false,
+        }
+    }
+
+    fn member_tag_starts_with_tagged_tpl(obj: &Expr) -> bool {
+        match obj {
+            Expr::TaggedTpl(..) => true,
+            Expr::Member(MemberExpr { obj, .. }) => Self::member_tag_starts_with_tagged_tpl(obj),
+            _ => false,
+        }
+    }
+
     fn wrap_callee(&mut self, e: &mut Expr) {
         match e {
             Expr::Lit(Lit::Num(..) | Lit::Str(..)) => (),
@@ -619,7 +635,9 @@ impl VisitMut for Fixer<'_> {
         match *node.callee {
             // `new foo()`bar`() constructs `foo`, while `new (foo()`bar`)()`
             // constructs the class returned by the tagged template expression.
-            Expr::TaggedTpl(TaggedTpl { ref tag, .. }) if matches!(**tag, Expr::Call(..)) => {
+            Expr::TaggedTpl(TaggedTpl { ref tag, .. })
+                if Self::should_wrap_tagged_tpl_new_callee(tag) =>
+            {
                 self.wrap(&mut node.callee)
             }
             Expr::Call(..)

--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -74,6 +74,7 @@ impl Fixer<'_> {
     fn should_wrap_tagged_tpl_new_callee(tag: &Expr) -> bool {
         match tag {
             Expr::Call(..) | Expr::New(..) => true,
+            Expr::TaggedTpl(TaggedTpl { tag, .. }) => Self::should_wrap_tagged_tpl_new_callee(tag),
             Expr::Member(MemberExpr { obj, .. }) => Self::member_tag_starts_with_tagged_tpl(obj),
             _ => false,
         }
@@ -754,6 +755,9 @@ impl VisitMut for Fixer<'_> {
             | Expr::Cond(..)
             | Expr::Bin(..)
             | Expr::Seq(..)
+            // `(new Foo)`bar`` tags with the constructed value, but
+            // `new Foo`bar`` tags `Foo` and then constructs the result.
+            | Expr::New(..)
             | Expr::Fn(..)
             | Expr::Assign(..)
             | Expr::Unary(..) => {

--- a/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/input.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/input.js
@@ -1,2 +1,12 @@
 const foo = () => (args) => class A {};
 new (foo()`bar`)();
+
+const taggedObject = () => (args) => ({
+    bar: (args) => class B {},
+});
+new ((taggedObject()`a`).bar`b`)();
+
+function Foo() {
+    return (args) => class C {};
+}
+new ((new Foo)`bar`)();

--- a/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/input.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/input.js
@@ -6,6 +6,9 @@ const taggedObject = () => (args) => ({
 });
 new ((taggedObject()`a`).bar`b`)();
 
+const nestedTag = () => (args) => (args) => class D {};
+new (nestedTag()`a``b`)();
+
 function Foo() {
     return (args) => class C {};
 }

--- a/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/input.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/input.js
@@ -1,0 +1,2 @@
+const foo = () => (args) => class A {};
+new (foo()`bar`)();

--- a/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/output.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/output.js
@@ -6,8 +6,11 @@ const taggedObject__2 = ()=>(args__5)=>({
                 }
         });
 new (taggedObject__2()`a`.bar`b`)();
+const nestedTag__2 = ()=>(args__8)=>(args__9)=>class D__10 {
+            };
+new (nestedTag__2()`a``b`)();
 function Foo__2() {
-    return (args__9)=>class C__10 {
+    return (args__12)=>class C__13 {
         };
 }
-new (new Foo__2`bar`)();
+new (new Foo__2)`bar`();

--- a/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/output.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/output.js
@@ -1,0 +1,3 @@
+const foo__2 = ()=>(args__3)=>class A__4 {
+        };
+new (foo__2()`bar`)();

--- a/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/output.js
+++ b/crates/swc_ecma_transforms_base/tests/resolver/issues/11921/output.js
@@ -1,3 +1,13 @@
 const foo__2 = ()=>(args__3)=>class A__4 {
         };
 new (foo__2()`bar`)();
+const taggedObject__2 = ()=>(args__5)=>({
+            bar: (args__6)=>class B__7 {
+                }
+        });
+new (taggedObject__2()`a`.bar`b`)();
+function Foo__2() {
+    return (args__9)=>class C__10 {
+        };
+}
+new (new Foo__2`bar`)();


### PR DESCRIPTION
**Description:**

Fixes #11921.

This preserves the explicit grouping required for `new (foo()`bar`)()` after fixer removes the original `ParenExpr`. When a `NewExpr` callee is a tagged template whose tag is a call expression, fixer now wraps the full tagged template expression so it does not print as `new foo()`bar`()`, which has different binding.

Added focused resolver coverage and an end-to-end compiler fixture for the issue.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

#11921

Verification:

- `git submodule update --init --recursive`
- `cargo test -p swc_ecma_transforms_base`
- targeted 11921 resolver fixture
- targeted 11921 swc fixture
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

Note: full `cargo test -p swc` and `UPDATE=1 cargo test -p swc` hit an existing unrelated `source_map::issue_622` failure from `sourcemap-validator` under Node.js v24.14.0: `There were no mappings in the file`.