### PR TITLE
fix(es/react-compiler): Correct catch and parameter scope resolution

### DIFF
--- a/.changeset/correct-react-compiler-scope-resolution.md
+++ b/.changeset/correct-react-compiler-scope-resolution.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_react_compiler: patch
+---
+
+fix(es/react-compiler): Correct catch and parameter scope resolution

--- a/crates/swc_ecma_react_compiler/src/convert_scope.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_scope.rs
@@ -191,6 +191,7 @@ pub struct Symbol {
     pub name: String,
     pub span: swc_common::Span,
     pub flags: SymbolFlags,
+    pub scope_id: ScopeId,
 }
 
 /// A reference to a symbol.
@@ -252,6 +253,10 @@ impl Scoping {
         self.symbols[symbol_id.0 as usize].span
     }
 
+    pub fn symbol_scope_id(&self, symbol_id: SymbolId) -> ScopeId {
+        self.symbols[symbol_id.0 as usize].scope_id
+    }
+
     pub fn scope_flags(&self, scope_id: ScopeId) -> ScopeFlags {
         self.scopes[scope_id.0 as usize].flags
     }
@@ -294,6 +299,9 @@ impl Scoping {
         }
 
         let bindings = std::mem::take(&mut self.scopes[from_scope_id.0 as usize].bindings);
+        for symbol_id in bindings.values().copied() {
+            self.symbols[symbol_id.0 as usize].scope_id = to_scope_id;
+        }
         self.scopes[to_scope_id.0 as usize]
             .bindings
             .extend(bindings);
@@ -328,6 +336,7 @@ impl Scoping {
             name: name.clone(),
             span,
             flags,
+            scope_id,
         });
         if let Some(scope) = self.scopes.get_mut(scope_id.0 as usize) {
             scope.bindings.insert(name, id);
@@ -1479,6 +1488,18 @@ impl SemanticBuilder {
             scope_to_out_scope.insert(scope_id, out_scope_id);
         }
 
+        for symbol_id in self.scoping.symbol_ids() {
+            if let Some(&binding_id) = symbol_to_binding.get(&symbol_id) {
+                let symbol_scope_id = self.scoping.symbol_scope_id(symbol_id);
+                let out_scope_id = output_scope_for_internal_scope(
+                    &self.scoping,
+                    &scope_to_out_scope,
+                    symbol_scope_id,
+                );
+                bindings[binding_id.0 as usize].scope = out_scope_id;
+            }
+        }
+
         // Second pass: Create all scopes and update binding scope references
         for scope_id in self.scoping.scope_descendants_from_root() {
             let scope_flags = self.scoping.scope_flags(scope_id);
@@ -1496,7 +1517,6 @@ impl SemanticBuilder {
                 if let Some(&binding_id) = symbol_to_binding.get(&symbol_id) {
                     let name = bindings[binding_id.0 as usize].name.clone();
                     scope_bindings.insert(name, binding_id);
-                    bindings[binding_id.0 as usize].scope = out_scope_id;
                 }
             }
 
@@ -1597,6 +1617,22 @@ fn output_parent_scope(
         parent_id = scoping.scope_parent_id(parent);
     }
     None
+}
+
+fn output_scope_for_internal_scope(
+    scoping: &Scoping,
+    scope_to_out_scope: &HashMap<ScopeId, react_compiler_ast::scope::ScopeId>,
+    mut scope_id: ScopeId,
+) -> react_compiler_ast::scope::ScopeId {
+    loop {
+        if let Some(&out_scope_id) = scope_to_out_scope.get(&scope_id) {
+            return out_scope_id;
+        }
+
+        scope_id = scoping
+            .scope_parent_id(scope_id)
+            .expect("internal scope should have an output ancestor");
+    }
 }
 
 /// Build a map from import specifier span start to its import data.

--- a/crates/swc_ecma_react_compiler/src/convert_scope.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_scope.rs
@@ -48,6 +48,7 @@ impl ScopeFlags {
     pub const ClassStaticBlock: Self = Self { bits: 1 << 2 };
     pub const For: Self = Self { bits: 1 << 3 };
     pub const Function: Self = Self { bits: 1 << 4 };
+    pub const Parameter: Self = Self { bits: 1 << 9 };
     pub const StrictMode: Self = Self { bits: 1 << 5 };
     pub const Switch: Self = Self { bits: 1 << 6 };
     pub const Top: Self = Self { bits: 1 << 7 };
@@ -99,6 +100,11 @@ impl ScopeFlags {
     #[inline]
     pub fn is_catch_clause(self) -> bool {
         self.contains(Self::CatchClause)
+    }
+
+    #[inline]
+    pub fn is_parameter(self) -> bool {
+        self.contains(Self::Parameter)
     }
 }
 
@@ -262,8 +268,24 @@ impl Scoping {
         self.scopes[scope_id.0 as usize].bindings.values().copied()
     }
 
+    pub fn iter_binding_entries_in(
+        &self,
+        scope_id: ScopeId,
+    ) -> impl Iterator<Item = (&str, SymbolId)> + '_ {
+        self.scopes[scope_id.0 as usize]
+            .bindings
+            .iter()
+            .map(|(name, &symbol_id)| (name.as_str(), symbol_id))
+    }
+
     pub fn get_binding(&self, scope_id: ScopeId, name: &str) -> Option<SymbolId> {
         self.scopes[scope_id.0 as usize].bindings.get(name).copied()
+    }
+
+    pub fn bind_symbol_on_scope(&mut self, scope_id: ScopeId, name: String, symbol_id: SymbolId) {
+        if let Some(scope) = self.scopes.get_mut(scope_id.0 as usize) {
+            scope.bindings.insert(name, symbol_id);
+        }
     }
 
     pub fn move_bindings(&mut self, from_scope_id: ScopeId, to_scope_id: ScopeId) {
@@ -488,6 +510,35 @@ impl SemanticBuilder {
         symbol_id
     }
 
+    fn declare_symbol_on_scope_with_alias(
+        &mut self,
+        span: swc_common::Span,
+        name: String,
+        flags: SymbolFlags,
+        scope_id: ScopeId,
+        alias_scope_id: Option<ScopeId>,
+    ) -> SymbolId {
+        let symbol_id = self.declare_symbol_on_scope(span, name.clone(), flags, scope_id);
+        if let Some(alias_scope_id) = alias_scope_id {
+            self.scoping
+                .bind_symbol_on_scope(alias_scope_id, name, symbol_id);
+        }
+        symbol_id
+    }
+
+    fn alias_bindings_to_scope(&mut self, from_scope_id: ScopeId, to_scope_id: ScopeId) {
+        let bindings: Vec<(String, SymbolId)> = self
+            .scoping
+            .iter_binding_entries_in(from_scope_id)
+            .map(|(name, symbol_id)| (name.to_string(), symbol_id))
+            .collect();
+
+        for (name, symbol_id) in bindings {
+            self.scoping
+                .bind_symbol_on_scope(to_scope_id, name, symbol_id);
+        }
+    }
+
     fn record_redeclaration_binding(&mut self, span: swc_common::Span, symbol_id: SymbolId) {
         let start = self.start(span);
         self.declaration_starts.insert(start);
@@ -523,9 +574,22 @@ impl SemanticBuilder {
                     return true;
                 }
             }
-            scope_id = self.scoping.scope_parent_id(sid);
+            scope_id = self.resolution_parent_id(sid);
         }
         false
+    }
+
+    fn resolution_parent_id(&self, scope_id: ScopeId) -> Option<ScopeId> {
+        let parent_id = self.scoping.scope_parent_id(scope_id)?;
+        if self.scoping.scope_flags(scope_id).is_parameter() {
+            // Parameter initializers run before the function body environment is
+            // visible. Check parameter aliases first, then continue at the
+            // outer scope instead of the function scope that will hold body
+            // bindings in the React Compiler-compatible output model.
+            return self.scoping.scope_parent_id(parent_id);
+        }
+
+        Some(parent_id)
     }
 
     /// Resolve references emitted while visiting function or catch parameters
