### PR TITLE
fix(es2015): avoid helper collisions with eval-preserved bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1574,9 +1574,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/swc_ecma_compat_es2015/src/instanceof.rs
+++ b/crates/swc_ecma_compat_es2015/src/instanceof.rs
@@ -31,8 +31,15 @@ pub fn instance_of() -> impl Pass {
 
 #[cfg(test)]
 mod tests {
+    use swc_common::Mark;
     use swc_ecma_parser::Syntax;
-    use swc_ecma_transforms_testing::test;
+    use swc_ecma_transforms_base::{
+        fixer,
+        helpers::inject_helpers,
+        hygiene::{hygiene_with_config, Config as HygieneConfig},
+        resolver,
+    };
+    use swc_ecma_transforms_testing::{test, Tester};
 
     use super::*;
 
@@ -80,4 +87,66 @@ mod tests {
         foo instanceof Bar;
         "
     );
+
+    #[test]
+    fn helper_does_not_collide_with_eval_preserved_binding() {
+        Tester::run(|tester| {
+            let unresolved_mark = Mark::new();
+            let top_level_mark = Mark::new();
+
+            let program = tester.apply_transform(
+                (
+                    resolver(unresolved_mark, top_level_mark, false),
+                    instance_of(),
+                    inject_helpers(unresolved_mark),
+                ),
+                "input.js",
+                Syntax::default(),
+                Some(false),
+                "
+                function outer() {
+                    function _class_call_check(e, t) {
+                        if (!(e instanceof t)) throw new TypeError('bad');
+                    }
+
+                    function _instanceof(e) {
+                        return new ZodCustom(e);
+                    }
+
+                    eval('');
+
+                    var Foo = function Foo() {
+                        _class_call_check(this, Foo);
+                    };
+
+                    new Foo();
+
+                    var ZodCustom = function ZodCustom(v) {
+                        this.v = v;
+                    };
+                }
+
+                outer();
+                ",
+            )?;
+
+            let program = program
+                .apply(hygiene_with_config(HygieneConfig {
+                    top_level_mark,
+                    ..Default::default()
+                }))
+                .apply(fixer::fixer(Some(&tester.comments)));
+
+            let output = tester.print(&program, &tester.comments.clone());
+
+            assert!(
+                output.contains("var _instanceof1 = require(\"@swc/helpers/_/_instanceof\");"),
+                "{output}"
+            );
+            assert!(output.contains("_instanceof1._(e, t)"), "{output}");
+            assert!(output.contains("function _instanceof(e)"), "{output}");
+
+            Ok(())
+        });
+    }
 }

--- a/crates/swc_ecma_transforms_base/src/rename/analyer_and_collector.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyer_and_collector.rs
@@ -144,6 +144,14 @@ impl Visit for AnalyzerAndCollector {
         maybe_grow_default(|| node.visit_children_with(self));
     }
 
+    fn visit_callee(&mut self, node: &Callee) {
+        if node.as_expr().is_some_and(|e| e.is_ident_ref_to("eval")) {
+            self.analyzer.mark_contains_eval();
+        }
+
+        node.visit_children_with(self);
+    }
+
     fn visit_catch_clause(&mut self, node: &CatchClause) {
         let old_decl_collector_is_pat_decl = self.decl_collector.is_pat_decl;
 
@@ -493,6 +501,12 @@ impl Visit for AnalyzerAndCollector {
 
         self.analyzer.is_pat_decl = old_analyzer_is_pat_decl;
         self.decl_collector.is_pat_decl = old_decl_collector_is_pat_decl;
+    }
+
+    fn visit_with_stmt(&mut self, node: &WithStmt) {
+        self.analyzer.mark_contains_eval();
+
+        node.visit_children_with(self);
     }
 
     fn visit_super_prop(&mut self, node: &SuperProp) {

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/mod.rs
@@ -81,6 +81,10 @@ impl Analyzer {
         self.scope.add_usage(id);
     }
 
+    pub(super) fn mark_contains_eval(&mut self) {
+        self.scope.mark_contains_eval();
+    }
+
     fn reserve_usage(&mut self, len: usize) {
         self.scope.reserve_usage(len);
     }
@@ -115,6 +119,9 @@ impl Analyzer {
 
     pub(super) fn exit_scope(&mut self, mut v: Self) {
         std::mem::swap(self, &mut v);
+        if v.scope.contains_eval() {
+            self.scope.mark_contains_eval();
+        }
         if !v.hoisted_vars.is_empty() {
             debug_assert!(matches!(v.scope.kind, ScopeKind::Block));
             self.reserve_usage(v.hoisted_vars.len());

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -47,6 +47,11 @@ pub(super) struct ScopeData {
     /// them. Generated bindings must not reuse these names after hygiene is
     /// removed.
     eval_reserved_symbols: FxHashSet<Atom>,
+
+    /// True if this scope, or one of its nested scopes, contains direct eval or
+    /// with. Only scopes on this path need to reserve eval-preserved names for
+    /// ancestor-generated bindings.
+    contains_eval: bool,
 }
 
 impl Scope {
@@ -85,15 +90,26 @@ impl Scope {
         self.data.all.reserve(len);
     }
 
+    pub(super) fn mark_contains_eval(&mut self) {
+        self.data.contains_eval = true;
+    }
+
+    pub(super) fn contains_eval(&self) -> bool {
+        self.data.contains_eval
+    }
+
     /// Copy `children.data.all` to `self.data.all`.
     pub(crate) fn prepare_renaming(&mut self) {
         self.children.iter_mut().for_each(|child| {
             child.prepare_renaming();
 
             self.data.all.extend(child.data.all.iter().cloned());
-            self.data
-                .eval_reserved_symbols
-                .extend(child.data.eval_reserved_symbols.iter().cloned());
+            if child.data.contains_eval {
+                self.data
+                    .eval_reserved_symbols
+                    .extend(child.data.eval_reserved_symbols.iter().cloned());
+                self.data.contains_eval = true;
+            }
         });
     }
 

--- a/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/analyzer/scope.rs
@@ -42,6 +42,11 @@ pub(super) struct ScopeData {
     all: FxHashSet<Id>,
 
     queue: FxIndexSet<Id>,
+
+    /// Raw names of user bindings preserved because direct eval can observe
+    /// them. Generated bindings must not reuse these names after hygiene is
+    /// removed.
+    eval_reserved_symbols: FxHashSet<Atom>,
 }
 
 impl Scope {
@@ -54,6 +59,7 @@ impl Scope {
 
         if !self.data.queue.contains(id) {
             if has_eval && id.1.outer().is_descendant_of(top_level_mark) {
+                self.data.eval_reserved_symbols.insert(id.0.clone());
                 return;
             }
 
@@ -85,6 +91,9 @@ impl Scope {
             child.prepare_renaming();
 
             self.data.all.extend(child.data.all.iter().cloned());
+            self.data
+                .eval_reserved_symbols
+                .extend(child.data.eval_reserved_symbols.iter().cloned());
         });
     }
 
@@ -159,7 +168,9 @@ impl Scope {
             loop {
                 let sym = renamer.new_name_for(&id, &mut n);
 
-                if preserved_symbols.contains(&sym) {
+                if preserved_symbols.contains(&sym)
+                    || self.data.eval_reserved_symbols.contains(&sym)
+                {
                     continue;
                 }
 
@@ -305,7 +316,9 @@ impl Scope {
                 let sym = renamer.new_name_for(&id, &mut n);
 
                 // TODO: Use base54::decode
-                if preserved_symbols.contains(&sym) {
+                if preserved_symbols.contains(&sym)
+                    || self.data.eval_reserved_symbols.contains(&sym)
+                {
                     continue;
                 }
 


### PR DESCRIPTION
Fixes #12001.

### Summary
- Reserve raw binding names that must be preserved because of direct `eval`.
- Avoid choosing generated/helper names that would collide with those eval-preserved names after hygiene removes marks.
- Add a regression test for the `instanceof` helper being shadowed by a local `_instanceof` binding.

### Testing
- `cargo fmt`
- `cargo test -p swc_ecma_compat_es2015 instanceof`
- `cargo test -p swc_ecma_transforms_base hygiene`
- `cargo test -p swc_ecma_transforms_base rename`
- `cargo test -p swc_ecma_compat_es2015 --all-features instanceof`
- `cargo test -p swc_ecma_transforms_base --lib`
- `cargo test -p swc_ecma_transforms_base --lib --features swc_ecma_transforms_base/concurrent`
- `$env:EXEC='0'; cargo test -p swc_ecma_compat_es2015`