### PR TITLE
fix(es/parser): prevent nested expression stack overflow

### DIFF
--- a/.changeset/fix-parser-stack-overflow.md
+++ b/.changeset/fix-parser-stack-overflow.md
@@ -1,0 +1,5 @@
+---
+swc_ecma_parser: patch
+---
+
+fix(es/parser): Prevent stack overflow on deeply nested expressions

--- a/crates/swc_ecma_parser/src/error.rs
+++ b/crates/swc_ecma_parser/src/error.rs
@@ -41,6 +41,7 @@ impl Error {
 #[non_exhaustive]
 pub enum SyntaxError {
     Eof,
+    TooManyNestedExpressions,
     DeclNotAllowed,
 
     UsingDeclNotAllowed,
@@ -532,6 +533,7 @@ impl SyntaxError {
             SyntaxError::TS1141 => "literal in an import type should be string literal".into(),
 
             SyntaxError::Eof => "Unexpected eof".into(),
+            SyntaxError::TooManyNestedExpressions => "Too many nested expressions".into(),
 
             SyntaxError::TS2703 => {
                 "The operand of a delete operator must be a property reference.".into()

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -540,6 +540,10 @@ impl<I: Tokens> Parser<I> {
         tracing::instrument(level = "debug", skip_all)
     )]
     fn parse_array_lit(&mut self) -> PResult<Box<Expr>> {
+        self.with_expression_nesting(Self::parse_array_lit_inner)
+    }
+
+    fn parse_array_lit_inner(&mut self) -> PResult<Box<Expr>> {
         trace_cur!(self, parse_array_lit);
 
         let start = self.input().cur_pos();
@@ -987,6 +991,10 @@ impl<I: Tokens> Parser<I> {
         tracing::instrument(skip_all)
     )]
     pub(crate) fn parse_args(&mut self, is_dynamic_import: bool) -> PResult<Vec<ExprOrSpread>> {
+        self.with_expression_nesting(|parser| parser.parse_args_inner(is_dynamic_import))
+    }
+
+    fn parse_args_inner(&mut self, is_dynamic_import: bool) -> PResult<Vec<ExprOrSpread>> {
         trace_cur!(self, parse_args);
 
         self.do_outside_of_context(Context::WillExpectColonForCond, |p| {
@@ -2619,6 +2627,16 @@ impl<I: Tokens> Parser<I> {
         tracing::instrument(level = "debug", skip_all)
     )]
     fn parse_paren_expr_or_arrow_fn(
+        &mut self,
+        can_be_arrow: bool,
+        async_span: Option<Span>,
+    ) -> PResult<Box<Expr>> {
+        self.with_expression_nesting(|parser| {
+            parser.parse_paren_expr_or_arrow_fn_inner(can_be_arrow, async_span)
+        })
+    }
+
+    fn parse_paren_expr_or_arrow_fn_inner(
         &mut self,
         can_be_arrow: bool,
         async_span: Option<Span>,

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -73,7 +73,7 @@ pub struct Parser<I: self::input::Tokens> {
         not(feature = "stacker"),
         miri
     ))]
-    expression_nesting: u8,
+    expression_nesting: u16,
     #[cfg(feature = "flow")]
     allow_super_call: bool,
 }
@@ -113,7 +113,12 @@ impl<I: Tokens> Parser<I> {
             miri
         ))]
         {
-            const MAX_EXPRESSION_NESTING: u8 = 64;
+            // Wasm has enough stack for existing real-world inputs beyond the
+            // conservative native fallback, but still needs a finite guard.
+            #[cfg(target_arch = "wasm32")]
+            const MAX_EXPRESSION_NESTING: u16 = 256;
+            #[cfg(not(target_arch = "wasm32"))]
+            const MAX_EXPRESSION_NESTING: u16 = 64;
 
             if self.expression_nesting >= MAX_EXPRESSION_NESTING {
                 return Err(Error::new(

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -67,6 +67,13 @@ pub struct Parser<I: self::input::Tokens> {
     state: State,
     input: self::input::Buffer<I>,
     found_module_item: bool,
+    #[cfg(any(
+        target_arch = "wasm32",
+        target_arch = "arm",
+        not(feature = "stacker"),
+        miri
+    ))]
+    expression_nesting: u8,
     #[cfg(feature = "flow")]
     allow_super_call: bool,
 }
@@ -90,6 +97,43 @@ impl<I: Tokens> Parser<I> {
     #[inline(always)]
     fn state_mut(&mut self) -> &mut State {
         &mut self.state
+    }
+
+    #[inline]
+    fn with_expression_nesting<T>(
+        &mut self,
+        parse: impl FnOnce(&mut Self) -> PResult<T>,
+    ) -> PResult<T> {
+        // Structural expressions recurse through the parser. Grow the stack where
+        // supported, and use a conservative limit on targets without `stacker`.
+        #[cfg(any(
+            target_arch = "wasm32",
+            target_arch = "arm",
+            not(feature = "stacker"),
+            miri
+        ))]
+        {
+            const MAX_EXPRESSION_NESTING: u8 = 64;
+
+            if self.expression_nesting >= MAX_EXPRESSION_NESTING {
+                return Err(Error::new(
+                    self.input().cur_span(),
+                    SyntaxError::TooManyNestedExpressions,
+                ));
+            }
+            self.expression_nesting += 1;
+            let result = parse(self);
+            self.expression_nesting -= 1;
+            result
+        }
+
+        #[cfg(all(
+            not(any(target_arch = "wasm32", target_arch = "arm", miri)),
+            feature = "stacker"
+        ))]
+        {
+            crate::maybe_grow(256 * 1024, 1024 * 1024, || parse(self))
+        }
     }
 
     #[cfg(all(feature = "typescript", feature = "flow"))]
