### PR TITLE
fix(es/minifier): preserve argument aliases in nested scopes

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -787,7 +787,9 @@ impl Optimizer<'_> {
                 ) && var.usage_count == 0
                     && var.flags.contains(VarUsageInfoFlags::DECLARED)
                     && (!var.flags.contains(VarUsageInfoFlags::DECLARED_AS_FN_PARAM)
-                        || !self.data.used_arguments(self.ctx.scope)
+                        // The assignment can be inside a nested function, so query the
+                        // parameter's declaring scope instead of the current scope.
+                        || !self.data.used_arguments(i.id.ctxt)
                         || self.ctx.expr_ctx.in_strict)
                 {
                     report_change!(

--- a/crates/swc_ecma_minifier/tests/fixture/issues/12032/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/12032/config.json
@@ -1,0 +1,5 @@
+{
+    "defaults": true,
+    "toplevel": false,
+    "passes": 0
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/12032/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/12032/input.js
@@ -1,0 +1,13 @@
+function run(f) {
+    f();
+}
+
+function foo(b) {
+    run(() => {
+        b = 2;
+    });
+
+    console.log(arguments[0]);
+}
+
+foo(1);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/12032/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/12032/output.js
@@ -1,0 +1,9 @@
+function run(f) {
+    f();
+}
+function foo(b) {
+    run(()=>{
+        b = 2;
+    }), console.log(arguments[0]);
+}
+foo(1);


### PR DESCRIPTION
**Description:**

Assignments to a function parameter can occur inside a nested closure. The unused-assignment optimizer was checking `arguments` usage in that nested scope, which allowed it to remove the assignment even when the parameter is aliased by the outer non-strict function's `arguments` object.

This changes the lookup to use the parameter's declaring syntax context and adds a regression fixture for the nested-assignment case.

Verification:
- `cargo test -p swc_ecma_minifier --test compress 12032 -- --nocapture`
- `cargo test -p swc_ecma_minifier` (2,128 passed, 1 ignored)
- `cargo clippy -p swc_ecma_minifier --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- Node execution of both fixture input and optimized output (`2` in both cases)

Fixes #12032

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

#12032
