### PR TITLE
refactor(es/react-compiler): Preserve TS metadata during AST roundtrip

### DIFF
--- a/.changeset/preserve-react-compiler-ts-metadata.md
+++ b/.changeset/preserve-react-compiler-ts-metadata.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_react_compiler: patch
+---
+
+fix(es/react-compiler): Preserve TypeScript metadata during AST roundtrip

--- a/crates/swc_ecma_react_compiler/src/convert_ast.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_ast.rs
@@ -463,6 +463,8 @@ impl<'a> ConvertCtx<'a> {
     }
 
     fn convert_catch_clause(&self, clause: &swc::CatchClause) -> CatchClause {
+        self.preserved_ast.borrow_mut().save_catch_clause(clause);
+
         CatchClause {
             base: self.make_base_node(clause.span),
             param: clause.param.as_ref().map(|p| self.convert_pat(p)),

--- a/crates/swc_ecma_react_compiler/src/convert_ast_reverse.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_ast_reverse.rs
@@ -42,481 +42,11 @@ impl ReverseCtx {
         }
     }
 
-    #[cold]
-    fn span_from_json_value(&self, value: &serde_json::Value) -> Span {
-        let start = json_u64(value, "start");
-        let end = json_u64(value, "end");
-        match (start, end) {
-            (Some(start), Some(end)) => Span::new(BytePos(start as u32), BytePos(end as u32)),
-            (Some(start), None) => Span::new(BytePos(start as u32), BytePos(start as u32)),
-            _ => DUMMY_SP,
-        }
-    }
-
-    #[cold]
-    fn span_from_raw_node(&self, value: &RawNode) -> Span {
-        self.span_from_json_value(&value.parse_value())
-    }
-
     fn any_ts_type(&self, span: Span) -> Box<swc::TsType> {
         Box::new(swc::TsType::TsKeywordType(swc::TsKeywordType {
             span,
             kind: swc::TsKeywordTypeKind::TsAnyKeyword,
         }))
-    }
-
-    #[cold]
-    fn convert_ts_type_annotation_from_json(
-        &self,
-        value: &serde_json::Value,
-    ) -> Option<Box<swc::TsTypeAnn>> {
-        let ty = if json_type(value) == Some("TSTypeAnnotation") {
-            self.convert_ts_type_from_json(value.get("typeAnnotation")?)?
-        } else {
-            self.convert_ts_type_from_json(value)?
-        };
-        Some(Box::new(swc::TsTypeAnn {
-            span: self.span_from_json_value(value),
-            type_ann: ty,
-        }))
-    }
-
-    #[cold]
-    fn convert_ts_type_annotation_option(
-        &self,
-        value: Option<&RawNode>,
-    ) -> Option<Box<swc::TsTypeAnn>> {
-        value.and_then(|value| {
-            let value = value.parse_value();
-            self.convert_ts_type_annotation_from_json(&value)
-        })
-    }
-
-    #[cold]
-    fn convert_ts_type_from_json(&self, value: &serde_json::Value) -> Option<Box<swc::TsType>> {
-        let span = self.span_from_json_value(value);
-        let type_name = json_type(value)?;
-        if let Some(kind) = ts_keyword_type_kind(type_name) {
-            return Some(Box::new(swc::TsType::TsKeywordType(swc::TsKeywordType {
-                span,
-                kind,
-            })));
-        }
-
-        let ty = match type_name {
-            "TSThisType" => swc::TsType::TsThisType(swc::TsThisType { span }),
-            "TSArrayType" => swc::TsType::TsArrayType(swc::TsArrayType {
-                span,
-                elem_type: self.convert_ts_type_from_json(value.get("elementType")?)?,
-            }),
-            "TSUnionType" => {
-                let types = json_array(value, "types")?
-                    .iter()
-                    .filter_map(|ty| self.convert_ts_type_from_json(ty))
-                    .collect();
-                swc::TsType::TsUnionOrIntersectionType(swc::TsUnionOrIntersectionType::TsUnionType(
-                    swc::TsUnionType { span, types },
-                ))
-            }
-            "TSParenthesizedType" => swc::TsType::TsParenthesizedType(swc::TsParenthesizedType {
-                span,
-                type_ann: self.convert_ts_type_from_json(value.get("typeAnnotation")?)?,
-            }),
-            "TSTypeOperator" => {
-                let op = ts_type_operator_op(json_str(value, "operator")?)?;
-                swc::TsType::TsTypeOperator(swc::TsTypeOperator {
-                    span,
-                    op,
-                    type_ann: self.convert_ts_type_from_json(value.get("typeAnnotation")?)?,
-                })
-            }
-            "TSTypeReference" => swc::TsType::TsTypeRef(swc::TsTypeRef {
-                span,
-                type_name: self.convert_ts_type_name_from_json(value.get("typeName")?)?,
-                type_params: self.convert_ts_type_parameter_instantiation_alias_from_json(value),
-            }),
-            "TSTypeQuery" => swc::TsType::TsTypeQuery(swc::TsTypeQuery {
-                span,
-                expr_name: self
-                    .convert_ts_type_query_expr_name_from_json(value.get("exprName")?)?,
-                type_args: self.convert_ts_type_parameter_instantiation_alias_from_json(value),
-            }),
-            "TSIndexedAccessType" => swc::TsType::TsIndexedAccessType(swc::TsIndexedAccessType {
-                span,
-                readonly: false,
-                obj_type: self.convert_ts_type_from_json(value.get("objectType")?)?,
-                index_type: self.convert_ts_type_from_json(value.get("indexType")?)?,
-            }),
-            "TSLiteralType" => swc::TsType::TsLitType(swc::TsLitType {
-                span,
-                lit: self.convert_ts_literal_from_json(value.get("literal")?)?,
-            }),
-            _ => return None,
-        };
-        Some(Box::new(ty))
-    }
-
-    #[cold]
-    fn convert_ts_type_name_from_json(
-        &self,
-        value: &serde_json::Value,
-    ) -> Option<swc::TsEntityName> {
-        let span = self.span_from_json_value(value);
-        match json_type(value)? {
-            "Identifier" => Some(swc::TsEntityName::Ident(swc::Ident {
-                span,
-                ctxt: SyntaxContext::empty(),
-                sym: Atom::from(json_str(value, "name")?),
-                optional: false,
-            })),
-            "TSQualifiedName" => {
-                let left = self.convert_ts_type_name_from_json(value.get("left")?)?;
-                let right_value = value.get("right")?;
-                let right = swc::IdentName::new(
-                    Atom::from(json_str(right_value, "name")?),
-                    self.span_from_json_value(right_value),
-                );
-                Some(swc::TsEntityName::TsQualifiedName(Box::new(
-                    swc::TsQualifiedName { span, left, right },
-                )))
-            }
-            _ => None,
-        }
-    }
-
-    #[cold]
-    fn convert_ts_type_query_expr_name_from_json(
-        &self,
-        value: &serde_json::Value,
-    ) -> Option<swc::TsTypeQueryExpr> {
-        Some(swc::TsTypeQueryExpr::TsEntityName(
-            self.convert_ts_type_name_from_json(value)?,
-        ))
-    }
-
-    #[cold]
-    fn convert_ts_type_parameter_instantiation_from_json(
-        &self,
-        value: &serde_json::Value,
-    ) -> Option<Box<swc::TsTypeParamInstantiation>> {
-        let params = json_array(value, "params")?
-            .iter()
-            .filter_map(|ty| self.convert_ts_type_from_json(ty))
-            .collect();
-        Some(Box::new(swc::TsTypeParamInstantiation {
-            span: self.span_from_json_value(value),
-            params,
-        }))
-    }
-
-    #[cold]
-    fn convert_ts_type_parameter_instantiation_option(
-        &self,
-        value: Option<&serde_json::Value>,
-    ) -> Option<Box<swc::TsTypeParamInstantiation>> {
-        value.and_then(|value| self.convert_ts_type_parameter_instantiation_from_json(value))
-    }
-
-    #[cold]
-    fn convert_ts_type_parameter_instantiation_alias_from_json(
-        &self,
-        value: &serde_json::Value,
-    ) -> Option<Box<swc::TsTypeParamInstantiation>> {
-        self.convert_ts_type_parameter_instantiation_option(
-            value
-                .get("typeParameters")
-                .or_else(|| value.get("typeArguments")),
-        )
-    }
-
-    #[cold]
-    fn convert_ts_type_parameter_instantiation_pair(
-        &self,
-        type_parameters: Option<&RawNode>,
-        type_arguments: Option<&RawNode>,
-    ) -> Option<Box<swc::TsTypeParamInstantiation>> {
-        type_parameters.or(type_arguments).and_then(|value| {
-            let value = value.parse_value();
-            self.convert_ts_type_parameter_instantiation_from_json(&value)
-        })
-    }
-
-    #[cold]
-    fn convert_ts_literal_from_json(&self, value: &serde_json::Value) -> Option<swc::TsLit> {
-        let span = self.span_from_json_value(value);
-        match json_type(value)? {
-            "BooleanLiteral" => Some(swc::TsLit::Bool(swc::Bool {
-                span,
-                value: json_bool(value, "value")?,
-            })),
-            "NumericLiteral" => Some(swc::TsLit::Number(swc::Number {
-                span,
-                value: json_f64(value, "value")?,
-                raw: None,
-            })),
-            "StringLiteral" => Some(swc::TsLit::Str(swc::Str {
-                span,
-                value: json_str(value, "value")?.into(),
-                raw: None,
-            })),
-            "BigIntLiteral" => {
-                let value = json_str(value, "value")?;
-                Some(swc::TsLit::BigInt(swc::BigInt {
-                    span,
-                    value: Box::new(bigint_literal_value(value).parse().ok()?),
-                    raw: Some(bigint_literal_raw(value)),
-                }))
-            }
-            _ => None,
-        }
-    }
-
-    // JSON reconstruction is only a fidelity fallback when no preserved SWC
-    // shell is available for TypeScript metadata.
-    #[cold]
-    fn cold_fill_ts_as_expr_from_json(
-        &self,
-        expr: &mut swc::TsAsExpr,
-        type_annotation: &RawNode,
-        fallback_span: Span,
-    ) {
-        let type_annotation = type_annotation.parse_value();
-        expr.type_ann = self
-            .convert_ts_type_from_json(&type_annotation)
-            .unwrap_or_else(|| self.any_ts_type(fallback_span));
-    }
-
-    #[cold]
-    fn cold_fill_ts_satisfies_expr_from_json(
-        &self,
-        expr: &mut swc::TsSatisfiesExpr,
-        type_annotation: &RawNode,
-        fallback_span: Span,
-    ) {
-        let type_annotation = type_annotation.parse_value();
-        expr.type_ann = self
-            .convert_ts_type_from_json(&type_annotation)
-            .unwrap_or_else(|| self.any_ts_type(fallback_span));
-    }
-
-    #[cold]
-    fn cold_fill_ts_type_assertion_from_json(
-        &self,
-        expr: &mut swc::TsTypeAssertion,
-        type_annotation: &RawNode,
-        fallback_span: Span,
-    ) {
-        let type_annotation = type_annotation.parse_value();
-        expr.type_ann = self
-            .convert_ts_type_from_json(&type_annotation)
-            .unwrap_or_else(|| self.any_ts_type(fallback_span));
-    }
-
-    #[cold]
-    fn cold_fill_ts_instantiation_from_json(
-        &self,
-        expr: &mut swc::TsInstantiation,
-        type_parameters: &RawNode,
-        fallback_span: Span,
-    ) {
-        let type_parameters = type_parameters.parse_value();
-        expr.type_args = self
-            .convert_ts_type_parameter_instantiation_from_json(&type_parameters)
-            .unwrap_or_else(|| {
-                Box::new(swc::TsTypeParamInstantiation {
-                    span: fallback_span,
-                    params: vec![],
-                })
-            });
-    }
-
-    #[cold]
-    fn cold_fill_call_type_args_from_json(
-        &self,
-        call: &mut swc::CallExpr,
-        type_parameters: Option<&RawNode>,
-        type_arguments: Option<&RawNode>,
-    ) {
-        call.type_args =
-            self.convert_ts_type_parameter_instantiation_pair(type_parameters, type_arguments);
-    }
-
-    #[cold]
-    fn cold_fill_opt_call_type_args_from_json(
-        &self,
-        call: &mut swc::OptCall,
-        type_parameters: Option<&RawNode>,
-        type_arguments: Option<&RawNode>,
-    ) {
-        call.type_args =
-            self.convert_ts_type_parameter_instantiation_pair(type_parameters, type_arguments);
-    }
-
-    #[cold]
-    fn cold_fill_new_type_args_from_json(
-        &self,
-        expr: &mut swc::NewExpr,
-        type_parameters: Option<&RawNode>,
-        type_arguments: Option<&RawNode>,
-    ) {
-        expr.type_args =
-            self.convert_ts_type_parameter_instantiation_pair(type_parameters, type_arguments);
-    }
-
-    #[cold]
-    fn cold_fill_tagged_tpl_type_params_from_json(
-        &self,
-        tpl: &mut swc::TaggedTpl,
-        type_parameters: Option<&RawNode>,
-    ) {
-        tpl.type_params = type_parameters.and_then(|value| {
-            let value = value.parse_value();
-            self.convert_ts_type_parameter_instantiation_from_json(&value)
-        });
-    }
-
-    #[cold]
-    fn cold_fill_jsx_opening_type_args_from_json(
-        &self,
-        opening: &mut swc::JSXOpeningElement,
-        type_parameters: Option<&RawNode>,
-    ) {
-        opening.type_args = type_parameters.and_then(|value| {
-            let value = value.parse_value();
-            self.convert_ts_type_parameter_instantiation_from_json(&value)
-        });
-    }
-
-    #[cold]
-    fn cold_fill_function_types_from_json(
-        &self,
-        function: &mut swc::Function,
-        params: &[PatternLike],
-        return_type: Option<&RawNode>,
-    ) {
-        function.params = params
-            .iter()
-            .map(|param| self.convert_pattern_like_as_formal_parameter(param))
-            .collect();
-        function.return_type = self.convert_ts_type_annotation_option(return_type);
-    }
-
-    #[cold]
-    fn cold_fill_arrow_types_from_json(
-        &self,
-        arrow: &mut swc::ArrowExpr,
-        params: &[PatternLike],
-        return_type: Option<&RawNode>,
-    ) {
-        arrow.params = params
-            .iter()
-            .map(|param| self.convert_pattern_like(param))
-            .collect();
-        arrow.return_type = self.convert_ts_type_annotation_option(return_type);
-    }
-
-    #[cold]
-    fn cold_fill_var_decl_types_from_json(
-        &self,
-        decl: &mut swc::VarDecl,
-        declarations: &[VariableDeclarator],
-    ) {
-        for (decl, source) in decl.decls.iter_mut().zip(declarations) {
-            decl.name = self.convert_pattern_like(&source.id);
-        }
-    }
-
-    #[cold]
-    fn cold_fill_ts_type_alias_from_json(
-        &self,
-        decl: &mut swc::TsTypeAliasDecl,
-        type_annotation: &RawNode,
-        fallback_span: Span,
-    ) {
-        let type_annotation = type_annotation.parse_value();
-        decl.type_ann = self
-            .convert_ts_type_from_json(&type_annotation)
-            .unwrap_or_else(|| self.any_ts_type(fallback_span));
-    }
-
-    fn has_type_args(type_parameters: Option<&RawNode>, type_arguments: Option<&RawNode>) -> bool {
-        type_parameters.is_some() || type_arguments.is_some()
-    }
-
-    fn has_type_annotation(value: Option<&RawNode>) -> bool {
-        value.is_some()
-    }
-
-    fn patterns_have_type_annotations(params: &[PatternLike]) -> bool {
-        params.iter().any(Self::pattern_has_type_annotation)
-    }
-
-    fn variable_declarations_have_type_annotations(declarations: &[VariableDeclarator]) -> bool {
-        declarations
-            .iter()
-            .any(|declarator| Self::pattern_has_type_annotation(&declarator.id))
-    }
-
-    fn pattern_has_type_annotation(pattern: &PatternLike) -> bool {
-        match pattern {
-            PatternLike::Identifier(pattern) => pattern.type_annotation.is_some(),
-            PatternLike::ObjectPattern(pattern) => {
-                pattern.type_annotation.is_some()
-                    || pattern
-                        .properties
-                        .iter()
-                        .any(Self::object_pattern_property_has_type_annotation)
-            }
-            PatternLike::ArrayPattern(pattern) => {
-                pattern.type_annotation.is_some()
-                    || pattern
-                        .elements
-                        .iter()
-                        .flatten()
-                        .any(Self::pattern_has_type_annotation)
-            }
-            PatternLike::AssignmentPattern(pattern) => {
-                pattern.type_annotation.is_some()
-                    || Self::pattern_has_type_annotation(&pattern.left)
-            }
-            PatternLike::RestElement(pattern) => {
-                pattern.type_annotation.is_some()
-                    || Self::pattern_has_type_annotation(&pattern.argument)
-            }
-            PatternLike::TSAsExpression(_)
-            | PatternLike::TSSatisfiesExpression(_)
-            | PatternLike::TSTypeAssertion(_)
-            | PatternLike::TypeCastExpression(_) => true,
-            PatternLike::TSNonNullExpression(pattern) => {
-                Self::expression_has_type_annotation(&pattern.expression)
-            }
-            PatternLike::MemberExpression(_) => false,
-        }
-    }
-
-    fn object_pattern_property_has_type_annotation(prop: &ObjectPatternProperty) -> bool {
-        match prop {
-            ObjectPatternProperty::ObjectProperty(prop) => {
-                Self::pattern_has_type_annotation(&prop.value)
-            }
-            ObjectPatternProperty::RestElement(rest) => {
-                rest.type_annotation.is_some() || Self::pattern_has_type_annotation(&rest.argument)
-            }
-        }
-    }
-
-    fn expression_has_type_annotation(expr: &Expression) -> bool {
-        match expr {
-            Expression::TSAsExpression(_)
-            | Expression::TSSatisfiesExpression(_)
-            | Expression::TSTypeAssertion(_)
-            | Expression::TSInstantiationExpression(_)
-            | Expression::TypeCastExpression(_) => true,
-            Expression::TSNonNullExpression(expr) => {
-                Self::expression_has_type_annotation(expr.expression.as_ref())
-            }
-            _ => false,
-        }
     }
 
     fn expression_base(expr: &Expression) -> Option<&BaseNode> {
@@ -871,7 +401,7 @@ impl ReverseCtx {
             Statement::ClassDeclaration(class) => {
                 swc::Stmt::Decl(swc::Decl::Class(swc::ClassDecl {
                     ident: class.id.as_ref().map_or_else(
-                        || self.private_ident("__default_class", &class.base),
+                        || self.quote_ident("__default_class"),
                         |id| self.convert_identifier(id),
                     ),
                     declare: class.declare.unwrap_or(false),
@@ -952,14 +482,24 @@ impl ReverseCtx {
     }
 
     fn convert_catch_clause(&self, clause: &CatchClause) -> swc::CatchClause {
-        swc::CatchClause {
+        let mut catch_clause = swc::CatchClause {
             span: self.span_from_base(&clause.base),
             param: clause
                 .param
                 .as_ref()
-                .map(|param| self.convert_pattern_like(param)),
+                .map(|param| self.convert_pattern_like_omitting_types(param)),
             body: self.convert_block_statement(&clause.body),
+        };
+        if !self
+            .preserved_ast
+            .borrow_mut()
+            .load_catch_clause(&mut catch_clause)
+        {
+            if let (Some(param), Some(source)) = (&mut catch_clause.param, &clause.param) {
+                self.cold_fill_pat_type_from_pattern_like(param, source);
+            }
         }
+        catch_clause
     }
 
     fn convert_for_init(&self, init: &ForInit) -> swc::VarDeclOrExpr {
@@ -989,46 +529,45 @@ impl ReverseCtx {
                 swc::ForHead::VarDecl(decl)
             }
             ForInOfLeft::Pattern(pattern) => {
-                swc::ForHead::Pat(Box::new(self.convert_pattern_like(pattern)))
+                swc::ForHead::Pat(Box::new(self.convert_pattern_like_omitting_types(pattern)))
             }
         }
     }
 
     fn convert_variable_declaration(&self, decl: &VariableDeclaration) -> swc::Decl {
-        let kind = self.convert_variable_declaration_kind(&decl.kind);
         let span = self.span_from_base(&decl.base);
-        let type_ann_mode = if matches!(decl.kind, VariableDeclarationKind::Using) {
-            PatternTypeAnnMode::FromJson
-        } else {
-            PatternTypeAnnMode::Omit
-        };
+
         let decls = decl
             .declarations
             .iter()
-            .map(|declarator| self.convert_variable_declarator(declarator, kind, type_ann_mode))
+            .map(|declarator| self.convert_variable_declarator(declarator))
             .collect();
 
-        if matches!(decl.kind, VariableDeclarationKind::Using) {
-            swc::Decl::Using(Box::new(swc::UsingDecl {
+        if let VariableDeclarationKind::Using = decl.kind {
+            return swc::UsingDecl {
                 span,
+                // [TODO]: VariableDeclarationKind::AwaitUsing
                 is_await: false,
                 decls,
-            }))
-        } else {
-            let mut var_decl = swc::VarDecl {
-                span,
-                ctxt: SyntaxContext::empty(),
-                kind,
-                declare: decl.declare.unwrap_or(false),
-                decls,
-            };
-            if !self.preserved_ast.borrow_mut().load_var_decl(&mut var_decl)
-                && Self::variable_declarations_have_type_annotations(&decl.declarations)
-            {
-                self.cold_fill_var_decl_types_from_json(&mut var_decl, &decl.declarations);
             }
-            swc::Decl::Var(Box::new(var_decl))
+            .into();
         }
+
+        let mut var_decl = swc::VarDecl {
+            span,
+            ctxt: SyntaxContext::empty(),
+            kind: self.convert_variable_declaration_kind(&decl.kind),
+            declare: decl.declare.unwrap_or(false),
+            decls,
+        };
+        if !self.preserved_ast.borrow_mut().load_var_decl(&mut var_decl) {
+            self.cold_fill_var_decl_types_from_variable_declarators(
+                &mut var_decl,
+                &decl.declarations,
+            );
+        }
+
+        var_decl.into()
     }
 
     fn convert_variable_declaration_kind(
@@ -1038,21 +577,15 @@ impl ReverseCtx {
         match kind {
             VariableDeclarationKind::Var => swc::VarDeclKind::Var,
             VariableDeclarationKind::Let => swc::VarDeclKind::Let,
-            VariableDeclarationKind::Const | VariableDeclarationKind::Using => {
-                swc::VarDeclKind::Const
-            }
+            VariableDeclarationKind::Const => swc::VarDeclKind::Const,
+            _ => unreachable!("Unexpected variable declaration kind"),
         }
     }
 
-    fn convert_variable_declarator(
-        &self,
-        declarator: &VariableDeclarator,
-        _kind: swc::VarDeclKind,
-        type_ann_mode: PatternTypeAnnMode,
-    ) -> swc::VarDeclarator {
+    fn convert_variable_declarator(&self, declarator: &VariableDeclarator) -> swc::VarDeclarator {
         swc::VarDeclarator {
             span: self.span_from_base(&declarator.base),
-            name: self.convert_pattern_like_with_type_ann_mode(&declarator.id, type_ann_mode),
+            name: self.convert_pattern_like_omitting_types(&declarator.id),
             init: declarator
                 .init
                 .as_ref()
@@ -1064,8 +597,7 @@ impl ReverseCtx {
     // ===== Expressions =====
 
     fn convert_expression(&self, expr: &Expression) -> swc::Expr {
-        let span = self.expression_span(expr);
-        let mut swc_expr = match expr {
+        match expr {
             Expression::Identifier(id) => swc::Expr::Ident(self.convert_identifier(id)),
             Expression::StringLiteral(lit) => {
                 swc::Expr::Lit(swc::Lit::Str(self.convert_string_literal(lit)))
@@ -1105,13 +637,8 @@ impl ReverseCtx {
                     args: self.convert_expression_list(&call.arguments),
                     type_args: None,
                 };
-                if !self.preserved_ast.borrow_mut().load_opt_call(&mut opt_call)
-                    && Self::has_type_args(
-                        call.type_parameters.as_ref(),
-                        call.type_arguments.as_ref(),
-                    )
-                {
-                    self.cold_fill_opt_call_type_args_from_json(
+                if !self.preserved_ast.borrow_mut().load_opt_call(&mut opt_call) {
+                    self.cold_fill_opt_call_type_args_from_raw_nodes(
                         &mut opt_call,
                         call.type_parameters.as_ref(),
                         call.type_arguments.as_ref(),
@@ -1209,13 +736,8 @@ impl ReverseCtx {
                     args: Some(self.convert_expression_list(&new.arguments)),
                     type_args: None,
                 };
-                if !self.preserved_ast.borrow_mut().load_new(&mut new_expr)
-                    && Self::has_type_args(
-                        new.type_parameters.as_ref(),
-                        new.type_arguments.as_ref(),
-                    )
-                {
-                    self.cold_fill_new_type_args_from_json(
+                if !self.preserved_ast.borrow_mut().load_new(&mut new_expr) {
+                    self.cold_fill_new_type_args_from_raw_nodes(
                         &mut new_expr,
                         new.type_parameters.as_ref(),
                         new.type_arguments.as_ref(),
@@ -1236,9 +758,8 @@ impl ReverseCtx {
                     .preserved_ast
                     .borrow_mut()
                     .load_tagged_tpl(&mut tagged_tpl)
-                    && Self::has_type_annotation(tagged.type_parameters.as_ref())
                 {
-                    self.cold_fill_tagged_tpl_type_params_from_json(
+                    self.cold_fill_tagged_tpl_type_params_from_raw_node(
                         &mut tagged_tpl,
                         tagged.type_parameters.as_ref(),
                     );
@@ -1312,7 +833,7 @@ impl ReverseCtx {
                     type_ann: self.any_ts_type(span),
                 };
                 if !self.preserved_ast.borrow_mut().load_ts_as_expr(&mut expr) {
-                    self.cold_fill_ts_as_expr_from_json(&mut expr, &ts.type_annotation, span);
+                    self.cold_fill_ts_as_expr_from_raw_node(&mut expr, &ts.type_annotation, span);
                 }
                 swc::Expr::TsAs(expr)
             }
@@ -1328,7 +849,7 @@ impl ReverseCtx {
                     .borrow_mut()
                     .load_ts_satisfies_expr(&mut expr)
                 {
-                    self.cold_fill_ts_satisfies_expr_from_json(
+                    self.cold_fill_ts_satisfies_expr_from_raw_node(
                         &mut expr,
                         &ts.type_annotation,
                         span,
@@ -1352,7 +873,7 @@ impl ReverseCtx {
                     .borrow_mut()
                     .load_ts_type_assertion(&mut expr)
                 {
-                    self.cold_fill_ts_type_assertion_from_json(
+                    self.cold_fill_ts_type_assertion_from_raw_node(
                         &mut expr,
                         &ts.type_annotation,
                         span,
@@ -1375,18 +896,18 @@ impl ReverseCtx {
                     .borrow_mut()
                     .load_ts_instantiation(&mut expr)
                 {
-                    self.cold_fill_ts_instantiation_from_json(&mut expr, &ts.type_parameters, span);
+                    self.cold_fill_ts_instantiation_from_raw_node(
+                        &mut expr,
+                        &ts.type_parameters,
+                        span,
+                    );
                 }
                 swc::Expr::TsInstantiation(expr)
             }
             Expression::TypeCastExpression(type_cast) => {
                 self.convert_expression(&type_cast.expression)
             }
-        };
-        self.preserved_ast
-            .borrow_mut()
-            .load_ts_expr_for_span(&mut swc_expr, span);
-        swc_expr
+        }
     }
 
     fn convert_call_expression(&self, call: &CallExpression) -> swc::CallExpr {
@@ -1408,10 +929,8 @@ impl ReverseCtx {
             args: self.convert_expression_list(&call.arguments),
             type_args: None,
         };
-        if !self.preserved_ast.borrow_mut().load_call(&mut call_expr)
-            && Self::has_type_args(call.type_parameters.as_ref(), call.type_arguments.as_ref())
-        {
-            self.cold_fill_call_type_args_from_json(
+        if !self.preserved_ast.borrow_mut().load_call(&mut call_expr) {
+            self.cold_fill_call_type_args_from_raw_nodes(
                 &mut call_expr,
                 call.type_parameters.as_ref(),
                 call.type_arguments.as_ref(),
@@ -1529,11 +1048,8 @@ impl ReverseCtx {
             }
             ObjectExpressionProperty::ObjectMethod(method) => {
                 let mut function = self.convert_object_method_to_function(method);
-                if !self.preserved_ast.borrow_mut().load_function(&mut function)
-                    && (Self::patterns_have_type_annotations(&method.params)
-                        || Self::has_type_annotation(method.return_type.as_ref()))
-                {
-                    self.cold_fill_function_types_from_json(
+                if !self.preserved_ast.borrow_mut().load_function(&mut function) {
+                    self.cold_fill_function_types_from_raw_node(
                         &mut function,
                         &method.params,
                         method.return_type.as_ref(),
@@ -1652,11 +1168,8 @@ impl ReverseCtx {
             type_params: None,
             return_type: None,
         };
-        if !self.preserved_ast.borrow_mut().load_function(&mut function)
-            && (Self::patterns_have_type_annotations(&f.params)
-                || Self::has_type_annotation(f.return_type.as_ref()))
-        {
-            self.cold_fill_function_types_from_json(
+        if !self.preserved_ast.borrow_mut().load_function(&mut function) {
+            self.cold_fill_function_types_from_raw_node(
                 &mut function,
                 &f.params,
                 f.return_type.as_ref(),
@@ -1664,7 +1177,7 @@ impl ReverseCtx {
         }
         swc::FnDecl {
             ident: f.id.as_ref().map_or_else(
-                || self.private_ident("__default", &f.base),
+                || self.quote_ident("__default"),
                 |id| self.convert_identifier(id),
             ),
             declare: f.declare.unwrap_or(false),
@@ -1721,11 +1234,8 @@ impl ReverseCtx {
             type_params: None,
             return_type: None,
         };
-        if !self.preserved_ast.borrow_mut().load_function(&mut function)
-            && (Self::patterns_have_type_annotations(&f.params)
-                || Self::has_type_annotation(f.return_type.as_ref()))
-        {
-            self.cold_fill_function_types_from_json(
+        if !self.preserved_ast.borrow_mut().load_function(&mut function) {
+            self.cold_fill_function_types_from_raw_node(
                 &mut function,
                 &f.params,
                 f.return_type.as_ref(),
@@ -1774,11 +1284,8 @@ impl ReverseCtx {
             type_params: None,
             return_type: None,
         };
-        if !self.preserved_ast.borrow_mut().load_arrow(&mut arrow_expr)
-            && (Self::patterns_have_type_annotations(&arrow.params)
-                || Self::has_type_annotation(arrow.return_type.as_ref()))
-        {
-            self.cold_fill_arrow_types_from_json(
+        if !self.preserved_ast.borrow_mut().load_arrow(&mut arrow_expr) {
+            self.cold_fill_arrow_types_from_raw_node(
                 &mut arrow_expr,
                 &arrow.params,
                 arrow.return_type.as_ref(),
@@ -1788,92 +1295,32 @@ impl ReverseCtx {
         swc::Expr::Arrow(arrow_expr)
     }
 
-    fn convert_pattern_like_as_formal_parameter(&self, param: &PatternLike) -> swc::Param {
-        self.convert_pattern_like_as_formal_parameter_with_mode(param, PatternTypeAnnMode::FromJson)
-    }
-
     fn convert_pattern_like_as_formal_parameter_omitting_types(
         &self,
         param: &PatternLike,
     ) -> swc::Param {
-        self.convert_pattern_like_as_formal_parameter_with_mode(param, PatternTypeAnnMode::Omit)
-    }
-
-    fn convert_pattern_like_as_formal_parameter_with_mode(
-        &self,
-        param: &PatternLike,
-        type_ann_mode: PatternTypeAnnMode,
-    ) -> swc::Param {
         swc::Param {
             span: self.pattern_span(param),
             decorators: vec![],
-            pat: self.convert_pattern_like_with_type_ann_mode(param, type_ann_mode),
+            pat: self.convert_pattern_like_omitting_types(param),
         }
-    }
-
-    fn pattern_type_annotation(
-        &self,
-        pattern: &PatternLike,
-        type_ann_mode: PatternTypeAnnMode,
-    ) -> Option<Box<swc::TsTypeAnn>> {
-        match type_ann_mode {
-            PatternTypeAnnMode::FromJson => self.cold_pattern_type_annotation_from_json(pattern),
-            PatternTypeAnnMode::Omit => None,
-        }
-    }
-
-    #[cold]
-    fn cold_pattern_type_annotation_from_json(
-        &self,
-        pattern: &PatternLike,
-    ) -> Option<Box<swc::TsTypeAnn>> {
-        match pattern {
-            PatternLike::Identifier(id) => {
-                self.convert_ts_type_annotation_option(id.type_annotation.as_ref())
-            }
-            PatternLike::ObjectPattern(pattern) => {
-                self.convert_ts_type_annotation_option(pattern.type_annotation.as_ref())
-            }
-            PatternLike::ArrayPattern(pattern) => {
-                self.convert_ts_type_annotation_option(pattern.type_annotation.as_ref())
-            }
-            PatternLike::AssignmentPattern(pattern) => {
-                self.convert_ts_type_annotation_option(pattern.type_annotation.as_ref())
-            }
-            PatternLike::RestElement(pattern) => {
-                self.convert_ts_type_annotation_option(pattern.type_annotation.as_ref())
-            }
-            _ => None,
-        }
-    }
-
-    fn convert_pattern_like(&self, pattern: &PatternLike) -> swc::Pat {
-        self.convert_pattern_like_with_type_ann_mode(pattern, PatternTypeAnnMode::FromJson)
     }
 
     fn convert_pattern_like_omitting_types(&self, pattern: &PatternLike) -> swc::Pat {
-        self.convert_pattern_like_with_type_ann_mode(pattern, PatternTypeAnnMode::Omit)
-    }
-
-    fn convert_pattern_like_with_type_ann_mode(
-        &self,
-        pattern: &PatternLike,
-        type_ann_mode: PatternTypeAnnMode,
-    ) -> swc::Pat {
         match pattern {
             PatternLike::Identifier(id) => swc::Pat::Ident(swc::BindingIdent {
                 id: self.convert_identifier(id),
-                type_ann: self.pattern_type_annotation(pattern, type_ann_mode),
+                type_ann: None,
             }),
             PatternLike::ObjectPattern(obj) => swc::Pat::Object(swc::ObjectPat {
                 span: self.span_from_base(&obj.base),
                 props: obj
                     .properties
                     .iter()
-                    .map(|prop| self.convert_object_pattern_property(prop, type_ann_mode))
+                    .map(|prop| self.convert_object_pattern_property_omitting_types(prop))
                     .collect(),
                 optional: false,
-                type_ann: self.pattern_type_annotation(pattern, type_ann_mode),
+                type_ann: None,
             }),
             PatternLike::ArrayPattern(arr) => swc::Pat::Array(swc::ArrayPat {
                 span: self.span_from_base(&arr.base),
@@ -1881,28 +1328,23 @@ impl ReverseCtx {
                     .elements
                     .iter()
                     .map(|elem| {
-                        elem.as_ref().map(|elem| {
-                            self.convert_pattern_like_with_type_ann_mode(elem, type_ann_mode)
-                        })
+                        elem.as_ref()
+                            .map(|elem| self.convert_pattern_like_omitting_types(elem))
                     })
                     .collect(),
                 optional: false,
-                type_ann: self.pattern_type_annotation(pattern, type_ann_mode),
+                type_ann: None,
             }),
             PatternLike::AssignmentPattern(assign) => swc::Pat::Assign(swc::AssignPat {
                 span: self.span_from_base(&assign.base),
-                left: Box::new(
-                    self.convert_pattern_like_with_type_ann_mode(&assign.left, type_ann_mode),
-                ),
+                left: Box::new(self.convert_pattern_like_omitting_types(&assign.left)),
                 right: Box::new(self.convert_expression(&assign.right)),
             }),
             PatternLike::RestElement(rest) => swc::Pat::Rest(swc::RestPat {
                 span: self.span_from_base(&rest.base),
                 dot3_token: self.span_from_base(&rest.base),
-                arg: Box::new(
-                    self.convert_pattern_like_with_type_ann_mode(&rest.argument, type_ann_mode),
-                ),
-                type_ann: self.pattern_type_annotation(pattern, type_ann_mode),
+                arg: Box::new(self.convert_pattern_like_omitting_types(&rest.argument)),
+                type_ann: None,
             }),
             PatternLike::MemberExpression(member) => {
                 swc::Pat::Expr(Box::new(self.convert_member_expression(member)))
@@ -1919,37 +1361,33 @@ impl ReverseCtx {
             PatternLike::TSTypeAssertion(ts) => swc::Pat::Expr(Box::new(
                 self.convert_expression(&Expression::TSTypeAssertion(ts.clone())),
             )),
-            PatternLike::TypeCastExpression(type_cast) => self
-                .convert_pattern_like_with_type_ann_mode(
-                    &PatternLike::TSAsExpression(TSAsExpression {
-                        base: type_cast.base.clone(),
-                        expression: type_cast.expression.clone(),
-                        type_annotation: type_cast.type_annotation.clone(),
-                    }),
-                    type_ann_mode,
-                ),
+            PatternLike::TypeCastExpression(type_cast) => self.convert_pattern_like_omitting_types(
+                &PatternLike::TSAsExpression(TSAsExpression {
+                    base: type_cast.base.clone(),
+                    expression: type_cast.expression.clone(),
+                    type_annotation: type_cast.type_annotation.clone(),
+                }),
+            ),
         }
     }
 
-    fn convert_object_pattern_property(
+    fn convert_object_pattern_property_omitting_types(
         &self,
         prop: &ObjectPatternProperty,
-        type_ann_mode: PatternTypeAnnMode,
     ) -> swc::ObjectPatProp {
         match prop {
             ObjectPatternProperty::ObjectProperty(prop) => {
-                self.convert_object_pattern_prop(prop, type_ann_mode)
+                self.convert_object_pattern_prop_omitting_types(prop)
             }
             ObjectPatternProperty::RestElement(rest) => {
-                self.convert_rest_element_as_object_pat_prop(rest, type_ann_mode)
+                self.convert_rest_element_as_object_pat_prop_omitting_types(rest)
             }
         }
     }
 
-    fn convert_object_pattern_prop(
+    fn convert_object_pattern_prop_omitting_types(
         &self,
         prop: &ObjectPatternProp,
-        type_ann_mode: PatternTypeAnnMode,
     ) -> swc::ObjectPatProp {
         if prop.shorthand {
             if let Expression::Identifier(key) = prop.key.as_ref() {
@@ -1959,7 +1397,7 @@ impl ReverseCtx {
                             span: self.span_from_base(&prop.base),
                             key: swc::BindingIdent {
                                 id: self.convert_identifier(id),
-                                type_ann: self.pattern_type_annotation(&prop.value, type_ann_mode),
+                                type_ann: None,
                             },
                             value: None,
                         });
@@ -1970,8 +1408,7 @@ impl ReverseCtx {
                                 span: self.span_from_base(&prop.base),
                                 key: swc::BindingIdent {
                                     id: self.convert_identifier(id),
-                                    type_ann: self
-                                        .pattern_type_annotation(&assign.left, type_ann_mode),
+                                    type_ann: None,
                                 },
                                 value: Some(Box::new(self.convert_expression(&assign.right))),
                             });
@@ -1985,21 +1422,17 @@ impl ReverseCtx {
 
         swc::ObjectPatProp::KeyValue(swc::KeyValuePatProp {
             key: self.convert_expression_as_prop_name(&prop.key, prop.computed),
-            value: Box::new(
-                self.convert_pattern_like_with_type_ann_mode(&prop.value, type_ann_mode),
-            ),
+            value: Box::new(self.convert_pattern_like_omitting_types(&prop.value)),
         })
     }
 
-    fn convert_rest_element_as_object_pat_prop(
+    fn convert_rest_element_as_object_pat_prop_omitting_types(
         &self,
         rest: &RestElement,
-        type_ann_mode: PatternTypeAnnMode,
     ) -> swc::ObjectPatProp {
-        let swc::Pat::Rest(rest) = self.convert_pattern_like_with_type_ann_mode(
-            &PatternLike::RestElement(rest.clone()),
-            type_ann_mode,
-        ) else {
+        let swc::Pat::Rest(rest) =
+            self.convert_pattern_like_omitting_types(&PatternLike::RestElement(rest.clone()))
+        else {
             return swc::ObjectPatProp::Rest(swc::RestPat {
                 span: self.span_from_base(&rest.base),
                 dot3_token: self.span_from_base(&rest.base),
@@ -2011,7 +1444,7 @@ impl ReverseCtx {
     }
 
     fn convert_pattern_like_as_assign_target(&self, pattern: &PatternLike) -> swc::AssignTarget {
-        match self.convert_pattern_like(pattern).try_into() {
+        match self.convert_pattern_like_omitting_types(pattern).try_into() {
             Ok(target) => target,
             Err(pattern) => match pattern {
                 swc::Pat::Expr(expr) => expr.try_into().unwrap_or_else(|expr: Box<swc::Expr>| {
@@ -2060,9 +1493,8 @@ impl ReverseCtx {
             .preserved_ast
             .borrow_mut()
             .load_jsx_opening_element(&mut opening)
-            && Self::has_type_annotation(el.type_parameters.as_ref())
         {
-            self.cold_fill_jsx_opening_type_args_from_json(
+            self.cold_fill_jsx_opening_type_args_from_raw_node(
                 &mut opening,
                 el.type_parameters.as_ref(),
             );
@@ -2359,7 +1791,7 @@ impl ReverseCtx {
             }
             Declaration::ClassDeclaration(class) => swc::Decl::Class(swc::ClassDecl {
                 ident: class.id.as_ref().map_or_else(
-                    || self.private_ident("__default_class", &class.base),
+                    || self.quote_ident("__default_class"),
                     |id| self.convert_identifier(id),
                 ),
                 declare: class.declare.unwrap_or(false),
@@ -2459,7 +1891,7 @@ impl ReverseCtx {
             span: self.span_from_base(&decl.base),
             decl: swc::DefaultDecl::TsInterfaceDecl(Box::new(swc::TsInterfaceDecl {
                 span: self.span_from_base(&decl.base),
-                id: self.private_ident("__default_interface", &decl.base),
+                id: self.quote_ident("__default_interface"),
                 declare: false,
                 type_params: None,
                 extends: vec![],
@@ -2505,9 +1937,9 @@ impl ReverseCtx {
                 }))
             }
             ExportDefaultDecl::Expression(expr) => Err(self.convert_expression(expr)),
-            ExportDefaultDecl::EnumDeclaration(enum_decl) => Err(swc::Expr::Ident(
-                self.private_ident(&enum_decl.id.name, &enum_decl.base),
-            )),
+            ExportDefaultDecl::EnumDeclaration(enum_decl) => {
+                Err(swc::Expr::Ident(self.quote_ident(&enum_decl.id.name)))
+            }
         }
     }
 
@@ -2628,12 +2060,10 @@ impl ReverseCtx {
         }
     }
 
-    fn private_ident(&self, name: &str, base: &BaseNode) -> swc::Ident {
+    fn quote_ident(&self, name: &str) -> swc::Ident {
         swc::Ident {
-            span: self.span_from_base(base),
-            ctxt: SyntaxContext::empty(),
             sym: self.atom(name),
-            optional: false,
+            ..Default::default()
         }
     }
 
@@ -2676,7 +2106,7 @@ impl ReverseCtx {
             .borrow_mut()
             .load_ts_type_alias(&mut ts_decl)
         {
-            self.cold_fill_ts_type_alias_from_json(
+            self.cold_fill_ts_type_alias_from_raw_node(
                 &mut ts_decl,
                 &decl.type_annotation,
                 self.span_from_base(&decl.base),
@@ -2697,13 +2127,11 @@ impl ReverseCtx {
                 body: vec![],
             },
         };
-        if !self
-            .preserved_ast
+
+        self.preserved_ast
             .borrow_mut()
-            .load_ts_interface(&mut ts_decl)
-        {
-            ts_decl.body.span = self.span_from_raw_node(&decl.body);
-        }
+            .load_ts_interface(&mut ts_decl);
+
         swc::Stmt::Decl(swc::Decl::TsInterface(Box::new(ts_decl))).into()
     }
 
@@ -2720,95 +2148,37 @@ impl ReverseCtx {
     }
 
     fn convert_ts_module_declaration(&self, decl: &TSModuleDeclaration) -> swc::ModuleItem {
-        let id = self.convert_ts_module_id_from_json(decl);
-        let placeholder_id = id.clone().unwrap_or_else(|| {
-            swc::TsModuleName::Ident(self.private_ident("__namespace", &decl.base))
-        });
+        let span = self.span_from_base(&decl.base);
+        let id = self.quote_ident("__namespace");
 
         let mut item: swc::ModuleItem =
             swc::Stmt::Decl(swc::Decl::TsModule(Box::new(swc::TsModuleDecl {
-                span: self.span_from_base(&decl.base),
+                span,
+                id: id.into(),
                 declare: decl.declare.unwrap_or(false),
                 global: decl.global.unwrap_or(false),
                 namespace: false,
-                id: placeholder_id,
                 body: None,
             })))
             .into();
-        self.preserved_ast
-            .borrow_mut()
-            .load_module_item(&mut item, id);
+
+        if !self.preserved_ast.borrow_mut().load_module_item(&mut item) {
+            // Skip unrecognized module items.
+            // We believe the React compiler does not emit additional module items.
+            item = swc::Stmt::Empty(swc::EmptyStmt { span }).into();
+        }
         item
-    }
-
-    #[cold]
-    fn convert_ts_module_id_from_json(
-        &self,
-        decl: &TSModuleDeclaration,
-    ) -> Option<swc::TsModuleName> {
-        self.convert_ts_module_name_from_json(&decl.id)
-    }
-
-    #[cold]
-    fn convert_ts_module_name_from_json(&self, value: &RawNode) -> Option<swc::TsModuleName> {
-        let value = value.parse_value();
-        match json_type(&value) {
-            Some("Identifier") => self
-                .convert_ident_from_json(&value)
-                .map(swc::TsModuleName::Ident),
-            Some("StringLiteral") => self
-                .convert_str_from_json(&value)
-                .map(swc::TsModuleName::Str),
-            Some(_) => None,
-            None if value.get("name").is_some() => self
-                .convert_ident_from_json(&value)
-                .map(swc::TsModuleName::Ident),
-            None if value.get("value").is_some() => self
-                .convert_str_from_json(&value)
-                .map(swc::TsModuleName::Str),
-            None => None,
-        }
-    }
-
-    #[cold]
-    fn convert_ident_from_json(&self, value: &serde_json::Value) -> Option<swc::Ident> {
-        Some(swc::Ident {
-            span: self.span_from_json_value(value),
-            ctxt: SyntaxContext::empty(),
-            sym: self.atom(json_str(value, "name")?),
-            optional: json_bool(value, "optional").unwrap_or(false),
-        })
-    }
-
-    #[cold]
-    fn convert_str_from_json(&self, value: &serde_json::Value) -> Option<swc::Str> {
-        Some(swc::Str {
-            span: self.span_from_json_value(value),
-            value: json_str(value, "value")?.into(),
-            raw: None,
-        })
-    }
-
-    #[cold]
-    fn convert_raw_pattern_like(&self, index: usize, _raw: &RawNode) -> swc::Param {
-        let name = format!("_{index}");
-
-        swc::Ident {
-            ctxt: SyntaxContext::empty(),
-            sym: self.atom(&name),
-            ..Default::default()
-        }
-        .into()
     }
 
     fn convert_ts_declare_function(&self, decl: &TSDeclareFunction) -> swc::ModuleItem {
         let id = decl.id.as_ref().map_or_else(
-            || self.private_ident("__declare", &decl.base),
+            || self.quote_ident("__declare"),
             |id| self.convert_identifier(id),
         );
         let mut function = swc::Function {
             span: self.span_from_base(&decl.base),
             ctxt: SyntaxContext::empty(),
+
             is_generator: decl.generator.unwrap_or(false),
             is_async: decl.is_async.unwrap_or(false),
             ..Default::default()
@@ -2818,14 +2188,11 @@ impl ReverseCtx {
             .borrow_mut()
             .load_ts_function(&mut function)
         {
-            function.params = decl
-                .params
-                .iter()
-                .enumerate()
-                .map(|(index, param)| self.convert_raw_pattern_like(index, param))
-                .collect();
-            function.return_type =
-                self.convert_ts_type_annotation_option(decl.return_type.as_ref());
+            self.cold_fill_ts_function_from_raw_node(
+                &mut function,
+                &decl.params,
+                decl.return_type.as_ref(),
+            );
         }
 
         swc::Stmt::Decl(swc::Decl::Fn(swc::FnDecl {
@@ -2845,7 +2212,7 @@ impl ReverseCtx {
             decls: vec![swc::VarDeclarator {
                 span: self.span_from_base(base),
                 name: swc::Pat::Ident(swc::BindingIdent {
-                    id: self.private_ident("__unsupported_declaration", base),
+                    id: self.quote_ident("__unsupported_declaration"),
                     type_ann: None,
                 }),
                 init: None,
@@ -2855,10 +2222,556 @@ impl ReverseCtx {
     }
 }
 
-#[derive(Clone, Copy)]
-enum PatternTypeAnnMode {
-    FromJson,
-    Omit,
+impl ReverseCtx {
+    // JSON reconstruction is only a fidelity fallback when no preserved SWC
+    // shell is available for TypeScript metadata.
+
+    #[cold]
+    fn cold_convert_ts_type_annotation_from_raw_node(
+        &self,
+        value: Option<&RawNode>,
+    ) -> Option<Box<swc::TsTypeAnn>> {
+        value.and_then(|value| {
+            let value = value.parse_value();
+            self.convert_ts_type_annotation_from_json(&value)
+        })
+    }
+
+    #[cold]
+    fn cold_convert_ts_type_parameter_instantiation_from_raw_nodes(
+        &self,
+        type_parameters: Option<&RawNode>,
+        type_arguments: Option<&RawNode>,
+    ) -> Option<Box<swc::TsTypeParamInstantiation>> {
+        type_parameters.or(type_arguments).and_then(|value| {
+            let value = value.parse_value();
+            self.convert_ts_type_parameter_instantiation_from_json(&value)
+        })
+    }
+
+    #[cold]
+    fn cold_fill_ts_as_expr_from_raw_node(
+        &self,
+        expr: &mut swc::TsAsExpr,
+        type_annotation: &RawNode,
+        fallback_span: Span,
+    ) {
+        let type_annotation = type_annotation.parse_value();
+        expr.type_ann = self
+            .convert_ts_type_from_json(&type_annotation)
+            .unwrap_or_else(|| self.any_ts_type(fallback_span));
+    }
+
+    #[cold]
+    fn cold_fill_ts_satisfies_expr_from_raw_node(
+        &self,
+        expr: &mut swc::TsSatisfiesExpr,
+        type_annotation: &RawNode,
+        fallback_span: Span,
+    ) {
+        let type_annotation = type_annotation.parse_value();
+        expr.type_ann = self
+            .convert_ts_type_from_json(&type_annotation)
+            .unwrap_or_else(|| self.any_ts_type(fallback_span));
+    }
+
+    #[cold]
+    fn cold_fill_ts_type_assertion_from_raw_node(
+        &self,
+        expr: &mut swc::TsTypeAssertion,
+        type_annotation: &RawNode,
+        fallback_span: Span,
+    ) {
+        let type_annotation = type_annotation.parse_value();
+        expr.type_ann = self
+            .convert_ts_type_from_json(&type_annotation)
+            .unwrap_or_else(|| self.any_ts_type(fallback_span));
+    }
+
+    #[cold]
+    fn cold_fill_ts_instantiation_from_raw_node(
+        &self,
+        expr: &mut swc::TsInstantiation,
+        type_parameters: &RawNode,
+        fallback_span: Span,
+    ) {
+        let type_parameters = type_parameters.parse_value();
+        expr.type_args = self
+            .convert_ts_type_parameter_instantiation_from_json(&type_parameters)
+            .unwrap_or_else(|| {
+                Box::new(swc::TsTypeParamInstantiation {
+                    span: fallback_span,
+                    params: vec![],
+                })
+            });
+    }
+
+    #[cold]
+    fn cold_fill_call_type_args_from_raw_nodes(
+        &self,
+        call: &mut swc::CallExpr,
+        type_parameters: Option<&RawNode>,
+        type_arguments: Option<&RawNode>,
+    ) {
+        call.type_args = self.cold_convert_ts_type_parameter_instantiation_from_raw_nodes(
+            type_parameters,
+            type_arguments,
+        );
+    }
+
+    #[cold]
+    fn cold_fill_opt_call_type_args_from_raw_nodes(
+        &self,
+        call: &mut swc::OptCall,
+        type_parameters: Option<&RawNode>,
+        type_arguments: Option<&RawNode>,
+    ) {
+        call.type_args = self.cold_convert_ts_type_parameter_instantiation_from_raw_nodes(
+            type_parameters,
+            type_arguments,
+        );
+    }
+
+    #[cold]
+    fn cold_fill_new_type_args_from_raw_nodes(
+        &self,
+        expr: &mut swc::NewExpr,
+        type_parameters: Option<&RawNode>,
+        type_arguments: Option<&RawNode>,
+    ) {
+        expr.type_args = self.cold_convert_ts_type_parameter_instantiation_from_raw_nodes(
+            type_parameters,
+            type_arguments,
+        );
+    }
+
+    #[cold]
+    fn cold_fill_tagged_tpl_type_params_from_raw_node(
+        &self,
+        tpl: &mut swc::TaggedTpl,
+        type_parameters: Option<&RawNode>,
+    ) {
+        tpl.type_params = type_parameters.and_then(|value| {
+            let value = value.parse_value();
+            self.convert_ts_type_parameter_instantiation_from_json(&value)
+        });
+    }
+
+    #[cold]
+    fn cold_fill_jsx_opening_type_args_from_raw_node(
+        &self,
+        opening: &mut swc::JSXOpeningElement,
+        type_parameters: Option<&RawNode>,
+    ) {
+        opening.type_args = type_parameters.and_then(|value| {
+            let value = value.parse_value();
+            self.convert_ts_type_parameter_instantiation_from_json(&value)
+        });
+    }
+
+    #[cold]
+    fn cold_fill_function_types_from_raw_node(
+        &self,
+        function: &mut swc::Function,
+        params: &[PatternLike],
+        return_type: Option<&RawNode>,
+    ) {
+        for (param, source) in function.params.iter_mut().zip(params) {
+            self.cold_fill_param_type_from_pattern_like(param, source);
+        }
+        function.return_type = self.cold_convert_ts_type_annotation_from_raw_node(return_type);
+    }
+
+    #[cold]
+    fn cold_fill_ts_function_from_raw_node(
+        &self,
+        function: &mut swc::Function,
+        params: &[RawNode],
+        return_type: Option<&RawNode>,
+    ) {
+        function.params = params
+            .iter()
+            .enumerate()
+            .map(|(index, raw_param)| self.cold_convert_ts_declare_raw_param(index, raw_param))
+            .collect();
+        function.return_type = self.cold_convert_ts_type_annotation_from_raw_node(return_type);
+    }
+
+    #[cold]
+    fn cold_convert_ts_declare_raw_param(&self, index: usize, raw_param: &RawNode) -> swc::Param {
+        let value = raw_param.parse_value();
+        let span = self.span_from_json(&value);
+        let fallback_name = format!("_{index}");
+        let mut param: swc_ecma_ast::Param = swc::Param {
+            span,
+            decorators: vec![],
+            pat: self.cold_convert_ts_declare_raw_param_pat(&value, &fallback_name),
+        };
+
+        self.cold_fill_raw_pat_type_ann(&mut param.pat, &value);
+
+        param
+    }
+
+    #[cold]
+    fn cold_convert_ts_declare_raw_param_pat(
+        &self,
+        value: &Value,
+        fallback_name: &str,
+    ) -> swc::Pat {
+        match json_type(value) {
+            Some("Identifier") => self
+                .raw_binding_ident(
+                    DUMMY_SP,
+                    json_str(value, "name").unwrap_or(fallback_name),
+                    json_bool(value, "optional").unwrap_or(false),
+                )
+                .into(),
+            Some("RestElement") => swc::RestPat {
+                span: DUMMY_SP,
+                dot3_token: DUMMY_SP,
+                arg: Box::new(swc::Pat::Ident(self.raw_binding_ident(
+                    DUMMY_SP,
+                    fallback_name,
+                    false,
+                ))),
+                type_ann: None,
+            }
+            .into(),
+            _ => self
+                .raw_binding_ident(
+                    DUMMY_SP,
+                    fallback_name,
+                    json_bool(value, "optional").unwrap_or(false),
+                )
+                .into(),
+        }
+    }
+
+    fn raw_binding_ident(&self, span: Span, name: &str, optional: bool) -> swc::BindingIdent {
+        swc::BindingIdent {
+            id: swc::Ident {
+                span,
+                ctxt: SyntaxContext::empty(),
+                sym: self.atom(name),
+                optional,
+            },
+            type_ann: None,
+        }
+    }
+
+    #[cold]
+    fn cold_fill_raw_pat_type_ann(&self, pat: &mut swc::Pat, value: &Value) {
+        let Some(type_ann_value) = top_level_raw_pattern_type_ann(value) else {
+            return;
+        };
+        let Some(type_ann) = self.convert_ts_type_annotation_from_json(type_ann_value) else {
+            return;
+        };
+
+        set_top_level_pat_type_ann(pat, type_ann);
+    }
+
+    #[cold]
+    fn cold_fill_arrow_types_from_raw_node(
+        &self,
+        arrow: &mut swc::ArrowExpr,
+        params: &[PatternLike],
+        return_type: Option<&RawNode>,
+    ) {
+        for (param, source) in arrow.params.iter_mut().zip(params) {
+            self.cold_fill_pat_type_from_pattern_like(param, source);
+        }
+        arrow.return_type = self.cold_convert_ts_type_annotation_from_raw_node(return_type);
+    }
+
+    #[cold]
+    fn cold_fill_var_decl_types_from_variable_declarators(
+        &self,
+        decl: &mut swc::VarDecl,
+        declarations: &[VariableDeclarator],
+    ) {
+        for (decl, source) in decl.decls.iter_mut().zip(declarations) {
+            self.cold_fill_pat_type_from_pattern_like(&mut decl.name, &source.id);
+        }
+    }
+
+    #[cold]
+    fn cold_fill_param_type_from_pattern_like(&self, param: &mut swc::Param, source: &PatternLike) {
+        self.cold_fill_pat_type_from_pattern_like(&mut param.pat, source);
+    }
+
+    #[cold]
+    fn cold_fill_pat_type_from_pattern_like(&self, pat: &mut swc::Pat, source: &PatternLike) {
+        let Some(type_ann) = self.cold_pattern_type_annotation_from_pattern_like(source) else {
+            return;
+        };
+
+        set_top_level_pat_type_ann(pat, type_ann);
+    }
+
+    #[cold]
+    fn cold_fill_ts_type_alias_from_raw_node(
+        &self,
+        decl: &mut swc::TsTypeAliasDecl,
+        type_annotation: &RawNode,
+        fallback_span: Span,
+    ) {
+        let type_annotation = type_annotation.parse_value();
+        decl.type_ann = self
+            .convert_ts_type_from_json(&type_annotation)
+            .unwrap_or_else(|| self.any_ts_type(fallback_span));
+    }
+
+    #[cold]
+    fn cold_pattern_type_annotation_from_pattern_like(
+        &self,
+        pattern: &PatternLike,
+    ) -> Option<Box<swc::TsTypeAnn>> {
+        self.cold_convert_ts_type_annotation_from_raw_node(top_level_pattern_type_ann(pattern))
+    }
+}
+
+impl ReverseCtx {
+    #[cold]
+    fn span_from_json(&self, value: &serde_json::Value) -> Span {
+        let start = json_u64(value, "start");
+        let end = json_u64(value, "end");
+        match (start, end) {
+            (Some(start), Some(end)) => Span::new(BytePos(start as u32), BytePos(end as u32)),
+            (Some(start), None) => Span::new(BytePos(start as u32), BytePos(start as u32)),
+            _ => DUMMY_SP,
+        }
+    }
+
+    #[cold]
+    fn convert_ts_type_annotation_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<Box<swc::TsTypeAnn>> {
+        let ty = if json_type(value) == Some("TSTypeAnnotation") {
+            self.convert_ts_type_from_json(value.get("typeAnnotation")?)?
+        } else {
+            self.convert_ts_type_from_json(value)?
+        };
+        Some(Box::new(swc::TsTypeAnn {
+            span: self.span_from_json(value),
+            type_ann: ty,
+        }))
+    }
+
+    #[cold]
+    fn convert_ts_type_from_json(&self, value: &serde_json::Value) -> Option<Box<swc::TsType>> {
+        let span = self.span_from_json(value);
+        let type_name = json_type(value)?;
+        if let Some(kind) = ts_keyword_type_kind(type_name) {
+            return Some(Box::new(swc::TsType::TsKeywordType(swc::TsKeywordType {
+                span,
+                kind,
+            })));
+        }
+
+        let ty = match type_name {
+            "TSThisType" => swc::TsType::TsThisType(swc::TsThisType { span }),
+            "TSArrayType" => swc::TsType::TsArrayType(swc::TsArrayType {
+                span,
+                elem_type: self.convert_ts_type_from_json(value.get("elementType")?)?,
+            }),
+            "TSUnionType" => {
+                let types = json_array(value, "types")?
+                    .iter()
+                    .filter_map(|ty| self.convert_ts_type_from_json(ty))
+                    .collect();
+                swc::TsType::TsUnionOrIntersectionType(swc::TsUnionOrIntersectionType::TsUnionType(
+                    swc::TsUnionType { span, types },
+                ))
+            }
+            "TSParenthesizedType" => swc::TsType::TsParenthesizedType(swc::TsParenthesizedType {
+                span,
+                type_ann: self.convert_ts_type_from_json(value.get("typeAnnotation")?)?,
+            }),
+            "TSTypeOperator" => {
+                let op = ts_type_operator_op(json_str(value, "operator")?)?;
+                swc::TsType::TsTypeOperator(swc::TsTypeOperator {
+                    span,
+                    op,
+                    type_ann: self.convert_ts_type_from_json(value.get("typeAnnotation")?)?,
+                })
+            }
+            "TSTypeReference" => swc::TsType::TsTypeRef(swc::TsTypeRef {
+                span,
+                type_name: self.convert_ts_type_name_from_json(value.get("typeName")?)?,
+                type_params: self.convert_ts_type_parameter_instantiation_alias_from_json(value),
+            }),
+            "TSTypeQuery" => swc::TsType::TsTypeQuery(swc::TsTypeQuery {
+                span,
+                expr_name: self
+                    .convert_ts_type_query_expr_name_from_json(value.get("exprName")?)?,
+                type_args: self.convert_ts_type_parameter_instantiation_alias_from_json(value),
+            }),
+            "TSIndexedAccessType" => swc::TsType::TsIndexedAccessType(swc::TsIndexedAccessType {
+                span,
+                readonly: false,
+                obj_type: self.convert_ts_type_from_json(value.get("objectType")?)?,
+                index_type: self.convert_ts_type_from_json(value.get("indexType")?)?,
+            }),
+            "TSLiteralType" => swc::TsType::TsLitType(swc::TsLitType {
+                span,
+                lit: self.convert_ts_literal_from_json(value.get("literal")?)?,
+            }),
+            _ => return None,
+        };
+        Some(Box::new(ty))
+    }
+
+    #[cold]
+    fn convert_ts_type_name_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<swc::TsEntityName> {
+        let span = self.span_from_json(value);
+        match json_type(value)? {
+            "Identifier" => Some(swc::TsEntityName::Ident(swc::Ident {
+                span,
+                ctxt: SyntaxContext::empty(),
+                sym: Atom::from(json_str(value, "name")?),
+                optional: false,
+            })),
+            "TSQualifiedName" => {
+                let left = self.convert_ts_type_name_from_json(value.get("left")?)?;
+                let right_value = value.get("right")?;
+                let right = swc::IdentName::new(
+                    Atom::from(json_str(right_value, "name")?),
+                    self.span_from_json(right_value),
+                );
+                Some(swc::TsEntityName::TsQualifiedName(Box::new(
+                    swc::TsQualifiedName { span, left, right },
+                )))
+            }
+            _ => None,
+        }
+    }
+
+    #[cold]
+    fn convert_ts_type_query_expr_name_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<swc::TsTypeQueryExpr> {
+        Some(swc::TsTypeQueryExpr::TsEntityName(
+            self.convert_ts_type_name_from_json(value)?,
+        ))
+    }
+
+    #[cold]
+    fn convert_ts_type_parameter_instantiation_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<Box<swc::TsTypeParamInstantiation>> {
+        let params = json_array(value, "params")?
+            .iter()
+            .filter_map(|ty| self.convert_ts_type_from_json(ty))
+            .collect();
+        Some(Box::new(swc::TsTypeParamInstantiation {
+            span: self.span_from_json(value),
+            params,
+        }))
+    }
+
+    #[cold]
+    fn convert_ts_type_parameter_instantiation_option_from_json(
+        &self,
+        value: Option<&serde_json::Value>,
+    ) -> Option<Box<swc::TsTypeParamInstantiation>> {
+        value.and_then(|value| self.convert_ts_type_parameter_instantiation_from_json(value))
+    }
+
+    #[cold]
+    fn convert_ts_type_parameter_instantiation_alias_from_json(
+        &self,
+        value: &serde_json::Value,
+    ) -> Option<Box<swc::TsTypeParamInstantiation>> {
+        self.convert_ts_type_parameter_instantiation_option_from_json(
+            value
+                .get("typeParameters")
+                .or_else(|| value.get("typeArguments")),
+        )
+    }
+
+    #[cold]
+    fn convert_ts_literal_from_json(&self, value: &serde_json::Value) -> Option<swc::TsLit> {
+        let span = self.span_from_json(value);
+        match json_type(value)? {
+            "BooleanLiteral" => Some(swc::TsLit::Bool(swc::Bool {
+                span,
+                value: json_bool(value, "value")?,
+            })),
+            "NumericLiteral" => Some(swc::TsLit::Number(swc::Number {
+                span,
+                value: json_f64(value, "value")?,
+                raw: None,
+            })),
+            "StringLiteral" => Some(swc::TsLit::Str(swc::Str {
+                span,
+                value: json_str(value, "value")?.into(),
+                raw: None,
+            })),
+            "BigIntLiteral" => {
+                let value = json_str(value, "value")?;
+                Some(swc::TsLit::BigInt(swc::BigInt {
+                    span,
+                    value: Box::new(bigint_literal_value(value).parse().ok()?),
+                    raw: Some(bigint_literal_raw(value)),
+                }))
+            }
+            _ => None,
+        }
+    }
+}
+
+fn top_level_pattern_type_ann(pattern: &PatternLike) -> Option<&RawNode> {
+    match pattern {
+        PatternLike::Identifier(pattern) => pattern.type_annotation.as_ref(),
+        PatternLike::ObjectPattern(pattern) => pattern.type_annotation.as_ref(),
+        PatternLike::ArrayPattern(pattern) => pattern.type_annotation.as_ref(),
+        PatternLike::AssignmentPattern(pattern) => pattern
+            .type_annotation
+            .as_ref()
+            .or_else(|| top_level_pattern_type_ann(&pattern.left)),
+        PatternLike::RestElement(pattern) => pattern.type_annotation.as_ref(),
+        PatternLike::MemberExpression(_)
+        | PatternLike::TSAsExpression(_)
+        | PatternLike::TSSatisfiesExpression(_)
+        | PatternLike::TSNonNullExpression(_)
+        | PatternLike::TSTypeAssertion(_)
+        | PatternLike::TypeCastExpression(_) => None,
+    }
+}
+
+fn top_level_raw_pattern_type_ann(value: &Value) -> Option<&Value> {
+    value.get("typeAnnotation").or_else(|| {
+        if json_type(value) == Some("AssignmentPattern") {
+            value.get("left").and_then(top_level_raw_pattern_type_ann)
+        } else {
+            None
+        }
+    })
+}
+
+fn set_top_level_pat_type_ann(pattern: &mut swc::Pat, type_ann: Box<swc::TsTypeAnn>) {
+    match top_level_typed_pat_mut(pattern) {
+        swc::Pat::Ident(pattern) => pattern.type_ann = Some(type_ann),
+        swc::Pat::Array(pattern) => pattern.type_ann = Some(type_ann),
+        swc::Pat::Object(pattern) => pattern.type_ann = Some(type_ann),
+        swc::Pat::Rest(pattern) => pattern.type_ann = Some(type_ann),
+        _ => {}
+    }
+}
+
+fn top_level_typed_pat_mut(pattern: &mut swc::Pat) -> &mut swc::Pat {
+    match pattern {
+        swc::Pat::Assign(pattern) => &mut pattern.left,
+        _ => pattern,
+    }
 }
 
 trait MemberExpressionExt {

--- a/crates/swc_ecma_react_compiler/src/preserved_ast.rs
+++ b/crates/swc_ecma_react_compiler/src/preserved_ast.rs
@@ -1,5 +1,5 @@
 use rustc_hash::FxHashMap;
-use swc_common::{source_map::SmallPos, util::take::Take, Span};
+use swc_common::{source_map::SmallPos, util::take::Take, Span, Spanned};
 use swc_ecma_ast::*;
 
 #[derive(Default, Clone)]
@@ -11,21 +11,20 @@ pub struct PreservedAst {
 #[derive(Clone)]
 pub enum PreservedNode {
     Arrow(Box<ArrowShell>),
-    Call(Box<CallShell>),
+    Catch(Box<PatternTypeShell>),
     Class(Box<Class>),
     Directive(Box<Str>),
     Function(Box<FunctionShell>),
     Import(Box<ImportShell>),
-    JsxOpeningElement(Box<JsxOpeningElementShell>),
-    New(Box<NewShell>),
-    TaggedTemplate(Box<TaggedTemplateShell>),
-    TsExpr(Box<TsExprShell>),
     TsEnum(Box<TsEnumDecl>),
     TsExportAssignment(TsExportAssignment),
+    TsExpr(Box<TsExprShell>),
     TsImportEquals(Box<TsImportEqualsDecl>),
+    TsInstantiation(Box<TsInstantiationShell>),
     TsInterface(Box<TsInterfaceDecl>),
     TsModule(Box<TsModuleDecl>),
     TsNamespaceExport(TsNamespaceExportDecl),
+    TsOptionalInstantiation(Box<TsOptionalInstantiationShell>),
     TsTypeAlias(Box<TsTypeAliasDecl>),
     Variable(Box<VariableShell>),
 }
@@ -58,29 +57,9 @@ pub struct VariableShell {
 
 /// Typescript pattern metadata attached to the outer binding pattern.
 #[derive(Clone)]
-pub enum PatternTypeShell {
-    Ident {
-        type_ann: Option<Box<TsTypeAnn>>,
-        optional: bool,
-    },
-    Array {
-        type_ann: Option<Box<TsTypeAnn>>,
-        optional: bool,
-    },
-    Object {
-        type_ann: Option<Box<TsTypeAnn>>,
-        optional: bool,
-    },
-    Rest {
-        type_ann: Option<Box<TsTypeAnn>>,
-    },
-}
-
-/// Lightweight call metadata not represented losslessly in React Compiler's
-/// AST.
-#[derive(Clone)]
-pub struct CallShell {
-    type_args: Option<Box<TsTypeParamInstantiation>>,
+pub struct PatternTypeShell {
+    type_ann: Option<Box<TsTypeAnn>>,
+    optional: bool,
 }
 
 /// Lightweight import metadata that SWC's import declaration shape cannot
@@ -90,48 +69,27 @@ pub struct ImportShell {
     phase: ImportPhase,
 }
 
-/// Lightweight JSX opening element metadata not represented losslessly in
+/// Lightweight instantiation metadata not represented losslessly in React
+/// Compiler's AST.
+#[derive(Clone)]
+pub struct TsInstantiationShell {
+    span: Span,
+    type_args: Box<TsTypeParamInstantiation>,
+}
+
+/// Lightweight optional instantiation metadata not represented losslessly in
 /// React Compiler's AST.
 #[derive(Clone)]
-pub struct JsxOpeningElementShell {
+pub struct TsOptionalInstantiationShell {
     type_args: Option<Box<TsTypeParamInstantiation>>,
 }
 
-/// Lightweight new expression metadata not represented losslessly in React
-/// Compiler's AST.
+/// Lightweight Typescript expression wrapper metadata. These wrappers use the
+/// wrapped expression's `span.hi` as their preservation key.
 #[derive(Clone)]
-pub struct NewShell {
-    type_args: Option<Box<TsTypeParamInstantiation>>,
-}
-
-/// Lightweight tagged template metadata not represented losslessly in React
-/// Compiler's AST.
-#[derive(Clone)]
-pub struct TaggedTemplateShell {
-    type_params: Option<Box<TsTypeParamInstantiation>>,
-}
-
-/// Lightweight Typescript expression wrapper metadata. These wrappers use
-/// `span.hi` as their preservation key because their `span.lo` is often shared
-/// with the wrapped expression.
-#[derive(Clone)]
-pub enum TsExprShell {
-    As {
-        span: Span,
-        type_ann: Box<TsType>,
-    },
-    Satisfies {
-        span: Span,
-        type_ann: Box<TsType>,
-    },
-    TypeAssertion {
-        span: Span,
-        type_ann: Box<TsType>,
-    },
-    Instantiation {
-        span: Span,
-        type_args: Box<TsTypeParamInstantiation>,
-    },
+pub struct TsExprShell {
+    span: Span,
+    type_ann: Box<TsType>,
 }
 
 impl PreservedAst {
@@ -174,28 +132,31 @@ impl PreservedAst {
     pub fn save_call(&mut self, call: &CallExpr) {
         self.nodes.insert(
             call.span.lo.to_u32(),
-            PreservedNode::Call(Box::new(CallShell {
-                type_args: call.type_args.clone(),
-            })),
+            PreservedNode::TsOptionalInstantiation(Box::new(
+                TsOptionalInstantiationShell::from_optional_type_args(&call.type_args),
+            )),
         );
     }
 
     pub fn save_opt_call(&mut self, span: Span, call: &OptCall) {
         self.nodes.insert(
             span.lo.to_u32(),
-            PreservedNode::Call(Box::new(CallShell {
-                type_args: call.type_args.clone(),
-            })),
+            PreservedNode::TsOptionalInstantiation(Box::new(
+                TsOptionalInstantiationShell::from_optional_type_args(&call.type_args),
+            )),
         );
     }
 
     pub fn load_call(&mut self, call: &mut CallExpr) -> bool {
         let key = call.span.lo.to_u32();
-        if !matches!(self.nodes.get(&key), Some(PreservedNode::Call(_))) {
+        if !matches!(
+            self.nodes.get(&key),
+            Some(PreservedNode::TsOptionalInstantiation(_))
+        ) {
             return false;
         }
 
-        let Some(PreservedNode::Call(snapshot)) = self.nodes.remove(&key) else {
+        let Some(PreservedNode::TsOptionalInstantiation(snapshot)) = self.nodes.remove(&key) else {
             unreachable!()
         };
 
@@ -206,15 +167,47 @@ impl PreservedAst {
 
     pub fn load_opt_call(&mut self, call: &mut OptCall) -> bool {
         let key = call.span.lo.to_u32();
-        if !matches!(self.nodes.get(&key), Some(PreservedNode::Call(_))) {
+        if !matches!(
+            self.nodes.get(&key),
+            Some(PreservedNode::TsOptionalInstantiation(_))
+        ) {
             return false;
         }
 
-        let Some(PreservedNode::Call(snapshot)) = self.nodes.remove(&key) else {
+        let Some(PreservedNode::TsOptionalInstantiation(snapshot)) = self.nodes.remove(&key) else {
             unreachable!()
         };
 
         call.type_args = snapshot.type_args;
+
+        true
+    }
+
+    pub fn save_catch_clause(&mut self, clause: &CatchClause) {
+        let type_ann = clause.param.as_ref().and_then(pattern_type_ann);
+
+        self.nodes.insert(
+            clause.span.lo.to_u32(),
+            PreservedNode::Catch(Box::new(PatternTypeShell {
+                type_ann,
+                optional: false,
+            })),
+        );
+    }
+
+    pub fn load_catch_clause(&mut self, clause: &mut CatchClause) -> bool {
+        let key = clause.span.lo.to_u32();
+        if !matches!(self.nodes.get(&key), Some(PreservedNode::Catch(_))) {
+            return false;
+        }
+
+        let Some(PreservedNode::Catch(snapshot)) = self.nodes.remove(&key) else {
+            unreachable!()
+        };
+
+        if let (Some(param), Some(param_type)) = (&mut clause.param, snapshot.type_ann) {
+            apply_pattern_type_ann(param, param_type);
+        }
 
         true
     }
@@ -343,9 +336,9 @@ impl PreservedAst {
     pub fn save_jsx_opening_element(&mut self, el: &JSXOpeningElement) {
         self.nodes.insert(
             el.span.lo.to_u32(),
-            PreservedNode::JsxOpeningElement(Box::new(JsxOpeningElementShell {
-                type_args: el.type_args.clone(),
-            })),
+            PreservedNode::TsOptionalInstantiation(Box::new(
+                TsOptionalInstantiationShell::from_optional_type_args(&el.type_args),
+            )),
         );
     }
 
@@ -353,12 +346,12 @@ impl PreservedAst {
         let key = el.span.lo.to_u32();
         if !matches!(
             self.nodes.get(&key),
-            Some(PreservedNode::JsxOpeningElement(_))
+            Some(PreservedNode::TsOptionalInstantiation(_))
         ) {
             return false;
         }
 
-        let Some(PreservedNode::JsxOpeningElement(snapshot)) = self.nodes.remove(&key) else {
+        let Some(PreservedNode::TsOptionalInstantiation(snapshot)) = self.nodes.remove(&key) else {
             unreachable!()
         };
 
@@ -370,19 +363,22 @@ impl PreservedAst {
     pub fn save_new(&mut self, new: &NewExpr) {
         self.nodes.insert(
             new.span.lo.to_u32(),
-            PreservedNode::New(Box::new(NewShell {
-                type_args: new.type_args.clone(),
-            })),
+            PreservedNode::TsOptionalInstantiation(Box::new(
+                TsOptionalInstantiationShell::from_optional_type_args(&new.type_args),
+            )),
         );
     }
 
     pub fn load_new(&mut self, new: &mut NewExpr) -> bool {
         let key = new.span.lo.to_u32();
-        if !matches!(self.nodes.get(&key), Some(PreservedNode::New(_))) {
+        if !matches!(
+            self.nodes.get(&key),
+            Some(PreservedNode::TsOptionalInstantiation(_))
+        ) {
             return false;
         }
 
-        let Some(PreservedNode::New(snapshot)) = self.nodes.remove(&key) else {
+        let Some(PreservedNode::TsOptionalInstantiation(snapshot)) = self.nodes.remove(&key) else {
             unreachable!()
         };
 
@@ -394,23 +390,26 @@ impl PreservedAst {
     pub fn save_tagged_tpl(&mut self, tagged: &TaggedTpl) {
         self.nodes.insert(
             tagged.span.lo.to_u32(),
-            PreservedNode::TaggedTemplate(Box::new(TaggedTemplateShell {
-                type_params: tagged.type_params.clone(),
-            })),
+            PreservedNode::TsOptionalInstantiation(Box::new(
+                TsOptionalInstantiationShell::from_optional_type_args(&tagged.type_params),
+            )),
         );
     }
 
     pub fn load_tagged_tpl(&mut self, tagged: &mut TaggedTpl) -> bool {
         let key = tagged.span.lo.to_u32();
-        if !matches!(self.nodes.get(&key), Some(PreservedNode::TaggedTemplate(_))) {
+        if !matches!(
+            self.nodes.get(&key),
+            Some(PreservedNode::TsOptionalInstantiation(_))
+        ) {
             return false;
         }
 
-        let Some(PreservedNode::TaggedTemplate(snapshot)) = self.nodes.remove(&key) else {
+        let Some(PreservedNode::TsOptionalInstantiation(snapshot)) = self.nodes.remove(&key) else {
             unreachable!()
         };
 
-        tagged.type_params = snapshot.type_params;
+        tagged.type_params = snapshot.type_args;
 
         true
     }
@@ -450,131 +449,16 @@ impl PreservedAst {
         true
     }
 
+    // expr as T
     pub fn save_ts_as_expr(&mut self, expr: &TsAsExpr) {
         self.nodes.insert(
-            expr.span.hi.to_u32(),
+            expr.expr.span_hi().to_u32(),
             PreservedNode::TsExpr(Box::new(TsExprShell::from_ts_as_expr(expr))),
         );
     }
 
     pub fn load_ts_as_expr(&mut self, expr: &mut TsAsExpr) -> bool {
-        let key = expr.span.hi.to_u32();
-        if !matches!(
-            self.nodes.get(&key),
-            Some(PreservedNode::TsExpr(shell)) if matches!(shell.as_ref(), TsExprShell::As { .. })
-        ) {
-            return false;
-        }
-
-        let Some(PreservedNode::TsExpr(snapshot)) = self.nodes.remove(&key) else {
-            unreachable!()
-        };
-
-        let TsExprShell::As { span, type_ann } = *snapshot else {
-            unreachable!()
-        };
-
-        expr.span = span;
-        expr.type_ann = type_ann;
-
-        true
-    }
-
-    pub fn save_ts_satisfies_expr(&mut self, expr: &TsSatisfiesExpr) {
-        self.nodes.insert(
-            expr.span.hi.to_u32(),
-            PreservedNode::TsExpr(Box::new(TsExprShell::from_ts_satisfies_expr(expr))),
-        );
-    }
-
-    pub fn load_ts_satisfies_expr(&mut self, expr: &mut TsSatisfiesExpr) -> bool {
-        let key = expr.span.hi.to_u32();
-        if !matches!(
-            self.nodes.get(&key),
-            Some(PreservedNode::TsExpr(shell))
-                if matches!(shell.as_ref(), TsExprShell::Satisfies { .. })
-        ) {
-            return false;
-        }
-
-        let Some(PreservedNode::TsExpr(snapshot)) = self.nodes.remove(&key) else {
-            unreachable!()
-        };
-
-        let TsExprShell::Satisfies { span, type_ann } = *snapshot else {
-            unreachable!()
-        };
-
-        expr.span = span;
-        expr.type_ann = type_ann;
-
-        true
-    }
-
-    pub fn save_ts_type_assertion(&mut self, expr: &TsTypeAssertion) {
-        self.nodes.insert(
-            expr.span.hi.to_u32(),
-            PreservedNode::TsExpr(Box::new(TsExprShell::from_ts_type_assertion(expr))),
-        );
-    }
-
-    pub fn load_ts_type_assertion(&mut self, expr: &mut TsTypeAssertion) -> bool {
-        let key = expr.span.hi.to_u32();
-        if !matches!(
-            self.nodes.get(&key),
-            Some(PreservedNode::TsExpr(shell))
-                if matches!(shell.as_ref(), TsExprShell::TypeAssertion { .. })
-        ) {
-            return false;
-        }
-
-        let Some(PreservedNode::TsExpr(snapshot)) = self.nodes.remove(&key) else {
-            unreachable!()
-        };
-
-        let TsExprShell::TypeAssertion { span, type_ann } = *snapshot else {
-            unreachable!()
-        };
-
-        expr.span = span;
-        expr.type_ann = type_ann;
-
-        true
-    }
-
-    pub fn save_ts_instantiation(&mut self, expr: &TsInstantiation) {
-        self.nodes.insert(
-            expr.span.hi.to_u32(),
-            PreservedNode::TsExpr(Box::new(TsExprShell::from_ts_instantiation(expr))),
-        );
-    }
-
-    pub fn load_ts_instantiation(&mut self, expr: &mut TsInstantiation) -> bool {
-        let key = expr.span.hi.to_u32();
-        if !matches!(
-            self.nodes.get(&key),
-            Some(PreservedNode::TsExpr(shell))
-                if matches!(shell.as_ref(), TsExprShell::Instantiation { .. })
-        ) {
-            return false;
-        }
-
-        let Some(PreservedNode::TsExpr(snapshot)) = self.nodes.remove(&key) else {
-            unreachable!()
-        };
-
-        let TsExprShell::Instantiation { span, type_args } = *snapshot else {
-            unreachable!()
-        };
-
-        expr.span = span;
-        expr.type_args = type_args;
-
-        true
-    }
-
-    pub fn load_ts_expr_for_span(&mut self, expr: &mut Expr, span: Span) -> bool {
-        let key = span.hi.to_u32();
+        let key = expr.expr.span_hi().to_u32();
         if !matches!(self.nodes.get(&key), Some(PreservedNode::TsExpr(_))) {
             return false;
         }
@@ -583,8 +467,85 @@ impl PreservedAst {
             unreachable!()
         };
 
-        let current = expr.take();
-        *expr = snapshot.wrap(current);
+        expr.span = snapshot.span;
+        expr.type_ann = snapshot.type_ann;
+
+        true
+    }
+
+    // expr satisfies T
+    pub fn save_ts_satisfies_expr(&mut self, expr: &TsSatisfiesExpr) {
+        self.nodes.insert(
+            expr.expr.span_hi().to_u32(),
+            PreservedNode::TsExpr(Box::new(TsExprShell::from_ts_satisfies_expr(expr))),
+        );
+    }
+
+    pub fn load_ts_satisfies_expr(&mut self, expr: &mut TsSatisfiesExpr) -> bool {
+        let key = expr.expr.span_hi().to_u32();
+        if !matches!(self.nodes.get(&key), Some(PreservedNode::TsExpr(_))) {
+            return false;
+        }
+
+        let Some(PreservedNode::TsExpr(snapshot)) = self.nodes.remove(&key) else {
+            unreachable!()
+        };
+
+        expr.span = snapshot.span;
+        expr.type_ann = snapshot.type_ann;
+
+        true
+    }
+
+    // <T>expr
+    pub fn save_ts_type_assertion(&mut self, expr: &TsTypeAssertion) {
+        self.nodes.insert(
+            expr.span.lo.to_u32(),
+            PreservedNode::TsExpr(Box::new(TsExprShell::from_ts_type_assertion(expr))),
+        );
+    }
+
+    pub fn load_ts_type_assertion(&mut self, expr: &mut TsTypeAssertion) -> bool {
+        let key = expr.span.lo.to_u32();
+        if !matches!(self.nodes.get(&key), Some(PreservedNode::TsExpr(_))) {
+            return false;
+        }
+
+        let Some(PreservedNode::TsExpr(snapshot)) = self.nodes.remove(&key) else {
+            unreachable!()
+        };
+
+        expr.span = snapshot.span;
+        expr.type_ann = snapshot.type_ann;
+
+        true
+    }
+
+    // expr<T>
+    pub fn save_ts_instantiation(&mut self, expr: &TsInstantiation) {
+        self.nodes.insert(
+            expr.expr.span_hi().to_u32(),
+            PreservedNode::TsInstantiation(Box::new(TsInstantiationShell::from_ts_instantiation(
+                expr,
+            ))),
+        );
+    }
+
+    pub fn load_ts_instantiation(&mut self, expr: &mut TsInstantiation) -> bool {
+        let key = expr.expr.span_hi().to_u32();
+        if !matches!(
+            self.nodes.get(&key),
+            Some(PreservedNode::TsInstantiation(_))
+        ) {
+            return false;
+        }
+
+        let Some(PreservedNode::TsInstantiation(snapshot)) = self.nodes.remove(&key) else {
+            unreachable!()
+        };
+
+        expr.span = snapshot.span;
+        expr.type_args = snapshot.type_args;
 
         true
     }
@@ -707,7 +668,7 @@ impl PreservedAst {
         true
     }
 
-    pub fn load_module_item(&mut self, item: &mut ModuleItem, id: Option<TsModuleName>) -> bool {
+    pub fn load_module_item(&mut self, item: &mut ModuleItem) -> bool {
         let key = match module_item_span(item) {
             Some(span) => span.lo.to_u32(),
             None => return false,
@@ -732,22 +693,13 @@ impl PreservedAst {
             PreservedNode::TsExportAssignment(decl) => {
                 *item = ModuleItem::ModuleDecl(ModuleDecl::TsExportAssignment(decl));
             }
-            PreservedNode::TsImportEquals(mut decl) => {
-                if let Some(TsModuleName::Ident(id)) = id {
-                    decl.id = id;
-                }
+            PreservedNode::TsImportEquals(decl) => {
                 *item = ModuleItem::ModuleDecl(ModuleDecl::TsImportEquals(decl));
             }
-            PreservedNode::TsModule(mut decl) => {
-                if let Some(id) = id {
-                    decl.id = id;
-                }
+            PreservedNode::TsModule(decl) => {
                 *item = ModuleItem::Stmt(Stmt::Decl(Decl::TsModule(decl)));
             }
-            PreservedNode::TsNamespaceExport(mut decl) => {
-                if let Some(TsModuleName::Ident(id)) = id {
-                    decl.id = id;
-                }
+            PreservedNode::TsNamespaceExport(decl) => {
                 *item = ModuleItem::ModuleDecl(ModuleDecl::TsNamespaceExport(decl));
             }
             _ => unreachable!(),
@@ -766,44 +718,65 @@ fn module_item_span(item: &ModuleItem) -> Option<swc_common::Span> {
     }
 }
 
+fn pattern_type_ann(pattern: &Pat) -> Option<Box<TsTypeAnn>> {
+    match PatternTypeShell::typed_pat(pattern) {
+        Pat::Ident(pattern) => pattern.type_ann.clone(),
+        Pat::Array(pattern) => pattern.type_ann.clone(),
+        Pat::Object(pattern) => pattern.type_ann.clone(),
+        Pat::Rest(pattern) => pattern.type_ann.clone(),
+        _ => None,
+    }
+}
+
+fn apply_pattern_type_ann(pattern: &mut Pat, type_ann: Box<TsTypeAnn>) {
+    match PatternTypeShell::typed_pat_mut(pattern) {
+        Pat::Ident(pattern) => pattern.type_ann = Some(type_ann),
+        Pat::Array(pattern) => pattern.type_ann = Some(type_ann),
+        Pat::Object(pattern) => pattern.type_ann = Some(type_ann),
+        Pat::Rest(pattern) => pattern.type_ann = Some(type_ann),
+        _ => {}
+    }
+}
+
 impl PatternTypeShell {
     fn from_pat(pattern: &Pat) -> Option<Self> {
         match Self::typed_pat(pattern) {
-            Pat::Ident(pattern) => Some(Self::Ident {
+            Pat::Ident(pattern) => Some(Self {
                 type_ann: pattern.type_ann.clone(),
                 optional: pattern.id.optional,
             }),
-            Pat::Array(pattern) => Some(Self::Array {
+            Pat::Array(pattern) => Some(Self {
                 type_ann: pattern.type_ann.clone(),
                 optional: pattern.optional,
             }),
-            Pat::Object(pattern) => Some(Self::Object {
+            Pat::Object(pattern) => Some(Self {
                 type_ann: pattern.type_ann.clone(),
                 optional: pattern.optional,
             }),
-            Pat::Rest(pattern) => Some(Self::Rest {
+            Pat::Rest(pattern) => Some(Self {
                 type_ann: pattern.type_ann.clone(),
+                optional: false,
             }),
             _ => None,
         }
     }
 
     fn apply_to_pat(self, pattern: &mut Pat) {
-        match (self, Self::typed_pat_mut(pattern)) {
-            (Self::Ident { type_ann, optional }, Pat::Ident(pattern)) => {
-                pattern.type_ann = type_ann;
-                pattern.id.optional = optional;
+        match Self::typed_pat_mut(pattern) {
+            Pat::Ident(pattern) => {
+                pattern.type_ann = self.type_ann;
+                pattern.id.optional = self.optional;
             }
-            (Self::Array { type_ann, optional }, Pat::Array(pattern)) => {
-                pattern.type_ann = type_ann;
-                pattern.optional = optional;
+            Pat::Array(pattern) => {
+                pattern.type_ann = self.type_ann;
+                pattern.optional = self.optional;
             }
-            (Self::Object { type_ann, optional }, Pat::Object(pattern)) => {
-                pattern.type_ann = type_ann;
-                pattern.optional = optional;
+            Pat::Object(pattern) => {
+                pattern.type_ann = self.type_ann;
+                pattern.optional = self.optional;
             }
-            (Self::Rest { type_ann }, Pat::Rest(pattern)) => {
-                pattern.type_ann = type_ann;
+            Pat::Rest(pattern) => {
+                pattern.type_ann = self.type_ann;
             }
             _ => {}
         }
@@ -824,61 +797,42 @@ impl PatternTypeShell {
     }
 }
 
+impl TsInstantiationShell {
+    fn from_ts_instantiation(expr: &TsInstantiation) -> Self {
+        Self {
+            span: expr.span,
+            type_args: expr.type_args.clone(),
+        }
+    }
+}
+
+impl TsOptionalInstantiationShell {
+    fn from_optional_type_args(type_args: &Option<Box<TsTypeParamInstantiation>>) -> Self {
+        Self {
+            type_args: type_args.clone(),
+        }
+    }
+}
+
 impl TsExprShell {
     fn from_ts_as_expr(expr: &TsAsExpr) -> Self {
-        Self::As {
+        Self {
             span: expr.span,
             type_ann: expr.type_ann.clone(),
         }
     }
 
     fn from_ts_satisfies_expr(expr: &TsSatisfiesExpr) -> Self {
-        Self::Satisfies {
+        Self {
             span: expr.span,
             type_ann: expr.type_ann.clone(),
         }
     }
 
     fn from_ts_type_assertion(expr: &TsTypeAssertion) -> Self {
-        Self::TypeAssertion {
+        Self {
             span: expr.span,
             type_ann: expr.type_ann.clone(),
-        }
-    }
-
-    fn from_ts_instantiation(expr: &TsInstantiation) -> Self {
-        Self::Instantiation {
-            span: expr.span,
-            type_args: expr.type_args.clone(),
-        }
-    }
-
-    fn wrap(self, expr: Expr) -> Expr {
-        match self {
-            TsExprShell::As { span, type_ann } => Expr::TsAs(TsAsExpr {
-                span,
-                expr: Box::new(expr),
-                type_ann,
-            }),
-            TsExprShell::Satisfies { span, type_ann } => Expr::TsSatisfies(TsSatisfiesExpr {
-                span,
-                expr: Box::new(expr),
-                type_ann,
-            }),
-            TsExprShell::TypeAssertion { span, type_ann } => {
-                Expr::TsTypeAssertion(TsTypeAssertion {
-                    span,
-                    expr: Box::new(expr),
-                    type_ann,
-                })
-            }
-            TsExprShell::Instantiation { span, type_args } => {
-                Expr::TsInstantiation(TsInstantiation {
-                    span,
-                    expr: Box::new(expr),
-                    type_args,
-                })
-            }
         }
     }
 }

--- a/crates/swc_ecma_react_compiler/src/preserved_ast.rs
+++ b/crates/swc_ecma_react_compiler/src/preserved_ast.rs
@@ -1,5 +1,5 @@
 use rustc_hash::FxHashMap;
-use swc_common::{source_map::SmallPos, util::take::Take, Span, Spanned};
+use swc_common::{source_map::SmallPos, util::take::Take, Span};
 use swc_ecma_ast::*;
 
 #[derive(Default, Clone)]
@@ -452,13 +452,13 @@ impl PreservedAst {
     // expr as T
     pub fn save_ts_as_expr(&mut self, expr: &TsAsExpr) {
         self.nodes.insert(
-            expr.expr.span_hi().to_u32(),
+            expr.span.hi.to_u32(),
             PreservedNode::TsExpr(Box::new(TsExprShell::from_ts_as_expr(expr))),
         );
     }
 
     pub fn load_ts_as_expr(&mut self, expr: &mut TsAsExpr) -> bool {
-        let key = expr.expr.span_hi().to_u32();
+        let key = expr.span.hi.to_u32();
         if !matches!(self.nodes.get(&key), Some(PreservedNode::TsExpr(_))) {
             return false;
         }
@@ -476,13 +476,13 @@ impl PreservedAst {
     // expr satisfies T
     pub fn save_ts_satisfies_expr(&mut self, expr: &TsSatisfiesExpr) {
         self.nodes.insert(
-            expr.expr.span_hi().to_u32(),
+            expr.span.hi.to_u32(),
             PreservedNode::TsExpr(Box::new(TsExprShell::from_ts_satisfies_expr(expr))),
         );
     }
 
     pub fn load_ts_satisfies_expr(&mut self, expr: &mut TsSatisfiesExpr) -> bool {
-        let key = expr.expr.span_hi().to_u32();
+        let key = expr.span.hi.to_u32();
         if !matches!(self.nodes.get(&key), Some(PreservedNode::TsExpr(_))) {
             return false;
         }
@@ -524,7 +524,7 @@ impl PreservedAst {
     // expr<T>
     pub fn save_ts_instantiation(&mut self, expr: &TsInstantiation) {
         self.nodes.insert(
-            expr.expr.span_hi().to_u32(),
+            expr.span.hi.to_u32(),
             PreservedNode::TsInstantiation(Box::new(TsInstantiationShell::from_ts_instantiation(
                 expr,
             ))),
@@ -532,7 +532,7 @@ impl PreservedAst {
     }
 
     pub fn load_ts_instantiation(&mut self, expr: &mut TsInstantiation) -> bool {
-        let key = expr.expr.span_hi().to_u32();
+        let key = expr.span.hi.to_u32();
         if !matches!(
             self.nodes.get(&key),
             Some(PreservedNode::TsInstantiation(_))

--- a/crates/swc_ecma_react_compiler/tests/fixture/ast-roundtrip/input/expressions_and_patterns.tsx
+++ b/crates/swc_ecma_react_compiler/tests/fixture/ast-roundtrip/input/expressions_and_patterns.tsx
@@ -7,9 +7,9 @@ const fallback = {
     label: "fallback",
 };
 
-const namedFunctionExpression = function NamedFunctionExpression<TValue extends number = number>(
-    value: TValue,
-) {
+const namedFunctionExpression = function NamedFunctionExpression<
+    TValue extends number = number,
+>(value: TValue) {
     return value + fallback.count;
 };
 
@@ -46,6 +46,7 @@ export async function expressionShapes<TInput = any>(
     const satisfied = { name: nonNull } satisfies NamedValue;
     const tuple = [satisfied.name, big] as const;
     const instantiatedFactory = input.makeBox<string>;
+    const factory = input.makeBox<string> as { value: string };
     const sequence = (total++, total--, total);
 
     delete others.skip;
@@ -67,7 +68,10 @@ export async function expressionShapes<TInput = any>(
     };
 }
 
-function tag<TValue = string>(strings: TemplateStringsArray, ...values: unknown[]): TValue {
+function tag<TValue = string>(
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+): TValue {
     return (strings.raw.join("|") + values.length) as TValue;
 }
 
@@ -94,3 +98,15 @@ export function* generatedIds(seed: number) {
 export function App() {
     return <div data-kind="expressions" />;
 }
+
+1 as unknown as number;
+
+function foo<T>(): <U>() => [T, U] {
+    return function <U>(): [T, U] {
+        throw new Error("not implemented");
+    };
+}
+
+const f = foo<string>()<number>;
+
+const value: [string, number] = f();

--- a/crates/swc_ecma_react_compiler/tests/fixture/ast-roundtrip/output/expressions_and_patterns.tsx
+++ b/crates/swc_ecma_react_compiler/tests/fixture/ast-roundtrip/output/expressions_and_patterns.tsx
@@ -49,6 +49,9 @@ export async function expressionShapes<TInput = any>(input: TInput & any, loader
         big
     ] as const;
     const instantiatedFactory = input.makeBox<string>;
+    const factory = input.makeBox<string> as {
+        value: string;
+    };
     const sequence = (total++, total--, total);
     delete others.skip;
     void import.meta.url;
@@ -102,3 +105,11 @@ export function App() {
     }
     return t0;
 }
+1 as unknown as number;
+function foo<T>(): <U>() => [T, U] {
+    return function<U>(): [T, U] {
+        throw new Error("not implemented");
+    };
+}
+const f = foo<string>()<number>;
+const value: [string, number] = f();


### PR DESCRIPTION
**Description:**

This PR improves TypeScript metadata preservation in the React Compiler AST roundtrip.

React Compiler's AST does not losslessly represent several SWC TypeScript fields, so reverse conversion now restores those fields from explicit preserved SWC shells first and uses RawNode parsing only as a cold fallback.

Main changes:
- Preserve typed catch clause parameters during forward conversion and restore them in reverse conversion.
- Replace separate JSX opening/new/tagged type-argument shells with a shared `TsOptionalInstantiation`.
- Split TS instantiation metadata out of `TsExprShell`, and simplify `TsExprShell` to wrapper span plus type annotation.
- Remove the generic `load_ts_expr_for_span` post-pass; TS expression wrappers now restore their own preserved metadata in their concrete branches.
- Convert pattern-like nodes without type annotations on the hot path, then fill top-level TS metadata from preserved AST or cold RawNode fallback.
- Improve `TSDeclareFunction` fallback params by recovering raw identifier/rest names, optional flags, and top-level type annotations instead of placeholder params.
- Restore preserved TS module-like items directly instead of rebuilding module ids from RawNode JSON.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A