### PR TITLE
feat: compress native npm bindings

### DIFF
--- a/.changeset/compress-native-bindings.md
+++ b/.changeset/compress-native-bindings.md
@@ -1,0 +1,58 @@
+---
+"@swc/core": major
+"@swc/core-darwin-arm64": major
+"@swc/core-darwin-x64": major
+"@swc/core-linux-arm-gnueabihf": major
+"@swc/core-linux-arm64-gnu": major
+"@swc/core-linux-arm64-musl": major
+"@swc/core-linux-ppc64-gnu": major
+"@swc/core-linux-s390x-gnu": major
+"@swc/core-linux-x64-gnu": major
+"@swc/core-linux-x64-musl": major
+"@swc/core-win32-arm64-msvc": major
+"@swc/core-win32-ia32-msvc": major
+"@swc/core-win32-x64-msvc": major
+"@swc/html": major
+"@swc/html-darwin-arm64": major
+"@swc/html-darwin-x64": major
+"@swc/html-linux-arm-gnueabihf": major
+"@swc/html-linux-arm64-gnu": major
+"@swc/html-linux-arm64-musl": major
+"@swc/html-linux-ppc64-gnu": major
+"@swc/html-linux-s390x-gnu": major
+"@swc/html-linux-x64-gnu": major
+"@swc/html-linux-x64-musl": major
+"@swc/html-win32-arm64-msvc": major
+"@swc/html-win32-ia32-msvc": major
+"@swc/html-win32-x64-msvc": major
+"@swc/minifier": major
+"@swc/minifier-darwin-arm64": major
+"@swc/minifier-darwin-x64": major
+"@swc/minifier-linux-arm-gnueabihf": major
+"@swc/minifier-linux-arm64-gnu": major
+"@swc/minifier-linux-arm64-musl": major
+"@swc/minifier-linux-ppc64-gnu": major
+"@swc/minifier-linux-s390x-gnu": major
+"@swc/minifier-linux-x64-gnu": major
+"@swc/minifier-linux-x64-musl": major
+"@swc/minifier-win32-arm64-msvc": major
+"@swc/minifier-win32-ia32-msvc": major
+"@swc/minifier-win32-x64-msvc": major
+"@swc/react-compiler": major
+"@swc/react-compiler-darwin-arm64": major
+"@swc/react-compiler-darwin-x64": major
+"@swc/react-compiler-linux-arm-gnueabihf": major
+"@swc/react-compiler-linux-arm64-gnu": major
+"@swc/react-compiler-linux-arm64-musl": major
+"@swc/react-compiler-linux-ppc64-gnu": major
+"@swc/react-compiler-linux-s390x-gnu": major
+"@swc/react-compiler-linux-x64-gnu": major
+"@swc/react-compiler-linux-x64-musl": major
+"@swc/react-compiler-win32-arm64-msvc": major
+"@swc/react-compiler-win32-ia32-msvc": major
+"@swc/react-compiler-win32-x64-msvc": major
+---
+
+Compress native `.node` packages into a small Rust loader with a zstd-packed addon payload. The first load verifies the payload SHA-512, materializes the raw addon using OS transparent compression when available, and falls back to a per-user cache otherwise, reducing native package download and install size.
+
+This also raises the Node.js engine requirement for all native SWC npm packages to Node 20 or newer.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -406,7 +406,7 @@ jobs:
       - uses: ./.github/actions/setup-node
         id: setup-node
         with:
-          node-version: 18
+          node-version: 20
           install-dependencies: "false"
 
       - name: Set platform name
@@ -465,7 +465,7 @@ jobs:
       - uses: ./.github/actions/setup-node
         id: setup-node
         with:
-          node-version: 18
+          node-version: 20
           install-dependencies: "false"
 
       - name: Prepare

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "binding_compressed_node_loader"
+version = "0.1.0"
+dependencies = [
+ "decmpfs",
+ "hex",
+ "libloading",
+ "napi-build",
+ "napi-sys",
+]
+
+[[package]]
 name = "binding_core_node"
 version = "0.2.0"
 dependencies = [
@@ -878,6 +889,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97463e1064cb1b1c1384ad0a0b9c8abd0988e2a91f52606c80ef14aadb63e36"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -1810,6 +1823,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "decmpfs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "651715809b4119e14ba1ba88650756d8a7012686473a32ec14c0e602e90fc47f"
+dependencies = [
+ "libc",
+ "sha2",
+ "windows-sys 0.59.0",
+ "zstd",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2543,9 +2568,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.2.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -3299,6 +3335,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "jobserver"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c00acbd29eabad4a2392fa0e921c874934dbbf4194312ad20f04a0ed67a3cb3"
+dependencies = [
+ "getrandom 0.4.3",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3462,9 +3508,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -4777,6 +4823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5500,9 +5552,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -6015,6 +6067,17 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_visit",
  "swc_sourcemap",
+]
+
+[[package]]
+name = "swc_compressed_binding_tool"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "decmpfs",
+ "hex",
+ "sha2",
+ "zstd",
 ]
 
 [[package]]
@@ -9963,4 +10026,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.110",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -384,6 +384,7 @@ dependencies = [
  "napi-build",
  "napi-sys",
  "sha2",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ dependencies = [
  "libloading",
  "napi-build",
  "napi-sys",
+ "sha2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "xtask",
   "bindings/*",
   "crates/*",
+  "tools/swc-compressed-binding-tool",
   "tools/generate-code",
   "tools/swc-releaser",
 ]
@@ -48,6 +49,7 @@ copyless                  = "0.1.5"
 crc                       = "2.1.0"
 criterion                 = "0.5.1"
 dashmap                   = "6.1.0"
+decmpfs                   = { version = "0.1.0", default-features = false }
 dialoguer                 = "0.10.2"
 difference                = "2"
 dragonbox_ecma            = "0.1.0"
@@ -67,6 +69,7 @@ jsonc-parser              = "0.26.2"
 kstring                   = "2.0.0"
 lazy_static               = "1.4.0"
 lexical                   = "6.1.0"
+libloading                = "0.8.1"
 lightningcss              = "1.0.0-alpha.68"
 lru                       = "0.16.1"
 memchr                    = "2.6.1"
@@ -74,6 +77,7 @@ miette                    = "7.6.0"
 napi                      = { version = "3", default-features = false }
 napi-build                = "2"
 napi-derive               = { version = "3", default-features = false }
+napi-sys                  = "3"
 new_debug_unreachable     = "1.0.6"
 nom                       = "7.1.3"
 ntest                     = "0.7.2"
@@ -138,6 +142,7 @@ wasm-bindgen-futures      = "0.4.50"
 wasmer                    = { version = "6.1.0-rc.3", default-features = false }
 wasmer-wasix              = { version = "0.601.0-rc.3", default-features = false }
 wasmtime                  = { version = "38", default-features = false }
+zstd                      = "0.13.3"
 
 
 cbor4ii         = "1.2"

--- a/bindings/binding_compressed_node_loader/Cargo.toml
+++ b/bindings/binding_compressed_node_loader/Cargo.toml
@@ -21,3 +21,4 @@ hex        = { workspace = true }
 libloading = { workspace = true }
 napi-sys   = { workspace = true, features = ["napi9"] }
 sha2       = { workspace = true }
+zstd       = { workspace = true }

--- a/bindings/binding_compressed_node_loader/Cargo.toml
+++ b/bindings/binding_compressed_node_loader/Cargo.toml
@@ -20,3 +20,4 @@ decmpfs    = { workspace = true, features = ["addon"] }
 hex        = { workspace = true }
 libloading = { workspace = true }
 napi-sys   = { workspace = true, features = ["napi9"] }
+sha2       = { workspace = true }

--- a/bindings/binding_compressed_node_loader/Cargo.toml
+++ b/bindings/binding_compressed_node_loader/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+authors = ["강동윤 <kdy1997.dev@gmail.com>"]
+build   = "build.rs"
+edition = "2021"
+exclude = ["artifacts.json", "index.node"]
+license = "Apache-2.0"
+name    = "binding_compressed_node_loader"
+publish = false
+version = "0.1.0"
+
+[lib]
+bench      = false
+crate-type = ["cdylib"]
+
+[build-dependencies]
+napi-build = { workspace = true }
+
+[dependencies]
+decmpfs    = { workspace = true, features = ["addon"] }
+hex        = { workspace = true }
+libloading = { workspace = true }
+napi-sys   = { workspace = true, features = ["napi9"] }

--- a/bindings/binding_compressed_node_loader/build.rs
+++ b/bindings/binding_compressed_node_loader/build.rs
@@ -1,0 +1,53 @@
+use std::{
+    env, fs, io,
+    path::{Path, PathBuf},
+};
+
+fn main() {
+    napi_build::setup();
+
+    println!("cargo:rerun-if-env-changed=SWC_COMPRESSED_BINDING_PAYLOAD");
+
+    let out_dir = PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR must be set"));
+    let generated = out_dir.join("pressed_data.rs");
+
+    match env::var_os("SWC_COMPRESSED_BINDING_PAYLOAD") {
+        Some(payload) => {
+            let payload = PathBuf::from(payload);
+            println!("cargo:rerun-if-changed={}", payload.display());
+            let data_path = out_dir.join("pressed-data.bin");
+            copy_payload(&payload, &data_path).unwrap_or_else(|err| {
+                panic!(
+                    "failed to copy compressed binding payload from {}: {err}",
+                    payload.display()
+                )
+            });
+            fs::write(
+                generated,
+                r#"
+#[used]
+#[cfg_attr(target_os = "macos", link_section = "__SMOL,__PRESSED_DATA")]
+#[cfg_attr(all(unix, not(target_os = "macos")), link_section = ".PRESSED_DATA")]
+#[cfg_attr(windows, link_section = ".PRESSED")]
+pub static PRESSED_DATA: [u8; include_bytes!(concat!(env!("OUT_DIR"), "/pressed-data.bin")).len()] =
+  *include_bytes!(concat!(env!("OUT_DIR"), "/pressed-data.bin"));
+"#,
+            )
+            .expect("failed to write generated pressed data module");
+        }
+        None => {
+            fs::write(
+                generated,
+                r#"
+#[used]
+pub static PRESSED_DATA: [u8; 0] = [];
+"#,
+            )
+            .expect("failed to write empty pressed data module");
+        }
+    }
+}
+
+fn copy_payload(from: &Path, to: &Path) -> io::Result<()> {
+    fs::copy(from, to).map(|_| ())
+}

--- a/bindings/binding_compressed_node_loader/src/lib.rs
+++ b/bindings/binding_compressed_node_loader/src/lib.rs
@@ -25,7 +25,7 @@ const PLATFORM_METADATA_LEN: usize = 3;
 const INTEGRITY_HASH_LEN: usize = 64;
 const SMOL_CONFIG_FLAG_LEN: usize = 1;
 const SMOL_CONFIG_BINARY_LEN: usize = 1192;
-const MAX_DECOMPRESSED: u64 = 512 * 1024 * 1024;
+const MAX_DECOMPRESSED: u64 = 2 * 1024 * 1024 * 1024;
 const HEADER_LEN: usize = MAGIC_MARKER.len()
     + 16
     + CACHE_KEY_LEN
@@ -39,6 +39,7 @@ type RegisterModule = unsafe extern "C" fn(napi_env, napi_value) -> napi_value;
 struct PressedDataMetadata {
     compressed_len: u64,
     uncompressed_len: u64,
+    payload_offset: usize,
     compressed_sha512: [u8; INTEGRITY_HASH_LEN],
     raw_sha512: Option<[u8; INTEGRITY_HASH_LEN]>,
 }
@@ -113,7 +114,7 @@ fn register_original_addon(env: napi_env, exports: napi_value) -> Result<napi_va
         }
     }
 
