### PR TITLE
fix(common): Replace unreachable_unchecked with safe panic in CacheCell::resolve

### DIFF
--- a/crates/swc_common/src/cache.rs
+++ b/crates/swc_common/src/cache.rs
@@ -34,8 +34,6 @@ impl<T> Default for CacheCell<T> {
 
 #[cfg(feature = "rkyv-impl")]
 mod rkyv_impl {
-    use std::hint::unreachable_unchecked;
-
     use rancor::Fallible;
     use rkyv::{
         munge::munge, option::ArchivedOption, traits::NoUndef, Archive, Deserialize, Place,
@@ -81,9 +79,7 @@ mod rkyv_impl {
                     let value = if let Some(value) = self.get() {
                         value
                     } else {
-                        unsafe {
-                            unreachable_unchecked();
-                        }
+                        unreachable!("CacheCell resolved before being serialized");
                     };
 
                     value.resolve(resolver, out_value);
@@ -112,5 +108,28 @@ mod rkyv_impl {
                 ArchivedOption::None => CacheCell::new(),
             })
         }
+    }
+}
+
+#[cfg(all(test, feature = "rkyv-impl"))]
+mod tests {
+    use rkyv::{option::ArchivedOption, Archive, Place};
+
+    use super::*;
+
+    /// Regression test for <https://github.com/swc-project/swc/issues/11991>:
+    /// `Archive::resolve` must panic safely instead of triggering UB when
+    /// called with `Some(resolver)` on an unpopulated `CacheCell`.
+    #[test]
+    #[should_panic(expected = "CacheCell resolved before being serialized")]
+    fn resolve_empty_cell_with_some_resolver_panics() {
+        let cell: CacheCell<()> = CacheCell::new();
+        let mut storage = ArchivedOption::<()>::None;
+        // SAFETY: `Place::new_unchecked` requires that the pointer is
+        // properly aligned, initialized, and points to valid memory for
+        // the archived type. `&mut storage` satisfies all of these for
+        // `ArchivedOption<()>`.
+        let out = unsafe { Place::new_unchecked(0, &mut storage) };
+        <CacheCell<()> as Archive>::resolve(&cell, Some(()), out);
     }
 }

--- a/crates/swc_common/src/errors/snippet.rs
+++ b/crates/swc_common/src/errors/snippet.rs
@@ -167,6 +167,7 @@ impl Annotation {
 #[derive(Debug)]
 pub struct StyledString {
     pub text: String,
+    #[allow(dead_code)]
     pub style: Style,
 }
 


### PR DESCRIPTION
### Description

**What was the issue?**

`CacheCell<T>` implements `rkyv::Archive`. The safe trait method `Archive::resolve` used `unreachable_unchecked()` on the cold path when `self.get()` returned `None` but the resolver was `Some(resolver)`. Since `CacheCell::new()` and `CacheCell::default()` are safe public constructors creating empty cells, safe downstream code can instantiate an empty cell, construct a valid `Some(resolver)` (e.g., `Some(())` for types where `T::Resolver = ()`), and call `resolve(Some(()), out)` — triggering Undefined Behavior from safe Rust code.

**Where was the issue?**

`crates/swc_common/src/cache.rs`, lines 84-86, inside the `rkyv_impl` module's `impl<T: Archive> Archive for CacheCell<T>`.

**How was it fixed?**

Replaced `unsafe { unreachable_unchecked(); }` with `unreachable!("CacheCell resolved before being serialized")` so the cold path panics safely instead of invoking UB. Removed the now-unused `use std::hint::unreachable_unchecked;` import. Added a `#[should_panic]` regression test that reproduces the exact scenario from the issue — an empty `CacheCell::new()` resolved with `Some(())` — and verifies it panics cleanly.

Additionally fixed a pre-existing `dead_code` warning on `StyledString.style` in `errors/snippet.rs` so `clippy -D warnings` passes cleanly.

**Why this method over alternatives?**

`unreachable!()` is the standard Rust idiom for "this code path should be impossible." Unlike `unreachable_unchecked()`, it panics safely instead of invoking UB. It carries the semantic meaning of a logic error / invariant violation, matching the original intent. It has zero runtime cost for the normal path and only costs a cold-path panic if the invariant is violated.

**How to test locally?**

```bash
cargo test -p swc_common --features rkyv-impl
cargo fmt --all
cargo clippy -p swc_common --features rkyv-impl --all-targets -- -D warnings
```

---

### BREAKING CHANGE

None.

---

### Related issue

Closes #11991

---

### Changeset

```
---
swc_common: patch
---

fix(common): Replace unreachable_unchecked with safe panic in CacheCell::resolve
```