### PR TITLE
refactor(es/module): introduce source module lowering pipeline

### DIFF
--- a/.changeset/es-module-source-module-pipeline.md
+++ b/.changeset/es-module-source-module-pipeline.md
@@ -1,0 +1,7 @@
+---
+swc: patch
+swc_core: patch
+swc_ecma_transforms_module: patch
+---
+
+refactor(es/module): Introduce source module lowering pipeline

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -603,9 +603,9 @@ impl Options {
             Some(ModuleConfig::Es6(..)) => TsImportExportAssignConfig::EsNext,
             Some(ModuleConfig::CommonJs(..))
             | Some(ModuleConfig::Amd(..))
-            | Some(ModuleConfig::Umd(..)) => TsImportExportAssignConfig::Preserve,
+            | Some(ModuleConfig::Umd(..))
+            | Some(ModuleConfig::SystemJs(..)) => TsImportExportAssignConfig::Preserve,
             Some(ModuleConfig::NodeNext(..)) => TsImportExportAssignConfig::NodeNext,
-            // TODO: should Preserve for SystemJS
             _ => TsImportExportAssignConfig::Classic,
         };
 

--- a/crates/swc/tests/fixture/issues-4xxx/4898/output/index.ts
+++ b/crates/swc/tests/fixture/issues-4xxx/4898/output/index.ts
@@ -1,9 +1,9 @@
 define([
     "require",
     "assert"
-], function(require, _assert) {
+], function(require, assert) {
     "use strict";
-    _assert(true);
+    assert(true);
     let foo = 1;
     foo = 2;
     return foo;

--- a/crates/swc/tests/fixture/issues-8xxx/8505/output/index.ts
+++ b/crates/swc/tests/fixture/issues-8xxx/8505/output/index.ts
@@ -1,11 +1,10 @@
 System.register([], function(_export, _context) {
     "use strict";
-    var _default;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
-            _export("default", _default = ()=>{
+            _export("default", ()=>{
                 class Rectangle {
                     height = 0;
                     constructor(height, width){

--- a/crates/swc/tests/tsc-references/ambientExternalModuleMerging.1.normal.js
+++ b/crates/swc/tests/tsc-references/ambientExternalModuleMerging.1.normal.js
@@ -1,16 +1,12 @@
 //// [ambientExternalModuleMerging_use.ts]
 define([
     "require",
-    "exports",
     "M"
-], function(require, exports, _M) {
+], function(require, M) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     // Should be strings
-    var x = _M.x;
-    var y = _M.y;
+    var x = M.x;
+    var y = M.y;
 });
 //// [ambientExternalModuleMerging_declare.ts]
 define([

--- a/crates/swc/tests/tsc-references/ambientExternalModuleMerging.2.minified.js
+++ b/crates/swc/tests/tsc-references/ambientExternalModuleMerging.2.minified.js
@@ -1,12 +1,9 @@
 //// [ambientExternalModuleMerging_use.ts]
 define([
     "require",
-    "exports",
     "M"
-], function(require, exports, _M) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), _M.x, _M.y;
+], function(require, M) {
+    M.x, M.y;
 });
 //// [ambientExternalModuleMerging_declare.ts]
 define([

--- a/crates/swc/tests/tsc-references/amdImportAsPrimaryExpression.1.normal.js
+++ b/crates/swc/tests/tsc-references/amdImportAsPrimaryExpression.1.normal.js
@@ -23,14 +23,10 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
+], function(require, foo) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
-    if (_foo_0.E1.A === 0) {
+    if (foo.E1.A === 0) {
     // Should cause runtime import - interesting optimization possibility, as gets inlined to 0.
     }
 });

--- a/crates/swc/tests/tsc-references/amdImportAsPrimaryExpression.2.minified.js
+++ b/crates/swc/tests/tsc-references/amdImportAsPrimaryExpression.2.minified.js
@@ -16,10 +16,7 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), _foo_0.E1.A;
+], function(require, foo) {
+    foo.E1.A;
 });

--- a/crates/swc/tests/tsc-references/anonymousDefaultExportsSystem.1.normal.js
+++ b/crates/swc/tests/tsc-references/anonymousDefaultExportsSystem.1.normal.js
@@ -1,12 +1,11 @@
 //// [a.ts]
 System.register([], function(_export, _context) {
     "use strict";
-    var _default;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
-            _export("default", _default = class _default {
+            _export("default", class {
             });
         }
     };
@@ -14,8 +13,7 @@ System.register([], function(_export, _context) {
 //// [b.ts]
 System.register([], function(_export, _context) {
     "use strict";
-    function _default() {}
-    _export("default", _default);
+    _export("default", function() {});
     return {
         setters: [],
         execute: function() {}

--- a/crates/swc/tests/tsc-references/awaitUsingDeclarationsTopLevelOfModule.1(module=system).1.normal.js
+++ b/crates/swc/tests/tsc-references/awaitUsingDeclarationsTopLevelOfModule.1(module=system).1.normal.js
@@ -4,7 +4,7 @@ System.register([
     "@swc/helpers/_/_ts_dispose_resources"
 ], function(_export, _context) {
     "use strict";
-    var _default, _ts_add_disposable_resource, _ts_dispose_resources, env, w, x, y, z;
+    var _ts_add_disposable_resource, _ts_dispose_resources, env, w, x, y, z;
     _export({
         default: void 0,
         w: void 0,
@@ -41,7 +41,7 @@ System.register([
             }
             _export("x", x = 1);
             _export("w", w = 3);
-            _export("default", _default = 4);
+            _export("default", 4);
         }
     };
 });

--- a/crates/swc/tests/tsc-references/commonJSImportAsPrimaryExpression.1.normal.js
+++ b/crates/swc/tests/tsc-references/commonJSImportAsPrimaryExpression.1.normal.js
@@ -18,9 +18,6 @@ var C1 = function C1() {
 C1.s1 = true;
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo = require("./foo_0");
 if (foo.C1.s1) {
 // Should cause runtime import

--- a/crates/swc/tests/tsc-references/commonJSImportAsPrimaryExpression.2.minified.js
+++ b/crates/swc/tests/tsc-references/commonJSImportAsPrimaryExpression.2.minified.js
@@ -12,6 +12,4 @@ var _class_call_check = require("@swc/helpers/_/_class_call_check"), C1 = functi
 };
 C1.s1 = !0;
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-}), require("./foo_0").C1.s1;
+require("./foo_0").C1.s1;

--- a/crates/swc/tests/tsc-references/contextuallyTypedStringLiteralsInJsxAttributes02.1.normal.js
+++ b/crates/swc/tests/tsc-references/contextuallyTypedStringLiteralsInJsxAttributes02.1.normal.js
@@ -3,7 +3,7 @@ define([
     "require",
     "exports",
     "react"
-], function(require, exports, _react) {
+], function(require, exports, React) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
@@ -32,30 +32,30 @@ define([
         }
         return this._buildMainButton(props);
     }
-    var b0 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b0 = /*#__PURE__*/ React.createElement(MainButton, {
         onClick: function onClick(k) {
             console.log(k);
         },
         extra: true
     }); // k has type "left" | "right"
-    var b2 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b2 = /*#__PURE__*/ React.createElement(MainButton, {
         onClick: function onClick(k) {
             console.log(k);
         },
         extra: true
     }); // k has type "left" | "right"
-    var b3 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b3 = /*#__PURE__*/ React.createElement(MainButton, {
         goTo: "home",
         extra: true
     }); // goTo has type"home" | "contact"
-    var b4 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b4 = /*#__PURE__*/ React.createElement(MainButton, {
         goTo: "home",
         extra: true
     }); // goTo has type "home" | "contact"
     function NoOverload(buttonProps) {
         return undefined;
     }
-    var c1 = /*#__PURE__*/ _react.createElement(NoOverload, {
+    var c1 = /*#__PURE__*/ React.createElement(NoOverload, {
         onClick: function onClick(k) {
             console.log(k);
         },
@@ -64,7 +64,7 @@ define([
     function NoOverload1(linkProps) {
         return undefined;
     }
-    var d1 = /*#__PURE__*/ _react.createElement(NoOverload1, {
+    var d1 = /*#__PURE__*/ React.createElement(NoOverload1, {
         goTo: "home",
         extra: true
     }); // goTo has type "home" | "contact"

--- a/crates/swc/tests/tsc-references/contextuallyTypedStringLiteralsInJsxAttributes02.2.minified.js
+++ b/crates/swc/tests/tsc-references/contextuallyTypedStringLiteralsInJsxAttributes02.2.minified.js
@@ -3,7 +3,7 @@ define([
     "require",
     "exports",
     "react"
-], function(require, exports, _react) {
+], function(require, exports, React) {
     Object.defineProperty(exports, "__esModule", {
         value: !0
     });

--- a/crates/swc/tests/tsc-references/exportAsNamespace4(module=system).1.normal.js
+++ b/crates/swc/tests/tsc-references/exportAsNamespace4(module=system).1.normal.js
@@ -36,7 +36,7 @@ System.register([
     "./0"
 ], function(_export, _context) {
     "use strict";
-    var _default, ns;
+    var ns;
     _export("default", void 0);
     return {
         setters: [
@@ -45,7 +45,7 @@ System.register([
             }
         ],
         execute: function() {
-            _export("default", _default = ns);
+            _export("default", ns);
         }
     };
 });

--- a/crates/swc/tests/tsc-references/exportAssignmentCircularModules.1.normal.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentCircularModules.1.normal.js
@@ -2,10 +2,10 @@
 define([
     "require",
     "./foo_1"
-], function(require, _foo_1) {
+], function(require, foo1) {
     "use strict";
     (function(Foo) {
-        Foo.x = _foo_1.x;
+        Foo.x = foo1.x;
     })(Foo || (Foo = {}));
     var Foo;
     return Foo;
@@ -14,10 +14,10 @@ define([
 define([
     "require",
     "./foo_2"
-], function(require, _foo_2) {
+], function(require, foo2) {
     "use strict";
     (function(Foo) {
-        Foo.x = _foo_2.x;
+        Foo.x = foo2.x;
     })(Foo || (Foo = {}));
     var Foo;
     return Foo;
@@ -26,10 +26,10 @@ define([
 define([
     "require",
     "./foo_0"
-], function(require, _foo_0) {
+], function(require, foo0) {
     "use strict";
     (function(Foo) {
-        Foo.x = _foo_0.x;
+        Foo.x = foo0.x;
     })(Foo || (Foo = {}));
     var Foo;
     return Foo;

--- a/crates/swc/tests/tsc-references/exportAssignmentCircularModules.2.minified.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentCircularModules.2.minified.js
@@ -2,23 +2,23 @@
 define([
     "require",
     "./foo_1"
-], function(require, _foo_1) {
+], function(require, foo1) {
     var Foo;
-    return (Foo || (Foo = {})).x = _foo_1.x, Foo;
+    return (Foo || (Foo = {})).x = foo1.x, Foo;
 });
 //// [foo_1.ts]
 define([
     "require",
     "./foo_2"
-], function(require, _foo_2) {
+], function(require, foo2) {
     var Foo;
-    return (Foo || (Foo = {})).x = _foo_2.x, Foo;
+    return (Foo || (Foo = {})).x = foo2.x, Foo;
 });
 //// [foo_2.ts]
 define([
     "require",
     "./foo_0"
-], function(require, _foo_0) {
+], function(require, foo0) {
     var Foo;
-    return (Foo || (Foo = {})).x = _foo_0.x, Foo;
+    return (Foo || (Foo = {})).x = foo0.x, Foo;
 });

--- a/crates/swc/tests/tsc-references/exportAssignmentConstrainedGenericType.1.normal.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentConstrainedGenericType.1.normal.js
@@ -8,9 +8,6 @@ var Foo = function Foo(x) {
 module.exports = Foo;
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo = require("./foo_0");
 var x = new foo(true); // Should error
 var y = new foo({

--- a/crates/swc/tests/tsc-references/exportAssignmentConstrainedGenericType.2.minified.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentConstrainedGenericType.2.minified.js
@@ -4,9 +4,6 @@ module.exports = function Foo(x) {
     _class_call_check._(this, Foo);
 };
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-});
 var foo = require("./foo_0");
 new foo(!0), new foo({
     a: "test",

--- a/crates/swc/tests/tsc-references/exportAssignmentGenericType.1.normal.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentGenericType.1.normal.js
@@ -8,9 +8,6 @@ var Foo = function Foo() {
 module.exports = Foo;
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo = require("./foo_0");
 var x = new foo();
 var y = x.test;

--- a/crates/swc/tests/tsc-references/exportAssignmentGenericType.2.minified.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentGenericType.2.minified.js
@@ -4,6 +4,4 @@ module.exports = function Foo() {
     _class_call_check._(this, Foo);
 };
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-}), new (require("./foo_0"))().test;
+new (require("./foo_0"))().test;

--- a/crates/swc/tests/tsc-references/exportAssignmentMergedModule.1.normal.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentMergedModule.1.normal.js
@@ -20,9 +20,6 @@ var Foo;
 module.exports = Foo;
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo = require("./foo_0");
 var a = foo.a();
 if (!!foo.b) {

--- a/crates/swc/tests/tsc-references/exportAssignmentMergedModule.2.minified.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentMergedModule.2.minified.js
@@ -6,8 +6,5 @@ var Foo, Foo1, Foo2;
     return a;
 }, (Foo2.Test || (Foo2.Test = {})).answer = 42, module.exports = Foo;
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-});
 var foo = require("./foo_0");
 foo.a(), foo.b && (foo.Test.answer = foo.c(42));

--- a/crates/swc/tests/tsc-references/exportAssignmentTopLevelClodule.1.normal.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentTopLevelClodule.1.normal.js
@@ -17,14 +17,10 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
+], function(require, foo) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
-    if (_foo_0.answer === 42) {
-        var x = new _foo_0();
+    if (foo.answer === 42) {
+        var x = new foo();
     }
 });

--- a/crates/swc/tests/tsc-references/exportAssignmentTopLevelClodule.2.minified.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentTopLevelClodule.2.minified.js
@@ -11,10 +11,7 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), 42 === _foo_0.answer && new _foo_0();
+], function(require, foo) {
+    42 === foo.answer && new foo();
 });

--- a/crates/swc/tests/tsc-references/exportAssignmentTopLevelEnumdule.1.normal.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentTopLevelEnumdule.1.normal.js
@@ -17,15 +17,11 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
+], function(require, foo) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     var color;
-    if (color === _foo_0.green) {
-        color = _foo_0.answer;
+    if (color === foo.green) {
+        color = foo.answer;
     }
 });

--- a/crates/swc/tests/tsc-references/exportAssignmentTopLevelEnumdule.2.minified.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentTopLevelEnumdule.2.minified.js
@@ -8,11 +8,8 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
+], function(require, foo) {
     var color;
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), color === _foo_0.green && (color = _foo_0.answer);
+    color === foo.green && (color = foo.answer);
 });

--- a/crates/swc/tests/tsc-references/exportAssignmentTopLevelFundule.1.normal.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentTopLevelFundule.1.normal.js
@@ -14,14 +14,10 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
+], function(require, foo) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
-    if (_foo_0.answer === 42) {
-        var x = _foo_0();
+    if (foo.answer === 42) {
+        var x = foo();
     }
 });

--- a/crates/swc/tests/tsc-references/exportAssignmentTopLevelFundule.2.minified.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentTopLevelFundule.2.minified.js
@@ -10,10 +10,7 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), 42 === _foo_0.answer && _foo_0();
+], function(require, foo) {
+    42 === foo.answer && foo();
 });

--- a/crates/swc/tests/tsc-references/exportAssignmentTopLevelIdentifier.1.normal.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentTopLevelIdentifier.1.normal.js
@@ -12,12 +12,8 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
+], function(require, foo) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
-    if (_foo_0.answer === 42) {}
+    if (foo.answer === 42) {}
 });

--- a/crates/swc/tests/tsc-references/exportAssignmentTopLevelIdentifier.2.minified.js
+++ b/crates/swc/tests/tsc-references/exportAssignmentTopLevelIdentifier.2.minified.js
@@ -8,10 +8,7 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), _foo_0.answer;
+], function(require, foo) {
+    foo.answer;
 });

--- a/crates/swc/tests/tsc-references/exportsAndImports4-amd.1.normal.js
+++ b/crates/swc/tests/tsc-references/exportsAndImports4-amd.1.normal.js
@@ -26,29 +26,31 @@ define([
     "require",
     "exports",
     "@swc/helpers/_/_interop_require_wildcard",
+    "./t1",
     "./t1"
-], function(require, exports, _interop_require_wildcard, _t1) {
+], function(require, exports, _interop_require_wildcard, _t1, a) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
-    var _t11 = /*#__PURE__*/ _interop_require_wildcard._(_t1);
+    _t1 = /*#__PURE__*/ _interop_require_wildcard._(_t1);
+    a.default;
     _t1.default;
-    _t11.default;
-    _t11.default;
-    _t11.default;
-    _t11.default;
-    _t11.default;
-    _t11.default;
-    _t11.default;
+    _t1.default;
+    _t1.default;
+    _t1.default;
+    _t1.default;
+    _t1.default;
+    _t1.default;
 });
 //// [t3.ts]
 define([
     "require",
     "exports",
     "@swc/helpers/_/_interop_require_wildcard",
+    "./t1",
     "./t1"
-], function(require, exports, _interop_require_wildcard, _t1) {
+], function(require, exports, _interop_require_wildcard, _t1, a) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
@@ -61,37 +63,37 @@ define([
     }
     _export(exports, {
         get a () {
-            return _t1;
+            return a;
         },
         get b () {
-            return _t11.default;
+            return _t1.default;
         },
         get c () {
-            return _t11;
+            return _t1;
         },
         get d () {
-            return _t11.default;
+            return _t1.default;
         },
         get e1 () {
-            return _t11.default;
+            return _t1.default;
         },
         get e2 () {
-            return _t11;
+            return _t1;
         },
         get f1 () {
-            return _t11.default;
+            return _t1.default;
         },
         get f2 () {
-            return _t11.default;
+            return _t1.default;
         }
     });
-    var _t11 = /*#__PURE__*/ _interop_require_wildcard._(_t1);
+    _t1 = /*#__PURE__*/ _interop_require_wildcard._(_t1);
+    a.default;
     _t1.default;
-    _t11.default;
-    _t11.default;
-    _t11.default;
-    _t11.default;
-    _t11.default;
-    _t11.default;
-    _t11.default;
+    _t1.default;
+    _t1.default;
+    _t1.default;
+    _t1.default;
+    _t1.default;
+    _t1.default;
 });

--- a/crates/swc/tests/tsc-references/exportsAndImports4-amd.2.minified.js
+++ b/crates/swc/tests/tsc-references/exportsAndImports4-amd.2.minified.js
@@ -22,54 +22,53 @@ define([
     "require",
     "exports",
     "@swc/helpers/_/_interop_require_wildcard",
+    "./t1",
     "./t1"
-], function(require, exports, _interop_require_wildcard, _t1) {
+], function(require, exports, _interop_require_wildcard, _t1, a) {
     Object.defineProperty(exports, "__esModule", {
         value: !0
-    });
-    var _t11 = /*#__PURE__*/ _interop_require_wildcard._(_t1);
-    _t1.default, _t11.default, _t11.default, _t11.default, _t11.default, _t11.default, _t11.default, _t11.default;
+    }), _t1 = /*#__PURE__*/ _interop_require_wildcard._(_t1), a.default, _t1.default, _t1.default, _t1.default, _t1.default, _t1.default, _t1.default, _t1.default;
 });
 //// [t3.ts]
 define([
     "require",
     "exports",
     "@swc/helpers/_/_interop_require_wildcard",
+    "./t1",
     "./t1"
-], function(require, exports, _interop_require_wildcard, _t1) {
+], function(require, exports, _interop_require_wildcard, _t1, a) {
     Object.defineProperty(exports, "__esModule", {
         value: !0
     });
     var all = {
         get a () {
-            return _t1;
+            return a;
         },
         get b () {
-            return _t11.default;
+            return _t1.default;
         },
         get c () {
-            return _t11;
+            return _t1;
         },
         get d () {
-            return _t11.default;
+            return _t1.default;
         },
         get e1 () {
-            return _t11.default;
+            return _t1.default;
         },
         get e2 () {
-            return _t11;
+            return _t1;
         },
         get f1 () {
-            return _t11.default;
+            return _t1.default;
         },
         get f2 () {
-            return _t11.default;
+            return _t1.default;
         }
     };
     for(var name in all)Object.defineProperty(exports, name, {
         enumerable: !0,
         get: Object.getOwnPropertyDescriptor(all, name).get
     });
-    var _t11 = /*#__PURE__*/ _interop_require_wildcard._(_t1);
-    _t1.default, _t11.default, _t11.default, _t11.default, _t11.default, _t11.default, _t11.default, _t11.default;
+    _t1 = /*#__PURE__*/ _interop_require_wildcard._(_t1), a.default, _t1.default, _t1.default, _t1.default, _t1.default, _t1.default, _t1.default, _t1.default;
 });

--- a/crates/swc/tests/tsc-references/importCallExpressionInExportEqualsUMD.1.normal.js
+++ b/crates/swc/tests/tsc-references/importCallExpressionInExportEqualsUMD.1.normal.js
@@ -2,7 +2,7 @@
 (function(global, factory) {
     if (typeof module === "object" && typeof module.exports === "object") module.exports = factory();
     else if (typeof define === "function" && define.amd) define([], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) module.exports = factory();
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) global.somethingTs = factory();
 })(this, function() {
     "use strict";
     return 42;
@@ -13,7 +13,7 @@
     else if (typeof define === "function" && define.amd) define([
         "@swc/helpers/_/_interop_require_wildcard"
     ], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) module.exports = factory(global.interopRequireWildcard);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) global.indexTs = factory(global.interopRequireWildcard);
 })(this, function(_interop_require_wildcard) {
     "use strict";
     return async function() {

--- a/crates/swc/tests/tsc-references/importCallExpressionInExportEqualsUMD.2.minified.js
+++ b/crates/swc/tests/tsc-references/importCallExpressionInExportEqualsUMD.2.minified.js
@@ -2,7 +2,7 @@
 var global, factory;
 global = this, factory = function() {
     return 42;
-}, "object" == typeof module && "object" == typeof module.exports ? module.exports = factory() : "function" == typeof define && define.amd ? define([], factory) : (global = "u" > typeof globalThis ? globalThis : global || self) && (module.exports = factory());
+}, "object" == typeof module && "object" == typeof module.exports ? module.exports = factory() : "function" == typeof define && define.amd ? define([], factory) : (global = "u" > typeof globalThis ? globalThis : global || self) && (global.somethingTs = factory());
 //// [index.ts]
 var global, factory;
 global = this, factory = function(_interop_require_wildcard) {
@@ -11,4 +11,4 @@ global = this, factory = function(_interop_require_wildcard) {
     };
 }, "object" == typeof module && "object" == typeof module.exports ? module.exports = factory(require("@swc/helpers/_/_interop_require_wildcard")) : "function" == typeof define && define.amd ? define([
     "@swc/helpers/_/_interop_require_wildcard"
-], factory) : (global = "u" > typeof globalThis ? globalThis : global || self) && (module.exports = factory(global.interopRequireWildcard));
+], factory) : (global = "u" > typeof globalThis ? globalThis : global || self) && (global.indexTs = factory(global.interopRequireWildcard));

--- a/crates/swc/tests/tsc-references/importCallExpressionNestedSystem.1.normal.js
+++ b/crates/swc/tests/tsc-references/importCallExpressionNestedSystem.1.normal.js
@@ -1,12 +1,11 @@
 //// [foo.ts]
 System.register([], function(_export, _context) {
     "use strict";
-    var _default;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
-            _export("default", _default = "./foo");
+            _export("default", "./foo");
         }
     };
 });

--- a/crates/swc/tests/tsc-references/importCallExpressionNestedSystem2.1.normal.js
+++ b/crates/swc/tests/tsc-references/importCallExpressionNestedSystem2.1.normal.js
@@ -1,12 +1,11 @@
 //// [foo.ts]
 System.register([], function(_export, _context) {
     "use strict";
-    var _default;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
-            _export("default", _default = "./foo");
+            _export("default", "./foo");
         }
     };
 });

--- a/crates/swc/tests/tsc-references/importImportOnlyModule.1.normal.js
+++ b/crates/swc/tests/tsc-references/importImportOnlyModule.1.normal.js
@@ -31,12 +31,8 @@ define([
 //// [foo_2.ts]
 define([
     "require",
-    "exports",
     "./foo_1"
-], function(require, exports, _foo_1) {
+], function(require, foo) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
-    var x = _foo_1; // Cause a runtime dependency
+    var x = foo; // Cause a runtime dependency
 });

--- a/crates/swc/tests/tsc-references/importImportOnlyModule.2.minified.js
+++ b/crates/swc/tests/tsc-references/importImportOnlyModule.2.minified.js
@@ -24,10 +24,5 @@ define([
 //// [foo_2.ts]
 define([
     "require",
-    "exports",
     "./foo_1"
-], function(require, exports, _foo_1) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    });
-});
+], function(require, foo) {});

--- a/crates/swc/tests/tsc-references/importNonExternalModule.1.normal.js
+++ b/crates/swc/tests/tsc-references/importNonExternalModule.1.normal.js
@@ -11,13 +11,9 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
+], function(require, foo) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     // Import should fail.  foo_0 not an external module
-    if (_foo_0.answer === 42) {}
+    if (foo.answer === 42) {}
 });

--- a/crates/swc/tests/tsc-references/importNonExternalModule.2.minified.js
+++ b/crates/swc/tests/tsc-references/importNonExternalModule.2.minified.js
@@ -8,10 +8,7 @@ define([
 //// [foo_1.ts]
 define([
     "require",
-    "exports",
     "./foo_0"
-], function(require, exports, _foo_0) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), _foo_0.answer;
+], function(require, foo) {
+    foo.answer;
 });

--- a/crates/swc/tests/tsc-references/importTsBeforeDTs.1.normal.js
+++ b/crates/swc/tests/tsc-references/importTsBeforeDTs.1.normal.js
@@ -24,9 +24,6 @@ Object.defineProperty(exports, "y", {
 var y = 42;
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo = require("./foo_0");
 var z1 = foo.x + 10; // Should error, as .ts preferred over .d.ts
 var z2 = foo.y + 10; // Should resolve

--- a/crates/swc/tests/tsc-references/importTsBeforeDTs.2.minified.js
+++ b/crates/swc/tests/tsc-references/importTsBeforeDTs.2.minified.js
@@ -19,8 +19,5 @@ Object.defineProperty(exports, "__esModule", {
 });
 var y = 42;
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-});
 var foo = require("./foo_0");
 foo.x, foo.y;

--- a/crates/swc/tests/tsc-references/nameDelimitedBySlashes.1.normal.js
+++ b/crates/swc/tests/tsc-references/nameDelimitedBySlashes.1.normal.js
@@ -12,8 +12,5 @@ Object.defineProperty(exports, "foo", {
 var foo = 42;
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo = require("./test/foo_0");
 var x = foo.foo + 42;

--- a/crates/swc/tests/tsc-references/nameDelimitedBySlashes.2.minified.js
+++ b/crates/swc/tests/tsc-references/nameDelimitedBySlashes.2.minified.js
@@ -9,6 +9,4 @@ Object.defineProperty(exports, "__esModule", {
 });
 var foo = 42;
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-}), require("./test/foo_0").foo;
+require("./test/foo_0").foo;

--- a/crates/swc/tests/tsc-references/nameWithFileExtension.1.normal.js
+++ b/crates/swc/tests/tsc-references/nameWithFileExtension.1.normal.js
@@ -12,8 +12,5 @@ Object.defineProperty(exports, "foo", {
 var foo = 42;
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo = require("./foo_0.js");
 var x = foo.foo + 42;

--- a/crates/swc/tests/tsc-references/nameWithFileExtension.2.minified.js
+++ b/crates/swc/tests/tsc-references/nameWithFileExtension.2.minified.js
@@ -9,6 +9,4 @@ Object.defineProperty(exports, "__esModule", {
 });
 var foo = 42;
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-}), require("./foo_0.js").foo;
+require("./foo_0.js").foo;

