### PR TITLE
fix(es): preserve numeric property key identity

### DIFF
--- a/.changeset/fix-numeric-property-key.md
+++ b/.changeset/fix-numeric-property-key.md
@@ -1,0 +1,12 @@
+---
+swc_core: minor
+swc_ecma_compat_es2015: patch
+swc_ecma_minifier: patch
+swc_ecma_transformer: patch
+swc_ecma_transforms_compat: patch
+swc_ecma_transforms_optimization: patch
+swc_ecma_utils: minor
+swc_typescript: patch
+---
+
+fix(es): preserve numeric property key identity

--- a/crates/swc_ecma_compat_es2015/src/classes/prop_name.rs
+++ b/crates/swc_ecma_compat_es2015/src/classes/prop_name.rs
@@ -1,6 +1,7 @@
 use swc_atoms::Wtf8Atom;
 use swc_common::{Span, Spanned};
 use swc_ecma_ast::*;
+use swc_ecma_utils::number::ToJsString;
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum HashKey {
@@ -14,7 +15,7 @@ impl From<&PropName> for HashKey {
         match p {
             PropName::Ident(IdentName { sym: value, .. }) => HashKey::Str(value.clone().into()),
             PropName::Str(Str { value, .. }) => HashKey::Str(value.clone()),
-            PropName::Num(Number { value, .. }) => HashKey::Str(value.to_string().into()),
+            PropName::Num(Number { value, .. }) => HashKey::Str(value.to_js_string().into()),
             PropName::BigInt(BigInt { value, .. }) => HashKey::Str(value.to_string().into()),
             PropName::Computed(expr) => HashKey::Computed(expr.span()),
             #[cfg(swc_ast_unknown)]

--- a/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/evaluate.rs
@@ -3,7 +3,7 @@ use swc_atoms::atom;
 use swc_common::{util::take::Take, Spanned, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{
-    number::ToJsString,
+    number::{parse_canonical_index, ToJsString},
     unicode::{is_high_surrogate, is_low_surrogate},
     ExprExt, IsEmpty, Type, Value,
 };
@@ -412,7 +412,9 @@ impl Pure<'_> {
             MemberProp::Computed(p) => {
                 if let Expr::Lit(Lit::Str(s)) = &*p.expr {
                     if let Some(value) = s.value.as_str() {
-                        if let Ok(value) = value.parse::<u32>() {
+                        if let Some(value) =
+                            parse_canonical_index(value).and_then(|value| u32::try_from(value).ok())
+                        {
                             p.expr = Lit::Num(Number {
                                 span: s.span,
                                 value: value as f64,

--- a/crates/swc_ecma_minifier/src/compress/pure/member_expr.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/member_expr.rs
@@ -5,7 +5,10 @@ use swc_ecma_ast::{
     ArrayLit, Expr, ExprOrSpread, IdentName, Lit, MemberExpr, MemberProp, ObjectLit, Prop,
     PropOrSpread, SeqExpr, Str,
 };
-use swc_ecma_utils::{prop_name_eq, ExprExt, Known};
+use swc_ecma_utils::{
+    number::{parse_canonical_index, ToJsString},
+    prop_name_eq, ExprExt, Known,
+};
 
 use super::Pure;
 use crate::compress::pure::Ctx;
@@ -150,6 +153,31 @@ fn is_string_symbol(sym: &str) -> bool {
     STRING_SYMBOLS.contains(sym) || is_object_symbol(sym)
 }
 
+/// A statically known property key with optional metadata for literal indexing.
+///
+/// `property_key` is always the exact ECMAScript property key. `index` is only
+/// populated for canonical non-negative decimal keys that can index a literal
+/// array or string without reinterpreting the property key.
+struct KnownMemberKey {
+    property_key: Atom,
+    index: Option<usize>,
+}
+
+impl KnownMemberKey {
+    fn from_number(value: f64) -> Self {
+        Self::from_property_key(Atom::from(value.to_js_string()))
+    }
+
+    fn from_property_key(property_key: Atom) -> Self {
+        let index = parse_canonical_index(property_key.as_str());
+
+        Self {
+            property_key,
+            index,
+        }
+    }
+}
+
 /// Checks if the given key exists in the given properties, taking the
 /// `__proto__` property and order of keys into account (the order of keys
 /// matters for nested `__proto__` properties).
@@ -258,29 +286,13 @@ impl Pure<'_> {
             return None;
         }
 
-        /// Taken from `simplify::expr`.
-        ///
-        /// `x.length` is handled as `IndexStr`, since `x.length` calls for
-        /// String and Array are handled in `simplify::expr` (the `length`
-        /// prototype for both of these types cannot be changed).
-        #[derive(Clone, PartialEq)]
-        enum KnownOp {
-            // [a, b][2]
-            //
-            // ({})[1]
-            Index(f64),
-
-            /// ({}).foo
-            ///
-            /// ({}).length
-            IndexStr(Atom),
-        }
-
         let op = match prop {
-            MemberProp::Ident(IdentName { sym, .. }) => KnownOp::IndexStr(sym.clone()),
+            MemberProp::Ident(IdentName { sym, .. }) => {
+                KnownMemberKey::from_property_key(sym.clone())
+            }
 
             MemberProp::Computed(c) => match &*c.expr {
-                Expr::Lit(Lit::Num(n)) => KnownOp::Index(n.value),
+                Expr::Lit(Lit::Num(n)) => KnownMemberKey::from_number(n.value),
 
                 Expr::Ident(..) => {
                     return None;
@@ -291,11 +303,7 @@ impl Pure<'_> {
                         return None;
                     };
 
-                    if let Ok(n) = s.parse::<f64>() {
-                        KnownOp::Index(n)
-                    } else {
-                        KnownOp::IndexStr(Atom::from(s))
-                    }
+                    KnownMemberKey::from_property_key(Atom::from(s))
                 }
             },
 
@@ -328,9 +336,9 @@ impl Pure<'_> {
             }
 
             Expr::Lit(Lit::Str(Str { value, span, .. })) => {
-                match op {
-                    KnownOp::Index(idx) => {
-                        if idx.fract() != 0.0 || idx < 0.0 || idx as usize >= value.len() {
+                match op.index {
+                    Some(index) => {
+                        if index >= value.len() {
                             Some(*Expr::undefined(*span))
                         } else {
                             // idx is in bounds, this is handled in simplify
@@ -338,7 +346,9 @@ impl Pure<'_> {
                         }
                     }
 
-                    KnownOp::IndexStr(key) => {
+                    None => {
+                        let key = op.property_key;
+
                         if key == "length" {
                             // handled in simplify::expr
                             return None;
@@ -365,9 +375,9 @@ impl Pure<'_> {
                     return None;
                 }
 
-                match op {
-                    KnownOp::Index(idx) => {
-                        if idx >= 0.0 && (idx as usize) < elems.len() && idx.fract() == 0.0 {
+                match op.index {
+                    Some(index) => {
+                        if index < elems.len() {
                             // idx is in bounds, handled in simplify
                             return None;
                         }
@@ -400,7 +410,9 @@ impl Pure<'_> {
                         })
                     }
 
-                    KnownOp::IndexStr(key) if key != "length" /* handled in simplify */ => {
+                    None if op.property_key != "length" /* handled in simplify */ => {
+                        let key = op.property_key;
+
                         // If the property is a known symbol, e.g. [].push
                         let is_known_symbol = is_array_symbol(&key);
 
@@ -490,13 +502,10 @@ impl Pure<'_> {
                 }
 
                 // Get key as Atom
-                let key = match op {
-                    KnownOp::Index(i) => Atom::from(i.to_string()),
-                    KnownOp::IndexStr(key) if key != *"yield" => key,
-                    _ => {
-                        return None;
-                    }
-                };
+                let key = op.property_key;
+                if key == "yield" {
+                    return None;
+                }
 
                 // Check if key exists
                 let exists = does_key_exist(&key, props);

--- a/crates/swc_ecma_minifier/tests/compress.rs
+++ b/crates/swc_ecma_minifier/tests/compress.rs
@@ -348,6 +348,14 @@ fn custom_fixture(input: PathBuf) {
 
         println!("{}", input.display());
 
+        if let Ok(expected_stdout) = read_to_string(dir.join("expected.stdout")) {
+            let actual = stdout_of(&output).expect("failed to execute the optimized code");
+            assert_eq!(
+                DebugUsingDisplay(&actual),
+                DebugUsingDisplay(&expected_stdout)
+            );
+        }
+
         NormalizedOutput::from(output)
             .compare_to_file(dir.join("output.js"))
             .unwrap();

--- a/crates/swc_ecma_minifier/tests/fixture/issues/numeric-property-key/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/numeric-property-key/config.json
@@ -1,0 +1,4 @@
+{
+    "defaults": true,
+    "passes": 2
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/numeric-property-key/expected.stdout
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/numeric-property-key/expected.stdout
@@ -1,0 +1,1 @@
+correct,correct,correct,correct,correct,correct,correct,correct,correct,correct,correct,correct,undefined,c,undefined

--- a/crates/swc_ecma_minifier/tests/fixture/issues/numeric-property-key/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/numeric-property-key/input.js
@@ -1,0 +1,49 @@
+console.log([
+    ({
+        Infinity: "correct",
+        inf: "wrong",
+    })[Infinity],
+    ({
+        "-Infinity": "correct",
+        "-inf": "wrong",
+    })[-Infinity],
+    ({
+        0: "correct",
+        "-0": "wrong",
+    })[-0],
+    ({
+        1e21: "correct",
+    })["1e+21"],
+    ({
+        Infinity: "wrong",
+        inf: "correct",
+    })["inf"],
+    ({
+        "-Infinity": "wrong",
+        "-inf": "correct",
+    })["-inf"],
+    ({
+        0: "wrong",
+        "-0": "correct",
+    })["-0"],
+    ({
+        1: "wrong",
+        "01": "correct",
+    })["01"],
+    ({
+        1: "wrong",
+        "+1": "correct",
+    })["+1"],
+    ({
+        1: "wrong",
+        "1.0": "correct",
+    })["1.0"],
+    ({
+        1e21: "wrong",
+        "1000000000000000000000": "correct",
+    })["1000000000000000000000"],
+    ["correct"]["0"],
+    ["zero", "wrong"]["01"],
+    "correct"["0"],
+    "wrong"["01"],
+].map(String).join(","));

--- a/crates/swc_ecma_minifier/tests/fixture/issues/numeric-property-key/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/numeric-property-key/output.js
@@ -1,0 +1,20 @@
+console.log([
+    "correct",
+    {
+        "-Infinity": "correct",
+        "-inf": "wrong"
+    }[-1 / 0],
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+    void 0,
+    "c",
+    void 0
+].map(String).join(","));

--- a/crates/swc_ecma_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transformer/src/es2018/object_rest_spread.rs
@@ -5,7 +5,9 @@ use swc_common::{util::take::Take, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_hooks::VisitMutHook;
 use swc_ecma_transforms_base::{assumptions::Assumptions, helper, helper_expr};
-use swc_ecma_utils::{alias_if_required, private_ident, quote_ident, ExprFactory};
+use swc_ecma_utils::{
+    alias_if_required, number::ToJsString, private_ident, quote_ident, ExprFactory,
+};
 
 use crate::TraverseCtx;
 
@@ -1053,7 +1055,7 @@ fn make_rest_call(config: Config, source: Ident, excluded: Vec<PropName>) -> Exp
                 PropName::Str(s) => Expr::Lit(Lit::Str(s)),
                 PropName::Num(n) => Expr::Lit(Lit::Str(Str {
                     span: n.span,
-                    value: n.value.to_string().into(),
+                    value: n.value.to_js_string().into(),
                     raw: None,
                 })),
                 PropName::Computed(c) if impure_count == 1 && !is_lit_str(&c.expr) => CallExpr {

--- a/crates/swc_ecma_transforms_compat/tests/classes/numeric-property-key/exec.js
+++ b/crates/swc_ecma_transforms_compat/tests/classes/numeric-property-key/exec.js
@@ -1,0 +1,23 @@
+class Example {
+    get 1e21() {
+        return this.finiteValue;
+    }
+
+    set "1e+21"(value) {
+        this.finiteValue = value;
+    }
+
+    get 1e999() {
+        return this.infinityValue;
+    }
+
+    set "Infinity"(value) {
+        this.infinityValue = value;
+    }
+}
+
+const instance = new Example();
+instance[1e21] = 42;
+console.log(instance["1e+21"]);
+instance[1e999] = 43;
+console.log(instance["Infinity"]);

--- a/crates/swc_ecma_transforms_compat/tests/object-rest-spread/numeric-property-key/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/object-rest-spread/numeric-property-key/input.js
@@ -1,0 +1,11 @@
+const source = {
+    "Infinity": "excluded infinity",
+    "1e+21": "excluded finite",
+    keep: "kept",
+};
+
+const {
+    1e999: excludedInfinity,
+    1e21: excludedFinite,
+    ...rest
+} = source;

--- a/crates/swc_ecma_transforms_compat/tests/object-rest-spread/numeric-property-key/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/object-rest-spread/numeric-property-key/output.js
@@ -1,0 +1,9 @@
+const source = {
+    "Infinity": "excluded infinity",
+    "1e+21": "excluded finite",
+    keep: "kept"
+};
+const { 1e999: excludedInfinity, 1e21: excludedFinite } = source, rest = _object_without_properties(source, [
+    "Infinity",
+    "1e+21"
+]);

--- a/crates/swc_ecma_transforms_optimization/src/json_parse.rs
+++ b/crates/swc_ecma_transforms_optimization/src/json_parse.rs
@@ -3,7 +3,7 @@ use swc_atoms::Wtf8Atom;
 use swc_common::{util::take::Take, Spanned, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::perf::Parallel;
-use swc_ecma_utils::{calc_literal_cost, member_expr, ExprFactory};
+use swc_ecma_utils::{calc_literal_cost, member_expr, number::ToJsString, ExprFactory};
 use swc_ecma_visit::{noop_visit_mut_type, visit_mut_pass, VisitMut, VisitMutWith};
 
 /// Transform to optimize performance of literals.
@@ -130,7 +130,7 @@ fn jsonify(e: Expr) -> Value {
                     let key = match p.key {
                         PropName::Str(s) => wtf8_to_json_string(&s.value),
                         PropName::Ident(id) => id.sym.to_string(),
-                        PropName::Num(n) => format!("{}", n.value),
+                        PropName::Num(n) => n.value.to_js_string(),
                         _ => unreachable!(),
                     };
                     (key, value)

--- a/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/expr/mod.rs
@@ -17,7 +17,7 @@ use swc_ecma_transforms_base::{
 };
 use swc_ecma_utils::{
     is_literal,
-    number::{minify_number, JsNumber},
+    number::{minify_number, parse_canonical_index, JsNumber, ToJsString},
     prop_name_eq, to_int32, BoolType, ExprCtx, ExprExt, NullType, NumberType, ObjectType,
     StringType, SymbolType, UndefinedType, Value,
 };
@@ -606,6 +606,31 @@ fn need_zero_for_this(e: &Expr) -> bool {
     e.directness_matters() || e.is_seq()
 }
 
+/// A statically known property key with optional metadata for literal indexing.
+///
+/// `property_key` is always the exact ECMAScript property key. `index` is only
+/// populated for canonical non-negative decimal keys that can index a literal
+/// array or string without reinterpreting the property key.
+struct KnownMemberKey {
+    property_key: Atom,
+    index: Option<usize>,
+}
+
+impl KnownMemberKey {
+    fn from_number(value: f64) -> Self {
+        Self::from_property_key(Atom::from(value.to_js_string()))
+    }
+
+    fn from_property_key(property_key: Atom) -> Self {
+        let index = parse_canonical_index(property_key.as_str());
+
+        Self {
+            property_key,
+            index,
+        }
+    }
+}
+
 /// Gets the value of the given key from the given object properties, if the key
 /// exists. If the key does exist, `Some` is returned and the property is
 /// removed from the given properties.
@@ -687,24 +712,17 @@ pub fn optimize_member_expr(
         _ => return,
     };
 
-    #[derive(Clone, PartialEq, Debug)]
     enum KnownOp {
         /// [a, b].length
         Len,
 
-        /// [a, b][0]
-        ///
-        /// {0.5: "bar"}[0.5]
-        /// Note: callers need to check `v.fract() == 0.0` in some cases.
-        /// ie non-integer indexes for arrays result in `undefined`
-        /// but not for objects (because indexing an object
-        /// returns the value of the key, ie `0.5` will not
-        /// return `undefined` if a key `0.5` exists
-        /// and its value is not `undefined`).
-        Index(f64),
-
-        /// ({}).foo
-        IndexStr(Atom),
+        /// A known ECMAScript property key.
+        Key {
+            key: KnownMemberKey,
+            // Numeric keys preserve the existing object-folding eligibility;
+            // other keys still require a fully literal object.
+            requires_literal_object: bool,
+        },
     }
     let op = match prop {
         MemberProp::Ident(IdentName { sym, .. }) if &**sym == "length" && !obj.is_object() => {
@@ -715,7 +733,10 @@ pub fn optimize_member_expr(
                 return;
             }
 
-            KnownOp::IndexStr(sym.clone())
+            KnownOp::Key {
+                key: KnownMemberKey::from_property_key(sym.clone()),
+                requires_literal_object: true,
+            }
         }
         MemberProp::Computed(ComputedPropName { expr, .. }) => {
             if is_callee {
@@ -724,17 +745,19 @@ pub fn optimize_member_expr(
 
             if let Expr::Lit(Lit::Num(Number { value, .. })) = &**expr {
                 // x[5]
-                KnownOp::Index(*value)
+                KnownOp::Key {
+                    key: KnownMemberKey::from_number(*value),
+                    requires_literal_object: false,
+                }
             } else if let Known(s) = expr.as_pure_string(expr_ctx) {
                 if s == "length" && !obj.is_object() {
                     // Length of non-object type
                     KnownOp::Len
-                } else if let Ok(n) = s.parse::<f64>() {
-                    // x['0'] is treated as x[0]
-                    KnownOp::Index(n)
                 } else {
-                    // x[''] or x[...] where ... is an expression like [], ie x[[]]
-                    KnownOp::IndexStr(s.into())
+                    KnownOp::Key {
+                        key: KnownMemberKey::from_property_key(s.into()),
+                        requires_literal_object: true,
+                    }
                 }
             } else {
                 return;
@@ -771,14 +794,18 @@ pub fn optimize_member_expr(
             }
 
             // 'foo'[1]
-            KnownOp::Index(idx) => {
-                if idx.fract() != 0.0 || idx < 0.0 || idx as usize >= value.len() {
+            KnownOp::Key { key, .. } => {
+                let Some(index) = key.index else {
+                    return;
+                };
+
+                if index >= value.len() {
                     // Prototype changes affect indexing if the index is out of bounds, so we
                     // don't replace out-of-bound indexes.
                     return;
                 }
 
-                let c = nth_char(value, idx as _);
+                let c = nth_char(value, index);
                 *changed = true;
 
                 // `nth_char` always returns a code point within the UTF-16 range.
@@ -792,11 +819,6 @@ pub fn optimize_member_expr(
                 })
                 .into()
             }
-
-            // 'foo'['']
-            //
-            // Handled in compress
-            KnownOp::IndexStr(..) => {}
         },
 
         // [1, 2, 3].length
@@ -837,22 +859,23 @@ pub fn optimize_member_expr(
                     .into();
                 }
 
-                KnownOp::Index(idx) => {
-                    // If the fraction part is non-zero, or if the index is out of bounds,
-                    // then we handle this in compress as Array's prototype may be modified.
-                    if idx.fract() != 0.0 || idx < 0.0 || idx as usize >= elems.len() {
+                KnownOp::Key { key, .. } => {
+                    let Some(index) = key.index else {
+                        return;
+                    };
+
+                    // Out-of-bound indexes are handled in compress because Array's
+                    // prototype may be modified.
+                    if index >= elems.len() {
                         return;
                     }
 
                     // Don't change if after has side effects.
                     let after_has_side_effect =
-                        elems
-                            .iter()
-                            .skip((idx as usize + 1) as _)
-                            .any(|elem| match elem {
-                                Some(elem) => elem.expr.may_have_side_effects(expr_ctx),
-                                None => false,
-                            });
+                        elems.iter().skip(index + 1).any(|elem| match elem {
+                            Some(elem) => elem.expr.may_have_side_effects(expr_ctx),
+                            None => false,
+                        });
 
                     if after_has_side_effect {
                         return;
@@ -861,7 +884,7 @@ pub fn optimize_member_expr(
                     *changed = true;
 
                     // elements before target element
-                    let before: Vec<Option<ExprOrSpread>> = elems.drain(..(idx as usize)).collect();
+                    let before: Vec<Option<ExprOrSpread>> = elems.drain(..index).collect();
                     let mut iter = elems.take().into_iter();
                     // element at idx
                     let e = iter.next().flatten();
@@ -903,9 +926,6 @@ pub fn optimize_member_expr(
                     exprs.push(val);
                     *expr = *Expr::from_exprs(exprs);
                 }
-
-                // Handled in compress
-                KnownOp::IndexStr(..) => {}
             }
         }
 
@@ -915,8 +935,14 @@ pub fn optimize_member_expr(
         Expr::Object(ObjectLit { props, span }) => {
             // get key
             let key = match op {
-                KnownOp::Index(i) => Atom::from(i.to_string()),
-                KnownOp::IndexStr(key) if key != *"yield" && is_literal(props) => key,
+                KnownOp::Key {
+                    key,
+                    requires_literal_object,
+                } if key.property_key != *"yield"
+                    && (!requires_literal_object || is_literal(props)) =>
+                {
+                    key.property_key
+                }
                 _ => return,
             };
 

--- a/crates/swc_ecma_transforms_optimization/tests/expr-simplifier/property-key-identity/input.js
+++ b/crates/swc_ecma_transforms_optimization/tests/expr-simplifier/property-key-identity/input.js
@@ -1,0 +1,25 @@
+const stringKeys = [
+    ({ Infinity: "wrong", inf: "correct" })["inf"],
+    ({ "-Infinity": "wrong", "-inf": "correct" })["-inf"],
+    ({ 0: "wrong", "-0": "correct" })["-0"],
+    ({ 1: "wrong", "01": "correct" })["01"],
+    ({ 1: "wrong", "+1": "correct" })["+1"],
+    ({ 1: "wrong", "1.0": "correct" })["1.0"],
+    ({ 1e21: "wrong", "1000000000000000000000": "correct" })[
+        "1000000000000000000000"
+    ],
+];
+
+const numberKeys = [
+    ({ Infinity: "correct" })[1e999],
+    ({ "-Infinity": "correct" })[-1e999],
+    ({ 0: "correct" })[-0],
+    ({ 1e21: "correct" })[1e21],
+];
+
+const canonicalArrayIndex = ["zero", "correct"]["1"];
+const nonCanonicalArrayIndex = ["zero", "wrong"]["01"];
+const canonicalStringIndex = "correct"["0"];
+const nonCanonicalStringIndex = "wrong"["01"];
+const numericNonLiteralObject = ({ 1: value })[1];
+const stringNonLiteralObject = ({ key: value })["key"];

--- a/crates/swc_ecma_transforms_optimization/tests/expr-simplifier/property-key-identity/output.js
+++ b/crates/swc_ecma_transforms_optimization/tests/expr-simplifier/property-key-identity/output.js
@@ -1,0 +1,18 @@
+const stringKeys = [
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+    "correct",
+];
+const numberKeys = ["correct", "correct", "correct", "correct"];
+const canonicalArrayIndex = "correct";
+const nonCanonicalArrayIndex = ["zero", "wrong"]["01"];
+const canonicalStringIndex = "c";
+const nonCanonicalStringIndex = "wrong"["01"];
+const numericNonLiteralObject = value;
+const stringNonLiteralObject = {
+    key: value,
+}["key"];

--- a/crates/swc_ecma_transforms_optimization/tests/fixture.rs
+++ b/crates/swc_ecma_transforms_optimization/tests/fixture.rs
@@ -4,7 +4,10 @@ use swc_common::{pass::Repeat, Mark};
 use swc_ecma_ast::Pass;
 use swc_ecma_parser::{EsSyntax, Syntax};
 use swc_ecma_transforms_base::fixer::paren_remover;
-use swc_ecma_transforms_optimization::simplify::{dce::dce, expr_simplifier};
+use swc_ecma_transforms_optimization::{
+    json_parse,
+    simplify::{dce::dce, expr_simplifier},
+};
 use swc_ecma_transforms_testing::{test_fixture, Tester};
 use swc_ecma_visit::visit_mut_pass;
 
@@ -84,6 +87,27 @@ fn expr(input: PathBuf) {
             (
                 remover(t),
                 Repeat::new(expr_simplifier(top_level_mark, Default::default())),
+            )
+        },
+        &input,
+        &output,
+        Default::default(),
+    );
+}
+
+#[testing::fixture("tests/json-parse/**/input.js")]
+fn json_parse_fixture(input: PathBuf) {
+    let output = input.with_file_name("output.js");
+
+    test_fixture(
+        Syntax::Es(Default::default()),
+        &|t| {
+            let top_level_mark = Mark::fresh(Mark::root());
+
+            (
+                remover(t),
+                Repeat::new(expr_simplifier(top_level_mark, Default::default())),
+                json_parse(0),
             )
         },
         &input,

--- a/crates/swc_ecma_transforms_optimization/tests/json-parse/numeric-property-key/input.js
+++ b/crates/swc_ecma_transforms_optimization/tests/json-parse/numeric-property-key/input.js
@@ -1,0 +1,3 @@
+const value = {
+    1e21: true,
+};

--- a/crates/swc_ecma_transforms_optimization/tests/json-parse/numeric-property-key/output.js
+++ b/crates/swc_ecma_transforms_optimization/tests/json-parse/numeric-property-key/output.js
@@ -1,0 +1,1 @@
+const value = JSON.parse('{"1e+21":true}');

--- a/crates/swc_ecma_utils/src/lib.rs
+++ b/crates/swc_ecma_utils/src/lib.rs
@@ -2061,7 +2061,7 @@ pub fn prop_name_eq(p: &PropName, key: &str) -> bool {
     match p {
         PropName::Ident(i) => i.sym == *key,
         PropName::Str(s) => s.value == *key,
-        PropName::Num(n) => n.value.to_string() == *key,
+        PropName::Num(n) => n.value.to_js_string() == *key,
         PropName::BigInt(_) => false,
         PropName::Computed(e) => match &*e.expr {
             Expr::Lit(Lit::Str(Str { value, .. })) => *value == *key,

--- a/crates/swc_ecma_utils/src/number.rs
+++ b/crates/swc_ecma_utils/src/number.rs
@@ -10,6 +10,25 @@ impl ToJsString for f64 {
     }
 }
 
+/// Parses the canonical non-negative decimal representation of a `usize`.
+///
+/// This does not apply numeric coercion, so distinct ECMAScript property keys
+/// such as `"01"`, `"1.0"`, and `"+1"` are not reinterpreted as the index `1`.
+pub fn parse_canonical_index(property_key: &str) -> Option<usize> {
+    let bytes = property_key.as_bytes();
+    let is_canonical = match bytes {
+        [b'0'] => true,
+        [b'1'..=b'9', rest @ ..] => rest.iter().all(u8::is_ascii_digit),
+        _ => false,
+    };
+
+    if !is_canonical {
+        return None;
+    }
+
+    property_key.parse().ok()
+}
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct JsNumber(f64);
 
@@ -263,6 +282,17 @@ pub fn minify_number(num: f64, detect_dot: &mut bool) -> String {
 #[cfg(test)]
 mod test_js_number {
     use super::*;
+
+    #[test]
+    fn test_parse_canonical_index() {
+        assert_eq!(parse_canonical_index("0"), Some(0));
+        assert_eq!(parse_canonical_index("42"), Some(42));
+        assert_eq!(parse_canonical_index(""), None);
+        assert_eq!(parse_canonical_index("01"), None);
+        assert_eq!(parse_canonical_index("1.0"), None);
+        assert_eq!(parse_canonical_index("+1"), None);
+        assert_eq!(parse_canonical_index("-0"), None);
+    }
 
     #[test]
     fn test_as_int32() {

--- a/crates/swc_typescript/src/fast_dts/util/ast_ext.rs
+++ b/crates/swc_typescript/src/fast_dts/util/ast_ext.rs
@@ -6,6 +6,7 @@ use swc_ecma_ast::{
     BindingIdent, ComputedPropName, Expr, Ident, Lit, MemberProp, ObjectPatProp, Pat, Prop,
     PropName, TsTypeAnn,
 };
+use swc_ecma_utils::number::ToJsString;
 
 pub trait ExprExit {
     fn get_root_ident(&self) -> Option<&Ident>;
@@ -144,7 +145,7 @@ impl PropNameExit for PropName {
         match self {
             PropName::Ident(ident_name) => Some(Cow::Borrowed(ident_name.sym.as_str())),
             PropName::Str(string) => Some(Cow::Borrowed(string.value.as_str()?)),
-            PropName::Num(number) => Some(Cow::Owned(number.value.to_string())),
+            PropName::Num(number) => Some(Cow::Owned(number.value.to_js_string())),
             PropName::BigInt(big_int) => Some(Cow::Owned(big_int.value.to_string())),
             PropName::Computed(computed_prop_name) => computed_prop_name.static_name(),
             #[cfg(swc_ast_unknown)]
@@ -167,7 +168,7 @@ impl PropNameExit for ComputedPropName {
                 Lit::Str(string) => Some(Cow::Borrowed(string.value.as_str()?)),
                 Lit::Bool(b) => Some(Cow::Owned(b.value.to_string())),
                 Lit::Null(_) => Some(Cow::Borrowed("null")),
-                Lit::Num(number) => Some(Cow::Owned(number.value.to_string())),
+                Lit::Num(number) => Some(Cow::Owned(number.value.to_js_string())),
                 Lit::BigInt(big_int) => Some(Cow::Owned(big_int.value.to_string())),
                 Lit::Regex(regex) => Some(Cow::Owned(regex.exp.to_string())),
                 Lit::JSXText(_) => None,

--- a/crates/swc_typescript/tests/fixture/numeric-property-names.snap
+++ b/crates/swc_typescript/tests/fixture/numeric-property-names.snap
@@ -1,0 +1,14 @@
+```==================== .D.TS ====================
+
+export declare class NumericPropertyNames {
+    get 1e21(): string;
+    set "1e+21"(value: string);
+    get 1e999(): number;
+    set "Infinity"(value: number);
+}
+export declare const computedNumericPropertyNames: {
+    [1e21]: string;
+    [1e999]: number;
+};
+
+

--- a/crates/swc_typescript/tests/fixture/numeric-property-names.ts
+++ b/crates/swc_typescript/tests/fixture/numeric-property-names.ts
@@ -1,0 +1,27 @@
+export class NumericPropertyNames {
+    get 1e21(): string {
+        return "";
+    }
+
+    set "1e+21"(value) {}
+
+    get 1e999(): number {
+        return 0;
+    }
+
+    set "Infinity"(value) {}
+}
+
+export const computedNumericPropertyNames = {
+    get [1e21](): string {
+        return "";
+    },
+
+    set ["1e+21"](value) {},
+
+    get [1e999](): number {
+        return 0;
+    },
+
+    set ["Infinity"](value) {},
+};


### PR DESCRIPTION
**Description:**

Several property-key optimizations rely on Rust number formatting or eagerly parse strings as numbers. This can merge distinct ECMAScript keys, including `Infinity` and `inf`, `-0` and `0`, or `"01"` and `"1"`.

This PR introduces shared canonical-index parsing and ECMAScript number-to-string conversion, then uses them across property-key transforms, literal folding, and TypeScript name extraction. Each path now preserves property-key identity before optimizing it.

**Related issue (if exists):**

- Close: #12061
---
- #12043
  - #12047
    - **#12050** (current)
      - #12048
        - #12051
      - #12052
        - #12053
      - #12054
      - #12055
      - #12056
      - #12057
    - #12058
    - #12049
      - #12059
        - #12060