### PR TITLE
fix(es/parser): handle Flow async generic arrows

### DIFF
--- a/.changeset/fix-flow-parser-11925.md
+++ b/.changeset/fix-flow-parser-11925.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+fix(es/parser): Parse Flow async generic arrows and declare class anonymous function params

--- a/crates/swc_ecma_parser/src/parser/pat.rs
+++ b/crates/swc_ecma_parser/src/parser/pat.rs
@@ -783,7 +783,9 @@ impl<I: Tokens> Parser<I> {
             let decorators = self.parse_decorators(false)?;
             let pat_start = self.cur_pos();
 
-            let pat = if self.input_mut().eat(Token::DotDotDot) {
+            let pat = if let Some(pat) = self.try_parse_flow_anon_formal_param(params.len())? {
+                pat
+            } else if self.input_mut().eat(Token::DotDotDot) {
                 let dot3_token = self.span(pat_start);
 
                 let mut pat = self.parse_binding_pat_or_ident(false)?;
@@ -827,6 +829,9 @@ impl<I: Tokens> Parser<I> {
                 self.parse_formal_param_pat()?
             };
             let is_rest = matches!(pat, Pat::Rest(_));
+            if is_rest {
+                rest_span = pat.span();
+            }
 
             params.push(Param {
                 span: self.span(param_start),

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -3214,6 +3214,8 @@ impl<I: Tokens> Parser<I> {
             TsFnParam::Array(param) => Pat::Array(param),
             TsFnParam::Rest(param) => Pat::Rest(param),
             TsFnParam::Object(param) => Pat::Object(param),
+            #[cfg(swc_ast_unknown)]
+            _ => unreachable!(),
         }
     }
 

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -3208,6 +3208,15 @@ impl<I: Tokens> Parser<I> {
         }
     }
 
+    fn flow_anon_fn_param_to_pat(param: TsFnParam) -> Pat {
+        match param {
+            TsFnParam::Ident(param) => Pat::Ident(param),
+            TsFnParam::Array(param) => Pat::Array(param),
+            TsFnParam::Rest(param) => Pat::Rest(param),
+            TsFnParam::Object(param) => Pat::Object(param),
+        }
+    }
+
     fn flow_starts_like_anon_signature_param_type(&mut self) -> bool {
         let cur = self.input().cur();
 
@@ -3288,6 +3297,21 @@ impl<I: Tokens> Parser<I> {
         Ok(Some(
             self.make_flow_anon_fn_param(start, index, dot3_token, ty),
         ))
+    }
+
+    pub(crate) fn try_parse_flow_anon_formal_param(
+        &mut self,
+        index: usize,
+    ) -> PResult<Option<Pat>> {
+        if !self.input().syntax().flow() || !self.ctx().contains(Context::InDeclare) {
+            return Ok(None);
+        }
+
+        // Flow declare signatures allow anonymous function type parameters where
+        // normal formal parameters still require a binding pattern.
+        Ok(self
+            .try_parse_ts(|p| p.in_type(|p| p.try_parse_flow_anon_signature_param(index)))
+            .map(Self::flow_anon_fn_param_to_pat))
     }
 
     fn try_parse_flow_anon_fn_type(&mut self) -> PResult<Option<TsFnType>> {
@@ -5182,7 +5206,15 @@ impl<I: Tokens> Parser<I> {
                     .map(|p| p.pat)
                     .collect();
                 expect!(p, Token::RParen);
-                let return_type = p.try_parse_ts_type_or_type_predicate_ann()?;
+                let return_type = if p.input().syntax().flow() {
+                    // In arrow return type context, `T => expr` belongs to the
+                    // outer arrow unless the function type is parenthesized.
+                    p.do_inside_of_context(Context::DisallowFlowAnonFnType, |p| {
+                        p.try_parse_ts_type_or_type_predicate_ann()
+                    })?
+                } else {
+                    p.try_parse_ts_type_or_type_predicate_ann()?
+                };
                 expect!(p, Token::Arrow);
 
                 Ok(Some((type_params, params, return_type)))

--- a/crates/swc_ecma_parser/src/parser/typescript_stubs.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript_stubs.rs
@@ -82,6 +82,13 @@ impl<I: Tokens> Parser<I> {
         Ok(None)
     }
 
+    pub(crate) fn try_parse_flow_anon_formal_param(
+        &mut self,
+        _index: usize,
+    ) -> PResult<Option<Pat>> {
+        Ok(None)
+    }
+
     pub(super) fn next_then_parse_ts_type(&mut self) -> PResult<Box<TsType>> {
         unreachable!("next_then_parse_ts_type should not be called without typescript feature")
     }

--- a/crates/swc_ecma_parser/tests/flow/issue-11925-async-generic-arrow/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/issue-11925-async-generic-arrow/basic.js
@@ -1,0 +1,2 @@
+const f = async <T>(x: T): Promise<T> => x;
+

--- a/crates/swc_ecma_parser/tests/flow/issue-11925-async-generic-arrow/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11925-async-generic-arrow/basic.js.json
@@ -1,0 +1,180 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 44
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 1,
+        "end": 44
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 7,
+            "end": 43
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 7,
+              "end": 8
+            },
+            "ctxt": 0,
+            "value": "f",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "span": {
+              "start": 11,
+              "end": 43
+            },
+            "ctxt": 0,
+            "params": [
+              {
+                "type": "Identifier",
+                "span": {
+                  "start": 21,
+                  "end": 22
+                },
+                "ctxt": 0,
+                "value": "x",
+                "optional": false,
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 22,
+                    "end": 25
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeReference",
+                    "span": {
+                      "start": 24,
+                      "end": 25
+                    },
+                    "typeName": {
+                      "type": "Identifier",
+                      "span": {
+                        "start": 24,
+                        "end": 25
+                      },
+                      "ctxt": 0,
+                      "value": "T",
+                      "optional": false
+                    },
+                    "typeParams": null
+                  }
+                }
+              }
+            ],
+            "body": {
+              "type": "Identifier",
+              "span": {
+                "start": 42,
+                "end": 43
+              },
+              "ctxt": 0,
+              "value": "x",
+              "optional": false
+            },
+            "async": true,
+            "generator": false,
+            "typeParameters": {
+              "type": "TsTypeParameterDeclaration",
+              "span": {
+                "start": 17,
+                "end": 20
+              },
+              "parameters": [
+                {
+                  "type": "TsTypeParameter",
+                  "span": {
+                    "start": 18,
+                    "end": 19
+                  },
+                  "name": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 18,
+                      "end": 19
+                    },
+                    "ctxt": 0,
+                    "value": "T",
+                    "optional": false
+                  },
+                  "in": false,
+                  "out": false,
+                  "const": false,
+                  "constraint": null,
+                  "default": null
+                }
+              ]
+            },
+            "returnType": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 26,
+                "end": 38
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 28,
+                  "end": 38
+                },
+                "typeName": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 28,
+                    "end": 35
+                  },
+                  "ctxt": 0,
+                  "value": "Promise",
+                  "optional": false
+                },
+                "typeParams": {
+                  "type": "TsTypeParameterInstantiation",
+                  "span": {
+                    "start": 35,
+                    "end": 38
+                  },
+                  "params": [
+                    {
+                      "type": "TsTypeReference",
+                      "span": {
+                        "start": 36,
+                        "end": 37
+                      },
+                      "typeName": {
+                        "type": "Identifier",
+                        "span": {
+                          "start": 36,
+                          "end": 37
+                        },
+                        "ctxt": 0,
+                        "value": "T",
+                        "optional": false
+                      },
+                      "typeParams": null
+                    }
+                  ]
+                }
+              }
+            }
+          },
+          "definite": false
+        }
+      ]
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/issue-11925-declare-class-anon-param/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/issue-11925-declare-class-anon-param/basic.js
@@ -1,0 +1,5 @@
+declare class C {
+  first((e: mixed) => void): void;
+  second(a: string, (e: mixed) => void): void;
+}
+

