### PR TITLE
refactor(es/ast): Remove Hash from ECMA AST nodes

### DIFF
--- a/.changeset/remove-ecma-ast-hash.md
+++ b/.changeset/remove-ecma-ast-hash.md
@@ -1,0 +1,10 @@
+---
+swc_bundler: major
+swc_core: major
+swc_ecma_ast: major
+swc_ecma_lints: major
+swc_ecma_minifier: major
+swc_ecma_parser: major
+---
+
+refactor(es/ast): Remove `Hash` implementations from ECMA AST nodes

--- a/crates/swc_bundler/src/bundler/export.rs
+++ b/crates/swc_bundler/src/bundler/export.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 use rustc_hash::FxBuildHasher;
-use swc_atoms::{atom, Atom};
-use swc_common::{FileName, SyntaxContext};
+use swc_atoms::{atom, Atom, Wtf8Atom};
+use swc_common::{FileName, Span, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_utils::find_pat_ids;
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
@@ -42,8 +42,71 @@ where
 
 #[derive(Debug, Default)]
 pub(super) struct RawExports {
-    /// Key is None if it's exported from the module itself.
-    pub items: IndexMap<Option<Str>, Vec<Specifier>, FxBuildHasher>,
+    /// Exports declared by the module itself.
+    pub items: Vec<Specifier>,
+
+    /// Exports forwarded from exactly matching source nodes, in declaration
+    /// order.
+    pub reexports: IndexMap<RawExportSource, Vec<Specifier>, FxBuildHasher>,
+}
+
+impl RawExports {
+    /// Returns the group for an exactly matching source node.
+    ///
+    /// A private key preserves ordered-map performance and semantics without
+    /// requiring [`Str`] to implement `Hash`.
+    fn reexports_for(&mut self, src: Str) -> &mut Vec<Specifier> {
+        self.reexports.entry(src.into()).or_default()
+    }
+}
+
+/// Hashable representation used only by the bundler's export index.
+///
+/// Exhaustive conversions ensure this key stays aligned with [`Str`] if the
+/// AST node gains or loses fields.
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub(super) struct RawExportSource {
+    span: Span,
+    value: Wtf8Atom,
+    raw: Option<Atom>,
+}
+
+impl From<Str> for RawExportSource {
+    fn from(src: Str) -> Self {
+        let Str { span, value, raw } = src;
+
+        Self { span, value, raw }
+    }
+}
+
+impl From<RawExportSource> for Str {
+    fn from(src: RawExportSource) -> Self {
+        let RawExportSource { span, value, raw } = src;
+
+        Self { span, value, raw }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use swc_common::DUMMY_SP;
+
+    use super::*;
+
+    #[test]
+    fn groups_identical_reexport_sources() {
+        let src = Str {
+            span: DUMMY_SP,
+            value: "dependency".into(),
+            raw: None,
+        };
+        let mut exports = RawExports::default();
+
+        let _ = exports.reexports_for(src.clone());
+        let _ = exports.reexports_for(src);
+
+        assert_eq!(exports.reexports.len(), 1);
+    }
 }
 
 #[derive(Debug, Default)]
@@ -151,7 +214,7 @@ where
             //                return ModuleItem::Stmt(Stmt::Empty(EmptyStmt { span: DUMMY_SP }));
             //            }
             ModuleItem::ModuleDecl(ModuleDecl::ExportDecl(decl)) => {
-                let v = self.info.items.entry(None).or_default();
+                let v = &mut self.info.items;
                 v.push({
                     let i = match decl.decl {
                         Decl::Class(ref c) => &c.ident,
@@ -179,25 +242,17 @@ where
             }
 
             ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultDecl(_decl)) => {
-                self.info
-                    .items
-                    .entry(None)
-                    .or_default()
-                    .push(Specifier::Specific {
-                        local: Id::new(atom!("default"), SyntaxContext::empty()),
-                        alias: None,
-                    });
+                self.info.items.push(Specifier::Specific {
+                    local: Id::new(atom!("default"), SyntaxContext::empty()),
+                    alias: None,
+                });
             }
 
             ModuleItem::ModuleDecl(ModuleDecl::ExportDefaultExpr(_expr)) => {
-                self.info
-                    .items
-                    .entry(None)
-                    .or_default()
-                    .push(Specifier::Specific {
-                        local: Id::new(atom!("default"), SyntaxContext::empty()),
-                        alias: None,
-                    });
+                self.info.items.push(Specifier::Specific {
+                    local: Id::new(atom!("default"), SyntaxContext::empty()),
+                    alias: None,
+                });
             }
 
             ModuleItem::ModuleDecl(ModuleDecl::ExportNamed(named)) => {
@@ -207,11 +262,11 @@ where
                 });
                 let mut need_wrapping = false;
 
-                let v = self
-                    .info
-                    .items
-                    .entry(named.src.clone().map(|v| *v))
-                    .or_default();
+                let v = if let Some(src) = named.src.clone() {
+                    self.info.reexports_for(*src)
+                } else {
+                    &mut self.info.items
+                };
                 for s in &mut named.specifiers {
                     match s {
                         ExportSpecifier::Namespace(n) => {
@@ -309,7 +364,7 @@ where
                     .encode(&mut all.with);
                 }
 
-                self.info.items.entry(Some(*all.src.clone())).or_default();
+                let _ = self.info.reexports_for(*all.src.clone());
             }
             _ => {}
         }

--- a/crates/swc_bundler/src/bundler/load.rs
+++ b/crates/swc_bundler/src/bundler/load.rs
@@ -235,46 +235,35 @@ where
             let mut files = Vec::new();
 
             let mut exports = Exports::default();
+            exports.items.extend(raw.items);
 
-            let items = raw
-                .items
+            let reexports = raw
+                .reexports
                 .into_par_iter()
                 .map(|(src, ss)| -> Result<_, Error> {
                     self.run(|| {
-                        let info = match src {
-                            Some(src) => {
-                                let name = self.resolve(base, &src.value.to_string_lossy())?;
-                                let (id, local_mark, export_mark) =
-                                    self.scope.module_id_gen.gen(&name);
-                                Some((id, local_mark, export_mark, name, src))
-                            }
-                            None => None,
-                        };
+                        let src: Str = src.into();
+                        let name = self.resolve(base, &src.value.to_string_lossy())?;
+                        let (id, local_mark, export_mark) = self.scope.module_id_gen.gen(&name);
 
-                        Ok((info, ss))
+                        Ok(((id, local_mark, export_mark, name, src), ss))
                     })
                 })
                 .collect::<Vec<_>>();
 
-            for res in items {
-                let (info, specifiers) = res?;
+            for res in reexports {
+                let ((id, local_mark, export_mark, name, src), specifiers) = res?;
 
-                match info {
-                    None => exports.items.extend(specifiers),
-                    Some((id, local_mark, export_mark, name, src)) => {
-                        //
-                        let src = Source {
-                            is_loaded_synchronously: true,
-                            is_unconditional: false,
-                            module_id: id,
-                            local_ctxt: SyntaxContext::empty().apply_mark(local_mark),
-                            export_ctxt: SyntaxContext::empty().apply_mark(export_mark),
-                            src,
-                        };
-                        exports.reexports.push((src.clone(), specifiers));
-                        files.push((src, name));
-                    }
-                }
+                let src = Source {
+                    is_loaded_synchronously: true,
+                    is_unconditional: false,
+                    module_id: id,
+                    local_ctxt: SyntaxContext::empty().apply_mark(local_mark),
+                    export_ctxt: SyntaxContext::empty().apply_mark(export_mark),
+                    src,
+                };
+                exports.reexports.push((src.clone(), specifiers));
+                files.push((src, name));
             }
 
             Ok((exports, files))
@@ -413,7 +402,7 @@ pub(crate) enum Specifier {
     },
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Source {
     pub is_loaded_synchronously: bool,
     pub is_unconditional: bool,

--- a/crates/swc_bundler/src/util.rs
+++ b/crates/swc_bundler/src/util.rs
@@ -2,6 +2,7 @@
 
 use std::hash::Hash;
 
+#[cfg(feature = "concurrent")]
 use rustc_hash::FxBuildHasher;
 #[cfg(not(feature = "concurrent"))]
 use rustc_hash::FxHashMap;

--- a/crates/swc_ecma_ast/src/class.rs
+++ b/crates/swc_ecma_ast/src/class.rs
@@ -15,7 +15,7 @@ use crate::{
 };
 
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Class {
@@ -67,7 +67,7 @@ impl Take for Class {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ClassMember {
@@ -104,7 +104,7 @@ impl Take for ClassMember {
 }
 
 #[ast_node("ClassProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ClassProp {
@@ -162,7 +162,7 @@ pub struct ClassProp {
 }
 
 #[ast_node("PrivateProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct PrivateProp {
@@ -216,7 +216,7 @@ pub struct PrivateProp {
 }
 
 #[ast_node("ClassMethod")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ClassMethod {
@@ -244,7 +244,7 @@ pub struct ClassMethod {
 }
 
 #[ast_node("PrivateMethod")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct PrivateMethod {
@@ -272,7 +272,7 @@ pub struct PrivateMethod {
 }
 
 #[ast_node("Constructor")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Constructor {
@@ -303,7 +303,7 @@ pub struct Constructor {
 }
 
 #[ast_node("Decorator")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Decorator {
@@ -313,7 +313,7 @@ pub struct Decorator {
     pub expr: Box<Expr>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
@@ -333,7 +333,7 @@ pub enum MethodKind {
 }
 
 #[ast_node("StaticBlock")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct StaticBlock {
@@ -352,7 +352,7 @@ impl Take for StaticBlock {
 
 /// Either a private name or a public name.
 #[ast_node]
-#[derive(Is, Eq, Hash, EqIgnoreSpan)]
+#[derive(Is, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Key {
@@ -386,7 +386,7 @@ impl Default for Key {
 }
 
 #[ast_node("AutoAccessor")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AutoAccessor {

--- a/crates/swc_ecma_ast/src/decl.rs
+++ b/crates/swc_ecma_ast/src/decl.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Decl {
@@ -95,7 +95,7 @@ impl Take for Decl {
 }
 
 #[ast_node("FunctionDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct FnDecl {
@@ -121,7 +121,7 @@ impl Take for FnDecl {
 }
 
 #[ast_node("ClassDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ClassDecl {
@@ -147,7 +147,7 @@ impl Take for ClassDecl {
 }
 
 #[ast_node("VariableDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct VarDecl {
@@ -170,7 +170,7 @@ impl Take for VarDecl {
     }
 }
 
-#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
+#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
@@ -189,7 +189,7 @@ pub enum VarDeclKind {
 }
 
 #[ast_node("VariableDeclarator")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct VarDeclarator {
@@ -222,7 +222,7 @@ impl Take for VarDeclarator {
 }
 
 #[ast_node("UsingDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct UsingDecl {

--- a/crates/swc_ecma_ast/src/expr.rs
+++ b/crates/swc_ecma_ast/src/expr.rs
@@ -27,7 +27,7 @@ use crate::{
 };
 
 #[ast_node(no_clone)]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Expr {
@@ -495,7 +495,7 @@ boxed_expr!(OptChainExpr);
 boxed_expr!(Invalid);
 
 #[ast_node("ThisExpression")]
-#[derive(Eq, Hash, Copy, EqIgnoreSpan)]
+#[derive(Eq, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ThisExpr {
@@ -510,7 +510,7 @@ impl Take for ThisExpr {
 
 /// Array literal.
 #[ast_node("ArrayExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ArrayLit {
@@ -535,7 +535,7 @@ impl Take for ArrayLit {
 
 /// Object literal.
 #[ast_node("ObjectExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ObjectLit {
@@ -609,7 +609,7 @@ impl From<ImportWith> for ObjectLit {
 /// strings or idents as keys, can't be nested, can only have string literals as
 /// values:
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, EqIgnoreSpan)]
+#[derive(Debug, Clone, PartialEq, Eq, EqIgnoreSpan)]
 pub struct ImportWith {
     pub span: Span,
     pub values: Vec<ImportWithItem>,
@@ -627,7 +627,7 @@ impl ImportWith {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, EqIgnoreSpan)]
+#[derive(Debug, Clone, PartialEq, Eq, EqIgnoreSpan)]
 pub struct ImportWithItem {
     pub key: IdentName,
     pub value: Str,
@@ -643,7 +643,7 @@ impl Take for ObjectLit {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum PropOrSpread {
@@ -667,7 +667,7 @@ impl Take for PropOrSpread {
 }
 
 #[ast_node("SpreadElement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SpreadElement {
@@ -690,7 +690,7 @@ impl Take for SpreadElement {
 }
 
 #[ast_node("UnaryExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct UnaryExpr {
@@ -714,7 +714,7 @@ impl Take for UnaryExpr {
 }
 
 #[ast_node("UpdateExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct UpdateExpr {
@@ -741,7 +741,7 @@ impl Take for UpdateExpr {
 }
 
 #[ast_node("BinaryExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BinExpr {
@@ -768,7 +768,7 @@ impl Take for BinExpr {
 
 /// Function expression.
 #[ast_node("FunctionExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct FnExpr {
@@ -807,7 +807,7 @@ bridge_expr_from!(FnExpr, Box<Function>);
 
 /// Class expression.
 #[ast_node("ClassExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ClassExpr {
@@ -842,7 +842,7 @@ bridge_from!(ClassExpr, Box<Class>, Class);
 bridge_expr_from!(ClassExpr, Box<Class>);
 
 #[ast_node("AssignmentExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignExpr {
@@ -874,7 +874,7 @@ impl AssignExpr {
 }
 
 #[ast_node("MemberExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct MemberExpr {
@@ -888,7 +888,7 @@ pub struct MemberExpr {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum MemberProp {
@@ -907,7 +907,7 @@ impl MemberProp {
 }
 
 #[ast_node("SuperPropExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SuperPropExpr {
@@ -920,7 +920,7 @@ pub struct SuperPropExpr {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum SuperProp {
@@ -965,7 +965,7 @@ impl Default for SuperProp {
 }
 
 #[ast_node("ConditionalExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct CondExpr {
@@ -992,7 +992,7 @@ impl Take for CondExpr {
 }
 
 #[ast_node("CallExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct CallExpr {
@@ -1020,7 +1020,7 @@ impl Take for CallExpr {
 }
 
 #[ast_node("NewExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct NewExpr {
@@ -1053,7 +1053,7 @@ impl Take for NewExpr {
 }
 
 #[ast_node("SequenceExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SeqExpr {
@@ -1073,7 +1073,7 @@ impl Take for SeqExpr {
 }
 
 #[ast_node("ArrowFunctionExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ArrowExpr {
@@ -1116,7 +1116,7 @@ impl Take for ArrowExpr {
 }
 
 #[ast_node("YieldExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct YieldExpr {
@@ -1144,7 +1144,7 @@ impl Take for YieldExpr {
 }
 
 #[ast_node("MetaProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan, Copy)]
+#[derive(Eq, EqIgnoreSpan, Copy)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct MetaPropExpr {
@@ -1152,7 +1152,7 @@ pub struct MetaPropExpr {
     pub kind: MetaPropKind,
 }
 
-#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan)]
+#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
@@ -1168,7 +1168,7 @@ pub enum MetaPropKind {
 }
 
 #[ast_node("AwaitExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AwaitExpr {
@@ -1179,7 +1179,7 @@ pub struct AwaitExpr {
 }
 
 #[ast_node("TemplateLiteral")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Tpl {
@@ -1202,7 +1202,7 @@ impl Take for Tpl {
 }
 
 #[ast_node("TaggedTemplateExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TaggedTpl {
@@ -1231,7 +1231,7 @@ impl Take for TaggedTpl {
 }
 
 #[ast_node("TemplateElement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TplElement {
     pub span: Span,
@@ -1282,7 +1282,7 @@ impl<'a> arbitrary::Arbitrary<'a> for TplElement {
 }
 
 #[ast_node("ParenthesisExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ParenExpr {
@@ -1301,7 +1301,7 @@ impl Take for ParenExpr {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Callee {
@@ -1329,7 +1329,7 @@ impl Take for Callee {
 }
 
 #[ast_node("Super")]
-#[derive(Eq, Hash, Copy, EqIgnoreSpan, Default)]
+#[derive(Eq, Copy, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Super {
@@ -1343,7 +1343,7 @@ impl Take for Super {
 }
 
 #[ast_node("Import")]
-#[derive(Eq, Hash, Copy, EqIgnoreSpan)]
+#[derive(Eq, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Import {
@@ -1360,7 +1360,7 @@ impl Take for Import {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash, EqIgnoreSpan)]
+#[derive(Clone, Debug, PartialEq, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
@@ -1413,7 +1413,7 @@ impl From<Box<Expr>> for ExprOrSpread {
 bridge_from!(ExprOrSpread, Box<Expr>, Expr);
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
@@ -1446,7 +1446,7 @@ impl Take for BlockStmtOrExpr {
 }
 
 #[ast_node]
-#[derive(Is, Eq, Hash, EqIgnoreSpan)]
+#[derive(Is, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum AssignTarget {
@@ -1500,7 +1500,7 @@ impl TryFrom<Box<Expr>> for AssignTarget {
 }
 
 #[ast_node]
-#[derive(Is, Eq, Hash, EqIgnoreSpan)]
+#[derive(Is, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum AssignTargetPat {
@@ -1557,7 +1557,7 @@ impl TryFrom<Pat> for AssignTargetPat {
 }
 
 #[ast_node]
-#[derive(Is, Eq, Hash, EqIgnoreSpan)]
+#[derive(Is, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum SimpleAssignTarget {
@@ -1682,7 +1682,7 @@ impl Take for AssignTarget {
 }
 
 #[ast_node("OptionalChainingExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct OptChainExpr {
@@ -1693,7 +1693,7 @@ pub struct OptChainExpr {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum OptChainBase {
@@ -1710,7 +1710,7 @@ impl Default for OptChainBase {
 }
 
 #[ast_node("CallExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct OptCall {

--- a/crates/swc_ecma_ast/src/function.rs
+++ b/crates/swc_ecma_ast/src/function.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// Common parts of function and method.
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Function {
@@ -62,7 +62,7 @@ impl Take for Function {
 }
 
 #[ast_node("Parameter")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Param {
@@ -83,7 +83,7 @@ impl From<Pat> for Param {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ParamOrTsParamProp {

--- a/crates/swc_ecma_ast/src/ident.rs
+++ b/crates/swc_ecma_ast/src/ident.rs
@@ -15,7 +15,7 @@ use swc_common::{
 use crate::{typescript::TsTypeAnn, Expr};
 
 /// Identifier used as a pattern.
-#[derive(Clone, Debug, PartialEq, Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Clone, Debug, PartialEq, Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
@@ -155,7 +155,7 @@ bridge_from!(BindingIdent, Ident, Id);
 /// There's a type named [Id] which only contains minimal information to
 /// distinguish identifiers.
 #[ast_node("Identifier")]
-#[derive(Eq, Hash, Default)]
+#[derive(Eq, Default)]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Ident {
     pub span: Span,
@@ -391,7 +391,7 @@ impl Ident {
 }
 
 #[ast_node("Identifier")]
-#[derive(Eq, Hash, Default, EqIgnoreSpan)]
+#[derive(Eq, Default, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct IdentName {
@@ -552,7 +552,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Ident {
 }
 
 #[ast_node("PrivateName")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct PrivateName {

--- a/crates/swc_ecma_ast/src/jsx.rs
+++ b/crates/swc_ecma_ast/src/jsx.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// Used for `obj` property of `JSXMemberExpr`.
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
@@ -23,7 +23,7 @@ pub enum JSXObject {
 }
 
 #[ast_node("JSXMemberExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXMemberExpr {
@@ -38,7 +38,7 @@ pub struct JSXMemberExpr {
 
 /// XML-based namespace syntax:
 #[ast_node("JSXNamespacedName")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXNamespacedName {
@@ -49,7 +49,7 @@ pub struct JSXNamespacedName {
 }
 
 #[ast_node("JSXEmptyExpression")]
-#[derive(Eq, Hash, Copy, EqIgnoreSpan)]
+#[derive(Eq, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXEmptyExpr {
@@ -57,7 +57,7 @@ pub struct JSXEmptyExpr {
 }
 
 #[ast_node("JSXExpressionContainer")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXExprContainer {
@@ -67,7 +67,7 @@ pub struct JSXExprContainer {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
@@ -79,7 +79,7 @@ pub enum JSXExpr {
 }
 
 #[ast_node("JSXSpreadChild")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXSpreadChild {
@@ -89,7 +89,7 @@ pub struct JSXSpreadChild {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXElementName {
@@ -108,7 +108,7 @@ impl Take for JSXElementName {
 }
 
 #[ast_node("JSXOpeningElement")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXOpeningElement {
@@ -145,7 +145,7 @@ impl Take for JSXOpeningElement {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
@@ -157,7 +157,7 @@ pub enum JSXAttrOrSpread {
 }
 
 #[ast_node("JSXClosingElement")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXClosingElement {
@@ -166,7 +166,7 @@ pub struct JSXClosingElement {
 }
 
 #[ast_node("JSXAttribute")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXAttr {
@@ -181,7 +181,7 @@ pub struct JSXAttr {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXAttrName {
@@ -192,7 +192,7 @@ pub enum JSXAttrName {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXAttrValue {
@@ -210,7 +210,7 @@ pub enum JSXAttrValue {
 }
 
 #[ast_node("JSXText")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXText {
     pub span: Span,
@@ -231,7 +231,7 @@ impl<'a> arbitrary::Arbitrary<'a> for JSXText {
 }
 
 #[ast_node("JSXElement")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXElement {
@@ -257,7 +257,7 @@ impl Take for JSXElement {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum JSXElementChild {
@@ -278,7 +278,7 @@ pub enum JSXElementChild {
 }
 
 #[ast_node("JSXFragment")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXFragment {
@@ -304,7 +304,7 @@ impl Take for JSXFragment {
 }
 
 #[ast_node("JSXOpeningFragment")]
-#[derive(Eq, Hash, Copy, EqIgnoreSpan)]
+#[derive(Eq, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXOpeningFragment {
@@ -318,7 +318,7 @@ impl Take for JSXOpeningFragment {
 }
 
 #[ast_node("JSXClosingFragment")]
-#[derive(Eq, Hash, Copy, EqIgnoreSpan)]
+#[derive(Eq, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct JSXClosingFragment {

--- a/crates/swc_ecma_ast/src/lib.rs
+++ b/crates/swc_ecma_ast/src/lib.rs
@@ -332,7 +332,7 @@ where
 
 /// Represents a invalid node.
 #[ast_node("Invalid")]
-#[derive(Eq, Default, Hash, Copy, EqIgnoreSpan)]
+#[derive(Eq, Default, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Invalid {

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -1,7 +1,6 @@
 use std::{
     borrow::Cow,
     fmt::{self, Display, Formatter},
-    hash::{Hash, Hasher},
 };
 
 use is_macro::Is;
@@ -15,7 +14,7 @@ use swc_common::{ast_node, errors::HANDLER, util::take::Take, EqIgnoreSpan, Span
 use crate::{jsx::JSXText, TplElement};
 
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan, Is)]
+#[derive(Eq, EqIgnoreSpan, Is)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Lit {
@@ -83,7 +82,7 @@ impl Lit {
 }
 
 #[ast_node("BigIntLiteral")]
-#[derive(Eq, Hash)]
+#[derive(Eq)]
 pub struct BigInt {
     pub span: Span,
     #[cfg_attr(feature = "encoding-impl", encoding(with = "EncodeBigInt2"))]
@@ -162,7 +161,7 @@ impl From<BigIntValue> for BigInt {
 
 /// A string literal.
 #[ast_node("StringLiteral")]
-#[derive(Eq, Hash)]
+#[derive(Eq)]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Str {
     pub span: Span,
@@ -433,7 +432,7 @@ bridge_from!(Str, Atom, Cow<'_, str>);
 ///
 /// All of `Box<Expr>`, `Expr`, `Lit`, `Bool` implements `From<bool>`.
 #[ast_node("BooleanLiteral")]
-#[derive(Copy, Eq, Hash, EqIgnoreSpan)]
+#[derive(Copy, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Bool {
@@ -461,7 +460,7 @@ impl From<bool> for Bool {
 }
 
 #[ast_node("NullLiteral")]
-#[derive(Copy, Eq, Hash, EqIgnoreSpan)]
+#[derive(Copy, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Null {
@@ -475,7 +474,7 @@ impl Take for Null {
 }
 
 #[ast_node("RegExpLiteral")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Regex {
     pub span: Span,
@@ -527,8 +526,6 @@ impl<'a> arbitrary::Arbitrary<'a> for Regex {
 pub struct Number {
     pub span: Span,
     /// **Note**: This should not be `NaN`. Use [crate::Ident] to represent NaN.
-    ///
-    /// If you store `NaN` in this field, a hash map will behave strangely.
     pub value: f64,
 
     /// Use `None` value only for transformations to avoid recalculate
@@ -545,30 +542,6 @@ impl Eq for Number {}
 impl EqIgnoreSpan for Number {
     fn eq_ignore_span(&self, other: &Self) -> bool {
         self.value == other.value && self.value.is_sign_positive() == other.value.is_sign_positive()
-    }
-}
-
-#[allow(clippy::derived_hash_with_manual_eq)]
-#[allow(unnecessary_transmutes)]
-impl Hash for Number {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        fn integer_decode(val: f64) -> (u64, i16, i8) {
-            let bits: u64 = val.to_bits();
-            let sign: i8 = if bits >> 63 == 0 { 1 } else { -1 };
-            let mut exponent: i16 = ((bits >> 52) & 0x7ff) as i16;
-            let mantissa = if exponent == 0 {
-                (bits & 0xfffffffffffff) << 1
-            } else {
-                (bits & 0xfffffffffffff) | 0x10000000000000
-            };
-
-            exponent -= 1023 + 52;
-            (mantissa, exponent, sign)
-        }
-
-        self.span.hash(state);
-        integer_decode(self.value).hash(state);
-        self.raw.hash(state);
     }
 }
 

--- a/crates/swc_ecma_ast/src/module.rs
+++ b/crates/swc_ecma_ast/src/module.rs
@@ -5,7 +5,7 @@ use swc_common::{ast_node, util::take::Take, EqIgnoreSpan, Span, DUMMY_SP};
 use crate::{module_decl::ModuleDecl, stmt::Stmt};
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Program {
@@ -22,7 +22,7 @@ impl Take for Program {
 }
 
 #[ast_node("Module")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Module {
     pub span: Span,
@@ -62,7 +62,7 @@ impl Take for Module {
 }
 
 #[ast_node("Script")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct Script {
     pub span: Span,
@@ -102,7 +102,7 @@ impl Take for Script {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ModuleItem {

--- a/crates/swc_ecma_ast/src/module_decl.rs
+++ b/crates/swc_ecma_ast/src/module_decl.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ModuleDecl {
@@ -94,7 +94,7 @@ impl Take for ModuleDecl {
 ///
 /// is [`ExportDefaultExpr`] and it's not hoisted.
 #[ast_node("ExportDefaultExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultExpr {
@@ -105,7 +105,7 @@ pub struct ExportDefaultExpr {
 }
 
 #[ast_node("ExportDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDecl {
@@ -116,7 +116,7 @@ pub struct ExportDecl {
 }
 
 #[ast_node("ImportDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportDecl {
@@ -142,7 +142,7 @@ pub struct ImportDecl {
     pub phase: ImportPhase,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Default, EqIgnoreSpan)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Default, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
@@ -176,7 +176,7 @@ impl Take for ImportDecl {
 
 /// `export * from 'mod'`
 #[ast_node("ExportAllDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportAll {
@@ -210,7 +210,7 @@ impl Take for ExportAll {
 /// `export { foo } from 'mod'`
 /// `export { foo as bar } from 'mod'`
 #[ast_node("ExportNamedDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct NamedExport {
@@ -249,7 +249,7 @@ impl Take for NamedExport {
 }
 
 #[ast_node("ExportDefaultDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultDecl {
@@ -259,7 +259,7 @@ pub struct ExportDefaultDecl {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum DefaultDecl {
@@ -275,7 +275,7 @@ pub enum DefaultDecl {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ImportSpecifier {
@@ -320,7 +320,7 @@ impl ImportSpecifier {
 
 /// e.g. `import foo from 'mod.js'`
 #[ast_node("ImportDefaultSpecifier")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportDefaultSpecifier {
@@ -330,7 +330,7 @@ pub struct ImportDefaultSpecifier {
 }
 /// e.g. `import * as foo from 'mod.js'`.
 #[ast_node("ImportNamespaceSpecifier")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportStarAsSpecifier {
@@ -342,7 +342,7 @@ pub struct ImportStarAsSpecifier {
 /// e.g. local = bar, imported = Some(foo) for `import { foo as bar } from
 /// 'mod.js'`
 #[ast_node("ImportSpecifier")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ImportNamedSpecifier {
@@ -362,7 +362,7 @@ pub struct ImportNamedSpecifier {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ExportSpecifier {
@@ -378,7 +378,7 @@ pub enum ExportSpecifier {
 
 /// `export * as foo from 'src';`
 #[ast_node("ExportNamespaceSpecifier")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportNamespaceSpecifier {
@@ -389,7 +389,7 @@ pub struct ExportNamespaceSpecifier {
 
 // export v from 'mod';
 #[ast_node("ExportDefaultSpecifier")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportDefaultSpecifier {
@@ -398,7 +398,7 @@ pub struct ExportDefaultSpecifier {
 }
 
 #[ast_node("ExportSpecifier")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExportNamedSpecifier {
@@ -418,7 +418,7 @@ pub struct ExportNamedSpecifier {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 // https://tc39.es/ecma262/#prod-ModuleExportName

--- a/crates/swc_ecma_ast/src/operators.rs
+++ b/crates/swc_ecma_ast/src/operators.rs
@@ -1,7 +1,7 @@
 use string_enum::StringEnum;
 use swc_common::EqIgnoreSpan;
 
-#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
+#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
@@ -113,7 +113,7 @@ impl BinaryOp {
     }
 }
 
-#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
+#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
@@ -189,7 +189,7 @@ impl AssignOp {
     }
 }
 
-#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
+#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
@@ -205,7 +205,7 @@ pub enum UpdateOp {
     MinusMinus,
 }
 
-#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash, EqIgnoreSpan, Default)]
+#[derive(StringEnum, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(

--- a/crates/swc_ecma_ast/src/pat.rs
+++ b/crates/swc_ecma_ast/src/pat.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 #[ast_node(no_clone)]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Pat {
@@ -86,7 +86,7 @@ pat_to_other!(RestPat);
 pat_to_other!(Box<Expr>);
 
 #[ast_node("ArrayPattern")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ArrayPat {
@@ -112,7 +112,7 @@ pub struct ArrayPat {
 }
 
 #[ast_node("ObjectPattern")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ObjectPat {
@@ -134,7 +134,7 @@ pub struct ObjectPat {
 }
 
 #[ast_node("AssignmentPattern")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignPat {
@@ -147,7 +147,7 @@ pub struct AssignPat {
 
 /// EsTree `RestElement`
 #[ast_node("RestElement")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct RestPat {
@@ -168,7 +168,7 @@ pub struct RestPat {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ObjectPatProp {
@@ -184,7 +184,7 @@ pub enum ObjectPatProp {
 
 /// `{key: value}`
 #[ast_node("KeyValuePatternProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct KeyValuePatProp {
@@ -196,7 +196,7 @@ pub struct KeyValuePatProp {
 }
 /// `{key}` or `{key = value}`
 #[ast_node("AssignmentPatternProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignPatProp {

--- a/crates/swc_ecma_ast/src/prop.rs
+++ b/crates/swc_ecma_ast/src/prop.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Prop {
@@ -41,7 +41,7 @@ pub enum Prop {
 bridge_from!(Prop, Ident, IdentName);
 
 #[ast_node("KeyValueProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct KeyValueProp {
@@ -53,7 +53,7 @@ pub struct KeyValueProp {
 }
 
 #[ast_node("AssignmentProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct AssignProp {
@@ -63,7 +63,7 @@ pub struct AssignProp {
 }
 
 #[ast_node("GetterProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct GetterProp {
@@ -83,7 +83,7 @@ pub struct GetterProp {
     pub body: Option<BlockStmt>,
 }
 #[ast_node("SetterProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SetterProp {
@@ -103,7 +103,7 @@ pub struct SetterProp {
     pub body: Option<BlockStmt>,
 }
 #[ast_node("MethodProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct MethodProp {
@@ -115,7 +115,7 @@ pub struct MethodProp {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum PropName {
@@ -172,7 +172,7 @@ impl From<PropName> for MemberProp {
 }
 
 #[ast_node("Computed")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ComputedPropName {

--- a/crates/swc_ecma_ast/src/stmt.rs
+++ b/crates/swc_ecma_ast/src/stmt.rs
@@ -10,7 +10,7 @@ use crate::{
 
 /// Use when only block statements are allowed.
 #[ast_node("BlockStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BlockStmt {
@@ -33,7 +33,7 @@ impl Take for BlockStmt {
 }
 
 #[ast_node(no_clone)]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum Stmt {
@@ -214,7 +214,7 @@ impl Take for Stmt {
 }
 
 #[ast_node("ExpressionStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ExprStmt {
@@ -224,7 +224,7 @@ pub struct ExprStmt {
 }
 
 #[ast_node("EmptyStatement")]
-#[derive(Eq, Hash, Copy, EqIgnoreSpan)]
+#[derive(Eq, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct EmptyStmt {
@@ -233,7 +233,7 @@ pub struct EmptyStmt {
 }
 
 #[ast_node("DebuggerStatement")]
-#[derive(Eq, Hash, Copy, EqIgnoreSpan)]
+#[derive(Eq, Copy, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct DebuggerStmt {
@@ -241,7 +241,7 @@ pub struct DebuggerStmt {
 }
 
 #[ast_node("WithStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct WithStmt {
@@ -252,7 +252,7 @@ pub struct WithStmt {
 }
 
 #[ast_node("ReturnStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ReturnStmt {
@@ -266,7 +266,7 @@ pub struct ReturnStmt {
 }
 
 #[ast_node("LabeledStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct LabeledStmt {
@@ -276,7 +276,7 @@ pub struct LabeledStmt {
 }
 
 #[ast_node("BreakStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct BreakStmt {
@@ -290,7 +290,7 @@ pub struct BreakStmt {
 }
 
 #[ast_node("ContinueStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ContinueStmt {
@@ -304,7 +304,7 @@ pub struct ContinueStmt {
 }
 
 #[ast_node("IfStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct IfStmt {
@@ -323,7 +323,7 @@ pub struct IfStmt {
 }
 
 #[ast_node("SwitchStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SwitchStmt {
@@ -333,7 +333,7 @@ pub struct SwitchStmt {
 }
 
 #[ast_node("ThrowStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ThrowStmt {
@@ -343,7 +343,7 @@ pub struct ThrowStmt {
 }
 
 #[ast_node("TryStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TryStmt {
@@ -367,7 +367,7 @@ pub struct TryStmt {
 }
 
 #[ast_node("WhileStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct WhileStmt {
@@ -377,7 +377,7 @@ pub struct WhileStmt {
 }
 
 #[ast_node("DoWhileStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct DoWhileStmt {
@@ -387,7 +387,7 @@ pub struct DoWhileStmt {
 }
 
 #[ast_node("ForStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForStmt {
@@ -418,7 +418,7 @@ pub struct ForStmt {
 }
 
 #[ast_node("ForInStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForInStmt {
@@ -429,7 +429,7 @@ pub struct ForInStmt {
 }
 
 #[ast_node("ForOfStatement")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct ForOfStmt {
@@ -453,7 +453,7 @@ impl Take for ForOfStmt {
 }
 
 #[ast_node("SwitchCase")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct SwitchCase {
@@ -482,7 +482,7 @@ impl Take for SwitchCase {
 }
 
 #[ast_node("CatchClause")]
-#[derive(Eq, Hash, EqIgnoreSpan, Default)]
+#[derive(Eq, EqIgnoreSpan, Default)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct CatchClause {
@@ -503,7 +503,7 @@ pub struct CatchClause {
 
 /// A head for for-in and for-of loop.
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum ForHead {
@@ -533,7 +533,7 @@ impl Default for ForHead {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]

--- a/crates/swc_ecma_ast/src/typescript.rs
+++ b/crates/swc_ecma_ast/src/typescript.rs
@@ -24,7 +24,7 @@ use crate::{
 };
 
 #[ast_node("TsTypeAnnotation")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeAnn {
@@ -34,7 +34,7 @@ pub struct TsTypeAnn {
 }
 
 #[ast_node("TsTypeParameterDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeParamDecl {
@@ -44,7 +44,7 @@ pub struct TsTypeParamDecl {
 }
 
 #[ast_node("TsTypeParameter")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeParam {
@@ -76,7 +76,7 @@ pub struct TsTypeParam {
 }
 
 #[ast_node("TsTypeParameterInstantiation")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeParamInstantiation {
@@ -85,7 +85,7 @@ pub struct TsTypeParamInstantiation {
 }
 
 #[ast_node("TsParameterProperty")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsParamProp {
@@ -106,7 +106,7 @@ pub struct TsParamProp {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsParamPropParam {
@@ -118,7 +118,7 @@ pub enum TsParamPropParam {
 }
 
 #[ast_node("TsQualifiedName")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsQualifiedName {
@@ -128,7 +128,7 @@ pub struct TsQualifiedName {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
@@ -145,7 +145,7 @@ pub enum TsEntityName {
 // ================
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsTypeElement {
@@ -172,7 +172,7 @@ pub enum TsTypeElement {
 }
 
 #[ast_node("TsCallSignatureDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsCallSignatureDecl {
@@ -193,7 +193,7 @@ pub struct TsCallSignatureDecl {
 }
 
 #[ast_node("TsConstructSignatureDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConstructSignatureDecl {
@@ -214,7 +214,7 @@ pub struct TsConstructSignatureDecl {
 }
 
 #[ast_node("TsPropertySignature")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsPropertySignature {
@@ -232,7 +232,7 @@ pub struct TsPropertySignature {
 }
 
 #[ast_node("TsGetterSignature")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsGetterSignature {
@@ -248,7 +248,7 @@ pub struct TsGetterSignature {
 }
 
 #[ast_node("TsSetterSignature")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsSetterSignature {
@@ -259,7 +259,7 @@ pub struct TsSetterSignature {
 }
 
 #[ast_node("TsMethodSignature")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsMethodSignature {
@@ -283,7 +283,7 @@ pub struct TsMethodSignature {
 }
 
 #[ast_node("TsIndexSignature")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsIndexSignature {
@@ -306,7 +306,7 @@ pub struct TsIndexSignature {
 // ================
 
 #[ast_node(no_clone)]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsType {
@@ -406,7 +406,7 @@ impl Clone for TsType {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsFnOrConstructorType {
@@ -441,7 +441,7 @@ impl From<TsIntersectionType> for TsType {
 }
 
 #[ast_node("TsKeywordType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsKeywordType {
@@ -449,7 +449,7 @@ pub struct TsKeywordType {
     pub kind: TsKeywordTypeKind,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, EqIgnoreSpan)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
@@ -500,7 +500,7 @@ pub enum TsKeywordTypeKind {
 }
 
 #[ast_node("TsThisType")]
-#[derive(Copy, Eq, Hash, EqIgnoreSpan)]
+#[derive(Copy, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsThisType {
@@ -508,7 +508,7 @@ pub struct TsThisType {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsFnParam {
@@ -526,7 +526,7 @@ pub enum TsFnParam {
 }
 
 #[ast_node("TsFunctionType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsFnType {
@@ -544,7 +544,7 @@ pub struct TsFnType {
 }
 
 #[ast_node("TsConstructorType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConstructorType {
@@ -562,7 +562,7 @@ pub struct TsConstructorType {
 }
 
 #[ast_node("TsTypeReference")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeRef {
@@ -577,7 +577,7 @@ pub struct TsTypeRef {
 }
 
 #[ast_node("TsTypePredicate")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypePredicate {
@@ -593,7 +593,7 @@ pub struct TsTypePredicate {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[allow(variant_size_differences)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
@@ -607,7 +607,7 @@ pub enum TsThisTypeOrIdent {
 
 /// `typeof` operator
 #[ast_node("TsTypeQuery")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeQuery {
@@ -622,7 +622,7 @@ pub struct TsTypeQuery {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsTypeQueryExpr {
@@ -634,7 +634,7 @@ pub enum TsTypeQueryExpr {
 }
 
 #[ast_node("TsImportCallOptions")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsImportCallOptions {
@@ -644,7 +644,7 @@ pub struct TsImportCallOptions {
 }
 
 #[ast_node("TsImportType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsImportType {
@@ -671,7 +671,7 @@ pub struct TsImportType {
 }
 
 #[ast_node("TsTypeLiteral")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeLit {
@@ -680,7 +680,7 @@ pub struct TsTypeLit {
 }
 
 #[ast_node("TsArrayType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsArrayType {
@@ -689,7 +689,7 @@ pub struct TsArrayType {
 }
 
 #[ast_node("TsTupleType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTupleType {
@@ -698,7 +698,7 @@ pub struct TsTupleType {
 }
 
 #[ast_node("TsTupleElement")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTupleElement {
@@ -713,7 +713,7 @@ pub struct TsTupleElement {
 }
 
 #[ast_node("TsOptionalType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsOptionalType {
@@ -723,7 +723,7 @@ pub struct TsOptionalType {
 }
 
 #[ast_node("TsRestType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsRestType {
@@ -733,7 +733,7 @@ pub struct TsRestType {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsUnionOrIntersectionType {
@@ -745,7 +745,7 @@ pub enum TsUnionOrIntersectionType {
 }
 
 #[ast_node("TsUnionType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsUnionType {
@@ -754,7 +754,7 @@ pub struct TsUnionType {
 }
 
 #[ast_node("TsIntersectionType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsIntersectionType {
@@ -763,7 +763,7 @@ pub struct TsIntersectionType {
 }
 
 #[ast_node("TsConditionalType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConditionalType {
@@ -775,7 +775,7 @@ pub struct TsConditionalType {
 }
 
 #[ast_node("TsInferType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInferType {
@@ -784,7 +784,7 @@ pub struct TsInferType {
 }
 
 #[ast_node("TsParenthesizedType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsParenthesizedType {
@@ -794,7 +794,7 @@ pub struct TsParenthesizedType {
 }
 
 #[ast_node("TsTypeOperator")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeOperator {
@@ -804,7 +804,7 @@ pub struct TsTypeOperator {
     pub type_ann: Box<TsType>,
 }
 
-#[derive(StringEnum, Clone, Copy, PartialEq, Eq, Hash, EqIgnoreSpan)]
+#[derive(StringEnum, Clone, Copy, PartialEq, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
@@ -822,7 +822,7 @@ pub enum TsTypeOperatorOp {
 }
 
 #[ast_node("TsIndexedAccessType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsIndexedAccessType {
@@ -833,7 +833,7 @@ pub struct TsIndexedAccessType {
     pub index_type: Box<TsType>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EqIgnoreSpan)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 #[cfg_attr(
@@ -905,7 +905,7 @@ impl<'de> Deserialize<'de> for TruePlusMinus {
 }
 
 #[ast_node("TsMappedType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsMappedType {
@@ -938,7 +938,7 @@ pub struct TsMappedType {
 }
 
 #[ast_node("TsLiteralType")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsLitType {
@@ -948,7 +948,7 @@ pub struct TsLitType {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsLit {
@@ -969,7 +969,7 @@ pub enum TsLit {
 }
 
 #[ast_node("TemplateLiteral")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTplLitType {
@@ -985,7 +985,7 @@ pub struct TsTplLitType {
 // // ================
 
 #[ast_node("TsInterfaceDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInterfaceDecl {
@@ -1003,7 +1003,7 @@ pub struct TsInterfaceDecl {
 }
 
 #[ast_node("TsInterfaceBody")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInterfaceBody {
@@ -1012,7 +1012,7 @@ pub struct TsInterfaceBody {
 }
 
 #[ast_node("TsExpressionWithTypeArguments")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsExprWithTypeArgs {
@@ -1028,7 +1028,7 @@ pub struct TsExprWithTypeArgs {
 }
 
 #[ast_node("TsTypeAliasDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeAliasDecl {
@@ -1046,7 +1046,7 @@ pub struct TsTypeAliasDecl {
 }
 
 #[ast_node("TsEnumDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsEnumDecl {
@@ -1058,7 +1058,7 @@ pub struct TsEnumDecl {
 }
 
 #[ast_node("TsEnumMember")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsEnumMember {
@@ -1075,7 +1075,7 @@ pub struct TsEnumMember {
 ///
 /// - Invalid: [Ident] with empty symbol.
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsEnumMemberId {
@@ -1087,7 +1087,7 @@ pub enum TsEnumMemberId {
 }
 
 #[ast_node("TsModuleDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsModuleDecl {
@@ -1109,7 +1109,7 @@ pub struct TsModuleDecl {
 /// `namespace A.B { }` is a namespace named `A` with another TsNamespaceDecl as
 /// its body.
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsNamespaceBody {
@@ -1121,7 +1121,7 @@ pub enum TsNamespaceBody {
 }
 
 #[ast_node("TsModuleBlock")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsModuleBlock {
@@ -1130,7 +1130,7 @@ pub struct TsModuleBlock {
 }
 
 #[ast_node("TsNamespaceDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsNamespaceDecl {
@@ -1143,7 +1143,7 @@ pub struct TsNamespaceDecl {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsModuleName {
@@ -1155,7 +1155,7 @@ pub enum TsModuleName {
 }
 
 #[ast_node("TsImportEqualsDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsImportEqualsDecl {
@@ -1167,7 +1167,7 @@ pub struct TsImportEqualsDecl {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, Is, EqIgnoreSpan)]
+#[derive(Eq, Is, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub enum TsModuleRef {
@@ -1180,7 +1180,7 @@ pub enum TsModuleRef {
 }
 
 #[ast_node("TsExternalModuleReference")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsExternalModuleRef {
@@ -1193,7 +1193,7 @@ pub struct TsExternalModuleRef {
 /// `export =`. But for @babel/parser, `export default` is an ExportDefaultDecl,
 /// so a TsExportAssignment is always `export =`.
 #[ast_node("TsExportAssignment")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsExportAssignment {
@@ -1203,7 +1203,7 @@ pub struct TsExportAssignment {
 }
 
 #[ast_node("TsNamespaceExportDeclaration")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsNamespaceExportDecl {
@@ -1216,7 +1216,7 @@ pub struct TsNamespaceExportDecl {
 // // ================
 
 #[ast_node("TsAsExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsAsExpr {
@@ -1228,7 +1228,7 @@ pub struct TsAsExpr {
 }
 
 #[ast_node("TsTypeAssertion")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsTypeAssertion {
@@ -1240,7 +1240,7 @@ pub struct TsTypeAssertion {
 }
 
 #[ast_node("TsNonNullExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsNonNullExpr {
@@ -1250,7 +1250,7 @@ pub struct TsNonNullExpr {
 }
 
 #[ast_node("TsSatisfiesExpression")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsSatisfiesExpr {
@@ -1261,7 +1261,7 @@ pub struct TsSatisfiesExpr {
     pub type_ann: Box<TsType>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EqIgnoreSpan)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "serde-impl", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
@@ -1280,7 +1280,7 @@ pub enum Accessibility {
 }
 
 #[ast_node("TsConstAssertion")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsConstAssertion {
@@ -1290,7 +1290,7 @@ pub struct TsConstAssertion {
 }
 
 #[ast_node("TsInstantiation")]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 #[cfg_attr(feature = "arbitrary", derive(arbitrary::Arbitrary))]
 #[cfg_attr(feature = "shrink-to-fit", derive(shrink_to_fit::ShrinkToFit))]
 pub struct TsInstantiation {

--- a/crates/swc_ecma_lints/src/rules/no_bitwise.rs
+++ b/crates/swc_ecma_lints/src/rules/no_bitwise.rs
@@ -1,4 +1,3 @@
-use rustc_hash::FxHashSet;
 use serde::{Deserialize, Serialize};
 use swc_common::{errors::HANDLER, Span};
 use swc_ecma_ast::*;
@@ -26,8 +25,8 @@ pub fn no_bitwise(config: &RuleConfig<NoBitwiseConfig>) -> Option<Box<dyn Rule>>
 #[derive(Debug, Default)]
 struct NoBitwise {
     expected_reaction: LintRuleReaction,
-    allow_binary_ops: Option<FxHashSet<BinaryOp>>,
-    allow_assign_ops: Option<FxHashSet<AssignOp>>,
+    allow_binary_ops: u32,
+    allow_assign_ops: u32,
     allow_bitwise_not: bool,
     allow_int_32_hint: bool,
 }
@@ -36,8 +35,8 @@ impl NoBitwise {
     fn new(config: &RuleConfig<NoBitwiseConfig>) -> Self {
         let rule_config = config.get_rule_config();
 
-        let mut allow_binary_ops: Option<FxHashSet<BinaryOp>> = None;
-        let mut allow_assign_ops: Option<FxHashSet<AssignOp>> = None;
+        let mut allow_binary_ops = 0;
+        let mut allow_assign_ops = 0;
         let mut allow_bitwise_not: bool = false;
 
         if let Some(allow) = &rule_config.allow {
@@ -48,39 +47,17 @@ impl NoBitwise {
                     "~" => {
                         allow_bitwise_not = true;
                     }
-                    "&" | "^" | "<<" | ">>" | ">>>" => {
-                        if allow_binary_ops.is_none() {
-                            allow_binary_ops = Some(Default::default());
-                        }
-
-                        let allow_binary_ops = allow_binary_ops.as_mut().unwrap();
-
-                        match op {
-                            "&" => allow_binary_ops.insert(op!("&")),
-                            "^" => allow_binary_ops.insert(op!("^")),
-                            "<<" => allow_binary_ops.insert(op!("<<")),
-                            ">>" => allow_binary_ops.insert(op!(">>")),
-                            ">>>" => allow_binary_ops.insert(op!(">>>")),
-                            _ => false,
-                        };
-                    }
-                    "|=" | "&=" | "<<=" | ">>=" | ">>>=" | "^=" => {
-                        if allow_assign_ops.is_none() {
-                            allow_assign_ops = Some(Default::default());
-                        }
-
-                        let allow_assign_ops = allow_assign_ops.as_mut().unwrap();
-
-                        match op {
-                            "|=" => allow_assign_ops.insert(op!("|=")),
-                            "&=" => allow_assign_ops.insert(op!("&=")),
-                            "<<=" => allow_assign_ops.insert(op!("<<=")),
-                            ">>=" => allow_assign_ops.insert(op!(">>=")),
-                            ">>>=" => allow_assign_ops.insert(op!(">>>=")),
-                            "^=" => allow_assign_ops.insert(op!("^=")),
-                            _ => false,
-                        };
-                    }
+                    "&" => allow_binary_ops |= binary_op_bit(op!("&")),
+                    "^" => allow_binary_ops |= binary_op_bit(op!("^")),
+                    "<<" => allow_binary_ops |= binary_op_bit(op!("<<")),
+                    ">>" => allow_binary_ops |= binary_op_bit(op!(">>")),
+                    ">>>" => allow_binary_ops |= binary_op_bit(op!(">>>")),
+                    "|=" => allow_assign_ops |= assign_op_bit(op!("|=")),
+                    "&=" => allow_assign_ops |= assign_op_bit(op!("&=")),
+                    "<<=" => allow_assign_ops |= assign_op_bit(op!("<<=")),
+                    ">>=" => allow_assign_ops |= assign_op_bit(op!(">>=")),
+                    ">>>=" => allow_assign_ops |= assign_op_bit(op!(">>>=")),
+                    "^=" => allow_assign_ops |= assign_op_bit(op!("^=")),
                     _ => {}
                 };
             });
@@ -110,14 +87,37 @@ impl NoBitwise {
     }
 }
 
+/// Maps a supported binary operator to its bit in the allow mask.
+const fn binary_op_bit(op: BinaryOp) -> u32 {
+    match op {
+        BinaryOp::BitAnd => 1 << 0,
+        BinaryOp::BitXor => 1 << 1,
+        BinaryOp::LShift => 1 << 2,
+        BinaryOp::RShift => 1 << 3,
+        BinaryOp::ZeroFillRShift => 1 << 4,
+        _ => 0,
+    }
+}
+
+/// Maps a supported assignment operator to its bit in the allow mask.
+const fn assign_op_bit(op: AssignOp) -> u32 {
+    match op {
+        AssignOp::BitOrAssign => 1 << 0,
+        AssignOp::BitAndAssign => 1 << 1,
+        AssignOp::LShiftAssign => 1 << 2,
+        AssignOp::RShiftAssign => 1 << 3,
+        AssignOp::ZeroFillRShiftAssign => 1 << 4,
+        AssignOp::BitXorAssign => 1 << 5,
+        _ => 0,
+    }
+}
+
 impl Visit for NoBitwise {
     noop_visit_type!();
 
     fn visit_bin_expr(&mut self, bin_expr: &BinExpr) {
-        if let Some(allow) = &self.allow_binary_ops {
-            if allow.contains(&bin_expr.op) {
-                return;
-            }
+        if self.allow_binary_ops & binary_op_bit(bin_expr.op) != 0 {
+            return;
         }
 
         match bin_expr.op {
@@ -154,10 +154,8 @@ impl Visit for NoBitwise {
     }
 
     fn visit_assign_expr(&mut self, assign_expr: &AssignExpr) {
-        if let Some(allow) = &self.allow_assign_ops {
-            if allow.contains(&assign_expr.op) {
-                return;
-            }
+        if self.allow_assign_ops & assign_op_bit(assign_expr.op) != 0 {
+            return;
         }
 
         match assign_expr.op {

--- a/crates/swc_ecma_minifier/src/option/mod.rs
+++ b/crates/swc_ecma_minifier/src/option/mod.rs
@@ -1,13 +1,12 @@
 #![cfg_attr(not(feature = "extra-serde"), allow(unused))]
 
 use std::{
-    hash::{Hash, Hasher},
     ops::{Deref, DerefMut},
     sync::Arc,
 };
 
 use parking_lot::RwLock;
-use rustc_hash::{FxHashMap, FxHasher};
+use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use swc_atoms::Atom;
 use swc_common::Mark;
@@ -40,7 +39,7 @@ pub struct ExtraOptions {
     pub mangle_name_cache: Option<Arc<dyn MangleCache>>,
 }
 
-#[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "extra-serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "extra-serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "extra-serde", serde(deny_unknown_fields))]
@@ -156,15 +155,15 @@ impl Default for CompressExperimentalOptions {
     }
 }
 
-/// Please do not rely on Hash for GlobalDefs.
-/// This implementation uses XOR to combine per-pair hashes, which may lead to
-/// hash collisions in some cases.
+/// Global expression replacements applied before compression.
+///
+/// Entries are matched in order, and the first matching expression wins.
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
-pub struct GlobalDefs(pub FxHashMap<Box<Expr>, Box<Expr>>);
+pub struct GlobalDefs(pub Vec<(Box<Expr>, Box<Expr>)>);
 
 impl From<FxHashMap<Box<Expr>, Box<Expr>>> for GlobalDefs {
     fn from(value: FxHashMap<Box<Expr>, Box<Expr>>) -> Self {
-        GlobalDefs(value)
+        GlobalDefs(value.into_iter().collect())
     }
 }
 
@@ -175,7 +174,7 @@ impl FromIterator<(Box<Expr>, Box<Expr>)> for GlobalDefs {
 }
 
 impl Deref for GlobalDefs {
-    type Target = FxHashMap<Box<Expr>, Box<Expr>>;
+    type Target = Vec<(Box<Expr>, Box<Expr>)>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -188,29 +187,8 @@ impl DerefMut for GlobalDefs {
     }
 }
 
-impl Hash for GlobalDefs {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        // Use iteration order-independent hash combination.
-        // Method: Mix all key-value pair hashes with XOR, and include the length for
-        // distinction.
-        let mut hash = 0u64;
-        for (k, v) in &self.0 {
-            // let mut pair_hasher = std::collections::hash_map::DefaultHasher::new();
-            let mut pair_hasher = FxHasher::default();
-            k.hash(&mut pair_hasher);
-            v.hash(&mut pair_hasher);
-            // XOR ensures order independence: a ^ b == b ^ a
-            hash ^= pair_hasher.finish();
-        }
-        // Mix length to prevent conflicts like `[("a",1),("b",2)]` and
-        // `[("a",1),("b",2),("a",1),("b",2)]`
-        self.0.len().hash(state);
-        hash.hash(state);
-    }
-}
-
 /// https://terser.org/docs/api-reference.html#compress-options
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "extra-serde", derive(Serialize, Deserialize))]
 #[cfg_attr(feature = "extra-serde", serde(rename_all = "camelCase"))]
 #[cfg_attr(feature = "extra-serde", serde(deny_unknown_fields))]

--- a/crates/swc_ecma_parser/examples/perf.rs
+++ b/crates/swc_ecma_parser/examples/perf.rs
@@ -1,14 +1,11 @@
 extern crate swc_malloc;
 
-use std::{collections::hash_map::DefaultHasher, hash::Hash};
-
 use codspeed_criterion_compat::black_box;
 use swc_common::{sync::Lrc, SourceMap};
 use swc_ecma_parser::{lexer::Lexer, Parser, StringInput, Syntax, TsSyntax};
 
 fn main() {
     let mut cnt = 0;
-    let mut hasher = DefaultHasher::new();
 
     for entry in walkdir::WalkDir::new("tests/typescript") {
         let entry = entry.unwrap();
@@ -37,15 +34,10 @@ fn main() {
 
         let module = parser.parse_typescript_module();
 
-        if let Ok(module) = &module {
-            module.hash(&mut hasher);
-        }
-
         let _ = black_box(module);
 
         cnt += 1;
     }
 
     eprintln!("Parsed {cnt} files");
-    eprintln!("Hash: {hasher:?}");
 }

--- a/crates/swc_ecma_parser/src/legacy.rs
+++ b/crates/swc_ecma_parser/src/legacy.rs
@@ -163,7 +163,7 @@ pub mod token {
         Other,
     }
 
-    #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub enum TokenKind {
         Word(WordKind),
         Arrow,

--- a/crates/swc_plugin_backend_tests/tests/ecma_loss.rs
+++ b/crates/swc_plugin_backend_tests/tests/ecma_loss.rs
@@ -52,7 +52,7 @@ fn build_plugin(dir: &Path) -> Result<PathBuf, Error> {
 
 // Fake Program
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 enum Program2 {
     #[tag("Module")]
     Module(Module),
@@ -63,7 +63,7 @@ enum Program2 {
 }
 
 #[ast_node]
-#[derive(Eq, Hash, EqIgnoreSpan)]
+#[derive(Eq, EqIgnoreSpan)]
 struct SourceString {
     span: Span,
     #[not_spanned]


### PR DESCRIPTION
**Description:**

Remove `Hash` implementations from ECMA AST nodes and adapt downstream users.

Maintaining a `Hash` contract constrains how special `f64` values are represented. Removing it unblocks representing `NaN` and `Infinity` as `Lit::Num` again.

**BREAKING CHANGE:**

ECMA AST nodes and dependent public types no longer implement `Hash`.