@@ -189,6 +233,13 @@ impl<I: Tokens> Parser<I> {
             state: Default::default(),
             input: crate::parser::input::Buffer::new(input),
             found_module_item: false,
+            #[cfg(any(
+                target_arch = "wasm32",
+                target_arch = "arm",
+                not(feature = "stacker"),
+                miri
+            ))]
+            expression_nesting: 0,
             #[cfg(feature = "flow")]
             allow_super_call: false,
         };

--- a/crates/swc_ecma_parser/src/parser/object.rs
+++ b/crates/swc_ecma_parser/src/parser/object.rs
@@ -516,6 +516,10 @@ impl<I: Tokens> Parser<I> {
     }
 
     pub(crate) fn parse_object_expr(&mut self) -> PResult<Expr> {
+        self.with_expression_nesting(Self::parse_object_expr_inner)
+    }
+
+    fn parse_object_expr_inner(&mut self) -> PResult<Expr> {
         self.parse_object(Self::parse_expr_object_prop, Self::make_expr_object)
     }
 }

--- a/crates/swc_ecma_parser/tests/stack_overflow.rs
+++ b/crates/swc_ecma_parser/tests/stack_overflow.rs
@@ -82,3 +82,22 @@ fn deeply_nested_expressions_return_an_error_without_stacker() {
         .join()
         .expect("parser should reject the input without overflowing its stack");
 }
+
+#[cfg(target_arch = "wasm32")]
+#[test]
+fn wasm_accepts_existing_real_world_nesting_depth() {
+    let depth = 180;
+    let source = format!("{}0{}", "(".repeat(depth), ")".repeat(depth));
+    let end = BytePos(source.len() as u32);
+    let mut parser = Parser::new(
+        Syntax::default(),
+        StringInput::new(&source, BytePos(0), end),
+        None,
+    );
+
+    let expr = parser
+        .parse_expr()
+        .expect("moderately nested wasm expression should parse");
+    assert!(parser.take_errors().is_empty());
+    std::mem::forget(expr);
+}

