### PR TITLE
fix(es/minifier): handle unknown member props

### DIFF
--- a/.changeset/handle-unknown-minifier-member-props.md
+++ b/.changeset/handle-unknown-minifier-member-props.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): Handle unknown member props in hoisted property optimization

--- a/crates/swc_ecma_minifier/src/compress/optimize/util.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/util.rs
@@ -528,6 +528,8 @@ impl VisitMut for Finalizer<'_> {
                             _ => break 'a,
                         },
                         MemberProp::PrivateName(_) => break 'a,
+                        #[cfg(swc_ast_unknown)]
+                        _ => break 'a,
                     };
 
                     if let Some(ident) = self.hoisted_props.get(&(obj.to_id(), sym.clone())) {


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Fixes a build failure when `swc_ecma_minifier` is compiled with `RUSTFLAGS="--cfg swc_ast_unknown"`.

With `swc_ast_unknown`, `MemberProp` is treated as non-exhaustive, so the hoisted property replacement match in the minifier needs to account for future or unknown variants. Unknown member props now simply skip this optimization path, preserving the original expression and normal traversal behavior.

Also adds a patch changeset for `swc_ecma_minifier` and `swc_core`.

Validated with:

- `RUSTFLAGS="--cfg swc_ast_unknown" cargo check -p swc_ecma_minifier`
- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo test -p swc_ecma_minifier`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Closes #11910
