### PR TITLE
fix(es/react): Emit jsxdev source for fragments

### DIFF
--- a/.changeset/jsxdev-fragment-source.md
+++ b/.changeset/jsxdev-fragment-source.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_react: patch
+---
+
+fix(es/react): Emit jsxdev source for fragments

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -30,7 +30,10 @@ use swc_ecma_utils::{
 use swc_ecma_visit::VisitMut;
 
 use self::static_check::should_use_create_element;
-use crate::refresh::options::{deserialize_refresh, RefreshOptions};
+use crate::{
+    jsx_self::JsxSelfCtx,
+    refresh::options::{deserialize_refresh, RefreshOptions},
+};
 
 mod static_check;
 #[cfg(test)]
@@ -245,6 +248,7 @@ where
             .throw_if_namespace
             .unwrap_or_else(default_throw_if_namespace),
         top_level_node: true,
+        self_ctx: JsxSelfCtx::new(),
     }
 }
 
@@ -295,6 +299,7 @@ where
     pragma_frag: Lrc<Box<Expr>>,
     development: bool,
     throw_if_namespace: bool,
+    self_ctx: JsxSelfCtx,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -489,6 +494,47 @@ impl<C> Jsx<C>
 where
     C: Comments,
 {
+    /// Build the JSXDEV source argument for fragments, which cannot carry
+    /// synthetic attributes.
+    fn jsx_dev_source_arg(&self, span: Span) -> ExprOrSpread {
+        if span == DUMMY_SP {
+            return Expr::undefined(DUMMY_SP).as_arg();
+        }
+
+        let loc = self.cm.lookup_char_pos(span.lo);
+
+        ObjectLit {
+            span: DUMMY_SP,
+            props: vec![
+                PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                    key: PropName::Ident(quote_ident!("fileName")),
+                    value: Box::new(Expr::Lit(Lit::Str(Str {
+                        span: DUMMY_SP,
+                        raw: None,
+                        value: loc.file.name.to_string().into(),
+                    }))),
+                }))),
+                PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                    key: PropName::Ident(quote_ident!("lineNumber")),
+                    value: loc.line.into(),
+                }))),
+                PropOrSpread::Prop(Box::new(Prop::KeyValue(KeyValueProp {
+                    key: PropName::Ident(quote_ident!("columnNumber")),
+                    value: (loc.col.0 + 1).into(),
+                }))),
+            ],
+        }
+        .as_arg()
+    }
+
+    fn jsx_dev_self_arg(&self) -> ExprOrSpread {
+        if self.self_ctx.can_add_self() {
+            ThisExpr { span: DUMMY_SP }.as_arg()
+        } else {
+            Expr::undefined(DUMMY_SP).as_arg()
+        }
+    }
+
     /// Process JSX attribute value, handling JSXElements and JSXFragments
     fn process_attr_value(&mut self, value: Option<JSXAttrValue>) -> Box<Expr> {
         match value {
@@ -636,6 +682,8 @@ where
                         props_obj.as_arg(),
                         Expr::undefined(DUMMY_SP).as_arg(),
                         use_jsxs.as_arg(),
+                        self.jsx_dev_source_arg(el.opening.span),
+                        self.jsx_dev_self_arg(),
                     ]
                 } else {
                     vec![fragment.as_arg(), props_obj.as_arg()]
@@ -1160,6 +1208,86 @@ impl<C> VisitMutHook<()> for Jsx<C>
 where
     C: Comments,
 {
+    fn enter_class(&mut self, n: &mut Class, _ctx: &mut ()) {
+        self.self_ctx.enter_class(n);
+    }
+
+    fn exit_class(&mut self, _n: &mut Class, _ctx: &mut ()) {
+        self.self_ctx.pop();
+    }
+
+    fn enter_fn_decl(&mut self, _n: &mut FnDecl, _ctx: &mut ()) {
+        self.self_ctx.enter_non_constructor_scope();
+    }
+
+    fn exit_fn_decl(&mut self, _n: &mut FnDecl, _ctx: &mut ()) {
+        self.self_ctx.pop();
+    }
+
+    fn enter_fn_expr(&mut self, _n: &mut FnExpr, _ctx: &mut ()) {
+        self.self_ctx.enter_non_constructor_scope();
+    }
+
+    fn exit_fn_expr(&mut self, _n: &mut FnExpr, _ctx: &mut ()) {
+        self.self_ctx.pop();
+    }
+
+    fn enter_getter_prop(&mut self, _n: &mut GetterProp, _ctx: &mut ()) {
+        self.self_ctx.enter_non_constructor_scope();
+    }
+
+    fn exit_getter_prop(&mut self, _n: &mut GetterProp, _ctx: &mut ()) {
+        self.self_ctx.pop();
+    }
+
+    fn enter_setter_prop(&mut self, _n: &mut SetterProp, _ctx: &mut ()) {
+        self.self_ctx.enter_non_constructor_scope();
+    }
+
+    fn exit_setter_prop(&mut self, _n: &mut SetterProp, _ctx: &mut ()) {
+        self.self_ctx.pop();
+    }
+
+    fn enter_method_prop(&mut self, _n: &mut MethodProp, _ctx: &mut ()) {
+        self.self_ctx.enter_non_constructor_scope();
+    }
+
+    fn exit_method_prop(&mut self, _n: &mut MethodProp, _ctx: &mut ()) {
+        self.self_ctx.pop();
+    }
+
+    fn enter_constructor(&mut self, _n: &mut Constructor, _ctx: &mut ()) {
+        self.self_ctx.enter_constructor();
+    }
+
+    fn exit_constructor(&mut self, _n: &mut Constructor, _ctx: &mut ()) {
+        self.self_ctx.pop();
+    }
+
+    fn enter_class_method(&mut self, _n: &mut ClassMethod, _ctx: &mut ()) {
+        self.self_ctx.enter_non_constructor_scope();
+    }
+
+    fn exit_class_method(&mut self, _n: &mut ClassMethod, _ctx: &mut ()) {
+        self.self_ctx.pop();
+    }
+
+    fn enter_private_method(&mut self, _n: &mut PrivateMethod, _ctx: &mut ()) {
+        self.self_ctx.enter_non_constructor_scope();
+    }
+
+    fn exit_private_method(&mut self, _n: &mut PrivateMethod, _ctx: &mut ()) {
+        self.self_ctx.pop();
+    }
+
+    fn enter_static_block(&mut self, _n: &mut StaticBlock, _ctx: &mut ()) {
+        self.self_ctx.enter_non_constructor_scope();
+    }
+
+    fn exit_static_block(&mut self, _n: &mut StaticBlock, _ctx: &mut ()) {
+        self.self_ctx.pop();
+    }
+
     /// Called after visiting children of an expression.
     ///
     /// This is where we transform JSX syntax to JavaScript function calls.

--- a/crates/swc_ecma_transforms_react/src/jsx_self/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx_self/mod.rs
@@ -12,7 +12,7 @@ mod tests;
 pub fn hook(dev: bool) -> impl VisitMutHook<()> {
     JsxSelf {
         dev,
-        ctx_stack: vec![Context::default()],
+        ctx: JsxSelfCtx::new(),
     }
 }
 
@@ -23,28 +23,76 @@ struct Context {
     in_derived_class: bool,
 }
 
-struct JsxSelf {
-    dev: bool,
+/// Tracks when JSXDEV can safely use `this` for the self argument.
+///
+/// This mirrors Babel's `transform-react-jsx-self` constructor guard. Arrow
+/// functions keep the surrounding `this`, so they intentionally do not enter a
+/// new context.
+pub(crate) struct JsxSelfCtx {
     ctx_stack: Vec<Context>,
 }
 
-impl JsxSelf {
-    fn current_ctx(&self) -> Context {
+impl JsxSelfCtx {
+    pub(crate) fn new() -> Self {
+        Self {
+            ctx_stack: vec![Context::default()],
+        }
+    }
+
+    fn current(&self) -> Context {
         *self
             .ctx_stack
             .last()
             .expect("context stack should never be empty")
     }
 
-    fn push_ctx(&mut self, ctx: Context) {
+    fn push(&mut self, ctx: Context) {
         self.ctx_stack.push(ctx);
     }
 
-    fn pop_ctx(&mut self) {
+    pub(crate) fn pop(&mut self) {
         if self.ctx_stack.len() > 1 {
             self.ctx_stack.pop();
         }
     }
+
+    pub(crate) fn enter_class(&mut self, class: &Class) {
+        let mut new_ctx = self.current();
+        new_ctx.in_derived_class = class.super_class.is_some();
+        self.push(new_ctx);
+    }
+
+    pub(crate) fn enter_constructor(&mut self) {
+        let mut new_ctx = self.current();
+        new_ctx.in_constructor = true;
+        self.push(new_ctx);
+    }
+
+    /// Enter a function-like scope where `this` is no longer the current
+    /// constructor's uninitialized `this`.
+    pub(crate) fn enter_non_constructor_scope(&mut self) {
+        let mut new_ctx = self.current();
+        new_ctx.in_constructor = false;
+        self.push(new_ctx);
+    }
+
+    /// Return whether a JSXDEV call can safely use `this` for the self
+    /// argument.
+    pub(crate) fn can_add_self(&self) -> bool {
+        let ctx = self.current();
+        !(ctx.in_constructor && ctx.in_derived_class)
+    }
+}
+
+impl Default for JsxSelfCtx {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+struct JsxSelf {
+    dev: bool,
+    ctx: JsxSelfCtx,
 }
 
 // For tests
@@ -61,103 +109,83 @@ fn jsx_self(dev: bool) -> impl Pass {
 
 impl VisitMutHook<()> for JsxSelf {
     fn enter_class(&mut self, n: &mut Class, _ctx: &mut ()) {
-        let mut new_ctx = self.current_ctx();
-        new_ctx.in_derived_class = n.super_class.is_some();
-        self.push_ctx(new_ctx);
+        self.ctx.enter_class(n);
     }
 
     fn exit_class(&mut self, _n: &mut Class, _ctx: &mut ()) {
-        self.pop_ctx();
+        self.ctx.pop();
     }
 
     fn enter_fn_decl(&mut self, _n: &mut FnDecl, _ctx: &mut ()) {
-        let mut new_ctx = self.current_ctx();
-        new_ctx.in_constructor = false;
-        self.push_ctx(new_ctx);
+        self.ctx.enter_non_constructor_scope();
     }
 
     fn exit_fn_decl(&mut self, _n: &mut FnDecl, _ctx: &mut ()) {
-        self.pop_ctx();
+        self.ctx.pop();
     }
 
     fn enter_fn_expr(&mut self, _n: &mut FnExpr, _ctx: &mut ()) {
-        let mut new_ctx = self.current_ctx();
-        new_ctx.in_constructor = false;
-        self.push_ctx(new_ctx);
+        self.ctx.enter_non_constructor_scope();
     }
 
     fn exit_fn_expr(&mut self, _n: &mut FnExpr, _ctx: &mut ()) {
-        self.pop_ctx();
+        self.ctx.pop();
     }
 
     fn enter_getter_prop(&mut self, _n: &mut GetterProp, _ctx: &mut ()) {
-        let mut new_ctx = self.current_ctx();
-        new_ctx.in_constructor = false;
-        self.push_ctx(new_ctx);
+        self.ctx.enter_non_constructor_scope();
     }
 
     fn exit_getter_prop(&mut self, _n: &mut GetterProp, _ctx: &mut ()) {
-        self.pop_ctx();
+        self.ctx.pop();
     }
 
     fn enter_setter_prop(&mut self, _n: &mut SetterProp, _ctx: &mut ()) {
-        let mut new_ctx = self.current_ctx();
-        new_ctx.in_constructor = false;
-        self.push_ctx(new_ctx);
+        self.ctx.enter_non_constructor_scope();
     }
 
     fn exit_setter_prop(&mut self, _n: &mut SetterProp, _ctx: &mut ()) {
-        self.pop_ctx();
+        self.ctx.pop();
     }
 
     fn enter_method_prop(&mut self, _n: &mut MethodProp, _ctx: &mut ()) {
-        let mut new_ctx = self.current_ctx();
-        new_ctx.in_constructor = false;
-        self.push_ctx(new_ctx);
+        self.ctx.enter_non_constructor_scope();
     }
 
     fn exit_method_prop(&mut self, _n: &mut MethodProp, _ctx: &mut ()) {
-        self.pop_ctx();
+        self.ctx.pop();
     }
 
     fn enter_constructor(&mut self, _n: &mut Constructor, _ctx: &mut ()) {
-        let mut new_ctx = self.current_ctx();
-        new_ctx.in_constructor = true;
-        self.push_ctx(new_ctx);
+        self.ctx.enter_constructor();
     }
 
     fn exit_constructor(&mut self, _n: &mut Constructor, _ctx: &mut ()) {
-        self.pop_ctx();
+        self.ctx.pop();
     }
 
     fn enter_class_method(&mut self, _n: &mut ClassMethod, _ctx: &mut ()) {
-        let mut new_ctx = self.current_ctx();
-        new_ctx.in_constructor = false;
-        self.push_ctx(new_ctx);
+        self.ctx.enter_non_constructor_scope();
     }
 
     fn exit_class_method(&mut self, _n: &mut ClassMethod, _ctx: &mut ()) {
-        self.pop_ctx();
+        self.ctx.pop();
     }
 
     fn enter_private_method(&mut self, _n: &mut PrivateMethod, _ctx: &mut ()) {
-        let mut new_ctx = self.current_ctx();
-        new_ctx.in_constructor = false;
-        self.push_ctx(new_ctx);
+        self.ctx.enter_non_constructor_scope();
     }
 
     fn exit_private_method(&mut self, _n: &mut PrivateMethod, _ctx: &mut ()) {
-        self.pop_ctx();
+        self.ctx.pop();
     }
 
     fn enter_static_block(&mut self, _n: &mut StaticBlock, _ctx: &mut ()) {
-        let mut new_ctx = self.current_ctx();
-        new_ctx.in_constructor = false;
-        self.push_ctx(new_ctx);
+        self.ctx.enter_non_constructor_scope();
     }
 
     fn exit_static_block(&mut self, _n: &mut StaticBlock, _ctx: &mut ()) {
-        self.pop_ctx();
+        self.ctx.pop();
     }
 
     fn enter_jsx_opening_element(&mut self, n: &mut JSXOpeningElement, _ctx: &mut ()) {
@@ -165,10 +193,8 @@ impl VisitMutHook<()> for JsxSelf {
             return;
         }
 
-        let ctx = self.current_ctx();
-
         // https://github.com/babel/babel/blob/1bdb1a4175ed1fc40751fb84dc4ad1900260f28f/packages/babel-plugin-transform-react-jsx-self/src/index.ts#L50
-        if ctx.in_constructor && ctx.in_derived_class {
+        if !self.ctx.can_add_self() {
             return;
         }
 

--- a/crates/swc_ecma_transforms_react/tests/integration/fixture/issue-11990/input.js
+++ b/crates/swc_ecma_transforms_react/tests/integration/fixture/issue-11990/input.js
@@ -1,0 +1,2 @@
+const a = <div />;
+const b = <></>;

--- a/crates/swc_ecma_transforms_react/tests/integration/fixture/issue-11990/options.json
+++ b/crates/swc_ecma_transforms_react/tests/integration/fixture/issue-11990/options.json
@@ -1,0 +1,1 @@
+{ "runtime": "automatic", "development": true }

--- a/crates/swc_ecma_transforms_react/tests/integration/fixture/issue-11990/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/integration/fixture/issue-11990/output.mjs
@@ -1,0 +1,12 @@
+import { jsxDEV as _jsxDEV, Fragment as _Fragment } from "react/jsx-dev-runtime";
+
+const a = /*#__PURE__*/_jsxDEV("div", {}, void 0, false, {
+  fileName: "input.js",
+  lineNumber: 1,
+  columnNumber: 11
+}, this);
+const b = /*#__PURE__*/_jsxDEV(_Fragment, {}, void 0, false, {
+  fileName: "input.js",
+  lineNumber: 2,
+  columnNumber: 11
+}, this);

--- a/crates/swc_ecma_transforms_react/tests/integration/fixture/jsx-dev-transform/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/integration/fixture/jsx-dev-transform/output.mjs
@@ -14,7 +14,11 @@ const App = /*#__PURE__*/ _jsxDEV("div", {
                 lineNumber: 5,
                 columnNumber: 13
             }, this)
-        }, void 0, false)
+        }, void 0, false, {
+            fileName: "input.js",
+            lineNumber: 4,
+            columnNumber: 9
+        }, this)
     ]
 }, void 0, true, {
     fileName: "input.js",

--- a/crates/swc_ecma_transforms_react/tests/integration/fixture/jsxdev-args-with-fragment/output.js
+++ b/crates/swc_ecma_transforms_react/tests/integration/fixture/jsxdev-args-with-fragment/output.js
@@ -1,17 +1,23 @@
 import { jsxDEV as _jsxDEV, Fragment as _Fragment } from "react/jsx-dev-runtime";
-
-var x = /*#__PURE__*/_jsxDEV(_Fragment, {
-  children: [/*#__PURE__*/_jsxDEV("div", {
-    children: "hoge"
-  }, void 0, false, {
+var x = /*#__PURE__*/ _jsxDEV(_Fragment, {
+    children: [
+        /*#__PURE__*/ _jsxDEV("div", {
+            children: "hoge"
+        }, void 0, false, {
+            fileName: "input.js",
+            lineNumber: 3,
+            columnNumber: 9
+        }, this),
+        /*#__PURE__*/ _jsxDEV("div", {
+            children: "fuga"
+        }, void 0, false, {
+            fileName: "input.js",
+            lineNumber: 4,
+            columnNumber: 9
+        }, this)
+    ]
+}, void 0, true, {
     fileName: "input.js",
-    lineNumber: 3,
-    columnNumber: 9
-  }, this), /*#__PURE__*/_jsxDEV("div", {
-    children: "fuga"
-  }, void 0, false, {
-    fileName: "input.js",
-    lineNumber: 4,
-    columnNumber: 9
-  }, this)]
-}, void 0, true);
+    lineNumber: 2,
+    columnNumber: 5
+}, this);

--- a/crates/swc_ecma_transforms_react/tests/integration/fixture/jsxdev-fragment-derived-constructor/input.js
+++ b/crates/swc_ecma_transforms_react/tests/integration/fixture/jsxdev-fragment-derived-constructor/input.js
@@ -1,0 +1,5 @@
+class Child extends Parent {
+    constructor() {
+        super(<></>);
+    }
+}

--- a/crates/swc_ecma_transforms_react/tests/integration/fixture/jsxdev-fragment-derived-constructor/options.json
+++ b/crates/swc_ecma_transforms_react/tests/integration/fixture/jsxdev-fragment-derived-constructor/options.json
@@ -1,0 +1,1 @@
+{ "runtime": "automatic", "development": true }

--- a/crates/swc_ecma_transforms_react/tests/integration/fixture/jsxdev-fragment-derived-constructor/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/integration/fixture/jsxdev-fragment-derived-constructor/output.mjs
@@ -1,0 +1,10 @@
+import { jsxDEV as _jsxDEV, Fragment as _Fragment } from "react/jsx-dev-runtime";
+class Child extends Parent {
+    constructor(){
+        super(/*#__PURE__*/ _jsxDEV(_Fragment, {}, void 0, false, {
+            fileName: "input.js",
+            lineNumber: 3,
+            columnNumber: 15
+        }, void 0));
+    }
+}

--- a/crates/swc_ecma_transforms_react/tests/integration/fixture/jsxdev-fragment/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/integration/fixture/jsxdev-fragment/output.mjs
@@ -1,17 +1,23 @@
 import { jsxDEV as _jsxDEV, Fragment as _Fragment } from "react/jsx-dev-runtime";
-
-const App = /*#__PURE__*/_jsxDEV(_Fragment, {
-  children: [/*#__PURE__*/_jsxDEV("div", {
-    children: "hoge"
-  }, void 0, false, {
+const App = /*#__PURE__*/ _jsxDEV(_Fragment, {
+    children: [
+        /*#__PURE__*/ _jsxDEV("div", {
+            children: "hoge"
+        }, void 0, false, {
+            fileName: "input.js",
+            lineNumber: 3,
+            columnNumber: 9
+        }, this),
+        /*#__PURE__*/ _jsxDEV("div", {
+            children: "fuga"
+        }, void 0, false, {
+            fileName: "input.js",
+            lineNumber: 4,
+            columnNumber: 9
+        }, this)
+    ]
+}, void 0, true, {
     fileName: "input.js",
-    lineNumber: 3,
-    columnNumber: 9
-  }, this), /*#__PURE__*/_jsxDEV("div", {
-    children: "fuga"
-  }, void 0, false, {
-    fileName: "input.js",
-    lineNumber: 4,
-    columnNumber: 9
-  }, this)]
-}, void 0, true);
+    lineNumber: 2,
+    columnNumber: 5
+}, this);

--- a/crates/swc_ecma_transforms_react/tests/integration/fixture/with-pragma/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/integration/fixture/with-pragma/output.mjs
@@ -14,7 +14,11 @@ import { jsxDEV as _jsxDEV, Fragment as _Fragment } from "react/jsx-dev-runtime"
                 lineNumber: 6,
                 columnNumber: 13
             }, this)
-        }, void 0, false)
+        }, void 0, false, {
+            fileName: "input.js",
+            lineNumber: 5,
+            columnNumber: 9
+        }, this)
     ]
 }, void 0, true, {
     fileName: "input.js",

--- a/crates/swc_ecma_transforms_react/tests/script/integration/jsx-dev-transform/output.js
+++ b/crates/swc_ecma_transforms_react/tests/script/integration/jsx-dev-transform/output.js
@@ -14,7 +14,11 @@ const App = /*#__PURE__*/ _jsxDEV("div", {
                 lineNumber: 5,
                 columnNumber: 13
             }, this)
-        }, void 0, false)
+        }, void 0, false, {
+            fileName: "input.js",
+            lineNumber: 4,
+            columnNumber: 9
+        }, this)
     ]
 }, void 0, true, {
     fileName: "input.js",

--- a/crates/swc_ecma_transforms_react/tests/script/integration/jsxdev-args-with-fragment/output.js
+++ b/crates/swc_ecma_transforms_react/tests/script/integration/jsxdev-args-with-fragment/output.js
@@ -16,4 +16,8 @@ var x = /*#__PURE__*/ _jsxDEV(_Fragment, {
             columnNumber: 9
         }, this)
     ]
