### PR TITLE
feat(es/react-compiler): expose `reactCompiler.environment.enableFunctionOutlining`

### DIFF
--- a/.changeset/expose-react-compiler-environment.md
+++ b/.changeset/expose-react-compiler-environment.md
@@ -1,0 +1,6 @@
+---
+swc: minor
+swc_core: minor
+---
+
+feat(swc): Expose React Compiler function outlining configuration

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1914,7 +1914,7 @@ impl ReactCompilerConfig {
             options.dynamic_gating = Some(dynamic_gating.into());
         }
         if let Some(environment) = self.environment {
-            environment.apply_to(&mut options.environment);
+            environment.apply_to(&mut options);
         }
 
         options
@@ -2051,19 +2051,23 @@ impl From<ReactCompilerDynamicGatingConfig> for swc_ecma_react_compiler::Dynamic
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ReactCompilerEnvironmentConfig {
     /// Extract anonymous functions that do not close over local variables into
-    /// top-level helper functions. Maps to
-    /// `EnvironmentConfig::enable_function_outlining` (default `true`).
+    /// top-level helper functions. Maps to the compiler's
+    /// `environment.enable_function_outlining` (default `true`).
     #[serde(default)]
     pub enable_function_outlining: Option<bool>,
 }
 
 #[cfg(feature = "react-compiler")]
 impl ReactCompilerEnvironmentConfig {
-    /// Apply the set (`Some`) overrides onto the compiler's environment config,
+    /// Apply the set (`Some`) overrides onto the compiler options' environment,
     /// leaving unset fields at their existing (default) values.
-    fn apply_to(self, env: &mut swc_ecma_react_compiler::EnvironmentConfig) {
+    ///
+    /// This mutates the public `environment` field in place rather than naming
+    /// the upstream `EnvironmentConfig` type, so the config layer does not
+    /// require that type to be re-exported.
+    fn apply_to(self, options: &mut swc_ecma_react_compiler::PluginOptions) {
         if let Some(enable_function_outlining) = self.enable_function_outlining {
-            env.enable_function_outlining = enable_function_outlining;
+            options.environment.enable_function_outlining = enable_function_outlining;
         }
     }
 }

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -1816,8 +1816,8 @@ pub struct TransformConfig {
 /// Public `.swcrc` configuration for React Compiler.
 ///
 /// This intentionally mirrors only a curated subset of upstream
-/// `PluginOptions`; the deep `environment` configuration is kept internal for
-/// the first SWC integration.
+/// `PluginOptions`. The nested `environment` object likewise exposes only a
+/// curated subset of the compiler's environment configuration.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Merge)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct ReactCompilerConfig {
@@ -1859,6 +1859,9 @@ pub struct ReactCompilerConfig {
 
     #[serde(default)]
     pub dynamic_gating: Option<ReactCompilerDynamicGatingConfig>,
+
+    #[serde(default)]
+    pub environment: Option<ReactCompilerEnvironmentConfig>,
 }
 
 #[cfg(feature = "react-compiler")]
@@ -1909,6 +1912,9 @@ impl ReactCompilerConfig {
         }
         if let Some(dynamic_gating) = self.dynamic_gating {
             options.dynamic_gating = Some(dynamic_gating.into());
+        }
+        if let Some(environment) = self.environment {
+            environment.apply_to(&mut options.environment);
         }
 
         options
@@ -2030,6 +2036,34 @@ impl From<ReactCompilerDynamicGatingConfig> for swc_ecma_react_compiler::Dynamic
     fn from(config: ReactCompilerDynamicGatingConfig) -> Self {
         Self {
             source: config.source,
+        }
+    }
+}
+
+/// Curated subset of the React Compiler `environment` options exposed through
+/// the SWC config, mirroring Babel's `reactCompiler.environment` object.
+///
+/// Only fields wired end-to-end into the compiler are exposed here. A field
+/// left unset (`None`) leaves the compiler default untouched, so a partial
+/// object such as `{ "enableFunctionOutlining": false }` overrides only that
+/// setting.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, rename_all = "camelCase")]
+pub struct ReactCompilerEnvironmentConfig {
+    /// Extract anonymous functions that do not close over local variables into
+    /// top-level helper functions. Maps to
+    /// `EnvironmentConfig::enable_function_outlining` (default `true`).
+    #[serde(default)]
+    pub enable_function_outlining: Option<bool>,
+}
+
+#[cfg(feature = "react-compiler")]
+impl ReactCompilerEnvironmentConfig {
+    /// Apply the set (`Some`) overrides onto the compiler's environment config,
+    /// leaving unset fields at their existing (default) values.
+    fn apply_to(self, env: &mut swc_ecma_react_compiler::EnvironmentConfig) {
+        if let Some(enable_function_outlining) = self.enable_function_outlining {
+            env.enable_function_outlining = enable_function_outlining;
         }
     }
 }

--- a/crates/swc/src/config/tests.rs
+++ b/crates/swc/src/config/tests.rs
@@ -115,3 +115,31 @@ fn react_compiler_config_object() {
         Some("shared-runtime")
     );
 }