@@ -574,6 +638,30 @@ impl SemanticBuilder {
     }
 
     fn collect_pat_bindings(&mut self, pat: &Pat, flags: SymbolFlags) {
+        self.collect_pat_bindings_in_scope(pat, flags, self.current_scope(), None);
+    }
+
+    fn collect_parameter_pat_bindings(
+        &mut self,
+        pat: &Pat,
+        function_scope_id: ScopeId,
+        parameter_scope_id: ScopeId,
+    ) {
+        self.collect_pat_bindings_in_scope(
+            pat,
+            Self::param_flags(),
+            function_scope_id,
+            Some(parameter_scope_id),
+        );
+    }
+
+    fn collect_pat_bindings_in_scope(
+        &mut self,
+        pat: &Pat,
+        flags: SymbolFlags,
+        scope_id: ScopeId,
+        alias_scope_id: Option<ScopeId>,
+    ) {
         match pat {
             Pat::Ident(binding_ident) => {
                 // TypeScript `this` pseudo-parameters are type annotations only.
@@ -581,15 +669,17 @@ impl SemanticBuilder {
                 if binding_ident.id.sym.as_str() == "this" {
                     return;
                 }
-                self.declare_symbol(
+                self.declare_symbol_on_scope_with_alias(
                     binding_ident.id.span,
                     binding_ident.id.sym.to_string(),
                     flags,
+                    scope_id,
+                    alias_scope_id,
                 );
             }
             Pat::Array(arr) => {
                 for p in arr.elems.iter().flatten() {
-                    self.collect_pat_bindings(p, flags);
+                    self.collect_pat_bindings_in_scope(p, flags, scope_id, alias_scope_id);
                 }
             }
             Pat::Object(obj) => {
@@ -599,32 +689,193 @@ impl SemanticBuilder {
                             if let PropName::Computed(computed) = &kv.key {
                                 computed.visit_with(self);
                             }
-                            self.collect_pat_bindings(&kv.value, flags);
+                            self.collect_pat_bindings_in_scope(
+                                &kv.value,
+                                flags,
+                                scope_id,
+                                alias_scope_id,
+                            );
                         }
                         ObjectPatProp::Assign(assign) => {
-                            self.declare_symbol(
+                            self.declare_symbol_on_scope_with_alias(
                                 assign.key.id.span,
                                 assign.key.id.sym.to_string(),
                                 flags,
+                                scope_id,
+                                alias_scope_id,
                             );
                             if let Some(value) = &assign.value {
                                 value.visit_with(self);
                             }
                         }
                         ObjectPatProp::Rest(rest) => {
-                            self.collect_pat_bindings(&rest.arg, flags);
+                            self.collect_pat_bindings_in_scope(
+                                &rest.arg,
+                                flags,
+                                scope_id,
+                                alias_scope_id,
+                            );
                         }
                     }
                 }
             }
             Pat::Rest(rest) => {
-                self.collect_pat_bindings(&rest.arg, flags);
+                self.collect_pat_bindings_in_scope(&rest.arg, flags, scope_id, alias_scope_id);
             }
             Pat::Assign(assign) => {
-                self.collect_pat_bindings(&assign.left, flags);
+                self.collect_pat_bindings_in_scope(&assign.left, flags, scope_id, alias_scope_id);
                 assign.right.visit_with(self);
             }
             Pat::Expr(_) | Pat::Invalid(_) => {}
+        }
+    }
+
+    fn visit_function_params(
+        &mut self,
+        function_scope_id: ScopeId,
+        scope_span: swc_common::Span,
+        params: &[Param],
+    ) {
+        if params
+            .iter()
+            .any(|param| Self::pat_needs_parameter_scope(&param.pat))
+        {
+            self.with_parameter_scope(function_scope_id, scope_span, |this, parameter_scope_id| {
+                for param in params {
+                    this.collect_parameter_pat_bindings(
+                        &param.pat,
+                        function_scope_id,
+                        parameter_scope_id,
+                    );
+                }
+            });
+        } else {
+            for param in params {
+                self.collect_pat_bindings_in_scope(
+                    &param.pat,
+                    Self::param_flags(),
+                    function_scope_id,
+                    None,
+                );
+            }
+        }
+    }
+
+    fn visit_arrow_params(
+        &mut self,
+        function_scope_id: ScopeId,
+        scope_span: swc_common::Span,
+        params: &[Pat],
+    ) {
+        if params.iter().any(Self::pat_needs_parameter_scope) {
+            self.with_parameter_scope(function_scope_id, scope_span, |this, parameter_scope_id| {
+                for param in params {
+                    this.collect_parameter_pat_bindings(
+                        param,
+                        function_scope_id,
+                        parameter_scope_id,
+                    );
+                }
+            });
+        } else {
+            for param in params {
+                self.collect_pat_bindings_in_scope(
+                    param,
+                    Self::param_flags(),
+                    function_scope_id,
+                    None,
+                );
+            }
+        }
+    }
+
+    fn visit_constructor_params(
+        &mut self,
+        function_scope_id: ScopeId,
+        scope_span: swc_common::Span,
+        params: &[ParamOrTsParamProp],
+    ) {
+        if params
+            .iter()
+            .any(Self::constructor_param_needs_parameter_scope)
+        {
+            self.with_parameter_scope(function_scope_id, scope_span, |this, parameter_scope_id| {
+                for param in params {
+                    this.collect_constructor_param_bindings(
+                        param,
+                        function_scope_id,
+                        Some(parameter_scope_id),
+                    );
+                }
+            });
+        } else {
+            for param in params {
+                self.collect_constructor_param_bindings(param, function_scope_id, None);
+            }
+        }
+    }
+
+    fn visit_accessor_param(
+        &mut self,
+        function_scope_id: ScopeId,
+        scope_span: swc_common::Span,
+        param: &Pat,
+    ) {
+        if Self::pat_needs_parameter_scope(param) {
+            self.with_parameter_scope(function_scope_id, scope_span, |this, parameter_scope_id| {
+                this.collect_parameter_pat_bindings(param, function_scope_id, parameter_scope_id);
+            });
+        } else {
+            self.collect_pat_bindings_in_scope(param, Self::param_flags(), function_scope_id, None);
+        }
+    }
+
+    fn with_parameter_scope<F>(
+        &mut self,
+        function_scope_id: ScopeId,
+        scope_span: swc_common::Span,
+        visit_params: F,
+    ) where
+        F: FnOnce(&mut Self, ScopeId),
+    {
+        let checkpoint = self.unresolved_references.len();
+        let parameter_scope_id = self.push_scope(ScopeFlags::Parameter, scope_span);
+        // Named function expression bindings are visible in parameter defaults,
+        // but body bindings are not. Parameters are declared in the function
+        // scope for output compatibility and aliased here for resolution.
+        self.alias_bindings_to_scope(function_scope_id, parameter_scope_id);
+        visit_params(self, parameter_scope_id);
+        self.pop_scope();
+        self.resolve_references_from_checkpoint(checkpoint);
+    }
+
+    fn pat_needs_parameter_scope(pat: &Pat) -> bool {
+        match pat {
+            Pat::Ident(_) | Pat::Invalid(_) => false,
+            Pat::Array(arr) => arr
+                .elems
+                .iter()
+                .flatten()
+                .any(Self::pat_needs_parameter_scope),
+            Pat::Object(obj) => obj.props.iter().any(|prop| match prop {
+                ObjectPatProp::KeyValue(kv) => {
+                    matches!(kv.key, PropName::Computed(_))
+                        || Self::pat_needs_parameter_scope(&kv.value)
+                }
+                ObjectPatProp::Assign(assign) => assign.value.is_some(),
+                ObjectPatProp::Rest(rest) => Self::pat_needs_parameter_scope(&rest.arg),
+            }),
+            Pat::Rest(rest) => Self::pat_needs_parameter_scope(&rest.arg),
+            Pat::Assign(_) | Pat::Expr(_) => true,
+        }
+    }
+
+    fn constructor_param_needs_parameter_scope(param: &ParamOrTsParamProp) -> bool {
+        match param {
+            ParamOrTsParamProp::Param(param) => Self::pat_needs_parameter_scope(&param.pat),
+            ParamOrTsParamProp::TsParamProp(param_prop) => {
+                matches!(param_prop.param, TsParamPropParam::Assign(_))
+            }
         }
     }
 
@@ -649,16 +900,12 @@ impl SemanticBuilder {
         function: &Function,
         flags: ScopeFlags,
     ) {
-        let _scope_id = self.push_scope(
+        let scope_id = self.push_scope(
             self.body_scope_flags(flags, function.body.as_ref()),
             scope_span,
         );
 
-        let checkpoint = self.unresolved_references.len();
-        for param in &function.params {
-            self.collect_pat_bindings(&param.pat, Self::param_flags());
-        }
-        self.resolve_references_from_checkpoint(checkpoint);
+        self.visit_function_params(scope_id, scope_span, &function.params);
 
         if let Some(body) = &function.body {
             self.function_body_spans.insert(self.start(body.span));
@@ -669,16 +916,12 @@ impl SemanticBuilder {
     }
 
     fn visit_constructor_inner(&mut self, constructor: &Constructor) {
-        let _scope_id = self.push_scope(
+        let scope_id = self.push_scope(
             self.body_scope_flags(ScopeFlags::Function, constructor.body.as_ref()),
             constructor.span,
         );
 
-        let checkpoint = self.unresolved_references.len();
-        for param in &constructor.params {
-            self.collect_constructor_param_bindings(param);
-        }
-        self.resolve_references_from_checkpoint(checkpoint);
+        self.visit_constructor_params(scope_id, constructor.span, &constructor.params);
 
         if let Some(body) = &constructor.body {
             self.function_body_spans.insert(self.start(body.span));
@@ -688,21 +931,38 @@ impl SemanticBuilder {
         self.pop_scope();
     }
 
-    fn collect_constructor_param_bindings(&mut self, param: &ParamOrTsParamProp) {
+    fn collect_constructor_param_bindings(
+        &mut self,
+        param: &ParamOrTsParamProp,
+        function_scope_id: ScopeId,
+        alias_scope_id: Option<ScopeId>,
+    ) {
         match param {
             ParamOrTsParamProp::Param(param) => {
-                self.collect_pat_bindings(&param.pat, Self::param_flags());
+                self.collect_pat_bindings_in_scope(
+                    &param.pat,
+                    Self::param_flags(),
+                    function_scope_id,
+                    alias_scope_id,
+                );
             }
             ParamOrTsParamProp::TsParamProp(param_prop) => match &param_prop.param {
                 TsParamPropParam::Ident(binding_ident) => {
-                    self.declare_symbol(
+                    self.declare_symbol_on_scope_with_alias(
                         binding_ident.id.span,
                         binding_ident.id.sym.to_string(),
                         Self::param_flags(),
+                        function_scope_id,
+                        alias_scope_id,
                     );
                 }
                 TsParamPropParam::Assign(assign) => {
-                    self.collect_pat_bindings(&assign.left, Self::param_flags());
+                    self.collect_pat_bindings_in_scope(
+                        &assign.left,
+                        Self::param_flags(),
+                        function_scope_id,
+                        alias_scope_id,
+                    );
                     assign.right.visit_with(self);
                 }
             },
@@ -715,12 +975,10 @@ impl SemanticBuilder {
         param: Option<&Pat>,
         body: Option<&BlockStmt>,
     ) {
-        let _scope_id = self.push_scope(self.body_scope_flags(ScopeFlags::Function, body), span);
+        let scope_id = self.push_scope(self.body_scope_flags(ScopeFlags::Function, body), span);
 
         if let Some(param) = param {
-            let checkpoint = self.unresolved_references.len();
-            self.collect_pat_bindings(param, Self::param_flags());
-            self.resolve_references_from_checkpoint(checkpoint);
+            self.visit_accessor_param(scope_id, span, param);
         }
 
         if let Some(body) = body {
@@ -831,7 +1089,7 @@ impl Visit for SemanticBuilder {
 
     fn visit_fn_expr(&mut self, fn_expr: &FnExpr) {
         let flags = self.body_scope_flags(ScopeFlags::Function, fn_expr.function.body.as_ref());
-        self.push_scope(flags, fn_expr.function.span);
+        let scope_id = self.push_scope(flags, fn_expr.function.span);
 
         if let Some(ident) = &fn_expr.ident {
             self.declare_symbol(
@@ -841,11 +1099,7 @@ impl Visit for SemanticBuilder {
             );
         }
 
-        let checkpoint = self.unresolved_references.len();
-        for param in &fn_expr.function.params {
-            self.collect_pat_bindings(&param.pat, Self::param_flags());
-        }
-        self.resolve_references_from_checkpoint(checkpoint);
+        self.visit_function_params(scope_id, fn_expr.function.span, &fn_expr.function.params);
 
         if let Some(body) = &fn_expr.function.body {
             self.function_body_spans.insert(self.start(body.span));
@@ -862,13 +1116,9 @@ impl Visit for SemanticBuilder {
             }
             BlockStmtOrExpr::Expr(_) => ScopeFlags::Function,
         };
-        self.push_scope(flags, arrow.span);
+        let scope_id = self.push_scope(flags, arrow.span);
 
-        let checkpoint = self.unresolved_references.len();
-        for param in &arrow.params {
-            self.collect_pat_bindings(param, Self::param_flags());
-        }
-        self.resolve_references_from_checkpoint(checkpoint);
+        self.visit_arrow_params(scope_id, arrow.span, &arrow.params);
 
         match &*arrow.body {
             BlockStmtOrExpr::BlockStmt(block) => {
@@ -1165,55 +1415,7 @@ impl Visit for SemanticBuilder {
 
 impl SemanticBuilder {
     fn collect_pat_bindings_with_scope(&mut self, pat: &Pat, flags: SymbolFlags, scope: ScopeId) {
-        match pat {
-            Pat::Ident(binding_ident) => {
-                let _symbol_id = self.declare_symbol_on_scope(
-                    binding_ident.id.span,
-                    binding_ident.id.sym.to_string(),
-                    flags,
-                    scope,
-                );
-            }
-            Pat::Array(arr) => {
-                for p in arr.elems.iter().flatten() {
-                    self.collect_pat_bindings_with_scope(p, flags, scope);
-                }
-            }
-            Pat::Object(obj) => {
-                for prop in &obj.props {
-                    match prop {
-                        ObjectPatProp::KeyValue(kv) => {
-                            if let PropName::Computed(computed) = &kv.key {
-                                computed.visit_with(self);
-                            }
-                            self.collect_pat_bindings_with_scope(&kv.value, flags, scope);
-                        }
-                        ObjectPatProp::Assign(assign) => {
-                            let _symbol_id = self.declare_symbol_on_scope(
-                                assign.key.id.span,
-                                assign.key.id.sym.to_string(),
-                                flags,
-                                scope,
-                            );
-                            if let Some(value) = &assign.value {
-                                value.visit_with(self);
-                            }
-                        }
-                        ObjectPatProp::Rest(rest) => {
-                            self.collect_pat_bindings_with_scope(&rest.arg, flags, scope);
-                        }
-                    }
-                }
-            }
-            Pat::Rest(rest) => {
-                self.collect_pat_bindings_with_scope(&rest.arg, flags, scope);
-            }
-            Pat::Assign(assign) => {
-                self.collect_pat_bindings_with_scope(&assign.left, flags, scope);
-                assign.right.visit_with(self);
-            }
-            Pat::Expr(_) | Pat::Invalid(_) => {}
-        }
+        self.collect_pat_bindings_in_scope(pat, flags, scope, None);
     }
 
     /// Consume the builder and produce a React Compiler [`ScopeInfo`].
@@ -1265,12 +1467,27 @@ impl SemanticBuilder {
             });
         }
 
+        // Parameter scopes are internal resolution environments. They must not
+        // overwrite BindingData.scope or appear as scope-creating AST nodes in
+        // the React Compiler ScopeInfo.
+        let mut scope_to_out_scope: HashMap<ScopeId, OutScopeId> = HashMap::new();
+        for scope_id in self.scoping.scope_descendants_from_root() {
+            if self.scoping.scope_flags(scope_id).is_parameter() {
+                continue;
+            }
+            let out_scope_id = OutScopeId(scope_to_out_scope.len() as u32);
+            scope_to_out_scope.insert(scope_id, out_scope_id);
+        }
+
         // Second pass: Create all scopes and update binding scope references
         for scope_id in self.scoping.scope_descendants_from_root() {
             let scope_flags = self.scoping.scope_flags(scope_id);
-            let parent = self.scoping.scope_parent_id(scope_id);
+            if scope_flags.is_parameter() {
+                continue;
+            }
 
-            let out_scope_id = OutScopeId(scope_id.0);
+            let out_scope_id = scope_to_out_scope[&scope_id];
+            let parent = output_parent_scope(&self.scoping, &scope_to_out_scope, scope_id);
 
             let kind = get_scope_kind(scope_flags);
 
@@ -1297,7 +1514,7 @@ impl SemanticBuilder {
 
             scopes.push(ScopeData {
                 id: out_scope_id,
-                parent: parent.map(|p| OutScopeId(p.0)),
+                parent,
                 kind,
                 bindings: scope_bindings,
             });
@@ -1352,7 +1569,7 @@ impl SemanticBuilder {
             }
         }
 
-        let program_scope = OutScopeId(self.scoping.root_scope_id().0);
+        let program_scope = scope_to_out_scope[&self.scoping.root_scope_id()];
 
         ScopeInfo {
             scopes,
@@ -1365,6 +1582,21 @@ impl SemanticBuilder {
             program_scope,
         }
     }
+}
+
+fn output_parent_scope(
+    scoping: &Scoping,
+    scope_to_out_scope: &HashMap<ScopeId, react_compiler_ast::scope::ScopeId>,
+    scope_id: ScopeId,
+) -> Option<react_compiler_ast::scope::ScopeId> {
+    let mut parent_id = scoping.scope_parent_id(scope_id);
+    while let Some(parent) = parent_id {
+        if let Some(&out_parent) = scope_to_out_scope.get(&parent) {
+            return Some(out_parent);
+        }
+        parent_id = scoping.scope_parent_id(parent);
+    }
+    None
 }
 
 /// Build a map from import specifier span start to its import data.

--- a/crates/swc_ecma_react_compiler/src/convert_scope.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_scope.rs
@@ -293,20 +293,6 @@ impl Scoping {
         }
     }
 
-    pub fn move_bindings(&mut self, from_scope_id: ScopeId, to_scope_id: ScopeId) {
-        if from_scope_id == to_scope_id {
-            return;
-        }
-
-        let bindings = std::mem::take(&mut self.scopes[from_scope_id.0 as usize].bindings);
-        for symbol_id in bindings.values().copied() {
-            self.symbols[symbol_id.0 as usize].scope_id = to_scope_id;
-        }
-        self.scopes[to_scope_id.0 as usize]
-            .bindings
-            .extend(bindings);
-    }
-
     pub fn root_scope_id(&self) -> ScopeId {
         ScopeId(0)
     }
@@ -1146,11 +1132,7 @@ impl Visit for SemanticBuilder {
         if self.function_body_spans.remove(&self.start(block.span)) {
             block.visit_children_with(self);
         } else {
-            let parent_scope = self.current_scope();
-            let scope_id = self.push_scope(ScopeFlags::empty(), block.span);
-            if self.scoping.scope_flags(parent_scope).is_catch_clause() {
-                self.scoping.move_bindings(parent_scope, scope_id);
-            }
+            self.push_scope(ScopeFlags::empty(), block.span);
             block.visit_children_with(self);
             self.pop_scope();
         }

--- a/crates/swc_ecma_react_compiler/src/convert_scope.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_scope.rs
@@ -266,6 +266,17 @@ impl Scoping {
         self.scopes[scope_id.0 as usize].bindings.get(name).copied()
     }
 
+    pub fn move_bindings(&mut self, from_scope_id: ScopeId, to_scope_id: ScopeId) {
+        if from_scope_id == to_scope_id {
+            return;
+        }
+
+        let bindings = std::mem::take(&mut self.scopes[from_scope_id.0 as usize].bindings);
+        self.scopes[to_scope_id.0 as usize]
+            .bindings
+            .extend(bindings);
+    }
+
     pub fn root_scope_id(&self) -> ScopeId {
         ScopeId(0)
     }
@@ -876,7 +887,11 @@ impl Visit for SemanticBuilder {
         if self.function_body_spans.remove(&self.start(block.span)) {
             block.visit_children_with(self);
         } else {
-            self.push_scope(ScopeFlags::empty(), block.span);
+            let parent_scope = self.current_scope();
+            let scope_id = self.push_scope(ScopeFlags::empty(), block.span);
+            if self.scoping.scope_flags(parent_scope).is_catch_clause() {
+                self.scoping.move_bindings(parent_scope, scope_id);
+            }
             block.visit_children_with(self);
             self.pop_scope();
         }
@@ -922,7 +937,6 @@ impl Visit for SemanticBuilder {
             self.resolve_references_from_checkpoint(checkpoint);
         }
 
-        self.function_body_spans.insert(self.start(catch.body.span));
         catch.body.visit_with(self);
 
         self.pop_scope();

--- a/crates/swc_ecma_react_compiler/src/convert_scope.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_scope.rs
@@ -461,8 +461,14 @@ impl SemanticBuilder {
     ) -> SymbolId {
         if flags.contains(SymbolFlags::FunctionScopedVariable) {
             if let Some(symbol_id) = self.scoping.get_binding(scope_id, &name) {
-                self.record_redeclaration_binding(span, symbol_id);
-                return symbol_id;
+                if !self
+                    .scoping
+                    .symbol_flags(symbol_id)
+                    .contains(SymbolFlags::FunctionExpression)
+                {
+                    self.record_redeclaration_binding(span, symbol_id);
+                    return symbol_id;
+                }
             }
         }
 

--- a/crates/swc_ecma_react_compiler/src/convert_scope.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_scope.rs
@@ -140,6 +140,12 @@ impl SymbolFlags {
     pub const FunctionScopedVariable: Self = Self { bits: 1 << 7 };
     pub const Import: Self = Self { bits: 1 << 8 };
     pub const Param: Self = Self { bits: 1 << 9 };
+    pub const Value: Self = Self {
+        bits: Self::Variable.bits | Self::Class.bits | Self::Function.bits | Self::Enum.bits,
+    };
+    pub const Variable: Self = Self {
+        bits: Self::FunctionScopedVariable.bits | Self::BlockScopedVariable.bits,
+    };
 
     #[inline]
     pub const fn contains(self, other: Self) -> bool {
@@ -153,17 +159,7 @@ impl SymbolFlags {
 
     #[inline]
     pub fn is_value(self) -> bool {
-        self.intersects(
-            Self::FunctionScopedVariable
-                | Self::BlockScopedVariable
-                | Self::Function
-                | Self::FunctionExpression
-                | Self::Class
-                | Self::Enum
-                | Self::Import
-                | Self::Param
-                | Self::CatchVariable,
-        )
+        self.intersects(Self::Value | Self::Import)
     }
 
     #[inline]
@@ -349,7 +345,7 @@ pub struct SemanticBuilder {
     declaration_starts: std::collections::HashSet<u32>,
     /// Re-declaration sites that should resolve to an existing binding.
     redeclaration_bindings: HashMap<u32, SymbolId>,
-    /// Flat list of unresolved references: (name, reference_id).
+    /// Flat list of unresolved references: (name, `reference_id`).
     unresolved_references: Vec<(String, ReferenceId)>,
     /// Track function body spans so they don't create extra block scopes.
     function_body_spans: std::collections::HashSet<u32>,
@@ -515,6 +511,21 @@ impl SemanticBuilder {
         false
     }
 
+    /// Resolve references emitted while visiting function or catch parameters
+    /// before body bindings are added to the same scope.
+    fn resolve_references_from_checkpoint(&mut self, checkpoint: usize) {
+        if checkpoint >= self.unresolved_references.len() {
+            return;
+        }
+
+        let references = self.unresolved_references.split_off(checkpoint);
+        for (name, reference_id) in references {
+            if !self.walk_up_resolve_reference(&name, reference_id) {
+                self.unresolved_references.push((name, reference_id));
+            }
+        }
+    }
+
     fn try_resolve_reference(&mut self, reference_id: ReferenceId, symbol_id: SymbolId) -> bool {
         let symbol_flags = self.scoping.symbol_flags(symbol_id);
 
@@ -538,6 +549,11 @@ impl SemanticBuilder {
                 flags.is_var()
             })
             .unwrap_or(ScopeId(0))
+    }
+
+    #[inline]
+    fn param_flags() -> SymbolFlags {
+        SymbolFlags::FunctionScopedVariable | SymbolFlags::Param
     }
 
     fn collect_pat_bindings(&mut self, pat: &Pat, flags: SymbolFlags) {
@@ -595,6 +611,17 @@ impl SemanticBuilder {
         }
     }
 
+    /// A simple catch parameter is function-scoped for `var` redeclaration
+    /// compatibility, while destructuring is block-scoped.
+    fn collect_catch_pat_bindings(&mut self, pat: &Pat) {
+        let flags = if matches!(pat, Pat::Ident(_)) {
+            SymbolFlags::FunctionScopedVariable | SymbolFlags::CatchVariable
+        } else {
+            SymbolFlags::BlockScopedVariable | SymbolFlags::CatchVariable
+        };
+        self.collect_pat_bindings(pat, flags);
+    }
+
     fn visit_function_inner(&mut self, function: &Function, flags: ScopeFlags) {
         self.visit_function_inner_with_span(function.span, function, flags);
     }
@@ -610,9 +637,11 @@ impl SemanticBuilder {
             scope_span,
         );
 
+        let checkpoint = self.unresolved_references.len();
         for param in &function.params {
-            self.collect_pat_bindings(&param.pat, SymbolFlags::Param);
+            self.collect_pat_bindings(&param.pat, Self::param_flags());
         }
+        self.resolve_references_from_checkpoint(checkpoint);
 
         if let Some(body) = &function.body {
             self.function_body_spans.insert(self.start(body.span));
@@ -628,9 +657,11 @@ impl SemanticBuilder {
             constructor.span,
         );
 
+        let checkpoint = self.unresolved_references.len();
         for param in &constructor.params {
             self.collect_constructor_param_bindings(param);
         }
+        self.resolve_references_from_checkpoint(checkpoint);
 
         if let Some(body) = &constructor.body {
             self.function_body_spans.insert(self.start(body.span));
@@ -643,18 +674,18 @@ impl SemanticBuilder {
     fn collect_constructor_param_bindings(&mut self, param: &ParamOrTsParamProp) {
         match param {
             ParamOrTsParamProp::Param(param) => {
-                self.collect_pat_bindings(&param.pat, SymbolFlags::Param);
+                self.collect_pat_bindings(&param.pat, Self::param_flags());
             }
             ParamOrTsParamProp::TsParamProp(param_prop) => match &param_prop.param {
                 TsParamPropParam::Ident(binding_ident) => {
                     self.declare_symbol(
                         binding_ident.id.span,
                         binding_ident.id.sym.to_string(),
-                        SymbolFlags::Param,
+                        Self::param_flags(),
                     );
                 }
                 TsParamPropParam::Assign(assign) => {
-                    self.collect_pat_bindings(&assign.left, SymbolFlags::Param);
+                    self.collect_pat_bindings(&assign.left, Self::param_flags());
                     assign.right.visit_with(self);
                 }
             },
@@ -670,7 +701,9 @@ impl SemanticBuilder {
         let _scope_id = self.push_scope(self.body_scope_flags(ScopeFlags::Function, body), span);
 
         if let Some(param) = param {
-            self.collect_pat_bindings(param, SymbolFlags::Param);
+            let checkpoint = self.unresolved_references.len();
+            self.collect_pat_bindings(param, Self::param_flags());
+            self.resolve_references_from_checkpoint(checkpoint);
         }
 
         if let Some(body) = body {
@@ -787,13 +820,15 @@ impl Visit for SemanticBuilder {
             self.declare_symbol(
                 ident.span,
                 ident.sym.to_string(),
-                SymbolFlags::FunctionExpression,
+                SymbolFlags::Function | SymbolFlags::FunctionExpression,
             );
         }
 
+        let checkpoint = self.unresolved_references.len();
         for param in &fn_expr.function.params {
-            self.collect_pat_bindings(&param.pat, SymbolFlags::Param);
+            self.collect_pat_bindings(&param.pat, Self::param_flags());
         }
+        self.resolve_references_from_checkpoint(checkpoint);
 
         if let Some(body) = &fn_expr.function.body {
             self.function_body_spans.insert(self.start(body.span));
@@ -812,9 +847,11 @@ impl Visit for SemanticBuilder {
         };
         self.push_scope(flags, arrow.span);
 
+        let checkpoint = self.unresolved_references.len();
         for param in &arrow.params {
-            self.collect_pat_bindings(param, SymbolFlags::Param);
+            self.collect_pat_bindings(param, Self::param_flags());
         }
+        self.resolve_references_from_checkpoint(checkpoint);
 
         match &*arrow.body {
             BlockStmtOrExpr::BlockStmt(block) => {
@@ -874,7 +911,9 @@ impl Visit for SemanticBuilder {
         self.push_scope(ScopeFlags::CatchClause, catch.span);
 
         if let Some(param) = &catch.param {
-            self.collect_pat_bindings(param, SymbolFlags::CatchVariable);
+            let checkpoint = self.unresolved_references.len();
+            self.collect_catch_pat_bindings(param);
+            self.resolve_references_from_checkpoint(checkpoint);
         }
 
         self.function_body_spans.insert(self.start(catch.body.span));
@@ -1366,7 +1405,7 @@ fn build_import_map(
     map
 }
 
-/// Map our ScopeFlags to react_compiler_ast ScopeKind.
+/// Map our `ScopeFlags` to `react_compiler_ast` `ScopeKind`.
 fn get_scope_kind(flags: ScopeFlags) -> react_compiler_ast::scope::ScopeKind {
     use react_compiler_ast::scope::ScopeKind;
 
@@ -1397,7 +1436,7 @@ fn get_scope_kind(flags: ScopeFlags) -> react_compiler_ast::scope::ScopeKind {
     ScopeKind::Block
 }
 
-/// Map our SymbolFlags to react_compiler_ast BindingKind.
+/// Map our `SymbolFlags` to `react_compiler_ast` `BindingKind`.
 fn get_binding_kind(flags: SymbolFlags) -> react_compiler_ast::scope::BindingKind {
     use react_compiler_ast::scope::BindingKind;
 
@@ -1420,9 +1459,8 @@ fn get_binding_kind(flags: SymbolFlags) -> react_compiler_ast::scope::BindingKin
     if flags.contains(SymbolFlags::BlockScopedVariable) {
         if flags.contains(SymbolFlags::ConstVariable) {
             return BindingKind::Const;
-        } else {
-            return BindingKind::Let;
         }
+        return BindingKind::Let;
     }
 
     if flags.contains(SymbolFlags::FunctionExpression) {

--- a/crates/swc_ecma_react_compiler/src/convert_scope.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_scope.rs
@@ -161,7 +161,8 @@ impl SymbolFlags {
                 | Self::Class
                 | Self::Enum
                 | Self::Import
-                | Self::Param,
+                | Self::Param
+                | Self::CatchVariable,
         )
     }
 

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -540,6 +540,35 @@ fn scope_named_function_expression_is_local() {
 }
 
 #[test]
+fn scope_named_function_expression_allows_same_named_param() {
+    let source = "const g = function f(f) { return f; };";
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let f_bindings: Vec<_> = info.bindings.iter().filter(|b| b.name == "f").collect();
+    assert_eq!(f_bindings.len(), 2, "should create separate f bindings");
+
+    let function_binding = f_bindings
+        .iter()
+        .find(|binding| matches!(binding.kind, BindingKind::Local))
+        .expect("should find named function expression binding");
+    let param_binding = f_bindings
+        .iter()
+        .find(|binding| matches!(binding.kind, BindingKind::Param))
+        .expect("should find parameter binding");
+
+    let return_ref = source.find("return f").expect("should find return f") as u32 + 8;
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&return_ref).copied(),
+        Some(param_binding.id)
+    );
+    assert_ne!(
+        info.ref_node_id_to_binding.get(&return_ref).copied(),
+        Some(function_binding.id)
+    );
+}
+
+#[test]
 fn scope_export_default_function_named_binding_is_program_scoped() {
     let source = "export default function App() { return App; }";
     let program = parse_program(source);

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -573,10 +573,57 @@ fn scope_named_function_expression_allows_same_named_param() {
         .find(|binding| matches!(binding.kind, BindingKind::Param))
         .expect("should find parameter binding");
 
+    assert!(matches!(
+        info.scopes[function_binding.scope.0 as usize].kind,
+        ScopeKind::Function
+    ));
+    assert!(matches!(
+        info.scopes[param_binding.scope.0 as usize].kind,
+        ScopeKind::Function
+    ));
+
     let return_ref = source.find("return f").expect("should find return f") as u32 + 8;
     assert_eq!(
         info.ref_node_id_to_binding.get(&return_ref).copied(),
         Some(param_binding.id)
+    );
+    assert_ne!(
+        info.ref_node_id_to_binding.get(&return_ref).copied(),
+        Some(function_binding.id)
+    );
+}
+
+#[test]
+fn scope_named_function_expression_preserves_scope_when_shadowed_by_var() {
+    let source = "const g = function f() { var f; return f; };";
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let f_bindings: Vec<_> = info.bindings.iter().filter(|b| b.name == "f").collect();
+    assert_eq!(f_bindings.len(), 2, "should create separate f bindings");
+
+    let function_binding = f_bindings
+        .iter()
+        .find(|binding| matches!(binding.kind, BindingKind::Local))
+        .expect("should find named function expression binding");
+    let var_binding = f_bindings
+        .iter()
+        .find(|binding| matches!(binding.kind, BindingKind::Var))
+        .expect("should find var binding");
+
+    assert!(matches!(
+        info.scopes[function_binding.scope.0 as usize].kind,
+        ScopeKind::Function
+    ));
+    assert!(matches!(
+        info.scopes[var_binding.scope.0 as usize].kind,
+        ScopeKind::Function
+    ));
+
+    let return_ref = source.find("return f").expect("should find return f") as u32 + 8;
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&return_ref).copied(),
+        Some(var_binding.id)
     );
     assert_ne!(
         info.ref_node_id_to_binding.get(&return_ref).copied(),

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -1137,14 +1137,7 @@ fn scope_catch_clause_creates_scope() {
         .expect("should find binding e");
     assert!(matches!(e_binding.kind, BindingKind::Let));
     let scope = &info.scopes[e_binding.scope.0 as usize];
-    assert!(matches!(scope.kind, ScopeKind::Block));
-    let parent = scope
-        .parent
-        .expect("catch param block should have a parent");
-    assert!(matches!(
-        info.scopes[parent.0 as usize].kind,
-        ScopeKind::Catch
-    ));
+    assert!(matches!(scope.kind, ScopeKind::Catch));
 }
 
 #[test]
@@ -1415,6 +1408,58 @@ fn scope_resolves_catch_param_references_before_body_bindings() {
     assert_eq!(
         info.ref_node_id_to_binding.get(&value_ref).copied(),
         Some(catch_value)
+    );
+}
+
+#[test]
+fn scope_catch_param_binding_covers_initializer_references() {
+    let source = r#"
+        try {
+        } catch ({ e = () => e }) {
+            e();
+        }
+        const e = "outer";
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let source_pos = |needle: &str| {
+        source
+            .find(needle)
+            .unwrap_or_else(|| panic!("should find {needle:?}")) as u32
+            + 1
+    };
+    let binding_id_at = |name: &str, needle: &str| {
+        let start = source_pos(needle);
+        info.bindings
+            .iter()
+            .find(|binding| binding.name == name && binding.declaration_start == Some(start))
+            .unwrap_or_else(|| panic!("should find binding {name} at {needle:?}"))
+            .id
+    };
+
+    let catch_e = binding_id_at("e", "e = ()");
+    let outer_e = binding_id_at("e", "e = \"outer\"");
+    let initializer_e_ref = source_pos("=> e") + 3;
+    let body_e_ref = source_pos("e();");
+    let catch_binding = &info.bindings[catch_e.0 as usize];
+
+    assert!(matches!(catch_binding.kind, BindingKind::Let));
+    assert!(matches!(
+        info.scopes[catch_binding.scope.0 as usize].kind,
+        ScopeKind::Catch
+    ));
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&initializer_e_ref).copied(),
+        Some(catch_e)
+    );
+    assert_ne!(
+        info.ref_node_id_to_binding.get(&initializer_e_ref).copied(),
+        Some(outer_e)
+    );
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&body_e_ref).copied(),
+        Some(catch_e)
     );
 }
 

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -1074,7 +1074,14 @@ fn scope_catch_clause_creates_scope() {
         .expect("should find binding e");
     assert!(matches!(e_binding.kind, BindingKind::Let));
     let scope = &info.scopes[e_binding.scope.0 as usize];
-    assert!(matches!(scope.kind, ScopeKind::Catch));
+    assert!(matches!(scope.kind, ScopeKind::Block));
+    let parent = scope
+        .parent
+        .expect("catch param block should have a parent");
+    assert!(matches!(
+        info.scopes[parent.0 as usize].kind,
+        ScopeKind::Catch
+    ));
 }
 
 #[test]
@@ -1148,12 +1155,12 @@ fn scope_resolves_function_param_references_before_body_bindings() {
 #[test]
 fn scope_resolves_catch_param_references_before_body_bindings() {
     let source = r#"
-        const key = "outer";
         try {
         } catch ({ [key]: value }) {
             const key = "inner";
             console.log(value);
         }
+        const key = "outer";
     "#;
     let program = parse_program(source);
     let info = SemanticBuilder::new().build(&program);

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -1081,6 +1081,85 @@ fn scope_for_loop_creates_scope() {
 }
 
 #[test]
+fn scope_resolves_function_param_references_before_body_bindings() {
+    let source = r#"
+        const fallback = "outer";
+        function useValue(value = fallback) {
+            const fallback = "inner";
+            return value;
+        }
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let source_pos = |needle: &str| {
+        source
+            .find(needle)
+            .unwrap_or_else(|| panic!("should find {needle:?}")) as u32
+            + 1
+    };
+    let binding_id_at = |name: &str, needle: &str| {
+        let start = source_pos(needle);
+        info.bindings
+            .iter()
+            .find(|binding| binding.name == name && binding.declaration_start == Some(start))
+            .unwrap_or_else(|| panic!("should find binding {name} at {needle:?}"))
+            .id
+    };
+
+    let outer_fallback = binding_id_at("fallback", "fallback = \"outer\"");
+    let inner_fallback = binding_id_at("fallback", "fallback = \"inner\"");
+    let fallback_ref = source_pos("fallback) {");
+    let resolved = info.ref_node_id_to_binding.get(&fallback_ref).copied();
+
+    assert_eq!(resolved, Some(outer_fallback));
+    assert_ne!(resolved, Some(inner_fallback));
+}
+
+#[test]
+fn scope_resolves_catch_param_references_before_body_bindings() {
+    let source = r#"
+        const key = "outer";
+        try {
+        } catch ({ [key]: value }) {
+            const key = "inner";
+            console.log(value);
+        }
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let source_pos = |needle: &str| {
+        source
+            .find(needle)
+            .unwrap_or_else(|| panic!("should find {needle:?}")) as u32
+            + 1
+    };
+    let binding_id_at = |name: &str, needle: &str| {
+        let start = source_pos(needle);
+        info.bindings
+            .iter()
+            .find(|binding| binding.name == name && binding.declaration_start == Some(start))
+            .unwrap_or_else(|| panic!("should find binding {name} at {needle:?}"))
+            .id
+    };
+
+    let outer_key = binding_id_at("key", "key = \"outer\"");
+    let inner_key = binding_id_at("key", "key = \"inner\"");
+    let catch_value = binding_id_at("value", "value })");
+    let key_ref = source_pos("key]: value");
+    let value_ref = source_pos("value);");
+
+    let resolved_key = info.ref_node_id_to_binding.get(&key_ref).copied();
+    assert_eq!(resolved_key, Some(outer_key));
+    assert_ne!(resolved_key, Some(inner_key));
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&value_ref).copied(),
+        Some(catch_value)
+    );
+}
+
+#[test]
 fn scope_resolves_references_inside_var_decl_patterns() {
     let source = r#"
         const key = "name";

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -5,7 +5,7 @@
 
 use react_compiler::entrypoint::plugin_options::{CompilerTarget, PluginOptions};
 use react_compiler_ast::{
-    scope::{BindingKind, ScopeKind},
+    scope::{BindingId, BindingKind, ScopeInfo, ScopeKind},
     statements::Statement,
     File,
 };
@@ -92,6 +92,22 @@ fn parse_module(source: &str) -> swc_ecma_ast::Module {
         &mut errors,
     )
     .expect("Failed to parse")
+}
+
+fn source_pos(source: &str, needle: &str) -> u32 {
+    source
+        .find(needle)
+        .unwrap_or_else(|| panic!("should find {needle:?}")) as u32
+        + 1
+}
+
+fn binding_id_at(info: &ScopeInfo, source: &str, name: &str, needle: &str) -> BindingId {
+    let start = source_pos(source, needle);
+    info.bindings
+        .iter()
+        .find(|binding| binding.name == name && binding.declaration_start == Some(start))
+        .unwrap_or_else(|| panic!("should find binding {name} at {needle:?}"))
+        .id
 }
 
 fn parse_ts_program(source: &str) -> swc_ecma_ast::Program {
@@ -1150,6 +1166,166 @@ fn scope_resolves_function_param_references_before_body_bindings() {
 
     assert_eq!(resolved, Some(outer_fallback));
     assert_ne!(resolved, Some(inner_fallback));
+}
+
+#[test]
+fn scope_resolves_deferred_function_param_references_from_outer_scope() {
+    let source = r#"
+        function useValue(value = fallback) {
+            const fallback = "inner";
+            return value;
+        }
+        const fallback = "outer";
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let outer_fallback = binding_id_at(&info, source, "fallback", "fallback = \"outer\"");
+    let inner_fallback = binding_id_at(&info, source, "fallback", "fallback = \"inner\"");
+    let fallback_ref = source_pos(source, "fallback) {");
+    let resolved = info.ref_node_id_to_binding.get(&fallback_ref).copied();
+
+    assert_eq!(resolved, Some(outer_fallback));
+    assert_ne!(resolved, Some(inner_fallback));
+}
+
+#[test]
+fn scope_does_not_resolve_function_param_references_to_body_var() {
+    let source = r#"
+        function useValue(value = fallback) {
+            var fallback = "inner";
+            return value;
+        }
+        const fallback = "outer";
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let outer_fallback = binding_id_at(&info, source, "fallback", "fallback = \"outer\"");
+    let body_fallback = binding_id_at(&info, source, "fallback", "fallback = \"inner\"");
+    let fallback_ref = source_pos(source, "fallback) {");
+    let resolved = info.ref_node_id_to_binding.get(&fallback_ref).copied();
+
+    assert_eq!(resolved, Some(outer_fallback));
+    assert_ne!(resolved, Some(body_fallback));
+}
+
+#[test]
+fn scope_leaves_function_param_references_unresolved_without_outer_binding() {
+    let source = r#"
+        function useValue(value = fallback) {
+            const fallback = "inner";
+            return value;
+        }
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let body_fallback = binding_id_at(&info, source, "fallback", "fallback = \"inner\"");
+    let fallback_ref = source_pos(source, "fallback) {");
+    let resolved = info.ref_node_id_to_binding.get(&fallback_ref).copied();
+
+    assert_eq!(resolved, None);
+    assert_ne!(resolved, Some(body_fallback));
+}
+
+#[test]
+fn scope_resolves_function_param_references_to_later_params() {
+    let source = r#"
+        function useValue(value = fallback, fallback) {
+            return value;
+        }
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let fallback_param = binding_id_at(&info, source, "fallback", "fallback) {");
+    let fallback_ref = source_pos(source, "fallback, fallback");
+
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&fallback_ref).copied(),
+        Some(fallback_param)
+    );
+}
+
+#[test]
+fn scope_resolves_function_expression_name_in_param_default() {
+    let source = r#"
+        const useValue = function inner(value = inner) {
+            return value;
+        };
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let function_binding = binding_id_at(&info, source, "inner", "inner(value");
+    let inner_ref = source_pos(source, "inner) {");
+
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&inner_ref).copied(),
+        Some(function_binding)
+    );
+}
+
+#[test]
+fn scope_resolves_same_named_function_expression_param_default_to_param() {
+    let source = r#"
+        const useValue = function inner(inner = inner) {
+            return inner;
+        };
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let function_binding = binding_id_at(&info, source, "inner", "inner(inner");
+    let param_binding = binding_id_at(&info, source, "inner", "inner = inner");
+    let default_ref = source_pos(source, "inner) {");
+    let return_ref = source_pos(source, "inner;");
+
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&default_ref).copied(),
+        Some(param_binding)
+    );
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&return_ref).copied(),
+        Some(param_binding)
+    );
+    assert_ne!(
+        info.ref_node_id_to_binding.get(&default_ref).copied(),
+        Some(function_binding)
+    );
+}
+
+#[test]
+fn scope_resolves_computed_function_param_references_outside_body_scope() {
+    let source = r#"
+        function useValue({ [key]: value }) {
+            const key = "inner";
+            return value;
+        }
+        const key = "outer";
+    "#;
+    let program = parse_program(source);
+    let info = SemanticBuilder::new().build(&program);
+
+    let outer_key = binding_id_at(&info, source, "key", "key = \"outer\"");
+    let inner_key = binding_id_at(&info, source, "key", "key = \"inner\"");
+    let value_param = binding_id_at(&info, source, "value", "value })");
+    let key_ref = source_pos(source, "key]: value");
+    let value_ref = source_pos(source, "value;");
+
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&key_ref).copied(),
+        Some(outer_key)
+    );
+    assert_ne!(
+        info.ref_node_id_to_binding.get(&key_ref).copied(),
+        Some(inner_key)
+    );
+    assert_eq!(
+        info.ref_node_id_to_binding.get(&value_ref).copied(),
+        Some(value_param)
+    );
 }
 
 #[test]

--- a/crates/swc_ecma_react_compiler/tests/fixture/compile-pass/catch-binding/input/use_callback_async.tsx
+++ b/crates/swc_ecma_react_compiler/tests/fixture/compile-pass/catch-binding/input/use_callback_async.tsx
@@ -1,0 +1,11 @@
+import { useCallback } from "react";
+
+export function useRepro() {
+    return useCallback(async () => {
+        try {
+            await 0;
+        } catch (error) {
+            return error;
+        }
+    }, []);
+}

--- a/crates/swc_ecma_react_compiler/tests/fixture/compile-pass/catch-binding/output/use_callback_async.tsx
+++ b/crates/swc_ecma_react_compiler/tests/fixture/compile-pass/catch-binding/output/use_callback_async.tsx
@@ -1,0 +1,13 @@
+import { useCallback } from "react";
+export function useRepro() {
+    return _temp;
+}
+async function _temp() {
+    ;
+    try {
+        await 0;
+    } catch (t0) {
+        const error = t0;
+        return error;
+    }
+}

--- a/crates/swc_ecma_react_compiler/tests/fixture/compile-pass/catch-binding/parser.json
+++ b/crates/swc_ecma_react_compiler/tests/fixture/compile-pass/catch-binding/parser.json
@@ -1,0 +1,4 @@
+{
+    "syntax": "typescript",
+    "tsx": true
+}


### PR DESCRIPTION
**Description:**

Fixes React Compiler scope conversion for catch and parameter bindings.

The bug from #11982 was exposed by compiling an async `useCallback` with `catch (error) { return error; }`: the converted scope info did not consistently model the catch parameter as a value binding, so references to the catch value could be left unresolved and produce incorrect compiled output.

This PR updates `SemanticBuilder` so declaration-space flags carry value-ness explicitly, with marker flags (`Param`, `CatchVariable`, `FunctionExpression`) layered onto value-bearing flags. Catch bindings stay in the catch scope and can be resolved from catch bodies and catch parameter initializers.

It also models parameter initializers and destructuring patterns with a temporary internal resolution scope. Function, arrow, constructor, accessor, and catch parameters now resolve references before body bindings are collected, so defaults and computed pattern keys observe the intended lexical visibility: function expression names and parameter bindings are visible, while body bindings do not shadow parameter initialization. These internal parameter scopes are skipped when emitting React Compiler `ScopeInfo`, preserving the public scope tree.

Coverage includes:
- the async `useCallback` catch-binding compile-pass fixture for #11982
- catch destructuring with computed keys and initializer references
- function parameter defaults resolving to outer bindings, later parameters, or named function expressions
- named function expressions shadowed by params or body `var` declarations

**BREAKING CHANGE:**

None.

**Related issue (if exists):**
- Close: #11982