### PR TITLE
fix(es/minifier): preserve invalid Array lengths

### DIFF
--- a/.changeset/preserve-invalid-array-lengths.md
+++ b/.changeset/preserve-invalid-array-lengths.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): Preserve invalid Array constructor lengths

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -1137,17 +1137,19 @@ impl Pure<'_> {
             if let ExprOrSpread { spread: None, expr } = &args[0] {
                 match &**expr {
                     Expr::Lit(Lit::Num(num)) => {
-                        if num.value <= 5_f64 && num.value >= 0_f64 {
-                            Some(
-                                ArrayLit {
-                                    span: *span,
-                                    elems: vec![None; num.value as usize],
-                                }
-                                .into(),
-                            )
-                        } else {
-                            None
+                        let length = num.value;
+
+                        if !(0_f64..=5_f64).contains(&length) || length.fract() != 0_f64 {
+                            return None;
                         }
+
+                        Some(
+                            ArrayLit {
+                                span: *span,
+                                elems: vec![None; length as usize],
+                            }
+                            .into(),
+                        )
                     }
                     Expr::Lit(_) => Some(
                         ArrayLit {

--- a/crates/swc_ecma_minifier/tests/fixture/issues/array-constructor-length/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/array-constructor-length/config.json
@@ -1,0 +1,3 @@
+{
+    "defaults": true
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/array-constructor-length/expected.stdout
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/array-constructor-length/expected.stdout
@@ -1,0 +1,1 @@
+RangeError,RangeError,0,5,0

--- a/crates/swc_ecma_minifier/tests/fixture/issues/array-constructor-length/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/array-constructor-length/input.js
@@ -1,0 +1,15 @@
+function result(factory) {
+    try {
+        return factory().length;
+    } catch (error) {
+        return error.name;
+    }
+}
+
+console.log([
+    result(() => Array(0.5)),
+    result(() => new Array(1.5)),
+    result(() => Array(0)),
+    result(() => Array(5)),
+    result(() => Array(-0)),
+].join(","));

--- a/crates/swc_ecma_minifier/tests/fixture/issues/array-constructor-length/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/array-constructor-length/output.js
@@ -1,0 +1,20 @@
+function result(factory) {
+    try {
+        return factory().length;
+    } catch (error) {
+        return error.name;
+    }
+}
+console.log([
+    result(()=>Array(0.5)),
+    result(()=>Array(1.5)),
+    result(()=>[]),
+    result(()=>[
+            ,
+            ,
+            ,
+            ,
+            , 
+        ]),
+    result(()=>[])
+].join(","));


### PR DESCRIPTION
**Description:**

`Array(length)` throws a `RangeError` when the length is fractional or otherwise invalid. Folding every small numeric length into an array literal suppresses that observable exception.

This PR requires candidate lengths to be integers before applying the literal-folding optimization and adds runtime coverage for invalid lengths. Valid small arrays are still folded as before.

**Related issue (if exists):**

- #12043
  - #12047
    - #12050
      - #12048
        - #12051
      - #12052
        - #12053
      - #12054
      - #12055
      - **#12056** (current)
      - #12057
    - #12058
    - #12049
      - #12059
        - #12060