### PR TITLE
fix(es/minifier): preserve non-canonical arguments access

### DIFF
--- a/.changeset/fix-arguments-canonical-index.md
+++ b/.changeset/fix-arguments-canonical-index.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): Preserve non-canonical `arguments` property accesses.

--- a/crates/swc_ecma_minifier/src/compress/optimize/arguments.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/arguments.rs
@@ -2,7 +2,11 @@ use std::iter::repeat_with;
 
 use swc_common::{util::take::Take, DUMMY_SP};
 use swc_ecma_ast::*;
-use swc_ecma_utils::{find_pat_ids, is_valid_prop_ident, private_ident};
+use swc_ecma_utils::{
+    find_pat_ids, is_valid_prop_ident,
+    number::{parse_canonical_index, ToJsString},
+    private_ident,
+};
 use swc_ecma_visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
 use super::Optimizer;
@@ -179,64 +183,17 @@ impl VisitMut for ArgReplacer<'_> {
 
         n.visit_mut_children_with(self);
 
-        if let Expr::Member(MemberExpr {
-            obj,
-            prop: MemberProp::Computed(c),
-            ..
-        }) = n
-        {
-            match &**obj {
-                Expr::Ident(Ident { sym, .. }) if &**sym == "arguments" => {
-                    match &*c.expr {
-                        Expr::Lit(Lit::Str(Str { value, .. })) => {
-                            let Some(value) = value.as_str() else {
-                                return;
-                            };
-                            let idx = value.parse::<usize>();
-                            let idx = match idx {
-                                Ok(v) => v,
-                                _ => return,
-                            };
+        let Some(idx) = argument_access_index(n) else {
+            return;
+        };
 
-                            self.inject_params_if_required(idx);
+        self.inject_params_if_required(idx);
 
-                            if let Some(param) = self.params.get(idx) {
-                                if let Pat::Ident(i) = &param.pat {
-                                    self.changed = true;
-                                    report_change!(
-                                        "arguments: Replacing access to arguments to normal \
-                                         reference"
-                                    );
-                                    *n = i.id.clone().into();
-                                }
-                            }
-                        }
-                        Expr::Lit(Lit::Num(Number { value, .. })) => {
-                            if value.fract() != 0.0 {
-                                // We ignores non-integer values.
-                                return;
-                            }
-
-                            let idx = value.round() as i64 as usize;
-
-                            self.inject_params_if_required(idx);
-
-                            //
-                            if let Some(param) = self.params.get(idx) {
-                                if let Pat::Ident(i) = &param.pat {
-                                    report_change!(
-                                        "arguments: Replacing access to arguments to normal \
-                                         reference"
-                                    );
-                                    self.changed = true;
-                                    *n = i.id.clone().into();
-                                }
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                _ => (),
+        if let Some(param) = self.params.get(idx) {
+            if let Pat::Ident(i) = &param.pat {
+                self.changed = true;
+                report_change!("arguments: Replacing access to arguments to normal reference");
+                *n = i.id.clone().into();
             }
         }
     }
@@ -264,5 +221,31 @@ impl VisitMut for ArgReplacer<'_> {
         if let SuperProp::Computed(c) = &mut n.prop {
             c.visit_mut_with(self);
         }
+    }
+}
+
+/// Returns an `arguments` index only when the property key is already in its
+/// canonical non-negative integer spelling.
+fn argument_access_index(expr: &Expr) -> Option<usize> {
+    let Expr::Member(MemberExpr {
+        obj,
+        prop: MemberProp::Computed(computed),
+        ..
+    }) = expr
+    else {
+        return None;
+    };
+    let Expr::Ident(Ident { sym, .. }) = &**obj else {
+        return None;
+    };
+
+    if &**sym != "arguments" {
+        return None;
+    }
+
+    match &*computed.expr {
+        Expr::Lit(Lit::Str(Str { value, .. })) => parse_canonical_index(value.as_str()?),
+        Expr::Lit(Lit::Num(Number { value, .. })) => parse_canonical_index(&value.to_js_string()),
+        _ => None,
     }
 }

--- a/crates/swc_ecma_minifier/tests/fixture/issues/arguments-canonical-index/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/arguments-canonical-index/config.json
@@ -1,0 +1,5 @@
+{
+    "arguments": true,
+    "defaults": true,
+    "passes": 2
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/arguments-canonical-index/expected.stdout
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/arguments-canonical-index/expected.stdout
@@ -1,0 +1,1 @@
+undefined,undefined,undefined,undefined,zero,one

--- a/crates/swc_ecma_minifier/tests/fixture/issues/arguments-canonical-index/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/arguments-canonical-index/input.js
@@ -1,0 +1,10 @@
+(function (zero, one) {
+    console.log([
+        arguments["01"],
+        arguments[-1],
+        arguments[1.5],
+        arguments[1e21],
+        arguments[-0],
+        arguments[1],
+    ].map(String).join(","));
+})("zero", "one");

--- a/crates/swc_ecma_minifier/tests/fixture/issues/arguments-canonical-index/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/arguments-canonical-index/output.js
@@ -1,0 +1,10 @@
+!function(zero, one) {
+    console.log([
+        arguments["01"],
+        arguments[-1],
+        arguments[1.5],
+        arguments[1e21],
+        zero,
+        one
+    ].map(String).join(","));
+}("zero", "one");


### PR DESCRIPTION
**Description:**

Computed `arguments` properties are currently parsed or cast directly as numeric indices. Non-canonical names and invalid indices can therefore be mistaken for parameter positions and replaced incorrectly.

This PR resolves `arguments` slots through the shared canonical-index parser and ECMAScript number-to-string conversion before substituting parameters. An access is optimized only when its property denotes the same canonical argument index.

**Related issue (if exists):**

- Closes: #12066 

---

- #12043
  - #12047
    - #12050
      - #12048
        - #12051
      - **#12052** (current)
        - #12053
      - #12054
      - #12055
      - #12056
      - #12057
    - #12058
    - #12049
      - #12059
        - #12060