### PR TITLE
fix(es/parser): allow no-default builds

### DIFF
--- a/.changeset/fix-parser-no-default-flow.md
+++ b/.changeset/fix-parser-no-default-flow.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+fix(es/parser): allow compilation without default features

--- a/crates/swc_ecma_parser/src/parser/typescript_stubs.rs
+++ b/crates/swc_ecma_parser/src/parser/typescript_stubs.rs
@@ -1,16 +1,23 @@
 //! Stub implementations for TypeScript parsing methods when the `typescript`
 //! feature is disabled.
 //!
-//! These methods are never called at runtime (the calls are guarded by
-//! `syntax().typescript()` which returns `false` when the feature is disabled),
-//! but Rust needs them to exist for compilation to succeed.
+//! Shared parser modules call these methods even when the `typescript` feature
+//! is disabled. Runtime syntax checks make TypeScript and Flow behavior
+//! unavailable in this configuration, but Rust still needs matching method
+//! definitions for compilation to succeed.
 
-use swc_common::BytePos;
+use swc_common::{BytePos, Span};
 use swc_ecma_ast::*;
 
 use crate::{input::Tokens, lexer::Token, PResult, Parser};
 
 impl<I: Tokens> Parser<I> {
+    pub(super) fn is_flow_reserved_type_name(_name: &str) -> bool {
+        false
+    }
+
+    pub(super) fn emit_flow_reserved_type_name_error(&mut self, _span: Span, _name: &str) {}
+
     pub(crate) fn try_parse_ts<T, F>(&mut self, _op: F) -> Option<T>
     where
         F: FnOnce(&mut Self) -> PResult<Option<T>>,

--- a/tests.yml
+++ b/tests.yml
@@ -40,6 +40,8 @@ check:
         - "cargo hack check --feature-powerset --exclude-features __rkyv"
     swc_ecma_loader:
         - "cargo hack check --feature-powerset"
+    swc_ecma_parser:
+        - "cargo check --no-default-features"
     swc_ecma_transforms:
         # - "cargo hack check --feature-powerset"
         - "cargo check --features concurrent --features par-core/chili"


### PR DESCRIPTION
**Description:**

Fixes `swc_ecma_parser` compilation when default features are disabled. Shared parser modules reference Flow reserved-name helpers even when the `typescript` feature is disabled, but those helpers only existed in the TypeScript parser implementation. This adds matching no-op stubs in `typescript_stubs.rs`, so the no-default build compiles without enabling TypeScript or Flow behavior.

Also adds a `swc_ecma_parser` no-default check to `tests.yml` and a patch changeset for `swc_ecma_parser` and `swc_core`.

Validation:

- `git submodule update --init --recursive`
- `cargo check -p swc_ecma_parser --no-default-features`
- `cargo test -p swc_ecma_parser`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo check --no-default-features` from `crates/swc_ecma_parser`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Fixes #11942
