### PR TITLE
fix(es/react-compiler): Scope ClassStaticBlock and TsModuleBlock as var boundaries

### DIFF
--- a/.changeset/fix-react-compiler-scope.md
+++ b/.changeset/fix-react-compiler-scope.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_react_compiler: patch
+---
+
+fix(es/react-compiler): Scope class static blocks and TypeScript module blocks correctly

--- a/crates/swc_ecma_react_compiler/src/convert_scope.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_scope.rs
@@ -37,38 +37,60 @@ pub struct ScopeFlags {
 
 #[allow(non_upper_case_globals)]
 impl ScopeFlags {
-    pub const CatchClause: Self = Self { bits: 1 << 3 };
-    pub const Class: Self = Self { bits: 1 << 6 };
-    pub const For: Self = Self { bits: 1 << 4 };
-    pub const Function: Self = Self { bits: 1 << 1 };
-    pub const StrictMode: Self = Self { bits: 1 << 2 };
-    pub const Switch: Self = Self { bits: 1 << 5 };
-    pub const Top: Self = Self { bits: 1 << 0 };
+    pub const CatchClause: Self = Self { bits: 1 << 0 };
+    pub const Class: Self = Self { bits: 1 << 1 };
+    pub const ClassStaticBlock: Self = Self { bits: 1 << 2 };
+    pub const For: Self = Self { bits: 1 << 3 };
+    pub const Function: Self = Self { bits: 1 << 4 };
+    pub const StrictMode: Self = Self { bits: 1 << 5 };
+    pub const Switch: Self = Self { bits: 1 << 6 };
+    pub const Top: Self = Self { bits: 1 << 7 };
+    pub const TsModuleBlock: Self = Self { bits: 1 << 8 };
 
+    #[inline]
     pub const fn empty() -> Self {
         Self { bits: 0 }
     }
 
+    #[inline]
     pub const fn contains(self, other: Self) -> bool {
         (self.bits & other.bits) == other.bits
     }
 
+    #[inline]
     pub const fn intersects(self, other: Self) -> bool {
         (self.bits & other.bits) != 0
     }
 
+    #[inline]
     pub fn is_top(self) -> bool {
         self.contains(Self::Top)
     }
 
+    #[inline]
     pub fn is_function(self) -> bool {
         self.intersects(Self::Function)
     }
 
-    pub fn is_var(self) -> bool {
-        self.is_function() || self.is_top()
+    #[inline]
+    pub fn is_class_static_block(self) -> bool {
+        self.contains(Self::ClassStaticBlock)
     }
 
+    #[inline]
+    pub fn is_ts_module_block(self) -> bool {
+        self.contains(Self::TsModuleBlock)
+    }
+
+    #[inline]
+    pub fn is_var(self) -> bool {
+        self.is_function()
+            || self.is_top()
+            || self.is_class_static_block()
+            || self.is_ts_module_block()
+    }
+
+    #[inline]
     pub fn is_catch_clause(self) -> bool {
         self.contains(Self::CatchClause)
     }
@@ -113,14 +135,17 @@ impl SymbolFlags {
     pub const Import: Self = Self { bits: 1 << 8 };
     pub const Param: Self = Self { bits: 1 << 9 };
 
+    #[inline]
     pub const fn contains(self, other: Self) -> bool {
         (self.bits & other.bits) == other.bits
     }
 
+    #[inline]
     pub const fn intersects(self, other: Self) -> bool {
         (self.bits & other.bits) != 0
     }
 
+    #[inline]
     pub fn is_value(self) -> bool {
         self.intersects(
             Self::FunctionScopedVariable
@@ -134,6 +159,7 @@ impl SymbolFlags {
         )
     }
 
+    #[inline]
     pub fn can_be_referenced_by_value(self) -> bool {
         self.is_value()
     }
@@ -495,14 +521,14 @@ impl SemanticBuilder {
         true
     }
 
-    fn enclosing_function_scope(&self) -> ScopeId {
+    fn enclosing_var_scope(&self) -> ScopeId {
         self.scope_stack
             .iter()
             .rev()
             .copied()
             .find(|scope_id| {
                 let flags = self.scoping.scope_flags(*scope_id);
-                flags.is_function() || flags.is_top()
+                flags.is_var()
             })
             .unwrap_or(ScopeId(0))
     }
@@ -703,7 +729,7 @@ impl Visit for SemanticBuilder {
         };
 
         let target_scope = match var_decl.kind {
-            VarDeclKind::Var => self.enclosing_function_scope(),
+            VarDeclKind::Var => self.enclosing_var_scope(),
             VarDeclKind::Let | VarDeclKind::Const => self.current_scope(),
         };
 
@@ -730,7 +756,7 @@ impl Visit for SemanticBuilder {
     fn visit_fn_decl(&mut self, fn_decl: &FnDecl) {
         let current_scope = self.current_scope();
         let hoist_scope = if self.should_hoist_block_function(&fn_decl.function) {
-            self.enclosing_function_scope()
+            self.enclosing_var_scope()
         } else {
             current_scope
         };
@@ -892,7 +918,7 @@ impl Visit for SemanticBuilder {
         match &export.decl {
             DefaultDecl::Fn(fn_expr) => {
                 if let Some(ident) = &fn_expr.ident {
-                    let hoist_scope = self.enclosing_function_scope();
+                    let hoist_scope = self.enclosing_var_scope();
                     self.declare_symbol_on_scope(
                         ident.span,
                         ident.sym.to_string(),
@@ -920,6 +946,15 @@ impl Visit for SemanticBuilder {
         }
     }
 
+    fn visit_static_block(&mut self, block: &StaticBlock) {
+        self.push_scope(
+            ScopeFlags::ClassStaticBlock | ScopeFlags::StrictMode,
+            block.span,
+        );
+        block.visit_children_with(self);
+        self.pop_scope();
+    }
+
     fn visit_ts_import_equals_decl(&mut self, decl: &TsImportEqualsDecl) {
         self.declare_symbol(decl.id.span, decl.id.sym.to_string(), SymbolFlags::Import);
         decl.module_ref.visit_with(self);
@@ -943,7 +978,16 @@ impl Visit for SemanticBuilder {
         }
     }
 
-    fn visit_ts_module_decl(&mut self, _decl: &TsModuleDecl) {}
+    fn visit_ts_module_decl(&mut self, decl: &TsModuleDecl) {
+        self.push_scope(
+            ScopeFlags::TsModuleBlock | ScopeFlags::StrictMode,
+            decl.span,
+        );
+        if let Some(body) = &decl.body {
+            body.visit_with(self);
+        }
+        self.pop_scope();
+    }
 
     fn visit_ident(&mut self, ident: &Ident) {
         let start = self.start(ident.span);
@@ -1314,7 +1358,7 @@ fn get_scope_kind(flags: ScopeFlags) -> react_compiler_ast::scope::ScopeKind {
         return ScopeKind::Switch;
     }
 
-    if flags.contains(ScopeFlags::Class) {
+    if flags.contains(ScopeFlags::Class) || flags.is_class_static_block() {
         return ScopeKind::Class;
     }
 

--- a/crates/swc_ecma_react_compiler/src/convert_scope.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_scope.rs
@@ -963,10 +963,7 @@ impl Visit for SemanticBuilder {
     fn visit_ts_type_alias_decl(&mut self, _decl: &TsTypeAliasDecl) {}
 
     fn visit_ts_enum_decl(&mut self, decl: &TsEnumDecl) {
-        if !decl.declare {
-            self.declare_symbol(decl.id.span, decl.id.sym.to_string(), SymbolFlags::Enum);
-        }
-
+        self.declare_symbol(decl.id.span, decl.id.sym.to_string(), SymbolFlags::Enum);
         for member in &decl.members {
             member.visit_with(self);
         }
@@ -979,14 +976,42 @@ impl Visit for SemanticBuilder {
     }
 
     fn visit_ts_module_decl(&mut self, decl: &TsModuleDecl) {
+        if let TsModuleName::Ident(ident) = &decl.id {
+            self.declare_symbol(
+                ident.span,
+                ident.sym.to_string(),
+                SymbolFlags::FunctionScopedVariable,
+            );
+        }
+
+        if let Some(body) = &decl.body {
+            self.push_scope(
+                ScopeFlags::TsModuleBlock | ScopeFlags::StrictMode,
+                decl.span,
+            );
+            body.visit_with(self);
+            self.pop_scope();
+        }
+    }
+
+    fn visit_ts_namespace_decl(&mut self, decl: &TsNamespaceDecl) {
+        self.declare_symbol(
+            decl.id.span,
+            decl.id.sym.to_string(),
+            SymbolFlags::FunctionScopedVariable,
+        );
+
         self.push_scope(
             ScopeFlags::TsModuleBlock | ScopeFlags::StrictMode,
             decl.span,
         );
-        if let Some(body) = &decl.body {
-            body.visit_with(self);
-        }
+        decl.body.visit_with(self);
         self.pop_scope();
+    }
+
+    fn visit_ts_interface_decl(&mut self, _decl: &TsInterfaceDecl) {
+        // Type-only declaration; do not traverse children to avoid recording
+        // type references as value references.
     }
 
     fn visit_ident(&mut self, ident: &Ident) {

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -879,22 +879,27 @@ fn scope_ts_enum_binding_is_local() {
 }
 
 #[test]
-fn scope_declare_ts_enum_has_no_runtime_binding() {
+fn scope_declare_ts_enum_binding_is_local() {
     let source = "declare enum Status { Ready }\nconst value = Status.Ready;";
     let program = parse_ts_program(source);
     let info = SemanticBuilder::with_source_type(SourceType::script().with_typescript(true))
         .build(&program);
 
-    assert!(
-        info.bindings.iter().all(|binding| binding.name != "Status"),
-        "declare enum should not create a runtime binding"
-    );
+    let status_binding = info
+        .bindings
+        .iter()
+        .find(|binding| binding.name == "Status")
+        .expect("declare enum should create a binding for reference resolution");
+    assert!(matches!(status_binding.kind, BindingKind::Local));
 
     let status_ref = source
         .find("Status.Ready")
         .expect("should find enum reference") as u32
         + 1;
-    assert_eq!(info.ref_node_id_to_binding.get(&status_ref), None);
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&status_ref),
+        Some(&status_binding.id)
+    );
 }
 
 #[test]

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -1129,6 +1129,57 @@ fn scope_resolves_references_inside_object_assign_patterns() {
     );
 }
 
+#[test]
+fn scope_class_static_block_var_is_scoped() {
+    let source = r#"
+        const x = 1;
+        class C {
+            static { var x = 2; }
+        }
+        function App() { return x; }
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let x_bindings: Vec<_> = info.bindings.iter().filter(|b| b.name == "x").collect();
+    assert_eq!(x_bindings.len(), 2, "should have two x bindings");
+
+    let static_block_x = x_bindings
+        .iter()
+        .find(|b| matches!(b.kind, BindingKind::Var))
+        .expect("should find var x binding in static block");
+    let static_block_scope = &info.scopes[static_block_x.scope.0 as usize];
+    assert!(
+        matches!(static_block_scope.kind, ScopeKind::Class),
+        "static block var x should be scoped to Class scope"
+    );
+}
+
+#[test]
+fn scope_ts_module_block_creates_scope() {
+    let source = r#"
+        namespace N {
+            export const hidden = 1;
+        }
+        function App() { return N.hidden; }
+    "#;
+    let module = parse_ts_module(source);
+    let program = swc_ecma_ast::Program::Module(module);
+    let info = SemanticBuilder::new().build(&program);
+
+    let hidden_binding = info
+        .bindings
+        .iter()
+        .find(|b| b.name == "hidden")
+        .expect("should find hidden binding");
+
+    let hidden_scope = &info.scopes[hidden_binding.scope.0 as usize];
+    assert!(
+        !matches!(hidden_scope.kind, ScopeKind::Program),
+        "namespace member should not leak to Program scope"
+    );
+}
+
 // ── Full transform pipeline tests ───────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION


<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->


**Description:**

This PR fixes scope analysis edge cases in the React Compiler where `var` declarations and TypeScript constructs were incorrectly hoisted or leaked across scope boundaries.

**Design Notes:**

`declare` and `global` are TypeScript type-system annotations that don't affect runtime emission, yet they still create declarations that downstream code can reference. The analyzer must walk their bodies normally and create bindings accordingly, rather than skipping traversal.

**Changes:**

- **Class static blocks as `var` boundaries**  
  `var` declarations inside `static { }` blocks are now scoped to the block itself, matching ECMAScript semantics, instead of leaking into the enclosing function.

- **TypeScript namespace / module scopes**  
  `namespace` and `module` bodies now create proper `TsModuleBlock` scopes. Their members are no longer incorrectly hoisted to the Program scope.

- **Consistent binding for `declare enum`**  
  `declare enum` is now registered as a local binding so references resolve correctly.

- **Refactoring**  
  Renamed `enclosing_function_scope()` → `enclosing_var_scope()` and updated `ScopeFlags` definitions to make scope-kind checks clearer.

**Known Limitations:**

**TypeScript namespace merging is not yet supported.** The scope collector treats each `namespace`/`module` declaration as an isolated lexical scope. Exported members in one block are not visible to later merged blocks, and they are modeled as plain local bindings. This is a similar issue described in #11607.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
- https://github.com/swc-project/swc/pull/11917#discussion_r3410499589