### PR TITLE
fix(es/minifier): gate Number(x) -> +x on unsafe flag (#11944)

### DIFF
--- a/.changeset/gate-number-call-on-unsafe.md
+++ b/.changeset/gate-number-call-on-unsafe.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): Gate `Number(x)` -> `+x` on `unsafe` flag

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -1296,15 +1296,21 @@ impl Pure<'_> {
                             })
                             .into(),
                         ),
-                        // this is indeed very unsafe in case of BigInt
-                        [ExprOrSpread { spread: None, expr }] if self.options.unsafe_math => Some(
-                            UnaryExpr {
-                                span: *span,
-                                op: op!(unary, "+"),
-                                arg: expr.take(),
-                            }
-                            .into(),
-                        ),
+                        // This is indeed very unsafe in case of BigInt, so it
+                        // requires both `unsafe` and `unsafe_math`, matching
+                        // terser (since v4.3.11).
+                        [ExprOrSpread { spread: None, expr }]
+                            if self.options.unsafe_passes && self.options.unsafe_math =>
+                        {
+                            Some(
+                                UnaryExpr {
+                                    span: *span,
+                                    op: op!(unary, "+"),
+                                    arg: expr.take(),
+                                }
+                                .into(),
+                            )
+                        }
                         _ => None,
                     },
                     Expr::Ident(Ident { sym, .. }) if &**sym == "String" => match &mut args[..] {

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11944/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11944/config.json
@@ -1,0 +1,4 @@
+{
+    "unsafe": false,
+    "unsafe_math": true
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11944/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11944/input.js
@@ -1,0 +1,1 @@
+console.log(Number(x));

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11944/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11944/output.js
@@ -1,0 +1,1 @@
+console.log(Number(x));


### PR DESCRIPTION
**Description:**

SWC's minifier converted single-argument `Number(x)` into `+x` whenever `unsafe_math` was enabled, regardless of the `unsafe` flag.

This diverges from terser. Since terser v4.3.11 ([terser/terser#444](https://github.com/terser/terser/pull/444)), this transform requires **both** `unsafe` and `unsafe_math`, because `+x` is not equivalent to `Number(x)` for `BigInt` (e.g. `Number(1n) === 1` but `+1n` throws `TypeError`).

The root cause is in `crates/swc_ecma_minifier/src/compress/pure/misc.rs`, where the `Number(x)` arm was gated only on `unsafe_math`. This change gates it on `unsafe_passes && unsafe_math` (the `unsafe` terser option deserializes to the `unsafe_passes` field), mirroring the already-correct pattern in `evaluate.rs` and the sibling `String(x)` transform, which is gated on `unsafe_passes`.

**Before** (`{ "unsafe": false, "unsafe_math": true }`):

```js
// input
console.log(Number(x));
// output
console.log(+x);
```

**After** (`{ "unsafe": false, "unsafe_math": true }`):

```js
// input
console.log(Number(x));
// output
console.log(Number(x));
```

When both `unsafe` and `unsafe_math` are set, the transform still applies (unchanged), matching terser.

**Tests:**

Added an SWC-owned fixture at `crates/swc_ecma_minifier/tests/fixture/issues/11944/` covering the `unsafe: false, unsafe_math: true` case (a gap not covered by the existing `numbers/number_function_transform_with_unsafe_math` fixture, which sets both flags). With the unmodified gate the fixture produces `console.log(+x)`, so it fails before the fix and passes after it.

Verified fails-before / passes-after by reverting the gate (fails) and re-applying (passes). Full crate suite is green:

```
cargo test -p swc_ecma_minifier --features concurrent --features par-core/chili
test result: ok. 2861 passed; 0 failed; 27 ignored  (compress)
test result: ok. 2219 passed; 0 failed; 1 ignored   (mangle)
test result: ok. 2128 passed; 0 failed; 1 ignored   (terser_exec)
test result: ok. 481 passed; 0 failed; 13 ignored    (exec)
... all other binaries: 0 failed
```

`cargo +nightly-2026-04-10 fmt -- --check` passes with no diff.

A changeset is included (`swc_core: patch`, `swc_ecma_minifier: patch`).

**BREAKING CHANGE:**

None. This is a bug fix that makes the minifier more conservative (it now preserves `Number(x)` in a case where it previously rewrote it), aligning with terser.

**Related issue (if exists):**

Closes #11944

---

Prepared with AI assistance (Claude Code), reviewed by the author.
