### PR TITLE
perf(es/renamer): Skip identity rename mappings on apply

### DIFF
--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -318,7 +318,16 @@ where
         // later scopes can skip via `to.get(id)`. Without that (e.g. hygiene
         // alone, no resolver), the same Id is reprocessed in every scope and
         // the reverse map blows up.
-        map.retain(|id, v| v.atom() != &id.0);
+        //
+        // Keep identities when `keep_class_names` is set: Operator uses that
+        // flag to rewrite `class Foo` into `let Foo = class Foo`, and on the
+        // old path those identity entries were what kept the map non-empty so
+        // Operator ran. Minifier `keep_classnames` preserves class Ids instead
+        // (they never enter the map), so this does not reintroduce apply work
+        // for those fixtures.
+        if !self.config.keep_class_names {
+            map.retain(|id, v| v.atom() != &id.0);
+        }
 
         map
     }
@@ -328,14 +337,6 @@ where
             self.previous_cache = cache.into_owned();
             self.total_map = Some(Default::default());
         }
-    }
-
-    /// Whether the rename Operator should run.
-    ///
-    /// After stripping identities, an empty map no longer means "nothing to
-    /// do" — `keep_class_names` still needs a visit.
-    fn should_apply_rename_map(&self, map: &FxHashMap<Id, V>) -> bool {
-        !map.is_empty() || self.config.keep_class_names
     }
 }
 
@@ -351,7 +352,7 @@ macro_rules! unit {
             } else {
                 let map = self.get_map(n, false, false, false);
 
-                if self.should_apply_rename_map(&map) {
+                if !map.is_empty() {
                     n.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
                 }
             }
@@ -394,7 +395,7 @@ where
                 self.preserved.remove(&id);
             }
 
-            if self.should_apply_rename_map(&map) {
+            if !map.is_empty() {
                 n.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
             }
         }
@@ -412,7 +413,7 @@ where
                 self.preserved.remove(&id);
             }
 
-            if self.should_apply_rename_map(&map) {
+            if !map.is_empty() {
                 n.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
             }
         }
@@ -470,7 +471,7 @@ where
             m.visit_mut_children_with(self);
         }
 
-        if self.should_apply_rename_map(&map) {
+        if !map.is_empty() {
             m.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
         }
 
@@ -490,7 +491,7 @@ where
             m.visit_mut_children_with(self);
         }
 
-        if self.should_apply_rename_map(&map) {
+        if !map.is_empty() {
             m.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
         }
 

--- a/crates/swc_ecma_transforms_base/src/rename/mod.rs
+++ b/crates/swc_ecma_transforms_base/src/rename/mod.rs
@@ -311,6 +311,15 @@ where
             }
         }
 
+        // Drop identity mappings before apply. Operator already no-ops when
+        // `sym == ident.sym`, so they only inflate the apply walk.
+        //
+        // Identities must still be inserted into `map` *during* analysis so
+        // later scopes can skip via `to.get(id)`. Without that (e.g. hygiene
+        // alone, no resolver), the same Id is reprocessed in every scope and
+        // the reverse map blows up.
+        map.retain(|id, v| v.atom() != &id.0);
+
         map
     }
 
@@ -319,6 +328,14 @@ where
             self.previous_cache = cache.into_owned();
             self.total_map = Some(Default::default());
         }
+    }
+
+    /// Whether the rename Operator should run.
+    ///
+    /// After stripping identities, an empty map no longer means "nothing to
+    /// do" — `keep_class_names` still needs a visit.
+    fn should_apply_rename_map(&self, map: &FxHashMap<Id, V>) -> bool {
+        !map.is_empty() || self.config.keep_class_names
     }
 }
 
@@ -334,7 +351,7 @@ macro_rules! unit {
             } else {
                 let map = self.get_map(n, false, false, false);
 
-                if !map.is_empty() {
+                if self.should_apply_rename_map(&map) {
                     n.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
                 }
             }
@@ -377,7 +394,7 @@ where
                 self.preserved.remove(&id);
             }
 
-            if !map.is_empty() {
+            if self.should_apply_rename_map(&map) {
                 n.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
             }
         }
@@ -395,7 +412,7 @@ where
                 self.preserved.remove(&id);
             }
 
-            if !map.is_empty() {
+            if self.should_apply_rename_map(&map) {
                 n.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
             }
         }
@@ -453,7 +470,7 @@ where
             m.visit_mut_children_with(self);
         }
 
-        if !map.is_empty() {
+        if self.should_apply_rename_map(&map) {
             m.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
         }
 
@@ -473,7 +490,7 @@ where
             m.visit_mut_children_with(self);
         }
 
-        if !map.is_empty() {
+        if self.should_apply_rename_map(&map) {
             m.visit_mut_with(&mut rename_with_config(&map, self.config.clone()));
         }
 


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Hygiene often builds a rename map that is almost entirely identity entries (`foo` → `foo`). The apply Operator already no-ops those lookups, but still walks the full AST.

This change:
- Keeps identity entries in the map **during** analysis so later scopes can still skip via `to.get(id)` (required when hygiene runs without resolver; shared Ids would otherwise blow up the reverse map).
- Strips identity entries with `map.retain` **before** apply when `keep_class_names` is off.
- Leaves identity entries in place when `keep_class_names` is on, so Operator can still rewrite `class Foo` into `let Foo = class Foo` (existing behavior relied on a non-empty identity map). Minifier `keep_classnames` preserves class Ids so they never enter the map and still skip apply.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**