### PR TITLE
fix(es/minifier): Disable IIFE invoke when there's eval

### DIFF
--- a/.changeset/fix-minifier-eval-iife-invoke.md
+++ b/.changeset/fix-minifier-eval-iife-invoke.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): Disable IIFE invoke when there's eval

--- a/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/iife.rs
@@ -861,8 +861,24 @@ impl Optimizer<'_> {
         param_ids: impl ExactSizeIterator<Item = &'a Ident> + Clone,
         args: &[ExprOrSpread],
     ) -> bool {
-        // Don't create top-level variables.
+        if param_ids.len() == 0 {
+            return true;
+        }
+
         if !self.may_add_ident() {
+            // cannot add new ident, but sometimes inline or unused pass could remove those
+            // new vars
+            // but not when there's eval
+
+            if self
+                .data
+                .get_scope(self.ctx.scope)
+                .unwrap()
+                .contains(ScopeData::HAS_EVAL_CALL)
+            {
+                return false;
+            }
+
             for (idx, pid) in param_ids.clone().enumerate() {
                 if let Some(usage) = self.data.vars.get(&pid.to_id()) {
                     let arg = args.get(idx).map(|a| &*a.expr);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11977/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11977/config.json
@@ -1,0 +1,5 @@
+{
+    "defaults": true,
+    "toplevel": false,
+    "passes": 0
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11977/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11977/input.js
@@ -1,0 +1,22 @@
+var Subscription = (function () {
+    function Subscription1(listeners, listener) {}
+    Subscription1.prototype.add = function (subscription) {
+        if (this.unsubscribed) {
+        }
+    };
+})();
+try {
+    serverOnlyRequire = eval("require");
+} catch (err) {}
+var __require = /* @__PURE__ */ ((x) =>
+    ("TURBOPACK compile-time truthy", 1)
+        ? __turbopack_context__.z
+        : "TURBOPACK unreachable")(function (x) {})(ErrorType || {});
+var isRequestError = (error) => {
+    let u = i.getKey ?? ((p, s) => `x`),
+        f = async () => {
+            try {
+            } catch (s) {}
+        };
+};
+var x = class extends d {};

--- a/crates/swc_ecma_minifier/tests/fixture/issues/11977/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/11977/output.js
@@ -1,0 +1,12 @@
+var Subscription = function() {
+    (function(listeners, listener) {}).prototype.add = function(subscription) {
+        this.unsubscribed;
+    };
+}();
+try {
+    serverOnlyRequire = eval("require");
+} catch (err) {}
+var __require = /* @__PURE__ */ ((x)=>(0, __turbopack_context__.z))(function(x) {})(ErrorType || {}), isRequestError = (error)=>{
+    i.getKey;
+}, x = class extends d {
+};


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
See comment.

And I still don't really understand why this works in `transform` but not `minify`

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
#11977 