--- a/crates/swc_ecma_parser/tests/stack_overflow.rs
+++ b/crates/swc_ecma_parser/tests/stack_overflow.rs
@@ -1,0 +1,84 @@
+use swc_common::BytePos;
+#[cfg(any(
+    target_arch = "wasm32",
+    target_arch = "arm",
+    not(feature = "stacker"),
+    miri
+))]
+use swc_ecma_parser::error::SyntaxError;
+use swc_ecma_parser::{Parser, StringInput, Syntax};
+
+#[cfg(all(
+    not(any(target_arch = "wasm32", target_arch = "arm", miri)),
+    feature = "stacker"
+))]
+#[test]
+fn deeply_nested_expressions_do_not_overflow_the_stack() {
+    std::thread::Builder::new()
+        .stack_size(2 * 1024 * 1024)
+        .spawn(|| {
+            let depth = 5_000;
+            let sources = [
+                format!("{}0{}", "(".repeat(depth), ")".repeat(depth)),
+                format!("{}0{}", "[".repeat(depth), "]".repeat(depth)),
+                format!("{}0{}", "{a:".repeat(depth), "}".repeat(depth)),
+                format!("{}0{}", "f(".repeat(depth), ")".repeat(depth)),
+            ];
+
+            for source in sources {
+                let end = BytePos(source.len() as u32);
+                let mut parser = Parser::new(
+                    Syntax::default(),
+                    StringInput::new(&source, BytePos(0), end),
+                    None,
+                );
+
+                let expr = parser.parse_expr().expect("nested expression should parse");
+                assert!(parser.take_errors().is_empty());
+
+                // Dropping a deeply recursive AST is independent of parser stack usage.
+                std::mem::forget(expr);
+            }
+        })
+        .expect("test thread should start")
+        .join()
+        .expect("parser should not overflow its stack");
+}
+
+#[cfg(any(
+    target_arch = "wasm32",
+    target_arch = "arm",
+    not(feature = "stacker"),
+    miri
+))]
+#[test]
+fn deeply_nested_expressions_return_an_error_without_stacker() {
+    std::thread::Builder::new()
+        .stack_size(2 * 1024 * 1024)
+        .spawn(|| {
+            let depth = 5_000;
+            let sources = [
+                format!("{}0{}", "(".repeat(depth), ")".repeat(depth)),
+                format!("{}0{}", "[".repeat(depth), "]".repeat(depth)),
+                format!("{}0{}", "{a:".repeat(depth), "}".repeat(depth)),
+                format!("{}0{}", "f(".repeat(depth), ")".repeat(depth)),
+            ];
+
+            for source in sources {
+                let end = BytePos(source.len() as u32);
+                let mut parser = Parser::new(
+                    Syntax::default(),
+                    StringInput::new(&source, BytePos(0), end),
+                    None,
+                );
+
+                let error = parser
+                    .parse_expr()
+                    .expect_err("nested expression should be rejected");
+                assert_eq!(error.kind(), &SyntaxError::TooManyNestedExpressions);
+            }
+        })
+        .expect("test thread should start")
+        .join()
+        .expect("parser should reject the input without overflowing its stack");
+}


### PR DESCRIPTION
## What changed

- grow the parser stack around recursive parentheses, arrays, object literals, and call arguments on supported targets
- return a dedicated syntax error after a conservative nesting limit when `stacker` is unavailable
- add regression coverage for 5,000 nested expressions across all four shapes
- add a patch changeset for `swc_ecma_parser`

## Why

These structural expression parsers recursively called back into expression parsing without using the crate's existing stack-growth helper. Deeply nested input could therefore abort the process with a stack overflow instead of producing a parse result.

## Impact

Supported native targets can parse the reported deeply nested inputs without overflowing a 2 MiB test thread. Targets without `stacker` fail cleanly with `TooManyNestedExpressions` rather than aborting.

## Checks

- `cargo fmt --all -- --check`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo test -p swc_ecma_parser --test stack_overflow`
- `cargo test -p swc_ecma_parser --no-default-features --test stack_overflow`
- `cargo check -p swc_ecma_parser --no-default-features`
- `cargo test -p swc_ecma_parser` (all parser unit tests passed; the TypeScript fixture `invalid_type_only` fails identically on the unmodified base commit)

Fixes #12024

Implemented and tested with assistance from OpenAI Codex. I reviewed the final diff and validation results.
