### PR TITLE
fix(react-compiler): avoid reporting non-fatal success errors as diagnostics

### DIFF
--- a/.changeset/fix-react-compiler-success-diagnostics.md
+++ b/.changeset/fix-react-compiler-success-diagnostics.md
@@ -1,0 +1,6 @@
+---
+swc_core: major
+swc_ecma_react_compiler: major
+---
+
+fix(es/react-compiler): Avoid reporting non-fatal success events as diagnostics

--- a/crates/swc_ecma_react_compiler/src/diagnostics.rs
+++ b/crates/swc_ecma_react_compiler/src/diagnostics.rs
@@ -22,13 +22,16 @@ pub struct DiagnosticMessage {
 
 /// Convert a [`CompileResult`] into SWC-facing diagnostics.
 #[must_use]
-pub fn compile_result_to_diagnostics(result: &CompileResult) -> Vec<DiagnosticMessage> {
+pub fn compile_result_to_diagnostics(
+    result: &CompileResult,
+    emit_success_error_diagnostics: bool,
+) -> Vec<DiagnosticMessage> {
     let mut diagnostics = Vec::new();
 
     match result {
         CompileResult::Success { events, .. } => {
             for event in events {
-                if let Some(diag) = event_to_diagnostic(event, true) {
+                if let Some(diag) = event_to_diagnostic(event, !emit_success_error_diagnostics) {
                     diagnostics.push(diag);
                 }
             }
@@ -65,7 +68,7 @@ fn error_info_to_diagnostic(error: &CompilerErrorInfo) -> DiagnosticMessage {
 
 fn error_detail_to_diagnostic(
     detail: &CompilerErrorDetailInfo,
-    success: bool,
+    suppress_error_diagnostics: bool,
 ) -> Option<DiagnosticMessage> {
     let message = if let Some(description) = &detail.description {
         format!(
@@ -80,7 +83,7 @@ fn error_detail_to_diagnostic(
     // transform errors are represented separately by `CompileResult::Error`.
     let severity = match detail.severity.as_str() {
         "Off" => return None,
-        "Error" if success => return None,
+        "Error" if suppress_error_diagnostics => return None,
         "Error" => Severity::Error,
         // `Warning`, `Hint`, and any unknown future value surface as warnings.
         _ => Severity::Warning,
@@ -93,15 +96,18 @@ fn error_detail_to_diagnostic(
     })
 }
 
-fn event_to_diagnostic(event: &LoggerEvent, success: bool) -> Option<DiagnosticMessage> {
+fn event_to_diagnostic(
+    event: &LoggerEvent,
+    suppress_error_diagnostics: bool,
+) -> Option<DiagnosticMessage> {
     match event {
         LoggerEvent::CompileSuccess { .. } | LoggerEvent::CompileSkip { .. } => None,
         LoggerEvent::CompileError { detail, .. }
         | LoggerEvent::CompileErrorWithLoc { detail, .. } => {
-            error_detail_to_diagnostic(detail, success)
+            error_detail_to_diagnostic(detail, suppress_error_diagnostics)
         }
         LoggerEvent::CompileUnexpectedThrow { .. } | LoggerEvent::PipelineError { .. }
-            if success =>
+            if suppress_error_diagnostics =>
         {
             None
         }

--- a/crates/swc_ecma_react_compiler/src/diagnostics.rs
+++ b/crates/swc_ecma_react_compiler/src/diagnostics.rs
@@ -27,9 +27,8 @@ pub fn compile_result_to_diagnostics(result: &CompileResult) -> Vec<DiagnosticMe
 
     match result {
         CompileResult::Success { events, .. } => {
-            // Process logger events from successful compilation
             for event in events {
-                if let Some(diag) = event_to_diagnostic(event) {
+                if let Some(diag) = event_to_diagnostic(event, true) {
                     diagnostics.push(diag);
                 }
             }
@@ -40,7 +39,7 @@ pub fn compile_result_to_diagnostics(result: &CompileResult) -> Vec<DiagnosticMe
 
             // Process logger events from failed compilation
             for event in events {
-                if let Some(diag) = event_to_diagnostic(event) {
+                if let Some(diag) = event_to_diagnostic(event, false) {
                     diagnostics.push(diag);
                 }
             }
@@ -64,7 +63,10 @@ fn error_info_to_diagnostic(error: &CompilerErrorInfo) -> DiagnosticMessage {
     }
 }
 
-fn error_detail_to_diagnostic(detail: &CompilerErrorDetailInfo) -> Option<DiagnosticMessage> {
+fn error_detail_to_diagnostic(
+    detail: &CompilerErrorDetailInfo,
+    success: bool,
+) -> Option<DiagnosticMessage> {
     let message = if let Some(description) = &detail.description {
         format!(
             "[ReactCompiler] {}: {}. {}",
@@ -78,6 +80,7 @@ fn error_detail_to_diagnostic(detail: &CompilerErrorDetailInfo) -> Option<Diagno
     // transform errors are represented separately by `CompileResult::Error`.
     let severity = match detail.severity.as_str() {
         "Off" => return None,
+        "Error" if success => return None,
         "Error" => Severity::Error,
         // `Warning`, `Hint`, and any unknown future value surface as warnings.
         _ => Severity::Warning,
@@ -90,11 +93,18 @@ fn error_detail_to_diagnostic(detail: &CompilerErrorDetailInfo) -> Option<Diagno
     })
 }
 
-fn event_to_diagnostic(event: &LoggerEvent) -> Option<DiagnosticMessage> {
+fn event_to_diagnostic(event: &LoggerEvent, success: bool) -> Option<DiagnosticMessage> {
     match event {
         LoggerEvent::CompileSuccess { .. } | LoggerEvent::CompileSkip { .. } => None,
         LoggerEvent::CompileError { detail, .. }
-        | LoggerEvent::CompileErrorWithLoc { detail, .. } => error_detail_to_diagnostic(detail),
+        | LoggerEvent::CompileErrorWithLoc { detail, .. } => {
+            error_detail_to_diagnostic(detail, success)
+        }
+        LoggerEvent::CompileUnexpectedThrow { .. } | LoggerEvent::PipelineError { .. }
+            if success =>
+        {
+            None
+        }
         LoggerEvent::CompileUnexpectedThrow { data, .. } => Some(DiagnosticMessage {
             severity: Severity::Error,
             message: format!("[ReactCompiler] Unexpected error: {data}"),

--- a/crates/swc_ecma_react_compiler/src/lib.rs
+++ b/crates/swc_ecma_react_compiler/src/lib.rs
@@ -108,10 +108,11 @@ pub fn transform(
         file,
         preserved_ast,
     } = convert_program(program, source_text, comments);
+    let emit_success_error_diagnostics = options.no_emit;
     let result =
         react_compiler::entrypoint::program::compile_program(file, scope_info.clone(), options);
 
-    let diagnostics = compile_result_to_diagnostics(&result);
+    let diagnostics = compile_result_to_diagnostics(&result, emit_success_error_diagnostics);
     let (file, events, renames) = match result {
         react_compiler::entrypoint::compile_result::CompileResult::Success {
             ast,

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -17,8 +17,8 @@ use swc_ecma_parser::{parse_file_as_module, parse_file_as_program, EsSyntax, Syn
 use crate::{
     convert_ast::convert_program,
     convert_ast_reverse::convert_program_to_swc as convert_program_to_swc_with_preserved_ast,
-    convert_scope::SemanticBuilder, lint_source, prefilter::has_react_like_functions,
-    transform_source, SourceType,
+    convert_scope::SemanticBuilder, diagnostics::Severity, lint_source,
+    prefilter::has_react_like_functions, transform_source, SourceType,
 };
 
 fn convert_program_to_swc(file: &File) -> swc_ecma_ast::Program {
@@ -1301,6 +1301,34 @@ fn lint_simple_component_does_not_panic() {
     "#;
     let result = lint_source(source, Default::default(), default_options());
     let _ = result.diagnostics;
+}
+
+#[test]
+fn lint_reports_ref_access_error_with_default_panic_threshold() {
+    let source = r#"
+        import { useRef } from 'react';
+
+        function App() {
+            const ref = useRef(1);
+            return ref.current;
+        }
+    "#;
+
+    let result = lint_source(source, Default::default(), default_options());
+
+    assert_eq!(result.diagnostics.len(), 1);
+    assert!(
+        matches!(result.diagnostics[0].severity, Severity::Error),
+        "lint should preserve React Compiler error severity: {:#?}",
+        result.diagnostics
+    );
+    assert!(
+        result.diagnostics[0]
+            .message
+            .contains("[ReactCompiler] Refs: Cannot access refs during render"),
+        "unexpected diagnostic: {:#?}",
+        result.diagnostics
+    );
 }
 
 #[test]

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -1249,27 +1249,6 @@ fn transform_ref_access_error_is_not_swc_diagnostic_with_default_panic_threshold
         "non-fatal React Compiler events should not surface as SWC diagnostics: {:#?}",
         result.diagnostics
     );
-    assert!(
-        result.events.iter().any(|event| {
-            serde_json::to_value(event).ok().is_some_and(|event| {
-                event.get("kind").and_then(serde_json::Value::as_str) == Some("CompileError")
-                    && event
-                        .pointer("/detail/category")
-                        .and_then(serde_json::Value::as_str)
-                        == Some("Refs")
-                    && event
-                        .pointer("/detail/reason")
-                        .and_then(serde_json::Value::as_str)
-                        == Some("Cannot access refs during render")
-                    && event
-                        .pointer("/detail/severity")
-                        .and_then(serde_json::Value::as_str)
-                        == Some("Error")
-            })
-        }),
-        "React Compiler should still preserve the non-fatal error logger event: {:#?}",
-        result.events
-    );
 }
 
 #[test]

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -1228,6 +1228,51 @@ fn transform_component_with_hook_does_not_panic() {
 }
 
 #[test]
+fn transform_ref_access_error_is_not_swc_diagnostic_with_default_panic_threshold() {
+    let source = r#"
+        import { useRef } from 'react';
+
+        function App() {
+            const ref = useRef(1);
+            return ref.current;
+        }
+    "#;
+
+    let result = transform_source(source, Default::default(), default_options());
+
+    assert!(
+        result.program.is_none(),
+        "component with a ref access error should not be compiled"
+    );
+    assert!(
+        result.diagnostics.is_empty(),
+        "non-fatal React Compiler events should not surface as SWC diagnostics: {:#?}",
+        result.diagnostics
+    );
+    assert!(
+        result.events.iter().any(|event| {
+            serde_json::to_value(event).ok().is_some_and(|event| {
+                event.get("kind").and_then(serde_json::Value::as_str) == Some("CompileError")
+                    && event
+                        .pointer("/detail/category")
+                        .and_then(serde_json::Value::as_str)
+                        == Some("Refs")
+                    && event
+                        .pointer("/detail/reason")
+                        .and_then(serde_json::Value::as_str)
+                        == Some("Cannot access refs during render")
+                    && event
+                        .pointer("/detail/severity")
+                        .and_then(serde_json::Value::as_str)
+                        == Some("Error")
+            })
+        }),
+        "React Compiler should still preserve the non-fatal error logger event: {:#?}",
+        result.events
+    );
+}
+
+#[test]
 fn transform_non_react_code_returns_none() {
     let source = "const x = 1 + 2;";
     let result = transform_source(source, Default::default(), default_options());


### PR DESCRIPTION
## Summary

Avoid converting error-level React Compiler logger events from `CompileResult::Success` into SWC diagnostics.

React Compiler can preserve `CompileError` logger events while still returning `CompileResult::Success`, for example when `panicThreshold` is `none`. Those events should remain available on the transform result, but should not become SWC diagnostics that fail compilation.

Warning and hint events from successful results are still surfaced as SWC warnings. Fatal results (`CompileResult::Error`) keep the existing diagnostic behavior.

**Related issue (if exists):**

 https://github.com/web-infra-dev/rspack/issues/14517
