### PR TITLE
ci: use Node.js 24 for wasm publishing

### DIFF
--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -796,7 +796,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Install node dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
**Description:**

The WASM publishing matrix was still using Node.js 20 while installing `npm@latest`. In the failed publish run, that resolved to npm 12.0.1, which requires Node.js `^22.22.2 || ^24.15.0 || >=26.0.0`, so all six WASM packages failed in the `Update npm` step with `EBADENGINE`.

Use Node.js 24 for the WASM publish jobs, matching the repository's default Node.js version and the regular npm publish job that successfully installed the same npm release. This only changes the publishing environment and does not change the published packages' runtime compatibility.

Validation:
- `actionlint 1.7.12 -color -shellcheck=`
- `git diff --check`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

**Related issue (if exists):**

- Failed workflow: https://github.com/swc-project/swc/actions/runs/29675399141