### PR TITLE
fix(react-compiler): preserve class syntax context

### DIFF
--- a/.changeset/preserve-class-syntax-context.md
+++ b/.changeset/preserve-class-syntax-context.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_react_compiler: patch
+---
+
+fix(es/react-compiler): Preserve class syntax context during reverse conversion

--- a/crates/swc_ecma_react_compiler/src/convert_ast_reverse.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_ast_reverse.rs
@@ -1688,9 +1688,15 @@ impl ReverseCtx {
         body: &ClassBody,
         is_abstract: bool,
     ) -> swc::Class {
+        let span = self.span_from_base(base);
+        let ctxt = self
+            .preserved_ast
+            .borrow()
+            .class_ctxt_for_span(span)
+            .unwrap_or_else(SyntaxContext::empty);
         let mut class = swc::Class {
-            span: self.span_from_base(base),
-            ctxt: SyntaxContext::empty(),
+            span,
+            ctxt,
             decorators: vec![],
             body: self.convert_class_body(body),
             super_class: super_class.map(|expr| Box::new(self.convert_expression(expr))),

--- a/crates/swc_ecma_react_compiler/src/preserved_ast.rs
+++ b/crates/swc_ecma_react_compiler/src/preserved_ast.rs
@@ -1,5 +1,5 @@
 use rustc_hash::FxHashMap;
-use swc_common::{source_map::SmallPos, util::take::Take, Span};
+use swc_common::{source_map::SmallPos, util::take::Take, Span, SyntaxContext};
 use swc_ecma_ast::*;
 
 #[derive(Default, Clone)]
@@ -224,6 +224,15 @@ impl PreservedAst {
             class.span.lo.to_u32(),
             PreservedNode::Class(Box::new(class.clone())),
         );
+    }
+
+    pub fn class_ctxt_for_span(&self, span: Span) -> Option<SyntaxContext> {
+        let key = span.lo.to_u32();
+        let Some(PreservedNode::Class(snapshot)) = self.nodes.get(&key) else {
+            return None;
+        };
+
+        Some(snapshot.ctxt)
     }
 
     pub fn load_class(&mut self, class: &mut Class) -> bool {

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -9,7 +9,7 @@ use react_compiler_ast::{
     statements::Statement,
     File,
 };
-use swc_common::{sync::Lrc, FileName, SourceMap};
+use swc_common::{sync::Lrc, FileName, Globals, Mark, SourceMap, SyntaxContext, GLOBALS};
 use swc_ecma_ast::EsVersion;
 use swc_ecma_codegen::Node;
 use swc_ecma_parser::{parse_file_as_module, parse_file_as_program, EsSyntax, Syntax};
@@ -1355,6 +1355,38 @@ fn reverse_convert_multiple_statement_types() {
     let program = convert_program_to_swc(&file);
     let module = program.as_module().unwrap();
     assert_eq!(module.body.len(), 5);
+}
+
+#[test]
+fn reverse_convert_preserves_class_syntax_context() {
+    GLOBALS.set(&Globals::new(), || {
+        let source = "class Foo { method() { return 1; } }";
+        let mut module = parse_module(source);
+        let class_ctxt = SyntaxContext::empty().apply_mark(Mark::new());
+
+        let swc_ecma_ast::ModuleItem::Stmt(swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Class(
+            class_decl,
+        ))) = &mut module.body[0]
+        else {
+            panic!("expected class declaration");
+        };
+        class_decl.class.ctxt = class_ctxt;
+
+        let program = swc_ecma_ast::Program::Module(module);
+        let result = convert_program(&program, source, None);
+        let program = convert_program_to_swc_with_preserved_ast(&result.file, result.preserved_ast);
+        let module = program.as_module().unwrap();
+
+        let swc_ecma_ast::ModuleItem::Stmt(swc_ecma_ast::Stmt::Decl(swc_ecma_ast::Decl::Class(
+            class_decl,
+        ))) = &module.body[0]
+        else {
+            panic!("expected class declaration");
+        };
+
+        assert_eq!(class_decl.class.ctxt, class_ctxt);
+        assert_eq!(class_decl.class.body.len(), 1);
+    });
 }
 
 // ── TS module interop statements ────────────────────────────────────────────


### PR DESCRIPTION
**Description:**
Preserve the original SWC `Class.ctxt` while converting React Compiler AST back into SWC AST. The reverse converter now looks up the preserved class shell by span and uses its syntax context before loading the full preserved class, falling back to an empty context only when no preserved class exists.

This fixes a hygiene fidelity issue where class syntax context could be lost during round-trip conversion, while keeping the existing class shell restoration behavior for decorators, body, type metadata, and super-class handling. Added a regression test with a non-empty `SyntaxContext` to lock the behavior.

Validation:
- `cargo fmt --all`
- `git submodule update --init --recursive`
- `cargo test -p swc_ecma_react_compiler`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A