### PR TITLE
fix(es/es2022): Correct scope for private property brand checks

### DIFF
--- a/.changeset/fix-brand-check-scope.md
+++ b/.changeset/fix-brand-check-scope.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_transformer: patch
+swc_ecma_transforms_compat: patch
+---
+
+fix(es/es2022): Correct private property brand check scope

--- a/crates/swc_ecma_transformer/src/es2022/private_property_in_object.rs
+++ b/crates/swc_ecma_transformer/src/es2022/private_property_in_object.rs
@@ -127,6 +127,7 @@ impl Mode {
 #[derive(Default)]
 struct PrivatePropertyInObjectPass {
     vars: Vec<VarDeclarator>,
+    vars_stack: Vec<Vec<VarDeclarator>>,
     prepend_exprs: Vec<Expr>,
     prepend_exprs_stack: Vec<Vec<Expr>>,
 
@@ -537,8 +538,15 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
         }
     }
 
+    fn enter_stmts(&mut self, _s: &mut Vec<Stmt>, _ctx: &mut TraverseCtx) {
+        self.vars_stack.push(take(&mut self.vars));
+    }
+
     fn exit_stmts(&mut self, s: &mut Vec<Stmt>, _ctx: &mut TraverseCtx) {
-        if self.vars.is_empty() {
+        let current_vars = take(&mut self.vars);
+        self.vars = self.vars_stack.pop().unwrap_or_default();
+
+        if current_vars.is_empty() {
             return;
         }
 
@@ -548,15 +556,22 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                 span: DUMMY_SP,
                 kind: VarDeclKind::Var,
                 declare: Default::default(),
-                decls: take(&mut self.vars),
+                decls: current_vars,
                 ctxt: Default::default(),
             }
             .into(),
         );
     }
 
+    fn enter_module_items(&mut self, _items: &mut Vec<ModuleItem>, _ctx: &mut TraverseCtx) {
+        self.vars_stack.push(take(&mut self.vars));
+    }
+
     fn exit_module_items(&mut self, items: &mut Vec<ModuleItem>, _ctx: &mut TraverseCtx) {
-        if self.vars.is_empty() {
+        let current_vars = take(&mut self.vars);
+        self.vars = self.vars_stack.pop().unwrap_or_default();
+
+        if current_vars.is_empty() {
             return;
         }
 
@@ -566,7 +581,7 @@ impl VisitMutHook<TraverseCtx> for PrivatePropertyInObjectPass {
                 span: DUMMY_SP,
                 kind: VarDeclKind::Var,
                 declare: Default::default(),
-                decls: take(&mut self.vars),
+                decls: current_vars,
                 ctxt: Default::default(),
             }
             .into(),

--- a/crates/swc_ecma_transforms_compat/tests/private-in-object/private/issue-11931/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/private-in-object/private/issue-11931/input.js
@@ -1,0 +1,8 @@
+class Foo {
+  #x;
+  constructor(o) { #x in o; }
+} 
+class Bar extends Foo {
+  #y = null;
+} 
+new Foo({});

--- a/crates/swc_ecma_transforms_compat/tests/private-in-object/private/issue-11931/options.json
+++ b/crates/swc_ecma_transforms_compat/tests/private-in-object/private/issue-11931/options.json
@@ -1,0 +1,6 @@
+{
+  "plugins": [
+    "proposal-class-properties",
+    "proposal-private-property-in-object"
+  ]
+}

--- a/crates/swc_ecma_transforms_compat/tests/private-in-object/private/issue-11931/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/private-in-object/private/issue-11931/output.js
@@ -1,0 +1,20 @@
+var _x = /*#__PURE__*/ new WeakMap();
+class Foo {
+    constructor(o){
+        _class_private_field_init(this, _x, {
+            writable: true,
+            value: void 0
+        });
+        _x.has(o);
+    }
+}
+var _y = /*#__PURE__*/ new WeakMap();
+class Bar extends Foo {
+    constructor(...args){
+        super(...args), _class_private_field_init(this, _y, {
+            writable: true,
+            value: null
+        });
+    }
+}
+new Foo({});


### PR DESCRIPTION
Closes #11931.

**Description:**
This PR fixes a bug where `WeakSet` instances generated for `#field in object` brand checks were accidentally scoped to the closest following block statement (often a sibling class constructor) rather than the parent module scope. 

The bug was caused by a state leakage in `PrivatePropertyInObjectPass`. AST traversal would accumulate `self.vars` across classes and unconditionally dump them into the very next `exit_stmts` hook it encountered. 

I resolved this by introducing a `vars_stack` to the pass, pushing a fresh scope upon entering a block/module, and popping it on exit. This ensures injected variables strictly stay within the AST scope they were generated in.

**Testing:**
I have added a test fixture containing the exact reproduction code and configuration from #11931. The baseline output correctly places the `var _brand_check_x = new WeakSet();` outside of the child class scope.

**BREAKING CHANGE:**
None.

**Related issue (if exists):**
#11931