### PR TITLE
test(cli): cover watch out-file overwrite

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"
@@ -1574,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/swc_cli_impl/tests/issues.rs
+++ b/crates/swc_cli_impl/tests/issues.rs
@@ -764,6 +764,55 @@ fn issue_4017_watch_out_file_rebuilds_single_output() -> Result<()> {
 }
 
 #[test]
+fn issue_10524_watch_out_file_overwrites_rebuilt_output() -> Result<()> {
+    let sandbox = TempDir::new()?;
+    let source_path = sandbox.path().join("simple.js");
+    let output_path = sandbox.path().join("output.js");
+
+    fs::write(&source_path, "console.log(\"Hello, world!!\");\n")?;
+
+    let mut cmd = cli()?;
+    cmd.current_dir(&sandbox)
+        .arg("compile")
+        .arg("--watch")
+        .arg("--out-file")
+        .arg("output.js")
+        .arg("simple.js");
+
+    let mut child = spawn_watch_command(&mut cmd)?;
+
+    wait_for("initial out-file watch output", || {
+        Ok(fs::read_to_string(&output_path)
+            .map(|content| content.contains("Hello, world!!"))
+            .unwrap_or(false))
+    })?;
+    wait_for("watch process to stay alive", || {
+        Ok(child.try_wait()?.is_none())
+    })?;
+
+    fs::write(&source_path, "console.log(\"Hello, world 2!!\");\n")?;
+
+    wait_for("rebuilt out-file output", || {
+        Ok(fs::read_to_string(&output_path)
+            .map(|content| content.contains("Hello, world 2!!"))
+            .unwrap_or(false))
+    })?;
+
+    let output = fs::read_to_string(&output_path)?;
+    assert!(
+        !output.contains("Hello, world!!"),
+        "Expected rebuilt out-file output to drop stale content. Got: {output}"
+    );
+    assert_eq!(
+        output.matches("console.log").count(),
+        1,
+        "Expected rebuilt out-file output to be overwritten, not appended. Got: {output}"
+    );
+
+    Ok(())
+}
+
+#[test]
 fn issue_4017_watch_out_file_drops_deleted_explicit_inputs() -> Result<()> {
     let sandbox = TempDir::new()?;
     let keep_path = sandbox.path().join("keep.ts");


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Adds regression coverage for `swc compile --watch --out-file`, matching the Windows scenario reported in #10524.

The new CLI test starts watch mode with a single output file, waits for the initial output, rewrites the input file, and asserts that the rebuilt output:

- drops stale content from the first build
- contains only one `console.log`
- is overwritten instead of appended/prepended

This locks in the current rebuild behavior for single-file watch output.

This also bumps two `Cargo.lock` entries to clear current `cargo-deny` advisories reported by CI:

- `anyhow` from `1.0.100` to `1.0.103`
- `crossbeam-epoch` from `0.9.18` to `0.9.20`

Verified with:

- `cargo test -p swc_cli_impl issue_10524_watch_out_file_overwrites_rebuilt_output -- --nocapture`
- `cargo-deny 0.18.9 check`
- manual Windows watch repro using `target/debug/swc.exe compile src/app/v1/simple.js --out-file public/v1/output.js --watch`; after rewriting the input, `output.js` contained only `console.log("Hello, world 2!!");`
- `cargo fmt -p swc_cli_impl --check`
- `cargo clippy -p swc_cli_impl --tests -- -D warnings`

I also tried broader local checks on Windows:

- `cargo fmt --all --check` failed before formatting with `os error 206` (path too long)
- `cargo test -p swc_cli_impl -- --nocapture` ran the new test successfully, but the full suite has existing Windows failures unrelated to this change, including `issue_8265_1`/`issue_8667_1` using unavailable `ls`, plus existing path/root-mode/watch-dir failures

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Closes #10524