### PR TITLE
refactor(es/module): Align module transform records with spec terms

### DIFF
--- a/.changeset/align-module-records.md
+++ b/.changeset/align-module-records.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_module: patch
+---
+
+refactor(es/module): Align module transform records with spec terms

--- a/crates/swc_ecma_transforms_module/README.md
+++ b/crates/swc_ecma_transforms_module/README.md
@@ -1,0 +1,335 @@
+# CommonJS, AMD, and UMD Module Transforms
+
+This crate lowers ECMAScript module syntax into several legacy module formats.
+The CommonJS, AMD, and UMD passes share the same source-module collection model
+and then diverge only at the format-specific import/export emit boundary.
+
+```mermaid
+flowchart TD
+    Input["Input ECMAScript module AST"]
+    Prelude["Directives, strict mode, and top-level this"]
+    Extractor["ModuleSyntaxExtractor"]
+    Record["RequestedModules, LocalExportEntries, and export assignment"]
+    Reducer["ModuleRecordEntryReducer"]
+    Rewrite["ImportMap and export getter list"]
+    Cjs["CommonJS emitter"]
+    Amd["AMD emitter"]
+    Umd["UMD emitter"]
+    CjsOut["require calls, export getters, and module.exports"]
+    AmdOut["define dependency array and factory body"]
+    UmdOut["adapter IIFE and shared factory body"]
+
+    Input --> Prelude --> Extractor --> Record --> Reducer --> Rewrite
+    Rewrite --> Cjs --> CjsOut
+    Rewrite --> Amd --> AmdOut
+    Rewrite --> Umd --> UmdOut
+```
+
+SystemJS is implemented in the same crate, but it does not use the flow
+described here.
+
+## Shared Terminology
+
+The shared extractor in `src/module_record.rs` intentionally uses names close to
+the ECMAScript module record vocabulary:
+
+- `ModuleSyntaxExtractor` walks source module declarations, records their module
+  linkage information, and removes module declarations from the executable body.
+- `RequestedModules` is grouped by module request string and preserves source
+  order with `IndexMap`.
+- `RequestedModule` stores the first useful source span, the collected
+  `ModuleRecordEntry` set for that request, and `ModuleRequestUsage`.
+- `LocalExportEntries` stores local exports keyed by exported name.
+- `ModuleRecordEntry` represents import entries, indirect export entries,
+  star exports, and TypeScript `import = require(...)` entries.
+- `ModuleRecordEntryReducer` converts collected entries into emitter-facing
+  structures: an `ImportMap` for rewritten local references and an
+  `ExportObjectProperties` list for generated export getters.
+
+The model is not a full ECMAScript linker. It records the syntactic module graph
+information needed by CommonJS-like emitters and keeps unresolved binding access
+lazy through generated property reads.
+
+## Shared Front-End Flow
+
+Each transform starts with an AST `Module` and follows the same broad pipeline:
+
+1. Move initial directive statements into the output body.
+2. Insert `"use strict"` when `Config::strict_mode` requires it and the module
+   does not already contain one.
+3. Replace top-level `this` with `undefined` unless
+   `Config::allow_top_level_this` is enabled.
+4. Run `ModuleSyntaxExtractor`.
+5. Emit an `__esModule` marker when the input had module syntax, import interop
+   is enabled, and the module is not a TypeScript `export =` module.
+6. Convert collected module entries into format-specific import statements,
+   dependency parameters, export getters, and import-reference rewrites.
+7. Append the stripped executable body.
+8. Apply format-specific handling for `export =`, dynamic `import()`, and
+   `import.meta` where supported by that transform.
+9. Rewrite local import binding references using the generated `ImportMap`.
+
+The extractor strips module declarations while preserving executable
+declarations:
+
+- `import ... from "mod"` is removed after its import entries are collected.
+- `export const foo = 1` becomes `const foo = 1`, and `foo` is registered in
+  `LocalExportEntries`.
+- `export { foo as bar }` is removed and recorded as a local export entry.
+- `export { foo as bar } from "mod"` is removed and recorded as an indirect
+  export entry under the requested module.
+- `export * from "mod"` is removed and recorded as `StarExport`.
+- `export default function foo() {}` keeps the declaration and records
+  `"default" -> foo`.
+- `export default expr` becomes a generated `_default` binding and records
+  `"default" -> _default`.
+- Type-only imports and exports do not create runtime module entries.
+
+## Module Request Usage
+
+`ModuleRequestUsage` summarizes which runtime shape a requested module needs:
+
+- `NAMED` means generated code reads named properties from the module object.
+- `DEFAULT` means generated code may need default interop.
+- `NAMESPACE` is the combined named/default shape needed for namespace imports
+  and namespace re-exports.
+- `STAR_EXPORT` means generated code calls the `_export_star` helper.
+- `TS_IMPORT_EQUALS` tracks TypeScript `import x = require("mod")` entries that
+  may need access to the raw imported value in addition to an interop-wrapped
+  value.
+
+When `importInterop` is `none`, namespace usage is removed before emit because
+the transform must not inject interop helpers.
+
+## Entry Reduction
+
+`ModuleRecordEntryReducer` is the shared bridge from module-record-like entries
+to CommonJS-like emit structures:
+
+- Named imports add `local -> module.importName` entries to `ImportMap`.
+- Default imports add `local -> module.default`, except Node default interop can
+  map default-only imports directly to the module object.
+- Namespace imports add `local -> module`.
+- Indirect named/default exports add synthetic imported bindings to `ImportMap`
+  and then add export getter entries.
+- Indirect namespace exports add an export getter that returns the module object.
+- Star exports are emitted by the caller with `_export_star(...)`.
+- TypeScript `import = require(...)` maps to the raw module temporary when one is
+  needed, otherwise to the normal module temporary.
+
+Export getters are sorted by exported name before emit. A single export uses a
+direct `Object.defineProperty` call, while multiple exports use the shared
+`_export(exports, { ... })` helper shape.
+
+## CommonJS Binding Walkthrough
+
+The diagram below follows the current implementation names for a representative
+CommonJS transform. AMD and UMD reuse the `module_record.rs` collection and
+`ModuleRecordEntryReducer` stages, then replace the final `require` and export
+emission with wrapper-specific dependency and factory emission.
+
+```mermaid
+flowchart TD
+    subgraph Source["Representative source module"]
+        SourceImports["<code>Static imports<br/>import a from 'a'<br/>import { b as b1 } from 'b'<br/>import * as c from 'c'</code>"]:::code
+        SourceExports["<code>Exports<br/>export let d = 1<br/>export default expr<br/>export { g, h as i } from 'foo'<br/>export * from 'bar'</code>"]:::code
+        SourceBody["<code>Executable references<br/>b1()<br/>c()</code>"]:::code
+    end
+
+    subgraph Extraction["ModuleSyntaxExtractor in module_record.rs"]
+        Requested["<code>RequestedModules<br/>a: ImportDefault, usage DEFAULT<br/>b: ImportNamed, usage NAMED<br/>c: ImportNamespace, usage NAMESPACE<br/>foo: IndirectExportNamed, usage NAMED<br/>bar: StarExport, usage STAR_EXPORT</code>"]:::code
+        LocalExports["<code>LocalExportEntries<br/>d -&gt; local d<br/>default -&gt; generated _default</code>"]:::code
+        Stripped["<code>Stripped body<br/>import/export declarations removed<br/>local declarations kept<br/>default expr becomes _default declaration</code>"]:::code
+    end
+
+    subgraph Reduction["ModuleRecordEntryReducer::reduce"]
+        ImportMap["<code>ImportMap<br/>a -&gt; (_a, default)<br/>b1 -&gt; (_b, b)<br/>c -&gt; (_c, none)<br/>g -&gt; (_foo, g)<br/>i -&gt; (_foo, h)</code>"]:::code
+        ExportBindings["<code>ExportObjectProperties<br/>d -&gt; d<br/>default -&gt; _default<br/>g -&gt; synthetic local g<br/>i -&gt; synthetic local i</code>"]:::code
+    end
+
+    subgraph Emit["CommonJS emit in common_js.rs"]
+        RequireEmit["<code>Request emission<br/>resolver.make_require_call<br/>private temp from local_name_for_src<br/>lazy_require when config.lazy matches</code>"]:::code
+        InteropEmit["<code>Interop and re-export<br/>_interop_require_default for DEFAULT<br/>_interop_require_wildcard for NAMESPACE<br/>_export_star for STAR_EXPORT</code>"]:::code
+        ExportEmit["<code>Export emission<br/>sort_export_bindings<br/>emit_export_stmts(exports, ...)<br/>Object.defineProperty or _export</code>"]:::code
+        Rewrite["<code>rewrite_import_bindings<br/>getter/body refs become module property reads</code>"]:::code
+        Output["<code>Output shape<br/>directives and use strict<br/>define_es_module(exports)<br/>export getters using rewritten refs<br/>require temp declarations and side effects<br/>stripped executable body</code>"]:::code
+    end
+
+    SourceImports --> Requested
+    SourceExports --> Requested
+    SourceExports --> LocalExports
+    SourceBody --> Stripped
+    Requested --> ImportMap
+    Requested --> RequireEmit
+    LocalExports --> ExportBindings
+    ImportMap --> Rewrite
+    ExportBindings --> ExportEmit
+    Stripped --> Rewrite
+    RequireEmit --> InteropEmit
+    InteropEmit --> Output
+    ExportEmit --> Output
+    Rewrite --> Output
+
+    classDef code text-align:left,font-family:monospace;
+```
+
+## CommonJS Flow
+
+The CommonJS pass lives in `src/common_js.rs` and produces direct `require(...)`
+calls.
+
+CommonJS has one extra pre-collection step for TypeScript
+`import x = require("mod")`:
+
+- Non-exported `import x = require("mod")` becomes
+  `const x = require("mod")` or `var x = require("mod")`.
+- Exported `export import x = require("mod")` becomes
+  `exports.x = require("mod")` and adds `x -> exports.x` to the import map.
+- This pre-pass sets `has_ts_import_equals`, which participates in the
+  `__esModule` marker decision.
+
+For each requested module, CommonJS:
+
+1. Creates a stable private module identifier from the request string.
+2. Reduces module entries into `ImportMap` and export bindings.
+3. Builds `require("mod")` through the configured path resolver.
+4. Wraps the require call in `_export_star(require("mod"), exports)` for star
+   re-exports.
+5. Applies interop helpers:
+   - SWC default interop uses `_interop_require_default(...)`.
+   - SWC namespace/default combined usage uses
+     `_interop_require_wildcard(...)`.
+   - Node namespace usage uses `_interop_require_wildcard(..., true)`.
+6. Emits either a declaration for the module temporary, a lazy require wrapper,
+   or a side-effect-only statement.
+
+After module requests are emitted, CommonJS emits local and indirect export
+getters unless the module uses `export =`. For `export = expr`, the pass appends
+`module.exports = expr`.
+
+When `exportInteropAnnotation` is enabled, CommonJS also emits
+`cjs-module-lexer`-friendly dead-code annotations such as
+`0 && (exports.foo = 0)` and star re-export annotations.
+
+Dynamic `import()` is lowered to a `Promise.resolve(...).then(...)` shape that
+calls `require(...)`. Literal dynamic import paths are resolved before emit.
+`import.meta` is lowered to CommonJS equivalents such as `__filename`,
+`__dirname`, `require.resolve`, or `require.main == module` unless
+`preserveImportMeta` is enabled.
+
+## AMD Flow
+
+The AMD pass lives in `src/amd.rs` and emits one `define(...)` call.
+
+Before wrapping, AMD builds a factory body using the shared front-end flow. Each
+requested module contributes:
+
+1. A dependency entry in `dep_list`.
+2. A factory parameter identifier.
+3. Import-map and export-binding entries through `ModuleRecordEntryReducer`.
+4. Optional post-parameter interop assignment inside the factory body.
+
+The final wrapper dependency array always starts with `"require"` and a matching
+`require` factory parameter. The pass adds `"exports"` only when generated code
+needs the exports object, and `"module"` only when generated `import.meta`
+lowering needs it. Requested modules are appended after those special AMD
+dependencies.
+
+The call shape is:
+
+```javascript
+define([deps...], function (params...) {
+    // generated body
+});
+```
+
+If `Config::module_id` is present, it is emitted as the first `define` argument.
+If it is absent, the pass can read a TypeScript-style
+`/// <amd-module name="..."/>` leading line comment and use that name.
+
+For `export = expr`, AMD appends `return expr` from the factory body instead of
+using an exports object.
+
+Dynamic `import()` is lowered to:
+
+```javascript
+new Promise(function (resolve, reject) {
+    require([arg], function (m) {
+        resolve(interopedModule);
+    }, reject);
+});
+```
+
+`import.meta` is lowered with AMD primitives where possible, for example
+`module.uri`, `require.toUrl(...)`, and `module.id == "main"`.
+
+## UMD Flow
+
+The UMD pass lives in `src/umd.rs` and emits an adapter IIFE plus a factory.
+The factory body is produced with the same collection and reduction flow as AMD.
+Requested modules are stored in `dep_list` and become factory parameters.
+
+The wrapper chooses among CommonJS, AMD, and global execution:
+
+```javascript
+(function (global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") {
+        factory(exports, require("mod"));
+    } else if (typeof define === "function" && define.amd) {
+        define(["exports", "mod"], factory);
+    } else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) {
+        factory((global.lib = {}), global.mod);
+    }
+})(this, function (exports, mod) {
+    // generated body
+});
+```
+
+When `ModuleSyntaxExtractor` reports a TypeScript `export =` assignment, UMD
+does not create an exports object parameter. The generated factory returns the
+assigned expression, and the CommonJS branch assigns that factory result to
+`module.exports`:
+
+```javascript
+module.exports = factory(require("mod"));
+define(["mod"], factory);
+```
+
+Some TypeScript/CommonJS syntax paths are already represented as executable
+`module.exports = ...` statements in the factory body by the time the UMD wrapper
+is emitted; those paths keep the normal wrapper call shape.
+
+UMD determines the global export name from the configured `globals` and module
+name settings. It resolves dependency request strings before emitting the CJS
+`require(...)`, AMD dependency string, and browser global property access.
+
+Unlike the CommonJS and AMD passes, the current UMD pass does not rewrite
+dynamic `import()` or `import.meta` itself in this module-transform stage.
+
+## Helper Injection
+
+`src/import_analysis.rs` runs before module lowering to enable only the helpers
+required by the module syntax in the source:
+
+- `_export_star` is enabled when any module request has `STAR_EXPORT`.
+- `_interop_require_default` is enabled for SWC default-only interop.
+- `_interop_require_wildcard` is enabled for namespace usage and, when dynamic
+  import is not ignored, for possible dynamic-import interop.
+
+The emitters assume these helpers are available when they generate the
+corresponding helper calls.
+
+## Important Boundaries
+
+- `module_record.rs` owns source module extraction and conversion to
+  emitter-facing import/export structures.
+- `common_js.rs`, `amd.rs`, and `umd.rs` own wrapper shape, dependency emission,
+  interop application, and special runtime rewrites for their format.
+- `module_ref_rewriter.rs` owns replacing imported local binding references with
+  the generated property access.
+- `util.rs` owns shared helper-building code such as `define_es_module`,
+  `_export(...)` emission, export sorting, and property-name construction.
+
+Keeping these boundaries intact makes it easier to adjust interop behavior or
+add module-record fields without coupling the collector to a specific output
+format.

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -19,13 +19,16 @@ use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith
 
 pub use super::util::Config as InnerConfig;
 use crate::{
-    module_decl_strip::{Export, Link, LinkFlag, LinkItem, LinkSpecifierReducer, ModuleDeclStrip},
+    module_record::{
+        LocalExportEntries, ModuleRecordEntryReducer, ModuleRequestUsage, ModuleSyntaxExtractor,
+        RequestedModule, RequestedModules,
+    },
     module_ref_rewriter::{rewrite_import_bindings, ImportMap},
     path::Resolver,
     top_level_this::top_level_this,
     util::{
-        define_es_module, emit_export_stmts, local_name_for_src, sort_export_obj_prop_list,
-        use_strict, ImportInterop, VecStmtLike,
+        define_es_module, emit_export_stmts, local_name_for_src, sort_export_bindings, use_strict,
+        ImportInterop, VecStmtLike,
     },
     SpanCtx,
 };