-    let raw = decmpfs::addon::decode_pressed_data(&pressed_data::PRESSED_DATA)
+    let raw = decode_pressed_data(&pressed_data::PRESSED_DATA, &metadata)
         .ok_or_else(|| "failed to verify or decompress SWC native binding payload".to_string())?;
 
     #[cfg(unix)]
@@ -180,9 +181,35 @@ fn parse_pressed_data_metadata(data: &[u8]) -> Option<PressedDataMetadata> {
     Some(PressedDataMetadata {
         compressed_len,
         uncompressed_len,
+        payload_offset,
         compressed_sha512,
         raw_sha512,
     })
+}
+
+fn decode_pressed_data(data: &[u8], metadata: &PressedDataMetadata) -> Option<Vec<u8>> {
+    let compressed_len = usize::try_from(metadata.compressed_len).ok()?;
+    let payload_end = metadata.payload_offset.checked_add(compressed_len)?;
+    let payload = data.get(metadata.payload_offset..payload_end)?;
+
+    let compressed_sha512 = Sha512::digest(payload);
+    if compressed_sha512[..] != metadata.compressed_sha512[..] {
+        return None;
+    }
+
+    let raw = zstd::stream::decode_all(payload).ok()?;
+    if raw.len() as u64 != metadata.uncompressed_len {
+        return None;
+    }
+
+    if let Some(raw_sha512) = &metadata.raw_sha512 {
+        let actual = Sha512::digest(&raw);
+        if actual[..] != raw_sha512[..] {
+            return None;
+        }
+    }
+
+    Some(raw)
 }
 
 fn read_u64_le(buf: &[u8], at: usize) -> Option<u64> {
@@ -555,6 +582,23 @@ mod tests {
         data
     }
 
+    fn packed_pressed_data(raw: &[u8]) -> Vec<u8> {
+        let compressed = zstd::stream::encode_all(raw, 3).unwrap();
+        let compressed_sha512 = Sha512::digest(&compressed);
+        let raw_sha512 = Sha512::digest(raw);
+        let mut data = Vec::new();
+        data.extend_from_slice(MAGIC_MARKER);
+        data.extend_from_slice(&(compressed.len() as u64).to_le_bytes());
+        data.extend_from_slice(&(raw.len() as u64).to_le_bytes());
+        data.extend_from_slice(&[0x42; CACHE_KEY_LEN]);
+        data.extend_from_slice(&[0; PLATFORM_METADATA_LEN]);
+        data.extend_from_slice(&compressed_sha512);
+        data.push(0);
+        data.extend_from_slice(&compressed);
+        data.extend_from_slice(&raw_sha512);
+        data
+    }
+
     #[test]
     fn parses_pressed_data_metadata() {
         let metadata = parse_pressed_data_metadata(&valid_pressed_data_header()).unwrap();
@@ -572,6 +616,35 @@ mod tests {
         let metadata = parse_pressed_data_metadata(&data).unwrap();
 
         assert_eq!(metadata.raw_sha512, Some([0x80; INTEGRITY_HASH_LEN]));
+    }
+
+    #[test]
+    fn decodes_pressed_data_locally() {
+        let raw = b"raw addon fixture";
+        let data = packed_pressed_data(raw);
+        let metadata = parse_pressed_data_metadata(&data).unwrap();
+
+        assert_eq!(decode_pressed_data(&data, &metadata).unwrap(), raw);
+    }
+
+    #[test]
+    fn rejects_tampered_raw_hash_extension() {
+        let mut data = packed_pressed_data(b"raw addon fixture");
+        let last = data.len() - 1;
+        data[last] ^= 0xff;
+        let metadata = parse_pressed_data_metadata(&data).unwrap();
+
+        assert!(decode_pressed_data(&data, &metadata).is_none());
+    }
+
+    #[test]
+    fn rejects_tampered_compressed_payload() {
+        let mut data = packed_pressed_data(b"raw addon fixture");
+        let metadata = parse_pressed_data_metadata(&data).unwrap();
+        let at = metadata.payload_offset;
+        data[at] ^= 0xff;
+
+        assert!(decode_pressed_data(&data, &metadata).is_none());
     }
 
     #[test]
@@ -648,6 +721,7 @@ mod tests {
         let metadata = PressedDataMetadata {
             compressed_len: 1,
             uncompressed_len: raw.len() as u64,
+            payload_offset: HEADER_LEN,
             compressed_sha512: [0u8; INTEGRITY_HASH_LEN],
             raw_sha512: Some(sha512),
         };
@@ -668,6 +742,7 @@ mod tests {
         let metadata = PressedDataMetadata {
             compressed_len: 1,
             uncompressed_len: raw.len() as u64,
+            payload_offset: HEADER_LEN,
             compressed_sha512: [0u8; INTEGRITY_HASH_LEN],
             raw_sha512: None,
         };

--- a/bindings/binding_compressed_node_loader/src/lib.rs
+++ b/bindings/binding_compressed_node_loader/src/lib.rs
@@ -1,20 +1,19 @@
+#[cfg(unix)]
+use std::time::{SystemTime, UNIX_EPOCH};
 use std::{
     env,
     ffi::{CStr, CString},
-    fs,
+    fs::{self, File},
+    io::{self, Read},
     os::raw::c_char,
     path::{Path, PathBuf},
     ptr,
-};
-#[cfg(unix)]
-use std::{
-    io,
-    time::{SystemTime, UNIX_EPOCH},
 };
 
 use decmpfs::{compress_bytes, Gate, Outcome};
 use libloading::Library;
 use napi_sys::{napi_env, napi_value};
+use sha2::{Digest, Sha512};
 
 mod pressed_data {
     include!(concat!(env!("OUT_DIR"), "/pressed_data.rs"));
@@ -40,12 +39,13 @@ type RegisterModule = unsafe extern "C" fn(napi_env, napi_value) -> napi_value;
 struct PressedDataMetadata {
     compressed_len: u64,
     uncompressed_len: u64,
-    sha512: [u8; INTEGRITY_HASH_LEN],
+    compressed_sha512: [u8; INTEGRITY_HASH_LEN],
+    raw_sha512: Option<[u8; INTEGRITY_HASH_LEN]>,
 }
 
 impl PressedDataMetadata {
     fn cache_key(&self) -> String {
-        hex::encode(self.sha512)
+        hex::encode(self.raw_sha512.unwrap_or(self.compressed_sha512))
     }
 }
 
@@ -78,18 +78,34 @@ fn register_original_addon(env: napi_env, exports: napi_value) -> Result<napi_va
     let self_path = unsafe { module_file_name(env)? };
     let cache_path = cache_path_for(&cache_root(), &self_path, &metadata);
 
-    if cache_path.exists() && is_expected_raw_addon(&cache_path, metadata.uncompressed_len) {
-        match unsafe { load_and_register(&cache_path, env, exports) } {
-            Ok(exports) => {
+    if cache_path.exists() {
+        match verify_cached_raw_addon(&cache_path, &metadata) {
+            Ok(true) => match unsafe { load_and_register(&cache_path, env, exports) } {
+                Ok(exports) => {
+                    debug_log(format_args!(
+                        "loaded native binding cache {}",
+                        cache_path.display()
+                    ));
+                    return Ok(exports);
+                }
+                Err(err) => {
+                    debug_log(format_args!(
+                        "failed to load native binding cache {}: {err}",
+                        cache_path.display()
+                    ));
+                    let _ = fs::remove_file(&cache_path);
+                }
+            },
+            Ok(false) => {
                 debug_log(format_args!(
-                    "loaded native binding cache {}",
+                    "discarding invalid native binding cache {}",
                     cache_path.display()
                 ));
-                return Ok(exports);
+                let _ = fs::remove_file(&cache_path);
             }
             Err(err) => {
                 debug_log(format_args!(
-                    "failed to load native binding cache {}: {err}",
+                    "failed to verify native binding cache {}: {err}",
                     cache_path.display()
                 ));
                 let _ = fs::remove_file(&cache_path);
@@ -103,22 +119,11 @@ fn register_original_addon(env: napi_env, exports: napi_value) -> Result<napi_va
     #[cfg(unix)]
     if !env_flag("SWC_NATIVE_BINDING_DISABLE_SELF_REPLACE") {
         match try_self_replace(&self_path, &raw) {
-            Ok(Some(path)) => match unsafe { load_and_register(&path, env, exports) } {
-                Ok(exports) => {
-                    debug_log(format_args!(
-                        "loaded self-replaced native binding {}",
-                        path.display()
-                    ));
-                    return Ok(exports);
-                }
-                Err(err) => {
-                    debug_log(format_args!(
-                        "failed to load self-replaced native binding {}: {err}",
-                        path.display()
-                    ));
-                }
-            },
-            Ok(None) => {}
+            Ok(true) => debug_log(format_args!(
+                "self-replaced native binding {}; loading cache for current process",
+                self_path.display()
+            )),
+            Ok(false) => {}
             Err(err) => debug_log(format_args!(
                 "self-replace native binding path {} failed: {err}",
                 self_path.display()
@@ -150,8 +155,8 @@ fn parse_pressed_data_metadata(data: &[u8]) -> Option<PressedDataMetadata> {
 
     let integrity_offset = MAGIC_MARKER.len() + 16 + CACHE_KEY_LEN + PLATFORM_METADATA_LEN;
     let integrity = data.get(integrity_offset..integrity_offset + INTEGRITY_HASH_LEN)?;
-    let mut sha512 = [0; INTEGRITY_HASH_LEN];
-    sha512.copy_from_slice(integrity);
+    let mut compressed_sha512 = [0; INTEGRITY_HASH_LEN];
+    compressed_sha512.copy_from_slice(integrity);
 
     let config_flag_offset = integrity_offset + INTEGRITY_HASH_LEN;
     let has_config = *data.get(config_flag_offset)?;
@@ -162,12 +167,21 @@ fn parse_pressed_data_metadata(data: &[u8]) -> Option<PressedDataMetadata> {
         } else {
             SMOL_CONFIG_BINARY_LEN
         })?;
-    data.get(payload_offset..payload_offset.checked_add(compressed_len as usize)?)?;
+    let raw_hash_offset = payload_offset.checked_add(compressed_len as usize)?;
+    data.get(payload_offset..raw_hash_offset)?;
+    let raw_sha512 = data
+        .get(raw_hash_offset..raw_hash_offset + INTEGRITY_HASH_LEN)
+        .map(|integrity| {
+            let mut raw_sha512 = [0; INTEGRITY_HASH_LEN];
+            raw_sha512.copy_from_slice(integrity);
+            raw_sha512
+        });
 
     Some(PressedDataMetadata {
         compressed_len,
         uncompressed_len,
-        sha512,
+        compressed_sha512,
+        raw_sha512,
     })
 }
 
@@ -236,21 +250,66 @@ fn cache_path_for(root: &Path, module_path: &Path, metadata: &PressedDataMetadat
         .join(format!("{addon_name}-{}.node", metadata.cache_key()))
 }
 
-fn is_expected_raw_addon(path: &Path, expected_len: u64) -> bool {
-    fs::metadata(path)
-        .map(|metadata| metadata.is_file() && metadata.len() == expected_len)
-        .unwrap_or(false)
+fn verify_cached_raw_addon(path: &Path, metadata: &PressedDataMetadata) -> Result<bool, String> {
+    let file = match File::open(path) {
+        Ok(file) => file,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(err) => {
+            return Err(format!(
+                "failed to open native binding cache {}: {err}",
+                path.display()
+            ))
+        }
+    };
+    let file_metadata = file.metadata().map_err(|err| {
+        format!(
+            "failed to stat native binding cache {}: {err}",
+            path.display()
+        )
+    })?;
+
+    if !file_metadata.is_file() || file_metadata.len() != metadata.uncompressed_len {
+        return Ok(false);
+    }
+
+    let Some(raw_sha512) = &metadata.raw_sha512 else {
+        return Ok(false);
+    };
+
+    raw_addon_sha512_matches(file, raw_sha512)
+}
+
+fn raw_addon_sha512_matches<R>(
+    mut reader: R,
+    expected: &[u8; INTEGRITY_HASH_LEN],
+) -> Result<bool, String>
+where
+    R: Read,
+{
+    let mut hasher = Sha512::new();
+    let mut buf = [0u8; 64 * 1024];
+    loop {
+        let read = reader
+            .read(&mut buf)
+            .map_err(|err| format!("failed to hash native binding cache: {err}"))?;
+        if read == 0 {
+            break;
+        }
+        hasher.update(&buf[..read]);
+    }
+    let actual = hasher.finalize();
+    Ok(actual[..] == expected[..])
 }
 
 #[cfg(unix)]
-fn try_self_replace(self_path: &Path, raw: &[u8]) -> Result<Option<PathBuf>, String> {
+fn try_self_replace(self_path: &Path, raw: &[u8]) -> Result<bool, String> {
     let parent = match self_path.parent() {
         Some(parent) => parent,
-        None => return Ok(None),
+        None => return Ok(false),
     };
     let file_name = match self_path.file_name().and_then(|name| name.to_str()) {
         Some(file_name) => file_name,
-        None => return Ok(None),
+        None => return Ok(false),
     };
 
     let unique = SystemTime::now()
@@ -271,11 +330,11 @@ fn try_self_replace(self_path: &Path, raw: &[u8]) -> Result<Option<PathBuf>, Str
 
     if !is_os_compressed_outcome(&outcome) {
         let _ = fs::remove_file(&tmp);
-        return Ok(None);
+        return Ok(false);
     }
 
     match fs::rename(&tmp, self_path) {
-        Ok(()) => Ok(Some(self_path.to_path_buf())),
+        Ok(()) => Ok(true),
         Err(err) => {
             let _ = fs::remove_file(&tmp);
             if is_non_fatal_replace_error(&err) {
@@ -284,7 +343,7 @@ fn try_self_replace(self_path: &Path, raw: &[u8]) -> Result<Option<PathBuf>, Str
                     tmp.display(),
                     self_path.display()
                 ));
-                Ok(None)
+                Ok(false)
             } else {
                 Err(format!(
                     "failed to replace {} with {}: {err}",
@@ -370,7 +429,76 @@ unsafe fn module_file_name(env: napi_env) -> Result<PathBuf, String> {
     let path = unsafe { CStr::from_ptr(result) }
         .to_string_lossy()
         .into_owned();
-    Ok(PathBuf::from(path))
+    Ok(module_path_from_node_file_name(&path))
+}
+
+fn module_path_from_node_file_name(file_name: &str) -> PathBuf {
+    file_url_to_path(file_name).unwrap_or_else(|| PathBuf::from(file_name))
+}
+
+fn file_url_to_path(file_name: &str) -> Option<PathBuf> {
+    let rest = file_name.strip_prefix("file://")?;
+    let path_storage;
+    let path = if rest.starts_with('/') {
+        rest
+    } else if let Some(rest) = rest.strip_prefix("localhost/") {
+        path_storage = format!("/{rest}");
+        path_storage.as_str()
+    } else {
+        return None;
+    };
+
+    Some(bytes_to_path_buf(percent_decode(path.as_bytes())?))
+}
+
+fn percent_decode(bytes: &[u8]) -> Option<Vec<u8>> {
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let hi = hex_digit(*bytes.get(i + 1)?)?;
+            let lo = hex_digit(*bytes.get(i + 2)?)?;
+            decoded.push((hi << 4) | lo);
+            i += 3;
+        } else {
+            decoded.push(bytes[i]);
+            i += 1;
+        }
+    }
+    Some(decoded)
+}
+
+fn hex_digit(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+fn bytes_to_path_buf(bytes: Vec<u8>) -> PathBuf {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStringExt;
+
+        PathBuf::from(std::ffi::OsString::from_vec(bytes))
+    }
+
+    #[cfg(windows)]
+    {
+        let mut path = String::from_utf8_lossy(&bytes).into_owned();
+        let bytes = path.as_bytes();
+        if bytes.get(0) == Some(&b'/') && bytes.get(2) == Some(&b':') {
+            path.remove(0);
+        }
+        PathBuf::from(path.replace('/', "\\"))
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        PathBuf::from(String::from_utf8_lossy(&bytes).into_owned())
+    }
 }
 
 unsafe fn throw_napi_error(env: napi_env, msg: &str) {
@@ -433,7 +561,17 @@ mod tests {
 
         assert_eq!(metadata.compressed_len, 4);
         assert_eq!(metadata.uncompressed_len, 8);
-        assert_eq!(metadata.sha512, [0x7f; INTEGRITY_HASH_LEN]);
+        assert_eq!(metadata.compressed_sha512, [0x7f; INTEGRITY_HASH_LEN]);
+        assert!(metadata.raw_sha512.is_none());
+    }
+
+    #[test]
+    fn parses_raw_sha512_extension() {
+        let mut data = valid_pressed_data_header();
+        data.extend_from_slice(&[0x80; INTEGRITY_HASH_LEN]);
+        let metadata = parse_pressed_data_metadata(&data).unwrap();
+
+        assert_eq!(metadata.raw_sha512, Some([0x80; INTEGRITY_HASH_LEN]));
     }
 
     #[test]
@@ -488,5 +626,69 @@ mod tests {
         assert!(!is_os_compressed_outcome(&Outcome::Unsupported {
             reason: decmpfs::UnsupportedReason::Filesystem,
         }));
+    }
+
+    #[test]
+    fn verifies_cached_raw_addon_hash() {
+        let dir = env::temp_dir().join(format!(
+            "swc-native-binding-cache-test-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("addon.node");
+        let raw = b"verified raw addon bytes";
+        fs::write(&path, raw).unwrap();
+
+        let mut sha512 = [0u8; INTEGRITY_HASH_LEN];
+        sha512.copy_from_slice(&Sha512::digest(raw));
+        let metadata = PressedDataMetadata {
+            compressed_len: 1,
+            uncompressed_len: raw.len() as u64,
+            compressed_sha512: [0u8; INTEGRITY_HASH_LEN],
+            raw_sha512: Some(sha512),
+        };
+
+        assert!(verify_cached_raw_addon(&path, &metadata).unwrap());
+
+        let tampered = b"tampered raw addon bytes";
+        assert_eq!(tampered.len(), raw.len());
+        fs::write(&path, tampered).unwrap();
+        assert!(!verify_cached_raw_addon(&path, &metadata).unwrap());
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    #[test]
+    fn rejects_cache_when_raw_hash_is_absent() {
+        let raw = b"verified raw addon bytes";
+        let metadata = PressedDataMetadata {
+            compressed_len: 1,
+            uncompressed_len: raw.len() as u64,
+            compressed_sha512: [0u8; INTEGRITY_HASH_LEN],
+            raw_sha512: None,
+        };
+
+        assert!(!verify_cached_raw_addon(Path::new("/missing/addon.node"), &metadata).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn decodes_file_url_module_file_name() {
+        assert_eq!(
+            module_path_from_node_file_name("file:///tmp/swc%20core/swc.darwin-arm64.node"),
+            PathBuf::from("/tmp/swc core/swc.darwin-arm64.node")
+        );
+    }
+
+    #[test]
+    fn preserves_plain_module_file_name() {
+        assert_eq!(
+            module_path_from_node_file_name("/tmp/swc/swc.darwin-arm64.node"),
+            PathBuf::from("/tmp/swc/swc.darwin-arm64.node")
+        );
     }
 }

--- a/bindings/binding_compressed_node_loader/src/lib.rs
+++ b/bindings/binding_compressed_node_loader/src/lib.rs
@@ -1,0 +1,492 @@
+use std::{
+    env,
+    ffi::{CStr, CString},
+    fs,
+    os::raw::c_char,
+    path::{Path, PathBuf},
+    ptr,
+};
+#[cfg(unix)]
+use std::{
+    io,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+use decmpfs::{compress_bytes, Gate, Outcome};
+use libloading::Library;
+use napi_sys::{napi_env, napi_value};
+
+mod pressed_data {
+    include!(concat!(env!("OUT_DIR"), "/pressed_data.rs"));
+}
+
+const MAGIC_MARKER: &[u8; 32] = b"__SMOL_PRESSED_DATA_MAGIC_MARKER";
+const CACHE_KEY_LEN: usize = 16;
+const PLATFORM_METADATA_LEN: usize = 3;
+const INTEGRITY_HASH_LEN: usize = 64;
+const SMOL_CONFIG_FLAG_LEN: usize = 1;
+const SMOL_CONFIG_BINARY_LEN: usize = 1192;
+const MAX_DECOMPRESSED: u64 = 512 * 1024 * 1024;
+const HEADER_LEN: usize = MAGIC_MARKER.len()
+    + 16
+    + CACHE_KEY_LEN
+    + PLATFORM_METADATA_LEN
+    + INTEGRITY_HASH_LEN
+    + SMOL_CONFIG_FLAG_LEN;
+
+type RegisterModule = unsafe extern "C" fn(napi_env, napi_value) -> napi_value;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct PressedDataMetadata {
+    compressed_len: u64,
+    uncompressed_len: u64,
+    sha512: [u8; INTEGRITY_HASH_LEN],
+}
+
+impl PressedDataMetadata {
+    fn cache_key(&self) -> String {
+        hex::encode(self.sha512)
+    }
+}
+
+/// Node-API registration entrypoint exported by the compressed binding loader.
+///
+/// # Safety
+///
+/// Node.js must call this function with a valid `napi_env` and `exports` value
+/// for the addon being initialized. The loader forwards both values to the
+/// original addon entrypoint after materializing and dynamically loading it.
+#[no_mangle]
+pub unsafe extern "C" fn napi_register_module_v1(env: napi_env, exports: napi_value) -> napi_value {
+    setup_napi();
+
+    match register_original_addon(env, exports) {
+        Ok(exports) => exports,
+        Err(err) => {
+            unsafe {
+                throw_napi_error(env, &err);
+            }
+            exports
+        }
+    }
+}
+
+fn register_original_addon(env: napi_env, exports: napi_value) -> Result<napi_value, String> {
+    let metadata = parse_pressed_data_metadata(&pressed_data::PRESSED_DATA).ok_or_else(|| {
+        "SWC native binding loader did not contain a valid pressed-data payload".to_string()
+    })?;
+    let self_path = unsafe { module_file_name(env)? };
+    let cache_path = cache_path_for(&cache_root(), &self_path, &metadata);
+
+    if cache_path.exists() && is_expected_raw_addon(&cache_path, metadata.uncompressed_len) {
+        match unsafe { load_and_register(&cache_path, env, exports) } {
+            Ok(exports) => {
+                debug_log(format_args!(
+                    "loaded native binding cache {}",
+                    cache_path.display()
+                ));
+                return Ok(exports);
+            }
+            Err(err) => {
+                debug_log(format_args!(
+                    "failed to load native binding cache {}: {err}",
+                    cache_path.display()
+                ));
+                let _ = fs::remove_file(&cache_path);
+            }
+        }
+    }
+
+    let raw = decmpfs::addon::decode_pressed_data(&pressed_data::PRESSED_DATA)
+        .ok_or_else(|| "failed to verify or decompress SWC native binding payload".to_string())?;
+
+    #[cfg(unix)]
+    if !env_flag("SWC_NATIVE_BINDING_DISABLE_SELF_REPLACE") {
+        match try_self_replace(&self_path, &raw) {
+            Ok(Some(path)) => match unsafe { load_and_register(&path, env, exports) } {
+                Ok(exports) => {
+                    debug_log(format_args!(
+                        "loaded self-replaced native binding {}",
+                        path.display()
+                    ));
+                    return Ok(exports);
+                }
+                Err(err) => {
+                    debug_log(format_args!(
+                        "failed to load self-replaced native binding {}: {err}",
+                        path.display()
+                    ));
+                }
+            },
+            Ok(None) => {}
+            Err(err) => debug_log(format_args!(
+                "self-replace native binding path {} failed: {err}",
+                self_path.display()
+            )),
+        }
+    }
+
+    write_cache_addon(&cache_path, &raw)?;
+    unsafe { load_and_register(&cache_path, env, exports) }
+}
+
+fn parse_pressed_data_metadata(data: &[u8]) -> Option<PressedDataMetadata> {
+    if data.len() < HEADER_LEN {
+        return None;
+    }
+    if &data[..MAGIC_MARKER.len()] != MAGIC_MARKER.as_slice() {
+        return None;
+    }
+
+    let compressed_len = read_u64_le(data, MAGIC_MARKER.len())?;
+    let uncompressed_len = read_u64_le(data, MAGIC_MARKER.len() + 8)?;
+    if compressed_len == 0
+        || uncompressed_len == 0
+        || compressed_len > MAX_DECOMPRESSED
+        || uncompressed_len > MAX_DECOMPRESSED
+    {
+        return None;
+    }
+
+    let integrity_offset = MAGIC_MARKER.len() + 16 + CACHE_KEY_LEN + PLATFORM_METADATA_LEN;
+    let integrity = data.get(integrity_offset..integrity_offset + INTEGRITY_HASH_LEN)?;
+    let mut sha512 = [0; INTEGRITY_HASH_LEN];
+    sha512.copy_from_slice(integrity);
+
+    let config_flag_offset = integrity_offset + INTEGRITY_HASH_LEN;
+    let has_config = *data.get(config_flag_offset)?;
+    let payload_offset = config_flag_offset
+        .checked_add(SMOL_CONFIG_FLAG_LEN)?
+        .checked_add(if has_config == 0 {
+            0
+        } else {
+            SMOL_CONFIG_BINARY_LEN
+        })?;
+    data.get(payload_offset..payload_offset.checked_add(compressed_len as usize)?)?;
+
+    Some(PressedDataMetadata {
+        compressed_len,
+        uncompressed_len,
+        sha512,
+    })
+}
+
+fn read_u64_le(buf: &[u8], at: usize) -> Option<u64> {
+    let bytes = buf.get(at..at + 8)?;
+    let mut arr = [0; 8];
+    arr.copy_from_slice(bytes);
+    Some(u64::from_le_bytes(arr))
+}
+
+fn cache_root() -> PathBuf {
+    if let Some(dir) = env::var_os("SWC_NATIVE_BINDING_CACHE_DIR").filter(|v| !v.is_empty()) {
+        return PathBuf::from(dir);
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        if let Some(home) = env::var_os("HOME").filter(|v| !v.is_empty()) {
+            return PathBuf::from(home)
+                .join("Library")
+                .join("Caches")
+                .join("swc")
+                .join("native-bindings");
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        if let Some(local_app_data) = env::var_os("LOCALAPPDATA").filter(|v| !v.is_empty()) {
+            return PathBuf::from(local_app_data)
+                .join("swc")
+                .join("native-bindings");
+        }
+        if let Some(user_profile) = env::var_os("USERPROFILE").filter(|v| !v.is_empty()) {
+            return PathBuf::from(user_profile)
+                .join("AppData")
+                .join("Local")
+                .join("swc")
+                .join("native-bindings");
+        }
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    {
+        if let Some(xdg) = env::var_os("XDG_CACHE_HOME").filter(|v| !v.is_empty()) {
+            return PathBuf::from(xdg).join("swc").join("native-bindings");
+        }
+        if let Some(home) = env::var_os("HOME").filter(|v| !v.is_empty()) {
+            return PathBuf::from(home)
+                .join(".cache")
+                .join("swc")
+                .join("native-bindings");
+        }
+    }
+
+    env::temp_dir().join("swc-native-bindings")
+}
+
+fn cache_path_for(root: &Path, module_path: &Path, metadata: &PressedDataMetadata) -> PathBuf {
+    let addon_name = module_path
+        .file_stem()
+        .and_then(|name| name.to_str())
+        .filter(|name| !name.is_empty())
+        .unwrap_or("swc-native-binding");
+    root.join("v1")
+        .join(format!("{addon_name}-{}.node", metadata.cache_key()))
+}
+
+fn is_expected_raw_addon(path: &Path, expected_len: u64) -> bool {
+    fs::metadata(path)
+        .map(|metadata| metadata.is_file() && metadata.len() == expected_len)
+        .unwrap_or(false)
+}
+
+#[cfg(unix)]
+fn try_self_replace(self_path: &Path, raw: &[u8]) -> Result<Option<PathBuf>, String> {
+    let parent = match self_path.parent() {
+        Some(parent) => parent,
+        None => return Ok(None),
+    };
+    let file_name = match self_path.file_name().and_then(|name| name.to_str()) {
+        Some(file_name) => file_name,
+        None => return Ok(None),
+    };
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_nanos())
+        .unwrap_or_default();
+    let tmp = parent.join(format!(
+        ".{file_name}.swc-native-{}-{unique}.node",
+        std::process::id()
+    ));
+
+    let outcome = compress_bytes(&tmp, raw, &Gate::any())
+        .map_err(|err| format!("failed to write OS-compressed sibling addon: {err}"))?;
+    debug_log(format_args!(
+        "self-replace temp {} outcome {outcome:?}",
+        tmp.display()
+    ));
+
+    if !is_os_compressed_outcome(&outcome) {
+        let _ = fs::remove_file(&tmp);
+        return Ok(None);
+    }
+
+    match fs::rename(&tmp, self_path) {
+        Ok(()) => Ok(Some(self_path.to_path_buf())),
+        Err(err) => {
+            let _ = fs::remove_file(&tmp);
+            if is_non_fatal_replace_error(&err) {
+                debug_log(format_args!(
+                    "self-replace rename {} -> {} skipped: {err}",
+                    tmp.display(),
+                    self_path.display()
+                ));
+                Ok(None)
+            } else {
+                Err(format!(
+                    "failed to replace {} with {}: {err}",
+                    self_path.display(),
+                    tmp.display()
+                ))
+            }
+        }
+    }
+}
+
+fn write_cache_addon(cache_path: &Path, raw: &[u8]) -> Result<(), String> {
+    if let Some(parent) = cache_path.parent() {
+        fs::create_dir_all(parent).map_err(|err| {
+            format!(
+                "failed to create native binding cache directory {}: {err}",
+                parent.display()
+            )
+        })?;
+    }
+    let outcome = compress_bytes(cache_path, raw, &Gate::any()).map_err(|err| {
+        format!(
+            "failed to write native binding cache {}: {err}",
+            cache_path.display()
+        )
+    })?;
+    debug_log(format_args!(
+        "wrote native binding cache {} outcome {outcome:?}",
+        cache_path.display()
+    ));
+    Ok(())
+}
+
+fn is_os_compressed_outcome(outcome: &Outcome) -> bool {
+    matches!(
+        outcome,
+        Outcome::Compressed { .. } | Outcome::NoGain { .. } | Outcome::AlreadyCompressed { .. }
+    )
+}
+
+#[cfg(unix)]
+fn is_non_fatal_replace_error(err: &io::Error) -> bool {
+    matches!(
+        err.kind(),
+        io::ErrorKind::PermissionDenied
+            | io::ErrorKind::AlreadyExists
+            | io::ErrorKind::NotFound
+            | io::ErrorKind::Unsupported
+    )
+}
+
+unsafe fn load_and_register(
+    path: &Path,
+    env: napi_env,
+    exports: napi_value,
+) -> Result<napi_value, String> {
+    let library = unsafe { Library::new(path) }
+        .map_err(|err| format!("failed to load native binding {}: {err}", path.display()))?;
+    let register: RegisterModule = unsafe {
+        *library
+            .get::<RegisterModule>(b"napi_register_module_v1\0")
+            .map_err(|err| {
+                format!(
+                    "failed to resolve napi_register_module_v1 from {}: {err}",
+                    path.display()
+                )
+            })?
+    };
+    let exports = unsafe { register(env, exports) };
+    Box::leak(Box::new(library));
+    Ok(exports)
+}
+
+unsafe fn module_file_name(env: napi_env) -> Result<PathBuf, String> {
+    let mut result: *const c_char = ptr::null();
+    let status = unsafe { napi_sys::node_api_get_module_file_name(env, &mut result) };
+    if status != napi_sys::Status::napi_ok || result.is_null() {
+        return Err(format!(
+            "node_api_get_module_file_name failed with N-API status {status}"
+        ));
+    }
+
+    let path = unsafe { CStr::from_ptr(result) }
+        .to_string_lossy()
+        .into_owned();
+    Ok(PathBuf::from(path))
+}
+
+unsafe fn throw_napi_error(env: napi_env, msg: &str) {
+    let msg = sanitize_cstring(msg);
+    let _ = unsafe { napi_sys::napi_throw_error(env, ptr::null(), msg.as_ptr()) };
+}
+
+fn sanitize_cstring(value: &str) -> CString {
+    let mut bytes = value.as_bytes().to_vec();
+    for byte in &mut bytes {
+        if *byte == 0 {
+            *byte = b' ';
+        }
+    }
+    CString::new(bytes)
+        .unwrap_or_else(|_| CString::new("SWC native binding loader failed").unwrap())
+}
+
+fn env_flag(name: &str) -> bool {
+    env::var_os(name).as_deref() == Some(std::ffi::OsStr::new("1"))
+}
+
+fn debug_log(args: std::fmt::Arguments<'_>) {
+    if env_flag("SWC_NATIVE_BINDING_DEBUG") {
+        eprintln!("[swc-native-binding] {args}");
+    }
+}
+
+#[cfg(target_env = "msvc")]
+fn setup_napi() {
+    static NAPI_HOST: std::sync::OnceLock<Library> = std::sync::OnceLock::new();
+    let _ = NAPI_HOST.get_or_init(|| unsafe { napi_sys::setup() });
+}
+
+#[cfg(not(target_env = "msvc"))]
+fn setup_napi() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_pressed_data_header() -> Vec<u8> {
+        let compressed_len = 4u64;
+        let uncompressed_len = 8u64;
+        let mut data = Vec::new();
+        data.extend_from_slice(MAGIC_MARKER);
+        data.extend_from_slice(&compressed_len.to_le_bytes());
+        data.extend_from_slice(&uncompressed_len.to_le_bytes());
+        data.extend_from_slice(&[0x42; CACHE_KEY_LEN]);
+        data.extend_from_slice(&[0; PLATFORM_METADATA_LEN]);
+        data.extend_from_slice(&[0x7f; INTEGRITY_HASH_LEN]);
+        data.push(0);
+        data.extend_from_slice(&[1, 2, 3, 4]);
+        data
+    }
+
+    #[test]
+    fn parses_pressed_data_metadata() {
+        let metadata = parse_pressed_data_metadata(&valid_pressed_data_header()).unwrap();
+
+        assert_eq!(metadata.compressed_len, 4);
+        assert_eq!(metadata.uncompressed_len, 8);
+        assert_eq!(metadata.sha512, [0x7f; INTEGRITY_HASH_LEN]);
+    }
+
+    #[test]
+    fn rejects_short_pressed_data() {
+        assert!(parse_pressed_data_metadata(&valid_pressed_data_header()[..16]).is_none());
+    }
+
+    #[test]
+    fn rejects_wrong_magic() {
+        let mut data = valid_pressed_data_header();
+        data[0] = b'x';
+
+        assert!(parse_pressed_data_metadata(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_oversized_payload_claim() {
+        let mut data = valid_pressed_data_header();
+        let at = MAGIC_MARKER.len() + 8;
+        data[at..at + 8].copy_from_slice(&(MAX_DECOMPRESSED + 1).to_le_bytes());
+
+        assert!(parse_pressed_data_metadata(&data).is_none());
+    }
+
+    #[test]
+    fn derives_cache_path_from_module_name_and_hash() {
+        let metadata = parse_pressed_data_metadata(&valid_pressed_data_header()).unwrap();
+        let path = cache_path_for(
+            Path::new("/tmp/swc-cache"),
+            Path::new("/project/node_modules/@swc/core/swc.darwin-arm64.node"),
+            &metadata,
+        );
+
+        assert_eq!(path.parent().unwrap(), Path::new("/tmp/swc-cache/v1"));
+        assert!(path
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .starts_with("swc.darwin-arm64-7f7f7f"));
+    }
+
+    #[test]
+    fn self_replace_only_accepts_os_compressed_outcomes() {
+        assert!(is_os_compressed_outcome(&Outcome::Compressed {
+            before: 128,
+            after: 64
+        }));
+        assert!(is_os_compressed_outcome(&Outcome::NoGain {
+            before: 128,
+            after: 128
+        }));
+        assert!(!is_os_compressed_outcome(&Outcome::Unsupported {
+            reason: decmpfs::UnsupportedReason::Filesystem,
+        }));
+    }
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,7 +16,7 @@
         "tsc"
     ],
     "engines": {
-        "node": ">=10"
+        "node": ">=20"
     },
     "repository": {
         "type": "git",
@@ -56,8 +56,8 @@
         "pack": "wasm-pack",
         "build:ts": "tsc -d",
         "build:wasm": "npm-run-all \"pack -- build ../../bindings/binding_core_wasm --scope swc {1} -t {2} --features plugin\" --",
-        "build": "tsc -d && napi build --manifest-path ../../Cargo.toml --platform -p binding_core_node --js ./binding.js --dts ./binding.d.ts --release -o .",
-        "build:dev": "tsc -d && napi build --manifest-path ../../Cargo.toml --platform -p binding_core_node --js ./binding.js --dts ./binding.d.ts -o .",
+        "build": "tsc -d && cargo run -p swc_compressed_binding_tool -- build --package-dir . --manifest-path ../../Cargo.toml --raw-crate binding_core_node --js ./binding.js --dts ./binding.d.ts --release",
+        "build:dev": "tsc -d && cargo run -p swc_compressed_binding_tool -- build --package-dir . --manifest-path ../../Cargo.toml --raw-crate binding_core_node --js ./binding.js --dts ./binding.d.ts",
         "test": "rstest",
         "version": "napi version --npm-dir scripts/npm"
     },

--- a/packages/core/scripts/npm/darwin-arm64/package.json
+++ b/packages/core/scripts/npm/darwin-arm64/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/darwin-x64/package.json
+++ b/packages/core/scripts/npm/darwin-x64/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/linux-arm-gnueabihf/package.json
+++ b/packages/core/scripts/npm/linux-arm-gnueabihf/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/linux-arm64-gnu/package.json
+++ b/packages/core/scripts/npm/linux-arm64-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/linux-arm64-musl/package.json
+++ b/packages/core/scripts/npm/linux-arm64-musl/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/linux-ppc64-gnu/package.json
+++ b/packages/core/scripts/npm/linux-ppc64-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/linux-s390x-gnu/package.json
+++ b/packages/core/scripts/npm/linux-s390x-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/linux-x64-gnu/package.json
+++ b/packages/core/scripts/npm/linux-x64-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/linux-x64-musl/package.json
+++ b/packages/core/scripts/npm/linux-x64-musl/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/win32-arm64-msvc/package.json
+++ b/packages/core/scripts/npm/win32-arm64-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/win32-ia32-msvc/package.json
+++ b/packages/core/scripts/npm/win32-ia32-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/core/scripts/npm/win32-x64-msvc/package.json
+++ b/packages/core/scripts/npm/win32-x64-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/package.json
+++ b/packages/html/package.json
@@ -11,7 +11,7 @@
         "html"
     ],
     "engines": {
-        "node": ">=14"
+        "node": ">=20"
     },
     "repository": {
         "type": "git",
@@ -47,8 +47,8 @@
         "artifacts": "napi artifacts --npm-dir scripts/npm",
         "prepack": "tsc -d && napi prepublish -p scripts/npm --tag-style npm --skip-optional-publish",
         "build:ts": "tsc -d",
-        "build": "(tsc -d || true) && napi build --manifest-path ../../Cargo.toml --platform -p binding_html_node --no-js --dts ./binding.d.ts --release -o .",
-        "build:dev": "(tsc -d || true) && napi build --manifest-path ../../Cargo.toml --platform -p binding_html_node --no-js --dts ./binding.d.ts -o .",
+        "build": "(tsc -d || true) && cargo run -p swc_compressed_binding_tool -- build --package-dir . --manifest-path ../../Cargo.toml --raw-crate binding_html_node --no-js --dts ./binding.d.ts --release",
+        "build:dev": "(tsc -d || true) && cargo run -p swc_compressed_binding_tool -- build --package-dir . --manifest-path ../../Cargo.toml --raw-crate binding_html_node --no-js --dts ./binding.d.ts",
         "test": "echo 'done!'",
         "version": "napi version --npm-dir scripts/npm"
     },

--- a/packages/html/scripts/npm/darwin-arm64/package.json
+++ b/packages/html/scripts/npm/darwin-arm64/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/darwin-x64/package.json
+++ b/packages/html/scripts/npm/darwin-x64/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/linux-arm-gnueabihf/package.json
+++ b/packages/html/scripts/npm/linux-arm-gnueabihf/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/linux-arm64-gnu/package.json
+++ b/packages/html/scripts/npm/linux-arm64-gnu/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/linux-arm64-musl/package.json
+++ b/packages/html/scripts/npm/linux-arm64-musl/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/linux-ppc64-gnu/package.json
+++ b/packages/html/scripts/npm/linux-ppc64-gnu/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/linux-s390x-gnu/package.json
+++ b/packages/html/scripts/npm/linux-s390x-gnu/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/linux-x64-gnu/package.json
+++ b/packages/html/scripts/npm/linux-x64-gnu/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/linux-x64-musl/package.json
+++ b/packages/html/scripts/npm/linux-x64-musl/package.json
@@ -27,7 +27,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/win32-arm64-msvc/package.json
+++ b/packages/html/scripts/npm/win32-arm64-msvc/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/win32-ia32-msvc/package.json
+++ b/packages/html/scripts/npm/win32-ia32-msvc/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/html/scripts/npm/win32-x64-msvc/package.json
+++ b/packages/html/scripts/npm/win32-x64-msvc/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/package.json
+++ b/packages/minifier/package.json
@@ -12,7 +12,7 @@
         "minifier"
     ],
     "engines": {
-        "node": ">=12"
+        "node": ">=20"
     },
     "repository": {
         "type": "git",
@@ -51,8 +51,8 @@
         "pack": "wasm-pack",
         "build:ts": "tsc -d",
         "build:wasm": "npm-run-all \"pack -- build ../../bindings/binding_minifier_wasm --scope swc {1} -t {2}\" --",
-        "build": "tsc -d && napi build --platform --js ./src/binding.js --dts ./src/binding.d.ts --manifest-path ../../Cargo.toml -p binding_minifier_node --output-dir . --release",
-        "build:dev": "tsc -d && napi build --platform --js ./src/binding.js --dts ./src/binding.d.ts --manifest-path ../../Cargo.toml -p binding_minifier_node --output-dir .",
+        "build": "tsc -d && cargo run -p swc_compressed_binding_tool -- build --package-dir . --manifest-path ../../Cargo.toml --raw-crate binding_minifier_node --js ./src/binding.js --dts ./src/binding.d.ts --release",
+        "build:dev": "tsc -d && cargo run -p swc_compressed_binding_tool -- build --package-dir . --manifest-path ../../Cargo.toml --raw-crate binding_minifier_node --js ./src/binding.js --dts ./src/binding.d.ts",
         "test": "node --test tests/extract-comments.test.cjs",
         "version": "napi version --npm-dir scripts/npm"
     },

--- a/packages/minifier/scripts/npm/darwin-arm64/package.json
+++ b/packages/minifier/scripts/npm/darwin-arm64/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/darwin-x64/package.json
+++ b/packages/minifier/scripts/npm/darwin-x64/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/linux-arm-gnueabihf/package.json
+++ b/packages/minifier/scripts/npm/linux-arm-gnueabihf/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/linux-arm64-gnu/package.json
+++ b/packages/minifier/scripts/npm/linux-arm64-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/linux-arm64-musl/package.json
+++ b/packages/minifier/scripts/npm/linux-arm64-musl/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/linux-ppc64-gnu/package.json
+++ b/packages/minifier/scripts/npm/linux-ppc64-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/linux-s390x-gnu/package.json
+++ b/packages/minifier/scripts/npm/linux-s390x-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/linux-x64-gnu/package.json
+++ b/packages/minifier/scripts/npm/linux-x64-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/linux-x64-musl/package.json
+++ b/packages/minifier/scripts/npm/linux-x64-musl/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/win32-arm64-msvc/package.json
+++ b/packages/minifier/scripts/npm/win32-arm64-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/win32-ia32-msvc/package.json
+++ b/packages/minifier/scripts/npm/win32-ia32-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/minifier/scripts/npm/win32-x64-msvc/package.json
+++ b/packages/minifier/scripts/npm/win32-x64-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/package.json
+++ b/packages/react-compiler/package.json
@@ -56,8 +56,8 @@
     "prepack": "tsc -d && napi prepublish -p scripts/npm --tag-style npm --skip-optional-publish",
     "pack": "wasm-pack",
     "build:ts": "tsc -d",
-    "build": "tsc -d && napi build --platform --js ./binding.js --dts ./binding.d.ts --manifest-path ../../Cargo.toml -p binding_react_compiler_node --output-dir . --release",
-    "build:dev": "tsc -d && napi build --platform --js ./binding.js --dts ./binding.d.ts --manifest-path ../../Cargo.toml -p binding_react_compiler_node --output-dir .",
+    "build": "tsc -d && cargo run -p swc_compressed_binding_tool -- build --package-dir . --manifest-path ../../Cargo.toml --raw-crate binding_react_compiler_node --js ./binding.js --dts ./binding.d.ts --release",
+    "build:dev": "tsc -d && cargo run -p swc_compressed_binding_tool -- build --package-dir . --manifest-path ../../Cargo.toml --raw-crate binding_react_compiler_node --js ./binding.js --dts ./binding.d.ts",
     "test": "node --test tests/lint.test.cjs",
     "version": "napi version --npm-dir scripts/npm"
   },

--- a/packages/react-compiler/scripts/npm/darwin-arm64/package.json
+++ b/packages/react-compiler/scripts/npm/darwin-arm64/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/darwin-x64/package.json
+++ b/packages/react-compiler/scripts/npm/darwin-x64/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/linux-arm-gnueabihf/package.json
+++ b/packages/react-compiler/scripts/npm/linux-arm-gnueabihf/package.json
@@ -22,7 +22,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0",
   "engines": {
-    "node": ">=12"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/linux-arm64-gnu/package.json
+++ b/packages/react-compiler/scripts/npm/linux-arm64-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/linux-arm64-musl/package.json
+++ b/packages/react-compiler/scripts/npm/linux-arm64-musl/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/linux-ppc64-gnu/package.json
+++ b/packages/react-compiler/scripts/npm/linux-ppc64-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/linux-s390x-gnu/package.json
+++ b/packages/react-compiler/scripts/npm/linux-s390x-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/linux-x64-gnu/package.json
+++ b/packages/react-compiler/scripts/npm/linux-x64-gnu/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/linux-x64-musl/package.json
+++ b/packages/react-compiler/scripts/npm/linux-x64-musl/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/win32-arm64-msvc/package.json
+++ b/packages/react-compiler/scripts/npm/win32-arm64-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/win32-ia32-msvc/package.json
+++ b/packages/react-compiler/scripts/npm/win32-ia32-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/packages/react-compiler/scripts/npm/win32-x64-msvc/package.json
+++ b/packages/react-compiler/scripts/npm/win32-x64-msvc/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://swc.rs",
   "license": "Apache-2.0 AND MIT",
   "engines": {
-    "node": ">=10"
+    "node": ">=20"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/",

--- a/tools/swc-compressed-binding-tool/Cargo.toml
+++ b/tools/swc-compressed-binding-tool/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+authors = ["강동윤 <kdy1997.dev@gmail.com>"]
+edition = "2021"
+license = "Apache-2.0"
+name    = "swc_compressed_binding_tool"
+publish = false
+version = "0.1.0"
+
+[dependencies]
+anyhow = { workspace = true }
+hex    = { workspace = true }
+sha2   = { workspace = true }
+zstd   = { workspace = true }
+
+[dev-dependencies]
+decmpfs = { workspace = true, features = ["addon"] }

--- a/tools/swc-compressed-binding-tool/src/lib.rs
+++ b/tools/swc-compressed-binding-tool/src/lib.rs
@@ -1,0 +1,128 @@
+use anyhow::{bail, Context, Result};
+use sha2::{Digest, Sha256, Sha512};
+
+pub const MAGIC_MARKER: &[u8; 32] = b"__SMOL_PRESSED_DATA_MAGIC_MARKER";
+pub const CACHE_KEY_LEN: usize = 16;
+pub const PLATFORM_METADATA_LEN: usize = 3;
+pub const INTEGRITY_HASH_LEN: usize = 64;
+pub const SMOL_CONFIG_FLAG_LEN: usize = 1;
+pub const MAX_DECOMPRESSED: usize = 512 * 1024 * 1024;
+
+pub fn pack_pressed_data(raw_addon: &[u8], level: i32) -> Result<Vec<u8>> {
+    if raw_addon.is_empty() {
+        bail!("native addon payload is empty");
+    }
+    if raw_addon.len() > MAX_DECOMPRESSED {
+        bail!(
+            "native addon payload is {} bytes, exceeding the {MAX_DECOMPRESSED} byte limit",
+            raw_addon.len()
+        );
+    }
+
+    let compressed = zstd::stream::encode_all(raw_addon, level)
+        .with_context(|| format!("failed to zstd-compress native addon at level {level}"))?;
+    if compressed.len() > MAX_DECOMPRESSED {
+        bail!(
+            "compressed native addon payload is {} bytes, exceeding the {MAX_DECOMPRESSED} byte \
+             limit",
+            compressed.len()
+        );
+    }
+
+    let cache_key = Sha256::digest(raw_addon);
+    let integrity = Sha512::digest(&compressed);
+    let mut data = Vec::with_capacity(
+        MAGIC_MARKER.len()
+            + 16
+            + CACHE_KEY_LEN
+            + PLATFORM_METADATA_LEN
+            + INTEGRITY_HASH_LEN
+            + SMOL_CONFIG_FLAG_LEN
+            + compressed.len(),
+    );
+
+    data.extend_from_slice(MAGIC_MARKER);
+    data.extend_from_slice(&(compressed.len() as u64).to_le_bytes());
+    data.extend_from_slice(&(raw_addon.len() as u64).to_le_bytes());
+    data.extend_from_slice(&cache_key[..CACHE_KEY_LEN]);
+    data.extend_from_slice(&[0; PLATFORM_METADATA_LEN]);
+    data.extend_from_slice(&integrity);
+    data.push(0);
+    data.extend_from_slice(&compressed);
+
+    Ok(data)
+}
+
+pub fn pressed_data_sha512_hex(pressed_data: &[u8]) -> Result<String> {
+    let integrity_offset = MAGIC_MARKER.len() + 16 + CACHE_KEY_LEN + PLATFORM_METADATA_LEN;
+    let integrity = pressed_data
+        .get(integrity_offset..integrity_offset + INTEGRITY_HASH_LEN)
+        .context("pressed-data buffer is too short to contain the integrity hash")?;
+    Ok(hex::encode(integrity))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pack_fixture() -> Vec<u8> {
+        pack_pressed_data(b"raw native addon bytes", 19).unwrap()
+    }
+
+    #[test]
+    fn round_trips_through_decmpfs_decoder() {
+        let data = pack_fixture();
+
+        assert_eq!(
+            decmpfs::addon::decode_pressed_data(&data).unwrap(),
+            b"raw native addon bytes"
+        );
+    }
+
+    #[test]
+    fn rejects_short_buffer() {
+        assert!(decmpfs::addon::decode_pressed_data(&pack_fixture()[..8]).is_none());
+    }
+
+    #[test]
+    fn rejects_wrong_magic() {
+        let mut data = pack_fixture();
+        data[0] = b'x';
+
+        assert!(decmpfs::addon::decode_pressed_data(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_tampered_payload() {
+        let mut data = pack_fixture();
+        let last = data.len() - 1;
+        data[last] ^= 0xff;
+
+        assert!(decmpfs::addon::decode_pressed_data(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_wrong_uncompressed_length() {
+        let mut data = pack_fixture();
+        let offset = MAGIC_MARKER.len() + 8;
+        data[offset..offset + 8].copy_from_slice(&123_456u64.to_le_bytes());
+
+        assert!(decmpfs::addon::decode_pressed_data(&data).is_none());
+    }
+
+    #[test]
+    fn rejects_oversized_payload_claim() {
+        let mut data = pack_fixture();
+        let offset = MAGIC_MARKER.len() + 8;
+        data[offset..offset + 8].copy_from_slice(&((MAX_DECOMPRESSED as u64) + 1).to_le_bytes());
+
+        assert!(decmpfs::addon::decode_pressed_data(&data).is_none());
+    }
+
+    #[test]
+    fn exposes_payload_sha512() {
+        let data = pack_fixture();
+
+        assert_eq!(pressed_data_sha512_hex(&data).unwrap().len(), 128);
+    }
+}

--- a/tools/swc-compressed-binding-tool/src/lib.rs
+++ b/tools/swc-compressed-binding-tool/src/lib.rs
@@ -31,6 +31,7 @@ pub fn pack_pressed_data(raw_addon: &[u8], level: i32) -> Result<Vec<u8>> {
 
     let cache_key = Sha256::digest(raw_addon);
     let integrity = Sha512::digest(&compressed);
+    let raw_integrity = Sha512::digest(raw_addon);
     let mut data = Vec::with_capacity(
         MAGIC_MARKER.len()
             + 16
@@ -38,7 +39,8 @@ pub fn pack_pressed_data(raw_addon: &[u8], level: i32) -> Result<Vec<u8>> {
             + PLATFORM_METADATA_LEN
             + INTEGRITY_HASH_LEN
             + SMOL_CONFIG_FLAG_LEN
-            + compressed.len(),
+            + compressed.len()
+            + INTEGRITY_HASH_LEN,
     );
 
     data.extend_from_slice(MAGIC_MARKER);
@@ -49,6 +51,7 @@ pub fn pack_pressed_data(raw_addon: &[u8], level: i32) -> Result<Vec<u8>> {
     data.extend_from_slice(&integrity);
     data.push(0);
     data.extend_from_slice(&compressed);
+    data.extend_from_slice(&raw_integrity);
 
     Ok(data)
 }
@@ -95,7 +98,18 @@ mod tests {
     #[test]
     fn rejects_tampered_payload() {
         let mut data = pack_fixture();
-        let last = data.len() - 1;
+        let compressed_len = u64::from_le_bytes(
+            data[MAGIC_MARKER.len()..MAGIC_MARKER.len() + 8]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let payload_offset = MAGIC_MARKER.len()
+            + 16
+            + CACHE_KEY_LEN
+            + PLATFORM_METADATA_LEN
+            + INTEGRITY_HASH_LEN
+            + SMOL_CONFIG_FLAG_LEN;
+        let last = payload_offset + compressed_len - 1;
         data[last] ^= 0xff;
 
         assert!(decmpfs::addon::decode_pressed_data(&data).is_none());
@@ -124,5 +138,29 @@ mod tests {
         let data = pack_fixture();
 
         assert_eq!(pressed_data_sha512_hex(&data).unwrap().len(), 128);
+    }
+
+    #[test]
+    fn appends_raw_sha512_after_compressed_payload() {
+        let raw = b"raw native addon bytes";
+        let data = pack_pressed_data(raw, 19).unwrap();
+        let compressed_len = u64::from_le_bytes(
+            data[MAGIC_MARKER.len()..MAGIC_MARKER.len() + 8]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        let raw_hash_offset = MAGIC_MARKER.len()
+            + 16
+            + CACHE_KEY_LEN
+            + PLATFORM_METADATA_LEN
+            + INTEGRITY_HASH_LEN
+            + SMOL_CONFIG_FLAG_LEN
+            + compressed_len;
+
+        let raw_hash = Sha512::digest(raw);
+        assert_eq!(
+            &data[raw_hash_offset..raw_hash_offset + INTEGRITY_HASH_LEN],
+            &raw_hash[..]
+        );
     }
 }

--- a/tools/swc-compressed-binding-tool/src/lib.rs
+++ b/tools/swc-compressed-binding-tool/src/lib.rs
@@ -6,7 +6,7 @@ pub const CACHE_KEY_LEN: usize = 16;
 pub const PLATFORM_METADATA_LEN: usize = 3;
 pub const INTEGRITY_HASH_LEN: usize = 64;
 pub const SMOL_CONFIG_FLAG_LEN: usize = 1;
-pub const MAX_DECOMPRESSED: usize = 512 * 1024 * 1024;
+pub const MAX_DECOMPRESSED: usize = 2 * 1024 * 1024 * 1024;
 
 pub fn pack_pressed_data(raw_addon: &[u8], level: i32) -> Result<Vec<u8>> {
     if raw_addon.is_empty() {

--- a/tools/swc-compressed-binding-tool/src/main.rs
+++ b/tools/swc-compressed-binding-tool/src/main.rs
@@ -1,0 +1,502 @@
+use std::{
+    env,
+    ffi::OsStr,
+    fs,
+    path::{Component, Path, PathBuf},
+    process::Command,
+};
+
+use anyhow::{bail, Context, Result};
+use swc_compressed_binding_tool::{pack_pressed_data, pressed_data_sha512_hex};
+
+fn main() -> Result<()> {
+    let mut args = env::args().skip(1);
+    let command = args.next().context("expected subcommand: pack or build")?;
+
+    match command.as_str() {
+        "pack" => run_pack(parse_pack(args.collect())?),
+        "build" => run_build(parse_build(args.collect())?),
+        _ => bail!("unknown subcommand `{command}`; expected pack or build"),
+    }
+}
+
+#[derive(Debug)]
+struct PackOptions {
+    input: PathBuf,
+    output: PathBuf,
+    level: i32,
+}
+
+#[derive(Debug)]
+struct BuildOptions {
+    package_dir: PathBuf,
+    manifest_path: PathBuf,
+    raw_crate: String,
+    js: Option<PathBuf>,
+    dts: Option<PathBuf>,
+    no_js: bool,
+    release: bool,
+    napi_args: Vec<String>,
+}
+
+fn parse_pack(args: Vec<String>) -> Result<PackOptions> {
+    let mut input = None;
+    let mut output = None;
+    let mut level = 19;
+    let mut iter = args.into_iter();
+
+    while let Some(arg) = iter.next() {
+        if let Some(value) = arg.strip_prefix("--input=") {
+            input = Some(PathBuf::from(value));
+        } else if arg == "--input" {
+            input = Some(PathBuf::from(take_value(&mut iter, "--input")?));
+        } else if let Some(value) = arg.strip_prefix("--output=") {
+            output = Some(PathBuf::from(value));
+        } else if arg == "--output" {
+            output = Some(PathBuf::from(take_value(&mut iter, "--output")?));
+        } else if let Some(value) = arg.strip_prefix("--level=") {
+            level = value.parse().context("--level must be an integer")?;
+        } else if arg == "--level" {
+            level = take_value(&mut iter, "--level")?
+                .parse()
+                .context("--level must be an integer")?;
+        } else {
+            bail!("unknown pack option `{arg}`");
+        }
+    }
+
+    Ok(PackOptions {
+        input: input.context("missing --input")?,
+        output: output.context("missing --output")?,
+        level,
+    })
+}
+
+fn parse_build(args: Vec<String>) -> Result<BuildOptions> {
+    let mut package_dir = PathBuf::from(".");
+    let mut manifest_path = None;
+    let mut raw_crate = None;
+    let mut js = None;
+    let mut dts = None;
+    let mut no_js = false;
+    let mut release = false;
+    let mut napi_args = Vec::new();
+    let mut iter = args.into_iter();
+
+    while let Some(arg) = iter.next() {
+        if arg == "--" {
+            napi_args.extend(iter);
+            break;
+        } else if let Some(value) = arg.strip_prefix("--package-dir=") {
+            package_dir = PathBuf::from(value);
+        } else if arg == "--package-dir" {
+            package_dir = PathBuf::from(take_value(&mut iter, "--package-dir")?);
+        } else if let Some(value) = arg.strip_prefix("--manifest-path=") {
+            manifest_path = Some(PathBuf::from(value));
+        } else if arg == "--manifest-path" {
+            manifest_path = Some(PathBuf::from(take_value(&mut iter, "--manifest-path")?));
+        } else if let Some(value) = arg.strip_prefix("--raw-crate=") {
+            raw_crate = Some(value.to_string());
+        } else if arg == "--raw-crate" {
+            raw_crate = Some(take_value(&mut iter, "--raw-crate")?);
+        } else if let Some(value) = arg.strip_prefix("--js=") {
+            js = Some(PathBuf::from(value));
+        } else if arg == "--js" {
+            js = Some(PathBuf::from(take_value(&mut iter, "--js")?));
+        } else if let Some(value) = arg.strip_prefix("--dts=") {
+            dts = Some(PathBuf::from(value));
+        } else if arg == "--dts" {
+            dts = Some(PathBuf::from(take_value(&mut iter, "--dts")?));
+        } else if arg == "--no-js" {
+            no_js = true;
+        } else if arg == "--release" {
+            release = true;
+        } else {
+            napi_args.push(arg);
+        }
+    }
+
+    Ok(BuildOptions {
+        package_dir,
+        manifest_path: manifest_path.context("missing --manifest-path")?,
+        raw_crate: raw_crate.context("missing --raw-crate")?,
+        js,
+        dts,
+        no_js,
+        release,
+        napi_args,
+    })
+}
+
+fn take_value(iter: &mut impl Iterator<Item = String>, flag: &str) -> Result<String> {
+    iter.next()
+        .with_context(|| format!("expected a value after {flag}"))
+}
+
+fn run_pack(options: PackOptions) -> Result<()> {
+    let raw = fs::read(&options.input)
+        .with_context(|| format!("failed to read native addon {}", options.input.display()))?;
+    let pressed = pack_pressed_data(&raw, options.level)?;
+    if let Some(parent) = options.output.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create pressed-data output directory {}",
+                parent.display()
+            )
+        })?;
+    }
+    fs::write(&options.output, &pressed).with_context(|| {
+        format!(
+            "failed to write pressed-data output {}",
+            options.output.display()
+        )
+    })?;
+    eprintln!(
+        "packed {} -> {} (payload sha512 {})",
+        options.input.display(),
+        options.output.display(),
+        pressed_data_sha512_hex(&pressed)?
+    );
+    Ok(())
+}
+
+fn run_build(options: BuildOptions) -> Result<()> {
+    let cwd = env::current_dir().context("failed to read current directory")?;
+    let package_dir = resolve_path(&cwd, &options.package_dir)
+        .canonicalize()
+        .with_context(|| {
+            format!(
+                "failed to canonicalize package dir {}",
+                options.package_dir.display()
+            )
+        })?;
+    let manifest_path = resolve_path(&package_dir, &options.manifest_path)
+        .canonicalize()
+        .with_context(|| {
+            format!(
+                "failed to canonicalize workspace manifest {}",
+                options.manifest_path.display()
+            )
+        })?;
+    let workspace_root = manifest_path
+        .parent()
+        .context("workspace manifest has no parent directory")?;
+    let stage_dir = workspace_root
+        .join("target")
+        .join("swc-compressed-bindings")
+        .join(package_stage_name(&package_dir))
+        .join(if options.release { "release" } else { "debug" })
+        .join(sanitize_label(&target_label(&options.napi_args)));
+    let raw_dir = stage_dir.join("raw");
+    let pressed_data_path = stage_dir.join("pressed-data.bin");
+
+    if raw_dir.exists() {
+        fs::remove_dir_all(&raw_dir).with_context(|| {
+            format!(
+                "failed to clear raw addon staging dir {}",
+                raw_dir.display()
+            )
+        })?;
+    }
+    fs::create_dir_all(&raw_dir).with_context(|| {
+        format!(
+            "failed to create raw addon staging dir {}",
+            raw_dir.display()
+        )
+    })?;
+    prepare_raw_output_subdirs(&options, &raw_dir)?;
+
+    run_raw_build(&options, &package_dir, &manifest_path, &raw_dir)?;
+    copy_generated_binding_outputs(&options, &raw_dir, &package_dir)?;
+
+    let raw_addon = find_single_node_addon(&raw_dir)?;
+    let raw = fs::read(&raw_addon)
+        .with_context(|| format!("failed to read staged raw addon {}", raw_addon.display()))?;
+    let pressed = pack_pressed_data(&raw, 19)?;
+    fs::create_dir_all(&stage_dir).with_context(|| {
+        format!(
+            "failed to create pressed-data staging dir {}",
+            stage_dir.display()
+        )
+    })?;
+    fs::write(&pressed_data_path, &pressed).with_context(|| {
+        format!(
+            "failed to write pressed-data payload {}",
+            pressed_data_path.display()
+        )
+    })?;
+
+    eprintln!(
+        "packed raw addon {} ({} bytes) into {} ({} bytes, payload sha512 {})",
+        raw_addon.display(),
+        raw.len(),
+        pressed_data_path.display(),
+        pressed.len(),
+        pressed_data_sha512_hex(&pressed)?
+    );
+
+    run_loader_build(&options, &package_dir, &manifest_path, &pressed_data_path)?;
+
+    Ok(())
+}
+
+fn run_raw_build(
+    options: &BuildOptions,
+    package_dir: &Path,
+    manifest_path: &Path,
+    raw_dir: &Path,
+) -> Result<()> {
+    let mut command = pnpm_command();
+    command
+        .current_dir(package_dir)
+        .arg("exec")
+        .arg("napi")
+        .arg("build")
+        .arg("--manifest-path")
+        .arg(manifest_path)
+        .arg("--platform")
+        .arg("-p")
+        .arg(&options.raw_crate);
+
+    if options.no_js {
+        command.arg("--no-js");
+    } else if let Some(js) = &options.js {
+        command.arg("--js").arg(js);
+    }
+
+    if let Some(dts) = &options.dts {
+        command.arg("--dts").arg(dts);
+    }
+
+    if options.release {
+        command.arg("--release");
+    }
+
+    command.arg("--output-dir").arg(raw_dir);
+    command.args(&options.napi_args);
+    run_command(command)
+}
+
+fn prepare_raw_output_subdirs(options: &BuildOptions, raw_dir: &Path) -> Result<()> {
+    for path in options.js.iter().chain(options.dts.iter()) {
+        if path.is_absolute() {
+            continue;
+        }
+        if let Some(parent) = raw_dir.join(path).parent() {
+            fs::create_dir_all(parent).with_context(|| {
+                format!(
+                    "failed to create staged binding output directory {}",
+                    parent.display()
+                )
+            })?;
+        }
+    }
+    Ok(())
+}
+
+fn copy_generated_binding_outputs(
+    options: &BuildOptions,
+    raw_dir: &Path,
+    package_dir: &Path,
+) -> Result<()> {
+    for path in options.js.iter().chain(options.dts.iter()) {
+        if path.is_absolute() {
+            continue;
+        }
+
+        let source = raw_dir.join(path);
+        if !source.exists() {
+            continue;
+        }
+
+        copy_file(&source, &package_dir.join(path))?;
+
+        let normalized_path = strip_leading_current_dir(path);
+        if let Ok(package_relative_path) = normalized_path.strip_prefix("src") {
+            if !package_relative_path.as_os_str().is_empty() {
+                copy_file(&source, &package_dir.join(package_relative_path))?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn strip_leading_current_dir(path: &Path) -> PathBuf {
+    path.components()
+        .filter(|component| !matches!(component, Component::CurDir))
+        .collect()
+}
+
+fn copy_file(source: &Path, destination: &Path) -> Result<()> {
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!(
+                "failed to create binding output directory {}",
+                parent.display()
+            )
+        })?;
+    }
+    fs::copy(source, destination).with_context(|| {
+        format!(
+            "failed to copy generated binding {} to {}",
+            source.display(),
+            destination.display()
+        )
+    })?;
+    Ok(())
+}
+
+fn run_loader_build(
+    options: &BuildOptions,
+    package_dir: &Path,
+    manifest_path: &Path,
+    pressed_data_path: &Path,
+) -> Result<()> {
+    let mut command = pnpm_command();
+    command
+        .current_dir(package_dir)
+        .env("SWC_COMPRESSED_BINDING_PAYLOAD", pressed_data_path)
+        .arg("exec")
+        .arg("napi")
+        .arg("build")
+        .arg("--manifest-path")
+        .arg(manifest_path)
+        .arg("--platform")
+        .arg("-p")
+        .arg("binding_compressed_node_loader")
+        .arg("--no-js");
+
+    if options.release {
+        command.arg("--release");
+    }
+
+    command.arg("--output-dir").arg(package_dir);
+    command.args(loader_napi_args(&options.napi_args));
+    run_command(command)
+}
+
+fn run_command(mut command: Command) -> Result<()> {
+    let display = format!("{command:?}");
+    eprintln!("running {display}");
+    let status = command
+        .status()
+        .with_context(|| format!("failed to spawn {display}"))?;
+    if !status.success() {
+        bail!("command failed with {status}: {display}");
+    }
+    Ok(())
+}
+
+fn pnpm_command() -> Command {
+    if cfg!(windows) {
+        Command::new("pnpm.cmd")
+    } else {
+        Command::new("pnpm")
+    }
+}
+
+fn resolve_path(base: &Path, path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    }
+}
+
+fn package_stage_name(package_dir: &Path) -> String {
+    package_dir
+        .file_name()
+        .and_then(OsStr::to_str)
+        .map(sanitize_label)
+        .unwrap_or_else(|| "package".to_string())
+}
+
+fn sanitize_label(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-') {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn target_label(args: &[String]) -> String {
+    let mut iter = args.iter();
+    while let Some(arg) = iter.next() {
+        if arg == "--target" {
+            if let Some(target) = iter.next() {
+                return target.clone();
+            }
+        } else if let Some(target) = arg.strip_prefix("--target=") {
+            return target.to_string();
+        }
+    }
+    "host".to_string()
+}
+
+fn loader_napi_args(args: &[String]) -> Vec<String> {
+    let mut loader_args = Vec::new();
+    let mut iter = args.iter();
+
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--target" | "--target-dir" => {
+                loader_args.push(arg.clone());
+                if let Some(value) = iter.next() {
+                    loader_args.push(value.clone());
+                }
+            }
+            "--use-napi-cross" | "-x" | "--zig" => loader_args.push(arg.clone()),
+            value if value.starts_with("--target=") || value.starts_with("--target-dir=") => {
+                loader_args.push(value.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    loader_args
+}
+
+fn find_single_node_addon(dir: &Path) -> Result<PathBuf> {
+    let mut addons = Vec::new();
+    collect_node_addons(dir, &mut addons)?;
+    match addons.len() {
+        1 => Ok(addons.remove(0)),
+        0 => bail!(
+            "raw addon build did not produce a .node file in {}",
+            dir.display()
+        ),
+        _ => bail!(
+            "raw addon build produced multiple .node files in {}: {}",
+            dir.display(),
+            addons
+                .iter()
+                .map(|path| path.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    }
+}
+
+fn collect_node_addons(dir: &Path, addons: &mut Vec<PathBuf>) -> Result<()> {
+    for entry in
+        fs::read_dir(dir).with_context(|| format!("failed to read directory {}", dir.display()))?
+    {
+        let entry = entry.with_context(|| format!("failed to read entry in {}", dir.display()))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .with_context(|| format!("failed to read file type for {}", path.display()))?;
+        if file_type.is_dir() {
+            collect_node_addons(&path, addons)?;
+        } else if path.extension() == Some(OsStr::new("node")) {
+            addons.push(path);
+        }
+    }
+    Ok(())
+}

--- a/tools/swc-releaser/src/main.rs
+++ b/tools/swc-releaser/src/main.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::{hash_map::Entry, HashMap},
+    collections::{hash_map::Entry, HashMap, HashSet},
     env,
     path::{Path, PathBuf},
     process::Command,
@@ -54,6 +54,33 @@ fn run_bump(workspace_dir: &Path, dry_run: bool) -> Result<()> {
     }
 
     let (versions, graph) = get_data()?;
+    let rust_releases = changeset
+        .releases
+        .into_iter()
+        .filter_map(|(pkg_name, release)| {
+            if versions.contains_key(pkg_name.as_str()) {
+                Some((pkg_name, release))
+            } else {
+                eprintln!("Skipping non-Cargo changeset package: {pkg_name}");
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    if rust_releases.is_empty() {
+        eprintln!("No Rust changeset found");
+        return Ok(());
+    }
+    let rust_changeset_files = rust_releases
+        .iter()
+        .flat_map(|(_, release)| {
+            release
+                .changes
+                .iter()
+                .map(|change| change.unique_id.to_file_name())
+        })
+        .collect::<HashSet<_>>();
+
     let mut new_versions = VersionMap::new();
 
     let mut worker = Bump {
@@ -62,7 +89,7 @@ fn run_bump(workspace_dir: &Path, dry_run: bool) -> Result<()> {
         new_versions: &mut new_versions,
     };
 
-    for (pkg_name, release) in changeset.releases {
+    for (pkg_name, release) in rust_releases {
         let is_breaking = worker
             .is_breaking(pkg_name.as_str(), release.change_type())
             .with_context(|| format!("failed to check if package {pkg_name} is breaking"))?;
@@ -83,10 +110,15 @@ fn run_bump(workspace_dir: &Path, dry_run: bool) -> Result<()> {
         if !dry_run {
             for file in std::fs::read_dir(&changeset_dir)? {
                 let file = file?;
+                let path = file.path();
                 if file.file_type()?.is_file()
-                    && file.path().extension().unwrap_or_default() == "md"
+                    && path.extension().unwrap_or_default() == "md"
+                    && file
+                        .file_name()
+                        .to_str()
+                        .is_some_and(|name| rust_changeset_files.contains(name))
                 {
-                    std::fs::remove_file(file.path())?;
+                    std::fs::remove_file(path)?;
                 }
             }
         }

--- a/tools/swc-releaser/src/main.rs
+++ b/tools/swc-releaser/src/main.rs
@@ -54,6 +54,8 @@ fn run_bump(workspace_dir: &Path, dry_run: bool) -> Result<()> {
     }
 
     let (versions, graph) = get_data()?;
+    let removable_changeset_files = removable_rust_changeset_files(&changeset, &versions);
+
     let rust_releases = changeset
         .releases
         .into_iter()
@@ -71,16 +73,6 @@ fn run_bump(workspace_dir: &Path, dry_run: bool) -> Result<()> {
         eprintln!("No Rust changeset found");
         return Ok(());
     }
-    let rust_changeset_files = rust_releases
-        .iter()
-        .flat_map(|(_, release)| {
-            release
-                .changes
-                .iter()
-                .map(|change| change.unique_id.to_file_name())
-        })
-        .collect::<HashSet<_>>();
-
     let mut new_versions = VersionMap::new();
 
     let mut worker = Bump {
@@ -116,7 +108,7 @@ fn run_bump(workspace_dir: &Path, dry_run: bool) -> Result<()> {
                     && file
                         .file_name()
                         .to_str()
-                        .is_some_and(|name| rust_changeset_files.contains(name))
+                        .is_some_and(|name| removable_changeset_files.contains(name))
                 {
                     std::fs::remove_file(path)?;
                 }
@@ -134,6 +126,32 @@ fn run_bump(workspace_dir: &Path, dry_run: bool) -> Result<()> {
     git_tag_core(dry_run).context("failed to tag core")?;
 
     Ok(())
+}
+
+fn removable_rust_changeset_files(
+    changeset: &changesets::ChangeSet,
+    versions: &VersionMap,
+) -> HashSet<String> {
+    let mut files = HashMap::<String, bool>::new();
+
+    for (pkg_name, release) in &changeset.releases {
+        let is_rust_release = versions.contains_key(pkg_name.as_str());
+        for change in &release.changes {
+            match files.entry(change.unique_id.to_file_name()) {
+                Entry::Vacant(entry) => {
+                    entry.insert(is_rust_release);
+                }
+                Entry::Occupied(mut entry) => {
+                    *entry.get_mut() &= is_rust_release;
+                }
+            }
+        }
+    }
+
+    files
+        .into_iter()
+        .filter_map(|(file, is_rust_only)| is_rust_only.then_some(file))
+        .collect()
 }
 
 fn run_cargo_set_version(pkg_name: &str, version: &Version, dry_run: bool) -> Result<()> {
@@ -394,4 +412,45 @@ fn get_data() -> Result<(VersionMap, InternedGraph)> {
     }
 
     Ok((versions, graph))
+}
+
+#[cfg(test)]
+mod tests {
+    use changesets::{PackageChange, Release, UniqueId};
+
+    use super::*;
+
+    fn release(pkg_name: &str, file_name: &str) -> (String, Release) {
+        (
+            pkg_name.to_string(),
+            Release {
+                package_name: pkg_name.to_string(),
+                changes: vec![PackageChange {
+                    unique_id: UniqueId::from(file_name),
+                    change_type: ChangeType::Patch,
+                    summary: String::new(),
+                }],
+            },
+        )
+    }
+
+    #[test]
+    fn removes_only_changeset_files_with_rust_releases() {
+        let changeset = changesets::ChangeSet {
+            releases: HashMap::from([
+                release("swc_core", "rust-only"),
+                release("swc_common", "mixed"),
+                release("@swc/core", "mixed"),
+                release("@swc/html", "npm-only"),
+            ]),
+        };
+        let versions = HashMap::from([
+            ("swc_core".to_string(), Version::parse("1.0.0").unwrap()),
+            ("swc_common".to_string(), Version::parse("1.0.0").unwrap()),
+        ]);
+
+        let removable = removable_rust_changeset_files(&changeset, &versions);
+
+        assert_eq!(removable, HashSet::from(["rust_only.md".to_string()]));
+    }
 }


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Apply compressed native binding loading to the SWC native npm packages. Native `.node` builds now go through a shared wrapper that first builds the raw napi addon, packs it as zstd pressed-data with SHA-512 integrity, and then builds a small Rust loader as the shipped `.node` artifact.

The loader verifies and decompresses the embedded payload on first load, then materializes the raw addon through OS transparent compression when available or a per-user cache fallback otherwise. This keeps the public JS require path and exported N-API surface unchanged while reducing native package download/install size.

This also raises all native SWC npm package `engines.node` entries, including platform packages, to Node 20 or newer, and updates native CI jobs to Node 20.

Validation performed locally:

- `git submodule update --init --recursive`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_compressed_binding_tool`
- `cargo test -p binding_compressed_node_loader`
- `cargo test -p swc-releaser`
- `cd packages/core && pnpm build:dev && SWC_NATIVE_BINDING_DISABLE_SELF_REPLACE=1 SWC_NATIVE_BINDING_DEBUG=1 pnpm test`
- `cd packages/html && pnpm build:dev && SWC_NATIVE_BINDING_DISABLE_SELF_REPLACE=1 SWC_NATIVE_BINDING_DEBUG=1 pnpm test`
- `cd packages/html && SWC_NATIVE_BINDING_DISABLE_SELF_REPLACE=1 SWC_NATIVE_BINDING_DEBUG=1 node -e "const html = require('./'); const out = html.minifySync('<div>  hi </div>', {}); console.log(out.code);"`
- `cd packages/minifier && pnpm build:dev && SWC_NATIVE_BINDING_DISABLE_SELF_REPLACE=1 SWC_NATIVE_BINDING_DEBUG=1 pnpm test`
- `cd packages/minifier && SWC_NATIVE_BINDING_CACHE_DIR=$(mktemp -d) SWC_NATIVE_BINDING_DISABLE_SELF_REPLACE=1 SWC_NATIVE_BINDING_DEBUG=1 node -e "require('./').minifySync('function f(){ return 1 }', {})"`
- `cd packages/react-compiler && pnpm build:dev && SWC_NATIVE_BINDING_DISABLE_SELF_REPLACE=1 SWC_NATIVE_BINDING_DEBUG=1 pnpm test`

**BREAKING CHANGE:**

Native SWC npm packages now require Node.js 20 or newer.

**Related issue (if exists):**

N/A
