### PR TITLE
fix(es/minifier): preserve switch fallthrough termination

### DIFF
--- a/.changeset/fix-switch-fallthrough-termination.md
+++ b/.changeset/fix-switch-fallthrough-termination.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+swc_ecma_utils: patch
+---
+
+fix(es/minifier): Preserve switch fallthrough termination analysis

--- a/crates/swc_ecma_minifier/tests/exec.rs
+++ b/crates/swc_ecma_minifier/tests/exec.rs
@@ -12503,3 +12503,33 @@ console.log(out);
     })
     .unwrap();
 }
+
+#[test]
+fn issue_11970_switch_default_before_empty_case() {
+    let src = r#"
+async function classify(code) {
+    switch (code) {
+        case "66":
+            return 1;
+        case "0":
+            break;
+        default:
+            return 1;
+    }
+
+    return 2;
+}
+
+(async () => {
+    console.log(await classify("66"));
+    console.log(await classify("0"));
+    console.log(await classify("x"));
+})();
+"#;
+    let config = r#"{
+        "defaults": true,
+        "toplevel": true
+    }"#;
+
+    run_exec_test(src, config, false);
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11970/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11970/input.js
@@ -1,0 +1,12 @@
+export async function classify(code) {
+    switch (code) {
+        case "66":
+            return 1;
+        case "0":
+            break;
+        default:
+            return 1;
+    }
+
+    return 2;
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11970/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11970/output.js
@@ -1,0 +1,9 @@
+export async function classify(code) {
+    switch(code){
+        case "66":
+        default:
+            return 1;
+        case "0":
+    }
+    return 2;
+}

--- a/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
+++ b/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
@@ -9,6 +9,6 @@
 | react.js | 70.45 KiB | 22.45 KiB | 8.04 KiB |
 | terser.js | 1.08 MiB | 446.63 KiB | 120.49 KiB |
 | three.js | 1.19 MiB | 630.55 KiB | 154.77 KiB |
-| typescript.js | 10.45 MiB | 3.17 MiB | 840.61 KiB |
+| typescript.js | 10.45 MiB | 3.17 MiB | 840.60 KiB |
 | victory.js | 2.30 MiB | 694.04 KiB | 154.18 KiB |
 | vue.js | 334.13 KiB | 113.56 KiB | 41.80 KiB |

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -540,26 +540,28 @@ pub trait StmtExt {
                 }
                 Stmt::Switch(s) => {
                     let mut has_default = false;
-                    let mut has_non_empty_terminates = false;
+                    let mut next_case_terminates = false;
+                    let mut all_entries_terminate = true;
 
-                    for case in &s.cases {
+                    // A matching case can fall through into later cases, so each case entry
+                    // depends on the termination state of the following case.
+                    for case in s.cases.iter().rev() {
                         if case.test.is_none() {
                             has_default = true
                         }
 
-                        if !case.cons.is_empty() {
-                            let t = terminates_many(&case.cons, true, false, allow_throw)
-                                .unwrap_or(false);
+                        let case_terminates =
+                            match terminates_many(&case.cons, true, false, allow_throw) {
+                                Ok(true) => true,
+                                Ok(false) => next_case_terminates,
+                                Err(()) => false,
+                            };
 
-                            if t {
-                                has_non_empty_terminates = true
-                            } else {
-                                return Ok(false);
-                            }
-                        }
+                        all_entries_terminate &= case_terminates;
+                        next_case_terminates = case_terminates;
                     }
 
-                    has_default && has_non_empty_terminates
+                    has_default && all_entries_terminate
                 }
                 Stmt::Try(t) => {
                     if let Some(h) = &t.handler {
@@ -3894,6 +3896,55 @@ mod tests {
     fn top_level_export_await() {
         assert!(has_top_level_await("export const foo = await 1;"));
         assert!(has_top_level_await("export default await 1;"));
+    }
+
+    #[test]
+    fn switch_default_before_empty_case_does_not_terminate() {
+        assert!(!stmt_in_function_terminates(
+            r#"
+switch (foo) {
+    default:
+        return 1;
+    case "0":
+}
+"#
+        ));
+    }
+
+    #[test]
+    fn switch_empty_case_before_default_terminates() {
+        assert!(stmt_in_function_terminates(
+            r#"
+switch (foo) {
+    case "0":
+    default:
+        return 1;
+}
+"#
+        ));
+    }
+
+    #[test]
+    fn switch_non_terminating_case_falls_through_to_terminating_case() {
+        assert!(stmt_in_function_terminates(
+            r#"
+switch (foo) {
+    case "0":
+        foo();
+    default:
+        return 1;
+}
+"#
+        ));
+    }
+
+    fn stmt_in_function_terminates(text: &str) -> bool {
+        let module = parse_module(&format!("function f() {{ {text} }}"));
+        let ModuleItem::Stmt(Stmt::Decl(Decl::Fn(f))) = &module.body[0] else {
+            unreachable!("expected a function declaration")
+        };
+        let body = f.function.body.as_ref().unwrap();
+        body.stmts[0].terminates()
     }
 }
 


### PR DESCRIPTION
**Description:**

Fixes switch termination detection so fallthrough from matched cases into later cases is accounted for before dead-code elimination. This preserves code after switches like `default: return 1; case "0":`, where the later empty case can still complete normally.

This PR updates `StmtExt::terminates`, adds focused switch termination tests, adds issue #11970 minifier fixture coverage, and adds an exec regression proving `classify("0")` still reaches the post-switch `return 2`.

**Testing:**

- `git submodule update --init --recursive`
- `UPDATE=1 cargo test -p swc_ecma_minifier`
- `cargo test -p swc_ecma_utils`
- `cargo test -p swc_ecma_minifier`
- `(cd crates/swc_ecma_minifier && ./scripts/exec.sh issue_11970)`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

**Related issue (if exists):**

Closes #11970