### PR TITLE
fix(es/typescript): evaluate cooked enum templates

### DIFF
--- a/.changeset/fix-enum-template-cooked.md
+++ b/.changeset/fix-enum-template-cooked.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_transforms_typescript: patch
+swc_typescript: patch
+---
+
+fix(es/typescript): Evaluate enum templates from cooked values

--- a/crates/swc_ecma_transforms_typescript/src/semantic.rs
+++ b/crates/swc_ecma_transforms_typescript/src/semantic.rs
@@ -6,7 +6,7 @@ use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::{
     retain::{should_retain_decl, IsConcrete},
-    shared::{enum_member_id_atom, get_module_ident},
+    shared::{enum_member_name, get_module_ident},
     ts_enum::{EnumValueComputer, TsEnumRecord, TsEnumRecordKey, TsEnumRecordValue},
 };
 
@@ -277,7 +277,7 @@ impl SemanticAnalyzer {
                     // name as the runtime string value. The AST does not retain
                     // the explicit `of string` kind, so `Void` acts as the
                     // sentinel for Flow's default string mode here.
-                    TsEnumRecordValue::String(enum_member_id_atom(&member.id))
+                    TsEnumRecordValue::String(enum_member_name(&member.id))
                 } else {
                     default_init.clone()
                 }
