### PR TITLE
fix(es/parser): add Flow stubs for no-default builds

### DIFF
--- a/.changeset/fix-parser-no-default-flow.md
+++ b/.changeset/fix-parser-no-default-flow.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+fix(es/parser): allow compilation without default features

--- a/crates/swc_ecma_parser/src/parser/typescript_stubs.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript_stubs.rs
@@ -1,16 +1,23 @@
 //! Stub implementations for TypeScript parsing methods when the `typescript`
 //! feature is disabled.
 //!
-//! These methods are never called at runtime (the calls are guarded by
-//! `syntax().typescript()` which returns `false` when the feature is disabled),
-//! but Rust needs them to exist for compilation to succeed.
+//! Shared parser modules call these methods even when the `typescript` feature
+//! is disabled. Runtime syntax checks make TypeScript and Flow behavior
+//! unavailable in this configuration, but Rust still needs matching method
+//! definitions for compilation to succeed.
 
-use swc_common::BytePos;
+use swc_common::{BytePos, Span};
 use swc_ecma_ast::*;
 
 use crate::{input::Tokens, lexer::Token, PResult, Parser};
 
 impl<I: Tokens> Parser<I> {
+    pub(super) fn is_flow_reserved_type_name(_name: &str) -> bool {
+        false
+    }
+
+    pub(super) fn emit_flow_reserved_type_name_error(&mut self, _span: Span, _name: &str) {}
+
     pub(crate) fn try_parse_ts<T, F>(&mut self, _op: F) -> Option<T>
     where
         F: FnOnce(&mut Self) -> PResult<Option<T>>,

--- a/tests.yml
+++ b/tests.yml
@@ -40,6 +40,8 @@ check:
         - "cargo hack check --feature-powerset --exclude-features __rkyv"
     swc_ecma_loader:
         - "cargo hack check --feature-powerset"
+    swc_ecma_parser:
+        - "cargo check --no-default-features"
     swc_ecma_transforms:
         # - "cargo hack check --feature-powerset"
         - "cargo check --features concurrent --features par-core/chili"


### PR DESCRIPTION
**Description:**

`swc_ecma_parser --no-default-features` fails to compile because shared parser modules call `Parser<I>::is_flow_reserved_type_name` and `Parser<I>::emit_flow_reserved_type_name_error`, but no-TypeScript builds select `typescript_stubs.rs`, where those helpers were absent.

**Fix:** no-TypeScript parser stubs now define the Flow reserved-name helpers as `false` and no-op implementations. Flow builds still use the real helpers because `flow` enables `typescript`.

Verification:

| Check | Result |
| --- | --- |
| `cargo check -p swc_ecma_parser --no-default-features` | unpatched E0599, patched ok |
| default, TypeScript, and Flow parser checks | each configuration compiles |
| `cargo test -p swc_ecma_parser --features verify`, `--all-features` | parser CI gates pass |
| `./scripts/github/run-cargo-hack.sh swc_ecma_parser` | exercises the new `tests.yml` no-default entry |
| `cargo fmt --all -- --check`, `cargo clippy --all --all-targets -- -D warnings` | clean |

Review map:

- `crates/swc_ecma_parser/src/parser/typescript_stubs.rs`: supplies the missing no-TypeScript Flow helper boundary.
- `tests.yml`: pins the no-default parser compile contract.
- `.changeset/fix-parser-no-default-flow.md`: records patch releases.

**Related issue (if exists):**

Fixes #11942.
