### PR TITLE
fix(es/fixer): preserve parens around PURE-annotated receivers

### DIFF
--- a/crates/swc/tests/fixture/issues-12xxx/12019/input/.swcrc
+++ b/crates/swc/tests/fixture/issues-12xxx/12019/input/.swcrc
@@ -1,0 +1,10 @@
+{
+  "jsc": {
+    "parser": {
+      "syntax": "ecmascript"
+    },
+    "target": "es2022"
+  },
+  "minify": false,
+  "isModule": true
+}

--- a/crates/swc/tests/fixture/issues-12xxx/12019/input/input.js
+++ b/crates/swc/tests/fixture/issues-12xxx/12019/input/input.js
@@ -1,0 +1,7 @@
+(/* @__PURE__ */ new Set(x)).forEach(cb);
+
+(/* #__PURE__ */ new Set(x)).forEach(cb);
+
+(/* @__PURE__ */ foo()).bar();
+
+(/* @__NO_SIDE_EFFECTS__ */ new Set(x)).forEach(cb);

--- a/crates/swc/tests/fixture/issues-12xxx/12019/input/input.js
+++ b/crates/swc/tests/fixture/issues-12xxx/12019/input/input.js
@@ -5,3 +5,9 @@
 (/* @__PURE__ */ foo()).bar();
 
 (/* @__NO_SIDE_EFFECTS__ */ new Set(x)).forEach(cb);
+
+(/* @__PURE__ */ createHandler())();
+
+(/* @__PURE__ */ new Handler())();
+
+(/* @__NO_SIDE_EFFECTS__ */ createHandler())();

--- a/crates/swc/tests/fixture/issues-12xxx/12019/output/input.js
+++ b/crates/swc/tests/fixture/issues-12xxx/12019/output/input.js
@@ -1,0 +1,4 @@
+(/* @__PURE__ */ new Set(x)).forEach(cb);
+(/* #__PURE__ */ new Set(x)).forEach(cb);
+(/* @__PURE__ */ foo()).bar();
+(/* @__NO_SIDE_EFFECTS__ */ new Set(x)).forEach(cb);

--- a/crates/swc/tests/fixture/issues-12xxx/12019/output/input.js
+++ b/crates/swc/tests/fixture/issues-12xxx/12019/output/input.js
@@ -2,3 +2,6 @@
 (/* #__PURE__ */ new Set(x)).forEach(cb);
 (/* @__PURE__ */ foo()).bar();
 (/* @__NO_SIDE_EFFECTS__ */ new Set(x)).forEach(cb);
+(/* @__PURE__ */ createHandler())();
+(/* @__PURE__ */ new Handler())();
+(/* @__NO_SIDE_EFFECTS__ */ createHandler())();

--- a/crates/swc/tests/fixture/issues-2xxx/2154/case1/output/index.js
+++ b/crates/swc/tests/fixture/issues-2xxx/2154/case1/output/index.js
@@ -1,4 +1,4 @@
-var c = /*#__PURE__*/ React.createElement("img", {
+var c = (/*#__PURE__*/ React.createElement("img", {
     alt: "caf\xe9"
-}).props.alt;
+})).props.alt;
 console.log(c);

--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -71,28 +71,6 @@ enum Context {
 }
 
 impl Fixer<'_> {