@@ -136,26 +139,31 @@ where
 
         let import_interop = self.config.import_interop();
 
-        let mut strip = ModuleDeclStrip::new(self.const_var_kind);
-        n.body.visit_mut_with(&mut strip);
+        let mut extractor = ModuleSyntaxExtractor::new(self.const_var_kind);
+        n.body.visit_mut_with(&mut extractor);
 
-        let ModuleDeclStrip {
-            link,
-            export,
+        let ModuleSyntaxExtractor {
+            requested_modules,
+            local_export_entries,
             export_assign,
-            has_module_decl,
+            has_module_syntax,
             ..
-        } = strip;
+        } = extractor;
 
         let is_export_assign = export_assign.is_some();
 
-        if has_module_decl && !import_interop.is_none() && !is_export_assign {
+        if has_module_syntax && !import_interop.is_none() && !is_export_assign {
             stmts.push(define_es_module(self.exports()))
         }
 
         let mut import_map = Default::default();
 
-        stmts.extend(self.handle_import_export(&mut import_map, link, export, is_export_assign));
+        stmts.extend(self.handle_import_export(
+            &mut import_map,
+            requested_modules,
+            local_export_entries,
+            is_export_assign,
+        ));
 
         stmts.extend(n.body.take().into_iter().filter_map(|item| match item {
             ModuleItem::Stmt(stmt) if !stmt.is_empty() => Some(stmt),
@@ -281,6 +289,9 @@ where
                 let mut require = self.require.clone();
                 require.span = *import_span;
 
+                // `import()` is specified as an ImportCall. AMD lowers it to a
+                // promise around async `require([arg], ...)`.
+                // Spec: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-import-calls
                 *n = amd_dynamic_import(
                     *span,
                     args.take(),
@@ -296,6 +307,11 @@ where
                         .map(|p| p.kind == MetaPropKind::ImportMeta)
                         .unwrap_or_default() =>
             {
+                // `import.meta` is host-populated in the spec. AMD lowers
+                // supported host fields to loader-specific values.
+                // Spec:
+                // - https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-hostgetimportmetaproperties
+                // - https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-hostfinalizeimportmeta
                 let p = match prop {
                     MemberProp::Ident(IdentName { sym, .. }) => Cow::Borrowed(&**sym),
                     MemberProp::Computed(ComputedPropName { expr, .. }) => match &**expr {
@@ -402,27 +418,34 @@ where
     fn handle_import_export(
         &mut self,
         import_map: &mut ImportMap,
-        link: Link,
-        export: Export,
+        requested_modules: RequestedModules,
+        local_export_entries: LocalExportEntries,
         is_export_assign: bool,
     ) -> impl Iterator<Item = Stmt> {
         let import_interop = self.config.import_interop();
 
-        let mut stmts = Vec::with_capacity(link.len());
+        let mut stmts = Vec::with_capacity(requested_modules.len());
 
-        let mut export_obj_prop_list = export.into_iter().collect();
+        let mut export_bindings = local_export_entries.into_iter().collect();
 
-        link.into_iter().for_each(
-            |(src, LinkItem(src_span, link_specifier_set, mut link_flag))| {
-                let is_node_default = !link_flag.has_named() && import_interop.is_node();
+        requested_modules.into_iter().for_each(
+            |(
+                src,
+                RequestedModule {
+                    span: src_span,
+                    entries: module_entries,
+                    usage: mut module_usage,
+                },
+            )| {
+                let is_node_default = !module_usage.has_named() && import_interop.is_node();
 
                 if import_interop.is_none() {
-                    link_flag -= LinkFlag::NAMESPACE;
+                    module_usage -= ModuleRequestUsage::NAMESPACE;
                 }
 
-                let need_re_export = link_flag.export_star();
-                let need_interop = link_flag.interop();
-                let need_new_var = link_flag.need_raw_import();
+                let need_re_export = module_usage.has_star_export();
+                let need_interop = module_usage.needs_interop();
+                let need_new_var = module_usage.needs_raw_import_for_ts_import_equals();
 
                 let mod_ident = private_ident!(local_name_for_src(&src));
                 let new_var_ident = if need_new_var {
@@ -433,9 +456,9 @@ where
 
                 self.dep_list.push((mod_ident.clone(), src, src_span));
 
-                link_specifier_set.reduce(
+                module_entries.reduce(
                     import_map,
-                    &mut export_obj_prop_list,
+                    &mut export_bindings,
                     &new_var_ident,
                     &Some(mod_ident.clone()),
                     &mut false,
@@ -455,13 +478,15 @@ where
                 // _introp(mod);
                 if need_interop {
                     import_expr = match import_interop {
-                        ImportInterop::Swc if link_flag.interop() => if link_flag.namespace() {
-                            helper_expr!(interop_require_wildcard)
-                        } else {
-                            helper_expr!(interop_require_default)
+                        ImportInterop::Swc if module_usage.needs_interop() => {
+                            if module_usage.needs_namespace_object() {
+                                helper_expr!(interop_require_wildcard)
+                            } else {
+                                helper_expr!(interop_require_default)
+                            }
+                            .as_call(PURE_SP, vec![import_expr.as_arg()])
                         }
-                        .as_call(PURE_SP, vec![import_expr.as_arg()]),
-                        ImportInterop::Node if link_flag.namespace() => {
+                        ImportInterop::Node if module_usage.needs_namespace_object() => {
                             helper_expr!(interop_require_wildcard)
                                 .as_call(PURE_SP, vec![import_expr.as_arg(), true.as_arg()])
                         }
@@ -490,12 +515,12 @@ where
 
         let mut export_stmts = Default::default();
 
-        if !export_obj_prop_list.is_empty() && !is_export_assign {
-            sort_export_obj_prop_list(&mut export_obj_prop_list);
+        if !export_bindings.is_empty() && !is_export_assign {
+            sort_export_bindings(&mut export_bindings);
 
             let exports = self.exports();
 
-            export_stmts = emit_export_stmts(exports, export_obj_prop_list);
+            export_stmts = emit_export_stmts(exports, export_bindings);
         }
 
         export_stmts.into_iter().chain(stmts)

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -13,15 +13,16 @@ use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith
 
 pub use super::util::Config;
 use crate::{
-    module_decl_strip::{
-        Export, ExportKV, Link, LinkFlag, LinkItem, LinkSpecifierReducer, ModuleDeclStrip,
+    module_record::{
+        ExportBinding, LocalExportEntries, ModuleRecordEntryReducer, ModuleRequestUsage,
+        ModuleSyntaxExtractor, RequestedModule, RequestedModules,
     },
     module_ref_rewriter::{rewrite_import_bindings, ImportMap},
     path::Resolver,
     top_level_this::top_level_this,
     util::{
-        define_es_module, emit_export_stmts, local_name_for_src, prop_name,
-        sort_export_obj_prop_list, use_strict, ImportInterop, VecStmtLike,
+        define_es_module, emit_export_stmts, local_name_for_src, prop_name, sort_export_bindings,
+        use_strict, ImportInterop, VecStmtLike,
     },
 };
 
@@ -99,22 +100,22 @@ impl VisitMut for Cjs {
             }
         });
 
-        let mut strip = ModuleDeclStrip::new(self.const_var_kind);
-        n.body.visit_mut_with(&mut strip);
+        let mut extractor = ModuleSyntaxExtractor::new(self.const_var_kind);
+        n.body.visit_mut_with(&mut extractor);
 
-        let ModuleDeclStrip {
-            link,
-            export,
+        let ModuleSyntaxExtractor {
+            requested_modules,
+            local_export_entries,
             export_assign,
-            has_module_decl,
+            has_module_syntax,
             ..
-        } = strip;
+        } = extractor;
 
-        let has_module_decl = has_module_decl || has_ts_import_equals;
+        let has_module_syntax = has_module_syntax || has_ts_import_equals;
 
         let is_export_assign = export_assign.is_some();
 
-        if has_module_decl && !import_interop.is_none() && !is_export_assign {
+        if has_module_syntax && !import_interop.is_none() && !is_export_assign {
             stmts.push(define_es_module(self.exports()).into())
         }
 
@@ -126,8 +127,8 @@ impl VisitMut for Cjs {
             self.handle_import_export(
                 &mut module_map,
                 &mut lazy_record,
-                link,
-                export,
+                requested_modules,
+                local_export_entries,
                 is_export_assign,
             )
             .map(From::from),
@@ -201,6 +202,9 @@ impl VisitMut for Cjs {
 
                 let unresolved_ctxt = SyntaxContext::empty().apply_mark(self.unresolved_mark);
 
+                // `import()` is specified as an ImportCall. CommonJS lowers it
+                // to a promise chain that evaluates `require(...)`.
+                // Spec: https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-import-calls
                 *n = cjs_dynamic_import(
                     *span,
                     args.take(),
@@ -217,6 +221,11 @@ impl VisitMut for Cjs {
                         .map(|p| p.kind == MetaPropKind::ImportMeta)
                         .unwrap_or_default() =>
             {
+                // `import.meta` is host-populated in the spec. CommonJS
+                // lowers supported host fields to Node-like runtime values.
+                // Spec:
+                // - https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-hostgetimportmetaproperties
+                // - https://tc39.es/ecma262/multipage/ecmascript-language-expressions.html#sec-hostfinalizeimportmeta
                 let p = match prop {
                     MemberProp::Ident(IdentName { sym, .. }) => Cow::Borrowed(&**sym),
                     MemberProp::Computed(ComputedPropName { expr, .. }) => match &**expr {
@@ -303,47 +312,55 @@ impl Cjs {
         &mut self,
         import_map: &mut ImportMap,
         lazy_record: &mut FxHashSet<Id>,
-        link: Link,
-        export: Export,
+        requested_modules: RequestedModules,
+        local_export_entries: LocalExportEntries,
         is_export_assign: bool,
     ) -> impl Iterator<Item = Stmt> {
         let import_interop = self.config.import_interop();
         let export_interop_annotation = self.config.export_interop_annotation();
         let is_node = import_interop.is_node();
 
-        let mut stmts = Vec::with_capacity(link.len());
+        let mut stmts = Vec::with_capacity(requested_modules.len());
 
-        let mut export_obj_prop_list = export.into_iter().collect();
+        let mut export_bindings: Vec<ExportBinding> = local_export_entries.into_iter().collect();
 
         let lexer_reexport = if export_interop_annotation {
-            self.emit_lexer_reexport(&link)
+            self.emit_lexer_reexport(&requested_modules)
         } else {
             None
         };
 
-        link.into_iter().for_each(
-            |(src, LinkItem(src_span, link_specifier_set, mut link_flag))| {
-                let is_node_default = !link_flag.has_named() && is_node;
+        requested_modules.into_iter().for_each(
+            |(
+                src,
+                RequestedModule {
+                    span: src_span,
+                    entries: module_entries,
+                    usage: mut module_usage,
+                },
+            )| {
+                let is_node_default = !module_usage.has_named() && is_node;
 
                 if import_interop.is_none() {
-                    link_flag -= LinkFlag::NAMESPACE;
+                    module_usage -= ModuleRequestUsage::NAMESPACE;
                 }
 
                 let mod_ident = private_ident!(local_name_for_src(&src));
 
                 let mut decl_mod_ident = false;
 
-                link_specifier_set.reduce(
+                module_entries.reduce(
                     import_map,
-                    &mut export_obj_prop_list,
+                    &mut export_bindings,
                     &mod_ident,
                     &None,
                     &mut decl_mod_ident,
                     is_node_default,
                 );
 
-                let is_lazy =
-                    decl_mod_ident && !link_flag.export_star() && self.config.lazy.is_lazy(&src);
+                let is_lazy = decl_mod_ident
+                    && !module_usage.has_star_export()
+                    && self.config.lazy.is_lazy(&src);
 
                 if is_lazy {
                     lazy_record.insert(mod_ident.to_id());
@@ -355,7 +372,7 @@ impl Cjs {
                         .make_require_call(self.unresolved_mark, src, src_span.0);
 
                 // _export_star(require("mod"), exports);
-                let import_expr = if link_flag.export_star() {
+                let import_expr = if module_usage.has_star_export() {
                     helper_expr!(export_star).as_call(
                         DUMMY_SP,
                         vec![import_expr.as_arg(), self.exports().as_arg()],
@@ -367,13 +384,15 @@ impl Cjs {
                 // _introp(require("mod"));
                 let import_expr = {
                     match import_interop {
-                        ImportInterop::Swc if link_flag.interop() => if link_flag.namespace() {
-                            helper_expr!(interop_require_wildcard)
-                        } else {
-                            helper_expr!(interop_require_default)
+                        ImportInterop::Swc if module_usage.needs_interop() => {
+                            if module_usage.needs_namespace_object() {
+                                helper_expr!(interop_require_wildcard)
+                            } else {
+                                helper_expr!(interop_require_default)
+                            }
+                            .as_call(PURE_SP, vec![import_expr.as_arg()])
                         }
-                        .as_call(PURE_SP, vec![import_expr.as_arg()]),
-                        ImportInterop::Node if link_flag.namespace() => {
+                        ImportInterop::Node if module_usage.needs_namespace_object() => {
                             helper_expr!(interop_require_wildcard)
                                 .as_call(PURE_SP, vec![import_expr.as_arg(), true.as_arg()])
                         }
@@ -399,16 +418,16 @@ impl Cjs {
 
         let mut export_stmts: Vec<Stmt> = Default::default();
 
-        if !export_obj_prop_list.is_empty() && !is_export_assign {
-            sort_export_obj_prop_list(&mut export_obj_prop_list);
+        if !export_bindings.is_empty() && !is_export_assign {
+            sort_export_bindings(&mut export_bindings);
 
             let exports = self.exports();
 
-            if export_interop_annotation && export_obj_prop_list.len() > 1 {
-                export_stmts.extend(self.emit_lexer_exports_init(&export_obj_prop_list));
+            if export_interop_annotation && export_bindings.len() > 1 {
+                export_stmts.extend(self.emit_lexer_exports_init(&export_bindings));
             }
 
-            export_stmts.extend(emit_export_stmts(exports, export_obj_prop_list));
+            export_stmts.extend(emit_export_stmts(exports, export_bindings));
         }
 
         export_stmts.extend(lexer_reexport);
@@ -491,7 +510,7 @@ impl Cjs {
     /// 0 && (exports.foo = 0);
     /// 0 && (module.exports = { foo: _, bar: _ });
     /// ```
-    fn emit_lexer_exports_init(&mut self, export_id_list: &[ExportKV]) -> Option<Stmt> {
+    fn emit_lexer_exports_init(&mut self, export_id_list: &[ExportBinding]) -> Option<Stmt> {
         match export_id_list.len() {
             0 => None,
             1 => {
@@ -559,9 +578,10 @@ impl Cjs {
     /// ```javascript
     /// 0 && __export(require("foo")) && __export(require("bar"));
     /// ```
-    fn emit_lexer_reexport(&self, link: &Link) -> Option<Stmt> {
-        link.iter()
-            .filter(|(.., LinkItem(.., link_flag))| link_flag.export_star())
+    fn emit_lexer_reexport(&self, requested_modules: &RequestedModules) -> Option<Stmt> {
+        requested_modules
+            .iter()
+            .filter(|(.., RequestedModule { usage, .. })| usage.has_star_export())
             .map(|(src, ..)| {
                 let import_expr =
                     self.resolver

--- a/crates/swc_ecma_transforms_module/src/import_analysis.rs
+++ b/crates/swc_ecma_transforms_module/src/import_analysis.rs
@@ -6,7 +6,7 @@ use swc_ecma_visit::{
     noop_visit_mut_type, noop_visit_type, visit_mut_pass, Visit, VisitMut, VisitWith,
 };
 
-use crate::{module_decl_strip::LinkFlag, util::ImportInterop, wtf8::str_to_atom};
+use crate::{module_record::ModuleRequestUsage, util::ImportInterop, wtf8::str_to_atom};
 
 pub fn import_analyzer(import_interop: ImportInterop, ignore_dynamic: bool) -> impl Pass {
     visit_mut_pass(ImportAnalyzer {
@@ -21,7 +21,7 @@ pub struct ImportAnalyzer {
     import_interop: ImportInterop,
     ignore_dynamic: bool,
 
-    flag_record: FxHashMap<Atom, LinkFlag>,
+    flag_record: FxHashMap<Atom, ModuleRequestUsage>,
     dynamic_import_found: bool,
 }
 
@@ -46,7 +46,7 @@ impl Visit for ImportAnalyzer {
 
         let flag_record = &self.flag_record;
 
-        if flag_record.values().any(|flag| flag.export_star()) {
+        if flag_record.values().any(|flag| flag.has_star_export()) {
             enable_helper!(export_star);
         }
 
@@ -57,12 +57,15 @@ impl Visit for ImportAnalyzer {
         if self.import_interop.is_swc()
             && flag_record
                 .values()
-                .any(|flag| flag.interop() && !flag.has_named())
+                .any(|flag| flag.needs_interop() && !flag.has_named())
         {
             enable_helper!(interop_require_default);
         }
 
-        if flag_record.values().any(|flag| flag.namespace()) {
+        if flag_record
+            .values()
+            .any(|flag| flag.needs_namespace_object())
+        {
             enable_helper!(interop_require_wildcard);
         } else if !self.ignore_dynamic {
             // `import/export * as foo from "foo"` not found
@@ -99,7 +102,7 @@ impl Visit for ImportAnalyzer {
 
     fn visit_export_all(&mut self, n: &ExportAll) {
         let src = str_to_atom(&n.src);
-        *self.flag_record.entry(src).or_default() |= LinkFlag::EXPORT_STAR;
+        *self.flag_record.entry(src).or_default() |= ModuleRequestUsage::STAR_EXPORT;
     }
 
     fn visit_import(&mut self, _: &Import) {

--- a/crates/swc_ecma_transforms_module/src/lib.rs
+++ b/crates/swc_ecma_transforms_module/src/lib.rs
@@ -14,7 +14,7 @@ pub mod util;
 pub mod amd;
 pub mod common_js;
 pub mod import_analysis;
-pub(crate) mod module_decl_strip;
+pub(crate) mod module_record;
 pub(crate) mod module_ref_rewriter;
 pub mod path;
 pub mod rewriter;

--- a/crates/swc_ecma_transforms_module/src/module_record.rs
+++ b/crates/swc_ecma_transforms_module/src/module_record.rs
@@ -8,47 +8,58 @@ use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 use crate::{module_ref_rewriter::ImportMap, SpanCtx};
 
-/// key: module path
-pub type Link = IndexMap<Atom, LinkItem>;
-/// key: export binding name
-pub type Export = FxHashMap<Atom, ExportItem>;
+/// `Source Text Module Record.[[RequestedModules]]`, grouped by module request
+/// string and kept in source order for deterministic emit.
+///
+/// Spec:
+/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-source-text-module-records
+/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-module-request-records
+/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-modulerequests
+pub(crate) type RequestedModules = IndexMap<Atom, RequestedModule>;
+/// `Source Text Module Record.[[LocalExportEntries]]`, keyed by export name.
+///
+/// Spec: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-source-text-module-records
+pub(crate) type LocalExportEntries = FxHashMap<Atom, LocalExportEntry>;
 
+/// Extracts ECMAScript module syntax into module-record-like data while
+/// stripping module declarations from the body for legacy CommonJS/AMD/UMD
+/// emit.
 #[derive(Debug)]
-pub struct ModuleDeclStrip {
-    /// all imports/exports collected by path in source text order
-    pub link: Link,
+pub struct ModuleSyntaxExtractor {
+    /// Imported modules and indirect/star exports grouped by module request.
+    pub requested_modules: RequestedModules,
 
-    /// local exported binding
+    /// Local exported binding.
     ///
     /// `export { foo as "1", bar }`
     /// -> Map("1" => foo, bar => bar)
-    pub export: Export,
+    pub local_export_entries: LocalExportEntries,
 
     /// `export = ` detected
     pub export_assign: Option<Box<Expr>>,
 
-    pub has_module_decl: bool,
+    pub has_module_syntax: bool,
 
     /// `export default expr`
-    export_default: Option<Stmt>,
+    default_export_decl: Option<Stmt>,
 
     const_var_kind: VarDeclKind,
 }
 
-impl ModuleDeclStrip {
+impl ModuleSyntaxExtractor {
     pub fn new(const_var_kind: VarDeclKind) -> Self {
         Self {
-            link: Default::default(),
-            export: Default::default(),
+            requested_modules: Default::default(),
+            local_export_entries: Default::default(),
             export_assign: Default::default(),
-            has_module_decl: Default::default(),
-            export_default: Default::default(),
+            has_module_syntax: Default::default(),
+            default_export_decl: Default::default(),
             const_var_kind,
         }
     }
 }
 
-impl VisitMut for ModuleDeclStrip {
+impl VisitMut for ModuleSyntaxExtractor {
     noop_visit_mut_type!(fail);
 
     fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
@@ -59,9 +70,11 @@ impl VisitMut for ModuleDeclStrip {
                 ModuleItem::Stmt(stmt) => list.push(stmt.into()),
 
                 ModuleItem::ModuleDecl(mut module_decl) => {
-                    // collect link meta
+                    // Collect the source text module record entries produced
+                    // by ParseModule.
+                    // Spec: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-parsemodule
                     module_decl.visit_mut_with(self);
-                    self.has_module_decl = true;
+                    self.has_module_syntax = true;
 
                     // emit stmt
                     match module_decl {
@@ -83,7 +96,7 @@ impl VisitMut for ModuleDeclStrip {
                             _ => panic!("unable to access unknown nodes"),
                         },
                         ModuleDecl::ExportDefaultExpr(..) => {
-                            list.extend(self.export_default.take().map(From::from))
+                            list.extend(self.default_export_decl.take().map(From::from))
                         }
                         ModuleDecl::ExportAll(..) => continue,
                         ModuleDecl::TsImportEquals(..) => continue,
@@ -101,7 +114,10 @@ impl VisitMut for ModuleDeclStrip {
         *n = list;
     }
 
-    // collect all static import
+    // Collect ImportEntry records from static imports.
+    // Spec:
+    // - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-importentries
+    // - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-importentriesformodule
     fn visit_mut_import_decl(&mut self, n: &mut ImportDecl) {
         if n.type_only {
             return;
@@ -111,7 +127,7 @@ impl VisitMut for ModuleDeclStrip {
             specifiers, src, ..
         } = n.take();
 
-        self.link
+        self.requested_modules
             .entry(src.value.to_atom_lossy().into_owned())
             .or_default()
             .mut_dummy_span(src.span)
@@ -131,20 +147,24 @@ impl VisitMut for ModuleDeclStrip {
     /// function x() {}
     /// class y {}
     /// ```
+    /// Spec: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-exportentries
     fn visit_mut_export_decl(&mut self, n: &mut ExportDecl) {
         match &n.decl {
             Decl::Class(ClassDecl { ident, .. }) | Decl::Fn(FnDecl { ident, .. }) => {
-                self.export.insert(
+                self.local_export_entries.insert(
                     ident.sym.clone(),
-                    ExportItem::new((ident.span, ident.ctxt), ident.clone()),
+                    LocalExportEntry::new((ident.span, ident.ctxt), ident.clone()),
                 );
             }
 
             Decl::Var(v) => {
-                self.export.extend(
-                    find_pat_ids::<_, Ident>(&v.decls)
-                        .into_iter()
-                        .map(|id| (id.sym.clone(), ExportItem::new((id.span, id.ctxt), id))),
+                self.local_export_entries.extend(
+                    find_pat_ids::<_, Ident>(&v.decls).into_iter().map(|id| {
+                        (
+                            id.sym.clone(),
+                            LocalExportEntry::new((id.span, id.ctxt), id),
+                        )
+                    }),
                 );
             }
             _ => {}
@@ -157,6 +177,9 @@ impl VisitMut for ModuleDeclStrip {
     /// export * as foo from "mod";
     /// export * as "bar" from "mod";
     /// ```
+    /// Spec:
+    /// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-exportentries
+    /// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-exportentriesformodule
     fn visit_mut_named_export(&mut self, n: &mut NamedExport) {
         if n.type_only {
             return;
@@ -167,53 +190,54 @@ impl VisitMut for ModuleDeclStrip {
         } = n.take();
 
         if let Some(src) = src {
-            self.link
+            self.requested_modules
                 .entry(src.value.to_atom_lossy().into_owned())
                 .or_default()
                 .mut_dummy_span(src.span)
                 .extend(specifiers.into_iter().map(From::from));
         } else {
-            self.export.extend(specifiers.into_iter().map(|e| match e {
-                ExportSpecifier::Namespace(..) => {
-                    unreachable!("`export *` without src is invalid")
-                }
-                ExportSpecifier::Default(..) => {
-                    unreachable!("`export foo` without src is invalid")
-                }
-                ExportSpecifier::Named(ExportNamedSpecifier { orig, exported, .. }) => {
-                    let orig = match orig {
-                        ModuleExportName::Ident(id) => id,
-                        ModuleExportName::Str(_) => {
-                            unreachable!(r#"`export {{ "foo" }}` without src is invalid"#)
-                        }
-                        #[cfg(swc_ast_unknown)]
-                        _ => panic!("unable to access unknown nodes"),
-                    };
-
-                    if let Some(exported) = exported {
-                        let (export_name, export_name_span) = match exported {
-                            ModuleExportName::Ident(Ident {
-                                ctxt, span, sym, ..
-                            }) => (sym, (span, ctxt)),
-                            ModuleExportName::Str(Str { span, value, .. }) => (
-                                value.to_atom_lossy().into_owned(),
-                                (span, Default::default()),
-                            ),
+            self.local_export_entries
+                .extend(specifiers.into_iter().map(|e| match e {
+                    ExportSpecifier::Namespace(..) => {
+                        unreachable!("`export *` without src is invalid")
+                    }
+                    ExportSpecifier::Default(..) => {
+                        unreachable!("`export foo` without src is invalid")
+                    }
+                    ExportSpecifier::Named(ExportNamedSpecifier { orig, exported, .. }) => {
+                        let orig = match orig {
+                            ModuleExportName::Ident(id) => id,
+                            ModuleExportName::Str(_) => {
+                                unreachable!(r#"`export {{ "foo" }}` without src is invalid"#)
+                            }
                             #[cfg(swc_ast_unknown)]
                             _ => panic!("unable to access unknown nodes"),
                         };
 
-                        (export_name, ExportItem::new(export_name_span, orig))
-                    } else {
-                        (
-                            orig.sym.clone(),
-                            ExportItem::new((orig.span, orig.ctxt), orig),
-                        )
+                        if let Some(exported) = exported {
+                            let (export_name, export_name_span) = match exported {
+                                ModuleExportName::Ident(Ident {
+                                    ctxt, span, sym, ..
+                                }) => (sym, (span, ctxt)),
+                                ModuleExportName::Str(Str { span, value, .. }) => (
+                                    value.to_atom_lossy().into_owned(),
+                                    (span, Default::default()),
+                                ),
+                                #[cfg(swc_ast_unknown)]
+                                _ => panic!("unable to access unknown nodes"),
+                            };
+
+                            (export_name, LocalExportEntry::new(export_name_span, orig))
+                        } else {
+                            (
+                                orig.sym.clone(),
+                                LocalExportEntry::new((orig.span, orig.ctxt), orig),
+                            )
+                        }
                     }
-                }
-                #[cfg(swc_ast_unknown)]
-                _ => panic!("unable to access unknown nodes"),
-            }))
+                    #[cfg(swc_ast_unknown)]
+                    _ => panic!("unable to access unknown nodes"),
+                }))
         }
     }
 
@@ -238,9 +262,9 @@ impl VisitMut for ModuleDeclStrip {
                     .get_or_insert_with(|| private_ident!(n.span, "_default"))
                     .clone();
 
-                self.export.insert(
+                self.local_export_entries.insert(
                     atom!("default"),
-                    ExportItem::new((n.span, Default::default()), ident),
+                    LocalExportEntry::new((n.span, Default::default()), ident),
                 );
             }
             DefaultDecl::Fn(fn_expr) => {
@@ -249,9 +273,9 @@ impl VisitMut for ModuleDeclStrip {
                     .get_or_insert_with(|| private_ident!(n.span, "_default"))
                     .clone();
 
-                self.export.insert(
+                self.local_export_entries.insert(
                     atom!("default"),
-                    ExportItem::new((n.span, Default::default()), ident),
+                    LocalExportEntry::new((n.span, Default::default()), ident),
                 );
             }
             DefaultDecl::TsInterfaceDecl(_) => {}
@@ -272,12 +296,12 @@ impl VisitMut for ModuleDeclStrip {
     fn visit_mut_export_default_expr(&mut self, n: &mut ExportDefaultExpr) {
         let ident = private_ident!(n.span, "_default");
 
-        self.export.insert(
+        self.local_export_entries.insert(
             atom!("default"),
-            ExportItem::new((n.span, Default::default()), ident.clone()),
+            LocalExportEntry::new((n.span, Default::default()), ident.clone()),
         );
 
-        self.export_default = Some(
+        self.default_export_decl = Some(
             n.expr
                 .take()
                 .into_var_decl(self.const_var_kind, ident.into())
@@ -295,11 +319,11 @@ impl VisitMut for ModuleDeclStrip {
             ..
         } = *n.take().src;
 
-        self.link
+        self.requested_modules
             .entry(src_key.to_atom_lossy().into_owned())
             .or_default()
             .mut_dummy_span(src_span)
-            .insert(LinkSpecifier::ExportStar);
+            .insert(ModuleRecordEntry::StarExport);
     }
 
     /// ```javascript
@@ -329,17 +353,19 @@ impl VisitMut for ModuleDeclStrip {
         }) = module_ref
         {
             if *is_export {
-                self.export.insert(
+                self.local_export_entries.insert(
                     id.sym.clone(),
-                    ExportItem::new((id.span, id.ctxt), id.clone()),
+                    LocalExportEntry::new((id.span, id.ctxt), id.clone()),
                 );
             }
 
-            self.link
+            self.requested_modules
                 .entry(src_key.to_atom_lossy().into_owned())
                 .or_default()
                 .mut_dummy_span(*span)
-                .insert(LinkSpecifier::ImportEqual(id.to_id()));
+                .insert(ModuleRecordEntry::TsImportEquals {
+                    local_name: id.to_id(),
+                });
         }
     }
 
@@ -351,8 +377,15 @@ impl VisitMut for ModuleDeclStrip {
     }
 }
 
+/// ImportEntry and ExportEntry record fields used by this transform.
+///
+/// Spec:
+/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-importentry-record-fields
+/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-exportentry-record-fields
+/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-importentries
+/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-exportentries
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub enum LinkSpecifier {
+pub enum ModuleRecordEntry {
     ///```javascript
     /// import "mod";
     /// import {} from "mod",
@@ -366,27 +399,35 @@ pub enum LinkSpecifier {
     /// import { imported as local, local } from "mod";
     /// import { "imported" as local } from "mod";
     /// ```
-    /// Note: imported will never be `default`
-    ImportNamed { imported: Option<Atom>, local: Id },
+    /// Note: `import_name` will never be `default`.
+    ImportNamed {
+        import_name: Option<Atom>,
+        local_name: Id,
+    },
 
     /// ```javascript
     /// import foo from "mod";
     /// ```
-    ImportDefault(Id),
+    ImportDefault { local_name: Id },
 
     /// ```javascript
     /// import * as foo from "mod";
     /// ```
-    ImportStarAs(Id),
+    /// The spec resolves this to a Module Namespace Exotic Object. This legacy
+    /// module transform emits an interop object instead.
+    /// Spec:
+    /// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getmodulenamespace
+    /// - https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-module-namespace-exotic-objects
+    ImportNamespace { local_name: Id },
 
     /// ```javascript
     /// export { orig, orig as exported } from "mod";
     /// export { "orig", "orig" as "exported" } from "mod";
     /// ```
-    /// Note: orig will never be `default`
-    ExportNamed {
-        orig: (Atom, SpanCtx),
-        exported: Option<(Atom, SpanCtx)>,
+    /// Note: `import_name` will never be `default`.
+    IndirectExportNamed {
+        import_name: (Atom, SpanCtx),
+        export_name: Option<(Atom, SpanCtx)>,
     },
 
     /// ```javascript
@@ -394,49 +435,68 @@ pub enum LinkSpecifier {
     /// export { "default" } from "foo";
     /// export { default as foo } from "mod";
     /// ```
-    /// (default_span, local_sym, local_span)
-    ExportDefaultAs(SpanCtx, Atom, SpanCtx),
+    IndirectExportDefault {
+        export_name: Atom,
+        export_name_span: SpanCtx,
+    },
 
     /// ```javascript
     /// export * as foo from "mod";
     /// export * as "bar" from "mod";
     /// ```
-    ExportStarAs(Atom, SpanCtx),
+    /// The spec resolves this to a namespace export binding. This transform
+    /// emits a legacy interop object getter instead.
+    /// Spec:
+    /// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-resolveexport
+    /// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getmodulenamespace
+    IndirectExportNamespace {
+        export_name: Atom,
+        export_name_span: SpanCtx,
+    },
 
     /// ```javascript
     /// export * from "mod";
     /// ```
-    ExportStar,
+    /// Related spec operation: `GetExportedNames` walks
+    /// `[[StarExportEntries]]` and omits `default` from star-exported names.
+    /// https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getexportednames
+    StarExport,
 
     /// ```javascript
     /// import foo = require("foo");
     /// ```
-    ImportEqual(Id),
+    TsImportEquals { local_name: Id },
 }
 
-impl From<ImportSpecifier> for LinkSpecifier {
+impl From<ImportSpecifier> for ModuleRecordEntry {
     fn from(i: ImportSpecifier) -> Self {
         match i {
             ImportSpecifier::Namespace(ImportStarAsSpecifier { local, .. }) => {
-                Self::ImportStarAs(local.to_id())
+                Self::ImportNamespace {
+                    local_name: local.to_id(),
+                }
             }
 
-            ImportSpecifier::Default(ImportDefaultSpecifier { local, .. }) => {
-                Self::ImportDefault(local.to_id())
-            }
+            ImportSpecifier::Default(ImportDefaultSpecifier { local, .. }) => Self::ImportDefault {
+                local_name: local.to_id(),
+            },
             ImportSpecifier::Named(ImportNamedSpecifier {
                 is_type_only: false,
                 local,
                 imported: Some(ModuleExportName::Ident(Ident { sym: s, .. })),
                 ..
-            }) if &*s == "default" => Self::ImportDefault(local.to_id()),
+            }) if &*s == "default" => Self::ImportDefault {
+                local_name: local.to_id(),
+            },
 
             ImportSpecifier::Named(ImportNamedSpecifier {
                 is_type_only: false,
                 local,
                 imported: Some(ModuleExportName::Str(Str { value: s, .. })),
                 ..
-            }) if &s == "default" => Self::ImportDefault(local.to_id()),
+            }) if &s == "default" => Self::ImportDefault {
+                local_name: local.to_id(),
+            },
 
             ImportSpecifier::Named(ImportNamedSpecifier {
                 is_type_only: false,
@@ -444,7 +504,7 @@ impl From<ImportSpecifier> for LinkSpecifier {
                 imported,
                 ..
             }) => {
-                let imported = imported.and_then(|e| match e {
+                let import_name = imported.and_then(|e| match e {
                     ModuleExportName::Ident(Ident { sym, .. }) => Some(sym),
                     ModuleExportName::Str(Str { value, .. }) => value.as_atom().cloned(),
                     #[cfg(swc_ast_unknown)]
@@ -452,8 +512,8 @@ impl From<ImportSpecifier> for LinkSpecifier {
                 });
 
                 Self::ImportNamed {
-                    local: local.to_id(),
-                    imported,
+                    local_name: local.to_id(),
+                    import_name,
                 }
             }
             _ => Self::Empty,
@@ -461,7 +521,7 @@ impl From<ImportSpecifier> for LinkSpecifier {
     }
 }
 
-impl From<ExportSpecifier> for LinkSpecifier {
+impl From<ExportSpecifier> for ModuleRecordEntry {
     fn from(e: ExportSpecifier) -> Self {
         match e {
             ExportSpecifier::Namespace(ExportNamespaceSpecifier {
@@ -470,22 +530,24 @@ impl From<ExportSpecifier> for LinkSpecifier {
                         span, value: sym, ..
                     }),
                 ..
-            }) => Self::ExportStarAs(
-                sym.to_atom_lossy().into_owned(),
-                (span, SyntaxContext::empty()),
-            ),
+            }) => Self::IndirectExportNamespace {
+                export_name: sym.to_atom_lossy().into_owned(),
+                export_name_span: (span, SyntaxContext::empty()),
+            },
             ExportSpecifier::Namespace(ExportNamespaceSpecifier {
                 name: ModuleExportName::Ident(Ident { span, sym, .. }),
                 ..
-            }) => Self::ExportStarAs(sym, (span, SyntaxContext::empty())),
+            }) => Self::IndirectExportNamespace {
+                export_name: sym,
+                export_name_span: (span, SyntaxContext::empty()),
+            },
 
             ExportSpecifier::Default(ExportDefaultSpecifier { exported }) => {
                 // https://github.com/tc39/proposal-export-default-from
-                Self::ExportDefaultAs(
-                    (exported.span, exported.ctxt),
-                    exported.sym,
-                    (exported.span, exported.ctxt),
-                )
+                Self::IndirectExportDefault {
+                    export_name: exported.sym,
+                    export_name_span: (exported.span, exported.ctxt),
+                }
             }
 
             ExportSpecifier::Named(ExportNamedSpecifier {
@@ -523,12 +585,18 @@ impl From<ExportSpecifier> for LinkSpecifier {
                 });
 
                 match (&*orig.0, orig.1) {
-                    ("default", default_span) => {
+                    ("default", _) => {
                         let (sym, span) = exported.unwrap_or(orig);
 
-                        Self::ExportDefaultAs(default_span, sym, span)
+                        Self::IndirectExportDefault {
+                            export_name: sym,
+                            export_name_span: span,
+                        }
                     }
-                    _ => Self::ExportNamed { orig, exported },
+                    _ => Self::IndirectExportNamed {
+                        import_name: orig,
+                        export_name: exported,
+                    },
                 }
             }
             _ => Self::Empty,
@@ -537,23 +605,34 @@ impl From<ExportSpecifier> for LinkSpecifier {
 }
 
 #[derive(Debug, Default)]
-pub struct LinkItem(pub SpanCtx, pub FxHashSet<LinkSpecifier>, pub LinkFlag);
+pub struct RequestedModule {
+    /// First useful source span for the module request. The spec tracks this as
+    /// a ModuleRequest Record; emitters keep the span for generated literals
+    /// and diagnostics.
+    ///
+    /// Spec: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-module-request-records
+    pub span: SpanCtx,
+    /// ImportEntry and ExportEntry records associated with this module request.
+    pub entries: FxHashSet<ModuleRecordEntry>,
+    /// Emitter-only summary of which runtime module shape is needed.
+    pub usage: ModuleRequestUsage,
+}
 
 use bitflags::bitflags;
 
 bitflags! {
     #[derive(Default, Debug)]
-    pub struct LinkFlag: u8 {
+    pub struct ModuleRequestUsage: u8 {
         const NAMED = 1 << 0;
         const DEFAULT = 1 << 1;
         const NAMESPACE = Self::NAMED.bits() | Self::DEFAULT.bits();
-        const EXPORT_STAR = 1 << 2;
-        const IMPORT_EQUAL = 1 << 3;
+        const STAR_EXPORT = 1 << 2;
+        const TS_IMPORT_EQUALS = 1 << 3;
     }
 }
 
-impl LinkFlag {
-    pub fn interop(&self) -> bool {
+impl ModuleRequestUsage {
+    pub fn needs_interop(&self) -> bool {
         self.intersects(Self::DEFAULT)
     }
 
@@ -561,38 +640,38 @@ impl LinkFlag {
         self.intersects(Self::NAMED)
     }
 
-    pub fn namespace(&self) -> bool {
+    pub fn needs_namespace_object(&self) -> bool {
         self.contains(Self::NAMESPACE)
     }
 
-    pub fn need_raw_import(&self) -> bool {
-        self.interop() && self.intersects(Self::IMPORT_EQUAL)
+    pub fn needs_raw_import_for_ts_import_equals(&self) -> bool {
+        self.needs_interop() && self.intersects(Self::TS_IMPORT_EQUALS)
     }
 
-    pub fn export_star(&self) -> bool {
-        self.intersects(Self::EXPORT_STAR)
+    pub fn has_star_export(&self) -> bool {
+        self.intersects(Self::STAR_EXPORT)
     }
 }
 
-impl From<&LinkSpecifier> for LinkFlag {
-    fn from(s: &LinkSpecifier) -> Self {
+impl From<&ModuleRecordEntry> for ModuleRequestUsage {
+    fn from(s: &ModuleRecordEntry) -> Self {
         match s {
-            LinkSpecifier::Empty => Self::empty(),
-            LinkSpecifier::ImportStarAs(..) => Self::NAMESPACE,
-            LinkSpecifier::ImportDefault(..) => Self::DEFAULT,
-            LinkSpecifier::ImportNamed { .. } => Self::NAMED,
+            ModuleRecordEntry::Empty => Self::empty(),
+            ModuleRecordEntry::ImportNamespace { .. } => Self::NAMESPACE,
+            ModuleRecordEntry::ImportDefault { .. } => Self::DEFAULT,
+            ModuleRecordEntry::ImportNamed { .. } => Self::NAMED,
 
-            LinkSpecifier::ExportStarAs(..) => Self::NAMESPACE,
-            LinkSpecifier::ExportDefaultAs(..) => Self::DEFAULT,
-            LinkSpecifier::ExportNamed { .. } => Self::NAMED,
+            ModuleRecordEntry::IndirectExportNamespace { .. } => Self::NAMESPACE,
+            ModuleRecordEntry::IndirectExportDefault { .. } => Self::DEFAULT,
+            ModuleRecordEntry::IndirectExportNamed { .. } => Self::NAMED,
 
-            LinkSpecifier::ImportEqual(..) => Self::IMPORT_EQUAL,
-            LinkSpecifier::ExportStar => Self::EXPORT_STAR,
+            ModuleRecordEntry::TsImportEquals { .. } => Self::TS_IMPORT_EQUALS,
+            ModuleRecordEntry::StarExport => Self::STAR_EXPORT,
         }
     }
 }
 
-impl From<&ImportSpecifier> for LinkFlag {
+impl From<&ImportSpecifier> for ModuleRequestUsage {
     fn from(i: &ImportSpecifier) -> Self {
         match i {
             ImportSpecifier::Namespace(..) => Self::NAMESPACE,
@@ -621,7 +700,7 @@ impl From<&ImportSpecifier> for LinkFlag {
     }
 }
 
-impl From<&ExportSpecifier> for LinkFlag {
+impl From<&ExportSpecifier> for ModuleRequestUsage {
     fn from(e: &ExportSpecifier) -> Self {
         match e {
             ExportSpecifier::Namespace(..) => Self::NAMESPACE,
@@ -651,37 +730,44 @@ impl From<&ExportSpecifier> for LinkFlag {
     }
 }
 
-impl Extend<LinkSpecifier> for LinkItem {
-    fn extend<T: IntoIterator<Item = LinkSpecifier>>(&mut self, iter: T) {
+impl Extend<ModuleRecordEntry> for RequestedModule {
+    fn extend<T: IntoIterator<Item = ModuleRecordEntry>>(&mut self, iter: T) {
         iter.into_iter().for_each(|link| {
             self.insert(link);
         });
     }
 }
 
-impl LinkItem {
+impl RequestedModule {
     fn mut_dummy_span(&mut self, span: Span) -> &mut Self {
-        if self.0 .0.is_dummy() {
-            self.0 .0 = span;
+        if self.span.0.is_dummy() {
+            self.span.0 = span;
         }
 
         self
     }
 
-    fn insert(&mut self, link: LinkSpecifier) -> bool {
-        self.2 |= (&link).into();
-        self.1.insert(link)
+    fn insert(&mut self, entry: ModuleRecordEntry) -> bool {
+        self.usage |= (&entry).into();
+        self.entries.insert(entry)
     }
 }
 
-pub(crate) type ExportObjPropList = Vec<ExportKV>;
+pub(crate) type ExportObjectProperties = Vec<ExportBinding>;
 
-/// Reduce self to generate ImportMap and ExportObjPropList
-pub(crate) trait LinkSpecifierReducer {
+/// Reduce module record entries into the import map and export object
+/// properties required by CommonJS-like emitters.
+///
+/// This is not a full ECMAScript module linker. It only lowers collected
+/// syntactic entries to emitter-local data structures; the corresponding spec
+/// operations for linked modules are `GetExportedNames` and `ResolveExport`.
+/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getexportednames
+/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-resolveexport
+pub(crate) trait ModuleRecordEntryReducer {
     fn reduce(
         self,
         import_map: &mut ImportMap,
-        export_obj_prop_list: &mut ExportObjPropList,
+        export_bindings: &mut ExportObjectProperties,
         mod_ident: &Ident,
         raw_mod_ident: &Option<Ident>,
         ref_to_mod_ident: &mut bool,
@@ -690,42 +776,48 @@ pub(crate) trait LinkSpecifierReducer {
     );
 }
 
-impl LinkSpecifierReducer for FxHashSet<LinkSpecifier> {
+impl ModuleRecordEntryReducer for FxHashSet<ModuleRecordEntry> {
     fn reduce(
         self,
         import_map: &mut ImportMap,
-        export_obj_prop_list: &mut ExportObjPropList,
+        export_bindings: &mut ExportObjectProperties,
         mod_ident: &Ident,
         raw_mod_ident: &Option<Ident>,
         ref_to_mod_ident: &mut bool,
         default_nowrap: bool,
     ) {
         self.into_iter().for_each(|s| match s {
-            LinkSpecifier::ImportNamed { imported, local } => {
+            ModuleRecordEntry::ImportNamed {
+                import_name,
+                local_name,
+            } => {
                 *ref_to_mod_ident = true;
 
                 import_map.insert(
-                    local.clone(),
-                    (mod_ident.clone(), imported.or(Some(local.0))),
+                    local_name.clone(),
+                    (mod_ident.clone(), import_name.or(Some(local_name.0))),
                 );
             }
-            LinkSpecifier::ImportDefault(id) => {
+            ModuleRecordEntry::ImportDefault { local_name } => {
                 *ref_to_mod_ident = true;
 
                 import_map.insert(
-                    id,
+                    local_name,
                     (
                         mod_ident.clone(),
                         (!default_nowrap).then(|| atom!("default")),
                     ),
                 );
             }
-            LinkSpecifier::ImportStarAs(id) => {
+            ModuleRecordEntry::ImportNamespace { local_name } => {
                 *ref_to_mod_ident = true;
 
-                import_map.insert(id, (mod_ident.clone(), None));
+                import_map.insert(local_name, (mod_ident.clone(), None));
             }
-            LinkSpecifier::ExportNamed { orig, exported } => {
+            ModuleRecordEntry::IndirectExportNamed {
+                import_name,
+                export_name,
+            } => {
                 *ref_to_mod_ident = true;
 
                 // ```javascript
@@ -737,19 +829,27 @@ impl LinkSpecifierReducer for FxHashSet<LinkSpecifier> {
 
                 // foo -> mod.foo
                 import_map.insert(
-                    (orig.0.clone(), orig.1 .1),
-                    (mod_ident.clone(), Some(orig.0.clone())),
+                    (import_name.0.clone(), import_name.1 .1),
+                    (mod_ident.clone(), Some(import_name.0.clone())),
                 );
 
-                let (export_name, export_name_span) = exported.unwrap_or_else(|| orig.clone());
+                let (export_name, export_name_span) =
+                    export_name.unwrap_or_else(|| import_name.clone());
 
                 // bar -> foo
-                export_obj_prop_list.push((
+                export_bindings.push((
                     export_name,
-                    ExportItem::new(export_name_span, quote_ident!(orig.1 .1, orig.1 .0, orig.0)),
+                    LocalExportEntry::new(
+                        export_name_span,
+                        quote_ident!(import_name.1 .1, import_name.1 .0, import_name.0),
+                    ),
                 ))
             }
-            LinkSpecifier::ExportDefaultAs(_, key, span) => {
+            ModuleRecordEntry::IndirectExportDefault {
+                export_name,
+                export_name_span,
+                ..
+            } => {
                 *ref_to_mod_ident = true;
 
                 // ```javascript
@@ -761,41 +861,50 @@ impl LinkSpecifierReducer for FxHashSet<LinkSpecifier> {
 
                 // foo -> mod.default
                 import_map.insert(
-                    (key.clone(), span.1),
+                    (export_name.clone(), export_name_span.1),
                     (mod_ident.clone(), Some(atom!("default"))),
                 );
 
-                export_obj_prop_list.push((
-                    key.clone(),
-                    ExportItem::new(span, quote_ident!(span.1, span.0, key)),
+                export_bindings.push((
+                    export_name.clone(),
+                    LocalExportEntry::new(
+                        export_name_span,
+                        quote_ident!(export_name_span.1, export_name_span.0, export_name),
+                    ),
                 ));
             }
-            LinkSpecifier::ExportStarAs(key, span) => {
+            ModuleRecordEntry::IndirectExportNamespace {
+                export_name,
+                export_name_span,
+            } => {
                 *ref_to_mod_ident = true;
 
-                export_obj_prop_list.push((key, ExportItem::new(span, mod_ident.clone())));
+                export_bindings.push((
+                    export_name,
+                    LocalExportEntry::new(export_name_span, mod_ident.clone()),
+                ));
             }
-            LinkSpecifier::ExportStar => {}
-            LinkSpecifier::ImportEqual(id) => {
+            ModuleRecordEntry::StarExport => {}
+            ModuleRecordEntry::TsImportEquals { local_name } => {
                 *ref_to_mod_ident = true;
 
                 import_map.insert(
-                    id,
+                    local_name,
                     (
                         raw_mod_ident.clone().unwrap_or_else(|| mod_ident.clone()),
                         None,
                     ),
                 );
             }
-            LinkSpecifier::Empty => {}
+            ModuleRecordEntry::Empty => {}
         })
     }
 }
 
 #[derive(Debug)]
-pub struct ExportItem(SpanCtx, Ident);
+pub struct LocalExportEntry(SpanCtx, Ident);
 
-impl ExportItem {
+impl LocalExportEntry {
     pub fn new(export_name_span: SpanCtx, local_ident: Ident) -> Self {
         Self(export_name_span, local_ident)
     }
@@ -809,4 +918,4 @@ impl ExportItem {
     }
 }
 
-pub type ExportKV = (Atom, ExportItem);
+pub type ExportBinding = (Atom, LocalExportEntry);

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -14,13 +14,16 @@ use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith
 use self::config::BuiltConfig;
 pub use self::config::Config;
 use crate::{
-    module_decl_strip::{Export, Link, LinkFlag, LinkItem, LinkSpecifierReducer, ModuleDeclStrip},
+    module_record::{
+        LocalExportEntries, ModuleRecordEntryReducer, ModuleRequestUsage, ModuleSyntaxExtractor,
+        RequestedModule, RequestedModules,
+    },
     module_ref_rewriter::{rewrite_import_bindings, ImportMap},
     path::Resolver,
     top_level_this::top_level_this,
     util::{
-        define_es_module, emit_export_stmts, local_name_for_src, sort_export_obj_prop_list,
-        use_strict, ImportInterop, VecStmtLike,
+        define_es_module, emit_export_stmts, local_name_for_src, sort_export_bindings, use_strict,
+        ImportInterop, VecStmtLike,
     },
     SpanCtx,
 };
@@ -98,26 +101,31 @@ impl VisitMut for Umd {
 
         let import_interop = self.config.config.import_interop();
 
-        let mut strip = ModuleDeclStrip::new(self.const_var_kind);
-        module_items.visit_mut_with(&mut strip);
+        let mut extractor = ModuleSyntaxExtractor::new(self.const_var_kind);
+        module_items.visit_mut_with(&mut extractor);
 
-        let ModuleDeclStrip {
-            link,
-            export,
+        let ModuleSyntaxExtractor {
+            requested_modules,
+            local_export_entries,
             export_assign,
-            has_module_decl,
+            has_module_syntax,
             ..
-        } = strip;
+        } = extractor;
 
         let is_export_assign = export_assign.is_some();
 
-        if has_module_decl && !import_interop.is_none() && !is_export_assign {
+        if has_module_syntax && !import_interop.is_none() && !is_export_assign {
             stmts.push(define_es_module(self.exports()))
         }
 
         let mut import_map = Default::default();
 
-        stmts.extend(self.handle_import_export(&mut import_map, link, export, is_export_assign));
+        stmts.extend(self.handle_import_export(
+            &mut import_map,
+            requested_modules,
+            local_export_entries,
+            is_export_assign,
+        ));
 
         stmts.extend(module_items.take().into_iter().filter_map(|i| match i {
             ModuleItem::Stmt(stmt) if !stmt.is_empty() => Some(stmt),
@@ -172,27 +180,34 @@ impl Umd {
     fn handle_import_export(
         &mut self,
         import_map: &mut ImportMap,
-        link: Link,
-        export: Export,
+        requested_modules: RequestedModules,
+        local_export_entries: LocalExportEntries,
         is_export_assign: bool,
     ) -> impl Iterator<Item = Stmt> {
         let import_interop = self.config.config.import_interop();
 
-        let mut stmts = Vec::with_capacity(link.len());
+        let mut stmts = Vec::with_capacity(requested_modules.len());
 
-        let mut export_obj_prop_list = export.into_iter().collect();
+        let mut export_bindings = local_export_entries.into_iter().collect();
 
-        link.into_iter().for_each(
-            |(src, LinkItem(src_span, link_specifier_set, mut link_flag))| {
-                let is_node_default = !link_flag.has_named() && import_interop.is_node();
+        requested_modules.into_iter().for_each(
+            |(
+                src,
+                RequestedModule {
+                    span: src_span,
+                    entries: module_entries,
+                    usage: mut module_usage,
+                },
+            )| {
+                let is_node_default = !module_usage.has_named() && import_interop.is_node();
 
                 if import_interop.is_none() {
-                    link_flag -= LinkFlag::NAMESPACE;
+                    module_usage -= ModuleRequestUsage::NAMESPACE;
                 }
 
-                let need_re_export = link_flag.export_star();
-                let need_interop = link_flag.interop();
-                let need_new_var = link_flag.need_raw_import();
+                let need_re_export = module_usage.has_star_export();
+                let need_interop = module_usage.needs_interop();
+                let need_new_var = module_usage.needs_raw_import_for_ts_import_equals();
 
                 let mod_ident = private_ident!(local_name_for_src(&src));
                 let new_var_ident = if need_new_var {
@@ -203,9 +218,9 @@ impl Umd {
 
                 self.dep_list.push((mod_ident.clone(), src, src_span));
 
-                link_specifier_set.reduce(
+                module_entries.reduce(
                     import_map,
-                    &mut export_obj_prop_list,
+                    &mut export_bindings,
                     &new_var_ident,
                     &Some(mod_ident.clone()),
                     &mut false,
@@ -225,13 +240,15 @@ impl Umd {
                 // _introp(mod);
                 if need_interop {
                     import_expr = match import_interop {
-                        ImportInterop::Swc if link_flag.interop() => if link_flag.namespace() {
-                            helper_expr!(interop_require_wildcard)
-                        } else {
-                            helper_expr!(interop_require_default)
+                        ImportInterop::Swc if module_usage.needs_interop() => {
+                            if module_usage.needs_namespace_object() {
+                                helper_expr!(interop_require_wildcard)
+                            } else {
+                                helper_expr!(interop_require_default)
+                            }
+                            .as_call(PURE_SP, vec![import_expr.as_arg()])
                         }
-                        .as_call(PURE_SP, vec![import_expr.as_arg()]),
-                        ImportInterop::Node if link_flag.namespace() => {
+                        ImportInterop::Node if module_usage.needs_namespace_object() => {
                             helper_expr!(interop_require_wildcard)
                                 .as_call(PURE_SP, vec![import_expr.as_arg(), true.as_arg()])
                         }
@@ -260,12 +277,12 @@ impl Umd {
 
         let mut export_stmts = Default::default();
 
-        if !export_obj_prop_list.is_empty() && !is_export_assign {
-            sort_export_obj_prop_list(&mut export_obj_prop_list);
+        if !export_bindings.is_empty() && !is_export_assign {
+            sort_export_bindings(&mut export_bindings);
 
             let exports = self.exports();
 
-            export_stmts = emit_export_stmts(exports, export_obj_prop_list);
+            export_stmts = emit_export_stmts(exports, export_bindings);
         }
 
         export_stmts.into_iter().chain(stmts)

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -10,7 +10,7 @@ use swc_ecma_utils::{
 };
 
 use crate::{
-    module_decl_strip::{ExportItem, ExportKV},
+    module_record::{ExportBinding, LocalExportEntry},
     SpanCtx,
 };
 
@@ -335,11 +335,11 @@ pub(crate) fn esm_export() -> Function {
 /// Sort export properties by key without allocating cached keys or cloning
 /// `Atom`s for each entry.
 #[inline]
-pub(crate) fn sort_export_obj_prop_list(prop_list: &mut [ExportKV]) {
+pub(crate) fn sort_export_bindings(prop_list: &mut [ExportBinding]) {
     prop_list.sort_unstable_by(|a, b| a.0.cmp(&b.0));
 }
 
-pub(crate) fn emit_export_stmts(exports: Ident, mut prop_list: Vec<ExportKV>) -> Vec<Stmt> {
+pub(crate) fn emit_export_stmts(exports: Ident, mut prop_list: Vec<ExportBinding>) -> Vec<Stmt> {
     match prop_list.len() {
         0 | 1 => prop_list
             .pop()
@@ -349,7 +349,7 @@ pub(crate) fn emit_export_stmts(exports: Ident, mut prop_list: Vec<ExportKV>) ->
                     quote_str!(export_item.export_name_span().0, export_name).as_arg(),
                     prop_function((
                         "get".into(),
-                        ExportItem::new(Default::default(), export_item.into_local_ident()),
+                        LocalExportEntry::new(Default::default(), export_item.into_local_ident()),
                     ))
                     .into(),
                 )
@@ -423,7 +423,7 @@ impl From<IdentOrStr> for MemberProp {
 ///     },
 /// }
 /// ```
-pub(crate) fn prop_function((key, export_item): ExportKV) -> Prop {
+pub(crate) fn prop_function((key, export_item): ExportBinding) -> Prop {
     let key = prop_name(&key, export_item.export_name_span()).into();
 
     KeyValueProp {
@@ -447,7 +447,7 @@ pub(crate) fn prop_function((key, export_item): ExportKV) -> Prop {
 /// }
 /// ```
 /// Compatibility: getter is supported in Node.js v0.10+
-fn getter_function((key, export_item): ExportKV) -> Prop {
+fn getter_function((key, export_item): ExportBinding) -> Prop {
     let key = prop_name(&key, export_item.export_name_span()).into();
 
     GetterProp {


### PR DESCRIPTION
**Description:**

This PR refactors the shared CommonJS/AMD/UMD module-lowering collection layer to use terminology and boundaries closer to ECMAScript module records.

The old `ModuleDeclStrip` abstraction mixed declaration stripping, module request collection, export collection, and emitter-facing naming. This change renames and reshapes that layer into `module_record.rs` with clearer concepts:

- `ModuleRecordCollector`
- `RequestedModules` / `RequestedModule`
- `ModuleRecordEntry`
- `ModuleRequestUsage`
- `LocalExportEntries`
- `ModuleRecordEntryReducer`
- `ExportBinding`

CJS, AMD, and UMD now consume the same module-record-oriented data model while preserving their existing emit behavior. The format-specific passes still own wrapper shape, dependency emission, interop helper application, `export =` handling, and import-reference rewriting.

This is intended to be a behavior-preserving refactor. The main goal is to make the transform pipeline easier to reason about and maintain before future module interop work.

The README was also expanded with diagrams and a short walkthrough of the transform flow.

Verification:

- `cargo fmt --all`
- `cargo test -p swc_ecma_transforms_module`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A