--- a/crates/swc/tests/tsc-references/nameWithRelativePaths.1.normal.js
+++ b/crates/swc/tests/tsc-references/nameWithRelativePaths.1.normal.js
@@ -41,9 +41,6 @@ Object.defineProperty(exports, "M2", {
 var M2;
 //// [test/foo_3.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo0 = require("../foo_0");
 var foo1 = require("./test/foo_1");
 var foo2 = require("./.././test/foo_2");

--- a/crates/swc/tests/tsc-references/nameWithRelativePaths.2.minified.js
+++ b/crates/swc/tests/tsc-references/nameWithRelativePaths.2.minified.js
@@ -31,8 +31,5 @@ Object.defineProperty(exports, "__esModule", {
     }
 }), (M2 || (M2 = {})).x = !0;
 //// [test/foo_3.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-});
 var foo0 = require("../foo_0"), foo1 = require("./test/foo_1");
 require("./.././test/foo_2").M2.x && (foo0.foo, foo1.f());

--- a/crates/swc/tests/tsc-references/relativePathMustResolve.1.normal.js
+++ b/crates/swc/tests/tsc-references/relativePathMustResolve.1.normal.js
@@ -12,8 +12,5 @@ Object.defineProperty(exports, "x", {
 var x = 42;
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo = require("./test/foo");
 var z = foo.x + 10;

--- a/crates/swc/tests/tsc-references/relativePathMustResolve.2.minified.js
+++ b/crates/swc/tests/tsc-references/relativePathMustResolve.2.minified.js
@@ -9,6 +9,4 @@ Object.defineProperty(exports, "__esModule", {
 });
 var x = 42;
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-}), require("./test/foo").x;
+require("./test/foo").x;

--- a/crates/swc/tests/tsc-references/topLevelAmbientModule.1.normal.js
+++ b/crates/swc/tests/tsc-references/topLevelAmbientModule.1.normal.js
@@ -1,10 +1,7 @@
 //// [foo_0.ts]
 "use strict";
 //// [foo_1.ts]
-"use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 /// <reference path="foo_0.ts"/>
+"use strict";
 var foo = require("foo");
 var z = foo.x + 10;

--- a/crates/swc/tests/tsc-references/topLevelAmbientModule.2.minified.js
+++ b/crates/swc/tests/tsc-references/topLevelAmbientModule.2.minified.js
@@ -1,5 +1,3 @@
 //// [foo_0.ts]
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-}), require("foo").x;
+require("foo").x;

--- a/crates/swc/tests/tsc-references/topLevelFileModule.1.normal.js
+++ b/crates/swc/tests/tsc-references/topLevelFileModule.1.normal.js
@@ -17,9 +17,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo = require("./vs/foo_0");
 var fum = require("./vs/fum");
 var z = foo.x + fum.y;

--- a/crates/swc/tests/tsc-references/topLevelFileModule.2.minified.js
+++ b/crates/swc/tests/tsc-references/topLevelFileModule.2.minified.js
@@ -13,8 +13,5 @@ Object.defineProperty(exports, "__esModule", {
     value: !0
 });
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-});
 var foo = require("./vs/foo_0"), fum = require("./vs/fum");
 foo.x, fum.y;

--- a/crates/swc/tests/tsc-references/topLevelFileModuleMissing.1.normal.js
+++ b/crates/swc/tests/tsc-references/topLevelFileModuleMissing.1.normal.js
@@ -12,8 +12,5 @@ Object.defineProperty(exports, "x", {
 var x;
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo = require("vs/foo");
 var z = foo.x + 10;

--- a/crates/swc/tests/tsc-references/topLevelFileModuleMissing.2.minified.js
+++ b/crates/swc/tests/tsc-references/topLevelFileModuleMissing.2.minified.js
@@ -9,6 +9,4 @@ Object.defineProperty(exports, "__esModule", {
     }
 });
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-}), require("vs/foo").x;
+require("vs/foo").x;

--- a/crates/swc/tests/tsc-references/topLevelModuleDeclarationAndFile.1.normal.js
+++ b/crates/swc/tests/tsc-references/topLevelModuleDeclarationAndFile.1.normal.js
@@ -13,11 +13,8 @@ var x = 42;
 //// [foo_1.ts]
 "use strict";
 //// [foo_2.ts]
-"use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 /// <reference path="foo_1.ts"/>
+"use strict";
 var foo = require("vs/foo_0");
 var z1 = foo.x + 10; // Should error, as declaration should win
 var z2 = foo.y() + 10; // Should resolve

--- a/crates/swc/tests/tsc-references/topLevelModuleDeclarationAndFile.2.minified.js
+++ b/crates/swc/tests/tsc-references/topLevelModuleDeclarationAndFile.2.minified.js
@@ -10,8 +10,5 @@ Object.defineProperty(exports, "__esModule", {
 var x = 42;
 //// [foo_1.ts]
 //// [foo_2.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-});
 var foo = require("vs/foo_0");
 foo.x, foo.y();

--- a/crates/swc/tests/tsc-references/tsxElementResolution17.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxElementResolution17.1.normal.js
@@ -15,12 +15,8 @@ define([
 // Should keep s1 and elide s2
 define([
     "require",
-    "exports",
     "elements1"
-], function(require, exports, _elements1) {
+], function(require, s1) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
-    /*#__PURE__*/ React.createElement(_elements1.MyElement, null);
+    /*#__PURE__*/ React.createElement(s1.MyElement, null);
 });

--- a/crates/swc/tests/tsc-references/tsxElementResolution17.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxElementResolution17.2.minified.js
@@ -9,10 +9,7 @@ define([
 //// [consumer.tsx]
 define([
     "require",
-    "exports",
     "elements1"
-], function(require, exports, _elements1) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), _elements1.MyElement;
+], function(require, s1) {
+    s1.MyElement;
 });

--- a/crates/swc/tests/tsc-references/tsxPreserveEmit1.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxPreserveEmit1.1.normal.js
@@ -14,20 +14,16 @@ define([
 // Should emit 'react-router' in the AMD dependency list
 define([
     "require",
-    "exports",
     "react",
     "react-router"
-], function(require, exports, _react, _reactrouter) {
+], function(require, React, ReactRouter) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
-    var Route = _reactrouter.Route;
-    var routes1 = /*#__PURE__*/ _react.createElement(Route, null);
+    var Route = ReactRouter.Route;
+    var routes1 = /*#__PURE__*/ React.createElement(Route, null);
     (function(M) {})(M || (M = {}));
     (function(M) {
         // Should emit 'M.X' in both opening and closing tags
-        var y = /*#__PURE__*/ _react.createElement(X, null);
+        var y = /*#__PURE__*/ React.createElement(X, null);
     })(M || (M = {}));
     var M;
 });

--- a/crates/swc/tests/tsc-references/tsxPreserveEmit1.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxPreserveEmit1.2.minified.js
@@ -9,12 +9,9 @@ define([
 //// [test.tsx]
 define([
     "require",
-    "exports",
     "react",
     "react-router"
-], function(require, exports, _react, _reactrouter) {
+], function(require, React, ReactRouter) {
     var M;
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), _reactrouter.Route, M || (M = {}), M || (M = {}), X;
+    ReactRouter.Route, M || (M = {}), M || (M = {}), X;
 });

--- a/crates/swc/tests/tsc-references/tsxSfcReturnNull.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxSfcReturnNull.1.normal.js
@@ -1,19 +1,15 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
+], function(require, React) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     var Foo = function Foo(props) {
         return null;
     };
     function Greet(x) {
         return null;
     }
-    var foo = /*#__PURE__*/ _react.createElement(Foo, null);
-    var G = /*#__PURE__*/ _react.createElement(Greet, null);
+    var foo = /*#__PURE__*/ React.createElement(Foo, null);
+    var G = /*#__PURE__*/ React.createElement(Greet, null);
 });

--- a/crates/swc/tests/tsc-references/tsxSfcReturnNull.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxSfcReturnNull.2.minified.js
@@ -1,10 +1,5 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    });
-});
+], function(require, React) {});

--- a/crates/swc/tests/tsc-references/tsxSfcReturnNullStrictNullChecks.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxSfcReturnNullStrictNullChecks.1.normal.js
@@ -1,19 +1,15 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
+], function(require, React) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     var Foo = function Foo(props) {
         return null;
     };
     function Greet(x) {
         return null;
     }
-    var foo = /*#__PURE__*/ _react.createElement(Foo, null);
-    var G = /*#__PURE__*/ _react.createElement(Greet, null);
+    var foo = /*#__PURE__*/ React.createElement(Foo, null);
+    var G = /*#__PURE__*/ React.createElement(Greet, null);
 });

--- a/crates/swc/tests/tsc-references/tsxSfcReturnNullStrictNullChecks.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxSfcReturnNullStrictNullChecks.2.minified.js
@@ -1,10 +1,5 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    });
-});
+], function(require, React) {});

--- a/crates/swc/tests/tsc-references/tsxSfcReturnUndefinedStrictNullChecks.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxSfcReturnUndefinedStrictNullChecks.1.normal.js
@@ -1,13 +1,9 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
+], function(require, React) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     var Foo = function Foo(props) {
         return undefined;
     };
@@ -15,6 +11,6 @@ define([
         return undefined;
     }
     // Error
-    var foo = /*#__PURE__*/ _react.createElement(Foo, null);
-    var G = /*#__PURE__*/ _react.createElement(Greet, null);
+    var foo = /*#__PURE__*/ React.createElement(Foo, null);
+    var G = /*#__PURE__*/ React.createElement(Greet, null);
 });

