### PR TITLE
chore: add changeset for swc_plugin_macro release

### DIFF
--- a/.changeset/release-plugin-macro-wasm-import.md
+++ b/.changeset/release-plugin-macro-wasm-import.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_plugin_macro: patch
+---
+
+fix(plugin): publish swc_plugin_macro wasm import module fix


### PR DESCRIPTION
**Description:**

Adds a changeset that schedules patch releases for `swc_plugin_macro` and `swc_core`.

The `#[link(wasm_import_module = "env")]` fix for `swc_plugin_macro` is already on `main`, but `swc_plugin_macro` is still published at `1.1.0`. This changeset lets the release flow publish the fixed macro crate and a matching `swc_core` release that can point at it.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Fixes #11954

**Validation:**

- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_plugin_macro`
- `cargo test -p swc_core`
