### PR TITLE
fix(es/module): Rewrite `.tsx` imports to `.js` unless JSX is preserved

### DIFF
--- a/.changeset/rewrite-tsx-import-extension-to-js.md
+++ b/.changeset/rewrite-tsx-import-extension-to-js.md
@@ -4,4 +4,4 @@ swc: patch
 swc_ecma_transforms_module: patch
 ---
 
-fix(es/module): Make `rewriteRelativeImportExtensions` rewrite `.tsx`/`.jsx` imports to `.js` unless JSX is preserved
+fix(es/module): Make `rewriteRelativeImportExtensions` rewrite `.tsx` imports to `.js` unless JSX is preserved

--- a/.changeset/rewrite-tsx-import-extension-to-js.md
+++ b/.changeset/rewrite-tsx-import-extension-to-js.md
@@ -1,7 +1,7 @@
 ---
-swc_core: patch
+swc_core: major
 swc: patch
-swc_ecma_transforms_module: patch
+swc_ecma_transforms_module: major
 ---
 
 fix(es/module): Make `rewriteRelativeImportExtensions` rewrite `.tsx` imports to `.js` unless JSX is preserved

--- a/.changeset/rewrite-tsx-import-extension-to-js.md
+++ b/.changeset/rewrite-tsx-import-extension-to-js.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc: patch
+swc_ecma_transforms_module: patch
+---
+
+fix(es/module): Make `rewriteRelativeImportExtensions` rewrite `.tsx`/`.jsx` imports to `.js` unless JSX is preserved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,9 +168,9 @@ checksum = "70033777eb8b5124a81a1889416543dddef2de240019b674c81285a2635a7e1e"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "approx"

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -715,7 +715,9 @@ impl Options {
             };
 
             let typescript_import_rewriter = Optional::new(
-                modules::rewriter::typescript_import_rewriter(),
+                modules::rewriter::typescript_import_rewriter(
+                    transform.react.runtime == Some(react::Runtime::Preserve),
+                ),
                 rewrite_relative_import_extensions.into_bool(),
             );
 

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -702,6 +702,8 @@ impl Options {
             .map(|v| v.mangle.is_obj() || v.mangle.is_true())
             .unwrap_or(false);
 
+        let jsx_preserve = transform.react.runtime == Some(react::Runtime::Preserve);
+
         #[cfg(feature = "module")]
         let rewrite_import_pass: Box<dyn Pass> = {
             let swc_import_rewriter: Box<dyn Pass> = match resolver.clone() {
@@ -715,9 +717,7 @@ impl Options {
             };
 
             let typescript_import_rewriter = Optional::new(
-                modules::rewriter::typescript_import_rewriter(
-                    transform.react.runtime == Some(react::Runtime::Preserve),
-                ),
+                modules::rewriter::typescript_import_rewriter(jsx_preserve),
                 rewrite_relative_import_extensions.into_bool(),
             );
 
@@ -880,8 +880,7 @@ impl Options {
         {
             plugin_transforms.unwrap()
         } else {
-            let jsx_enabled =
-                syntax.jsx() && transform.react.runtime != Some(react::Runtime::Preserve);
+            let jsx_enabled = syntax.jsx() && !jsx_preserve;
 
             let decorator_pass: Box<dyn Pass> =
                 match transform.decorator_version.unwrap_or_default() {

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/ts-emit/output/main.ts
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/ts-emit/output/main.ts
@@ -4,7 +4,7 @@ const __require = _createRequire(import.meta.url);
 import "./foo.js";
 import "../foo.mjs";
 import "../../foo.cjs";
-import "./foo.jsx";
+import "./foo.js";
 const foo = __require("./foo.ts");
 import "./foo.js";
 export * from "./foo.js";
@@ -21,7 +21,7 @@ import(_ts_rewrite_relative_import_extension("" + "./foo.ts"));
 import "./foo.js";
 import "../foo.mjs";
 import "../../foo.cjs";
-import "./foo.jsx";
+import "./foo.js";
 import "./foo.js";
 export * from "./foo.js";
 // Shim

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit-preserve/input/.swcrc
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit-preserve/input/.swcrc
@@ -1,0 +1,18 @@
+{
+    "module": {
+        "type": "nodenext"
+    },
+    "jsc": {
+        "target": "esnext",
+        "rewriteRelativeImportExtensions": true,
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "transform": {
+            "react": {
+                "runtime": "preserve"
+            }
+        }
+    }
+}

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit-preserve/input/main.tsx
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit-preserve/input/main.tsx
@@ -1,0 +1,14 @@
+import { Badge } from "./Badge.tsx";
+import { Legacy } from "./Legacy.jsx";
+import { util } from "./util.ts";
+
+import("./Badge.tsx");
+import("" + "./Badge.tsx");
+
+export function App() {
+    return (
+        <Badge>
+            <Legacy label={util()} />
+        </Badge>
+    );
+}

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit-preserve/output/main.tsx
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit-preserve/output/main.tsx
@@ -1,0 +1,11 @@
+import { _ as _ts_rewrite_relative_import_extension } from "@swc/helpers/_/_ts_rewrite_relative_import_extension";
+import { Badge } from "./Badge.jsx";
+import { Legacy } from "./Legacy.jsx";
+import { util } from "./util.js";
+import("./Badge.jsx");
+import(_ts_rewrite_relative_import_extension("" + "./Badge.tsx", true));
+export function App() {
+    return <Badge>
+            <Legacy label={util()}/>
+        </Badge>;
+}

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit/input/.swcrc
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit/input/.swcrc
@@ -1,0 +1,18 @@
+{
+    "module": {
+        "type": "nodenext"
+    },
+    "jsc": {
+        "target": "esnext",
+        "rewriteRelativeImportExtensions": true,
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "transform": {
+            "react": {
+                "runtime": "automatic"
+            }
+        }
+    }
+}

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit/input/main.tsx
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit/input/main.tsx
@@ -1,0 +1,14 @@
+import { Badge } from "./Badge.tsx";
+import { Legacy } from "./Legacy.jsx";
+import { util } from "./util.ts";
+
+import("./Badge.tsx");
+import("" + "./Badge.tsx");
+
+export function App() {
+    return (
+        <Badge>
+            <Legacy label={util()} />
+        </Badge>
+    );
+}

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit/output/main.tsx
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit/output/main.tsx
@@ -1,7 +1,7 @@
 import { _ as _ts_rewrite_relative_import_extension } from "@swc/helpers/_/_ts_rewrite_relative_import_extension";
 import { jsx as _jsx } from "react/jsx-runtime";
 import { Badge } from "./Badge.js";
-import { Legacy } from "./Legacy.js";
+import { Legacy } from "./Legacy.jsx";
 import { util } from "./util.js";
 import("./Badge.js");
 import(_ts_rewrite_relative_import_extension("" + "./Badge.tsx"));

--- a/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit/output/main.tsx
+++ b/crates/swc/tests/typescript/rewrite-relative-import-specifier/tsx-emit/output/main.tsx
@@ -1,0 +1,14 @@
+import { _ as _ts_rewrite_relative_import_extension } from "@swc/helpers/_/_ts_rewrite_relative_import_extension";
+import { jsx as _jsx } from "react/jsx-runtime";
+import { Badge } from "./Badge.js";
+import { Legacy } from "./Legacy.js";
+import { util } from "./util.js";
+import("./Badge.js");
+import(_ts_rewrite_relative_import_extension("" + "./Badge.tsx"));
+export function App() {
+    return /*#__PURE__*/ _jsx(Badge, {
+        children: /*#__PURE__*/ _jsx(Legacy, {
+            label: util()
+        })
+    });
+}

--- a/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
+++ b/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
@@ -7,11 +7,16 @@ use swc_ecma_transforms_base::helper;
 use swc_ecma_visit::{visit_mut_pass, VisitMut, VisitMutWith};
 
 /// This is the implementation of rewriteRelativeImportExtensions in TypeScript
-pub fn typescript_import_rewriter() -> impl Pass {
-    visit_mut_pass(Rewriter)
+///
+/// `jsx_preserve` corresponds to TypeScript's `jsx: "preserve"`: when set,
+/// `.tsx`/`.jsx` specifiers are rewritten to `.jsx` instead of `.js`.
+pub fn typescript_import_rewriter(jsx_preserve: bool) -> impl Pass {
+    visit_mut_pass(Rewriter { jsx_preserve })
 }
 
-struct Rewriter;
+struct Rewriter {
+    jsx_preserve: bool,
+}
 
 impl VisitMut for Rewriter {
     fn visit_mut_call_expr(&mut self, e: &mut CallExpr) {
@@ -32,19 +37,26 @@ impl VisitMut for Rewriter {
 
         if let Some(ExprOrSpread { spread: None, expr }) = &mut e.args.get_mut(0) {
             if let Expr::Lit(Lit::Str(s)) = &mut **expr {
-                if let Some(src) = get_output_extension_wtf8(&s.value) {
+                if let Some(src) = get_output_extension_wtf8(&s.value, self.jsx_preserve) {
                     s.raw = None;
                     s.value = src;
                 }
             } else {
                 let importee = expr.take();
+                let mut args = vec![ExprOrSpread {
+                    spread: None,
+                    expr: importee,
+                }];
+                if self.jsx_preserve {
+                    args.push(ExprOrSpread {
+                        spread: None,
+                        expr: true.into(),
+                    });
+                }
                 **expr = Expr::Call(CallExpr {
                     span: DUMMY_SP,
                     callee: helper!(ts_rewrite_relative_import_extension),
-                    args: vec![ExprOrSpread {
-                        spread: None,
-                        expr: importee,
-                    }],
+                    args,
                     ..Default::default()
                 });
             }
@@ -52,7 +64,7 @@ impl VisitMut for Rewriter {
     }
 
     fn visit_mut_import_decl(&mut self, i: &mut ImportDecl) {
-        if let Some(src) = get_output_extension_wtf8(&i.src.value) {
+        if let Some(src) = get_output_extension_wtf8(&i.src.value, self.jsx_preserve) {
             i.src.value = src;
             i.src.raw = None;
         }
@@ -60,7 +72,7 @@ impl VisitMut for Rewriter {
 
     fn visit_mut_named_export(&mut self, e: &mut NamedExport) {
         if let Some(src) = &mut e.src {
-            if let Some(new_src) = get_output_extension_wtf8(&src.value) {
+            if let Some(new_src) = get_output_extension_wtf8(&src.value, self.jsx_preserve) {
                 src.value = new_src;
                 src.raw = None;
             }
@@ -68,14 +80,14 @@ impl VisitMut for Rewriter {
     }
 
     fn visit_mut_export_all(&mut self, n: &mut ExportAll) {
-        if let Some(new_src) = get_output_extension_wtf8(&n.src.value) {
+        if let Some(new_src) = get_output_extension_wtf8(&n.src.value, self.jsx_preserve) {
             n.src.value = new_src;
             n.src.raw = None;
         }
     }
 }
 
-fn get_output_extension(specifier: &Atom) -> Option<Atom> {
+fn get_output_extension(specifier: &Atom, jsx_preserve: bool) -> Option<Atom> {
     // https://github.com/microsoft/TypeScript/blob/3eb7b6a1794a6d2cde7948a3016c57e628b104b9/src/compiler/utilities.ts#L4331
     let path = Path::new(specifier.as_str());
     if !(path.starts_with("./")
@@ -96,7 +108,13 @@ fn get_output_extension(specifier: &Atom) -> Option<Atom> {
     let ext = match ext {
         "js" | "ts" => "js",
         "json" => "json",
-        "jsx" | "tsx" => "jsx",
+        "jsx" | "tsx" => {
+            if jsx_preserve {
+                "jsx"
+            } else {
+                "js"
+            }
+        }
         "mjs" | "mts" => "mjs",
         "cjs" | "cts" => "cjs",
         _ => return None,
@@ -105,7 +123,7 @@ fn get_output_extension(specifier: &Atom) -> Option<Atom> {
     Some(Atom::new(path.with_extension(ext).to_str()?))
 }
 
-fn get_output_extension_wtf8(specifier: &Wtf8Atom) -> Option<Wtf8Atom> {
+fn get_output_extension_wtf8(specifier: &Wtf8Atom, jsx_preserve: bool) -> Option<Wtf8Atom> {
     let normalized = specifier.to_atom_lossy();
-    get_output_extension(normalized.as_ref()).map(Into::into)
+    get_output_extension(normalized.as_ref(), jsx_preserve).map(Into::into)
 }

--- a/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
+++ b/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
@@ -108,7 +108,9 @@ fn get_output_extension(specifier: &Atom, jsx_preserve: bool) -> Option<Atom> {
     let ext = match ext {
         "js" | "ts" => "js",
         "json" => "json",
-        "jsx" | "tsx" => {
+        // `.jsx` is not rewritten: TypeScript only rewrites specifiers with a
+        // TS extension (`shouldRewriteModuleSpecifier` in utilities.ts).
+        "tsx" => {
             if jsx_preserve {
                 "jsx"
             } else {

--- a/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
+++ b/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
@@ -9,7 +9,7 @@ use swc_ecma_visit::{visit_mut_pass, VisitMut, VisitMutWith};
 /// This is the implementation of rewriteRelativeImportExtensions in TypeScript
 ///
 /// `jsx_preserve` corresponds to TypeScript's `jsx: "preserve"`: when set,
-/// `.tsx`/`.jsx` specifiers are rewritten to `.jsx` instead of `.js`.
+/// `.tsx` specifiers are rewritten to `.jsx` instead of `.js`.
 pub fn typescript_import_rewriter(jsx_preserve: bool) -> impl Pass {
     visit_mut_pass(Rewriter { jsx_preserve })
 }


### PR DESCRIPTION
**Description:**

(Note that this work was done by Claude Code)

With `jsc.rewriteRelativeImportExtensions: true`, SWC rewrites `.tsx` specifiers in relative imports to `.jsx` unconditionally:

```ts
import { Badge } from "./Badge.tsx";
// emits: import { Badge } from "./Badge.jsx";
```

But SWC compiles `Badge.tsx` to `Badge.js`, so the rewritten specifier points at a file that doesn't exist. TypeScript's `getOutputExtension` ([source](https://github.com/microsoft/TypeScript/blob/3eb7b6a1794a6d2cde7948a3016c57e628b104b9/src/compiler/emitter.ts#L540), already referenced in a comment in the rewriter) only maps to `.jsx` when `compilerOptions.jsx === "preserve"`; otherwise it maps to `.js`. Babel's `rewriteImportExtensions` also emits `.js`. The SWC port dropped that condition.

This PR mirrors tsc's behavior:

- `.tsx` specifiers now rewrite to `.js`, unless `jsc.transform.react.runtime` is `"preserve"` (SWC's JSX-passthrough mode), in which case they rewrite to `.jsx` as before.
- `.jsx` specifiers are never rewritten — tsc's `shouldRewriteModuleSpecifier` ([source](https://github.com/microsoft/TypeScript/blob/3eb7b6a1794a6d2cde7948a3016c57e628b104b9/src/compiler/utilities.ts#L4331)) only rewrites specifiers with a TS extension, and the `__rewriteRelativeImportExtension` runtime helper likewise leaves `.jsx` untouched.
- In preserve mode, the helper injected for non-literal dynamic imports now receives its `preserveJsx: true` second argument, keeping static and dynamic rewrites consistent (the helper already supported it and defaulted `.tsx` → `.js`, so the two paths previously disagreed).

`typescript_import_rewriter()` now takes a `jsx_preserve: bool`; the only call site (`crates/swc/src/config/mod.rs`) passes a `jsx_preserve` local shared with the existing `jsx_enabled` check. Since the added required parameter breaks the public signature re-exported through `swc_core`, the changeset marks `swc_ecma_transforms_module` and `swc_core` as `major`.

Tests: the `ts-emit` fixture output changes from `./foo.jsx` to `./foo.js`, and two new fixture cases cover a `.tsx` file importing `./Badge.tsx` / `./Legacy.jsx` (plus literal and non-literal dynamic imports) with `runtime: "automatic"` (expects `.js`, `.jsx` untouched) and `runtime: "preserve"` (expects `.jsx` and the helper flag).

Also bumps `anyhow` in `Cargo.lock` to fix the RUSTSEC-2026-0190 (unsound `Error::downcast_mut()`) advisory failing CI.

**BREAKING CHANGE:**

`swc_ecma_transforms_module::rewriter::typescript_import_rewriter` (re-exported via `swc_core`) now takes a `jsx_preserve: bool` argument. Behavior: `.tsx` specifiers are rewritten to `.js` instead of `.jsx` unless `jsc.transform.react.runtime` is `"preserve"`, and `.jsx` specifiers are no longer rewritten.

**Related issue (if exists):**

None filed; related but distinct: #11360, #11644, #11143.