@@ -572,7 +572,7 @@ impl Visit for SemanticAnalyzer {
 
             default_init = value.inc();
 
-            let member_name = enum_member_id_atom(&member.id);
+            let member_name = enum_member_name(&member.id);
             let key = TsEnumRecordKey {
                 enum_id: id.to_id(),
                 member_name,

--- a/crates/swc_ecma_transforms_typescript/src/shared.rs
+++ b/crates/swc_ecma_transforms_typescript/src/shared.rs
@@ -1,12 +1,12 @@
-use swc_atoms::Atom;
+use swc_atoms::Wtf8Atom;
 use swc_ecma_ast::{Ident, TsEntityName, TsEnumMemberId};
 
-/// Returns enum member key as an atom for record lookup.
+/// Returns an enum member name without discarding lone surrogates.
 #[inline]
-pub(crate) fn enum_member_id_atom(id: &TsEnumMemberId) -> Atom {
+pub(crate) fn enum_member_name(id: &TsEnumMemberId) -> Wtf8Atom {
     match id {
-        TsEnumMemberId::Ident(ident) => ident.sym.clone(),
-        TsEnumMemberId::Str(str_lit) => str_lit.value.to_atom_lossy().into_owned(),
+        TsEnumMemberId::Ident(ident) => ident.sym.clone().into(),
+        TsEnumMemberId::Str(str_lit) => str_lit.value.clone(),
         #[cfg(swc_ast_unknown)]
         _ => panic!("unable to access unknown nodes"),
     }

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -1,7 +1,7 @@
-use std::{iter, mem};
+use std::{borrow::Borrow, iter, mem};
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use swc_atoms::Atom;
+use swc_atoms::{Atom, Wtf8Atom};
 use swc_common::{
     errors::HANDLER, source_map::PURE_SP, util::take::Take, Mark, Span, Spanned, SyntaxContext,
     DUMMY_SP,
@@ -21,8 +21,8 @@ use crate::{
     config::TsImportExportAssignConfig,
     retain::{should_retain_module_item, should_retain_stmt},
     semantic::SemanticInfo,
-    shared::enum_member_id_atom,
-    ts_enum::{EnumValueComputer, TsEnumRecordKey, TsEnumRecordValue},
+    shared::enum_member_name,
+    ts_enum::{static_enum_member_name, EnumValueComputer, TsEnumRecordKey, TsEnumRecordValue},
     utils::{assign_value_to_this_private_prop, assign_value_to_this_prop, Factory},
 };
 
@@ -1118,7 +1118,7 @@ impl Transform {
             .into_iter()
             .map(|m| {
                 let span = m.span;
-                let name = enum_member_id_atom(&m.id);
+                let name = enum_member_name(&m.id);
 
                 let key = TsEnumRecordKey {
                     enum_id: id.to_id(),
@@ -1643,7 +1643,7 @@ impl Transform {
                 return;
             }
 
-            let Some(member_name) = get_member_key(prop) else {
+            let Some(member_name) = static_enum_member_name(prop) else {
                 return;
             };
 
@@ -1901,13 +1901,13 @@ impl QueryRef for ExportQuery {
 
 struct EnumMemberRefQuery<'a> {
     enum_id: &'a Id,
-    member_names: &'a FxHashSet<Atom>,
+    member_names: &'a FxHashSet<Wtf8Atom>,
     unresolved_ctxt: SyntaxContext,
 }
 
 impl QueryRef for EnumMemberRefQuery<'_> {
     fn query_ref(&self, ident: &Ident) -> Option<Box<Expr>> {
-        if ident.ctxt == self.unresolved_ctxt && self.member_names.contains(&ident.sym) {
+        if ident.ctxt == self.unresolved_ctxt && self.member_names.contains(ident.sym.borrow()) {
             Some(
                 self.enum_id
                     .clone()
@@ -1924,7 +1924,7 @@ impl QueryRef for EnumMemberRefQuery<'_> {
     }
 
     fn query_jsx(&self, ident: &Ident) -> Option<JSXElementName> {
-        if ident.ctxt == self.unresolved_ctxt && self.member_names.contains(&ident.sym) {
+        if ident.ctxt == self.unresolved_ctxt && self.member_names.contains(ident.sym.borrow()) {
             Some(
                 JSXMemberExpr {
                     span: DUMMY_SP,
@@ -1941,7 +1941,7 @@ impl QueryRef for EnumMemberRefQuery<'_> {
 
 struct EnumMemberItem {
     span: Span,
-    name: Atom,
+    name: Wtf8Atom,
     value: TsEnumRecordValue,
 }
 
@@ -1953,20 +1953,19 @@ impl EnumMemberItem {
     fn build_assign(self, enum_id: &Id) -> Stmt {
         let is_string = self.value.is_string();
         let value: Expr = self.value.into();
+        let name: Expr = Str::from(self.name).into();
 
         let inner_assign = value.make_assign_to(
             op!("="),
             Ident::from(enum_id.clone())
-                .computed_member(self.name.clone())
+                .computed_member(name.clone())
                 .into(),
         );
 
         let outer_assign = if is_string {
             inner_assign
         } else {
-            let value: Expr = self.name.clone().into();
-
-            value.make_assign_to(
+            name.make_assign_to(
                 op!("="),
                 Ident::from(enum_id.clone())
                     .computed_member(inner_assign)
@@ -2008,26 +2007,5 @@ fn get_enum_id(e: &Expr) -> Option<Id> {
         Some(ident.to_id())
     } else {
         None
-    }
-}
-
-fn get_member_key(prop: &MemberProp) -> Option<Atom> {
-    match prop {
-        MemberProp::Ident(ident) => Some(ident.sym.clone()),
-        MemberProp::Computed(ComputedPropName { expr, .. }) => match &**expr {
-            Expr::Lit(Lit::Str(Str { value, .. })) => Some(value.to_atom_lossy().into_owned()),
-            Expr::Tpl(Tpl { exprs, quasis, .. }) => match (exprs.len(), quasis.len()) {
-                (0, 1) => quasis[0]
-                    .cooked
-                    .as_ref()
-                    .map(|cooked| cooked.to_atom_lossy().into_owned())
-                    .or_else(|| Some(quasis[0].raw.clone())),
-                _ => None,
-            },
-            _ => None,
-        },
-        MemberProp::PrivateName(_) => None,
-        #[cfg(swc_ast_unknown)]
-        _ => panic!("unable to access unknown nodes"),
     }
 }

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -1,5 +1,5 @@
 use rustc_hash::FxHashMap;
-use swc_atoms::{Atom, Wtf8Atom};
+use swc_atoms::{wtf8::Wtf8Buf, Atom, Wtf8Atom};
 use swc_common::{SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{
@@ -7,25 +7,17 @@ use swc_ecma_utils::{
     ExprFactory,
 };
 
-#[inline]
-fn atom_from_wtf8_atom(value: &Wtf8Atom) -> Atom {
-    value
-        .as_str()
-        .map(Atom::from)
-        .unwrap_or_else(|| Atom::from(value.to_string_lossy()))
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct TsEnumRecordKey {
     pub enum_id: Id,
-    pub member_name: Atom,
+    pub member_name: Wtf8Atom,
 }
 
 pub(crate) type TsEnumRecord = FxHashMap<TsEnumRecordKey, TsEnumRecordValue>;
 
 #[derive(Debug, Clone)]
 pub(crate) enum TsEnumRecordValue {
-    String(Atom),
+    String(Wtf8Atom),
     Number(Number),
     Opaque(Box<Expr>),
     Void,
@@ -72,6 +64,16 @@ impl TsEnumRecordValue {
     pub fn has_value(&self) -> bool {
         !matches!(self, TsEnumRecordValue::Void)
     }
+
+    fn push_to_string(&self, output: &mut Wtf8Buf) -> bool {
+        match self {
+            Self::String(value) => output.push_wtf8(value),
+            Self::Number(value) => output.push_str(&value.value.to_js_string()),
+            Self::Opaque(_) | Self::Void => return false,
+        }
+
+        true
+    }
 }
 
 impl From<TsEnumRecordValue> for Expr {
@@ -97,6 +99,24 @@ pub(crate) struct EnumValueComputer<'a> {
     pub record: &'a TsEnumRecord,
 }
 
+/// Returns a statically known enum member key without discarding lone
+/// surrogates.
+pub(crate) fn static_enum_member_name(property: &MemberProp) -> Option<Wtf8Atom> {
+    match property {
+        MemberProp::Ident(ident) => Some(ident.sym.clone().into()),
+        MemberProp::Computed(ComputedPropName { expr, .. }) => match &**expr {
+            Expr::Lit(Lit::Str(string)) => Some(string.value.clone()),
+            Expr::Tpl(template) if template.exprs.is_empty() && template.quasis.len() == 1 => {
+                template.quasis[0].cooked.clone()
+            }
+            _ => None,
+        },
+        MemberProp::PrivateName(_) => None,
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unable to access unknown nodes"),
+    }
+}
+
 /// https://github.com/microsoft/TypeScript/pull/50528
 impl EnumValueComputer<'_> {
     pub fn compute(&self, expr: Box<Expr>) -> TsEnumRecordValue {
@@ -105,12 +125,12 @@ impl EnumValueComputer<'_> {
 
     fn compute_rec(&self, expr: Box<Expr>) -> TsEnumRecordValue {
         match *expr {
-            Expr::Lit(Lit::Str(s)) => TsEnumRecordValue::String(atom_from_wtf8_atom(&s.value)),
+            Expr::Lit(Lit::Str(s)) => TsEnumRecordValue::String(s.value),
             Expr::Lit(Lit::Num(n)) => TsEnumRecordValue::Number(n),
             Expr::Ident(ref ident) if ident.ctxt == self.unresolved_ctxt => {
                 if let Some(value) = self.record.get(&TsEnumRecordKey {
                     enum_id: self.enum_id.clone(),
-                    member_name: ident.sym.clone(),
+                    member_name: ident.sym.clone().into(),
                 }) {
                     if value.is_const() {
                         value.clone()
@@ -201,6 +221,14 @@ impl EnumValueComputer<'_> {
         let left = self.compute_rec(expr.left);
         let right = self.compute_rec(expr.right);
 
+        if expr.op == BinaryOp::Add && (left.is_string() || right.is_string()) {
+            let mut value = Wtf8Buf::new();
+
+            if left.push_to_string(&mut value) && right.push_to_string(&mut value) {
+                return TsEnumRecordValue::String(Wtf8Atom::from(&*value));
+            }
+        }
+
         match (left, right, expr.op) {
             (TsEnumRecordValue::Number(left), TsEnumRecordValue::Number(right), op) => {
                 let left = JsNumber::from(left.value);
@@ -223,19 +251,6 @@ impl EnumValueComputer<'_> {
 
                 TsEnumRecordValue::number(value)
             }
-            (TsEnumRecordValue::String(left), TsEnumRecordValue::String(right), op!(bin, "+")) => {
-                TsEnumRecordValue::String(format!("{left}{right}").into())
-            }
-            (TsEnumRecordValue::Number(left), TsEnumRecordValue::String(right), op!(bin, "+")) => {
-                let left = left.value.to_js_string();
-
-                TsEnumRecordValue::String(format!("{left}{right}").into())
-            }
-            (TsEnumRecordValue::String(left), TsEnumRecordValue::Number(right), op!(bin, "+")) => {
-                let right = right.value.to_js_string();
-
-                TsEnumRecordValue::String(format!("{left}{right}").into())
-            }
             (left, right, _) => {
                 let mut origin_expr = origin_expr;
 
@@ -253,22 +268,10 @@ impl EnumValueComputer<'_> {
     }
 
     fn compute_member(&self, expr: MemberExpr) -> TsEnumRecordValue {
-        if matches!(expr.prop, MemberProp::PrivateName(..)) {
-            return TsEnumRecordValue::Opaque(expr.into());
-        }
-
         let opaque_expr = TsEnumRecordValue::Opaque(expr.clone().into());
 
-        let member_name = match expr.prop {
-            MemberProp::Ident(ident) => ident.sym,
-            MemberProp::Computed(ComputedPropName { expr, .. }) => {
-                let Expr::Lit(Lit::Str(s)) = *expr else {
-                    return opaque_expr;
-                };
-
-                atom_from_wtf8_atom(&s.value)
-            }
-            _ => return opaque_expr,
+        let Some(member_name) = static_enum_member_name(&expr.prop) else {
+            return opaque_expr;
         };
 
         let Expr::Ident(ident) = *expr.obj else {
@@ -292,23 +295,27 @@ impl EnumValueComputer<'_> {
 
         let mut quasis_iter = quasis.into_iter();
 
-        let Some(mut string) = quasis_iter.next().map(|q| q.raw.to_string()) else {
+        let Some(first_quasi) = quasis_iter.next() else {
             return opaque_expr;
         };
+        let Some(first_cooked) = first_quasi.cooked.as_ref() else {
+            return opaque_expr;
+        };
+        let mut string = Wtf8Buf::from(first_cooked);
 
         for (q, expr) in quasis_iter.zip(exprs) {
             let expr = self.compute_rec(expr);
 
-            let expr = match expr {
-                TsEnumRecordValue::String(s) => s.to_string(),
-                TsEnumRecordValue::Number(n) => n.value.to_js_string(),
-                _ => return opaque_expr,
+            if !expr.push_to_string(&mut string) {
+                return opaque_expr;
+            }
+            let Some(cooked) = q.cooked.as_ref() else {
+                return opaque_expr;
             };
 
-            string.push_str(&expr);
-            string.push_str(&q.raw);
+            string.push_wtf8(cooked);
         }
 
-        TsEnumRecordValue::String(string.into())
+        TsEnumRecordValue::String(Wtf8Atom::from(&*string))
     }
 }

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/enum-template-cooked/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/enum-template-cooked/input.ts
@@ -1,0 +1,10 @@
+enum TemplateCooked {
+    "\uD800" = 1,
+    FromString = TemplateCooked["\uD800"] + 1,
+    FromTemplate = TemplateCooked[`\uD800`] + 2,
+    Escaped = `line\n`,
+    Interpolated = `value:\x20${1}\u0021`,
+    LoneSurrogate = `\uD800`,
+    InterpolatedSurrogate = `x${"\uD800"}y`,
+    ConcatenatedSurrogate = "\uD800" + "x",
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/enum-template-cooked/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/enum-template-cooked/output.js
@@ -1,0 +1,11 @@
+var TemplateCooked = /*#__PURE__*/ function(TemplateCooked) {
+    TemplateCooked[TemplateCooked["\uD800"] = 1] = "\uD800";
+    TemplateCooked[TemplateCooked["FromString"] = 2] = "FromString";
+    TemplateCooked[TemplateCooked["FromTemplate"] = 3] = "FromTemplate";
+    TemplateCooked["Escaped"] = "line\n";
+    TemplateCooked["Interpolated"] = "value: 1!";
+    TemplateCooked["LoneSurrogate"] = "\uD800";
+    TemplateCooked["InterpolatedSurrogate"] = "x\uD800y";
+    TemplateCooked["ConcatenatedSurrogate"] = "\uD800x";
+    return TemplateCooked;
+}(TemplateCooked || {});

--- a/crates/swc_typescript/src/fast_dts/enum.rs
+++ b/crates/swc_typescript/src/fast_dts/enum.rs
@@ -1,7 +1,8 @@
 use core::f64;
+use std::borrow::Borrow;
 
 use rustc_hash::FxHashMap;
-use swc_atoms::Atom;
+use swc_atoms::{wtf8::Wtf8Buf, Atom, Wtf8Atom};
 use swc_common::{Spanned, DUMMY_SP};
 use swc_ecma_ast::{
     BinExpr, BinaryOp, Expr, Lit, Number, Str, TsEnumDecl, TsEnumMemberId, UnaryExpr, UnaryOp,
@@ -13,7 +14,7 @@ use super::{util::ast_ext::MemberPropExt, FastDts};
 #[derive(Debug, Clone)]
 enum ConstantValue {
     Number(Number),
-    String(String),
+    String(Wtf8Atom),
 }
 
 impl ConstantValue {
@@ -34,6 +35,13 @@ impl ConstantValue {
             value,
             raw,
         })
+    }
+
+    fn push_to(self, output: &mut Wtf8Buf) {
+        match self {
+            Self::Number(number) => output.push_str(&number.value.to_js_string()),
+            Self::String(string) => output.push_wtf8(&string),
+        }
     }
 }
 
@@ -56,25 +64,15 @@ impl FastDts {
 
             prev_init_value = value.clone();
             if let Some(value) = &value {
-                let member_name = match &member.id {
-                    TsEnumMemberId::Ident(ident) => ident.sym.clone(),
-                    TsEnumMemberId::Str(s) => s
-                        .value
-                        .clone()
-                        .try_into_atom()
-                        .unwrap_or_else(|wtf8| Atom::from(&*wtf8.to_string_lossy())),
-                    #[cfg(swc_ast_unknown)]
-                    _ => panic!("unable to access unknown nodes"),
-                };
-                prev_members.insert(member_name.clone(), value.clone());
+                prev_members.insert(enum_member_name(&member.id), value.clone());
             }
 
             member.init = value.map(|value| {
                 Box::new(match value {
                     ConstantValue::Number(number) => Expr::Lit(Lit::Num(number)),
-                    ConstantValue::String(s) => Expr::Lit(Lit::Str(Str {
+                    ConstantValue::String(value) => Expr::Lit(Lit::Str(Str {
                         span: DUMMY_SP,
-                        value: s.clone().into(),
+                        value,
                         raw: None,
                     })),
                 })
@@ -86,11 +84,11 @@ impl FastDts {
         &self,
         expr: &Expr,
         enum_name: &Atom,
-        prev_members: &FxHashMap<Atom, ConstantValue>,
+        prev_members: &FxHashMap<Wtf8Atom, ConstantValue>,
     ) -> Option<ConstantValue> {
         match expr {
             Expr::Lit(lit) => match lit {
-                Lit::Str(s) => Some(ConstantValue::String(s.value.to_string_lossy().to_string())),
+                Lit::Str(string) => Some(ConstantValue::String(string.value.clone())),
                 Lit::Num(number) => Some(ConstantValue::Number(number.clone())),
                 Lit::Null(_) | Lit::BigInt(_) | Lit::Bool(_) | Lit::Regex(_) | Lit::JSXText(_) => {
                     None
@@ -98,12 +96,18 @@ impl FastDts {
                 #[cfg(swc_ast_unknown)]
                 _ => panic!("unable to access unknown nodes"),
             },
-            Expr::Tpl(tpl) => {
-                let mut value = String::new();
-                for part in &tpl.quasis {
-                    value.push_str(&part.raw);
+            Expr::Tpl(template) => {
+                let mut quasis = template.quasis.iter();
+                let first = quasis.next()?.cooked.as_ref()?;
+                let mut value = Wtf8Buf::from(first);
+
+                for (expr, quasi) in template.exprs.iter().zip(quasis) {
+                    self.evaluate(expr, enum_name, prev_members)?
+                        .push_to(&mut value);
+                    value.push_wtf8(quasi.cooked.as_ref()?);
                 }
-                Some(ConstantValue::String(value))
+
+                Some(ConstantValue::String(Wtf8Atom::from(&*value)))
             }
             Expr::Paren(expr) => self.evaluate(&expr.expr, enum_name, prev_members),
             Expr::Bin(bin_expr) => self.evaluate_binary_expr(bin_expr, enum_name, prev_members),
@@ -122,7 +126,7 @@ impl FastDts {
                         Some(ident.sym.clone()),
                     ))
                 } else {
-                    prev_members.get(&ident.sym).cloned()
+                    prev_members.get(ident.sym.borrow()).cloned()
                 }
             }
             Expr::Member(member) => {
@@ -152,11 +156,11 @@ impl FastDts {
         &self,
         expr: &UnaryExpr,
         enum_name: &Atom,
-        prev_members: &FxHashMap<Atom, ConstantValue>,
+        prev_members: &FxHashMap<Wtf8Atom, ConstantValue>,
     ) -> Option<ConstantValue> {
         let value = self.evaluate(&expr.arg, enum_name, prev_members)?;
         let value = match value {
-            ConstantValue::Number(n) => n.value,
+            ConstantValue::Number(number) => number.value,
             ConstantValue::String(_) => {
                 let value = if expr.op == UnaryOp::Minus {
                     ConstantValue::number(f64::NAN)
@@ -181,7 +185,7 @@ impl FastDts {
         &self,
         expr: &BinExpr,
         enum_name: &Atom,
-        prev_members: &FxHashMap<Atom, ConstantValue>,
+        prev_members: &FxHashMap<Wtf8Atom, ConstantValue>,
     ) -> Option<ConstantValue> {
         let left = self.evaluate(&expr.left, enum_name, prev_members)?;
         let right = self.evaluate(&expr.right, enum_name, prev_members)?;
@@ -190,28 +194,19 @@ impl FastDts {
             && (matches!(left, ConstantValue::String(_))
                 || matches!(right, ConstantValue::String(_)))
         {
-            let left_string = match left {
-                ConstantValue::Number(number) => number.value.to_js_string(),
-                ConstantValue::String(s) => s,
-            };
-
-            let right_string = match right {
-                ConstantValue::Number(number) => number.value.to_js_string(),
-                ConstantValue::String(s) => s,
-            };
-
-            return Some(ConstantValue::String(format!(
-                "{left_string}{right_string}"
-            )));
+            let mut value = Wtf8Buf::new();
+            left.push_to(&mut value);
+            right.push_to(&mut value);
+            return Some(ConstantValue::String(Wtf8Atom::from(&*value)));
         }
 
         let left = JsNumber::from(match left {
-            ConstantValue::Number(n) => n.value,
+            ConstantValue::Number(number) => number.value,
             ConstantValue::String(_) => return None,
         });
 
         let right = JsNumber::from(match right {
-            ConstantValue::Number(n) => n.value,
+            ConstantValue::Number(number) => number.value,
             ConstantValue::String(_) => return None,
         });
 
@@ -231,5 +226,14 @@ impl FastDts {
             _ => None,
         }
         .map(|number| ConstantValue::number(number.into()))
+    }
+}
+
+fn enum_member_name(member: &TsEnumMemberId) -> Wtf8Atom {
+    match member {
+        TsEnumMemberId::Ident(ident) => ident.sym.clone().into(),
+        TsEnumMemberId::Str(string) => string.value.clone(),
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unable to access unknown nodes"),
     }
 }

--- a/crates/swc_typescript/src/fast_dts/util/ast_ext.rs
+++ b/crates/swc_typescript/src/fast_dts/util/ast_ext.rs
@@ -1,6 +1,6 @@
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 
-use swc_atoms::Atom;
+use swc_atoms::{Atom, Wtf8Atom};
 use swc_common::Mark;
 use swc_ecma_ast::{
     BindingIdent, ComputedPropName, Expr, Ident, Lit, MemberProp, ObjectPatProp, Pat, Prop,
@@ -234,17 +234,17 @@ impl PropNameExit for Prop {
 }
 
 pub trait MemberPropExt {
-    fn static_name(&self) -> Option<&Atom>;
+    fn static_name(&self) -> Option<&Wtf8Atom>;
 }
 
 impl MemberPropExt for MemberProp {
-    fn static_name(&self) -> Option<&Atom> {
+    fn static_name(&self) -> Option<&Wtf8Atom> {
         match self {
-            MemberProp::Ident(ident_name) => Some(&ident_name.sym),
+            MemberProp::Ident(ident_name) => Some(ident_name.sym.borrow()),
             MemberProp::Computed(computed_prop_name) => match computed_prop_name.expr.as_ref() {
-                Expr::Lit(Lit::Str(s)) => s.value.as_atom(),
+                Expr::Lit(Lit::Str(s)) => Some(&s.value),
                 Expr::Tpl(tpl) if tpl.quasis.len() == 1 && tpl.exprs.is_empty() => {
-                    Some(&tpl.quasis[0].raw)
+                    tpl.quasis[0].cooked.as_ref()
                 }
                 _ => None,
             },

--- a/crates/swc_typescript/tests/fixture/enum-template-cooked.snap
+++ b/crates/swc_typescript/tests/fixture/enum-template-cooked.snap
@@ -1,0 +1,13 @@
+```==================== .D.TS ====================
+
+export declare enum TemplateMemberKeys {
+    "A" = 1,
+    FromCooked = 2,
+    "\uD800" = 1,
+    FromString = 2,
+    FromTemplate = 3,
+    LoneSurrogate = "\uD800",
+    InterpolatedSurrogate = "x\uD800y"
+}
+
+

--- a/crates/swc_typescript/tests/fixture/enum-template-cooked.ts
+++ b/crates/swc_typescript/tests/fixture/enum-template-cooked.ts
@@ -1,0 +1,9 @@
+export enum TemplateMemberKeys {
+    "A" = 1,
+    FromCooked = TemplateMemberKeys[`\x41`] + 1,
+    "\uD800" = 1,
+    FromString = TemplateMemberKeys["\uD800"] + 1,
+    FromTemplate = TemplateMemberKeys[`\uD800`] + 2,
+    LoneSurrogate = `\uD800`,
+    InterpolatedSurrogate = `x${"\uD800"}y`,
+}


### PR DESCRIPTION
**Description:**

Enum template evaluation currently reads raw template source and converts atoms lossily. Escapes, interpolation, and lone surrogates can therefore diverge from the cooked JavaScript string used at runtime.

This PR evaluates template quasis and static template member keys from cooked WTF-8 values in both the transform and fast-DTS paths. Lookup and concatenation retain lone surrogates without changing the surrounding enum evaluation model.

**Related issue (if exists):**

- #12043
  - #12047
    - #12050
      - #12048
        - #12051
      - #12052
        - #12053
      - #12054
      - #12055
      - #12056
      - #12057
    - #12058
    - #12049
      - **#12059** (current)
        - #12060