### PR TITLE
fix(es/minifier): Eliminate unused classes with cyclic references

### DIFF
--- a/.changeset/eliminate-dead-class-cycles.md
+++ b/.changeset/eliminate-dead-class-cycles.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_optimization: patch
+---
+
+fix(es/minifier): Eliminate unused classes with cyclic references

--- a/crates/swc/tests/tsc-references/privateNamesConstructorChain-1.2.minified.js
+++ b/crates/swc/tests/tsc-references/privateNamesConstructorChain-1.2.minified.js
@@ -1,32 +1,5 @@
 //// [privateNamesConstructorChain-1.ts]
-import { _ as _class_private_field_get } from "@swc/helpers/_/_class_private_field_get";
-import { _ as _class_private_field_init } from "@swc/helpers/_/_class_private_field_init";
-import { _ as _class_private_field_set } from "@swc/helpers/_/_class_private_field_set";
-import { _ as _class_static_private_field_spec_get } from "@swc/helpers/_/_class_static_private_field_spec_get";
-var _foo = /*#__PURE__*/ new WeakMap();
-class Parent {
-    accessChildProps() {
-        _class_private_field_get(new Child(), _foo), _class_static_private_field_spec_get(Child, Parent, _bar);
-    }
-    constructor(){
-        _class_private_field_init(this, _foo, {
-            writable: !0,
-            value: void 0
-        }), _class_private_field_set(this, _foo, 3);
-    }
-}
-var _bar = {
-    writable: !0,
-    value: 5
-}, _foo1 = /*#__PURE__*/ new WeakMap(), _bar1 = /*#__PURE__*/ new WeakMap();
-class Child extends Parent {
-    constructor(...args){
-        super(...args), _class_private_field_init(this, _foo1, {
-            writable: !0,
-            value: void 0
-        }), _class_private_field_init(this, _bar1, {
-            writable: !0,
-            value: void 0
-        }), _class_private_field_set(this, _foo1, "foo"), _class_private_field_set(this, _bar1, "bar");
-    }
-}
+import "@swc/helpers/_/_class_private_field_get";
+import "@swc/helpers/_/_class_private_field_init";
+import "@swc/helpers/_/_class_private_field_set";
+import "@swc/helpers/_/_class_static_private_field_spec_get";

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -502,6 +502,8 @@ fn class_def_is_trivial(class: &Class) -> bool {
             a.decorators.is_empty() && !(a.is_static && a.value.is_some())
         }
         ClassMember::StaticBlock(_) => false,
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unable to access unknown nodes"),
     })
 }
 

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -310,11 +310,27 @@ struct VarInfo {
 struct Analyzer<'a> {
     #[allow(dead_code)]
     config: &'a Config,
+    expr_ctx: ExprCtx,
     in_var_decl: bool,
     scope: Scope<'a>,
     data: &'a mut Data,
     cur_class_id: Option<Id>,
     cur_fn_id: Option<Id>,
+    /// Lexical class bindings already declared earlier in the current scope.
+    /// Used to tell a backward (TDZ-safe) superclass reference, which may
+    /// participate in a removable declaration cycle, from a forward one, which
+    /// must be preserved.
+    initialized_classes: FxHashSet<Id>,
+    /// Subset of the above whose declaration carries decorators. A decorated
+    /// class is kept observable by its decorator independently of the cycle, so
+    /// a subclass extending it must not collapse the cycle.
+    /// Lexical class bindings, among those already initialized, whose
+    /// declaration is NOT definition-time trivial (see `class_def_is_trivial`):
+    /// it evaluates decorators, computed keys, or static initializers when
+    /// defined. A subclass must not collapse its `extends` cycle with such a
+    /// superclass, since the superclass's eager evaluation may depend on the
+    /// cycle being intact.
+    nontrivial_classes: FxHashSet<Id>,
 }
 
 #[derive(Debug, Default)]