--- a/crates/swc_ecma_parser/tests/flow/issue-11925-declare-class-anon-param/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11925-declare-class-anon-param/basic.js.json
@@ -1,0 +1,340 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 102
+  },
+  "body": [
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 15,
+          "end": 16
+        },
+        "ctxt": 0,
+        "value": "C",
+        "optional": false
+      },
+      "declare": true,
+      "span": {
+        "start": 1,
+        "end": 102
+      },
+      "ctxt": 0,
+      "decorators": [],
+      "body": [
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 21,
+            "end": 53
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 21,
+              "end": 26
+            },
+            "value": "first"
+          },
+          "function": {
+            "params": [
+              {
+                "type": "Parameter",
+                "span": {
+                  "start": 27,
+                  "end": 45
+                },
+                "decorators": [],
+                "pat": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 27,
+                    "end": 27
+                  },
+                  "ctxt": 0,
+                  "value": "__flow_anon_param_0",
+                  "optional": false,
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 27,
+                      "end": 45
+                    },
+                    "typeAnnotation": {
+                      "type": "TsFunctionType",
+                      "span": {
+                        "start": 27,
+                        "end": 45
+                      },
+                      "params": [
+                        {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 28,
+                            "end": 29
+                          },
+                          "ctxt": 0,
+                          "value": "e",
+                          "optional": false,
+                          "typeAnnotation": {
+                            "type": "TsTypeAnnotation",
+                            "span": {
+                              "start": 29,
+                              "end": 36
+                            },
+                            "typeAnnotation": {
+                              "type": "TsTypeReference",
+                              "span": {
+                                "start": 31,
+                                "end": 36
+                              },
+                              "typeName": {
+                                "type": "Identifier",
+                                "span": {
+                                  "start": 31,
+                                  "end": 36
+                                },
+                                "ctxt": 0,
+                                "value": "mixed",
+                                "optional": false
+                              },
+                              "typeParams": null
+                            }
+                          }
+                        }
+                      ],
+                      "typeParams": null,
+                      "typeAnnotation": {
+                        "type": "TsTypeAnnotation",
+                        "span": {
+                          "start": 38,
+                          "end": 45
+                        },
+                        "typeAnnotation": {
+                          "type": "TsKeywordType",
+                          "span": {
+                            "start": 41,
+                            "end": 45
+                          },
+                          "kind": "void"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "decorators": [],
+            "span": {
+              "start": 21,
+              "end": 53
+            },
+            "ctxt": 0,
+            "body": null,
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 46,
+                "end": 52
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 48,
+                  "end": 52
+                },
+                "kind": "void"
+              }
+            }
+          },
+          "kind": "method",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false
+        },
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 56,
+            "end": 100
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 56,
+              "end": 62
+            },
+            "value": "second"
+          },
+          "function": {
+            "params": [
+              {
+                "type": "Parameter",
+                "span": {
+                  "start": 63,
+                  "end": 72
+                },
+                "decorators": [],
+                "pat": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 63,
+                    "end": 64
+                  },
+                  "ctxt": 0,
+                  "value": "a",
+                  "optional": false,
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 64,
+                      "end": 72
+                    },
+                    "typeAnnotation": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 66,
+                        "end": 72
+                      },
+                      "kind": "string"
+                    }
+                  }
+                }
+              },
+              {
+                "type": "Parameter",
+                "span": {
+                  "start": 74,
+                  "end": 92
+                },
+                "decorators": [],
+                "pat": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 74,
+                    "end": 74
+                  },
+                  "ctxt": 0,
+                  "value": "__flow_anon_param_1",
+                  "optional": false,
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 74,
+                      "end": 92
+                    },
+                    "typeAnnotation": {
+                      "type": "TsFunctionType",
+                      "span": {
+                        "start": 74,
+                        "end": 92
+                      },
+                      "params": [
+                        {
+                          "type": "Identifier",
+                          "span": {
+                            "start": 75,
+                            "end": 76
+                          },
+                          "ctxt": 0,
+                          "value": "e",
+                          "optional": false,
+                          "typeAnnotation": {
+                            "type": "TsTypeAnnotation",
+                            "span": {
+                              "start": 76,
+                              "end": 83
+                            },
+                            "typeAnnotation": {
+                              "type": "TsTypeReference",
+                              "span": {
+                                "start": 78,
+                                "end": 83
+                              },
+                              "typeName": {
+                                "type": "Identifier",
+                                "span": {
+                                  "start": 78,
+                                  "end": 83
+                                },
+                                "ctxt": 0,
+                                "value": "mixed",
+                                "optional": false
+                              },
+                              "typeParams": null
+                            }
+                          }
+                        }
+                      ],
+                      "typeParams": null,
+                      "typeAnnotation": {
+                        "type": "TsTypeAnnotation",
+                        "span": {
+                          "start": 85,
+                          "end": 92
+                        },
+                        "typeAnnotation": {
+                          "type": "TsKeywordType",
+                          "span": {
+                            "start": 88,
+                            "end": 92
+                          },
+                          "kind": "void"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "decorators": [],
+            "span": {
+              "start": 56,
+              "end": 100
+            },
+            "ctxt": 0,
+            "body": null,
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 93,
+                "end": 99
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 95,
+                  "end": 99
+                },
+                "kind": "void"
+              }
+            }
+          },
+          "kind": "method",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false
+        }
+      ],
+      "superClass": null,
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
**Description:**

Fixes two Flow parser gaps reported in #11925:

- Parse async generic arrows with typed params and explicit return annotations, such as `async <T>(x: T): Promise<T> => x`.
- Parse anonymous function-type parameters in `declare class` method signatures, preserving the existing `__flow_anon_param_N` synthetic parameter convention.
- Adds focused Flow parser fixtures for both cases.

Validated with:

- `cargo fmt --all`
- `cargo test -p swc_ecma_parser`
- `cargo test -p swc_ecma_parser --features flow --test flow -- --ignored`
- `cargo test -p swc_ecma_transforms_typescript flow_strip_reparses_as_javascript -- --ignored`
- `cargo test -p swc_ecma_parser --features flow --test flow_hermes`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

No.

**Related issue (if exists):**

Fixes #11925