-    /// Returns `true` if the given expression has a leading annotation comment
-    /// (e.g. `/* @__PURE__ */`, `/* #__PURE__ */`,
-    /// `/* @__NO_SIDE_EFFECTS__ */`) whose effective range would change if we
-    /// dropped surrounding parentheses.
-    ///
-    /// This matters for cases like `(/* @__PURE__ */ new Set(x)).forEach(cb)`.
-    /// Without the parens, downstream tools may treat the annotation as
-    /// applying to the whole chained call, which can cause the `.forEach(cb)`
-    /// side effect to be dropped by DCE.
-    fn has_range_sensitive_annotation(&self, expr: &Expr) -> bool {
-        let Some(comments) = self.comments else {
-            return false;
-        };
-
-        let span = expr.span();
-        if span.is_dummy() {
-            return false;
-        }
-
-        comments.has_flag(span.lo, "PURE") || comments.has_flag(span.lo, "NO_SIDE_EFFECTS")
-    }
-
     /// `Pat::Expr` is needed for parenthesized for-head expressions, but a
     /// bare identifier should use the same pattern shape as `for (x of y)`.
     fn normalize_for_head_pat(n: &mut ForHead) {
@@ -657,10 +635,20 @@ impl VisitMut for Fixer<'_> {
             // annotation like `/* @__PURE__ */` so downstream tools do not
             // interpret the annotation as applying to the full chained
             // expression. See issue #12019.
-            Expr::New(..) | Expr::Call(..) | Expr::TaggedTpl(..)
-                if self.has_range_sensitive_annotation(&n.obj) =>
-            {
-                self.wrap_preserving_leading_annotation(&mut n.obj);
+            Expr::New(..) | Expr::Call(..) | Expr::TaggedTpl(..) if !self.remove_only => {
+                let span = n.obj.span();
+                let has_annotation = !span.is_dummy()
+                    && self.comments.is_some_and(|c| {
+                        c.has_flag(span.lo, "PURE") || c.has_flag(span.lo, "NO_SIDE_EFFECTS")
+                    });
+                if has_annotation {
+                    let expr = n.obj.take();
+                    n.obj = ParenExpr {
+                        expr,
+                        span: DUMMY_SP,
+                    }
+                    .into();
+                }
             }
             _ => {}
         }
@@ -1135,25 +1123,6 @@ impl Fixer<'_> {
 
         let expr = Box::new(e.take());
         *e = ParenExpr { expr, span }.into();
-    }
-
-    /// Wrap with a paren while keeping any leading annotation comment
-    /// (e.g. `/* @__PURE__ */`) attached to the inner expression, so it
-    /// prints as `(/* @__PURE__ */ <expr>)` rather than
-    /// `/* @__PURE__ */ (<expr>)`. The outer `ParenExpr` uses a dummy span
-    /// so the codegen does not emit the inner expression's leading comments
-    /// before the opening paren.
-    fn wrap_preserving_leading_annotation(&mut self, e: &mut Expr) {
-        if self.remove_only {
-            return;
-        }
-
-        let expr = Box::new(e.take());
-        *e = ParenExpr {
-            expr,
-            span: DUMMY_SP,
-        }
-        .into();
     }
 
     /// Removes paren

--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -71,6 +71,28 @@ enum Context {
 }
 
 impl Fixer<'_> {
+    /// Returns `true` if the given expression has a leading annotation comment
+    /// (e.g. `/* @__PURE__ */`, `/* #__PURE__ */`,
+    /// `/* @__NO_SIDE_EFFECTS__ */`) whose effective range would change if we
+    /// dropped surrounding parentheses.
+    ///
+    /// This matters for cases like `(/* @__PURE__ */ new Set(x)).forEach(cb)`.
+    /// Without the parens, downstream tools may treat the annotation as
+    /// applying to the whole chained call, which can cause the `.forEach(cb)`
+    /// side effect to be dropped by DCE.
+    fn has_range_sensitive_annotation(&self, expr: &Expr) -> bool {
+        let Some(comments) = self.comments else {
+            return false;
+        };
+
+        let span = expr.span();
+        if span.is_dummy() {
+            return false;
+        }
+
+        comments.has_flag(span.lo, "PURE") || comments.has_flag(span.lo, "NO_SIDE_EFFECTS")
+    }
+
     /// `Pat::Expr` is needed for parenthesized for-head expressions, but a
     /// bare identifier should use the same pattern shape as `for (x of y)`.
     fn normalize_for_head_pat(n: &mut ForHead) {
@@ -631,6 +653,15 @@ impl VisitMut for Fixer<'_> {
             Expr::OptChain(..) if !self.in_opt_chain => {
                 self.wrap(&mut n.obj);
             }
+            // Preserve parentheses around expressions that carry a leading
+            // annotation like `/* @__PURE__ */` so downstream tools do not
+            // interpret the annotation as applying to the full chained
+            // expression. See issue #12019.
+            Expr::New(..) | Expr::Call(..) | Expr::TaggedTpl(..)
+                if self.has_range_sensitive_annotation(&n.obj) =>
+            {
+                self.wrap_preserving_leading_annotation(&mut n.obj);
+            }
             _ => {}
         }
     }