+
+#[test]
+fn react_compiler_config_environment_enable_function_outlining() {
+    let config = transform_config(
+        r#"{
+            "jsc": {
+                "transform": {
+                    "reactCompiler": {
+                        "environment": {
+                            "enableFunctionOutlining": false
+                        }
+                    }
+                }
+            }
+        }"#,
+    );
+
+    let Some(BoolOr::Data(config)) = config.react_compiler.into_inner() else {
+        panic!("expected object config");
+    };
+
+    assert_eq!(
+        config
+            .environment
+            .and_then(|environment| environment.enable_function_outlining),
+        Some(false)
+    );
+}

--- a/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-disabled/input/.swcrc
+++ b/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-disabled/input/.swcrc
@@ -1,0 +1,15 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "transform": {
+            "reactCompiler": {
+                "environment": {
+                    "enableFunctionOutlining": false
+                }
+            }
+        }
+    }
+}

--- a/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-disabled/input/index.tsx
+++ b/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-disabled/input/index.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+function createFoo() {
+  function Bar() {
+    return 'Bar';
+  }
+  return function Foo() {
+    'use memo';
+    const renderBar = React.useCallback(() => {
+      return <Bar />;
+    }, []);
+
+    return renderBar();
+  }
+}

--- a/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-disabled/input/index.tsx
+++ b/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-disabled/input/index.tsx
@@ -1,14 +1,12 @@
 import * as React from 'react';
-function createFoo() {
-  function Bar() {
-    return 'Bar';
-  }
-  return function Foo() {
-    'use memo';
-    const renderBar = React.useCallback(() => {
-      return <Bar />;
-    }, []);
 
-    return renderBar();
-  }
+export function Counter() {
+  'use memo';
+  // This callback captures no local variables (only the `console` global), so
+  // it is safe to outline into a top-level helper when outlining is enabled.
+  const onClick = React.useCallback(() => {
+    console.log('clicked');
+  }, []);
+
+  return <button onClick={onClick} />;
 }

--- a/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-disabled/output/index.tsx
+++ b/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-disabled/output/index.tsx
@@ -1,0 +1,29 @@
+import { c as _c } from "react/compiler-runtime";
+import * as React from "react";
+function createFoo() {
+    function Bar() {
+        return "Bar";
+    }
+    return function Foo() {
+        "use memo";
+        var $ = _c(2);
+        var t0;
+        if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+            t0 = function t0() {
+                return /*#__PURE__*/ React.createElement(Bar, null);
+            };
+            $[0] = t0;
+        } else {
+            t0 = $[0];
+        }
+        var renderBar = t0;
+        var t1;
+        if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+            t1 = renderBar();
+            $[1] = t1;
+        } else {
+            t1 = $[1];
+        }
+        return t1;
+    };
+}

--- a/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-disabled/output/index.tsx
+++ b/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-disabled/output/index.tsx
@@ -1,29 +1,26 @@
 import { c as _c } from "react/compiler-runtime";
 import * as React from "react";
-function createFoo() {
-    function Bar() {
-        return "Bar";
+export function Counter() {
+    "use memo";
+    var $ = _c(2);
+    var t0;
+    if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+        t0 = function t0() {
+            console.log("clicked");
+        };
+        $[0] = t0;
+    } else {
+        t0 = $[0];
     }
-    return function Foo() {
-        "use memo";
-        var $ = _c(2);
-        var t0;
-        if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-            t0 = function t0() {
-                return /*#__PURE__*/ React.createElement(Bar, null);
-            };
-            $[0] = t0;
-        } else {
-            t0 = $[0];
-        }
-        var renderBar = t0;
-        var t1;
-        if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
-            t1 = renderBar();
-            $[1] = t1;
-        } else {
-            t1 = $[1];
-        }
-        return t1;
-    };
+    var onClick = t0;
+    var t1;
+    if ($[1] === Symbol.for("react.memo_cache_sentinel")) {
+        t1 = /*#__PURE__*/ React.createElement("button", {
+            onClick: onClick
+        });
+        $[1] = t1;
+    } else {
+        t1 = $[1];
+    }
+    return t1;
 }

--- a/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-enabled/input/.swcrc
+++ b/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-enabled/input/.swcrc
@@ -1,0 +1,15 @@
+{
+    "jsc": {
+        "parser": {
+            "syntax": "typescript",
+            "tsx": true
+        },
+        "transform": {
+            "reactCompiler": {
+                "environment": {
+                    "enableFunctionOutlining": true
+                }
+            }
+        }
+    }
+}

--- a/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-enabled/input/index.tsx
+++ b/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-enabled/input/index.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+export function Counter() {
+  'use memo';
+  // This callback captures no local variables (only the `console` global), so
+  // it is safe to outline into a top-level helper when outlining is enabled.
+  const onClick = React.useCallback(() => {
+    console.log('clicked');
+  }, []);
+
+  return <button onClick={onClick} />;
+}