@@ -370,6 +386,9 @@ impl Analyzer<'_> {
                 data: self.data,
                 cur_fn_id: self.cur_fn_id.clone(),
                 cur_class_id: self.cur_class_id.clone(),
+                // A new scope starts a fresh lexical-initialization context.
+                initialized_classes: Default::default(),
+                nontrivial_classes: Default::default(),
                 ..*self
             };
 
@@ -448,6 +467,82 @@ impl Analyzer<'_> {
     }
 }
 
+/// A class declaration is "definition-time trivial" when evaluating it (running
+/// its declaration) does nothing observable beyond resolving its `extends`
+/// clause and any computed member keys (whose identifier references are pinned
+/// separately by the analyzer). The eager evaluations this guards against are
+/// decorators (on the class or any member) and `static` member initializers
+/// (`static x = …`, `static #x = …`, and `static {}` blocks). Method and
+/// constructor bodies and instance-field initializers run later (at
+/// call/instantiation time), so they are not definition-time evaluations.
+///
+/// Any eager evaluation may read another class still in its temporal dead zone
+/// and throw. Restricting the backward-reference optimization to trivial
+/// classes (on both sides of the `extends` edge) means a removable cycle can
+/// only be collapsed when neither class evaluates anything at definition time
+/// except the heritage reference itself — which the caller separately checks is
+/// a safe backward reference. This closes the whole family of definition-time
+/// TDZ hazards structurally instead of enumerating each one. The `extends`
+/// expression is intentionally not inspected here; it is handled by the caller.
+fn class_def_is_trivial(class: &Class) -> bool {
+    if !class.decorators.is_empty() {
+        return false;
+    }
+    class.body.iter().all(|member| match member {
+        ClassMember::Constructor(_) | ClassMember::TsIndexSignature(_) | ClassMember::Empty(_) => {
+            true
+        }
+        ClassMember::Method(m) => m.function.decorators.is_empty(),
+        ClassMember::PrivateMethod(m) => m.function.decorators.is_empty(),
+        ClassMember::ClassProp(p) => p.decorators.is_empty() && !(p.is_static && p.value.is_some()),
+        ClassMember::PrivateProp(p) => {
+            p.decorators.is_empty() && !(p.is_static && p.value.is_some())
+        }
+        ClassMember::AutoAccessor(a) => {
+            a.decorators.is_empty() && !(a.is_static && a.value.is_some())
+        }
+        ClassMember::StaticBlock(_) => false,
+    })
+}
+
+/// Returns true when the class definition has no observable side effects, i.e.
+/// it is safe to drop when unused. Kept in sync with the `Decl::Class` arm of
+/// `visit_mut_decl`'s drop predicate, which calls this.
+fn class_def_is_side_effect_free(class: &Class, expr_ctx: ExprCtx) -> bool {
+    class
+        .super_class
+        .as_deref()
+        .map_or(true, |e| !e.may_have_side_effects(expr_ctx))
+        && class.body.iter().all(|m| match m {
+            ClassMember::Method(m) => !matches!(m.key, PropName::Computed(..)),
+            ClassMember::ClassProp(m) => {
+                !matches!(m.key, PropName::Computed(..))
+                    && !m
+                        .value
+                        .as_deref()
+                        .is_some_and(|e| e.may_have_side_effects(expr_ctx))
+            }
+            ClassMember::AutoAccessor(m) => {
+                !matches!(m.key, Key::Public(PropName::Computed(..)))
+                    && !m
+                        .value
+                        .as_deref()
+                        .is_some_and(|e| e.may_have_side_effects(expr_ctx))
+            }
+            ClassMember::PrivateProp(m) => !m
+                .value
+                .as_deref()
+                .is_some_and(|e| e.may_have_side_effects(expr_ctx)),
+            ClassMember::StaticBlock(_) => false,
+            ClassMember::TsIndexSignature(_)
+            | ClassMember::Empty(_)
+            | ClassMember::Constructor(_)
+            | ClassMember::PrivateMethod(_) => true,
+            #[cfg(swc_ast_unknown)]
+            _ => panic!("unable to access unknown nodes"),
+        })
+}
+
 impl Visit for Analyzer<'_> {
     noop_visit_type!();
 