@@ -1104,6 +1135,25 @@ impl Fixer<'_> {
 
         let expr = Box::new(e.take());
         *e = ParenExpr { expr, span }.into();
+    }
+
+    /// Wrap with a paren while keeping any leading annotation comment
+    /// (e.g. `/* @__PURE__ */`) attached to the inner expression, so it
+    /// prints as `(/* @__PURE__ */ <expr>)` rather than
+    /// `/* @__PURE__ */ (<expr>)`. The outer `ParenExpr` uses a dummy span
+    /// so the codegen does not emit the inner expression's leading comments
+    /// before the opening paren.
+    fn wrap_preserving_leading_annotation(&mut self, e: &mut Expr) {
+        if self.remove_only {
+            return;
+        }
+
+        let expr = Box::new(e.take());
+        *e = ParenExpr {
+            expr,
+            span: DUMMY_SP,
+        }
+        .into();
     }
 
     /// Removes paren

--- a/crates/swc_ecma_transforms_base/src/fixer.rs
+++ b/crates/swc_ecma_transforms_base/src/fixer.rs
@@ -412,6 +412,25 @@ impl VisitMut for Fixer<'_> {
         if let Callee::Expr(e) = &mut node.callee {
             match &**e {
                 Expr::OptChain(_) if !self.in_opt_chain => self.wrap(e),
+                // Preserve parentheses around callees that carry a leading
+                // annotation like `/* @__PURE__ */` so downstream tools do not
+                // interpret the annotation as applying to the outer chained
+                // call expression. See issue #12019.
+                Expr::New(..) | Expr::Call(..) | Expr::TaggedTpl(..) if !self.remove_only => {
+                    let span = e.span();
+                    let has_annotation = !span.is_dummy()
+                        && self.comments.is_some_and(|c| {
+                            c.has_flag(span.lo, "PURE") || c.has_flag(span.lo, "NO_SIDE_EFFECTS")
+                        });
+                    if has_annotation {
+                        let expr = e.take();
+                        *e = ParenExpr {
+                            expr,
+                            span: DUMMY_SP,
+                        }
+                        .into();
+                    }
+                }
                 _ => self.wrap_callee(e),
             }
         }


### PR DESCRIPTION
Closes #12019

## Summary

When `paren_remover` unwraps `(/* @__PURE__ */ new Set(x))` inside a MemberExpr, the leading annotation ends up attached to the inner expression. Without the surrounding parens, downstream tools (Rollup, esbuild, minifiers) interpret the annotation as applying to the entire chained call, which can cause `.forEach(cb)` and other side-effecting calls to be dropped by DCE.

The fixer now detects a leading `@__PURE__`, `#__PURE__`, or `@__NO_SIDE_EFFECTS__` annotation on the object of a MemberExpr and wraps it in a ParenExpr whose span is dummy so that the annotation is emitted inside the parens.

## Test plan

- [x] New fixture test at `crates/swc/tests/fixture/issues-12xxx/12019`
- [x] Existing fixture `issues-2xxx/2154/case1` also updated (was affected by the same bug)
- [x] `swc_ecma_transforms_base` lib tests
- [x] `swc` fixture tests
- [x] `swc_ecma_minifier` full test suite
- [x] `swc_ecma_codegen` lib tests

🤖 Generated with [Claude Code](https://claude.ai/code)