### PR TITLE
fix(es/parser): parse Flow bare renders types

### DIFF
--- a/.changeset/fix-flow-bare-renders.md
+++ b/.changeset/fix-flow-bare-renders.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: minor
+---
+
+fix(es/parser): Parse Flow bare `renders` render types

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -4403,8 +4403,10 @@ impl<I: Tokens> Parser<I> {
                 }
                 p.bump();
 
-                if !p.input_mut().eat(Token::QuestionMark) {
-                    p.input_mut().eat(Token::Asterisk);
+                if matches!(p.input().cur(), Token::QuestionMark | Token::Asterisk)
+                    && p.input().prev_span().hi == p.input().cur_span().lo
+                {
+                    p.bump();
                 }
 
                 let type_ann = p.parse_ts_non_array_type()?;

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -2336,6 +2336,9 @@ impl<I: Tokens> Parser<I> {
             matches!(self.input().cur(), Token::LBrace | Token::LBracket);
 
         let cur = self.input().cur();
+        let starts_with_flow_renders = self.input().syntax().flow()
+            && cur.is_word()
+            && cur.take_word(&self.input) == atom!("renders");
         if cur == Token::RParen || cur == Token::DotDotDot {
             // ( )
             // ( ...
@@ -2360,12 +2363,18 @@ impl<I: Tokens> Parser<I> {
                 // ( xxx ,
                 // ( xxx ?
                 // ( xxx =
+                if starts_with_flow_renders && cur == Token::Comma {
+                    return Ok(false);
+                }
                 if disallow_flow_anon_fn_type && starts_with_parenthesized_object_or_array {
                     return Ok(false);
                 }
                 return Ok(true);
             }
             if self.input_mut().eat(Token::RParen) && self.input().cur() == Token::Arrow {
+                if starts_with_flow_renders {
+                    return Ok(false);
+                }
                 if disallow_flow_anon_fn_type {
                     // In arrow return type context, `(T) => U` should bind to
                     // the outer arrow unless the function type is parenthesized.
@@ -3216,6 +3225,15 @@ impl<I: Tokens> Parser<I> {
             TsFnParam::Object(param) => Pat::Object(param),
             #[cfg(swc_ast_unknown)]
             _ => unreachable!(),
+    fn is_flow_bare_renders_type(ty: &TsType) -> bool {
+        match ty {
+            TsType::TsTypeRef(TsTypeRef {
+                type_name: TsEntityName::Ident(ident),
+                type_params: None,
+                ..
+            }) => ident.sym == atom!("renders"),
+            TsType::TsParenthesizedType(ty) => Self::is_flow_bare_renders_type(&ty.type_ann),
+            _ => false,
         }
     }
 
@@ -3292,6 +3310,9 @@ impl<I: Tokens> Parser<I> {
         ) {
             return Ok(None);
         }
+        if Self::is_flow_bare_renders_type(&ty) {
+            return Ok(None);
+        }
         if !(self.input().is(Token::Comma) || self.input().is(Token::RParen)) {
             return Ok(None);
         }
@@ -3348,6 +3369,9 @@ impl<I: Tokens> Parser<I> {
                 self.input().cur(),
                 Token::Colon | Token::QuestionMark | Token::Eq
             ) {
+                return Ok(None);
+            }
+            if Self::is_flow_bare_renders_type(&ty) {
                 return Ok(None);
             }
 
@@ -3443,6 +3467,7 @@ impl<I: Tokens> Parser<I> {
                         && !self.input().had_line_break_before_cur()
                         && self.input().is(Token::Arrow)
                         && !matches!(&*ty, TsType::TsThisType(..))
+                        && !Self::is_flow_bare_renders_type(&ty)
                     {
                         let param = self.make_flow_anon_fn_param(ty.span_lo(), 0, None, ty);
                         let type_ann = self.parse_ts_type_or_type_predicate_ann(Token::Arrow)?;
@@ -4375,8 +4400,8 @@ impl<I: Tokens> Parser<I> {
                 }
                 p.bump();
 
-                if !(p.input_mut().eat(Token::QuestionMark) || p.input_mut().eat(Token::Asterisk)) {
-                    return Ok(None);
+                if !p.input_mut().eat(Token::QuestionMark) {
+                    p.input_mut().eat(Token::Asterisk);
                 }
 
                 let type_ann = p.parse_ts_non_array_type()?;

--- a/crates/swc_ecma_parser/src/parser/typescript.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript.rs
@@ -3225,6 +3225,9 @@ impl<I: Tokens> Parser<I> {
             TsFnParam::Object(param) => Pat::Object(param),
             #[cfg(swc_ast_unknown)]
             _ => unreachable!(),
+        }
+    }
+
     fn is_flow_bare_renders_type(ty: &TsType) -> bool {
         match ty {
             TsType::TsTypeRef(TsTypeRef {

--- a/crates/swc_ecma_parser/tests/flow/issue-11928-bare-renders-type/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/issue-11928-bare-renders-type/basic.js
@@ -1,4 +1,5 @@
 type Rendered = renders React.Node;
+type MaybeRendered = renders ?React.Node;
 
 function f(x: renders React.Node) {}
 

--- a/crates/swc_ecma_parser/tests/flow/issue-11928-bare-renders-type/basic.js
+++ b/crates/swc_ecma_parser/tests/flow/issue-11928-bare-renders-type/basic.js
@@ -1,0 +1,11 @@
+type Rendered = renders React.Node;
+
+function f(x: renders React.Node) {}
+
+type P = { node: renders React.Node };
+
+const g = (): renders React.Node => null;
+
+type X = Array<renders React.Node>;
+
+component Foo() renders React.Node {}

--- a/crates/swc_ecma_parser/tests/flow/issue-11928-bare-renders-type/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11928-bare-renders-type/basic.js.json
@@ -1,0 +1,503 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 233
+  },
+  "body": [
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 1,
+        "end": 36
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 6,
+          "end": 14
+        },
+        "ctxt": 0,
+        "value": "Rendered",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeReference",
+        "span": {
+          "start": 25,
+          "end": 35
+        },
+        "typeName": {
+          "type": "TsQualifiedName",
+          "span": {
+            "start": 25,
+            "end": 35
+          },
+          "left": {
+            "type": "Identifier",
+            "span": {
+              "start": 25,
+              "end": 30
+            },
+            "ctxt": 0,
+            "value": "React",
+            "optional": false
+          },
+          "right": {
+            "type": "Identifier",
+            "span": {
+              "start": 31,
+              "end": 35
+            },
+            "value": "Node"
+          }
+        },
+        "typeParams": null
+      }
+    },
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 47,
+          "end": 48
+        },
+        "ctxt": 0,
+        "value": "f",
+        "optional": false
+      },
+      "declare": false,
+      "params": [
+        {
+          "type": "Parameter",
+          "span": {
+            "start": 49,
+            "end": 70
+          },
+          "decorators": [],
+          "pat": {
+            "type": "Identifier",
+            "span": {
+              "start": 49,
+              "end": 50
+            },
+            "ctxt": 0,
+            "value": "x",
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 50,
+                "end": 70
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 60,
+                  "end": 70
+                },
+                "typeName": {
+                  "type": "TsQualifiedName",
+                  "span": {
+                    "start": 60,
+                    "end": 70
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 60,
+                      "end": 65
+                    },
+                    "ctxt": 0,
+                    "value": "React",
+                    "optional": false
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 66,
+                      "end": 70
+                    },
+                    "value": "Node"
+                  }
+                },
+                "typeParams": null
+              }
+            }
+          }
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 38,
+        "end": 74
+      },
+      "ctxt": 0,
+      "body": {
+        "type": "BlockStatement",
+        "span": {
+          "start": 72,
+          "end": 74
+        },
+        "ctxt": 0,
+        "stmts": []
+      },
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": null
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 76,
+        "end": 114
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 81,
+          "end": 82
+        },
+        "ctxt": 0,
+        "value": "P",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeLiteral",
+        "span": {
+          "start": 85,
+          "end": 113
+        },
+        "members": [
+          {
+            "type": "TsPropertySignature",
+            "span": {
+              "start": 87,
+              "end": 111
+            },
+            "readonly": false,
+            "key": {
+              "type": "Identifier",
+              "span": {
+                "start": 87,
+                "end": 91
+              },
+              "ctxt": 0,
+              "value": "node",
+              "optional": false
+            },
+            "computed": false,
+            "optional": false,
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 91,
+                "end": 111
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 101,
+                  "end": 111
+                },
+                "typeName": {
+                  "type": "TsQualifiedName",
+                  "span": {
+                    "start": 101,
+                    "end": 111
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 101,
+                      "end": 106
+                    },
+                    "ctxt": 0,
+                    "value": "React",
+                    "optional": false
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 107,
+                      "end": 111
+                    },
+                    "value": "Node"
+                  }
+                },
+                "typeParams": null
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 116,
+        "end": 157
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 122,
+            "end": 156
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 122,
+              "end": 123
+            },
+            "ctxt": 0,
+            "value": "g",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "ArrowFunctionExpression",
+            "span": {
+              "start": 126,
+              "end": 156
+            },
+            "ctxt": 0,
+            "params": [],
+            "body": {
+              "type": "NullLiteral",
+              "span": {
+                "start": 152,
+                "end": 156
+              }
+            },
+            "async": false,
+            "generator": false,
+            "typeParameters": null,
+            "returnType": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 128,
+                "end": 148
+              },
+              "typeAnnotation": {
+                "type": "TsTypeReference",
+                "span": {
+                  "start": 138,
+                  "end": 148
+                },
+                "typeName": {
+                  "type": "TsQualifiedName",
+                  "span": {
+                    "start": 138,
+                    "end": 148
+                  },
+                  "left": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 138,
+                      "end": 143
+                    },
+                    "ctxt": 0,
+                    "value": "React",
+                    "optional": false
+                  },
+                  "right": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 144,
+                      "end": 148
+                    },
+                    "value": "Node"
+                  }
+                },
+                "typeParams": null
+              }
+            }
+          },
+          "definite": false
+        }
+      ]
+    },
+    {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 159,
+        "end": 194
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 164,
+          "end": 165
+        },
+        "ctxt": 0,
+        "value": "X",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsTypeReference",
+        "span": {
+          "start": 168,
+          "end": 193
+        },
+        "typeName": {
+          "type": "Identifier",
+          "span": {
+            "start": 168,
+            "end": 173
+          },
+          "ctxt": 0,
+          "value": "Array",
+          "optional": false
+        },
+        "typeParams": {
+          "type": "TsTypeParameterInstantiation",
+          "span": {
+            "start": 173,
+            "end": 193
+          },
+          "params": [
+            {
+              "type": "TsTypeReference",
+              "span": {
+                "start": 182,
+                "end": 192
+              },
+              "typeName": {
+                "type": "TsQualifiedName",
+                "span": {
+                  "start": 182,
+                  "end": 192
+                },
+                "left": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 182,
+                    "end": 187
+                  },
+                  "ctxt": 0,
+                  "value": "React",
+                  "optional": false
+                },
+                "right": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 188,
+                    "end": 192
+                  },
+                  "value": "Node"
+                }
+              },
+              "typeParams": null
+            }
+          ]
+        }
+      }
+    },
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 206,
+          "end": 209
+        },
+        "ctxt": 0,
+        "value": "Foo",
+        "optional": false
+      },
+      "declare": false,
+      "params": [
+        {
+          "type": "Parameter",
+          "span": {
+            "start": 196,
+            "end": 211
+          },
+          "decorators": [],
+          "pat": {
+            "type": "ObjectPattern",
+            "span": {
+              "start": 196,
+              "end": 211
+            },
+            "properties": [],
+            "optional": false,
+            "typeAnnotation": null
+          }
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 196,
+        "end": 233
+      },
+      "ctxt": 0,
+      "body": {
+        "type": "BlockStatement",
+        "span": {
+          "start": 231,
+          "end": 233
+        },
+        "ctxt": 0,
+        "stmts": []
+      },
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 212,
+          "end": 230
+        },
+        "typeAnnotation": {
+          "type": "TsTypeReference",
+          "span": {
+            "start": 220,
+            "end": 230
+          },
+          "typeName": {
+            "type": "TsQualifiedName",
+            "span": {
+              "start": 220,
+              "end": 230
+            },
+            "left": {
+              "type": "Identifier",
+              "span": {
+                "start": 220,
+                "end": 225
+              },
+              "ctxt": 0,
+              "value": "React",
+              "optional": false
+            },
+            "right": {
+              "type": "Identifier",
+              "span": {
+                "start": 226,
+                "end": 230
+              },
+              "value": "Node"
+            }
+          },
+          "typeParams": null
+        }
+      }
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/flow/issue-11928-bare-renders-type/basic.js.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11928-bare-renders-type/basic.js.json
@@ -2,7 +2,7 @@
   "type": "Script",
   "span": {
     "start": 1,
-    "end": 233
+    "end": 275
   },
   "body": [
     {
@@ -58,12 +58,89 @@
       }
     },
     {
+      "type": "TsTypeAliasDeclaration",
+      "span": {
+        "start": 37,
+        "end": 78
+      },
+      "declare": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 42,
+          "end": 55
+        },
+        "ctxt": 0,
+        "value": "MaybeRendered",
+        "optional": false
+      },
+      "typeParams": null,
+      "typeAnnotation": {
+        "type": "TsUnionType",
+        "span": {
+          "start": 66,
+          "end": 77
+        },
+        "types": [
+          {
+            "type": "TsTypeReference",
+            "span": {
+              "start": 67,
+              "end": 77
+            },
+            "typeName": {
+              "type": "TsQualifiedName",
+              "span": {
+                "start": 67,
+                "end": 77
+              },
+              "left": {
+                "type": "Identifier",
+                "span": {
+                  "start": 67,
+                  "end": 72
+                },
+                "ctxt": 0,
+                "value": "React",
+                "optional": false
+              },
+              "right": {
+                "type": "Identifier",
+                "span": {
+                  "start": 73,
+                  "end": 77
+                },
+                "value": "Node"
+              }
+            },
+            "typeParams": null
+          },
+          {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 66,
+              "end": 77
+            },
+            "kind": "null"
+          },
+          {
+            "type": "TsKeywordType",
+            "span": {
+              "start": 66,
+              "end": 77
+            },
+            "kind": "undefined"
+          }
+        ]
+      }
+    },
+    {
       "type": "FunctionDeclaration",
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 47,
-          "end": 48
+          "start": 89,
+          "end": 90
         },
         "ctxt": 0,
         "value": "f",
