### PR TITLE
ci: allow memmap2 advisory

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -59,6 +59,7 @@ ignore = [
   "RUSTSEC-2026-0095", # wasmtime 38 has no patched release in this major line (transitive dep via swc_plugin_runner)
   "RUSTSEC-2026-0096", # wasmtime 38 has no patched release in this major line (transitive dep via swc_plugin_runner)
   "RUSTSEC-2026-0114", # wasmtime 38 has no patched release in this major line (transitive dep via swc_plugin_runner)
+  "RUSTSEC-2026-0186", # memmap2 is constrained by shared-buffer 0.1.4 via wasmer; shared-buffer has no patched release and only uses Mmap::map
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
**Description:**

Allow `RUSTSEC-2026-0186` in `deny.toml` so `cargo deny check` passes after the new RustSec advisory for `memmap2 0.6.2`.

`memmap2` is constrained by `shared-buffer 0.1.4`, which is pulled in through Wasmer. There is no newer crates.io release of `shared-buffer`, and local source inspection shows it only uses `Mmap::map`, not the affected range advice/flush APIs described by the advisory.

Validation:

- `git submodule update --init --recursive`
- `cargo deny check`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

CI job: https://github.com/swc-project/swc/actions/runs/28000731021/job/82872355038
