### PR TITLE
feat(swc): gate react compiler re-export

### DIFF
--- a/.changeset/gate-react-compiler-feature.md
+++ b/.changeset/gate-react-compiler-feature.md
@@ -1,0 +1,7 @@
+---
+swc: major
+swc_cli_impl: patch
+swc_core: major
+---
+
+feat(swc): Gate React Compiler behind opt-in Cargo features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5665,6 +5665,7 @@ dependencies = [
  "swc_ecma_minifier",
  "swc_ecma_parser",
  "swc_ecma_preset_env",
+ "swc_ecma_react_compiler",
  "swc_ecma_testing",
  "swc_ecma_transforms",
  "swc_ecma_transforms_base",

--- a/bindings/binding_core_node/Cargo.toml
+++ b/bindings/binding_core_node/Cargo.toml
@@ -63,5 +63,6 @@ swc_core = { path = "../../crates/swc_core", features = [
   "base_concurrent",
   "base_flow",
   "base_module",
+  "base_react_compiler",
 ] }
 swc_malloc = { path = "../../crates/swc_malloc" }

--- a/bindings/binding_core_wasm/Cargo.toml
+++ b/bindings/binding_core_wasm/Cargo.toml
@@ -45,6 +45,7 @@ swc_core = { path = "../../crates/swc_core", features = [
   "ecma_helpers_inline",
   "ecma_lints",
   "base_module",
+  "base_react_compiler",
 ] }
 tracing = { workspace = true, features = ["max_level_off"] }
 wasm-bindgen = { workspace = true, features = ["enable-interning"] }

--- a/crates/swc/Cargo.toml
+++ b/crates/swc/Cargo.toml
@@ -33,6 +33,10 @@ isolated-dts = ["swc_typescript"]
 # Bundlers typically don't need this as they handle module transforms themselves.
 module = ["swc_ecma_transforms/module", "swc_ecma_transforms_module"]
 node = ["napi", "napi-derive", "swc_compiler_base/node"]
+
+# Enable React Compiler APIs.
+react-compiler = ["dep:swc_ecma_react_compiler"]
+
 plugin = [
   "swc_plugin_runner/ecma",
   "swc_plugin_runner/encoding-impl",
@@ -104,6 +108,7 @@ swc_ecma_parser = { version = "41.0.1", path = "../swc_ecma_parser", default-fea
   "typescript",
 ] }
 swc_ecma_preset_env = { version = "56.0.0", path = "../swc_ecma_preset_env", default-features = false, features = ["serde-impl"] }
+swc_ecma_react_compiler = { version = "19.0.0", path = "../swc_ecma_react_compiler", optional = true }
 swc_ecma_transforms = { version = "55.0.1", path = "../swc_ecma_transforms", features = [
   "compat",
   "optimization",

--- a/crates/swc/src/lib.rs
+++ b/crates/swc/src/lib.rs
@@ -111,6 +111,10 @@
 
 pub extern crate swc_atoms as atoms;
 extern crate swc_common as common;
+/// React Compiler APIs.
+#[cfg(feature = "react-compiler")]
+#[cfg_attr(docsrs, doc(cfg(feature = "react-compiler")))]
+pub extern crate swc_ecma_react_compiler as react_compiler;
 
 use std::{
     fs::{read_to_string, File},

--- a/crates/swc/tests/projects.rs
+++ b/crates/swc/tests/projects.rs
@@ -800,6 +800,14 @@ fn tests(input_dir: PathBuf) {
         }
     }
 
+    #[cfg(not(feature = "react-compiler"))]
+    {
+        let input_dir_norm = input_dir.to_string_lossy().replace('\\', "/");
+        if input_dir_norm.contains("tests/fixture/options/react-compiler/") {
+            return;
+        }
+    }
+
     let output_dir = input_dir.parent().unwrap().join("output");
 
     for entry in WalkDir::new(&input_dir) {

--- a/crates/swc_cli_impl/Cargo.toml
+++ b/crates/swc_cli_impl/Cargo.toml
@@ -45,6 +45,7 @@ swc_core = { version = "68.1.2", features = [
   "base_concurrent",
   "base_flow",
   "base_module",
+  "base_react_compiler",
   "ecma_helpers_inline",
 ], path = "../swc_core" }
 

--- a/crates/swc_core/Cargo.toml
+++ b/crates/swc_core/Cargo.toml
@@ -66,6 +66,8 @@ base_flow = ["__base", "swc/flow"]
 # Enable module transforms (CommonJS, AMD, UMD, SystemJS).
 # Bundlers typically don't need this as they handle module transforms themselves.
 base_module = ["__base", "swc/module"]
+# Enable React Compiler APIs exposed via `base`.
+base_react_compiler = ["__base", "swc/react-compiler"]
 # Enables n-api related features.
 base_node = [
   "__base",


### PR DESCRIPTION
**Description:**

Add a non-default `react-compiler` feature to the `swc` crate. The feature enables an optional `swc_ecma_react_compiler` dependency and exposes it as `swc::react_compiler`.

Expose `base_react_compiler` from `swc_core` so `swc_core` users can opt into the same `swc` base API path without changing the existing `ecma_react_compiler` raw re-export feature.

Validation run:

- `cargo fmt --all`
- `cargo check -p swc --no-default-features`
- `cargo check -p swc --no-default-features --features react-compiler`
- `cargo check -p swc_core --no-default-features --features base`
- `cargo check -p swc_core --no-default-features --features base_react_compiler`
- `cargo test -p swc_core`
- `cargo clippy --all --all-targets -- -D warnings`

Note: `cargo test -p swc` was also run, but the existing `tests/source_map.rs::issue_622` fixture failed under Node v24.14.0 with `sourcemap-validator` reporting `There were no mappings in the file`.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

None.