### PR TITLE
fix(es/minifier): Preserve `cooked` when concatenating template literals

### DIFF
--- a/.changeset/minifier-concat-tpl-cooked.md
+++ b/.changeset/minifier-concat-tpl-cooked.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): Preserve `cooked` when concatenating template literals

--- a/crates/swc_ecma_minifier/src/compress/pure/strings.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/strings.rs
@@ -493,9 +493,19 @@ impl Pure<'_> {
                 {
                     let l_last = l.quasis.pop().unwrap();
                     let r_first = rt.quasis.first_mut().unwrap();
-                    let new: Atom = format!("{}{}", l_last.raw, r_first.raw).into();
 
-                    r_first.raw = new;
+                    let new_raw: Atom = format!("{}{}", l_last.raw, r_first.raw).into();
+                    r_first.raw = new_raw;
+
+                    let new_cooked = match (l_last.cooked, &r_first.cooked) {
+                        (Some(l_cooked), Some(r_cooked)) => {
+                            let mut c = Wtf8Buf::from(&l_cooked);
+                            c.push_wtf8(r_cooked);
+                            Some(c.into())
+                        }
+                        _ => None,
+                    };
+                    r_first.cooked = new_cooked;
                 }
 
                 l.quasis.extend(rt.quasis.take());

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -293,6 +293,19 @@ fn run_default_exec_test(input_src: &str) {
 }
 
 #[test]
+fn concat_tpl_keeps_delimiter_after_interpolation() {
+    run_default_exec_test(
+        r#"
+        console.log(`<b>${1}</b>` + `<i>${2}</i>`);
+        console.log(`width:${1}px;` + `height:${2}px;`);
+        console.log(`a${0}]` + `${0}b`);
+        console.log(`<a>${1}</a>` + `<b>${2}</b>` + `<c>${3}</c>`);
+        console.log(`x${1}|` + "mid" + `z${2}|`);
+        "#,
+    );
+}
+
+#[test]
 fn next_feedback_1_capture_1() {
     let src = r###"
 const arr = [];


### PR DESCRIPTION
**Description:**

When `compress` folds `a + b` and both sides are template literals, `concat_tpl` merges them into one template literal. Merging the boundary quasis — the last quasi of the left template with the first quasi of the right — updates `raw` but not `cooked`, leaving the merged quasi with `raw` and `cooked` out of sync. Downstream passes (`eval_tpl_as_str`, `eval_nested_tpl`, `compress_tpl`) evaluate the template to a string via `cooked`, so the text after the left template's last interpolation is silently dropped. The result is wrong but not a syntax error, so it ships.

Example (`@swc/core` 1.15.41):

```js
const { minifySync } = require("@swc/core");
const src = "const html = `<b>${1}</b>` + `<i>${2}</i>`;";
console.log(minifySync(src, { compress: true }).code);
```

Output — the closing `</b>` is dropped:

```js
const html = "<b>1<i>2</i>";   // expected: "<b>1</b><i>2</i>"
```

So at runtime the original yields `<b>1</b><i>2</i>`, but the minified code yields `<b>1<i>2</i>`.

The dropped text is whatever follows the **left** template's last interpolation:

| Source | Expected | Minified |
| --- | --- | --- |
| `` `<b>${1}</b>` + `<i>${2}</i>` `` | `<b>1</b><i>2</i>` | `<b>1<i>2</i>` |
| `` `width:${1}px;` + `height:${2}px;` `` | `width:1px;height:2px;` | `width:1height:2px;` |
| `` `(${1})` + ` (${2})` `` | `(1) (2)` | `(1 (2)` |

Smallest reproduction:

```js
require("@swc/core").minifySync("x = `a${0}]` + `${0}b`", { compress: true }).code
// actual:   x="a00b";
// expected: x="a0]0b";
```

The trigger requires **both** template literals to contain an interpolation (`` `a${1}b` + `plain` `` is unaffected, since the right side has none).

The sibling branches `Tpl + Str` and `Str + Tpl` already merge `cooked`; only the `Tpl + Tpl` branch was missing it.

**Fix:** in the `Tpl + Tpl` branch of `concat_tpl`, merge `cooked` the same way `raw` is merged, falling back to `None` if either side's `cooked` is `None` (an invalid escape sequence). Added an exec regression test that runs the original and the minified code and compares the output. `cargo test -p swc_ecma_minifier` passes (lib: 49, exec: 481, 0 failures).

**Related issue (if exists):**

None found — this appears to be unreported. It also surfaces through bundlers that wrap swc's JS minifier (e.g. rspack / rsbuild).
