### PR TITLE
fix(es/react-compiler): skip TypeScript `this` pseudo-params in scope collector

### DIFF
--- a/.changeset/fix-react-compiler-ts-this-param.md
+++ b/.changeset/fix-react-compiler-ts-this-param.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_react_compiler: patch
+---
+
+fix(es/react-compiler): Skip TypeScript `this` pseudo-params in scope collector

--- a/crates/swc_ecma_react_compiler/src/convert_scope.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_scope.rs
@@ -510,6 +510,11 @@ impl SemanticBuilder {
     fn collect_pat_bindings(&mut self, pat: &Pat, flags: SymbolFlags) {
         match pat {
             Pat::Ident(binding_ident) => {
+                // TypeScript `this` pseudo-parameters are type annotations only.
+                // They are erased before emit and must not be registered as bindings.
+                if binding_ident.id.sym.as_str() == "this" {
+                    return;
+                }
                 self.declare_symbol(
                     binding_ident.id.span,
                     binding_ident.id.sym.to_string(),

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -1435,6 +1435,42 @@ fn ts_import_equals_export_round_trips() {
     );
 }
 
+/// A TypeScript `this` parameter (`function f(this: T) {}`) declares the type
+/// of `this` inside the body. SWC represents it as a `Pat::Ident("this")`,
+/// indistinguishable from a real parameter. The scope collector must skip it
+/// to avoid a "reserved word" diagnostic.
+#[test]
+fn ts_this_param_in_function_is_not_a_reserved_identifier_error() {
+    let source = r#"
+        'use client';
+
+        import * as React from 'react';
+
+        function useClickHandler() {
+            const [count, setCount] = React.useState(0);
+            function handleClick(this: HTMLElement) {
+                setCount(c => c + 1);
+            }
+            return handleClick;
+        }
+    "#;
+
+    let result = transform_source(
+        source,
+        swc_ecma_parser::Syntax::Typescript(swc_ecma_parser::TsSyntax {
+            tsx: true,
+            ..Default::default()
+        }),
+        default_options(),
+    );
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "got unexpected diagnostic for TS `this` param: {:#?}",
+        result.diagnostics
+    );
+}
+
 fn emit_program(program: &swc_ecma_ast::Program) -> Result<String, String> {
     let cm = Lrc::new(SourceMap::default());
     let mut buf = Vec::new();


### PR DESCRIPTION
TypeScript allows `function f(this: T) {}` to declare the type of this inside a function body.

To swc, this looks like a real parameter. The scope collector was registering it as a binding, causing the compiler to emit an unexpected "reserved word" diagnostic for any hook containing a function with a TS-annotated `this` param.

This returns early specifically when the ident name is "this".