@@ -74,15 +151,15 @@
         {
           "type": "Parameter",
           "span": {
-            "start": 49,
-            "end": 70
+            "start": 91,
+            "end": 112
           },
           "decorators": [],
           "pat": {
             "type": "Identifier",
             "span": {
-              "start": 49,
-              "end": 50
+              "start": 91,
+              "end": 92
             },
             "ctxt": 0,
             "value": "x",
@@ -90,26 +167,26 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 50,
-                "end": 70
+                "start": 92,
+                "end": 112
               },
               "typeAnnotation": {
                 "type": "TsTypeReference",
                 "span": {
-                  "start": 60,
-                  "end": 70
+                  "start": 102,
+                  "end": 112
                 },
                 "typeName": {
                   "type": "TsQualifiedName",
                   "span": {
-                    "start": 60,
-                    "end": 70
+                    "start": 102,
+                    "end": 112
                   },
                   "left": {
                     "type": "Identifier",
                     "span": {
-                      "start": 60,
-                      "end": 65
+                      "start": 102,
+                      "end": 107
                     },
                     "ctxt": 0,
                     "value": "React",
@@ -118,8 +195,8 @@
                   "right": {
                     "type": "Identifier",
                     "span": {
-                      "start": 66,
-                      "end": 70
+                      "start": 108,
+                      "end": 112
                     },
                     "value": "Node"
                   }
@@ -132,15 +209,15 @@
       ],
       "decorators": [],
       "span": {
-        "start": 38,
-        "end": 74
+        "start": 80,
+        "end": 116
       },
       "ctxt": 0,
       "body": {
         "type": "BlockStatement",
         "span": {
-          "start": 72,
-          "end": 74
+          "start": 114,
+          "end": 116
         },
         "ctxt": 0,
         "stmts": []
@@ -153,15 +230,15 @@
     {
       "type": "TsTypeAliasDeclaration",
       "span": {
-        "start": 76,
-        "end": 114
+        "start": 118,
+        "end": 156
       },
       "declare": false,
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 81,
-          "end": 82
+          "start": 123,
+          "end": 124
         },
         "ctxt": 0,
         "value": "P",
@@ -171,22 +248,22 @@
       "typeAnnotation": {
         "type": "TsTypeLiteral",
         "span": {
-          "start": 85,
-          "end": 113
+          "start": 127,
+          "end": 155
         },
         "members": [
           {
             "type": "TsPropertySignature",
             "span": {
-              "start": 87,
-              "end": 111
+              "start": 129,
+              "end": 153
             },
             "readonly": false,
             "key": {
               "type": "Identifier",
               "span": {
-                "start": 87,
-                "end": 91
+                "start": 129,
+                "end": 133
               },
               "ctxt": 0,
               "value": "node",
@@ -197,26 +274,26 @@
             "typeAnnotation": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 91,
-                "end": 111
+                "start": 133,
+                "end": 153
               },
               "typeAnnotation": {
                 "type": "TsTypeReference",
                 "span": {
-                  "start": 101,
-                  "end": 111
+                  "start": 143,
+                  "end": 153
                 },
                 "typeName": {
                   "type": "TsQualifiedName",
                   "span": {
-                    "start": 101,
-                    "end": 111
+                    "start": 143,
+                    "end": 153
                   },
                   "left": {
                     "type": "Identifier",
                     "span": {
-                      "start": 101,
-                      "end": 106
+                      "start": 143,
+                      "end": 148
                     },
                     "ctxt": 0,
                     "value": "React",
@@ -225,8 +302,8 @@
                   "right": {
                     "type": "Identifier",
                     "span": {
-                      "start": 107,
-                      "end": 111
+                      "start": 149,
+                      "end": 153
                     },
                     "value": "Node"
                   }
@@ -241,8 +318,8 @@
     {
       "type": "VariableDeclaration",
       "span": {
-        "start": 116,
-        "end": 157
+        "start": 158,
+        "end": 199
       },
       "ctxt": 0,
       "kind": "const",
@@ -251,14 +328,14 @@
         {
           "type": "VariableDeclarator",
           "span": {
-            "start": 122,
-            "end": 156
+            "start": 164,
+            "end": 198
           },
           "id": {
             "type": "Identifier",
             "span": {
-              "start": 122,
-              "end": 123
+              "start": 164,
+              "end": 165
             },
             "ctxt": 0,
             "value": "g",
@@ -268,16 +345,16 @@
           "init": {
             "type": "ArrowFunctionExpression",
             "span": {
-              "start": 126,
-              "end": 156
+              "start": 168,
+              "end": 198
             },
             "ctxt": 0,
             "params": [],
             "body": {
               "type": "NullLiteral",
               "span": {
-                "start": 152,
-                "end": 156
+                "start": 194,
+                "end": 198
               }
             },
             "async": false,
@@ -286,26 +363,26 @@
             "returnType": {
               "type": "TsTypeAnnotation",
               "span": {
-                "start": 128,
-                "end": 148
+                "start": 170,
+                "end": 190
               },
               "typeAnnotation": {
                 "type": "TsTypeReference",
                 "span": {
-                  "start": 138,
-                  "end": 148
+                  "start": 180,
+                  "end": 190
                 },
                 "typeName": {
                   "type": "TsQualifiedName",
                   "span": {
-                    "start": 138,
-                    "end": 148
+                    "start": 180,
+                    "end": 190
                   },
                   "left": {
                     "type": "Identifier",
                     "span": {
-                      "start": 138,
-                      "end": 143
+                      "start": 180,
+                      "end": 185
                     },
                     "ctxt": 0,
                     "value": "React",
@@ -314,8 +391,8 @@
                   "right": {
                     "type": "Identifier",
                     "span": {
-                      "start": 144,
-                      "end": 148
+                      "start": 186,
+                      "end": 190
                     },
                     "value": "Node"
                   }
@@ -331,15 +408,15 @@
     {
       "type": "TsTypeAliasDeclaration",
       "span": {
-        "start": 159,
-        "end": 194
+        "start": 201,
+        "end": 236
       },
       "declare": false,
       "id": {
         "type": "Identifier",
         "span": {
-          "start": 164,
-          "end": 165
+          "start": 206,
+          "end": 207
         },
         "ctxt": 0,
         "value": "X",
@@ -349,14 +426,14 @@
       "typeAnnotation": {
         "type": "TsTypeReference",
         "span": {
-          "start": 168,
-          "end": 193
+          "start": 210,
+          "end": 235
         },
         "typeName": {
           "type": "Identifier",
           "span": {
-            "start": 168,
-            "end": 173
+            "start": 210,
+            "end": 215
           },
           "ctxt": 0,
           "value": "Array",
@@ -365,27 +442,27 @@
         "typeParams": {
           "type": "TsTypeParameterInstantiation",
           "span": {
-            "start": 173,
-            "end": 193
+            "start": 215,
+            "end": 235
           },
           "params": [
             {
               "type": "TsTypeReference",
               "span": {
-                "start": 182,
-                "end": 192
+                "start": 224,
+                "end": 234
               },
               "typeName": {
                 "type": "TsQualifiedName",
                 "span": {
-                  "start": 182,
-                  "end": 192
+                  "start": 224,
+                  "end": 234
                 },
                 "left": {
                   "type": "Identifier",
                   "span": {
-                    "start": 182,
-                    "end": 187
+                    "start": 224,
+                    "end": 229
                   },
                   "ctxt": 0,
                   "value": "React",
@@ -394,8 +471,8 @@
                 "right": {
                   "type": "Identifier",
                   "span": {
-                    "start": 188,
-                    "end": 192
+                    "start": 230,
+                    "end": 234
                   },
                   "value": "Node"
                 }
@@ -411,8 +488,8 @@
       "identifier": {
         "type": "Identifier",
         "span": {
-          "start": 206,
-          "end": 209
+          "start": 248,
+          "end": 251
         },
         "ctxt": 0,
         "value": "Foo",
@@ -423,15 +500,15 @@
         {
           "type": "Parameter",
           "span": {
-            "start": 196,
-            "end": 211
+            "start": 238,
+            "end": 253
           },
           "decorators": [],
           "pat": {
             "type": "ObjectPattern",
             "span": {
-              "start": 196,
-              "end": 211
+              "start": 238,
+              "end": 253
             },
             "properties": [],
             "optional": false,
@@ -441,15 +518,15 @@
       ],
       "decorators": [],
       "span": {
-        "start": 196,
-        "end": 233
+        "start": 238,
+        "end": 275
       },
       "ctxt": 0,
       "body": {
         "type": "BlockStatement",
         "span": {
-          "start": 231,
-          "end": 233
+          "start": 273,
+          "end": 275
         },
         "ctxt": 0,
         "stmts": []
@@ -460,26 +537,26 @@
       "returnType": {
         "type": "TsTypeAnnotation",
         "span": {
-          "start": 212,
-          "end": 230
+          "start": 254,
+          "end": 272
         },
         "typeAnnotation": {
           "type": "TsTypeReference",
           "span": {
-            "start": 220,
-            "end": 230
+            "start": 262,
+            "end": 272
           },
           "typeName": {
             "type": "TsQualifiedName",
             "span": {
-              "start": 220,
-              "end": 230
+              "start": 262,
+              "end": 272
             },
             "left": {
               "type": "Identifier",
               "span": {
-                "start": 220,
-                "end": 225
+                "start": 262,
+                "end": 267
               },
               "ctxt": 0,
               "value": "React",
@@ -488,8 +565,8 @@
             "right": {
               "type": "Identifier",
               "span": {
-                "start": 226,
-                "end": 230
+                "start": 268,
+                "end": 272
               },
               "value": "Node"
             }

--- a/crates/swc_ecma_parser/tests/flow/issue-11928-bare-renders-type/config.json
+++ b/crates/swc_ecma_parser/tests/flow/issue-11928-bare-renders-type/config.json
@@ -1,0 +1,3 @@
+{
+  "components": true
+}


### PR DESCRIPTION
**Description:**

Fixes Flow parser support for bare `renders T` in type positions. The parser previously only recognized the `renders? T` and `renders* T` forms, so bare `renders React.Node` was parsed as a type reference named `renders` and failed on the operand.

This change lets bare `renders` consume an operand type using the existing erased AST representation, while keeping invalid operand-less `renders` cases from being reinterpreted as Flow anonymous function type parameters.

Validation:

- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_parser --features flow --test flow`
- `FLOW_HERMES_FILTER=types/render_types/renders.js cargo test -p swc_ecma_parser --features flow --test flow_hermes hermes_flow_error_presence_parity`

Note: `cargo test -p swc_ecma_parser` still fails on the unrelated existing TypeScript fixture `errors_tests__typescript_errors__type_only_import_specifier__invalid_type_only__input_ts`, which also fails when run alone.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Fixes #11928
