### PR TITLE
ci: use Node.js 24 by default

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -4,7 +4,7 @@ inputs:
   node-version:
     description: "Node version to install"
     required: false
-    default: "20"
+    default: "24"
   install-dependencies:
     description: "Install pnpm dependencies after restoring the pnpm cache"
     required: false


### PR DESCRIPTION
**Description:**

Updates the shared Node.js setup action default from Node.js 20 to Node.js 24.

The publish workflow installs `npm@latest` for trusted publishing. npm 12.0.1 now requires Node.js `^22.22.2 || ^24.15.0 || >=26.0.0`, while the shared action default installed Node.js 20.20.2, causing all native package publish jobs to fail with `EBADENGINE`.

Explicit Node.js 18 and 20 selections remain unchanged, so compatibility jobs continue to use their requested versions.

Validation:
- `pnpm exec prettier --check .github/actions/setup-node/action.yml`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

**Related issue (if exists):**

CI failure: https://github.com/swc-project/swc/actions/runs/29629925600