-}, void 0, true);
+}, void 0, true, {
+    fileName: "input.js",
+    lineNumber: 2,
+    columnNumber: 5
+}, this);

--- a/crates/swc_ecma_transforms_react/tests/script/integration/jsxdev-fragment/output.js
+++ b/crates/swc_ecma_transforms_react/tests/script/integration/jsxdev-fragment/output.js
@@ -16,4 +16,8 @@ const App = /*#__PURE__*/ _jsxDEV(_Fragment, {
             columnNumber: 9
         }, this)
     ]
-}, void 0, true);
+}, void 0, true, {
+    fileName: "input.js",
+    lineNumber: 2,
+    columnNumber: 5
+}, this);

--- a/crates/swc_ecma_transforms_react/tests/script/integration/with-pragma/output.js
+++ b/crates/swc_ecma_transforms_react/tests/script/integration/with-pragma/output.js
@@ -14,7 +14,11 @@ const { jsxDEV: _jsxDEV, Fragment: _Fragment } = require("react/jsx-dev-runtime"
                 lineNumber: 6,
                 columnNumber: 13
             }, this)
-        }, void 0, false)
+        }, void 0, false, {
+            fileName: "input.js",
+            lineNumber: 5,
+            columnNumber: 9
+        }, this)
     ]
 }, void 0, true, {
     fileName: "input.js",


### PR DESCRIPTION
**Description:**

Fixes JSX development transform output for shorthand fragments.

Previously, JSX fragments transformed with `_jsxDEV` did not receive source metadata, so React dev tooling could not report the correct fragment location. This PR makes fragment `_jsxDEV` calls include the same source argument as JSX elements.

It also reuses the existing `jsx_self` constructor guard through a shared `JsxSelfCtx`, so fragments only emit `this` as the self argument when it is safe. In derived class constructors, fragments now use `void 0`, matching the existing JSX element behavior.

Added fixture coverage for:
- JSX fragment source metadata regression from #11990
- fragment self handling inside derived class constructors

Verified with:
- `cargo fmt --all`
- `cargo test -p swc_ecma_transforms_react`
- `cargo test -p swc_ecma_transforms_react issue_11990 -- --ignored`
- `cargo test -p swc_ecma_transforms_react jsxdev_fragment_derived_constructor -- --ignored`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue:**

- Close: #11990