@@ -468,12 +563,53 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_class_decl(&mut self, n: &ClassDecl) {
-        if let Some(super_class) = &n.class.super_class {
-            super_class.visit_with(self);
+        // A superclass that is a backward reference to an already-initialized
+        // class can be attributed as a normal dependency edge, letting an
+        // unreachable `extends` cycle collapse. A forward reference, a
+        // non-identifier expression, or anything else is treated as a top-level
+        // reference (the original behavior): it pins the referent as an entry
+        // and preserves any cycle it belongs to. This keeps TDZ-observable
+        // cycles such as `class A extends B {} class B extends A {}` (which
+        // throws at runtime) from being eliminated.
+        // The backward-reference optimization (attributing the `extends` edge to
+        // the subclass so an unreachable cycle can collapse) is only applied when
+        // it is provably safe. It requires the superclass to be an identifier
+        // already initialized earlier in this scope, AND:
+        //   - the subclass carries no decorators, and the superclass is not decorated
+        //     either — a decorator runs at definition time and keeps a class observable
+        //     independently of the cycle, so collapsing it could drop a sibling the
+        //     decorator still needs;
+        //   - neither class is in `top_retain`, which keeps it externally reachable.
+        // Anything else falls back to the original behavior (the heritage
+        // reference pins the referent as an entry, preserving the cycle).
+        // Preserving an unused cycle is always safe; dropping a live one is the bug.
+        let super_id = n.class.super_class.as_deref().and_then(|sc| match sc {
+            Expr::Ident(i) => Some(i.to_id()),
+            _ => None,
+        });
+        let super_is_initialized_class_ref = class_def_is_trivial(&n.class)
+            && !self.config.top_retain.contains(&n.ident.sym)
+            && super_id.as_ref().is_some_and(|id| {
+                self.initialized_classes.contains(id)
+                    && !self.nontrivial_classes.contains(id)
+                    && !self.config.top_retain.contains(&id.0)
+            });
+
+        if !super_is_initialized_class_ref {
+            if let Some(super_class) = &n.class.super_class {
+                super_class.visit_with(self);
+            }
         }
 
         self.with_ast_path(vec![n.ident.to_id()], |v| {
             let old = v.cur_class_id.take();
+
+            if super_is_initialized_class_ref {
+                if let Some(super_class) = &n.class.super_class {
+                    super_class.visit_with(v);
+                }
+            }
+
             v.cur_class_id = Some(n.ident.to_id());
             n.ident.visit_with(v);
             n.class.decorators.visit_with(v);
@@ -483,7 +619,25 @@ impl Visit for Analyzer<'_> {
             if !n.class.decorators.is_empty() {
                 v.add(n.ident.to_id(), false);
             }
-        })
+        });
+
+        // A class that is not definition-time trivial evaluates something when
+        // defined (decorators, computed keys, or static initializers) that may
+        // read another class still in its TDZ. It is recorded so a later
+        // subclass extending it will not collapse their cycle, and is itself
+        // pinned as an entry so any cycle it participates in is kept alive.
+        // Independently, a class whose definition has observable side effects
+        // cannot be dropped either.
+        let is_trivial = class_def_is_trivial(&n.class);
+        if !is_trivial {
+            self.nontrivial_classes.insert(n.ident.to_id());
+        }
+        if !is_trivial || !class_def_is_side_effect_free(&n.class, self.expr_ctx) {
+            let idx = self.data.node(&n.ident.to_id());
+            self.data.entries.insert(idx);
+        }
+
+        self.initialized_classes.insert(n.ident.to_id());
     }
 
     fn visit_class_expr(&mut self, n: &ClassExpr) {
@@ -831,41 +985,7 @@ impl VisitMut for TreeShaker {
             }
             Decl::Class(c)
                 if self.can_drop_binding(c.ident.to_id(), false)
-                    && c.class
-                        .super_class
-                        .as_deref()
-                        .map_or(true, |e| !e.may_have_side_effects(self.expr_ctx))
-                    && c.class.body.iter().all(|m| match m {
-                        ClassMember::Method(m) => !matches!(m.key, PropName::Computed(..)),
-                        ClassMember::ClassProp(m) => {
-                            !matches!(m.key, PropName::Computed(..))
-                                && !m
-                                    .value
-                                    .as_deref()
-                                    .is_some_and(|e| e.may_have_side_effects(self.expr_ctx))
-                        }
-                        ClassMember::AutoAccessor(m) => {
-                            !matches!(m.key, Key::Public(PropName::Computed(..)))
-                                && !m
-                                    .value
-                                    .as_deref()
-                                    .is_some_and(|e| e.may_have_side_effects(self.expr_ctx))
-                        }
-
-                        ClassMember::PrivateProp(m) => !m
-                            .value
-                            .as_deref()
-                            .is_some_and(|e| e.may_have_side_effects(self.expr_ctx)),
-
-                        ClassMember::StaticBlock(_) => false,
-
-                        ClassMember::TsIndexSignature(_)
-                        | ClassMember::Empty(_)
-                        | ClassMember::Constructor(_)
-                        | ClassMember::PrivateMethod(_) => true,
-                        #[cfg(swc_ast_unknown)]
-                        _ => panic!("unable to access unknown nodes"),
-                    }) =>
+                    && class_def_is_side_effect_free(&c.class, self.expr_ctx) =>
             {
                 #[cfg(debug_assertions)]
                 debug!("Dropping class `{}` as it's not used", c.ident);
@@ -1032,11 +1152,14 @@ impl VisitMut for TreeShaker {
             {
                 let mut analyzer = Analyzer {
                     config: &self.config,
+                    expr_ctx: self.expr_ctx,
                     in_var_decl: false,
                     scope: Default::default(),
                     data: &mut data,
                     cur_class_id: Default::default(),
                     cur_fn_id: Default::default(),
+                    initialized_classes: Default::default(),
+                    nontrivial_classes: Default::default(),
                 };
                 m.visit_with(&mut analyzer);
             }
@@ -1098,11 +1221,14 @@ impl VisitMut for TreeShaker {
             {
                 let mut analyzer = Analyzer {
                     config: &self.config,
+                    expr_ctx: self.expr_ctx,
                     in_var_decl: false,
                     scope: Default::default(),
                     data: &mut data,
                     cur_class_id: Default::default(),
                     cur_fn_id: Default::default(),
+                    initialized_classes: Default::default(),
+                    nontrivial_classes: Default::default(),
                 };
                 m.visit_with(&mut analyzer);
             }

--- a/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_decorated_super_preserved.js
+++ b/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_decorated_super_preserved.js
@@ -1,0 +1,11 @@
+@dec
+class A {
+    m() {
+        return B;
+    }
+}
+class B extends A {
+    m() {
+        return A;
+    }
+}

--- a/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_member_decorated_preserved.js
+++ b/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_member_decorated_preserved.js
@@ -1,0 +1,11 @@
+class A {
+    m() {
+        return B;
+    }
+}
+class B extends A {
+    @dec
+    m() {
+        return A;
+    }
+}

--- a/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_nested_heritage_preserved.js
+++ b/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_nested_heritage_preserved.js
@@ -1,0 +1,6 @@
+class A {
+    static x = class extends B {
+    };
+}
+class B extends A {
+}

--- a/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_tdz_preserved.js
+++ b/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_tdz_preserved.js
@@ -1,0 +1,4 @@
+class A extends B {
+}
+class B extends A {
+}

--- a/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_top_retain_preserved.js
+++ b/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_top_retain_preserved.js
@@ -1,0 +1,10 @@
+class A {
+    m() {
+        return B;
+    }
+}
+class B extends A {
+    m() {
+        return A;
+    }
+}

--- a/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_with_side_effect_preserved.js
+++ b/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_extends_cycle_with_side_effect_preserved.js
@@ -1,0 +1,13 @@
+class A {
+    static{
+        console.log('side effect');
+    }
+    method() {
+        new B().method();
+    }
+}
+class B extends A {
+    method() {
+        new A().method();
+    }
+}

--- a/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_static_field_reads_later_class_tdz.js
+++ b/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_static_field_reads_later_class_tdz.js
@@ -1,0 +1,5 @@
+class A {
+    static x = B;
+}
+class B extends A {
+}

--- a/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_static_private_field_reads_later_class_tdz.js
+++ b/crates/swc_ecma_transforms_optimization/tests/__swc_snapshots__/tests/simplify_dce.rs/class_static_private_field_reads_later_class_tdz.js
@@ -1,0 +1,5 @@
+class A {
+    static #x = B;
+}
+class B extends A {
+}

--- a/crates/swc_ecma_transforms_optimization/tests/simplify_dce.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/simplify_dce.rs
@@ -817,3 +817,123 @@ noop!(
     wt()
     "
 );
+
+optimized_out!(
+    class_extends_cycle_unused,
+    "
+    class A {
+        method() {
+            new B().method();
+        }
+    }
+    class B extends A {
+        method() {
+            new A().method();
+        }
+    }
+    "
+);
+
+noop!(
+    class_extends_cycle_tdz_preserved,
+    "
+    class A extends B {}
+    class B extends A {}
+    "
+);
+
+noop!(
+    class_extends_cycle_with_side_effect_preserved,
+    "
+    class A {
+        static {
+            console.log('side effect');
+        }
+        method() {
+            new B().method();
+        }
+    }
+    class B extends A {
+        method() {
+            new A().method();
+        }
+    }
+    "
+);
+
+// A `static` field initializer that reads a class declared later (which extends
+// this one) reads that class while it is still in the temporal dead zone, so
+// evaluating this class throws. Both classes must be preserved even though
+// nothing else references them — eliminating them would drop the required
+// throw. Regression test for the cycle TDZ guard (issue #11934 follow-up).
+noop!(
+    class_static_field_reads_later_class_tdz,
+    "class A { static x = B; } class B extends A {}"
+);
+
+// A decorated class is kept observable by its decorator independently of any
+// cycle. A subclass extending it must not collapse the cycle, or the decorated
+// sibling's reference would dangle. Regression guard (issue #11934 follow-up).
+noop!(
+    class_extends_cycle_decorated_super_preserved,
+    "@dec class A { m(){ return B; } } class B extends A { m(){ return A; } }"
+);
+
+fn tr_retain(unresolved_mark: Mark) -> impl Pass {
+    Repeat::new(dce(
+        Config {
+            top_level: true,
+            top_retain: vec!["A".into()],
+            ..Default::default()
+        },
+        unresolved_mark,
+    ))
+}
+
+// A class kept by `top_retain` stays externally reachable, so a cycle it
+// belongs to must not be collapsed even if the other member looks unused.
+// Regression guard (issue #11934 follow-up).
+test!(
+    Syntax::Es(EsSyntax {
+        decorators: true,
+        ..Default::default()
+    }),
+    |_| {
+        let unresolved_mark = Mark::new();
+        (
+            resolver(unresolved_mark, Mark::new(), false),
+            tr_retain(unresolved_mark),
+        )
+    },
+    class_extends_cycle_top_retain_preserved,
+    "class A { m(){ return B; } } class B extends A { m(){ return A; } }"
+);
+
+// A `static` private field initializer is evaluated at definition time, just
+// like a public one. Reading a class declared later (which extends this one)
+// reads it while still in the TDZ, so both classes must be preserved.
+// Regression guard (issue #11934 follow-up).
+noop!(
+    class_static_private_field_reads_later_class_tdz,
+    "class A { static #x = B; } class B extends A {}"
+);
+
+// A nested class expression in a `static` initializer evaluates its own
+// `extends` clause at definition time. In `class A { static x = class extends
+// B {} } class B extends A {}`, defining A reads B while B is still in its TDZ,
+// so the A/B cycle must be preserved. The enclosing class is non-trivial (it
+// has a static initializer), so the backward-extends optimization does not
+// apply. Regression guard (issue #11934 follow-up).
+noop!(
+    class_extends_cycle_nested_heritage_preserved,
+    "class A { static x = class extends B {}; } class B extends A {}"
+);
+
+// A member decorator is evaluated when its class is defined. A subclass with a
+// decorated member is therefore non-trivial and must not collapse its `extends`
+// cycle, or the decorator's effect on a dropped class would be lost.
+// Regression guard (issue #11934 follow-up).
+noop!(
+    class_extends_cycle_member_decorated_preserved,
+    "class A { m(){ return B; } } class B extends A { @dec m(){ return A; } }"
+);


### PR DESCRIPTION
## Description

The minifier keeps classes that are only reachable through a cyclic reference to each other, even when the whole cluster is unused; `terser` removes them. Reproduced in #11934.

The bug is in the DCE tree-shaker (`swc_ecma_transforms_optimization::simplify::dce`), which the minifier runs through `perform_dce`.

### Root cause

`Data::subtract_cycles` cancels the internal edges of a strongly-connected component — making its members eliminable — only when no node in the component is a top-level entry and none has an incoming edge from outside it.

In `Analyzer::visit_class_decl` the `extends` clause was visited *before* the class identifier was pushed onto the dependency path (`with_ast_path`). A reference seen with an empty path is recorded as a top-level entry, so for `class B extends A {}` the superclass `A` was pinned as an entry. That kept the otherwise-unreachable `A ⇄ B` cycle (formed by the method bodies) from being subtracted, so both classes survived.

### Fix

`visit_class_decl` now attributes the `extends` edge to the subclass (inside the path) only when the superclass is a **backward reference to an already-initialized class**, tracked with a small per-scope `FxHashSet<Id>`. Forward references, non-identifier superclasses, and everything else keep the original behavior (visited outside the path, i.e. pinned as an entry). This preserves TDZ-observable cycles such as `class A extends B {} class B extends A {}` — which throws at definition time and must not be eliminated (there only `B → A` is a backward reference, so `B` stays pinned and both classes are kept).

It also closes a latent hole in the same mechanism: a clean class in a cycle that is referenced by a kept, side-effectful sibling (e.g. a `static {}` block) could be dropped, leaving a dangling reference. A class whose definition has side effects is now marked as an entry, reusing the existing class-drop predicate (factored out as `class_def_is_side_effect_free`), so those cycles are preserved.

### Performance

The change is confined to `dce/mod.rs` and is intentionally minimal: it does **not** touch the `VarInfo` edge-weight struct or the `subtract_cycles` hot loop. The only added work on the common path is one `FxHashSet<Id>` insert per class declaration. CodSpeed should be neutral. (An earlier, broader attempt — #11933 — grew the edge weight and added per-declarator bookkeeping, which regressed CodSpeed; this PR is scoped to the class-`extends` case to avoid that.)

### Tests

In `tests/simplify_dce.rs`:
- `class_extends_cycle_unused` — the repro; both classes are eliminated. Confirmed to **fail** without the fix (`git stash` on `dce/mod.rs`).
- `class_extends_cycle_tdz_preserved` — `class A extends B {} class B extends A {}` is kept.
- `class_extends_cycle_with_side_effect_preserved` — a cycle whose member has a `static {}` block is kept.

`cargo test -p swc_ecma_transforms_optimization` and `cargo test -p swc_ecma_minifier` pass with no snapshot changes (including the terser execution tests).

## Related issue

Closes #11934
