### PR TITLE
ci: allow publish milestone PR updates

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -153,7 +153,7 @@ jobs:
     permissions:
       contents: read
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:


### PR DESCRIPTION
**Description:**

Fixes the publish workflow milestone manager permissions. The `manage-milestone` job updates milestones on merged pull requests through GitHub's issues API, but the job only had `pull-requests: read`, which caused GitHub to reject PR milestone updates with `HTTP 403 Resource not accessible by integration`.

This keeps the permission change scoped to the `manage-milestone` job and changes `pull-requests` from `read` to `write` so release milestone automation can update PR milestones.

Validation:

- `git diff --check -- .github/workflows/publish.yml`
- YAML parse check for `.github/workflows/publish.yml`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Related failing workflow job: https://github.com/swc-project/swc/actions/runs/27955860105/job/82869289735