--- a/crates/swc/tests/tsc-references/tsxSfcReturnUndefinedStrictNullChecks.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxSfcReturnUndefinedStrictNullChecks.2.minified.js
@@ -1,10 +1,5 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    });
-});
+], function(require, React) {});

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload1.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload1.1.normal.js
@@ -1,73 +1,69 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
+], function(require, React) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     // OK
-    var c1 = /*#__PURE__*/ _react.createElement(OneThing, {
+    var c1 = /*#__PURE__*/ React.createElement(OneThing, {
         yxx: "ok"
     });
-    var c2 = /*#__PURE__*/ _react.createElement(OneThing, {
+    var c2 = /*#__PURE__*/ React.createElement(OneThing, {
         yy: 100,
         yy1: "hello"
     });
-    var c3 = /*#__PURE__*/ _react.createElement(OneThing, {
+    var c3 = /*#__PURE__*/ React.createElement(OneThing, {
         yxx: "hello",
         "ignore-prop": true
     });
-    var c4 = /*#__PURE__*/ _react.createElement(OneThing, {
+    var c4 = /*#__PURE__*/ React.createElement(OneThing, {
         data: "hello",
         "data-prop": true
     });
-    var c5 = /*#__PURE__*/ _react.createElement(OneThing, {
+    var c5 = /*#__PURE__*/ React.createElement(OneThing, {
         yxx1: "ok"
     }, "Hello");
     // OK
-    var d1 = /*#__PURE__*/ _react.createElement(TestingOneThing, {
+    var d1 = /*#__PURE__*/ React.createElement(TestingOneThing, {
         y1: true,
         "extra-data": true
     });
-    var d2 = /*#__PURE__*/ _react.createElement(TestingOneThing, {
+    var d2 = /*#__PURE__*/ React.createElement(TestingOneThing, {
         "extra-data": "hello"
     });
-    var d3 = /*#__PURE__*/ _react.createElement(TestingOneThing, {
+    var d3 = /*#__PURE__*/ React.createElement(TestingOneThing, {
         "extra-data": "hello",
         yy: "hihi"
     });
-    var d4 = /*#__PURE__*/ _react.createElement(TestingOneThing, {
+    var d4 = /*#__PURE__*/ React.createElement(TestingOneThing, {
         "extra-data": "hello",
         yy: 9,
         direction: 10
     });
-    var d5 = /*#__PURE__*/ _react.createElement(TestingOneThing, {
+    var d5 = /*#__PURE__*/ React.createElement(TestingOneThing, {
         "extra-data": "hello",
         yy: "hello",
         name: "Bob"
     });
     // OK
-    var e1 = /*#__PURE__*/ _react.createElement(TestingOptional, null);
-    var e3 = /*#__PURE__*/ _react.createElement(TestingOptional, {
+    var e1 = /*#__PURE__*/ React.createElement(TestingOptional, null);
+    var e3 = /*#__PURE__*/ React.createElement(TestingOptional, {
         y1: "hello"
     });
-    var e4 = /*#__PURE__*/ _react.createElement(TestingOptional, {
+    var e4 = /*#__PURE__*/ React.createElement(TestingOptional, {
         y1: "hello",
         y2: 1000
     });
-    var e5 = /*#__PURE__*/ _react.createElement(TestingOptional, {
+    var e5 = /*#__PURE__*/ React.createElement(TestingOptional, {
         y1: true,
         y3: true
     });
-    var e6 = /*#__PURE__*/ _react.createElement(TestingOptional, {
+    var e6 = /*#__PURE__*/ React.createElement(TestingOptional, {
         y1: true,
         y3: true,
         y2: 10
     });
-    var e2 = /*#__PURE__*/ _react.createElement(TestingOptional, {
+    var e2 = /*#__PURE__*/ React.createElement(TestingOptional, {
         y1: true,
         y3: true,
         "extra-prop": true

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload1.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload1.2.minified.js
@@ -1,10 +1,7 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), OneThing, OneThing, OneThing, OneThing, OneThing, TestingOneThing, TestingOneThing, TestingOneThing, TestingOneThing, TestingOneThing, TestingOptional, TestingOptional, TestingOptional, TestingOptional, TestingOptional, TestingOptional;
+], function(require, React) {
+    OneThing, OneThing, OneThing, OneThing, OneThing, TestingOneThing, TestingOneThing, TestingOneThing, TestingOneThing, TestingOneThing, TestingOptional, TestingOptional, TestingOptional, TestingOptional, TestingOptional, TestingOptional;
 });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload2.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload2.1.normal.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
@@ -23,28 +23,28 @@ define([
     };
     var defaultObj;
     // OK
-    var c1 = /*#__PURE__*/ _react.createElement(OneThing, null);
-    var c2 = /*#__PURE__*/ _react.createElement(OneThing, obj);
-    var c3 = /*#__PURE__*/ _react.createElement(OneThing, {});
-    var c4 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread._({}, obj1, obj));
-    var c5 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj1), {
+    var c1 = /*#__PURE__*/ React.createElement(OneThing, null);
+    var c2 = /*#__PURE__*/ React.createElement(OneThing, obj);
+    var c3 = /*#__PURE__*/ React.createElement(OneThing, {});
+    var c4 = /*#__PURE__*/ React.createElement(OneThing, _object_spread._({}, obj1, obj));
+    var c5 = /*#__PURE__*/ React.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj1), {
         yy: 42,
         yy1: "hi"
     }));
-    var c6 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj1), {
+    var c6 = /*#__PURE__*/ React.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj1), {
         yy: 10000,
         yy1: "true"
     }));
-    var c7 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread._(_object_spread_props._(_object_spread._({}, defaultObj), {
+    var c7 = /*#__PURE__*/ React.createElement(OneThing, _object_spread._(_object_spread_props._(_object_spread._({}, defaultObj), {
         yy: true
     }), obj)); // No error. should pick second overload
-    var c8 = /*#__PURE__*/ _react.createElement(OneThing, {
+    var c8 = /*#__PURE__*/ React.createElement(OneThing, {
         "ignore-prop": 100
     });
-    var c9 = /*#__PURE__*/ _react.createElement(OneThing, {
+    var c9 = /*#__PURE__*/ React.createElement(OneThing, {
         "ignore-prop": 200
     });
-    var c10 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj2), {
+    var c10 = /*#__PURE__*/ React.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj2), {
         yy1: "boo"
     }));
 });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload2.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload2.2.minified.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     Object.defineProperty(exports, "__esModule", {
         value: !0
     });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload4.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload4.1.normal.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
@@ -16,54 +16,54 @@ define([
     };
     var obj2;
     // Error
-    var c0 = /*#__PURE__*/ _react.createElement(OneThing, {
+    var c0 = /*#__PURE__*/ React.createElement(OneThing, {
         extraProp: true
     }); // extra property;
-    var c1 = /*#__PURE__*/ _react.createElement(OneThing, {
+    var c1 = /*#__PURE__*/ React.createElement(OneThing, {
         yy: 10
     }); // missing property;
-    var c2 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj), {
+    var c2 = /*#__PURE__*/ React.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj), {
         yy1: true
     })); // type incompatible;
-    var c3 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj), {
+    var c3 = /*#__PURE__*/ React.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj), {
         extra: "extra attr"
     })); //  This is OK because all attribute are spread
-    var c4 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj), {
+    var c4 = /*#__PURE__*/ React.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj), {
         y1: 10000
     })); // extra property;
-    var c5 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj), {
+    var c5 = /*#__PURE__*/ React.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj), {
         yy: true
     })); // type incompatible;
-    var c6 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj2), {
+    var c6 = /*#__PURE__*/ React.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj2), {
         extra: "extra attr"
     })); // Should error as there is extra attribute that doesn't match any. Current it is not
-    var c7 = /*#__PURE__*/ _react.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj2), {
+    var c7 = /*#__PURE__*/ React.createElement(OneThing, _object_spread_props._(_object_spread._({}, obj2), {
         yy: true
     })); // Should error as there is extra attribute that doesn't match any. Current it is not
     // Error
-    var d1 = /*#__PURE__*/ _react.createElement(TestingOneThing, {
+    var d1 = /*#__PURE__*/ React.createElement(TestingOneThing, {
         "extra-data": true
     });
-    var d2 = /*#__PURE__*/ _react.createElement(TestingOneThing, {
+    var d2 = /*#__PURE__*/ React.createElement(TestingOneThing, {
         yy: "hello",
         direction: "left"
     });
     // Error
-    var e1 = /*#__PURE__*/ _react.createElement(TestingOptional, {
+    var e1 = /*#__PURE__*/ React.createElement(TestingOptional, {
         y1: true,
         y3: "hello"
     });
-    var e2 = /*#__PURE__*/ _react.createElement(TestingOptional, {
+    var e2 = /*#__PURE__*/ React.createElement(TestingOptional, {
         y1: "hello",
         y2: 1000,
         y3: true
     });
-    var e3 = /*#__PURE__*/ _react.createElement(TestingOptional, {
+    var e3 = /*#__PURE__*/ React.createElement(TestingOptional, {
         y1: "hello",
         y2: 1000,
         children: "hi"
     });
-    var e4 = /*#__PURE__*/ _react.createElement(TestingOptional, {
+    var e4 = /*#__PURE__*/ React.createElement(TestingOptional, {
         y1: "hello",
         y2: 1000
     }, "Hi");

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload4.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload4.2.minified.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     Object.defineProperty(exports, "__esModule", {
         value: !0
     });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload5.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload5.1.normal.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
@@ -35,36 +35,36 @@ define([
         return this._buildMainButton(props);
     }
     // Error
-    var b0 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b0 = /*#__PURE__*/ React.createElement(MainButton, {
         to: "/some/path",
         onClick: function onClick(e) {}
     }, "GO"); // extra property;
-    var b1 = /*#__PURE__*/ _react.createElement(MainButton, _object_spread._({
+    var b1 = /*#__PURE__*/ React.createElement(MainButton, _object_spread._({
         onClick: function onClick(e) {}
     }, obj0), "Hello world"); // extra property;
-    var b2 = /*#__PURE__*/ _react.createElement(MainButton, _object_spread._({
+    var b2 = /*#__PURE__*/ React.createElement(MainButton, _object_spread._({
         to: "10000"
     }, obj2)); // extra property
-    var b3 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b3 = /*#__PURE__*/ React.createElement(MainButton, {
         to: "10000",
         onClick: function onClick(k) {}
     }); // extra property
-    var b4 = /*#__PURE__*/ _react.createElement(MainButton, _object_spread_props._(_object_spread._({}, obj3), {
+    var b4 = /*#__PURE__*/ React.createElement(MainButton, _object_spread_props._(_object_spread._({}, obj3), {
         to: true
     })); // Should error because Incorrect type; but attributes are any so everything is allowed
-    var b5 = /*#__PURE__*/ _react.createElement(MainButton, _object_spread._({
+    var b5 = /*#__PURE__*/ React.createElement(MainButton, _object_spread._({
         onClick: function onClick(e) {}
     }, obj0)); // Spread retain method declaration (see GitHub #13365), so now there is an extra attributes
-    var b6 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b6 = /*#__PURE__*/ React.createElement(MainButton, {
         onClick: function onClick(e) {},
         children: 10
     }); // incorrect type for optional attribute
-    var b7 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b7 = /*#__PURE__*/ React.createElement(MainButton, {
         onClick: function onClick(e) {},
         children: "hello",
         className: true
     }); // incorrect type for optional attribute
-    var b8 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b8 = /*#__PURE__*/ React.createElement(MainButton, {
         "data-format": true
     }); // incorrect type for specified hyphanated name
 });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload5.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload5.2.minified.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     Object.defineProperty(exports, "__esModule", {
         value: !0
     }), Object.defineProperty(exports, "MainButton", {

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload6.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload6.1.normal.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
@@ -32,43 +32,43 @@ define([
         return this._buildMainButton(props);
     }
     // OK
-    var b0 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b0 = /*#__PURE__*/ React.createElement(MainButton, {
         to: "/some/path"
     }, "GO");
-    var b1 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b1 = /*#__PURE__*/ React.createElement(MainButton, {
         onClick: function onClick(e) {}
     }, "Hello world");
-    var b2 = /*#__PURE__*/ _react.createElement(MainButton, obj);
-    var b3 = /*#__PURE__*/ _react.createElement(MainButton, _object_spread._({
+    var b2 = /*#__PURE__*/ React.createElement(MainButton, obj);
+    var b3 = /*#__PURE__*/ React.createElement(MainButton, _object_spread._({
         to: 10000
     }, obj));
-    var b4 = /*#__PURE__*/ _react.createElement(MainButton, obj1); // any; just pick the first overload
-    var b5 = /*#__PURE__*/ _react.createElement(MainButton, _object_spread_props._(_object_spread._({}, obj1), {
+    var b4 = /*#__PURE__*/ React.createElement(MainButton, obj1); // any; just pick the first overload
+    var b5 = /*#__PURE__*/ React.createElement(MainButton, _object_spread_props._(_object_spread._({}, obj1), {
         to: "/to/somewhere"
     })); // should pick the second overload
-    var b6 = /*#__PURE__*/ _react.createElement(MainButton, obj2);
-    var b7 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b6 = /*#__PURE__*/ React.createElement(MainButton, obj2);
+    var b7 = /*#__PURE__*/ React.createElement(MainButton, {
         onClick: function onClick() {
             console.log("hi");
         }
     });
-    var b8 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b8 = /*#__PURE__*/ React.createElement(MainButton, {
         onClick: function onClick() {}
     }); // OK; method declaration get retained (See GitHub #13365)
-    var b9 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b9 = /*#__PURE__*/ React.createElement(MainButton, {
         to: "/some/path",
         "extra-prop": true
     }, "GO");
-    var b10 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b10 = /*#__PURE__*/ React.createElement(MainButton, {
         to: "/some/path",
         children: "hi"
     });
-    var b11 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b11 = /*#__PURE__*/ React.createElement(MainButton, {
         onClick: function onClick(e) {},
         className: "hello",
         "data-format": true
     }, "Hello world");
-    var b12 = /*#__PURE__*/ _react.createElement(MainButton, {
+    var b12 = /*#__PURE__*/ React.createElement(MainButton, {
         "data-format": "Hello world"
     });
 });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload6.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentOverload6.2.minified.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     var obj1;
     function MainButton(props) {
         return props.to ? this._buildMainLink(props) : this._buildMainButton(props);

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentWithDefaultTypeParameter1.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentWithDefaultTypeParameter1.1.normal.js
@@ -1,21 +1,17 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
+], function(require, React) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     function MyComponent(attr) {
-        return /*#__PURE__*/ _react.createElement("div", null, "attr.values");
+        return /*#__PURE__*/ React.createElement("div", null, "attr.values");
     }
     // OK
-    var i = /*#__PURE__*/ _react.createElement(MyComponent, {
+    var i = /*#__PURE__*/ React.createElement(MyComponent, {
         values: true
     }); // We infer type arguments here
-    var i1 = /*#__PURE__*/ _react.createElement(MyComponent, {
+    var i1 = /*#__PURE__*/ React.createElement(MyComponent, {
         values: "Hello"
     });
 });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentWithDefaultTypeParameter1.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentWithDefaultTypeParameter1.2.minified.js
@@ -1,10 +1,5 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    });
-});
+], function(require, React) {});

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentWithDefaultTypeParameter2.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentWithDefaultTypeParameter2.1.normal.js
@@ -1,18 +1,14 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
+], function(require, React) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     function MyComponent1(attr) {
-        return /*#__PURE__*/ _react.createElement("div", null, "attr.values");
+        return /*#__PURE__*/ React.createElement("div", null, "attr.values");
     }
     // Error
-    var i1 = /*#__PURE__*/ _react.createElement(MyComponent1, {
+    var i1 = /*#__PURE__*/ React.createElement(MyComponent1, {
         values: 5
     });
 });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentWithDefaultTypeParameter2.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentWithDefaultTypeParameter2.2.minified.js
@@ -1,10 +1,5 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    });
-});
+], function(require, React) {});

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponents3.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponents3.1.normal.js
@@ -1,24 +1,20 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
+], function(require, React) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     var Foo = function Foo(props) {
-        return /*#__PURE__*/ _react.createElement("div", null);
+        return /*#__PURE__*/ React.createElement("div", null);
     };
     // Should be OK
-    var foo = /*#__PURE__*/ _react.createElement(Foo, null);
+    var foo = /*#__PURE__*/ React.createElement(Foo, null);
     // Should be OK
     var MainMenu = function MainMenu(props) {
-        return /*#__PURE__*/ _react.createElement("div", null, /*#__PURE__*/ _react.createElement("h3", null, "Main Menu"));
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement("h3", null, "Main Menu"));
     };
     var App = function App(param) {
         var children = param.children;
-        return /*#__PURE__*/ _react.createElement("div", null, /*#__PURE__*/ _react.createElement(MainMenu, null));
+        return /*#__PURE__*/ React.createElement("div", null, /*#__PURE__*/ React.createElement(MainMenu, null));
     };
 });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponents3.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponents3.2.minified.js
@@ -1,10 +1,5 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    });
-});
+], function(require, React) {});

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments1.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments1.1.normal.js
@@ -1,20 +1,16 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
+], function(require, React) {
     "use strict";
-    Object.defineProperty(exports, "__esModule", {
-        value: true
-    });
     // OK
     function Baz(key1, value) {
-        var a0 = /*#__PURE__*/ _react.createElement(ComponentWithTwoAttributes, {
+        var a0 = /*#__PURE__*/ React.createElement(ComponentWithTwoAttributes, {
             key1: key1,
             value: value
         });
-        var a1 = /*#__PURE__*/ _react.createElement(ComponentWithTwoAttributes, {
+        var a1 = /*#__PURE__*/ React.createElement(ComponentWithTwoAttributes, {
             key1: key1,
             value: value,
             key: "Component"
@@ -22,17 +18,17 @@ define([
     }
     // OK
     function createLink(func) {
-        var o = /*#__PURE__*/ _react.createElement(Link, {
+        var o = /*#__PURE__*/ React.createElement(Link, {
             func: func
         });
     }
     function createLink1(func) {
-        var o = /*#__PURE__*/ _react.createElement(Link, {
+        var o = /*#__PURE__*/ React.createElement(Link, {
             func: func
         });
     }
     // OK
-    var i = /*#__PURE__*/ _react.createElement(InferParamComponent, {
+    var i = /*#__PURE__*/ React.createElement(InferParamComponent, {
         values: [
             1,
             2,

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments1.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments1.2.minified.js
@@ -1,10 +1,7 @@
 //// [file.tsx]
 define([
     "require",
-    "exports",
     "react"
-], function(require, exports, _react) {
-    Object.defineProperty(exports, "__esModule", {
-        value: !0
-    }), InferParamComponent;
+], function(require, React) {
+    InferParamComponent;
 });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments2.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments2.1.normal.js
@@ -5,29 +5,29 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
     // Error
     function Bar(arg) {
-        var a1 = /*#__PURE__*/ _react.createElement(ComponentSpecific1, _object_spread_props._(_object_spread._({}, arg), {
+        var a1 = /*#__PURE__*/ React.createElement(ComponentSpecific1, _object_spread_props._(_object_spread._({}, arg), {
             "ignore-prop": 10
         }));
     }
     // Error
     function Baz(arg) {
-        var a0 = /*#__PURE__*/ _react.createElement(ComponentSpecific1, arg);
+        var a0 = /*#__PURE__*/ React.createElement(ComponentSpecific1, arg);
     }
     // Error
     function createLink(func) {
-        var o = /*#__PURE__*/ _react.createElement(Link, {
+        var o = /*#__PURE__*/ React.createElement(Link, {
             func: func
         });
     }
     // Error
-    var i = /*#__PURE__*/ _react.createElement(InferParamComponent, {
+    var i = /*#__PURE__*/ React.createElement(InferParamComponent, {
         values: [
             1,
             2,

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments2.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments2.2.minified.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     Object.defineProperty(exports, "__esModule", {
         value: !0
     }), InferParamComponent;

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments3.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments3.1.normal.js
@@ -5,37 +5,37 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
     // OK
     function Baz(arg1, arg2) {
-        var a0 = /*#__PURE__*/ _react.createElement(OverloadComponent, _object_spread_props._(_object_spread._({}, arg1), {
+        var a0 = /*#__PURE__*/ React.createElement(OverloadComponent, _object_spread_props._(_object_spread._({}, arg1), {
             a: "hello",
             "ignore-prop": true
         }));
-        var a1 = /*#__PURE__*/ _react.createElement(OverloadComponent, _object_spread_props._(_object_spread._({}, arg2), {
+        var a1 = /*#__PURE__*/ React.createElement(OverloadComponent, _object_spread_props._(_object_spread._({}, arg2), {
             "ignore-pro": "hello world"
         }));
-        var a2 = /*#__PURE__*/ _react.createElement(OverloadComponent, arg2);
-        var a3 = /*#__PURE__*/ _react.createElement(OverloadComponent, _object_spread_props._(_object_spread._({}, arg1), {
+        var a2 = /*#__PURE__*/ React.createElement(OverloadComponent, arg2);
+        var a3 = /*#__PURE__*/ React.createElement(OverloadComponent, _object_spread_props._(_object_spread._({}, arg1), {
             "ignore-prop": true
         }));
-        var a4 = /*#__PURE__*/ _react.createElement(OverloadComponent, null);
-        var a5 = /*#__PURE__*/ _react.createElement(OverloadComponent, _object_spread._(_object_spread_props._(_object_spread._({}, arg2), {
+        var a4 = /*#__PURE__*/ React.createElement(OverloadComponent, null);
+        var a5 = /*#__PURE__*/ React.createElement(OverloadComponent, _object_spread._(_object_spread_props._(_object_spread._({}, arg2), {
             "ignore-prop": "hello"
         }), arg1));
-        var a6 = /*#__PURE__*/ _react.createElement(OverloadComponent, _object_spread._(_object_spread_props._(_object_spread._({}, arg2), {
+        var a6 = /*#__PURE__*/ React.createElement(OverloadComponent, _object_spread._(_object_spread_props._(_object_spread._({}, arg2), {
             "ignore-prop": true
         }), arg1));
     }
     function createLink(func) {
-        var o = /*#__PURE__*/ _react.createElement(Link, {
+        var o = /*#__PURE__*/ React.createElement(Link, {
             func: func
         });
-        var o1 = /*#__PURE__*/ _react.createElement(Link, {
+        var o1 = /*#__PURE__*/ React.createElement(Link, {
             func: function func(a, b) {}
         });
     }

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments3.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments3.2.minified.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     Object.defineProperty(exports, "__esModule", {
         value: !0
     });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments4.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments4.1.normal.js
@@ -5,17 +5,17 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
     // Error
     function Baz(arg1, arg2) {
-        var a0 = /*#__PURE__*/ _react.createElement(OverloadComponent, {
+        var a0 = /*#__PURE__*/ React.createElement(OverloadComponent, {
             a: arg1.b
         });
-        var a2 = /*#__PURE__*/ _react.createElement(OverloadComponent, _object_spread_props._(_object_spread._({}, arg1), {
+        var a2 = /*#__PURE__*/ React.createElement(OverloadComponent, _object_spread_props._(_object_spread._({}, arg1), {
             "ignore-prop": true
         }));
     // missing a

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments4.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments4.2.minified.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     Object.defineProperty(exports, "__esModule", {
         value: !0
     });

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments5.1.normal.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments5.1.normal.js
@@ -5,28 +5,28 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
     function createComponent(arg) {
-        var a1 = /*#__PURE__*/ _react.createElement(Component, arg);
-        var a2 = /*#__PURE__*/ _react.createElement(Component, _object_spread_props._(_object_spread._({}, arg), {
+        var a1 = /*#__PURE__*/ React.createElement(Component, arg);
+        var a2 = /*#__PURE__*/ React.createElement(Component, _object_spread_props._(_object_spread._({}, arg), {
             prop1: true
         }));
     }
     function Bar(arg) {
-        var a1 = /*#__PURE__*/ _react.createElement(ComponentSpecific, _object_spread_props._(_object_spread._({}, arg), {
+        var a1 = /*#__PURE__*/ React.createElement(ComponentSpecific, _object_spread_props._(_object_spread._({}, arg), {
             "ignore-prop": "hi"
         })); // U is number
-        var a2 = /*#__PURE__*/ _react.createElement(ComponentSpecific1, _object_spread_props._(_object_spread._({}, arg), {
+        var a2 = /*#__PURE__*/ React.createElement(ComponentSpecific1, _object_spread_props._(_object_spread._({}, arg), {
             "ignore-prop": 10
         })); // U is number
-        var a3 = /*#__PURE__*/ _react.createElement(ComponentSpecific, _object_spread_props._(_object_spread._({}, arg), {
+        var a3 = /*#__PURE__*/ React.createElement(ComponentSpecific, _object_spread_props._(_object_spread._({}, arg), {
             prop: "hello"
         })); // U is "hello"
-        var a4 = /*#__PURE__*/ _react.createElement(ComponentSpecific, _object_spread_props._(_object_spread._({}, arg), {
+        var a4 = /*#__PURE__*/ React.createElement(ComponentSpecific, _object_spread_props._(_object_spread._({}, arg), {
             prop1: "hello"
         })); // U is "hello"
     }

--- a/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments5.2.minified.js
+++ b/crates/swc/tests/tsc-references/tsxStatelessFunctionComponentsWithTypeArguments5.2.minified.js
@@ -5,7 +5,7 @@ define([
     "@swc/helpers/_/_object_spread",
     "@swc/helpers/_/_object_spread_props",
     "react"
-], function(require, exports, _object_spread, _object_spread_props, _react) {
+], function(require, exports, _object_spread, _object_spread_props, React) {
     Object.defineProperty(exports, "__esModule", {
         value: !0
     });

--- a/crates/swc/tests/tsc-references/typesOnlyExternalModuleStillHasInstance.1.normal.js
+++ b/crates/swc/tests/tsc-references/typesOnlyExternalModuleStillHasInstance.1.normal.js
@@ -5,9 +5,6 @@ Object.defineProperty(exports, "__esModule", {
 });
 //// [foo_1.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 var foo0 = require("./foo_0");
 // Per 11.2.3, foo_0 should still be "instantiated", albeit with no members
 var x = {};

--- a/crates/swc/tests/tsc-references/typesOnlyExternalModuleStillHasInstance.2.minified.js
+++ b/crates/swc/tests/tsc-references/typesOnlyExternalModuleStillHasInstance.2.minified.js
@@ -3,6 +3,4 @@ Object.defineProperty(exports, "__esModule", {
     value: !0
 });
 //// [foo_1.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-}), require("./foo_0");
+require("./foo_0");

--- a/crates/swc/tests/tsc-references/usingDeclarationsTopLevelOfModule.1(module=system).1.normal.js
+++ b/crates/swc/tests/tsc-references/usingDeclarationsTopLevelOfModule.1(module=system).1.normal.js
@@ -4,7 +4,7 @@ System.register([
     "@swc/helpers/_/_ts_dispose_resources"
 ], function(_export, _context) {
     "use strict";
-    var _default, _ts_add_disposable_resource, _ts_dispose_resources, env, w, x, y, z;
+    var _ts_add_disposable_resource, _ts_dispose_resources, env, w, x, y, z;
     _export({
         default: void 0,
         w: void 0,
@@ -40,7 +40,7 @@ System.register([
             }
             _export("x", x = 1);
             _export("w", w = 3);
-            _export("default", _default = 4);
+            _export("default", 4);
         }
     };
 });

--- a/crates/swc/tests/tsc-references/verbatimModuleSyntaxNoElisionCJS.1.normal.js
+++ b/crates/swc/tests/tsc-references/verbatimModuleSyntaxNoElisionCJS.1.normal.js
@@ -5,9 +5,6 @@
 module.exports = I;
 //// [/b.ts]
 "use strict";
-Object.defineProperty(exports, "__esModule", {
-    value: true
-});
 const I = require("./a");
 //// [/c.ts]
 "use strict";

--- a/crates/swc/tests/tsc-references/verbatimModuleSyntaxNoElisionCJS.2.minified.js
+++ b/crates/swc/tests/tsc-references/verbatimModuleSyntaxNoElisionCJS.2.minified.js
@@ -2,9 +2,7 @@
 //// [/a.ts]
 module.exports = I;
 //// [/b.ts]
-Object.defineProperty(exports, "__esModule", {
-    value: !0
-}), require("./a");
+require("./a");
 //// [/c.ts]
 var I;
 (I || (I = {})).x = 1, module.exports = I;

--- a/crates/swc_ecma_transforms_module/README.md
+++ b/crates/swc_ecma_transforms_module/README.md
@@ -10,22 +10,28 @@ CommonJS-like reducer.
 ```mermaid
 flowchart TD
     Input["Input ECMAScript module AST"]
-    Prelude["Directives, strict mode, and top-level this"]
-    Extractor["ModuleSyntaxExtractor"]
-    Record["RequestedModules, LocalExportEntries, and export assignment"]
+    TopLevelThis["Top-level this rewrite"]
+    Source["SourceModule::collect"]
+    Strip["syntax_strip::lower"]
     Reducer["ModuleRecordEntryReducer"]
     Rewrite["ImportMap and export getter list"]
     Cjs["CommonJS emitter"]
     Amd["AMD emitter"]
     Umd["UMD emitter"]
+    SysLower["SystemJS lower"]
+    SysRewrite["SystemJS rewrite"]
+    SysEmit["SystemJS emitter"]
     CjsOut["require calls, export getters, and module.exports"]
     AmdOut["define dependency array and factory body"]
     UmdOut["adapter IIFE and shared factory body"]
+    SysOut["System.register call"]
 
-    Input --> Prelude --> Extractor --> Record --> Reducer --> Rewrite
+    Input --> TopLevelThis --> Source
+    Source --> Strip --> Reducer --> Rewrite
     Rewrite --> Cjs --> CjsOut
     Rewrite --> Amd --> AmdOut
     Rewrite --> Umd --> UmdOut
+    Source --> SysLower --> SysRewrite --> SysEmit --> SysOut
 ```
 
 SystemJS is documented separately below because its live-binding and execution
@@ -34,46 +40,59 @@ model is organized around `System.register`, dependency setters, and an
 
 ## Shared Terminology
 
-The shared extractor in `src/module_record.rs` intentionally uses names close to
-the ECMAScript module record vocabulary:
+The shared collector in `src/module_record.rs` intentionally uses names close
+to the ECMAScript module record vocabulary:
 
-- `ModuleSyntaxExtractor` walks source module declarations, records their module
-  linkage information, and removes module declarations from the executable body.
-- `RequestedModules` is grouped by module request string and preserves source
+- `SourceModule::collect` walks source module declarations, records their
+  module linkage information, and keeps ordered executable source items.
+- `SourceModuleItem` keeps declarations that target lowerers still need to
+  lower, including exported declarations, default exports, and external
+  TypeScript `import = require(...)`.
+- `RequestedModules` is grouped by `ModuleRequestRecord` and preserves source
   order with `IndexMap`.
+- `ModuleRequestRecord` stores the module specifier and normalized import
+  attributes for that request.
 - `RequestedModule` stores the first useful source span, the collected
-  `ModuleRecordEntry` set for that request, and `ModuleRequestUsage`.
+  `ModuleRecordEntry` set, and `ModuleRequestUsage`.
 - `LocalExportEntries` stores local exports keyed by exported name.
-- `ModuleRecordEntry` represents import entries, indirect export entries,
-  star exports, and TypeScript `import = require(...)` entries.
+- `ModuleRecordEntry` represents import entries, indirect export entries, and
+  star exports.
+- `syntax_strip::lower` converts `SourceModule` into `SyntaxStrippedModule` for
+  the CommonJS, AMD, and UMD passes.
 - `ModuleRecordEntryReducer` converts collected entries into emitter-facing
   structures: an `ImportMap` for rewritten local references and an
   `ExportObjectProperties` list for generated export getters.
 
-The model is not a full ECMAScript linker. It records the syntactic module graph
-information needed by CommonJS-like emitters and keeps unresolved binding access
-lazy through generated property reads.
+`SourceModule` is a target-neutral collection model, not a full ECMAScript
+linker. `ModuleRecordEntryReducer` converts its syntactic linkage facts for
+CommonJS-like emitters and keeps unresolved binding access lazy through generated
+property reads.
+
+SystemJS preserves import attributes in its dependency metadata. CommonJS, AMD,
+and UMD do not process import attributes because their output formats cannot
+express them; those lowering paths assume attributed requests are not provided.
 
 ## Shared Front-End Flow
 
-Each transform starts with an AST `Module` and follows the same broad pipeline:
+The CommonJS, AMD, and UMD transforms follow the same broad pipeline:
 
-1. Move initial directive statements into the output body.
-2. Insert `"use strict"` when `Config::strict_mode` requires it and the module
-   does not already contain one.
-3. Replace top-level `this` with `undefined` unless
+1. Replace top-level `this` with `undefined` unless
    `Config::allow_top_level_this` is enabled.
-4. Run `ModuleSyntaxExtractor`.
-5. Emit an `__esModule` marker when the input had module syntax, import interop
+2. Run `SourceModule::collect`.
+3. Run `syntax_strip::lower` to remove module syntax from the executable body.
+4. Move initial directive statements into the output body.
+5. Insert `"use strict"` when `Config::strict_mode` requires it and the module
+   does not already contain one.
+6. Emit an `__esModule` marker when the input had module syntax, import interop
    is enabled, and the module is not a TypeScript `export =` module.
-6. Convert collected module entries into format-specific import statements,
+7. Convert collected module entries into format-specific import statements,
    dependency parameters, export getters, and import-reference rewrites.
-7. Append the stripped executable body.
-8. Apply format-specific handling for `export =`, dynamic `import()`, and
+8. Append the stripped executable body.
+9. Apply format-specific handling for `export =`, dynamic `import()`, and
    `import.meta` where supported by that transform.
-9. Rewrite local import binding references using the generated `ImportMap`.
+10. Rewrite local import binding references using the generated `ImportMap`.
 
-The extractor strips module declarations while preserving executable
+The strip step removes module declarations while preserving executable
 declarations:
 
 - `import ... from "mod"` is removed after its import entries are collected.
@@ -87,6 +106,12 @@ declarations:
   `"default" -> foo`.
 - `export default expr` becomes a generated `_default` binding and records
   `"default" -> _default`.
+- A non-exported external TypeScript `import x = require("mod")` is kept as an
+  ordered source item for the target lowerer. It models the CTS form of ES
+  `import.sync`, so it does not participate in ES module linking or mark the
+  source as an ES module.
+- The exported form also registers `x` in `LocalExportEntries` and therefore
+  participates in module linking.
 - Type-only imports and exports do not create runtime module entries.
 
 ## Module Request Usage
@@ -98,9 +123,6 @@ declarations:
 - `NAMESPACE` is the combined named/default shape needed for namespace imports
   and namespace re-exports.
 - `STAR_EXPORT` means generated code calls the `_export_star` helper.
-- `TS_IMPORT_EQUALS` tracks TypeScript `import x = require("mod")` entries that
-  may need access to the raw imported value in addition to an interop-wrapped
-  value.
 
 When `importInterop` is `none`, namespace usage is removed before emit because
 the transform must not inject interop helpers.
@@ -118,63 +140,26 @@ to CommonJS-like emit structures:
   and then add export getter entries.
 - Indirect namespace exports add an export getter that returns the module object.
 - Star exports are emitted by the caller with `_export_star(...)`.
-- TypeScript `import = require(...)` maps to the raw module temporary when one is
-  needed, otherwise to the normal module temporary.
 
 Export getters are sorted by exported name before emit. A single export uses a
 direct `Object.defineProperty` call, while multiple exports use the shared
 `_export(exports, { ... })` helper shape.
 
-## CommonJS Binding Walkthrough
+## CommonJS Binding Flow
 
-The diagram below follows the current implementation names for a representative
-CommonJS transform. AMD and UMD reuse the `module_record.rs` collection and
-`ModuleRecordEntryReducer` stages, then replace the final `require` and export
-emission with wrapper-specific dependency and factory emission.
+The CommonJS-like binding path can be summarized as:
 
 ```mermaid
-flowchart TD
-    subgraph Source["Representative source module"]
-        SourceImports["<code>Static imports<br/>import a from 'a'<br/>import { b as b1 } from 'b'<br/>import * as c from 'c'</code>"]:::code
-        SourceExports["<code>Exports<br/>export let d = 1<br/>export default expr<br/>export { g, h as i } from 'foo'<br/>export * from 'bar'</code>"]:::code
-        SourceBody["<code>Executable references<br/>b1()<br/>c()</code>"]:::code
-    end
-
-    subgraph Extraction["ModuleSyntaxExtractor in module_record.rs"]
-        Requested["<code>RequestedModules<br/>a: ImportDefault, usage DEFAULT<br/>b: ImportNamed, usage NAMED<br/>c: ImportNamespace, usage NAMESPACE<br/>foo: IndirectExportNamed, usage NAMED<br/>bar: StarExport, usage STAR_EXPORT</code>"]:::code
-        LocalExports["<code>LocalExportEntries<br/>d -&gt; local d<br/>default -&gt; generated _default</code>"]:::code
-        Stripped["<code>Stripped body<br/>import/export declarations removed<br/>local declarations kept<br/>default expr becomes _default declaration</code>"]:::code
-    end
-
-    subgraph Reduction["ModuleRecordEntryReducer::reduce"]
-        ImportMap["<code>ImportMap<br/>a -&gt; (_a, default)<br/>b1 -&gt; (_b, b)<br/>c -&gt; (_c, none)<br/>g -&gt; (_foo, g)<br/>i -&gt; (_foo, h)</code>"]:::code
-        ExportBindings["<code>ExportObjectProperties<br/>d -&gt; d<br/>default -&gt; _default<br/>g -&gt; synthetic local g<br/>i -&gt; synthetic local i</code>"]:::code
-    end
-
-    subgraph Emit["CommonJS emit in common_js.rs"]
-        RequireEmit["<code>Request emission<br/>resolver.make_require_call<br/>private temp from local_name_for_src<br/>lazy_require when config.lazy matches</code>"]:::code
-        InteropEmit["<code>Interop and re-export<br/>_interop_require_default for DEFAULT<br/>_interop_require_wildcard for NAMESPACE<br/>_export_star for STAR_EXPORT</code>"]:::code
-        ExportEmit["<code>Export emission<br/>sort_export_bindings<br/>emit_export_stmts(exports, ...)<br/>Object.defineProperty or _export</code>"]:::code
-        Rewrite["<code>rewrite_import_bindings<br/>getter/body refs become module property reads</code>"]:::code
-        Output["<code>Output shape<br/>directives and use strict<br/>define_es_module(exports)<br/>export getters using rewritten refs<br/>require temp declarations and side effects<br/>stripped executable body</code>"]:::code
-    end
-
-    SourceImports --> Requested
-    SourceExports --> Requested
-    SourceExports --> LocalExports
-    SourceBody --> Stripped
-    Requested --> ImportMap
-    Requested --> RequireEmit
-    LocalExports --> ExportBindings
-    ImportMap --> Rewrite
-    ExportBindings --> ExportEmit
-    Stripped --> Rewrite
-    RequireEmit --> InteropEmit
-    InteropEmit --> Output
-    ExportEmit --> Output
-    Rewrite --> Output
-
-    classDef code text-align:left,font-family:monospace;
+flowchart LR
+    Ast["ES module AST"] --> Collect["SourceModule::collect"]
+    Collect --> Strip["syntax_strip::lower"]
+    Strip --> Reduce["Entry reduction<br/>ImportMap + export bindings"]
+    Strip --> Body["Stripped body"]
+    Reduce --> Emit["Emit require/export statements"]
+    Emit --> Assemble["Assemble statements"]
+    Body --> Assemble
+    Reduce --> Rewrite["rewrite_import_bindings"]
+    Assemble --> Rewrite --> Output["CommonJS module"]
 ```
 
 ## CommonJS Flow
@@ -182,15 +167,13 @@ flowchart TD
 The CommonJS pass lives in `src/common_js.rs` and produces direct `require(...)`
 calls.
 
-CommonJS has one extra pre-collection step for TypeScript
-`import x = require("mod")`:
+CommonJS lowers external TypeScript `import x = require("mod")` after
+`syntax_strip::lower` keeps it in the executable body:
 
 - Non-exported `import x = require("mod")` becomes
   `const x = require("mod")` or `var x = require("mod")`.
 - Exported `export import x = require("mod")` becomes
   `exports.x = require("mod")` and adds `x -> exports.x` to the import map.
-- This pre-pass sets `has_ts_import_equals`, which participates in the
-  `__esModule` marker decision.
 
 For each requested module, CommonJS:
 
@@ -207,7 +190,7 @@ For each requested module, CommonJS:
 6. Emits either a declaration for the module temporary, a lazy require wrapper,
    or a side-effect-only statement.
 
-After module requests are emitted, CommonJS emits local and indirect export
+Before module request statements, CommonJS emits local and indirect export
 getters unless the module uses `export =`. For `export = expr`, the pass appends
 `module.exports = expr`.
 
@@ -232,6 +215,10 @@ requested module contributes:
 2. A factory parameter identifier.
 3. Import-map and export-binding entries through `ModuleRecordEntryReducer`.
 4. Optional post-parameter interop assignment inside the factory body.
+
+External TypeScript `import x = require("mod")` also contributes a dependency
+entry and factory parameter. Exported forms assign that parameter to
+`exports.x`.
 
 The final wrapper dependency array always starts with `"require"` and a matching
 `require` factory parameter. The pass adds `"exports"` only when generated code
@@ -273,6 +260,9 @@ The UMD pass lives in `src/umd.rs` and emits an adapter IIFE plus a factory.
 The factory body is produced with the same collection and reduction flow as AMD.
 Requested modules are stored in `dep_list` and become factory parameters.
 
+External TypeScript `import x = require("mod")` also becomes a factory
+parameter. Exported forms assign that parameter to `exports.x`.
+
 The wrapper chooses among CommonJS, AMD, and global execution:
 
 ```javascript
@@ -289,14 +279,16 @@ The wrapper chooses among CommonJS, AMD, and global execution:
 });
 ```
 
-When `ModuleSyntaxExtractor` reports a TypeScript `export =` assignment, UMD
-does not create an exports object parameter. The generated factory returns the
-assigned expression, and the CommonJS branch assigns that factory result to
-`module.exports`:
+When `SourceModule` records a TypeScript `export =` assignment, UMD does not
+create an exports object parameter. The generated factory returns the assigned
+expression, and the CommonJS branch assigns that factory result to
+`module.exports`. The browser fallback assigns the same result to the inferred
+global export name:
 
 ```javascript
 module.exports = factory(require("mod"));
 define(["mod"], factory);
+global.lib = factory(global.mod);
 ```
 
 Some TypeScript/CommonJS syntax paths are already represented as executable
@@ -319,41 +311,50 @@ the shared `util::Config`.
 
 ```mermaid
 flowchart LR
-    Ast["Module AST"] --> Extract["Extract records"]
-    Extract --> Lower["Lower to IR"]
+    Ast["Module AST"] --> Source["SourceModule::collect"]
+    Source --> Lower["Lower to IR"]
     Lower --> Rewrite["Scoped rewrites"]
     Rewrite --> Emit["Emit System.register"]
 ```
 
-SystemJS shares only the collection stage with the CommonJS-like passes. It runs
-`ModuleSyntaxExtractor` with `VarDeclKind::Var`, then lowers the collected
-`RequestedModules` and `LocalExportEntries` into a private SystemJS IR. It does
-not use `ModuleRecordEntryReducer`, `ImportMap`, export getter emission, or
-helper injection.
+SystemJS shares only the collection stage with the CommonJS-like passes. It
+lowers `RequestedModules`, `LocalExportEntries`, ordered source items, and
+TypeScript `export =` assignments into a private SystemJS IR. It does not use
+`syntax_strip::lower`, `ModuleRecordEntryReducer`, `ImportMap`, export getter
+emission, or helper injection.
 
-`src/system_js.rs` owns the public pass, directive handling, strict mode, and
-top-level `this` rewrite. The private `src/system_js/` modules then own the
-format-specific stages:
+`src/system_js.rs` owns the public pass, directive handling, strict mode,
+top-level `this` rewrite, and top-level-await detection. The private
+`src/system_js/` modules then own the format-specific stages:
 
 - `lower.rs` builds `SystemModule`: dependency slots, wrapper-scope bindings,
   export announcements, and execute-time statements.
 - `rewrite.rs` is the scoped visitor boundary for `import.meta`, dynamic
-  `import()`, `__moduleName`, live-binding updates, and top-level-await
-  detection.
+  `import()`, `__moduleName`, and live-binding updates.
 - `emit.rs` is the only layer that creates the final `System.register(...)`
   call.
 
-Lowering keeps SystemJS timing explicit. Dependency requests are merged in
-first-observed order, and each dependency slot owns the setter operations needed
-for imports and re-exports. Top-level function declarations stay in wrapper
-scope, while variable and class initializers run from `execute`. Import
-attributes stay attached to dependency slots and become the optional metadata
-argument to `System.register`.
+Lowering keeps SystemJS timing explicit. ECMAScript module requests are merged
+by `ModuleRequestRecord` in first-observed order, and each dependency slot owns
+the setter operations needed for imports and re-exports. Dependency requests
+from external TypeScript `import = require(...)` stay outside `RequestedModules`
+and lower to independent dependency slots. Top-level function declarations stay
+in wrapper scope, while variable and class initializers run from `execute`.
+Import attributes stay attached to dependency slots and become the optional
+metadata argument to `System.register`.
 
 Local exports are announced before the returned `{ setters, execute }` object:
-function exports use their function values, and other exports start as `void 0`.
-Later writes to exported locals call `_export`; exported destructuring and loop
-heads use setter patterns so local bindings and exported values stay in sync.
+function exports, including anonymous default functions, use their function
+values, and other exports start as `void 0`. Later writes to exported locals
+call `_export`; exported destructuring and loop heads use setter patterns so
+local bindings and exported values stay in sync.
+
+After ordered source items are lowered, TypeScript `export = expr` is appended
+to `execute` as a batch export update:
+
+```javascript
+_export(expr);
+```
 
 ## Helper Injection
 
@@ -370,10 +371,13 @@ corresponding helper calls.
 
 ## Important Boundaries
 
-- `module_record.rs` owns source module extraction and conversion to
-  emitter-facing import/export structures.
-- `common_js.rs`, `amd.rs`, and `umd.rs` own wrapper shape, dependency emission,
-  interop application, and special runtime rewrites for their format.
+- `module_record.rs` owns target-neutral source module collection and the
+  CommonJS-like `ModuleRecordEntryReducer`.
+- `syntax_strip.rs` owns the CommonJS-like module syntax stripping step.
+- `common_js.rs`, `amd.rs`, and `umd.rs` own target lowering, dependency
+  construction, interop application, and special runtime rewrites for their
+  format.
+- `amd/emit.rs` and `umd/emit.rs` own wrapper construction for those formats.
 - `system_js.rs` owns the SystemJS facade, while `src/system_js/` owns its
   private IR, lowering, rewrite traversal, and `System.register` emission.
 - `module_ref_rewriter.rs` owns replacing imported local binding references with

--- a/crates/swc_ecma_transforms_module/src/amd.rs
+++ b/crates/swc_ecma_transforms_module/src/amd.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
-use anyhow::Context;
 use regex::Regex;
+use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use swc_atoms::{atom, Atom};
 use swc_common::{
@@ -12,26 +12,28 @@ use swc_common::{
 };
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper_expr;
-use swc_ecma_utils::{
-    member_expr, private_ident, quote_ident, quote_str, ExprFactory, FunctionFactory, IsDirective,
-};
+use swc_ecma_utils::{member_expr, private_ident, quote_ident, quote_str, ExprFactory};
 use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
 
 pub use super::util::Config as InnerConfig;
 use crate::{
     module_record::{
-        LocalExportEntries, ModuleRecordEntryReducer, ModuleRequestUsage, ModuleSyntaxExtractor,
-        RequestedModule, RequestedModules,
+        exported_external_ts_import_equals_name, external_ts_import_equals_source,
+        LocalExportEntries, ModuleRecordEntryReducer, ModuleRequestUsage, RequestedModule,
+        RequestedModules, SourceModule,
     },
     module_ref_rewriter::{rewrite_import_bindings, ImportMap},
     path::Resolver,
+    syntax_strip::{self, SyntaxStrippedModule},
     top_level_this::top_level_this,
     util::{
         define_es_module, emit_export_stmts, local_name_for_src, sort_export_bindings, use_strict,
-        ImportInterop, VecStmtLike,
+        ImportInterop,
     },
     SpanCtx,
 };
+
+mod emit;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
@@ -116,59 +118,55 @@ where
             self.module_id = self.get_amd_module_id_from_comments(n.span);
         }
 
-        let mut stmts: Vec<Stmt> = Vec::with_capacity(n.body.len() + 4);
-
-        // Collect directives
-        stmts.extend(
-            &mut n
-                .body
-                .iter_mut()
-                .take_while(|i| i.directive_continue())
-                .map(|i| i.take())
-                .map(ModuleItem::expect_stmt),
-        );
-
-        // "use strict";
-        if self.config.strict_mode && !stmts.has_use_strict() {
-            stmts.push(use_strict());
-        }
-
         if !self.config.allow_top_level_this {
             top_level_this(&mut n.body, *Expr::undefined(DUMMY_SP));
         }
 
-        let import_interop = self.config.import_interop();
-
-        let mut extractor = ModuleSyntaxExtractor::new(self.const_var_kind);
-        n.body.visit_mut_with(&mut extractor);
-
-        let ModuleSyntaxExtractor {
+        let SyntaxStrippedModule {
+            directives,
+            has_use_strict,
             requested_modules,
             local_export_entries,
             export_assign,
+            body,
             has_module_syntax,
-            ..
-        } = extractor;
+        } = syntax_strip::lower(SourceModule::collect(n.body.take()), self.const_var_kind);
+
+        let mut stmts: Vec<Stmt> = Vec::with_capacity(body.len() + 4);
+        stmts.extend(directives);
+
+        // "use strict";
+        if self.config.strict_mode && !has_use_strict {
+            stmts.push(use_strict());
+        }
+
+        let import_interop = self.config.import_interop();
 
         let is_export_assign = export_assign.is_some();
 
         if has_module_syntax && !import_interop.is_none() && !is_export_assign {
-            stmts.push(define_es_module(self.exports()))
+            stmts.push(define_es_module(self.exports()));
         }
 
         let mut import_map = Default::default();
+        let ts_import_equals_exports: FxHashSet<Atom> = body
+            .iter()
+            .filter_map(exported_external_ts_import_equals_name)
+            .cloned()
+            .collect();
 
         stmts.extend(self.handle_import_export(
             &mut import_map,
             requested_modules,
             local_export_entries,
+            &ts_import_equals_exports,
             is_export_assign,
         ));
 
-        stmts.extend(n.body.take().into_iter().filter_map(|item| match item {
-            ModuleItem::Stmt(stmt) if !stmt.is_empty() => Some(stmt),
-            _ => None,
-        }));
+        stmts.extend(
+            body.into_iter()
+                .filter_map(|item| self.lower_body_item(&mut import_map, item)),
+        );
 
         if let Some(export_assign) = export_assign {
             let return_stmt = ReturnStmt {
@@ -176,7 +174,7 @@ where
                 arg: Some(export_assign),
             };
 
-            stmts.push(return_stmt.into())
+            stmts.push(return_stmt.into());
         }
 
         if !self.config.ignore_dynamic || !self.config.preserve_import_meta {
@@ -185,75 +183,18 @@ where
 
         rewrite_import_bindings(&mut stmts, import_map, Default::default());
 
-        // ====================
-        //  Emit
-        // ====================
-
-        let mut elems = vec![Some(quote_str!("require").as_arg())];
-        let mut params = vec![self.require.clone().into()];
-
-        if let Some(exports) = self.exports.take() {
-            elems.push(Some(quote_str!("exports").as_arg()));
-            params.push(exports.into())
-        }
-
-        if let Some(module) = self.module.clone() {
-            elems.push(Some(quote_str!("module").as_arg()));
-            params.push(module.into())
-        }
-
-        self.dep_list
-            .take()
-            .into_iter()
-            .for_each(|(ident, src_path, src_span)| {
-                let src_path = match &self.resolver {
-                    Resolver::Real { resolver, base } => resolver
-                        .resolve_import(base, &src_path)
-                        .with_context(|| format!("failed to resolve `{src_path}`"))
-                        .unwrap(),
-                    Resolver::Default => src_path,
-                };
-
-                elems.push(Some(quote_str!(src_span.0, src_path).as_arg()));
-                params.push(ident.into());
-            });
-
-        let mut amd_call_args = Vec::with_capacity(3);
-        if let Some(module_id) = self.module_id.clone() {
-            amd_call_args.push(quote_str!(module_id).as_arg());
-        }
-        amd_call_args.push(
-            ArrayLit {
-                span: DUMMY_SP,
-                elems,
-            }
-            .as_arg(),
+        n.body = emit::emit(
+            stmts,
+            emit::EmitModule {
+                module_id: self.module_id.clone(),
+                require: self.require.clone(),
+                exports: self.exports.take(),
+                module: self.module.clone(),
+                deps: self.dep_list.take(),
+            },
+            self.unresolved_mark,
+            &self.resolver,
         );
-
-        amd_call_args.push(
-            Function {
-                params,
-                decorators: Default::default(),
-                span: DUMMY_SP,
-                body: Some(BlockStmt {
-                    stmts,
-                    ..Default::default()
-                }),
-                is_generator: false,
-                is_async: false,
-                ..Default::default()
-            }
-            .into_fn_expr(None)
-            .as_arg(),
-        );
-
-        n.body = vec![quote_ident!(
-            SyntaxContext::empty().apply_mark(self.unresolved_mark),
-            "define"
-        )
-        .as_call(DUMMY_SP, amd_call_args)
-        .into_stmt()
-        .into()];
     }
 
     fn visit_mut_script(&mut self, _: &mut Script) {
@@ -304,8 +245,7 @@ where
                 if !self.config.preserve_import_meta
                     && obj
                         .as_meta_prop()
-                        .map(|p| p.kind == MetaPropKind::ImportMeta)
-                        .unwrap_or_default() =>
+                        .is_some_and(|p| p.kind == MetaPropKind::ImportMeta) =>
             {
                 // `import.meta` is host-populated in the spec. AMD lowers
                 // supported host fields to loader-specific values.
@@ -402,7 +342,7 @@ where
                         n.visit_mut_with(self);
                         return;
                     }
-                };
+                }
 
                 n.visit_mut_children_with(self);
             }
@@ -420,6 +360,7 @@ where
         import_map: &mut ImportMap,
         requested_modules: RequestedModules,
         local_export_entries: LocalExportEntries,
+        ts_import_equals_exports: &FxHashSet<Atom>,
         is_export_assign: bool,
     ) -> impl Iterator<Item = Stmt> {
         let import_interop = self.config.import_interop();
@@ -430,7 +371,7 @@ where
 
         requested_modules.into_iter().for_each(
             |(
-                request_key,
+                module_request,
                 RequestedModule {
                     span: src_span,
                     entries: module_entries,
@@ -438,7 +379,7 @@ where
                     ..
                 },
             )| {
-                let src = request_key.src().clone();
+                let src = module_request.src().clone();
                 let is_node_default = !module_usage.has_named() && import_interop.is_node();
 
                 if import_interop.is_none() {
@@ -447,22 +388,15 @@ where
 
                 let need_re_export = module_usage.has_star_export();
                 let need_interop = module_usage.needs_interop();
-                let need_new_var = module_usage.needs_raw_import_for_ts_import_equals();
 
                 let mod_ident = private_ident!(local_name_for_src(&src));
-                let new_var_ident = if need_new_var {
-                    private_ident!(local_name_for_src(&src))
-                } else {
-                    mod_ident.clone()
-                };
 
                 self.dep_list.push((mod_ident.clone(), src, src_span));
 
                 module_entries.reduce(
                     import_map,
                     &mut export_bindings,
-                    &new_var_ident,
-                    &Some(mod_ident.clone()),
+                    &mod_ident,
                     &mut false,
                     is_node_default,
                 );
@@ -494,28 +428,23 @@ where
                         }
                         _ => import_expr,
                     }
-                };
+                }
 
                 // mod = _introp(mod);
-                // var mod1 = _introp(mod);
-                if need_new_var {
-                    let stmt: Stmt = import_expr
-                        .into_var_decl(self.const_var_kind, new_var_ident.into())
-                        .into();
-
-                    stmts.push(stmt)
-                } else if need_interop {
+                if need_interop {
                     let stmt = import_expr
                         .make_assign_to(op!("="), mod_ident.into())
                         .into_stmt();
                     stmts.push(stmt);
                 } else if need_re_export {
                     stmts.push(import_expr.into_stmt());
-                };
+                }
             },
         );
 
         let mut export_stmts = Default::default();
+
+        export_bindings.retain(|(export_name, _)| !ts_import_equals_exports.contains(export_name));
 
         if !export_bindings.is_empty() && !is_export_assign {
             sort_export_bindings(&mut export_bindings);
@@ -526,6 +455,64 @@ where
         }
 
         export_stmts.into_iter().chain(stmts)
+    }
+
+    fn lower_body_item(&mut self, import_map: &mut ImportMap, item: ModuleItem) -> Option<Stmt> {
+        match item {
+            ModuleItem::Stmt(stmt) if !stmt.is_empty() => Some(stmt),
+            ModuleItem::ModuleDecl(ModuleDecl::TsImportEquals(import)) => {
+                self.lower_ts_import_equals(import_map, *import)
+            }
+            _ => None,
+        }
+    }
+
+    fn lower_ts_import_equals(
+        &mut self,
+        import_map: &mut ImportMap,
+        import: TsImportEqualsDecl,
+    ) -> Option<Stmt> {
+        let src = external_ts_import_equals_source(&import)?;
+        let src_span = src.span;
+        let request = src.value.to_atom_lossy().into_owned();
+        let TsImportEqualsDecl {
+            id: local,
+            is_export,
+            ..
+        } = import;
+        let param = if is_export {
+            local.clone().into_private()
+        } else {
+            local.clone()
+        };
+
+        self.dep_list
+            .push((param.clone(), request, (src_span, Default::default())));
+
+        if !is_export {
+            return None;
+        }
+
+        Some(self.emit_ts_import_equals(import_map, local, is_export, param.into()))
+    }
+
+    fn emit_ts_import_equals(
+        &mut self,
+        import_map: &mut ImportMap,
+        local: Ident,
+        is_export: bool,
+        value: Expr,
+    ) -> Stmt {
+        if is_export {
+            import_map.insert(local.to_id(), (self.exports(), Some(local.sym.clone())));
+            return value
+                .make_assign_to(op!("="), self.exports().make_member(local.into()).into())
+                .into_stmt();
+        }
+
+        value
+            .into_var_decl(self.const_var_kind, local.into())
+            .into()
     }
 
     fn module(&mut self) -> Ident {

--- a/crates/swc_ecma_transforms_module/src/amd/emit.rs
+++ b/crates/swc_ecma_transforms_module/src/amd/emit.rs
@@ -1,0 +1,87 @@
+use anyhow::Context;
+use swc_atoms::Atom;
+use swc_common::{Mark, SyntaxContext, DUMMY_SP};
+use swc_ecma_ast::*;
+use swc_ecma_utils::{quote_ident, quote_str, ExprFactory, FunctionFactory};
+
+use crate::{path::Resolver, SpanCtx};
+
+pub(super) struct EmitModule {
+    pub module_id: Option<String>,
+    pub require: Ident,
+    pub exports: Option<Ident>,
+    pub module: Option<Ident>,
+    pub deps: Vec<(Ident, Atom, SpanCtx)>,
+}
+
+pub(super) fn emit(
+    stmts: Vec<Stmt>,
+    mut module: EmitModule,
+    unresolved_mark: Mark,
+    resolver: &Resolver,
+) -> Vec<ModuleItem> {
+    let mut elems = vec![Some(quote_str!("require").as_arg())];
+    let mut params = vec![module.require.into()];
+
+    if let Some(exports) = module.exports {
+        elems.push(Some(quote_str!("exports").as_arg()));
+        params.push(exports.into());
+    }
+
+    if let Some(module) = module.module {
+        elems.push(Some(quote_str!("module").as_arg()));
+        params.push(module.into());
+    }
+
+    module
+        .deps
+        .into_iter()
+        .for_each(|(ident, src_path, src_span)| {
+            let src_path = match resolver {
+                Resolver::Real { resolver, base } => resolver
+                    .resolve_import(base, &src_path)
+                    .with_context(|| format!("failed to resolve `{src_path}`"))
+                    .unwrap(),
+                Resolver::Default => src_path,
+            };
+
+            elems.push(Some(quote_str!(src_span.0, src_path).as_arg()));
+            params.push(ident.into());
+        });
+
+    let mut amd_call_args = Vec::with_capacity(3);
+    if let Some(module_id) = module.module_id.take() {
+        amd_call_args.push(quote_str!(module_id).as_arg());
+    }
+    amd_call_args.push(
+        ArrayLit {
+            span: DUMMY_SP,
+            elems,
+        }
+        .as_arg(),
+    );
+
+    amd_call_args.push(
+        Function {
+            params,
+            decorators: Default::default(),
+            span: DUMMY_SP,
+            body: Some(BlockStmt {
+                stmts,
+                ..Default::default()
+            }),
+            is_generator: false,
+            is_async: false,
+            ..Default::default()
+        }
+        .into_fn_expr(None)
+        .as_arg(),
+    );
+
+    vec![
+        quote_ident!(SyntaxContext::empty().apply_mark(unresolved_mark), "define")
+            .as_call(DUMMY_SP, amd_call_args)
+            .into_stmt()
+            .into(),
+    ]
+}

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -1,28 +1,31 @@
 use std::borrow::Cow;
 
 use rustc_hash::FxHashSet;
+use swc_atoms::Atom;
 use swc_common::{
     source_map::PURE_SP, util::take::Take, Mark, Span, Spanned, SyntaxContext, DUMMY_SP,
 };
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper_expr;
 use swc_ecma_utils::{
-    member_expr, private_ident, quote_expr, quote_ident, ExprFactory, FunctionFactory, IsDirective,
+    member_expr, private_ident, quote_expr, quote_ident, ExprFactory, FunctionFactory,
 };
 use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
 
 pub use super::util::Config;
 use crate::{
     module_record::{
-        ExportBinding, LocalExportEntries, ModuleRecordEntryReducer, ModuleRequestUsage,
-        ModuleSyntaxExtractor, RequestedModule, RequestedModules,
+        exported_external_ts_import_equals_name, external_ts_import_equals_source, ExportBinding,
+        LocalExportEntries, ModuleRecordEntryReducer, ModuleRequestUsage, RequestedModule,
+        RequestedModules, SourceModule,
     },
     module_ref_rewriter::{rewrite_import_bindings, ImportMap},
     path::Resolver,
+    syntax_strip::{self, SyntaxStrippedModule},
     top_level_this::top_level_this,
     util::{
         define_es_module, emit_export_stmts, local_name_for_src, prop_name, sort_export_bindings,
-        use_strict, ImportInterop, VecStmtLike,
+        use_strict, ImportInterop,
     },
 };
 
@@ -32,6 +35,7 @@ pub struct FeatureFlag {
     pub support_arrow: bool,
 }
 
+#[must_use]
 pub fn common_js(
     resolver: Resolver,
     unresolved_mark: Mark,
@@ -63,22 +67,6 @@ impl VisitMut for Cjs {
     noop_visit_mut_type!(fail);
 
     fn visit_mut_module(&mut self, n: &mut Module) {
-        let mut stmts: Vec<ModuleItem> = Vec::with_capacity(n.body.len() + 6);
-
-        // Collect directives
-        stmts.extend(
-            &mut n
-                .body
-                .iter_mut()
-                .take_while(|i| i.directive_continue())
-                .map(|i| i.take()),
-        );
-
-        // "use strict";
-        if self.config.strict_mode && !stmts.has_use_strict() {
-            stmts.push(use_strict().into());
-        }
-
         if !self.config.allow_top_level_this {
             top_level_this(&mut n.body, *Expr::undefined(DUMMY_SP));
         }
@@ -87,39 +75,36 @@ impl VisitMut for Cjs {
 
         let mut module_map = Default::default();
 
-        let mut has_ts_import_equals = false;
-
-        // handle `import foo = require("mod")`
-        n.body.iter_mut().for_each(|item| {
-            if let ModuleItem::ModuleDecl(module_decl) = item {
-                *item = self.handle_ts_import_equals(
-                    module_decl.take(),
-                    &mut module_map,
-                    &mut has_ts_import_equals,
-                );
-            }
-        });
-
-        let mut extractor = ModuleSyntaxExtractor::new(self.const_var_kind);
-        n.body.visit_mut_with(&mut extractor);
-
-        let ModuleSyntaxExtractor {
+        let SyntaxStrippedModule {
+            directives,
+            has_use_strict,
             requested_modules,
             local_export_entries,
             export_assign,
+            body,
             has_module_syntax,
-            ..
-        } = extractor;
+        } = syntax_strip::lower(SourceModule::collect(n.body.take()), self.const_var_kind);
 
-        let has_module_syntax = has_module_syntax || has_ts_import_equals;
+        let mut stmts: Vec<ModuleItem> = Vec::with_capacity(body.len() + 6);
+        stmts.extend(directives.into_iter().map(ModuleItem::from));
+
+        // "use strict";
+        if self.config.strict_mode && !has_use_strict {
+            stmts.push(use_strict().into());
+        }
 
         let is_export_assign = export_assign.is_some();
 
         if has_module_syntax && !import_interop.is_none() && !is_export_assign {
-            stmts.push(define_es_module(self.exports()).into())
+            stmts.push(define_es_module(self.exports()).into());
         }
 
         let mut lazy_record = Default::default();
+        let ts_import_equals_exports: FxHashSet<Atom> = body
+            .iter()
+            .filter_map(exported_external_ts_import_equals_name)
+            .cloned()
+            .collect();
 
         // `import` -> `require`
         // `export` -> `_export(exports, {});`
@@ -129,15 +114,16 @@ impl VisitMut for Cjs {
                 &mut lazy_record,
                 requested_modules,
                 local_export_entries,
+                &ts_import_equals_exports,
                 is_export_assign,
             )
             .map(From::from),
         );
 
-        stmts.extend(n.body.take().into_iter().filter(|item| match item {
-            ModuleItem::Stmt(stmt) => !stmt.is_empty(),
-            _ => false,
-        }));
+        stmts.extend(
+            body.into_iter()
+                .filter_map(|item| self.lower_body_item(&mut module_map, item)),
+        );
 
         // `export = expr;` -> `module.exports = expr;`
         if let Some(export_assign) = export_assign {
@@ -154,7 +140,7 @@ impl VisitMut for Cjs {
                     )
                     .into_stmt()
                     .into(),
-            )
+            );
         }
 
         if !self.config.ignore_dynamic || !self.config.preserve_import_meta {
@@ -218,8 +204,7 @@ impl VisitMut for Cjs {
                 if !self.config.preserve_import_meta
                     && obj
                         .as_meta_prop()
-                        .map(|p| p.kind == MetaPropKind::ImportMeta)
-                        .unwrap_or_default() =>
+                        .is_some_and(|p| p.kind == MetaPropKind::ImportMeta) =>
             {
                 // `import.meta` is host-populated in the spec. CommonJS
                 // lowers supported host fields to Node-like runtime values.
@@ -298,7 +283,7 @@ impl VisitMut for Cjs {
                         n.visit_mut_with(self);
                         return;
                     }
-                };
+                }
 
                 n.visit_mut_children_with(self);
             }
@@ -314,6 +299,7 @@ impl Cjs {
         lazy_record: &mut FxHashSet<Id>,
         requested_modules: RequestedModules,
         local_export_entries: LocalExportEntries,
+        ts_import_equals_exports: &FxHashSet<Atom>,
         is_export_assign: bool,
     ) -> impl Iterator<Item = Stmt> {
         let import_interop = self.config.import_interop();
@@ -332,7 +318,7 @@ impl Cjs {
 
         requested_modules.into_iter().for_each(
             |(
-                request_key,
+                module_request,
                 RequestedModule {
                     span: src_span,
                     entries: module_entries,
@@ -340,13 +326,13 @@ impl Cjs {
                     ..
                 },
             )| {
-                let src = request_key.src().clone();
-                let is_node_default = !module_usage.has_named() && is_node;
+                let src = module_request.src().clone();
 
                 if import_interop.is_none() {
                     module_usage -= ModuleRequestUsage::NAMESPACE;
                 }
 
+                let is_node_default = !module_usage.has_named() && is_node;
                 let mod_ident = private_ident!(local_name_for_src(&src));
 
                 let mut decl_mod_ident = false;
@@ -355,7 +341,6 @@ impl Cjs {
                     import_map,
                     &mut export_bindings,
                     &mod_ident,
-                    &None,
                     &mut decl_mod_ident,
                     is_node_default,
                 );
@@ -371,7 +356,7 @@ impl Cjs {
                 // require("mod");
                 let import_expr =
                     self.resolver
-                        .make_require_call(self.unresolved_mark, src, src_span.0);
+                        .make_require_call(self.unresolved_mark, src.clone(), src_span.0);
 
                 // _export_star(require("mod"), exports);
                 let import_expr = if module_usage.has_star_export() {
@@ -420,6 +405,8 @@ impl Cjs {
 
         let mut export_stmts: Vec<Stmt> = Default::default();
 
+        export_bindings.retain(|(export_name, _)| !ts_import_equals_exports.contains(export_name));
+
         if !export_bindings.is_empty() && !is_export_assign {
             sort_export_bindings(&mut export_bindings);
 
@@ -437,67 +424,48 @@ impl Cjs {
         export_stmts.into_iter().chain(stmts)
     }
 
-    fn handle_ts_import_equals(
-        &self,
-        module_decl: ModuleDecl,
-        module_map: &mut ImportMap,
-        has_ts_import_equals: &mut bool,
-    ) -> ModuleItem {
-        match module_decl {
-            ModuleDecl::TsImportEquals(v)
-                if matches!(
-                    &*v,
-                    TsImportEqualsDecl {
-                        is_type_only: false,
-                        module_ref: TsModuleRef::TsExternalModuleRef(TsExternalModuleRef { .. }),
-                        ..
-                    }
-                ) =>
-            {
-                let TsImportEqualsDecl {
-                    span,
-                    is_export,
-                    id,
-                    module_ref,
-                    ..
-                } = *v;
-                let Str {
-                    span: src_span,
-                    value: src,
-                    ..
-                } = module_ref.expect_ts_external_module_ref().expr;
-
-                *has_ts_import_equals = true;
-
-                let require = self.resolver.make_require_call(
-                    self.unresolved_mark,
-                    src.to_atom_lossy().into_owned(),
-                    src_span,
-                );
-
-                if is_export {
-                    // exports.foo = require("mod")
-                    module_map.insert(id.to_id(), (self.exports(), Some(id.sym.clone())));
-
-                    let assign_expr = AssignExpr {
-                        span,
-                        op: op!("="),
-                        left: self.exports().make_member(id.into()).into(),
-                        right: Box::new(require),
-                    };
-
-                    assign_expr.into_stmt()
-                } else {
-                    // const foo = require("mod")
-                    let mut var_decl = require.into_var_decl(self.const_var_kind, id.into());
-                    var_decl.span = span;
-
-                    var_decl.into()
-                }
-                .into()
-            }
-            _ => module_decl.into(),
+    fn lower_body_item(&self, import_map: &mut ImportMap, item: ModuleItem) -> Option<ModuleItem> {
+        match item {
+            ModuleItem::Stmt(stmt) if !stmt.is_empty() => Some(stmt.into()),
+            ModuleItem::ModuleDecl(ModuleDecl::TsImportEquals(import)) => self
+                .lower_ts_import_equals(import_map, *import)
+                .map(From::from),
+            _ => None,
         }
+    }
+
+    fn lower_ts_import_equals(
+        &self,
+        import_map: &mut ImportMap,
+        import: TsImportEqualsDecl,
+    ) -> Option<Stmt> {
+        let src = external_ts_import_equals_source(&import)?;
+        let value = self.resolver.make_require_call(
+            self.unresolved_mark,
+            src.value.to_atom_lossy().into_owned(),
+            src.span,
+        );
+
+        Some(self.emit_ts_import_equals(import_map, import.id, import.is_export, value))
+    }
+
+    fn emit_ts_import_equals(
+        &self,
+        import_map: &mut ImportMap,
+        local: Ident,
+        is_export: bool,
+        value: Expr,
+    ) -> Stmt {
+        if is_export {
+            import_map.insert(local.to_id(), (self.exports(), Some(local.sym.clone())));
+            return value
+                .make_assign_to(op!("="), self.exports().make_member(local.into()).into())
+                .into_stmt();
+        }
+
+        value
+            .into_var_decl(self.const_var_kind, local.into())
+            .into()
     }
 
     fn exports(&self) -> Ident {
@@ -584,10 +552,10 @@ impl Cjs {
         requested_modules
             .iter()
             .filter(|(.., RequestedModule { usage, .. })| usage.has_star_export())
-            .map(|(request_key, ..)| {
+            .map(|(module_request, ..)| {
                 let import_expr = self.resolver.make_require_call(
                     self.unresolved_mark,
-                    request_key.src().clone(),
+                    module_request.src().clone(),
                     DUMMY_SP,
                 );
 
@@ -661,7 +629,7 @@ pub(crate) fn cjs_dynamic_import(
     )
 }
 
-/// require('url').pathToFileURL(__filename).toString()
+/// require('url').pathToFileURL(__`filename).toString()`
 fn cjs_import_meta_url(span: Span, require: Ident, unresolved_mark: Mark) -> Expr {
     require
         .as_call(DUMMY_SP, vec!["url".as_arg()])
@@ -687,6 +655,7 @@ fn cjs_import_meta_url(span: Span, require: Ident, unresolved_mark: Mark) -> Exp
 ///   return data;
 /// }
 /// ```
+#[must_use]
 pub fn lazy_require(expr: Expr, mod_ident: Ident, var_kind: VarDeclKind) -> FnDecl {
     let data = private_ident!("data");
     let data_decl = expr.into_var_decl(var_kind, data.clone().into());

--- a/crates/swc_ecma_transforms_module/src/import_analysis.rs
+++ b/crates/swc_ecma_transforms_module/src/import_analysis.rs
@@ -8,6 +8,7 @@ use swc_ecma_visit::{
 
 use crate::{module_record::ModuleRequestUsage, util::ImportInterop, wtf8::str_to_atom};
 
+#[must_use]
 pub fn import_analyzer(import_interop: ImportInterop, ignore_dynamic: bool) -> impl Pass {
     visit_mut_pass(ImportAnalyzer {
         import_interop,
@@ -38,7 +39,7 @@ impl Visit for ImportAnalyzer {
     noop_visit_type!(fail);
 
     fn visit_module_items(&mut self, n: &[ModuleItem]) {
-        for item in n.iter() {
+        for item in n {
             if item.is_module_decl() {
                 item.visit_with(self);
             }
@@ -46,7 +47,10 @@ impl Visit for ImportAnalyzer {
 
         let flag_record = &self.flag_record;
 
-        if flag_record.values().any(|flag| flag.has_star_export()) {
+        if flag_record
+            .values()
+            .any(super::module_record::ModuleRequestUsage::has_star_export)
+        {
             enable_helper!(export_star);
         }
 
@@ -64,13 +68,13 @@ impl Visit for ImportAnalyzer {
 
         if flag_record
             .values()
-            .any(|flag| flag.needs_namespace_object())
+            .any(super::module_record::ModuleRequestUsage::needs_namespace_object)
         {
             enable_helper!(interop_require_wildcard);
         } else if !self.ignore_dynamic {
             // `import/export * as foo from "foo"` not found
             // but it may be used with dynamic import
-            for item in n.iter() {
+            for item in n {
                 if item.is_stmt() {
                     item.visit_with(self);
                 }

--- a/crates/swc_ecma_transforms_module/src/lib.rs
+++ b/crates/swc_ecma_transforms_module/src/lib.rs
@@ -18,6 +18,7 @@ pub(crate) mod module_record;
 pub(crate) mod module_ref_rewriter;
 pub mod path;
 pub mod rewriter;
+pub(crate) mod syntax_strip;
 pub mod system_js;
 mod top_level_this;
 pub mod umd;

--- a/crates/swc_ecma_transforms_module/src/module_record.rs
+++ b/crates/swc_ecma_transforms_module/src/module_record.rs
@@ -3,66 +3,51 @@ use std::cmp::Ordering;
 use indexmap::IndexMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{atom, Atom, Wtf8Atom};
-use swc_common::{util::take::Take, Mark, Span, SyntaxContext};
+use swc_common::{Mark, Span, SyntaxContext};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{find_pat_ids, private_ident, quote_ident, ExprFactory};
-use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
+use swc_ecma_utils::{find_pat_ids, quote_ident, IsDirective};
 
 use crate::{module_ref_rewriter::ImportMap, SpanCtx};
 
 /// `Source Text Module Record.[[RequestedModules]]`, kept in source order for
 /// deterministic emit.
 ///
-/// By default entries are grouped by module specifier for emitters that only
-/// have string dependency slots. Callers that need per-dependency metadata can
-/// opt into grouping by ModuleRequest Record so import attributes stay paired
-/// with the matching dependency slot.
+/// Entries are grouped by `ModuleRequest` Record so import attributes stay
+/// paired with the matching dependency slot.
 ///
 /// Spec:
-/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-source-text-module-records
-/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-module-request-records
-/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-modulerequests
-pub(crate) type RequestedModules = IndexMap<RequestedModuleKey, RequestedModule>;
+/// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-source-text-module-records>
+/// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-module-request-records>
+/// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-modulerequests>
+pub(crate) type RequestedModules = IndexMap<ModuleRequestRecord, RequestedModule>;
 /// `Source Text Module Record.[[LocalExportEntries]]`, keyed by export name.
 ///
-/// Spec: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-source-text-module-records
+/// Spec: <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-source-text-module-records>
 pub(crate) type LocalExportEntries = FxHashMap<Atom, LocalExportEntry>;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) enum RequestedModuleKey {
-    Specifier(Atom),
-    ModuleRequest(ModuleRequestRecord),
+pub(crate) struct ModuleRequestRecord {
+    /// `ModuleRequest` Record [[Specifier]].
+    specifier: Atom,
+    /// `ModuleRequest` Record [[Attributes]].
+    attributes: Vec<ImportAttributeRecord>,
 }
 
-impl RequestedModuleKey {
+impl ModuleRequestRecord {
     pub fn src(&self) -> &Atom {
-        match self {
-            Self::Specifier(src) => src,
-            Self::ModuleRequest(request) => &request.specifier,
-        }
+        &self.specifier
     }
 
     pub fn attributes(&self) -> &[ImportAttributeRecord] {
-        match self {
-            Self::Specifier(_) => &[],
-            Self::ModuleRequest(request) => &request.attributes,
-        }
+        &self.attributes
     }
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
-pub(crate) struct ModuleRequestRecord {
-    /// ModuleRequest Record [[Specifier]].
-    specifier: Atom,
-    /// ModuleRequest Record [[Attributes]].
-    attributes: Vec<ImportAttributeRecord>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub(crate) struct ImportAttributeRecord {
-    /// ImportAttribute Record [[Key]].
+    /// `ImportAttribute` Record [[Key]].
     key: Atom,
-    /// ImportAttribute Record [[Value]].
+    /// `ImportAttribute` Record [[Value]].
     value: Wtf8Atom,
 }
 
@@ -76,6 +61,56 @@ impl ImportAttributeRecord {
     }
 }
 
+fn import_attributes(with: Option<Box<ObjectLit>>) -> Vec<ImportAttributeRecord> {
+    let Some(with) = with else {
+        return Vec::new();
+    };
+
+    let Some(mut attributes) = with
+        .props
+        .into_iter()
+        .map(|prop| import_attribute_record(&prop))
+        .collect::<Option<Vec<_>>>()
+    else {
+        return Vec::new();
+    };
+
+    attributes.sort_unstable_by(|a, b| {
+        cmp_utf16(a.key.as_str(), b.key.as_str()).then_with(|| a.value.cmp(&b.value))
+    });
+
+    attributes
+}
+
+fn import_attribute_record(prop: &PropOrSpread) -> Option<ImportAttributeRecord> {
+    let PropOrSpread::Prop(prop) = prop else {
+        return None;
+    };
+
+    let Prop::KeyValue(key_value) = &**prop else {
+        return None;
+    };
+
+    let key = match &key_value.key {
+        PropName::Ident(key) => key.sym.clone(),
+        PropName::Str(key) => key.value.as_str()?.into(),
+        _ => return None,
+    };
+
+    let Expr::Lit(Lit::Str(value)) = &*key_value.value else {
+        return None;
+    };
+
+    Some(ImportAttributeRecord {
+        key,
+        value: value.value.clone(),
+    })
+}
+
+fn cmp_utf16(a: &str, b: &str) -> Ordering {
+    a.encode_utf16().cmp(b.encode_utf16())
+}
+
 /// Source-level module syntax split into reusable module-record data and
 /// ordered body items.
 ///
@@ -83,174 +118,169 @@ impl ImportAttributeRecord {
 /// responsible for deciding how an exported declaration or expression becomes
 /// executable code in their output format.
 #[derive(Debug)]
-pub struct ModuleSyntaxExtractor {
-    /// Imported modules and indirect/star exports grouped by requested module
-    /// key.
+pub(crate) struct SourceModule {
+    /// Directive prologue statements, preserved before generated wrapper code.
+    pub directives: Vec<Stmt>,
+    /// Whether the original directive prologue contained `"use strict"`.
+    pub has_use_strict: bool,
     pub requested_modules: RequestedModules,
-
-    /// Local exported binding.
-    ///
-    /// `export { foo as "1", bar }`
-    /// -> Map("1" => foo, bar => bar)
     pub local_export_entries: LocalExportEntries,
-
-    /// `export = ` detected
-    pub export_assign: Option<Box<Expr>>,
-
+    /// TypeScript `export = expr` syntax is a source-level module record fact.
+    /// CJS-like lowerers consume it as an output-specific assignment.
+    pub ts_export_assignment: Option<Box<Expr>>,
+    pub body: Vec<SourceModuleItem>,
+    /// Whether the original source contained any module declaration.
+    /// This preserves the legacy extractor signal used for interop decisions.
     pub has_module_syntax: bool,
-
-    /// `export default expr`
-    default_export_decl: Option<Stmt>,
-
-    const_var_kind: VarDeclKind,
-    preserve_import_attributes: bool,
 }
 
-impl ModuleSyntaxExtractor {
-    pub fn new(const_var_kind: VarDeclKind) -> Self {
-        Self {
-            requested_modules: Default::default(),
-            local_export_entries: Default::default(),
-            export_assign: Default::default(),
-            has_module_syntax: Default::default(),
-            default_export_decl: Default::default(),
-            const_var_kind,
-            preserve_import_attributes: false,
-        }
-    }
-
-    pub fn preserve_import_attributes(mut self) -> Self {
-        self.preserve_import_attributes = true;
-        self
-    }
-
-    fn request_key(
-        &self,
-        specifier: Atom,
-        attributes: &[ImportAttributeRecord],
-    ) -> RequestedModuleKey {
-        if self.preserve_import_attributes {
-            return RequestedModuleKey::ModuleRequest(ModuleRequestRecord {
-                specifier,
-                attributes: attributes.to_vec(),
-            });
-        }
-
-        RequestedModuleKey::Specifier(specifier)
-    }
-
-    fn import_attributes(with: Option<Box<ObjectLit>>) -> Vec<ImportAttributeRecord> {
-        let Some(with) = with else {
-            return Vec::new();
-        };
-
-        let Some(mut attributes) = with
-            .props
-            .into_iter()
-            .map(|prop| Self::import_attribute_record(&prop))
-            .collect::<Option<Vec<_>>>()
-        else {
-            return Vec::new();
-        };
-
-        attributes.sort_unstable_by(|a, b| {
-            Self::cmp_utf16(a.key.as_str(), b.key.as_str()).then_with(|| a.value.cmp(&b.value))
-        });
-
-        attributes
-    }
-
-    fn import_attribute_record(prop: &PropOrSpread) -> Option<ImportAttributeRecord> {
-        let PropOrSpread::Prop(prop) = prop else {
-            return None;
-        };
-
-        let Prop::KeyValue(key_value) = &**prop else {
-            return None;
-        };
-
-        let key = match &key_value.key {
-            PropName::Ident(key) => key.sym.clone(),
-            PropName::Str(key) => key.value.as_str()?.into(),
-            _ => return None,
-        };
-
-        let Expr::Lit(Lit::Str(value)) = &*key_value.value else {
-            return None;
-        };
-
-        Some(ImportAttributeRecord {
-            key,
-            value: value.value.clone(),
-        })
-    }
-
-    fn cmp_utf16(a: &str, b: &str) -> Ordering {
-        a.encode_utf16().cmp(b.encode_utf16())
+impl SourceModule {
+    pub fn collect(body: Vec<ModuleItem>) -> Self {
+        SourceModuleCollector::default().collect(body)
     }
 }
 
-impl VisitMut for ModuleSyntaxExtractor {
-    noop_visit_mut_type!(fail);
+/// Ordered executable source items after top-level module declarations are
+/// recorded, but before any target-specific lowering removes export syntax.
+#[derive(Debug)]
+pub(crate) enum SourceModuleItem {
+    Stmt(Stmt),
+    ExportDecl(ExportDecl),
+    ExportDefaultDecl(ExportDefaultDecl),
+    ExportDefaultExpr(ExportDefaultExpr),
+    TsImportEquals(Box<TsImportEqualsDecl>),
+}
 
-    fn visit_mut_module_items(&mut self, n: &mut Vec<ModuleItem>) {
-        let mut list = Vec::with_capacity(n.len());
+pub(crate) fn external_ts_import_equals_source(import: &TsImportEqualsDecl) -> Option<&Str> {
+    if import.is_type_only {
+        return None;
+    }
 
-        for item in n.drain(..) {
+    match &import.module_ref {
+        TsModuleRef::TsExternalModuleRef(TsExternalModuleRef { expr, .. }) => Some(expr),
+        _ => None,
+    }
+}
+
+pub(crate) fn exported_external_ts_import_equals_name(item: &ModuleItem) -> Option<&Atom> {
+    let ModuleItem::ModuleDecl(ModuleDecl::TsImportEquals(import)) = item else {
+        return None;
+    };
+
+    if !import.is_export || external_ts_import_equals_source(import).is_none() {
+        return None;
+    }
+
+    Some(&import.id.sym)
+}
+
+#[derive(Default)]
+struct SourceModuleCollector {
+    requested_modules: RequestedModules,
+    local_export_entries: LocalExportEntries,
+    ts_export_assignment: Option<Box<Expr>>,
+    has_module_syntax: bool,
+}
+
+impl SourceModuleCollector {
+    fn collect(mut self, body: Vec<ModuleItem>) -> SourceModule {
+        let mut directives = Vec::new();
+        let mut has_use_strict = false;
+        let mut source_items = Vec::with_capacity(body.len());
+        let mut in_directive_prologue = true;
+
+        for item in body {
+            if in_directive_prologue && item.directive_continue() {
+                let stmt = item.expect_stmt();
+                if !has_use_strict {
+                    has_use_strict = stmt.is_use_strict();
+                }
+                directives.push(stmt);
+                continue;
+            }
+
+            in_directive_prologue = false;
+
             match item {
-                ModuleItem::Stmt(stmt) => list.push(stmt.into()),
-
-                ModuleItem::ModuleDecl(mut module_decl) => {
-                    // Collect the source text module record entries produced
-                    // by ParseModule.
-                    // Spec: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-parsemodule
-                    module_decl.visit_mut_with(self);
-                    self.has_module_syntax = true;
-
-                    // emit stmt
-                    match module_decl {
-                        ModuleDecl::Import(..) => continue,
-                        ModuleDecl::ExportDecl(ExportDecl { decl, .. }) => {
-                            list.push(decl.into());
+                ModuleItem::Stmt(stmt) => source_items.push(SourceModuleItem::Stmt(stmt)),
+                ModuleItem::ModuleDecl(module_decl) => {
+                    if match &module_decl {
+                        ModuleDecl::TsImportEquals(import) => {
+                            import.is_export && external_ts_import_equals_source(import).is_some()
                         }
-                        ModuleDecl::ExportNamed(..) => continue,
-                        ModuleDecl::ExportDefaultDecl(ExportDefaultDecl { decl, .. }) => match decl
-                        {
-                            DefaultDecl::Class(class_expr) => {
-                                list.extend(class_expr.as_class_decl().map(From::from))
-                            }
-                            DefaultDecl::Fn(fn_expr) => {
-                                list.extend(fn_expr.as_fn_decl().map(From::from))
-                            }
-                            DefaultDecl::TsInterfaceDecl(_) => continue,
-                            #[cfg(swc_ast_unknown)]
-                            _ => panic!("unable to access unknown nodes"),
-                        },
-                        ModuleDecl::ExportDefaultExpr(..) => {
-                            list.extend(self.default_export_decl.take().map(From::from))
-                        }
-                        ModuleDecl::ExportAll(..) => continue,
-                        ModuleDecl::TsImportEquals(..) => continue,
-                        ModuleDecl::TsExportAssignment(..) => continue,
-                        ModuleDecl::TsNamespaceExport(..) => continue,
-                        #[cfg(swc_ast_unknown)]
-                        _ => panic!("unable to access unknown nodes"),
-                    };
+                        _ => true,
+                    } {
+                        self.has_module_syntax = true;
+                    }
+
+                    if let Some(item) = self.collect_module_decl(module_decl) {
+                        source_items.push(item);
+                    }
                 }
                 #[cfg(swc_ast_unknown)]
                 _ => panic!("unable to access unknown nodes"),
-            };
+            }
         }
 
-        *n = list;
+        SourceModule {
+            directives,
+            has_use_strict,
+            requested_modules: self.requested_modules,
+            local_export_entries: self.local_export_entries,
+            ts_export_assignment: self.ts_export_assignment,
+            body: source_items,
+            has_module_syntax: self.has_module_syntax,
+        }
     }
 
-    // Collect ImportEntry records from static imports.
-    // Spec:
-    // - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-importentries
-    // - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-importentriesformodule
-    fn visit_mut_import_decl(&mut self, n: &mut ImportDecl) {
-        if n.type_only {
+    fn collect_module_decl(&mut self, module_decl: ModuleDecl) -> Option<SourceModuleItem> {
+        match module_decl {
+            ModuleDecl::Import(import) => {
+                self.collect_import_decl(import);
+                None
+            }
+            ModuleDecl::ExportDecl(export) => {
+                self.collect_export_decl(&export);
+                Some(SourceModuleItem::ExportDecl(export))
+            }
+            ModuleDecl::ExportNamed(export) => {
+                self.collect_named_export(export);
+                None
+            }
+            ModuleDecl::ExportDefaultDecl(export) => {
+                self.collect_export_default_decl(&export);
+                Some(SourceModuleItem::ExportDefaultDecl(export))
+            }
+            ModuleDecl::ExportDefaultExpr(export) => {
+                Some(SourceModuleItem::ExportDefaultExpr(export))
+            }
+            ModuleDecl::ExportAll(export) => {
+                self.collect_export_all(export);
+                None
+            }
+            ModuleDecl::TsImportEquals(import) => self.collect_ts_import_equals(import),
+            ModuleDecl::TsExportAssignment(export) => {
+                self.ts_export_assignment.get_or_insert(export.expr);
+                None
+            }
+            ModuleDecl::TsNamespaceExport(_) => None,
+            #[cfg(swc_ast_unknown)]
+            _ => panic!("unable to access unknown nodes"),
+        }
+    }
+
+    fn module_request(
+        specifier: Atom,
+        attributes: &[ImportAttributeRecord],
+    ) -> ModuleRequestRecord {
+        ModuleRequestRecord {
+            specifier,
+            attributes: attributes.to_vec(),
+        }
+    }
+
+    fn collect_import_decl(&mut self, import: ImportDecl) {
+        if import.type_only {
             return;
         }
 
@@ -259,35 +289,21 @@ impl VisitMut for ModuleSyntaxExtractor {
             src,
             with,
             ..
-        } = n.take();
+        } = import;
 
         let src_key = src.value.to_atom_lossy().into_owned();
-        let attributes = Self::import_attributes(with);
-        let request_key = self.request_key(src_key, &attributes);
+        let attributes = import_attributes(with);
+        let module_request = Self::module_request(src_key, &attributes);
 
         self.requested_modules
-            .entry(request_key)
+            .entry(module_request)
             .or_default()
             .mut_dummy_span(src.span)
             .extend(specifiers.into_iter().map(From::from));
     }
 
-    /// ```javascript
-    /// export const foo = 1, bar = 2, { baz } = { baz: 3 };
-    /// export let a = 1, [b] = [2];
-    /// export function x() {}
-    /// export class y {}
-    /// ```
-    /// ->
-    /// ```javascript
-    /// const foo = 1, bar = 2, { baz } = { baz: 3 };
-    /// let a = 1, [b] = [2];
-    /// function x() {}
-    /// class y {}
-    /// ```
-    /// Spec: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-exportentries
-    fn visit_mut_export_decl(&mut self, n: &mut ExportDecl) {
-        match &n.decl {
+    fn collect_export_decl(&mut self, export: &ExportDecl) {
+        match &export.decl {
             Decl::Class(ClassDecl { ident, .. }) | Decl::Fn(FnDecl { ident, .. }) => {
                 self.local_export_entries.insert(
                     ident.sym.clone(),
@@ -306,20 +322,11 @@ impl VisitMut for ModuleSyntaxExtractor {
                 );
             }
             _ => {}
-        };
+        }
     }
 
-    /// ```javascript
-    /// export { foo, foo as bar, foo as "baz" };
-    /// export { "foo", foo as bar, "foo" as "baz" } from "mod";
-    /// export * as foo from "mod";
-    /// export * as "bar" from "mod";
-    /// ```
-    /// Spec:
-    /// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-exportentries
-    /// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-exportentriesformodule
-    fn visit_mut_named_export(&mut self, n: &mut NamedExport) {
-        if n.type_only {
+    fn collect_named_export(&mut self, export: NamedExport) {
+        if export.type_only {
             return;
         }
 
@@ -328,100 +335,81 @@ impl VisitMut for ModuleSyntaxExtractor {
             src,
             with,
             ..
-        } = n.take();
+        } = export;
 
         if let Some(src) = src {
             let src_key = src.value.to_atom_lossy().into_owned();
-            let attributes = Self::import_attributes(with);
-            let request_key = self.request_key(src_key, &attributes);
+            let attributes = import_attributes(with);
+            let module_request = Self::module_request(src_key, &attributes);
 
             self.requested_modules
-                .entry(request_key)
+                .entry(module_request)
                 .or_default()
                 .mut_dummy_span(src.span)
                 .extend(specifiers.into_iter().map(From::from));
         } else {
             self.local_export_entries
-                .extend(specifiers.into_iter().map(|e| match e {
-                    ExportSpecifier::Namespace(..) => {
-                        unreachable!("`export *` without src is invalid")
-                    }
-                    ExportSpecifier::Default(..) => {
-                        unreachable!("`export foo` without src is invalid")
-                    }
-                    ExportSpecifier::Named(ExportNamedSpecifier { orig, exported, .. }) => {
-                        let orig = match orig {
-                            ModuleExportName::Ident(id) => id,
-                            ModuleExportName::Str(_) => {
-                                unreachable!(r#"`export {{ "foo" }}` without src is invalid"#)
-                            }
-                            #[cfg(swc_ast_unknown)]
-                            _ => panic!("unable to access unknown nodes"),
-                        };
-
-                        if let Some(exported) = exported {
-                            let (export_name, export_name_span) = match exported {
-                                ModuleExportName::Ident(Ident {
-                                    ctxt, span, sym, ..
-                                }) => (sym, (span, ctxt)),
-                                ModuleExportName::Str(Str { span, value, .. }) => (
-                                    value.to_atom_lossy().into_owned(),
-                                    (span, Default::default()),
-                                ),
-                                #[cfg(swc_ast_unknown)]
-                                _ => panic!("unable to access unknown nodes"),
-                            };
-
-                            (export_name, LocalExportEntry::new(export_name_span, orig))
-                        } else {
-                            (
-                                orig.sym.clone(),
-                                LocalExportEntry::new((orig.span, orig.ctxt), orig),
-                            )
-                        }
-                    }
-                    #[cfg(swc_ast_unknown)]
-                    _ => panic!("unable to access unknown nodes"),
-                }))
+                .extend(specifiers.into_iter().map(Self::local_export_entry));
         }
     }
 
-    /// ```javascript
-    /// export default class foo {};
-    /// export default class {};
-    /// export default function bar () {};
-    /// export default function () {};
-    /// ```
-    /// ->
-    /// ```javascript
-    /// class foo {};
-    /// class _default {};
-    /// function bar () {};
-    /// function _default () {};
-    /// ```
-    fn visit_mut_export_default_decl(&mut self, n: &mut ExportDefaultDecl) {
-        match &mut n.decl {
-            DefaultDecl::Class(class_expr) => {
-                let ident = class_expr
-                    .ident
-                    .get_or_insert_with(|| private_ident!(n.span, "_default"))
-                    .clone();
+    fn local_export_entry(specifier: ExportSpecifier) -> ExportBinding {
+        match specifier {
+            ExportSpecifier::Namespace(..) => unreachable!("`export *` without src is invalid"),
+            ExportSpecifier::Default(..) => unreachable!("`export foo` without src is invalid"),
+            ExportSpecifier::Named(ExportNamedSpecifier { orig, exported, .. }) => {
+                let orig = match orig {
+                    ModuleExportName::Ident(id) => id,
+                    ModuleExportName::Str(_) => {
+                        unreachable!(r#"`export {{ "foo" }}` without src is invalid"#)
+                    }
+                    #[cfg(swc_ast_unknown)]
+                    _ => panic!("unable to access unknown nodes"),
+                };
 
-                self.local_export_entries.insert(
-                    atom!("default"),
-                    LocalExportEntry::new((n.span, Default::default()), ident),
-                );
+                if let Some(exported) = exported {
+                    let (export_name, export_name_span) = match exported {
+                        ModuleExportName::Ident(Ident {
+                            ctxt, span, sym, ..
+                        }) => (sym, (span, ctxt)),
+                        ModuleExportName::Str(Str { span, value, .. }) => (
+                            value.to_atom_lossy().into_owned(),
+                            (span, Default::default()),
+                        ),
+                        #[cfg(swc_ast_unknown)]
+                        _ => panic!("unable to access unknown nodes"),
+                    };
+
+                    (export_name, LocalExportEntry::new(export_name_span, orig))
+                } else {
+                    (
+                        orig.sym.clone(),
+                        LocalExportEntry::new((orig.span, orig.ctxt), orig),
+                    )
+                }
+            }
+            #[cfg(swc_ast_unknown)]
+            _ => panic!("unable to access unknown nodes"),
+        }
+    }
+
+    fn collect_export_default_decl(&mut self, export: &ExportDefaultDecl) {
+        match &export.decl {
+            DefaultDecl::Class(class_expr) => {
+                if let Some(ident) = &class_expr.ident {
+                    self.local_export_entries.insert(
+                        atom!("default"),
+                        LocalExportEntry::new((export.span, Default::default()), ident.clone()),
+                    );
+                }
             }
             DefaultDecl::Fn(fn_expr) => {
-                let ident = fn_expr
-                    .ident
-                    .get_or_insert_with(|| private_ident!(n.span, "_default"))
-                    .clone();
-
-                self.local_export_entries.insert(
-                    atom!("default"),
-                    LocalExportEntry::new((n.span, Default::default()), ident),
-                );
+                if let Some(ident) = &fn_expr.ident {
+                    self.local_export_entries.insert(
+                        atom!("default"),
+                        LocalExportEntry::new((export.span, Default::default()), ident.clone()),
+                    );
+                }
             }
             DefaultDecl::TsInterfaceDecl(_) => {}
             #[cfg(swc_ast_unknown)]
@@ -429,112 +417,49 @@ impl VisitMut for ModuleSyntaxExtractor {
         }
     }
 
-    /// ```javascript
-    /// export default foo;
-    /// export default 1
-    /// ```
-    /// ->
-    /// ```javascript
-    /// var _default = foo;
-    /// var _default = 1;
-    /// ```
-    fn visit_mut_export_default_expr(&mut self, n: &mut ExportDefaultExpr) {
-        let ident = private_ident!(n.span, "_default");
-
-        self.local_export_entries.insert(
-            atom!("default"),
-            LocalExportEntry::new((n.span, Default::default()), ident.clone()),
-        );
-
-        self.default_export_decl = Some(
-            n.expr
-                .take()
-                .into_var_decl(self.const_var_kind, ident.into())
-                .into(),
-        );
-    }
-
-    /// ```javascript
-    /// export * from "mod";
-    /// ```
-    fn visit_mut_export_all(&mut self, n: &mut ExportAll) {
-        let ExportAll { src, with, .. } = n.take();
+    fn collect_export_all(&mut self, export: ExportAll) {
+        let ExportAll { src, with, .. } = export;
         let Str {
             value: src_key,
             span: src_span,
             ..
         } = *src;
 
-        let attributes = Self::import_attributes(with);
-        let request_key = self.request_key(src_key.to_atom_lossy().into_owned(), &attributes);
+        let attributes = import_attributes(with);
+        let module_request =
+            Self::module_request(src_key.to_atom_lossy().into_owned(), &attributes);
 
         self.requested_modules
-            .entry(request_key)
+            .entry(module_request)
             .or_default()
             .mut_dummy_span(src_span)
             .insert(ModuleRecordEntry::StarExport);
     }
 
-    /// ```javascript
-    /// import foo = require("mod");
-    /// export import foo = require("mod");
-    /// ```
-    fn visit_mut_ts_import_equals_decl(&mut self, n: &mut TsImportEqualsDecl) {
-        if n.is_type_only {
-            return;
+    fn collect_ts_import_equals(
+        &mut self,
+        import: Box<TsImportEqualsDecl>,
+    ) -> Option<SourceModuleItem> {
+        external_ts_import_equals_source(&import)?;
+
+        if import.is_export {
+            self.local_export_entries.insert(
+                import.id.sym.clone(),
+                LocalExportEntry::new((import.id.span, import.id.ctxt), import.id.clone()),
+            );
         }
 
-        let TsImportEqualsDecl {
-            id,
-            module_ref,
-            is_export,
-            ..
-        } = n;
-
-        if let TsModuleRef::TsExternalModuleRef(TsExternalModuleRef {
-            expr:
-                Str {
-                    span,
-                    value: src_key,
-                    ..
-                },
-            ..
-        }) = module_ref
-        {
-            if *is_export {
-                self.local_export_entries.insert(
-                    id.sym.clone(),
-                    LocalExportEntry::new((id.span, id.ctxt), id.clone()),
-                );
-            }
-
-            self.requested_modules
-                .entry(RequestedModuleKey::Specifier(
-                    src_key.to_atom_lossy().into_owned(),
-                ))
-                .or_default()
-                .mut_dummy_span(*span)
-                .insert(ModuleRecordEntry::TsImportEquals {
-                    local_name: id.to_id(),
-                });
-        }
-    }
-
-    /// ```javascript
-    /// export = expr;
-    /// ```
-    fn visit_mut_ts_export_assignment(&mut self, n: &mut TsExportAssignment) {
-        self.export_assign.get_or_insert(n.expr.take());
+        Some(SourceModuleItem::TsImportEquals(import))
     }
 }
 
-/// ImportEntry and ExportEntry record fields used by this transform.
+/// `ImportEntry` and `ExportEntry` record fields used by this transform.
 ///
 /// Spec:
-/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-importentry-record-fields
-/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-exportentry-record-fields
-/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-importentries
-/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-exportentries
+/// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-importentry-record-fields>
+/// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#table-exportentry-record-fields>
+/// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-importentries>
+/// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-static-semantics-exportentries>
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum ModuleRecordEntry {
     ///```javascript
@@ -567,8 +492,8 @@ pub enum ModuleRecordEntry {
     /// The spec resolves this to a Module Namespace Exotic Object. This legacy
     /// module transform emits an interop object instead.
     /// Spec:
-    /// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getmodulenamespace
-    /// - https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-module-namespace-exotic-objects
+    /// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getmodulenamespace>
+    /// - <https://tc39.es/ecma262/multipage/ordinary-and-exotic-objects-behaviours.html#sec-module-namespace-exotic-objects>
     ImportNamespace { local_name: Id },
 
     /// ```javascript
@@ -598,8 +523,8 @@ pub enum ModuleRecordEntry {
     /// The spec resolves this to a namespace export binding. This transform
     /// emits a legacy interop object getter instead.
     /// Spec:
-    /// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-resolveexport
-    /// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getmodulenamespace
+    /// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-resolveexport>
+    /// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getmodulenamespace>
     IndirectExportNamespace {
         export_name: Atom,
         export_name_span: SpanCtx,
@@ -610,13 +535,8 @@ pub enum ModuleRecordEntry {
     /// ```
     /// Related spec operation: `GetExportedNames` walks
     /// `[[StarExportEntries]]` and omits `default` from star-exported names.
-    /// https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getexportednames
+    /// <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getexportednames>
     StarExport,
-
-    /// ```javascript
-    /// import foo = require("foo");
-    /// ```
-    TsImportEquals { local_name: Id },
 }
 
 impl From<ImportSpecifier> for ModuleRecordEntry {
@@ -758,10 +678,10 @@ impl From<ExportSpecifier> for ModuleRecordEntry {
 #[derive(Debug, Default)]
 pub struct RequestedModule {
     /// First useful source span for the module request. The spec tracks this as
-    /// a ModuleRequest Record; emitters keep the span for generated literals
+    /// a `ModuleRequest` Record; emitters keep the span for generated literals
     /// and diagnostics.
     ///
-    /// Spec: https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-module-request-records
+    /// Spec: <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-module-request-records>
     pub span: SpanCtx,
     /// `ImportEntry` and `ExportEntry` records associated with this module
     /// request.
@@ -779,7 +699,6 @@ bitflags! {
         const DEFAULT = 1 << 1;
         const NAMESPACE = Self::NAMED.bits() | Self::DEFAULT.bits();
         const STAR_EXPORT = 1 << 2;
-        const TS_IMPORT_EQUALS = 1 << 3;
     }
 }
 
@@ -794,10 +713,6 @@ impl ModuleRequestUsage {
 
     pub fn needs_namespace_object(&self) -> bool {
         self.contains(Self::NAMESPACE)
-    }
-
-    pub fn needs_raw_import_for_ts_import_equals(&self) -> bool {
-        self.needs_interop() && self.intersects(Self::TS_IMPORT_EQUALS)
     }
 
     pub fn has_star_export(&self) -> bool {
@@ -817,7 +732,6 @@ impl From<&ModuleRecordEntry> for ModuleRequestUsage {
             ModuleRecordEntry::IndirectExportDefault { .. } => Self::DEFAULT,
             ModuleRecordEntry::IndirectExportNamed { .. } => Self::NAMED,
 
-            ModuleRecordEntry::TsImportEquals { .. } => Self::TS_IMPORT_EQUALS,
             ModuleRecordEntry::StarExport => Self::STAR_EXPORT,
         }
     }
@@ -913,15 +827,14 @@ pub(crate) type ExportObjectProperties = Vec<ExportBinding>;
 /// This is not a full ECMAScript module linker. It only lowers collected
 /// syntactic entries to emitter-local data structures; the corresponding spec
 /// operations for linked modules are `GetExportedNames` and `ResolveExport`.
-/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getexportednames
-/// - https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-resolveexport
+/// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-getexportednames>
+/// - <https://tc39.es/ecma262/multipage/ecmascript-language-scripts-and-modules.html#sec-resolveexport>
 pub(crate) trait ModuleRecordEntryReducer {
     fn reduce(
         self,
         import_map: &mut ImportMap,
         export_bindings: &mut ExportObjectProperties,
         mod_ident: &Ident,
-        raw_mod_ident: &Option<Ident>,
         ref_to_mod_ident: &mut bool,
         // do not emit `mod.default`, emit `mod` instead
         default_nowrap: bool,
@@ -934,7 +847,6 @@ impl ModuleRecordEntryReducer for FxHashSet<ModuleRecordEntry> {
         import_map: &mut ImportMap,
         export_bindings: &mut ExportObjectProperties,
         mod_ident: &Ident,
-        raw_mod_ident: &Option<Ident>,
         ref_to_mod_ident: &mut bool,
         default_nowrap: bool,
     ) {
@@ -995,7 +907,7 @@ impl ModuleRecordEntryReducer for FxHashSet<ModuleRecordEntry> {
                         export_name_span,
                         quote_ident!(import_name.1 .1, import_name.1 .0, import_name.0),
                     ),
-                ))
+                ));
             }
             ModuleRecordEntry::IndirectExportDefault {
                 export_name,
@@ -1037,19 +949,8 @@ impl ModuleRecordEntryReducer for FxHashSet<ModuleRecordEntry> {
                 ));
             }
             ModuleRecordEntry::StarExport => {}
-            ModuleRecordEntry::TsImportEquals { local_name } => {
-                *ref_to_mod_ident = true;
-
-                import_map.insert(
-                    local_name,
-                    (
-                        raw_mod_ident.clone().unwrap_or_else(|| mod_ident.clone()),
-                        None,
-                    ),
-                );
-            }
             ModuleRecordEntry::Empty => {}
-        })
+        });
     }
 }
 

--- a/crates/swc_ecma_transforms_module/src/module_ref_rewriter.rs
+++ b/crates/swc_ecma_transforms_module/src/module_ref_rewriter.rs
@@ -81,8 +81,7 @@ impl QueryRef for ImportQuery {
 
         self.import_map
             .get(&ident.to_id())
-            .map(|(_, prop)| prop.is_some())
-            .unwrap_or_default()
+            .is_some_and(|(_, prop)| prop.is_some())
     }
 }
 
@@ -100,7 +99,7 @@ pub(crate) fn rewrite_import_bindings<V>(
             helper_ctxt: {
                 HELPERS
                     .is_set()
-                    .then(|| HELPERS.with(|helper| helper.mark()))
+                    .then(|| HELPERS.with(swc_ecma_transforms_base::helpers::Helpers::mark))
                     .map(|mark| SyntaxContext::empty().apply_mark(mark))
             },
         },

--- a/crates/swc_ecma_transforms_module/src/path.rs
+++ b/crates/swc_ecma_transforms_module/src/path.rs
@@ -73,7 +73,7 @@ pub trait ImportResolver {
     fn resolve_import(&self, base: &FileName, module_specifier: &str) -> Result<Atom, Error>;
 }
 
-/// [ImportResolver] implementation which just uses original source.
+/// [`ImportResolver`] implementation which just uses original source.
 #[derive(Debug, Clone, Copy, Default)]
 pub struct NoopImportResolver;
 
@@ -83,11 +83,11 @@ impl ImportResolver for NoopImportResolver {
     }
 }
 
-/// [ImportResolver] implementation for node.js
+/// [`ImportResolver`] implementation for node.js
 ///
-/// Supports [FileName::Real] and [FileName::Anon] for `base`, [FileName::Real]
-/// and [FileName::Custom] for `target`. ([FileName::Custom] is used for core
-/// modules)
+/// Supports [`FileName::Real`] and [`FileName::Anon`] for `base`,
+/// [`FileName::Real`] and [`FileName::Custom`] for `target`.
+/// ([`FileName::Custom`] is used for core modules)
 #[derive(Debug, Clone, Default)]
 pub struct NodeImportResolver<R>
 where

--- a/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
+++ b/crates/swc_ecma_transforms_module/src/rewriter/import_rewriter_typescript.rs
@@ -10,6 +10,7 @@ use swc_ecma_visit::{visit_mut_pass, VisitMut, VisitMutWith};
 ///
 /// `jsx_preserve` corresponds to TypeScript's `jsx: "preserve"`: when set,
 /// `.tsx` specifiers are rewritten to `.jsx` instead of `.js`.
+#[must_use]
 pub fn typescript_import_rewriter(jsx_preserve: bool) -> impl Pass {
     visit_mut_pass(Rewriter { jsx_preserve })
 }

--- a/crates/swc_ecma_transforms_module/src/syntax_strip.rs
+++ b/crates/swc_ecma_transforms_module/src/syntax_strip.rs
@@ -1,0 +1,119 @@
+use swc_atoms::atom;
+use swc_ecma_ast::*;
+use swc_ecma_utils::{private_ident, ExprFactory};
+
+use crate::module_record::{
+    LocalExportEntries, LocalExportEntry, RequestedModules, SourceModule, SourceModuleItem,
+};
+
+/// Source module after module syntax is stripped from the executable body.
+#[derive(Debug)]
+pub(crate) struct SyntaxStrippedModule {
+    pub directives: Vec<Stmt>,
+    pub has_use_strict: bool,
+    pub requested_modules: RequestedModules,
+    pub local_export_entries: LocalExportEntries,
+    pub export_assign: Option<Box<Expr>>,
+    pub body: Vec<ModuleItem>,
+    pub has_module_syntax: bool,
+}
+
+pub(crate) fn lower(source: SourceModule, const_var_kind: VarDeclKind) -> SyntaxStrippedModule {
+    let SourceModule {
+        directives,
+        has_use_strict,
+        requested_modules,
+        mut local_export_entries,
+        ts_export_assignment,
+        body,
+        has_module_syntax,
+    } = source;
+    let mut lowered_body = Vec::with_capacity(body.len());
+
+    for item in body {
+        match item {
+            SourceModuleItem::Stmt(stmt) => lowered_body.push(stmt.into()),
+            SourceModuleItem::ExportDecl(export) => lowered_body.push(export.decl.into()),
+            SourceModuleItem::ExportDefaultDecl(export) => {
+                lowered_body.extend(lower_export_default_decl(export, &mut local_export_entries));
+            }
+            SourceModuleItem::ExportDefaultExpr(export) => {
+                lowered_body.push(lower_export_default_expr(
+                    export,
+                    &mut local_export_entries,
+                    const_var_kind,
+                ));
+            }
+            SourceModuleItem::TsImportEquals(import) => {
+                lowered_body.push(ModuleDecl::TsImportEquals(import).into());
+            }
+        }
+    }
+
+    SyntaxStrippedModule {
+        directives,
+        has_use_strict,
+        requested_modules,
+        local_export_entries,
+        export_assign: ts_export_assignment,
+        body: lowered_body,
+        has_module_syntax,
+    }
+}
+
+fn lower_export_default_decl(
+    export: ExportDefaultDecl,
+    local_export_entries: &mut LocalExportEntries,
+) -> Option<ModuleItem> {
+    match export.decl {
+        DefaultDecl::Class(mut class_expr) => {
+            let ident = class_expr
+                .ident
+                .get_or_insert_with(|| private_ident!(export.span, "_default"))
+                .clone();
+
+            local_export_entries.insert(
+                atom!("default"),
+                LocalExportEntry::new((export.span, Default::default()), ident),
+            );
+
+            class_expr.as_class_decl().map(From::from)
+        }
+        DefaultDecl::Fn(mut fn_expr) => {
+            let ident = fn_expr
+                .ident
+                .get_or_insert_with(|| private_ident!(export.span, "_default"))
+                .clone();
+
+            local_export_entries.insert(
+                atom!("default"),
+                LocalExportEntry::new((export.span, Default::default()), ident),
+            );
+
+            fn_expr.as_fn_decl().map(From::from)
+        }
+        DefaultDecl::TsInterfaceDecl(_) => None,
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unable to access unknown nodes"),
+    }
+}
+
+fn lower_export_default_expr(
+    export: ExportDefaultExpr,
+    local_export_entries: &mut LocalExportEntries,
+    const_var_kind: VarDeclKind,
+) -> ModuleItem {
+    let ident = private_ident!(export.span, "_default");
+
+    local_export_entries.insert(
+        atom!("default"),
+        LocalExportEntry::new((export.span, Default::default()), ident.clone()),
+    );
+
+    let stmt: Stmt = export
+        .expr
+        .into_var_decl(const_var_kind, ident.into())
+        .into();
+
+    stmt.into()
+}

--- a/crates/swc_ecma_transforms_module/src/system_js.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js.rs
@@ -1,16 +1,11 @@
 use swc_common::{util::take::Take, Mark, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{
-    contains_top_level_await, private_ident, quote_ident, ExprFactory, IsDirective,
-};
-use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
+use swc_ecma_utils::{contains_top_level_await, private_ident, quote_ident, ExprFactory};
+use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut};
 
 pub use super::util::Config;
 use crate::{
-    module_record::ModuleSyntaxExtractor,
-    path::Resolver,
-    top_level_this::top_level_this,
-    util::{use_strict, VecStmtLike},
+    module_record::SourceModule, path::Resolver, top_level_this::top_level_this, util::use_strict,
 };
 
 mod emit;
@@ -20,6 +15,7 @@ mod pattern;
 mod rewrite;
 mod util;
 
+#[must_use]
 pub fn system_js(resolver: Resolver, unresolved_mark: Mark, config: Config) -> impl Pass {
     visit_mut_pass(SystemJs {
         resolver,
@@ -38,42 +34,27 @@ impl VisitMut for SystemJs {
     noop_visit_mut_type!(fail);
 
     fn visit_mut_module(&mut self, n: &mut Module) {
-        let mut wrapper_stmts: Vec<Stmt> = Vec::with_capacity(n.body.len() + 8);
-
-        let directive_count = n
-            .body
-            .iter()
-            .take_while(|item| item.directive_continue())
-            .count();
-        wrapper_stmts.extend(n.body.drain(..directive_count).map(ModuleItem::expect_stmt));
-
-        if self.config.strict_mode && !wrapper_stmts.has_use_strict() {
-            wrapper_stmts.push(use_strict());
-        }
-
         if !self.config.allow_top_level_this {
             top_level_this(&mut n.body, *Expr::undefined(DUMMY_SP));
         }
 
-        let mut extractor =
-            ModuleSyntaxExtractor::new(VarDeclKind::Var).preserve_import_attributes();
-        n.body.visit_mut_with(&mut extractor);
+        let mut source = SourceModule::collect(n.body.take());
+        let has_use_strict = source.has_use_strict;
+        let mut wrapper_stmts = std::mem::take(&mut source.directives);
+        wrapper_stmts.reserve(8);
 
-        let ModuleSyntaxExtractor {
-            requested_modules,
-            local_export_entries,
-            ..
-        } = extractor;
+        if self.config.strict_mode && !has_use_strict {
+            wrapper_stmts.push(use_strict());
+        }
 
         let export_ident = private_ident!("_export");
         let context_ident = private_ident!("_context");
         let unresolved_ctxt = SyntaxContext::empty().apply_mark(self.unresolved_mark);
 
-        let mut module = lower::lower(n.body.take(), requested_modules, local_export_entries);
+        let mut module = lower::lower(source);
 
         rewrite::rewrite_special_refs(
-            &mut module.wrapper_fns,
-            &mut module.execute_stmts,
+            &mut module,
             context_ident.clone(),
             unresolved_ctxt,
             &self.resolver,
@@ -86,11 +67,7 @@ impl VisitMut for SystemJs {
             export_ident.clone(),
             module.export_setters.clone(),
         );
-        rewrite::rewrite_export_bindings(
-            &mut module.wrapper_fns,
-            &mut module.execute_stmts,
-            &mut export_rewriter,
-        );
+        rewrite::rewrite_export_bindings(&mut module, &mut export_rewriter);
         if export_rewriter.needs_old_temp() {
             module.wrapper_vars.push(export_rewriter.old_temp());
         }

--- a/crates/swc_ecma_transforms_module/src/system_js/emit.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js/emit.rs
@@ -7,7 +7,7 @@ use swc_ecma_utils::{
 };
 
 use super::{
-    ir::{DependencySlot, ExecuteStmt, ExportName, SetterOp, SystemModule},
+    ir::{DependencySlot, ExecuteStmt, ExportInit, ExportName, SetterOp, SystemModule},
     lower::{export_call, export_names_call},
     util::{export_object_init, member_expr_for, member_for_export, object_lit_prop_name},
 };
@@ -37,7 +37,8 @@ pub(super) fn emit(
     let deps = emit_dependency_array(&module.dependencies, resolver);
     let setters = emit_setters(&module.dependencies, &module, &export_ident);
     let metadata = emit_metadata_array(&module.dependencies);
-    let export_inits = emit_export_inits(&module, &export_ident);
+    let initialized_exports = module.export_inits.take();
+    let export_inits = emit_export_inits(&module, initialized_exports, &export_ident);
 
     emit_var_decl(&mut stmts, module.wrapper_vars.take());
     emit_export_setters(&mut stmts, &module, &export_ident);
@@ -132,6 +133,13 @@ fn emit_execute_stmt(stmt: ExecuteStmt, export_ident: &Ident) -> Stmt {
             .into();
             export_call(export_ident, &exports, assign).into_stmt()
         }
+        ExecuteStmt::ExportValue { export, value } => {
+            export_call(export_ident, &[export], *value).into_stmt()
+        }
+        ExecuteStmt::ExportBatch { value } => export_ident
+            .clone()
+            .as_call(value.span(), vec![value.as_arg()])
+            .into_stmt(),
         ExecuteStmt::ExportNames { exports, value } => {
             export_names_call(export_ident, &exports, value).into_stmt()
         }
@@ -419,7 +427,11 @@ fn emit_export_setters(stmts: &mut Vec<Stmt>, module: &SystemModule, export_iden
     );
 }
 
-fn emit_export_inits(module: &SystemModule, export_ident: &Ident) -> Vec<Stmt> {
+fn emit_export_inits(
+    module: &SystemModule,
+    initialized_exports: Vec<ExportInit>,
+    export_ident: &Ident,
+) -> Vec<Stmt> {
     let mut announced = Vec::new();
     let mut seen: IndexSet<Atom> = IndexSet::default();
     for export in &module.exports.announced {
@@ -432,7 +444,7 @@ fn emit_export_inits(module: &SystemModule, export_ident: &Ident) -> Vec<Stmt> {
         return Default::default();
     }
 
-    let function_exports = module
+    let mut initial_values = module
         .wrapper_fns
         .iter()
         .filter_map(|fn_decl| {
@@ -446,15 +458,18 @@ fn emit_export_inits(module: &SystemModule, export_ident: &Ident) -> Vec<Stmt> {
                 .iter()
                 .map(move |export| (export.name.clone(), ident.clone()))
         })
+        .map(|(export, ident)| (export, Expr::from(ident)))
         .collect::<IndexMap<_, _>>();
+    for ExportInit { export, value } in initialized_exports {
+        initial_values.insert(export.name, *value);
+    }
 
     let props = announced
         .into_iter()
         .map(|export| {
-            let value = function_exports
-                .get(&export.name)
-                .cloned()
-                .map_or_else(|| *Expr::undefined(DUMMY_SP), Expr::from);
+            let value = initial_values
+                .shift_remove(&export.name)
+                .unwrap_or_else(|| *Expr::undefined(DUMMY_SP));
             (export, value)
         })
         .collect::<Vec<_>>();

--- a/crates/swc_ecma_transforms_module/src/system_js/ir.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js/ir.rs
@@ -33,6 +33,19 @@ impl ExportTable {
     }
 }
 
+/// Export value initialized in the `System.register` declaration callback.
+#[derive(Debug)]
+pub(super) struct ExportInit {
+    pub export: ExportName,
+    pub value: Box<Expr>,
+}
+
+impl ExportInit {
+    pub fn new(export: ExportName, value: Box<Expr>) -> Self {
+        Self { export, value }
+    }
+}
+
 #[derive(Debug)]
 pub(super) enum SetterOp {
     Import {
@@ -70,6 +83,14 @@ pub(super) enum ExecuteStmt {
         local: Ident,
         right: Box<Expr>,
     },
+    ExportValue {
+        export: ExportName,
+        value: Box<Expr>,
+    },
+    /// SystemJS batch export update: `_export(value)`.
+    ExportBatch {
+        value: Box<Expr>,
+    },
     ExportNames {
         exports: Vec<ExportName>,
         value: Ident,
@@ -91,6 +112,14 @@ impl ExecuteStmt {
             local,
             right,
         }
+    }
+
+    pub fn export_value(export: ExportName, value: Box<Expr>) -> Self {
+        Self::ExportValue { export, value }
+    }
+
+    pub fn export_batch(value: Box<Expr>) -> Self {
+        Self::ExportBatch { value }
     }
 
     pub fn export_names(exports: &[ExportName], value: Ident) -> Self {
@@ -124,6 +153,12 @@ where
             ExecuteStmt::ExportAssign { right, .. } => {
                 right.visit_mut_with(visitor);
             }
+            ExecuteStmt::ExportValue { value, .. } => {
+                value.visit_mut_with(visitor);
+            }
+            ExecuteStmt::ExportBatch { value } => {
+                value.visit_mut_with(visitor);
+            }
             ExecuteStmt::ExportNames { .. } => {}
         }
     }
@@ -149,6 +184,12 @@ where
             ExecuteStmt::ExportAssign { right, .. } => {
                 right.visit_with(visitor);
             }
+            ExecuteStmt::ExportValue { value, .. } => {
+                value.visit_with(visitor);
+            }
+            ExecuteStmt::ExportBatch { value } => {
+                value.visit_with(visitor);
+            }
             ExecuteStmt::ExportNames { .. } => {}
         }
     }
@@ -158,6 +199,7 @@ where
 pub(super) struct SystemModule {
     pub dependencies: Vec<DependencySlot>,
     pub exports: ExportTable,
+    pub export_inits: Vec<ExportInit>,
     pub wrapper_vars: Vec<Ident>,
     pub wrapper_fns: Vec<FnDecl>,
     pub wrapper_stmts: Vec<Stmt>,
@@ -172,6 +214,7 @@ impl SystemModule {
         Self {
             dependencies: Default::default(),
             exports,
+            export_inits: Default::default(),
             wrapper_vars: Default::default(),
             wrapper_fns: Default::default(),
             wrapper_stmts: Default::default(),

--- a/crates/swc_ecma_transforms_module/src/system_js/lower.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js/lower.rs
@@ -5,36 +5,74 @@ use swc_ecma_utils::{find_pat_ids, private_ident, ExprFactory};
 
 use super::{
     ir::{
-        export_name as make_export_name, DependencySlot, ExecuteStmt, ExportName, ExportTable,
-        SetterOp, SystemModule,
+        export_name as make_export_name, DependencySlot, ExecuteStmt, ExportInit, ExportName,
+        ExportTable, SetterOp, SystemModule,
     },
     pattern::replace_exported_pat,
     util::object_lit_prop_name,
 };
 use crate::{
-    module_record::{LocalExportEntries, ModuleRecordEntry, RequestedModule, RequestedModules},
+    module_record::{
+        external_ts_import_equals_source, LocalExportEntries, ModuleRecordEntry, RequestedModule,
+        RequestedModules, SourceModule, SourceModuleItem,
+    },
     util::local_name_for_src,
 };
 
-pub(super) fn lower(
-    body: Vec<ModuleItem>,
-    requested_modules: RequestedModules,
-    local_export_entries: LocalExportEntries,
-) -> SystemModule {
+pub(super) fn lower(source: SourceModule) -> SystemModule {
+    let SourceModule {
+        directives: _directives,
+        has_use_strict: _has_use_strict,
+        requested_modules,
+        local_export_entries,
+        ts_export_assignment,
+        body,
+        has_module_syntax: _has_module_syntax,
+    } = source;
+    let default_value_exports = collect_default_value_exports(&body);
     let mut exports = collect_local_exports(local_export_entries);
+    exports.announced.extend(default_value_exports);
+    exports
+        .announced
+        .sort_unstable_by(|a, b| a.name.cmp(&b.name));
     let mut module = SystemModule::new(exports.clone());
 
     lower_dependencies(&mut module, &mut exports, requested_modules);
     module.exports = exports;
 
     for item in body {
-        let ModuleItem::Stmt(stmt) = item else {
-            continue;
-        };
-        lower_stmt(&mut module, stmt);
+        lower_source_item(&mut module, item);
+    }
+    if let Some(export_assignment) = ts_export_assignment {
+        module
+            .execute_stmts
+            .push(ExecuteStmt::export_batch(export_assignment));
     }
 
     module
+}
+
+fn collect_default_value_exports(body: &[SourceModuleItem]) -> Vec<ExportName> {
+    let mut exports = Vec::new();
+    for item in body {
+        match item {
+            SourceModuleItem::ExportDefaultExpr(export) => {
+                exports.push(default_export_name(export.span));
+            }
+            SourceModuleItem::ExportDefaultDecl(export) => match &export.decl {
+                DefaultDecl::Class(class_expr) if class_expr.ident.is_none() => {
+                    exports.push(default_export_name(export.span));
+                }
+                DefaultDecl::Fn(fn_expr) if fn_expr.ident.is_none() => {
+                    exports.push(default_export_name(export.span));
+                }
+                _ => {}
+            },
+            _ => {}
+        }
+    }
+
+    exports
 }
 
 fn collect_local_exports(local_export_entries: LocalExportEntries) -> ExportTable {
@@ -56,9 +94,9 @@ fn lower_dependencies(
     exports: &mut ExportTable,
     requested_modules: RequestedModules,
 ) {
-    for (request_key, RequestedModule { span, entries, .. }) in requested_modules {
-        let request = request_key.src().clone();
-        let attributes = request_key.attributes().to_vec();
+    for (module_request, RequestedModule { span, entries, .. }) in requested_modules {
+        let request = module_request.src().clone();
+        let attributes = module_request.attributes().to_vec();
         let namespace = namespace_ident_for(&request);
         let mut setter_ops = Vec::with_capacity(entries.len());
         let mut entries: Vec<_> = entries.into_iter().collect();
@@ -129,14 +167,6 @@ fn lower_dependencies(
                 ModuleRecordEntry::StarExport => {
                     setter_ops.push(SetterOp::StarExport);
                 }
-                ModuleRecordEntry::TsImportEquals { local_name } => {
-                    let local = ident_from_id(local_name, span.0);
-                    module.wrapper_vars.push(local.clone());
-                    setter_ops.push(SetterOp::Import {
-                        local,
-                        imported: None,
-                    });
-                }
             }
         }
 
@@ -150,12 +180,64 @@ fn lower_dependencies(
     }
 }
 
+fn lower_source_item(module: &mut SystemModule, item: SourceModuleItem) {
+    match item {
+        SourceModuleItem::Stmt(stmt) => lower_stmt(module, stmt),
+        SourceModuleItem::ExportDecl(export) => lower_decl(module, export.decl),
+        SourceModuleItem::ExportDefaultDecl(export) => lower_default_decl(module, export),
+        SourceModuleItem::ExportDefaultExpr(export) => {
+            module.execute_stmts.push(ExecuteStmt::export_value(
+                default_export_name(export.span),
+                export.expr,
+            ));
+        }
+        SourceModuleItem::TsImportEquals(import) => lower_ts_import_equals(module, *import),
+    }
+}
+
+fn default_export_name(span: swc_common::Span) -> ExportName {
+    make_export_name(atom!("default"), (span, Default::default()))
+}
+
+fn lower_ts_import_equals(module: &mut SystemModule, import: TsImportEqualsDecl) {
+    let Some(src) = external_ts_import_equals_source(&import) else {
+        return;
+    };
+
+    let request = src.value.to_atom_lossy().into_owned();
+    let span = (src.span, Default::default());
+    let namespace = namespace_ident_for(&request);
+    let local = import.id;
+
+    module.wrapper_vars.push(local.clone());
+    module.dependencies.push(DependencySlot {
+        request,
+        span,
+        attributes: Vec::new(),
+        namespace,
+        setter_ops: vec![SetterOp::Import {
+            local,
+            imported: None,
+        }],
+    });
+}
+
 fn lower_stmt(module: &mut SystemModule, stmt: Stmt) {
-    match stmt {
-        Stmt::Decl(Decl::Fn(fn_decl)) => {
+    if let Stmt::Decl(decl) = stmt {
+        lower_decl(module, decl);
+    } else {
+        let mut stmt = stmt;
+        lower_var_scoped_decls(module, &mut stmt);
+        module.execute_stmts.push(ExecuteStmt::source(stmt));
+    }
+}
+
+fn lower_decl(module: &mut SystemModule, decl: Decl) {
+    match decl {
+        Decl::Fn(fn_decl) => {
             module.wrapper_fns.push(fn_decl);
         }
-        Stmt::Decl(Decl::Class(class_decl)) => {
+        Decl::Class(class_decl) => {
             let ClassDecl {
                 ident,
                 declare: _,
@@ -173,14 +255,61 @@ fn lower_stmt(module: &mut SystemModule, stmt: Stmt) {
                 .into(),
             ));
         }
-        Stmt::Decl(Decl::Var(var_decl)) => {
+        Decl::Var(var_decl) => {
             lower_var_decl(module, *var_decl);
         }
-        _ => {
-            let mut stmt = stmt;
-            lower_var_scoped_decls(module, &mut stmt);
-            module.execute_stmts.push(ExecuteStmt::source(stmt));
+        _ => module
+            .execute_stmts
+            .push(ExecuteStmt::source(Stmt::Decl(decl))),
+    }
+}
+
+fn lower_default_decl(module: &mut SystemModule, export: ExportDefaultDecl) {
+    let export_span = export.span;
+
+    match export.decl {
+        DefaultDecl::Class(class_expr) => {
+            let Some(ident) = class_expr.ident else {
+                module.execute_stmts.push(ExecuteStmt::export_value(
+                    default_export_name(export_span),
+                    ClassExpr {
+                        ident: None,
+                        class: class_expr.class,
+                    }
+                    .into(),
+                ));
+                return;
+            };
+
+            module.wrapper_vars.push(ident.clone());
+            module.execute_stmts.push(assign_or_export(
+                module,
+                ident.clone(),
+                ClassExpr {
+                    ident: Some(ident),
+                    class: class_expr.class,
+                }
+                .into(),
+            ));
         }
+        DefaultDecl::Fn(fn_expr) => {
+            let Some(ident) = fn_expr.ident.clone() else {
+                module.export_inits.push(ExportInit::new(
+                    default_export_name(export_span),
+                    fn_expr.into(),
+                ));
+                return;
+            };
+
+            module.wrapper_fns.push(FnDecl {
+                ident,
+                declare: false,
+                function: fn_expr.function,
+            });
+        }
+        DefaultDecl::TsInterfaceDecl(_) => {}
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unable to access unknown nodes"),
     }
 }
 
@@ -429,32 +558,39 @@ fn ident_from_id((sym, ctxt): Id, span: swc_common::Span) -> Ident {
 }
 
 fn compare_module_entries(a: &ModuleRecordEntry, b: &ModuleRecordEntry) -> std::cmp::Ordering {
-    module_entry_key(a).cmp(&module_entry_key(b))
+    module_entry_rank(a)
+        .cmp(&module_entry_rank(b))
+        .then_with(|| module_entry_sort_name(a).cmp(&module_entry_sort_name(b)))
 }
 
-fn module_entry_key(entry: &ModuleRecordEntry) -> (u8, String) {
+fn module_entry_rank(entry: &ModuleRecordEntry) -> u8 {
     match entry {
-        ModuleRecordEntry::Empty => (0, String::new()),
-        ModuleRecordEntry::ImportDefault { local_name } => (1, local_name.0.to_string()),
-        ModuleRecordEntry::ImportNamespace { local_name } => (2, local_name.0.to_string()),
-        ModuleRecordEntry::ImportNamed { local_name, .. } => (3, local_name.0.to_string()),
-        ModuleRecordEntry::IndirectExportDefault { export_name, .. } => {
-            (4, export_name.to_string())
-        }
+        ModuleRecordEntry::Empty => 0,
+        ModuleRecordEntry::ImportDefault { .. } => 1,
+        ModuleRecordEntry::ImportNamespace { .. } => 2,
+        ModuleRecordEntry::ImportNamed { .. } => 3,
+        ModuleRecordEntry::IndirectExportDefault { .. } => 4,
+        ModuleRecordEntry::IndirectExportNamed { .. } => 5,
+        ModuleRecordEntry::IndirectExportNamespace { .. } => 6,
+        ModuleRecordEntry::StarExport => 7,
+    }
+}
+
+fn module_entry_sort_name(entry: &ModuleRecordEntry) -> Option<&Atom> {
+    match entry {
+        ModuleRecordEntry::ImportDefault { local_name }
+        | ModuleRecordEntry::ImportNamespace { local_name }
+        | ModuleRecordEntry::ImportNamed { local_name, .. } => Some(&local_name.0),
+        ModuleRecordEntry::IndirectExportDefault { export_name, .. }
+        | ModuleRecordEntry::IndirectExportNamespace { export_name, .. } => Some(export_name),
         ModuleRecordEntry::IndirectExportNamed {
             export_name,
             import_name,
-        } => (
-            5,
-            export_name.as_ref().map_or_else(
-                || import_name.0.to_string(),
-                |export_name| export_name.0.to_string(),
-            ),
+        } => Some(
+            export_name
+                .as_ref()
+                .map_or(&import_name.0, |export_name| &export_name.0),
         ),
-        ModuleRecordEntry::IndirectExportNamespace { export_name, .. } => {
-            (6, export_name.to_string())
-        }
-        ModuleRecordEntry::StarExport => (7, String::new()),
-        ModuleRecordEntry::TsImportEquals { local_name } => (8, local_name.0.to_string()),
+        ModuleRecordEntry::Empty | ModuleRecordEntry::StarExport => None,
     }
 }

--- a/crates/swc_ecma_transforms_module/src/system_js/rewrite.rs
+++ b/crates/swc_ecma_transforms_module/src/system_js/rewrite.rs
@@ -5,7 +5,7 @@ use swc_ecma_utils::{private_ident, quote_ident, ExprFactory};
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 use super::{
-    ir::{ExecuteStmt, ExportName},
+    ir::{ExportName, SystemModule},
     lower::export_names_call,
     pattern::replace_exported_pat,
     util::{context_member, context_meta},
@@ -13,8 +13,7 @@ use super::{
 use crate::path::Resolver;
 
 pub(super) fn rewrite_special_refs(
-    wrapper_fns: &mut [FnDecl],
-    stmts: &mut [ExecuteStmt],
+    module: &mut SystemModule,
     context_ident: Ident,
     unresolved_ctxt: SyntaxContext,
     resolver: &Resolver,
@@ -28,23 +27,28 @@ pub(super) fn rewrite_special_refs(
         ignore_dynamic,
         preserve_import_meta,
     };
-    for wrapper_fn in wrapper_fns {
+    for wrapper_fn in &mut module.wrapper_fns {
         wrapper_fn.visit_mut_with(&mut rewriter);
     }
-    for stmt in stmts {
+    for export_init in &mut module.export_inits {
+        export_init.value.visit_mut_with(&mut rewriter);
+    }
+    for stmt in &mut module.execute_stmts {
         stmt.visit_mut_with(&mut rewriter);
     }
 }
 
 pub(super) fn rewrite_export_bindings(
-    wrapper_fns: &mut [FnDecl],
-    stmts: &mut [ExecuteStmt],
+    module: &mut SystemModule,
     rewriter: &mut ExportBindingRewriter,
 ) {
-    for wrapper_fn in wrapper_fns {
+    for wrapper_fn in &mut module.wrapper_fns {
         wrapper_fn.visit_mut_with(rewriter);
     }
-    for stmt in stmts {
+    for export_init in &mut module.export_inits {
+        export_init.value.visit_mut_with(rewriter);
+    }
+    for stmt in &mut module.execute_stmts {
         stmt.visit_mut_with(rewriter);
     }
 }

--- a/crates/swc_ecma_transforms_module/src/umd.rs
+++ b/crates/swc_ecma_transforms_module/src/umd.rs
@@ -1,34 +1,32 @@
-use anyhow::Context;
+use rustc_hash::FxHashSet;
 use swc_atoms::Atom;
-use swc_common::{
-    source_map::PURE_SP, sync::Lrc, util::take::Take, Mark, SourceMap, Span, SyntaxContext,
-    DUMMY_SP,
-};
+use swc_common::{source_map::PURE_SP, sync::Lrc, util::take::Take, Mark, SourceMap, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper_expr;
-use swc_ecma_utils::{
-    is_valid_prop_ident, private_ident, quote_ident, quote_str, ExprFactory, IsDirective,
-};
-use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
+use swc_ecma_utils::{private_ident, ExprFactory};
+use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut};
 
 use self::config::BuiltConfig;
 pub use self::config::Config;
 use crate::{
     module_record::{
-        LocalExportEntries, ModuleRecordEntryReducer, ModuleRequestUsage, ModuleSyntaxExtractor,
-        RequestedModule, RequestedModules,
+        exported_external_ts_import_equals_name, external_ts_import_equals_source,
+        LocalExportEntries, ModuleRecordEntryReducer, ModuleRequestUsage, RequestedModule,
+        RequestedModules, SourceModule,
     },
     module_ref_rewriter::{rewrite_import_bindings, ImportMap},
     path::Resolver,
+    syntax_strip::{self, SyntaxStrippedModule},
     top_level_this::top_level_this,
     util::{
         define_es_module, emit_export_stmts, local_name_for_src, sort_export_bindings, use_strict,
-        ImportInterop, VecStmtLike,
+        ImportInterop,
     },
     SpanCtx,
 };
 
 mod config;
+mod emit;
 
 #[derive(Default)]
 pub struct FeatureFlag {
@@ -79,58 +77,58 @@ impl VisitMut for Umd {
     fn visit_mut_module(&mut self, module: &mut Module) {
         let module_items = &mut module.body;
 
-        let mut stmts: Vec<Stmt> = Vec::with_capacity(module_items.len() + 4);
-
-        // Collect directives
-        stmts.extend(
-            module_items
-                .iter_mut()
-                .take_while(|i| i.directive_continue())
-                .map(|i| i.take())
-                .map(ModuleItem::expect_stmt),
-        );
-
-        // "use strict";
-        if self.config.config.strict_mode && !stmts.has_use_strict() {
-            stmts.push(use_strict());
-        }
-
         if !self.config.config.allow_top_level_this {
             top_level_this(module_items, *Expr::undefined(DUMMY_SP));
         }
 
-        let import_interop = self.config.config.import_interop();
-
-        let mut extractor = ModuleSyntaxExtractor::new(self.const_var_kind);
-        module_items.visit_mut_with(&mut extractor);
-
-        let ModuleSyntaxExtractor {
+        let SyntaxStrippedModule {
+            directives,
+            has_use_strict,
             requested_modules,
             local_export_entries,
             export_assign,
+            body,
             has_module_syntax,
-            ..
-        } = extractor;
+        } = syntax_strip::lower(
+            SourceModule::collect(module_items.take()),
+            self.const_var_kind,
+        );
+
+        let mut stmts: Vec<Stmt> = Vec::with_capacity(body.len() + 4);
+        stmts.extend(directives);
+
+        // "use strict";
+        if self.config.config.strict_mode && !has_use_strict {
+            stmts.push(use_strict());
+        }
+
+        let import_interop = self.config.config.import_interop();
 
         let is_export_assign = export_assign.is_some();
 
         if has_module_syntax && !import_interop.is_none() && !is_export_assign {
-            stmts.push(define_es_module(self.exports()))
+            stmts.push(define_es_module(self.exports()));
         }
 
         let mut import_map = Default::default();
+        let ts_import_equals_exports: FxHashSet<Atom> = body
+            .iter()
+            .filter_map(exported_external_ts_import_equals_name)
+            .cloned()
+            .collect();
 
         stmts.extend(self.handle_import_export(
             &mut import_map,
             requested_modules,
             local_export_entries,
+            &ts_import_equals_exports,
             is_export_assign,
         ));
 
-        stmts.extend(module_items.take().into_iter().filter_map(|i| match i {
-            ModuleItem::Stmt(stmt) if !stmt.is_empty() => Some(stmt),
-            _ => None,
-        }));
+        stmts.extend(
+            body.into_iter()
+                .filter_map(|item| self.lower_body_item(&mut import_map, item)),
+        );
 
         if let Some(export_assign) = export_assign {
             let return_stmt = ReturnStmt {
@@ -138,41 +136,24 @@ impl VisitMut for Umd {
                 arg: Some(export_assign),
             };
 
-            stmts.push(return_stmt.into())
+            stmts.push(return_stmt.into());
         }
 
         rewrite_import_bindings(&mut stmts, import_map, Default::default());
 
-        // ====================
-        //  Emit
-        // ====================
-
-        let (adapter_fn_expr, factory_params) = self.adapter(module.span, is_export_assign);
-
-        let factory_fn_expr: Expr = Function {
-            params: factory_params,
-            decorators: Default::default(),
-            span: DUMMY_SP,
-            body: Some(BlockStmt {
-                stmts,
-                ..Default::default()
-            }),
-            is_generator: false,
-            is_async: false,
-            ..Default::default()
-        }
-        .into();
-
-        *module_items = vec![adapter_fn_expr
-            .as_call(
-                DUMMY_SP,
-                vec![
-                    ThisExpr { span: DUMMY_SP }.as_arg(),
-                    factory_fn_expr.as_arg(),
-                ],
-            )
-            .into_stmt()
-            .into()]
+        *module_items = emit::emit(
+            stmts,
+            emit::EmitModule {
+                span: module.span,
+                is_export_assign,
+                exports: self.exports.clone(),
+                deps: self.dep_list.take(),
+            },
+            &self.cm,
+            &self.config,
+            self.unresolved_mark,
+            &self.resolver,
+        );
     }
 }
 
@@ -182,6 +163,7 @@ impl Umd {
         import_map: &mut ImportMap,
         requested_modules: RequestedModules,
         local_export_entries: LocalExportEntries,
+        ts_import_equals_exports: &FxHashSet<Atom>,
         is_export_assign: bool,
     ) -> impl Iterator<Item = Stmt> {
         let import_interop = self.config.config.import_interop();
@@ -192,7 +174,7 @@ impl Umd {
 
         requested_modules.into_iter().for_each(
             |(
-                request_key,
+                module_request,
                 RequestedModule {
                     span: src_span,
                     entries: module_entries,
@@ -200,7 +182,7 @@ impl Umd {
                     ..
                 },
             )| {
-                let src = request_key.src().clone();
+                let src = module_request.src().clone();
                 let is_node_default = !module_usage.has_named() && import_interop.is_node();
 
                 if import_interop.is_none() {
@@ -209,22 +191,15 @@ impl Umd {
 
                 let need_re_export = module_usage.has_star_export();
                 let need_interop = module_usage.needs_interop();
-                let need_new_var = module_usage.needs_raw_import_for_ts_import_equals();
 
                 let mod_ident = private_ident!(local_name_for_src(&src));
-                let new_var_ident = if need_new_var {
-                    private_ident!(local_name_for_src(&src))
-                } else {
-                    mod_ident.clone()
-                };
 
                 self.dep_list.push((mod_ident.clone(), src, src_span));
 
                 module_entries.reduce(
                     import_map,
                     &mut export_bindings,
-                    &new_var_ident,
-                    &Some(mod_ident.clone()),
+                    &mod_ident,
                     &mut false,
                     is_node_default,
                 );
@@ -256,17 +231,10 @@ impl Umd {
                         }
                         _ => import_expr,
                     }
-                };
+                }
 
                 // mod = _introp(mod);
-                // var mod1 = _introp(mod);
-                if need_new_var {
-                    let stmt: Stmt = import_expr
-                        .into_var_decl(self.const_var_kind, new_var_ident.into())
-                        .into();
-
-                    stmts.push(stmt)
-                } else if need_interop {
+                if need_interop {
                     let stmt = import_expr
                         .make_assign_to(op!("="), mod_ident.into())
                         .into_stmt();
@@ -279,6 +247,8 @@ impl Umd {
 
         let mut export_stmts = Default::default();
 
+        export_bindings.retain(|(export_name, _)| !ts_import_equals_exports.contains(export_name));
+
         if !export_bindings.is_empty() && !is_export_assign {
             sort_export_bindings(&mut export_bindings);
 
@@ -290,223 +260,67 @@ impl Umd {
         export_stmts.into_iter().chain(stmts)
     }
 
+    fn lower_body_item(&mut self, import_map: &mut ImportMap, item: ModuleItem) -> Option<Stmt> {
+        match item {
+            ModuleItem::Stmt(stmt) if !stmt.is_empty() => Some(stmt),
+            ModuleItem::ModuleDecl(ModuleDecl::TsImportEquals(import)) => {
+                self.lower_ts_import_equals(import_map, *import)
+            }
+            _ => None,
+        }
+    }
+
+    fn lower_ts_import_equals(
+        &mut self,
+        import_map: &mut ImportMap,
+        import: TsImportEqualsDecl,
+    ) -> Option<Stmt> {
+        let src = external_ts_import_equals_source(&import)?;
+        let src_span = src.span;
+        let request = src.value.to_atom_lossy().into_owned();
+        let TsImportEqualsDecl {
+            id: local,
+            is_export,
+            ..
+        } = import;
+        let param = if is_export {
+            local.clone().into_private()
+        } else {
+            local.clone()
+        };
+
+        self.dep_list
+            .push((param.clone(), request, (src_span, Default::default())));
+
+        if !is_export {
+            return None;
+        }
+
+        Some(self.emit_ts_import_equals(import_map, local, is_export, param.into()))
+    }
+
+    fn emit_ts_import_equals(
+        &mut self,
+        import_map: &mut ImportMap,
+        local: Ident,
+        is_export: bool,
+        value: Expr,
+    ) -> Stmt {
+        if is_export {
+            import_map.insert(local.to_id(), (self.exports(), Some(local.sym.clone())));
+            return value
+                .make_assign_to(op!("="), self.exports().make_member(local.into()).into())
+                .into_stmt();
+        }
+
+        value
+            .into_var_decl(self.const_var_kind, local.into())
+            .into()
+    }
+
     fn exports(&mut self) -> Ident {
         self.exports
             .get_or_insert_with(|| private_ident!("exports"))
             .clone()
-    }
-
-    /// - Without `export =`
-    /// ```javascript
-    /// (function (global, factory) {
-    ///   if (typeof module === "object" && typeof module.exports === "object") {
-    ///     factory(exports, require("mod"));
-    ///   } else if (typeof define === "function" && define.amd) {
-    ///     define(["exports", "mod"], factory);
-    ///   } else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) {
-    ///     factory((global.lib = {}), global.mod);
-    ///   }
-    /// })(this, function (exports, mod) {
-    ///   ...
-    /// });
-    /// ```
-    /// - With `export =`
-    /// ```javascript
-    /// (function (global, factory) {
-    ///   if (typeof module === "object" && typeof module.exports === "object") {
-    ///     module.exports = factory(require("mod"));
-    ///   } else if (typeof define === "function" && define.amd) {
-    ///     define(["mod"], factory);
-    ///   } else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) {
-    ///     global.lib = factory(global.mod);
-    ///   }
-    /// })(this, function (mod) {
-    ///   ...
-    /// });
-    /// ```
-    /// Return: adapter expr and factory params
-    fn adapter(&mut self, module_span: Span, is_export_assign: bool) -> (FnExpr, Vec<Param>) {
-        macro_rules! js_typeof {
-            ($test:expr =>! $type:expr) => {
-                Expr::Unary(UnaryExpr {
-                    span: DUMMY_SP,
-                    op: op!("typeof"),
-                    arg: Box::new(Expr::from($test)),
-                })
-                .make_bin(op!("!=="), quote_str!($type))
-            };
-
-            ($test:expr => $type:expr) => {
-                Expr::Unary(UnaryExpr {
-                    span: DUMMY_SP,
-                    op: op!("typeof"),
-                    arg: Box::new(Expr::from($test)),
-                })
-                .make_bin(op!("==="), quote_str!($type))
-            };
-        }
-
-        // define unresolved ref
-        let module = quote_ident!(
-            SyntaxContext::empty().apply_mark(self.unresolved_mark),
-            "module"
-        );
-
-        let require = quote_ident!(
-            SyntaxContext::empty().apply_mark(self.unresolved_mark),
-            "require"
-        );
-        let define = quote_ident!(
-            SyntaxContext::empty().apply_mark(self.unresolved_mark),
-            "define"
-        );
-        let global_this = quote_ident!(
-            SyntaxContext::empty().apply_mark(self.unresolved_mark),
-            "globalThis"
-        );
-        let js_self = quote_ident!(
-            SyntaxContext::empty().apply_mark(self.unresolved_mark),
-            "self"
-        );
-
-        // adapter arguments
-        let global = private_ident!("global");
-        let factory = private_ident!("factory");
-
-        let module_exports = module.clone().make_member(quote_ident!("exports"));
-        let define_amd = define.clone().make_member(quote_ident!("amd"));
-
-        let mut cjs_args = Vec::new();
-        let mut amd_dep_list = Vec::new();
-        let mut browser_args = Vec::new();
-
-        let mut factory_params = Vec::new();
-
-        if !is_export_assign && self.exports.is_some() {
-            let filename = self.cm.span_to_filename(module_span);
-            let exported_name = self.config.determine_export_name(filename);
-            let global_lib = global.clone().make_member(exported_name.into());
-
-            cjs_args.push(quote_ident!("exports").as_arg());
-            amd_dep_list.push(Some(quote_str!("exports").as_arg()));
-            browser_args.push(
-                ObjectLit {
-                    span: DUMMY_SP,
-                    props: Default::default(),
-                }
-                .make_assign_to(op!("="), global_lib.into())
-                .as_arg(),
-            );
-            factory_params.push(self.exports().into());
-        }
-
-        self.dep_list
-            .take()
-            .into_iter()
-            .for_each(|(ident, src_path, src_span)| {
-                let src_path = match &self.resolver {
-                    Resolver::Real { resolver, base } => resolver
-                        .resolve_import(base, &src_path)
-                        .with_context(|| format!("failed to resolve `{src_path}`"))
-                        .unwrap(),
-                    Resolver::Default => src_path,
-                };
-
-                cjs_args.push(
-                    require
-                        .clone()
-                        .as_call(
-                            DUMMY_SP,
-                            vec![quote_str!(src_span.0, src_path.clone()).as_arg()],
-                        )
-                        .as_arg(),
-                );
-                amd_dep_list.push(Some(quote_str!(src_span.0, src_path.clone()).as_arg()));
-
-                let global_dep = {
-                    let dep_name = self.config.global_name(&src_path);
-                    let global = global.clone();
-                    if is_valid_prop_ident(&dep_name) {
-                        global.make_member(quote_ident!(dep_name))
-                    } else {
-                        global.computed_member(quote_str!(dep_name))
-                    }
-                };
-                browser_args.push(global_dep.as_arg());
-                factory_params.push(ident.into());
-            });
-
-        let cjs_if_test = js_typeof!(module => "object")
-            .make_bin(op!("&&"), js_typeof!(module_exports.clone() => "object"));
-        let mut cjs_if_body = factory.clone().as_call(DUMMY_SP, cjs_args);
-        if is_export_assign {
-            cjs_if_body = cjs_if_body.make_assign_to(op!("="), module_exports.clone().into());
-        }
-
-        let amd_if_test = js_typeof!(define.clone() => "function").make_bin(op!("&&"), define_amd);
-        let amd_if_body = define.as_call(
-            DUMMY_SP,
-            vec![
-                ArrayLit {
-                    span: DUMMY_SP,
-                    elems: amd_dep_list,
-                }
-                .as_arg(),
-                factory.clone().as_arg(),
-            ],
-        );
-
-        let browser_if_test = CondExpr {
-            span: DUMMY_SP,
-            test: Box::new(js_typeof!(global_this.clone() =>! "undefined")),
-            cons: Box::new(global_this.into()),
-            alt: Box::new(global.clone().make_bin(op!("||"), js_self)),
-        }
-        .make_assign_to(op!("="), global.clone().into());
-
-        let mut browser_if_body = factory.clone().as_call(DUMMY_SP, browser_args);
-        if is_export_assign {
-            browser_if_body = browser_if_body.make_assign_to(op!("="), module_exports.into());
-        }
-
-        let adapter_body = BlockStmt {
-            span: DUMMY_SP,
-            stmts: vec![IfStmt {
-                span: DUMMY_SP,
-                test: Box::new(cjs_if_test),
-                cons: Box::new(cjs_if_body.into_stmt()),
-                alt: Some(Box::new(
-                    IfStmt {
-                        span: DUMMY_SP,
-                        test: Box::new(amd_if_test),
-                        cons: Box::new(amd_if_body.into_stmt()),
-                        alt: Some(Box::new(
-                            IfStmt {
-                                span: DUMMY_SP,
-                                test: Box::new(browser_if_test),
-                                cons: Box::new(browser_if_body.into_stmt()),
-                                alt: None,
-                            }
-                            .into(),
-                        )),
-                    }
-                    .into(),
-                )),
-            }
-            .into()],
-            ..Default::default()
-        };
-
-        let adapter_fn_expr = Function {
-            params: vec![global.into(), factory.into()],
-            span: DUMMY_SP,
-            body: Some(adapter_body),
-            is_generator: false,
-            is_async: false,
-            ..Default::default()
-        }
-        .into();
-
-        (adapter_fn_expr, factory_params)
     }
 }

--- a/crates/swc_ecma_transforms_module/src/umd/config.rs
+++ b/crates/swc_ecma_transforms_module/src/umd/config.rs
@@ -43,7 +43,7 @@ impl Config {
                         )
                         .map_err(|e| {
                             if HANDLER.is_set() {
-                                HANDLER.with(|h| e.into_diagnostic(h).emit())
+                                HANDLER.with(|h| e.into_diagnostic(h).emit());
                             }
                         })
                         .unwrap()

--- a/crates/swc_ecma_transforms_module/src/umd/emit.rs
+++ b/crates/swc_ecma_transforms_module/src/umd/emit.rs
@@ -1,0 +1,261 @@
+use anyhow::Context;
+use swc_atoms::Atom;
+use swc_common::{sync::Lrc, Mark, SourceMap, Span, SyntaxContext, DUMMY_SP};
+use swc_ecma_ast::*;
+use swc_ecma_utils::{is_valid_prop_ident, private_ident, quote_ident, quote_str, ExprFactory};
+
+use super::config::BuiltConfig;
+use crate::{path::Resolver, SpanCtx};
+
+pub(super) struct EmitModule {
+    pub span: Span,
+    pub is_export_assign: bool,
+    pub exports: Option<Ident>,
+    pub deps: Vec<(Ident, Atom, SpanCtx)>,
+}
+
+pub(super) fn emit(
+    stmts: Vec<Stmt>,
+    module: EmitModule,
+    cm: &Lrc<SourceMap>,
+    config: &BuiltConfig,
+    unresolved_mark: Mark,
+    resolver: &Resolver,
+) -> Vec<ModuleItem> {
+    let (adapter_fn_expr, factory_params) =
+        emit_adapter(&module, cm, config, unresolved_mark, resolver);
+
+    let factory_fn_expr: Expr = Function {
+        params: factory_params,
+        decorators: Default::default(),
+        span: DUMMY_SP,
+        body: Some(BlockStmt {
+            stmts,
+            ..Default::default()
+        }),
+        is_generator: false,
+        is_async: false,
+        ..Default::default()
+    }
+    .into();
+
+    vec![adapter_fn_expr
+        .as_call(
+            DUMMY_SP,
+            vec![
+                ThisExpr { span: DUMMY_SP }.as_arg(),
+                factory_fn_expr.as_arg(),
+            ],
+        )
+        .into_stmt()
+        .into()]
+}
+
+/// Builds the UMD adapter function and returns it with the factory params.
+///
+/// The adapter always emits `CommonJS`, AMD, and global-fallback branches:
+/// ```javascript
+/// if (typeof module === "object" && typeof module.exports === "object") { ... }
+/// else if (typeof define === "function" && define.amd) { ... }
+/// else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) { ... }
+/// ```
+///
+/// For regular ES exports, `exports` is added as the first CommonJS/AMD
+/// dependency and factory param. The global fallback creates the configured
+/// export object and passes it as the first factory argument:
+/// ```javascript
+/// factory(exports, require("mod"));
+/// define(["exports", "mod"], factory);
+/// factory((global.lib = {}), global.mod);
+/// function (exports, mod) { ... }
+/// ```
+///
+/// For `export =`, there is no `exports` param. The factory returns the module
+/// value, `CommonJS` assigns that return value to `module.exports`, AMD only
+/// registers the dependency list, and the fallback branch assigns the factory
+/// result to the inferred global export name:
+/// ```javascript
+/// module.exports = factory(require("mod"));
+/// define(["mod"], factory);
+/// global.lib = factory(global.mod);
+/// function (mod) { ... }
+/// ```
+fn emit_adapter(
+    module: &EmitModule,
+    cm: &Lrc<SourceMap>,
+    config: &BuiltConfig,
+    unresolved_mark: Mark,
+    resolver: &Resolver,
+) -> (FnExpr, Vec<Param>) {
+    macro_rules! js_typeof {
+        ($test:expr =>! $type:expr) => {
+            Expr::Unary(UnaryExpr {
+                span: DUMMY_SP,
+                op: op!("typeof"),
+                arg: Box::new(Expr::from($test)),
+            })
+            .make_bin(op!("!=="), quote_str!($type))
+        };
+
+        ($test:expr => $type:expr) => {
+            Expr::Unary(UnaryExpr {
+                span: DUMMY_SP,
+                op: op!("typeof"),
+                arg: Box::new(Expr::from($test)),
+            })
+            .make_bin(op!("==="), quote_str!($type))
+        };
+    }
+
+    let module_ident = quote_ident!(SyntaxContext::empty().apply_mark(unresolved_mark), "module");
+    let require = quote_ident!(
+        SyntaxContext::empty().apply_mark(unresolved_mark),
+        "require"
+    );
+    let define = quote_ident!(SyntaxContext::empty().apply_mark(unresolved_mark), "define");
+    let global_this = quote_ident!(
+        SyntaxContext::empty().apply_mark(unresolved_mark),
+        "globalThis"
+    );
+    let js_self = quote_ident!(SyntaxContext::empty().apply_mark(unresolved_mark), "self");
+
+    let global = private_ident!("global");
+    let factory = private_ident!("factory");
+
+    let module_exports = module_ident.clone().make_member(quote_ident!("exports"));
+    let define_amd = define.clone().make_member(quote_ident!("amd"));
+
+    let mut cjs_args = Vec::new();
+    let mut amd_dep_list = Vec::new();
+    let mut browser_args = Vec::new();
+
+    let mut factory_params = Vec::new();
+
+    if !module.is_export_assign {
+        if let Some(exports) = &module.exports {
+            cjs_args.push(quote_ident!("exports").as_arg());
+            amd_dep_list.push(Some(quote_str!("exports").as_arg()));
+            browser_args.push(
+                ObjectLit::default()
+                    .make_assign_to(
+                        op!("="),
+                        module_global_export_member(module.span, cm, config, &global).into(),
+                    )
+                    .as_arg(),
+            );
+            factory_params.push(exports.clone().into());
+        }
+    }
+
+    module.deps.iter().for_each(|(ident, src_path, src_span)| {
+        let src_path = match resolver {
+            Resolver::Real { resolver, base } => resolver
+                .resolve_import(base, src_path)
+                .with_context(|| format!("failed to resolve `{src_path}`"))
+                .unwrap(),
+            Resolver::Default => src_path.clone(),
+        };
+
+        cjs_args.push(
+            require
+                .clone()
+                .as_call(
+                    DUMMY_SP,
+                    vec![quote_str!(src_span.0, src_path.clone()).as_arg()],
+                )
+                .as_arg(),
+        );
+        amd_dep_list.push(Some(quote_str!(src_span.0, src_path.clone()).as_arg()));
+
+        let global_dep = {
+            let dep_name = config.global_name(&src_path);
+            let global = global.clone();
+            if is_valid_prop_ident(&dep_name) {
+                global.make_member(quote_ident!(dep_name))
+            } else {
+                global.computed_member(quote_str!(dep_name))
+            }
+        };
+        browser_args.push(global_dep.as_arg());
+        factory_params.push(ident.clone().into());
+    });
+
+    let cjs_if_test = js_typeof!(module_ident.clone() => "object")
+        .make_bin(op!("&&"), js_typeof!(module_exports.clone() => "object"));
+    let mut cjs_if_body = factory.clone().as_call(DUMMY_SP, cjs_args);
+    if module.is_export_assign {
+        cjs_if_body = cjs_if_body.make_assign_to(op!("="), module_exports.clone().into());
+    }
+
+    let amd_if_test = js_typeof!(define.clone() => "function").make_bin(op!("&&"), define_amd);
+    let amd_if_body = define.as_call(
+        DUMMY_SP,
+        vec![
+            ArrayLit {
+                span: DUMMY_SP,
+                elems: amd_dep_list,
+            }
+            .as_arg(),
+            factory.clone().as_arg(),
+        ],
+    );
+
+    let browser_if_test = CondExpr {
+        span: DUMMY_SP,
+        test: Box::new(js_typeof!(global_this.clone() =>! "undefined")),
+        cons: Box::new(global_this.into()),
+        alt: Box::new(global.clone().make_bin(op!("||"), js_self)),
+    }
+    .make_assign_to(op!("="), global.clone().into());
+
+    let mut browser_if_body = factory.clone().as_call(DUMMY_SP, browser_args);
+    if module.is_export_assign {
+        browser_if_body = browser_if_body.make_assign_to(
+            op!("="),
+            module_global_export_member(module.span, cm, config, &global).into(),
+        );
+    }
+
+    let browser_if = if_stmt(browser_if_test, browser_if_body, None);
+    let amd_if = if_stmt(amd_if_test, amd_if_body, Some(browser_if));
+    let adapter_body = BlockStmt {
+        span: DUMMY_SP,
+        stmts: vec![if_stmt(cjs_if_test, cjs_if_body, Some(amd_if))],
+        ..Default::default()
+    };
+
+    let adapter_fn_expr = Function {
+        params: vec![global.into(), factory.into()],
+        span: DUMMY_SP,
+        body: Some(adapter_body),
+        is_generator: false,
+        is_async: false,
+        ..Default::default()
+    }
+    .into();
+
+    (adapter_fn_expr, factory_params)
+}
+
+fn if_stmt(test: Expr, body: Expr, alt: Option<Stmt>) -> Stmt {
+    IfStmt {
+        span: DUMMY_SP,
+        test: Box::new(test),
+        cons: Box::new(body.into_stmt()),
+        alt: alt.map(Box::new),
+    }
+    .into()
+}
+
+/// Returns the browser fallback global member for the current module.
+fn module_global_export_member(
+    module_span: Span,
+    cm: &Lrc<SourceMap>,
+    config: &BuiltConfig,
+    global: &Ident,
+) -> MemberExpr {
+    let filename = cm.span_to_filename(module_span);
+    let exported_name = config.determine_export_name(filename);
+
+    global.clone().make_member(exported_name.into())
+}

--- a/crates/swc_ecma_transforms_module/src/util.rs
+++ b/crates/swc_ecma_transforms_module/src/util.rs
@@ -6,7 +6,7 @@ use swc_config::file_pattern::FilePattern;
 use swc_ecma_ast::*;
 use swc_ecma_utils::{
     is_valid_prop_ident, member_expr, private_ident, quote_ident, quote_str, ExprFactory,
-    FunctionFactory, IsDirective,
+    FunctionFactory,
 };
 
 use crate::{
@@ -33,7 +33,7 @@ pub struct Config {
     /// swc will emit `cjs-module-lexer` detectable annotation with this option
     /// enabled.
     ///
-    /// Defaults to `true` if import_interop is Node, else `false`
+    /// Defaults to `true` if `import_interop` is Node, else `false`
     #[serde(default)]
     pub export_interop_annotation: Option<bool>,
     #[serde(default)]
@@ -52,6 +52,7 @@ pub struct Config {
 }
 
 impl Config {
+    #[must_use]
     pub fn default_js_ext() -> String {
         "js".to_string()
     }
@@ -100,12 +101,14 @@ impl From<bool> for ImportInterop {
 
 impl Config {
     #[inline(always)]
+    #[must_use]
     pub fn import_interop(&self) -> ImportInterop {
         self.import_interop
             .unwrap_or_else(|| self.no_interop.into())
     }
 
     #[inline(always)]
+    #[must_use]
     pub fn export_interop_annotation(&self) -> bool {
         self.export_interop_annotation
             .unwrap_or_else(|| self.import_interop == Some(ImportInterop::Node))
@@ -119,6 +122,7 @@ pub struct LazyObjectConfig {
 }
 
 impl LazyObjectConfig {
+    #[must_use]
     pub fn is_lazy(&self, src: &Atom) -> bool {
         self.patterns.iter().any(|pat| pat.is_match(src))
     }
@@ -133,6 +137,7 @@ pub enum Lazy {
 }
 
 impl Lazy {
+    #[must_use]
     pub fn is_lazy(&self, src: &Atom) -> bool {
         match *self {
             Lazy::Bool(false) => false,
@@ -157,14 +162,14 @@ pub(super) fn local_name_for_src(src: &Atom) -> Atom {
         .unwrap_or(src);
 
     let id = match Ident::verify_symbol(src) {
-        Ok(_) => src.into(),
+        Ok(()) => src.into(),
         Err(err) => err,
     };
 
-    if !id.starts_with('_') {
-        format!("_{id}").into()
-    } else {
+    if id.starts_with('_') {
         id.into()
+    } else {
+        format!("_{id}").into()
     }
 }
 
@@ -207,35 +212,6 @@ pub(super) fn define_es_module(exports: Ident) -> Stmt {
         .as_arg(),
     )
     .into_stmt()
-}
-
-pub(super) trait VecStmtLike {
-    type StmtLike: IsDirective;
-
-    fn as_ref(&self) -> &[Self::StmtLike];
-
-    fn has_use_strict(&self) -> bool {
-        self.as_ref()
-            .iter()
-            .take_while(|s| s.directive_continue())
-            .any(IsDirective::is_use_strict)
-    }
-}
-
-impl VecStmtLike for [ModuleItem] {
-    type StmtLike = ModuleItem;
-
-    fn as_ref(&self) -> &[Self::StmtLike] {
-        self
-    }
-}
-
-impl VecStmtLike for [Stmt] {
-    type StmtLike = Stmt;
-
-    fn as_ref(&self) -> &[Self::StmtLike] {
-        self
-    }
 }
 
 pub(super) fn use_strict() -> Stmt {

--- a/crates/swc_ecma_transforms_module/src/wtf8.rs
+++ b/crates/swc_ecma_transforms_module/src/wtf8.rs
@@ -10,8 +10,7 @@ use swc_ecma_ast::Str;
 pub(crate) fn normalize_wtf8_atom(value: &Wtf8Atom) -> Atom {
     value
         .as_str()
-        .map(Atom::from)
-        .unwrap_or_else(|| Atom::from(value.to_string_lossy()))
+        .map_or_else(|| Atom::from(value.to_string_lossy()), Atom::from)
 }
 
 /// Convert a [`Str`] literal into a UTF-8 [`Atom`], preserving valid UTF-8
@@ -22,8 +21,8 @@ pub(crate) fn str_to_atom(value: &Str) -> Atom {
 }
 
 pub(crate) fn wtf8_to_cow_str(value: &Wtf8Atom) -> Cow<'_, str> {
-    value
-        .as_str()
-        .map(Cow::Borrowed)
-        .unwrap_or_else(|| Cow::Owned(value.to_string_lossy().into_owned()))
+    value.as_str().map_or_else(
+        || Cow::Owned(value.to_string_lossy().into_owned()),
+        Cow::Borrowed,
+    )
 }

--- a/crates/swc_ecma_transforms_module/tests/amd.rs
+++ b/crates/swc_ecma_transforms_module/tests/amd.rs
@@ -23,7 +23,14 @@ fn tr(config: amd::Config, is_ts: bool, comments: Rc<SingleThreadedComments>) ->
 
     (
         resolver(unresolved_mark, top_level_mark, is_ts),
-        typescript::typescript(Default::default(), unresolved_mark, top_level_mark),
+        typescript::typescript(
+            typescript::Config {
+                import_export_assign_config: typescript::TsImportExportAssignConfig::Preserve,
+                ..Default::default()
+            },
+            unresolved_mark,
+            top_level_mark,
+        ),
         amd(
             Default::default(),
             unresolved_mark,

--- a/crates/swc_ecma_transforms_module/tests/common_js.rs
+++ b/crates/swc_ecma_transforms_module/tests/common_js.rs
@@ -23,7 +23,14 @@ fn tr(config: common_js::Config, is_ts: bool) -> impl Pass {
 
     (
         resolver(unresolved_mark, top_level_mark, is_ts),
-        typescript::typescript(Default::default(), unresolved_mark, top_level_mark),
+        typescript::typescript(
+            typescript::Config {
+                import_export_assign_config: typescript::TsImportExportAssignConfig::Preserve,
+                ..Default::default()
+            },
+            unresolved_mark,
+            top_level_mark,
+        ),
         common_js(
             Default::default(),
             unresolved_mark,

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/1/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/1/output.amd.ts
@@ -9,5 +9,5 @@ define("NamedModule", [
             this.x = 5;
         }
     }
-    module.exports = Foo;
+    return Foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/1/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/1/output.umd.ts
@@ -1,8 +1,8 @@
 ///<amd-module name='NamedModule'/>
 (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory();
+    if (typeof module === "object" && typeof module.exports === "object") module.exports = factory();
     else if (typeof define === "function" && define.amd) define([], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) global.input = factory();
 })(this, function() {
     "use strict";
     class Foo {
@@ -11,5 +11,5 @@
             this.x = 5;
         }
     }
-    module.exports = Foo;
+    return Foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/2/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/2/output.amd.ts
@@ -10,5 +10,5 @@ define("SecondModuleName", [
             this.x = 5;
         }
     }
-    module.exports = Foo;
+    return Foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/2/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/2/output.umd.ts
@@ -1,9 +1,9 @@
 ///<amd-module name='FirstModuleName'/>
 ///<amd-module name='SecondModuleName'/>
 (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory();
+    if (typeof module === "object" && typeof module.exports === "object") module.exports = factory();
     else if (typeof define === "function" && define.amd) define([], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) global.input = factory();
 })(this, function() {
     "use strict";
     class Foo {
@@ -12,5 +12,5 @@
             this.x = 5;
         }
     }
-    module.exports = Foo;
+    return Foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/3/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/3/output.amd.ts
@@ -9,5 +9,5 @@ define("NamedModule", [
             this.x = 5;
         }
     }
-    module.exports = Foo;
+    return Foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/3/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/3/output.umd.ts
@@ -1,8 +1,8 @@
 ///<AmD-moDulE nAme='NamedModule'/>
 (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory();
+    if (typeof module === "object" && typeof module.exports === "object") module.exports = factory();
     else if (typeof define === "function" && define.amd) define([], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) global.input = factory();
 })(this, function() {
     "use strict";
     class Foo {
@@ -11,5 +11,5 @@
             this.x = 5;
         }
     }
-    module.exports = Foo;
+    return Foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/4/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/4/output.amd.ts
@@ -8,5 +8,5 @@
             this.x = 5;
         }
     }
-    module.exports = Foo;
+    return Foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/4/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/amd-triple-slash-directive/4/output.umd.ts
@@ -1,7 +1,7 @@
 /*/<amd-module name='should-ignore'/> */ (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory();
+    if (typeof module === "object" && typeof module.exports === "object") module.exports = factory();
     else if (typeof define === "function" && define.amd) define([], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) global.input = factory();
 })(this, function() {
     "use strict";
     class Foo {
@@ -10,5 +10,5 @@
             this.x = 5;
         }
     }
-    module.exports = Foo;
+    return Foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/export-assign/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/export-assign/output.amd.ts
@@ -1,7 +1,7 @@
 define([
-    "require"
-], function(require) {
+    "require",
+    "foo"
+], function(require, foo) {
     "use strict";
-    const foo = require("foo");
-    module.exports = foo;
+    return foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/export-assign/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/export-assign/output.umd.ts
@@ -1,9 +1,10 @@
 (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory();
-    else if (typeof define === "function" && define.amd) define([], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
-})(this, function() {
+    if (typeof module === "object" && typeof module.exports === "object") module.exports = factory(require("foo"));
+    else if (typeof define === "function" && define.amd) define([
+        "foo"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) global.input = factory(global.foo);
+})(this, function(foo) {
     "use strict";
-    const foo = require("foo");
-    module.exports = foo;
+    return foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/export-import/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/export-import/output.amd.ts
@@ -1,6 +1,11 @@
 define([
-    "require"
-], function(require) {
+    "require",
+    "exports",
+    "foo"
+], function(require, exports, foo) {
     "use strict";
-    const foo = exports.foo = require("foo");
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    exports.foo = foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/export-import/output.cts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/export-import/output.cts
@@ -1,2 +1,5 @@
 "use strict";
-const foo = exports.foo = require("foo");
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.foo = require("foo");

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/export-import/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/export-import/output.umd.ts
@@ -1,8 +1,14 @@
 (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory();
-    else if (typeof define === "function" && define.amd) define([], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
-})(this, function() {
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("foo"));
+    else if (typeof define === "function" && define.amd) define([
+        "exports",
+        "foo"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.input = {}, global.foo);
+})(this, function(exports, foo) {
     "use strict";
-    const foo = exports.foo = require("foo");
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    exports.foo = foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/import-name-collision/input.cts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/import-name-collision/input.cts
@@ -1,0 +1,5 @@
+import d from "bar";
+import _bar = require("baz");
+
+d();
+_bar();

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/import-name-collision/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/import-name-collision/output.amd.ts
@@ -1,0 +1,14 @@
+define([
+    "require",
+    "exports",
+    "bar",
+    "baz"
+], function(require, exports, _bar, _bar1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    _bar = /*#__PURE__*/ _interop_require_default(_bar);
+    (0, _bar.default)();
+    _bar1();
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/import-name-collision/output.cts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/import-name-collision/output.cts
@@ -1,0 +1,8 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+const _bar = /*#__PURE__*/ _interop_require_default(require("bar"));
+const _bar1 = require("baz");
+(0, _bar.default)();
+_bar1();

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/import-name-collision/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/import-name-collision/output.umd.ts
@@ -1,0 +1,17 @@
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("bar"), require("baz"));
+    else if (typeof define === "function" && define.amd) define([
+        "exports",
+        "bar",
+        "baz"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.input = {}, global.bar, global.baz);
+})(this, function(exports, _bar, _bar1) {
+    "use strict";
+    Object.defineProperty(exports, "__esModule", {
+        value: true
+    });
+    _bar = /*#__PURE__*/ _interop_require_default(_bar);
+    (0, _bar.default)();
+    _bar1();
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/mixed/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/mixed/output.amd.ts
@@ -1,14 +1,14 @@
 define([
     "require",
     "exports",
+    "foo",
     "foo"
-], function(require, exports, _foo) {
+], function(require, exports, _foo, bar) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
     _foo = /*#__PURE__*/ _interop_require_default(_foo);
-    const bar = require("foo");
     (0, _foo.default)();
     bar();
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/mixed/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/cts-import-export/mixed/output.umd.ts
@@ -1,17 +1,17 @@
 (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("foo"));
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("foo"), require("foo"));
     else if (typeof define === "function" && define.amd) define([
         "exports",
+        "foo",
         "foo"
     ], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.input = {}, global.foo);
-})(this, function(exports, _foo) {
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.input = {}, global.foo, global.foo);
+})(this, function(exports, _foo, bar) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
     _foo = /*#__PURE__*/ _interop_require_default(_foo);
-    const bar = require("foo");
     (0, _foo.default)();
     bar();
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-4898/1/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-4898/1/output.amd.ts
@@ -1,7 +1,7 @@
 define([
-    "require"
-], function(require) {
+    "require",
+    "assert"
+], function(require, assert) {
     "use strict";
-    const assert = require("assert");
     assert(true);
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-4898/1/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-4898/1/output.umd.ts
@@ -1,9 +1,10 @@
 (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory();
-    else if (typeof define === "function" && define.amd) define([], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
-})(this, function() {
+    if (typeof module === "object" && typeof module.exports === "object") factory(require("assert"));
+    else if (typeof define === "function" && define.amd) define([
+        "assert"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.assert);
+})(this, function(assert) {
     "use strict";
-    const assert = require("assert");
     assert(true);
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-4898/2/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-4898/2/output.amd.ts
@@ -1,14 +1,14 @@
 define([
     "require",
     "exports",
+    "assert",
     "assert"
-], function(require, exports, _assert) {
+], function(require, exports, _assert, assert) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
     _assert = /*#__PURE__*/ _interop_require_default(_assert);
-    const assert = require("assert");
     assert(true);
     (0, _assert.default)(true);
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-4898/2/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-4898/2/output.umd.ts
@@ -1,17 +1,17 @@
 (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("assert"));
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("assert"), require("assert"));
     else if (typeof define === "function" && define.amd) define([
         "exports",
+        "assert",
         "assert"
     ], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.input = {}, global.assert);
-})(this, function(exports, _assert) {
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.input = {}, global.assert, global.assert);
+})(this, function(exports, _assert, assert) {
     "use strict";
     Object.defineProperty(exports, "__esModule", {
         value: true
     });
     _assert = /*#__PURE__*/ _interop_require_default(_assert);
-    const assert = require("assert");
     assert(true);
     (0, _assert.default)(true);
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-5042/1/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-5042/1/output.amd.ts
@@ -1,17 +1,18 @@
 define([
     "require",
-    "exports"
-], function(require, exports1) {
+    "exports",
+    "jquery"
+], function(require, exports, $) {
     "use strict";
-    Object.defineProperty(exports1, "__esModule", {
+    Object.defineProperty(exports, "__esModule", {
         value: true
     });
-    Object.defineProperty(exports1, "jquery", {
+    Object.defineProperty(exports, "jquery", {
         enumerable: true,
         get: function() {
-            return $;
+            return exports.$;
         }
     });
-    const $ = exports.$ = require("jquery");
-    $(".hello");
+    exports.$ = $;
+    (0, exports.$)(".hello");
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-5042/1/output.cts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-5042/1/output.cts
@@ -5,8 +5,8 @@ Object.defineProperty(exports, "__esModule", {
 Object.defineProperty(exports, "jquery", {
     enumerable: true,
     get: function() {
-        return $;
+        return exports.$;
     }
 });
-const $ = exports.$ = require("jquery");
-$(".hello");
+exports.$ = require("jquery");
+(0, exports.$)(".hello");

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-5042/1/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-5042/1/output.umd.ts
@@ -1,20 +1,21 @@
 (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory(exports);
+    if (typeof module === "object" && typeof module.exports === "object") factory(exports, require("jquery"));
     else if (typeof define === "function" && define.amd) define([
-        "exports"
+        "exports",
+        "jquery"
     ], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.input = {});
-})(this, function(exports1) {
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory(global.input = {}, global.jquery);
+})(this, function(exports, $) {
     "use strict";
-    Object.defineProperty(exports1, "__esModule", {
+    Object.defineProperty(exports, "__esModule", {
         value: true
     });
-    Object.defineProperty(exports1, "jquery", {
+    Object.defineProperty(exports, "jquery", {
         enumerable: true,
         get: function() {
-            return $;
+            return exports.$;
         }
     });
-    const $ = exports.$ = require("jquery");
-    $(".hello");
+    exports.$ = $;
+    (0, exports.$)(".hello");
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-5042/2/output.amd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-5042/2/output.amd.ts
@@ -1,9 +1,9 @@
 define([
-    "require"
-], function(require) {
+    "require",
+    "foo"
+], function(require, foo) {
     "use strict";
-    const foo = require("foo");
     foo.bar = 1;
     foo.bar = 2;
-    module.exports = foo;
+    return foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/issue-5042/2/output.umd.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/issue-5042/2/output.umd.ts
@@ -1,11 +1,12 @@
 (function(global, factory) {
-    if (typeof module === "object" && typeof module.exports === "object") factory();
-    else if (typeof define === "function" && define.amd) define([], factory);
-    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
-})(this, function() {
+    if (typeof module === "object" && typeof module.exports === "object") module.exports = factory(require("foo"));
+    else if (typeof define === "function" && define.amd) define([
+        "foo"
+    ], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) global.input = factory(global.foo);
+})(this, function(foo) {
     "use strict";
-    const foo = require("foo");
     foo.bar = 1;
     foo.bar = 2;
-    module.exports = foo;
+    return foo;
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-2/output.mjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-2/output.mjs
@@ -1,11 +1,10 @@
 System.register([], function(_export, _context) {
     "use strict";
-    var _default;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
-            _export("default", _default = {});
+            _export("default", {});
         }
     };
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-3/output.mjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-3/output.mjs
@@ -1,11 +1,10 @@
 System.register([], function(_export, _context) {
     "use strict";
-    var _default;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
-            _export("default", _default = []);
+            _export("default", []);
         }
     };
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-4/output.mjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-4/output.mjs
@@ -1,11 +1,10 @@
 System.register([], function(_export, _context) {
     "use strict";
-    var _default;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
-            _export("default", _default = foo);
+            _export("default", foo);
         }
     };
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-5/output.mjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-5/output.mjs
@@ -1,7 +1,6 @@
 System.register([], function(_export, _context) {
     "use strict";
-    function _default() {}
-    _export("default", _default);
+    _export("default", function() {});
     return {
         setters: [],
         execute: function() {}

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-6/output.mjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-6/output.mjs
@@ -1,11 +1,10 @@
 System.register([], function(_export, _context) {
     "use strict";
-    var _default;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
-            _export("default", _default = class _default {
+            _export("default", class {
             });
         }
     };

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-9/output.mjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default-9/output.mjs
@@ -1,11 +1,10 @@
 System.register([], function(_export, _context) {
     "use strict";
-    var _default;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
-            _export("default", _default = function() {
+            _export("default", function() {
                 return "foo";
             }());
         }

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default/output.mjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/export-default/output.mjs
@@ -1,11 +1,10 @@
 System.register([], function(_export, _context) {
     "use strict";
-    var _default;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
-            _export("default", _default = 42);
+            _export("default", 42);
         }
     };
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/issue-5288-default-class-not-hoisted/output.mjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/issue-5288-default-class-not-hoisted/output.mjs
@@ -1,12 +1,12 @@
 System.register([], function(_export, _context) {
     "use strict";
-    var _default, foo;
+    var foo;
     _export("default", void 0);
     return {
         setters: [],
         execute: function() {
             foo = 1;
-            _export("default", _default = class _default {
+            _export("default", class {
                 foo = foo;
             });
         }

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/overview/output.mjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/overview/output.mjs
@@ -4,7 +4,7 @@ System.register([
     "./directory/foo-bar"
 ], function(_export, _context) {
     "use strict";
-    var _default, bar, bar2, foo, foo2, test2;
+    var bar, bar2, foo, foo2, test2;
     _export({
         default: void 0,
         foo: void 0,
@@ -24,7 +24,7 @@ System.register([
         ],
         execute: function() {
             _export("test2", test2 = 5);
-            _export("default", _default = foo);
+            _export("default", foo);
         }
     };
 });

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/ts-export-assignment/input.ts
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/ts-export-assignment/input.ts
@@ -1,0 +1,9 @@
+function createExports() {
+    return {
+        value: 1,
+    };
+}
+
+export = createExports();
+
+console.log("Hello, World!");

--- a/crates/swc_ecma_transforms_module/tests/fixture/systemjs/ts-export-assignment/output.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/systemjs/ts-export-assignment/output.js
@@ -1,0 +1,15 @@
+System.register([], function(_export, _context) {
+    "use strict";
+    function createExports() {
+        return {
+            value: 1
+        };
+    }
+    return {
+        setters: [],
+        execute: function() {
+            console.log("Hello, World!");
+            _export(createExports());
+        }
+    };
+});

--- a/crates/swc_ecma_transforms_module/tests/system_js.rs
+++ b/crates/swc_ecma_transforms_module/tests/system_js.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use swc_common::{Mark, SyntaxContext};
 use swc_ecma_ast::{AssignExpr, Expr, Lit, Pass, Pat, Prop, PropName, SetterProp};
-use swc_ecma_parser::Syntax;
+use swc_ecma_parser::{Syntax, TsSyntax};
 use swc_ecma_transforms_base::resolver;
 use swc_ecma_transforms_module::system_js::{system_js, Config};
 use swc_ecma_transforms_testing::{test, test_fixture, FixtureTestConfig, Tester};
@@ -14,11 +14,24 @@ fn syntax() -> Syntax {
     Syntax::Es(Default::default())
 }
 
+fn ts_syntax() -> Syntax {
+    Syntax::Typescript(TsSyntax::default())
+}
+
 fn tr(_tester: &mut Tester<'_>, config: Config) -> impl Pass {
     let unresolved_mark = Mark::new();
     let top_level_mark = Mark::new();
     (
         resolver(unresolved_mark, top_level_mark, false),
+        system_js(Default::default(), unresolved_mark, config),
+    )
+}
+
+fn tr_ts(_tester: &mut Tester<'_>, config: Config) -> impl Pass {
+    let unresolved_mark = Mark::new();
+    let top_level_mark = Mark::new();
+    (
+        resolver(unresolved_mark, top_level_mark, true),
         system_js(Default::default(), unresolved_mark, config),
     )
 }
@@ -237,6 +250,24 @@ fn fixture(input: PathBuf) {
     test_fixture(
         syntax(),
         &|tester| tr(tester, Default::default()),
+        &input,
+        &output,
+        FixtureTestConfig {
+            module: Some(true),
+            ..Default::default()
+        },
+    );
+}
+
+#[testing::fixture("tests/fixture/systemjs/**/input.ts")]
+fn fixture_ts(input: PathBuf) {
+    let dir = input.parent().unwrap().to_path_buf();
+
+    let output = dir.join("output.js");
+
+    test_fixture(
+        ts_syntax(),
+        &|tester| tr_ts(tester, Default::default()),
         &input,
         &output,
         FixtureTestConfig {

--- a/crates/swc_ecma_transforms_module/tests/umd.rs
+++ b/crates/swc_ecma_transforms_module/tests/umd.rs
@@ -22,7 +22,14 @@ fn tr(tester: &mut Tester<'_>, config: Config, typescript: bool) -> impl Pass {
 
     (
         resolver(unresolved_mark, top_level_mark, typescript),
-        typescript::typescript(Default::default(), unresolved_mark, top_level_mark),
+        typescript::typescript(
+            typescript::Config {
+                import_export_assign_config: typescript::TsImportExportAssignConfig::Preserve,
+                ..Default::default()
+            },
+            unresolved_mark,
+            top_level_mark,
+        ),
         umd(
             tester.cm.clone(),
             Default::default(),


### PR DESCRIPTION
**Description:**

Refactor module transforms around a shared, target-neutral `SourceModule` collection stage.

`SourceModule` only collects source-level module facts. CommonJS, AMD, and UMD share syntax stripping and CommonJS-like module-entry reduction, while SystemJS intentionally bypasses those stages and lowers the collected source model into its own IR for dependency setters, live bindings, and execution timing.

Key decisions:

- Import attributes are retained for SystemJS. CommonJS, AMD, and UMD intentionally do not process them because those formats cannot express import attributes; these lowering paths assume attributed module requests are not provided.
- Module transforms now own TypeScript `import = require(...)` and `export =` lowering.
- A non-exported `import x = require(...)` is modeled as the CTS form of ES `import.sync`, outside the ES module linking stage. It therefore does not mark the file as ESM, emit an `__esModule` marker, or introduce an `exports` wrapper dependency. The exported form additionally registers `x` as a local export in the linking model.
- AMD and UMD emit `import = require(...)` as wrapper dependencies. UMD routes `export =` through the factory result, and SystemJS now supports `export =`.
- Anonymous SystemJS default functions are initialized in the `System.register` declaration callback to preserve their hoisting semantics.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A