--- a/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-enabled/output/index.tsx
+++ b/crates/swc/tests/fixture/options/react-compiler/environment-function-outlining-enabled/output/index.tsx
@@ -1,0 +1,20 @@
+import { c as _c } from "react/compiler-runtime";
+import * as React from "react";
+export function Counter() {
+    "use memo";
+    var $ = _c(1);
+    var onClick = _temp;
+    var t0;
+    if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
+        t0 = /*#__PURE__*/ React.createElement("button", {
+            onClick: onClick
+        });
+        $[0] = t0;
+    } else {
+        t0 = $[0];
+    }
+    return t0;
+}
+function _temp() {
+    console.log("clicked");
+}

--- a/crates/swc_ecma_react_compiler/src/lib.rs
+++ b/crates/swc_ecma_react_compiler/src/lib.rs
@@ -26,7 +26,8 @@ use react_compiler::entrypoint::compile_result::LoggerEvent;
 pub use react_compiler::entrypoint::plugin_options::{
     CompilerTarget, DynamicGatingConfig, GatingConfig, PluginOptions,
 };
-use react_compiler_hir::environment_config::EnvironmentConfig;
+// Re-exported so integrations needn't depend on the upstream `react_compiler_hir` crate.
+pub use react_compiler_hir::environment_config::EnvironmentConfig;
 pub use source_type::SourceType;
 use swc_common::{comments::SingleThreadedComments, sync::Lrc, FileName};
 use swc_ecma_ast::Program;

--- a/crates/swc_ecma_react_compiler/src/lib.rs
+++ b/crates/swc_ecma_react_compiler/src/lib.rs
@@ -26,8 +26,7 @@ use react_compiler::entrypoint::compile_result::LoggerEvent;
 pub use react_compiler::entrypoint::plugin_options::{
     CompilerTarget, DynamicGatingConfig, GatingConfig, PluginOptions,
 };
-// Re-exported so integrations needn't depend on the upstream `react_compiler_hir` crate.
-pub use react_compiler_hir::environment_config::EnvironmentConfig;
+use react_compiler_hir::environment_config::EnvironmentConfig;
 pub use source_type::SourceType;
 use swc_common::{comments::SingleThreadedComments, sync::Lrc, FileName};
 use swc_ecma_ast::Program;

--- a/packages/types/index.ts
+++ b/packages/types/index.ts
@@ -1012,6 +1012,13 @@ export interface ReactCompilerOptions {
      * Dynamically-gated compilation.
      */
     dynamicGating?: ReactCompilerDynamicGatingConfig;
+
+    /**
+     * Curated subset of the compiler's `environment` options.
+     *
+     * Unset fields leave the compiler defaults intact.
+     */
+    environment?: ReactCompilerEnvironmentConfig;
 }
 
 export interface ReactCompilerGatingConfig {
@@ -1031,6 +1038,16 @@ export interface ReactCompilerDynamicGatingConfig {
      * Module the gating import comes from.
      */
     source: string;
+}
+
+export interface ReactCompilerEnvironmentConfig {
+    /**
+     * Extract anonymous functions that do not close over local variables into
+     * top-level helper functions.
+     *
+     * Defaults to `true`.
+     */
+    enableFunctionOutlining?: boolean;
 }
 
 export interface ReactConfig {


### PR DESCRIPTION
**Description:**

The Babel React Compiler lets consumers configure `environment` options, but SWC's `reactCompiler` config previously exposed none of them — the compiler's `EnvironmentConfig` was always left at its defaults, unreachable from `.swcrc`.

This adds a curated `environment` object to the `reactCompiler` config that mirrors Babel's `reactCompiler.environment` shape. It currently exposes a single field, `enableFunctionOutlining`, wired through to `EnvironmentConfig::enable_function_outlining`:

```json
{
  "jsc": {
    "transform": {
      "reactCompiler": {
        "environment": { "enableFunctionOutlining": false }
      }
    }
  }
}
```

The object is a deliberate allowlist rather than a passthrough of the full `EnvironmentConfig`: unset fields leave the compiler defaults untouched, so a partial object overrides only what it names, and the public surface stays small and intentional. New fields can be added one at a time as they are wired and tested.

`EnvironmentConfig` is re-exported from `swc_ecma_react_compiler` so the config layer can name the type (it was already reachable via the public `PluginOptions.environment`).

Tests:
- unit test covering `environment.enableFunctionOutlining` deserialization;
- fixture `environment-function-outlining-disabled`: with outlining off, a
  closure that captures a local binding stays inline;
- fixture `environment-function-outlining-enabled`: with outlining on (default),
  a closure that captures nothing is outlined into a top-level helper.

**BREAKING CHANGE:**

None. `environment` is a new optional field; existing configs are unaffected.

**Related issue (if exists):**

N/A
