### PR TITLE
refactor(es/typescript): track enum evaluation context

### DIFF
--- a/.changeset/fix-enum-template-cooked.md
+++ b/.changeset/fix-enum-template-cooked.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_transforms_typescript: patch
+swc_typescript: patch
+---
+
+fix(es/typescript): Evaluate enum templates from cooked values

--- a/.changeset/refactor-enum-evaluation-context.md
+++ b/.changeset/refactor-enum-evaluation-context.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_transforms_typescript: patch
+swc_typescript: patch
+---
+
+fix(es/typescript): Track enum values by declaration order

--- a/crates/swc_ecma_transforms_typescript/src/semantic.rs
+++ b/crates/swc_ecma_transforms_typescript/src/semantic.rs
@@ -1,4 +1,7 @@
+use std::collections::VecDeque;
+
 use rustc_hash::{FxHashMap, FxHashSet};
+use swc_atoms::Wtf8Atom;
 use swc_common::{Mark, Span, SyntaxContext};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{find_pat_ids, stack_size::maybe_grow_default};
@@ -17,6 +20,8 @@ pub(crate) struct SemanticInfo {
     pub id_value: FxHashSet<Id>,
     pub exported_binding: FxHashMap<Id, Option<Id>>,
     pub enum_record: TsEnumRecord,
+    pub enum_member_names: FxHashMap<Id, FxHashSet<Wtf8Atom>>,
+    pub enum_member_values: FxHashMap<Id, VecDeque<TsEnumRecordValue>>,
     pub const_enum: FxHashSet<Id>,
     pub namespace_import_equals_usage: FxHashSet<Span>,
 }
@@ -49,10 +54,14 @@ pub(crate) fn analyze_program(
     seed_usage: FxHashSet<Id>,
     flow_syntax: bool,
 ) -> SemanticInfo {
+    let mut enum_member_name_collector = EnumMemberNameCollector::default();
+    program.visit_with(&mut enum_member_name_collector);
+
     let mut analyzer = SemanticAnalyzer {
         unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
         info: SemanticInfo {
             usage: seed_usage,
+            enum_member_names: enum_member_name_collector.names,
             ..Default::default()
         },
         import_chain: Default::default(),
@@ -65,6 +74,30 @@ pub(crate) fn analyze_program(
     program.visit_with(&mut analyzer);
 
     analyzer.finish()
+}
+
+#[derive(Default)]
+struct EnumMemberNameCollector {
+    names: FxHashMap<Id, FxHashSet<Wtf8Atom>>,
+}
+
+impl Visit for EnumMemberNameCollector {
+    noop_visit_type!();
+
+    fn visit_expr(&mut self, node: &Expr) {
+        maybe_grow_default(|| node.visit_children_with(self));
+    }
+
+    fn visit_ts_enum_decl(&mut self, node: &TsEnumDecl) {
+        let names = self.names.entry(node.id.to_id()).or_default();
+        names.extend(
+            node.members
+                .iter()
+                .map(|member| enum_member_name(&member.id)),
+        );
+
+        node.visit_children_with(self);
+    }
 }
 
 struct SemanticAnalyzer {
@@ -257,9 +290,12 @@ impl SemanticAnalyzer {
         enum_id: &Id,
         default_init: &TsEnumRecordValue,
         record: &TsEnumRecord,
+        enum_member_names: &FxHashMap<Id, FxHashSet<Wtf8Atom>>,
         unresolved_ctxt: SyntaxContext,
         flow_syntax: bool,
     ) -> TsEnumRecordValue {
+        let current_member_name = enum_member_name(&member.id);
+
         member
             .init
             .map(|expr| {
@@ -267,6 +303,8 @@ impl SemanticAnalyzer {
                     enum_id,
                     unresolved_ctxt,
                     record,
+                    enum_member_names,
+                    current_member_name: &current_member_name,
                 }
                 .compute(expr)
             })
@@ -559,13 +597,13 @@ impl Visit for SemanticAnalyzer {
         } else {
             0.0.into()
         };
-
         for member in members {
             let value = Self::transform_ts_enum_member(
                 member.clone(),
                 &id.to_id(),
                 &default_init,
                 &self.info.enum_record,
+                &self.info.enum_member_names,
                 self.unresolved_ctxt,
                 self.flow_syntax,
             );
@@ -578,7 +616,12 @@ impl Visit for SemanticAnalyzer {
                 member_name,
             };
 
-            self.info.enum_record.insert(key, value);
+            self.info
+                .enum_member_values
+                .entry(id.to_id())
+                .or_default()
+                .push_back(value.clone());
+            self.info.enum_record.entry(key).or_insert(value);
         }
     }
 
@@ -655,6 +698,7 @@ mod tests {
             &id("E"),
             &TsEnumRecordValue::Void,
             &Default::default(),
+            &Default::default(),
             SyntaxContext::empty(),
             true,
         );
@@ -671,6 +715,7 @@ mod tests {
             enum_member("A"),
             &id("E"),
             &TsEnumRecordValue::from(2.0),
+            &Default::default(),
             &Default::default(),
             SyntaxContext::empty(),
             false,

--- a/crates/swc_ecma_transforms_typescript/src/semantic.rs
+++ b/crates/swc_ecma_transforms_typescript/src/semantic.rs
@@ -6,7 +6,7 @@ use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use crate::{
     retain::{should_retain_decl, IsConcrete},
-    shared::{enum_member_id_atom, get_module_ident},
+    shared::{enum_member_name, get_module_ident},
     ts_enum::{EnumValueComputer, TsEnumRecord, TsEnumRecordKey, TsEnumRecordValue},
 };
 
@@ -277,7 +277,7 @@ impl SemanticAnalyzer {
                     // name as the runtime string value. The AST does not retain
                     // the explicit `of string` kind, so `Void` acts as the
                     // sentinel for Flow's default string mode here.
-                    TsEnumRecordValue::String(enum_member_id_atom(&member.id))
+                    TsEnumRecordValue::String(enum_member_name(&member.id))
                 } else {
                     default_init.clone()
                 }
@@ -572,7 +572,7 @@ impl Visit for SemanticAnalyzer {
 
             default_init = value.inc();
 
-            let member_name = enum_member_id_atom(&member.id);
+            let member_name = enum_member_name(&member.id);
             let key = TsEnumRecordKey {
                 enum_id: id.to_id(),
                 member_name,

--- a/crates/swc_ecma_transforms_typescript/src/shared.rs
+++ b/crates/swc_ecma_transforms_typescript/src/shared.rs
@@ -1,12 +1,12 @@
-use swc_atoms::Atom;
+use swc_atoms::Wtf8Atom;
 use swc_ecma_ast::{Ident, TsEntityName, TsEnumMemberId};
 
-/// Returns enum member key as an atom for record lookup.
+/// Returns an enum member name without discarding lone surrogates.
 #[inline]
-pub(crate) fn enum_member_id_atom(id: &TsEnumMemberId) -> Atom {
+pub(crate) fn enum_member_name(id: &TsEnumMemberId) -> Wtf8Atom {
     match id {
-        TsEnumMemberId::Ident(ident) => ident.sym.clone(),
-        TsEnumMemberId::Str(str_lit) => str_lit.value.to_atom_lossy().into_owned(),
+        TsEnumMemberId::Ident(ident) => ident.sym.clone().into(),
+        TsEnumMemberId::Str(str_lit) => str_lit.value.clone(),
         #[cfg(swc_ast_unknown)]
         _ => panic!("unable to access unknown nodes"),
     }

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -1,7 +1,7 @@
-use std::{iter, mem};
+use std::{borrow::Borrow, iter, mem};
 
 use rustc_hash::{FxHashMap, FxHashSet};
-use swc_atoms::Atom;
+use swc_atoms::{Atom, Wtf8Atom};
 use swc_common::{
     errors::HANDLER, source_map::PURE_SP, util::take::Take, Mark, Span, Spanned, SyntaxContext,
     DUMMY_SP,
@@ -21,8 +21,8 @@ use crate::{
     config::TsImportExportAssignConfig,
     retain::{should_retain_module_item, should_retain_stmt},
     semantic::SemanticInfo,
-    shared::enum_member_id_atom,
-    ts_enum::{EnumValueComputer, TsEnumRecordKey, TsEnumRecordValue},
+    shared::enum_member_name,
+    ts_enum::{static_enum_member_name, EnumValueComputer, TsEnumRecordKey, TsEnumRecordValue},
     utils::{assign_value_to_this_private_prop, assign_value_to_this_prop, Factory},
 };
 
@@ -1118,7 +1118,7 @@ impl Transform {
             .into_iter()
             .map(|m| {
                 let span = m.span;
-                let name = enum_member_id_atom(&m.id);
+                let name = enum_member_name(&m.id);
 
                 let key = TsEnumRecordKey {
                     enum_id: id.to_id(),
@@ -1643,7 +1643,7 @@ impl Transform {
                 return;
             }
 
-            let Some(member_name) = get_member_key(prop) else {
+            let Some(member_name) = static_enum_member_name(prop) else {
                 return;
             };
 
@@ -1901,13 +1901,13 @@ impl QueryRef for ExportQuery {
 
 struct EnumMemberRefQuery<'a> {
     enum_id: &'a Id,
-    member_names: &'a FxHashSet<Atom>,
+    member_names: &'a FxHashSet<Wtf8Atom>,
     unresolved_ctxt: SyntaxContext,
 }
 
 impl QueryRef for EnumMemberRefQuery<'_> {
     fn query_ref(&self, ident: &Ident) -> Option<Box<Expr>> {
-        if ident.ctxt == self.unresolved_ctxt && self.member_names.contains(&ident.sym) {
+        if ident.ctxt == self.unresolved_ctxt && self.member_names.contains(ident.sym.borrow()) {
             Some(
                 self.enum_id
                     .clone()
@@ -1924,7 +1924,7 @@ impl QueryRef for EnumMemberRefQuery<'_> {
     }
 
     fn query_jsx(&self, ident: &Ident) -> Option<JSXElementName> {
-        if ident.ctxt == self.unresolved_ctxt && self.member_names.contains(&ident.sym) {
+        if ident.ctxt == self.unresolved_ctxt && self.member_names.contains(ident.sym.borrow()) {
             Some(
                 JSXMemberExpr {
                     span: DUMMY_SP,
@@ -1941,7 +1941,7 @@ impl QueryRef for EnumMemberRefQuery<'_> {
 
 struct EnumMemberItem {
     span: Span,
-    name: Atom,
+    name: Wtf8Atom,
     value: TsEnumRecordValue,
 }
 
@@ -1953,20 +1953,19 @@ impl EnumMemberItem {
     fn build_assign(self, enum_id: &Id) -> Stmt {
         let is_string = self.value.is_string();
         let value: Expr = self.value.into();
+        let name: Expr = Str::from(self.name).into();
 
         let inner_assign = value.make_assign_to(
             op!("="),
             Ident::from(enum_id.clone())
-                .computed_member(self.name.clone())
+                .computed_member(name.clone())
                 .into(),
         );
 
         let outer_assign = if is_string {
             inner_assign
         } else {
-            let value: Expr = self.name.clone().into();
-
-            value.make_assign_to(
+            name.make_assign_to(
                 op!("="),
                 Ident::from(enum_id.clone())
                     .computed_member(inner_assign)
@@ -2008,26 +2007,5 @@ fn get_enum_id(e: &Expr) -> Option<Id> {
         Some(ident.to_id())
     } else {
         None
-    }
-}
-
-fn get_member_key(prop: &MemberProp) -> Option<Atom> {
-    match prop {
-        MemberProp::Ident(ident) => Some(ident.sym.clone()),
-        MemberProp::Computed(ComputedPropName { expr, .. }) => match &**expr {
-            Expr::Lit(Lit::Str(Str { value, .. })) => Some(value.to_atom_lossy().into_owned()),
-            Expr::Tpl(Tpl { exprs, quasis, .. }) => match (exprs.len(), quasis.len()) {
-                (0, 1) => quasis[0]
-                    .cooked
-                    .as_ref()
-                    .map(|cooked| cooked.to_atom_lossy().into_owned())
-                    .or_else(|| Some(quasis[0].raw.clone())),
-                _ => None,
-            },
-            _ => None,
-        },
-        MemberProp::PrivateName(_) => None,
-        #[cfg(swc_ast_unknown)]
-        _ => panic!("unable to access unknown nodes"),
     }
 }

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -1102,30 +1102,33 @@ impl Transform {
 
         let member_names = self
             .semantic
-            .enum_record
-            .keys()
-            .filter(|k| k.enum_id == id.to_id())
-            .map(|k| k.member_name.clone())
-            .collect();
-
-        let enum_computer = EnumValueComputer {
-            enum_id: &id.to_id(),
-            unresolved_ctxt: self.unresolved_ctxt,
-            record: &self.semantic.enum_record,
+            .enum_member_names
+            .get(&id.to_id())
+            .expect("enum member names should be collected before transforming enums");
+        let enum_id = id.to_id();
+        let member_values = if members.is_empty() {
+            Vec::new()
+        } else {
+            let values = self
+                .semantic
+                .enum_member_values
+                .get_mut(&enum_id)
+                .expect("enum member values should be recorded during semantic analysis");
+            (0..members.len())
+                .map(|_| {
+                    values
+                        .pop_front()
+                        .expect("each enum member should have one semantic value")
+                })
+                .collect::<Vec<_>>()
         };
 
         let member_list: Vec<_> = members
             .into_iter()
-            .map(|m| {
+            .zip(member_values)
+            .map(|(m, mut value)| {
                 let span = m.span;
                 let name = enum_member_name(&m.id);
-
-                let key = TsEnumRecordKey {
-                    enum_id: id.to_id(),
-                    member_name: name.clone(),
-                };
-
-                let mut value = self.semantic.enum_record.get(&key).unwrap().clone();
 
                 if matches!(value, TsEnumRecordValue::Opaque(..)) {
                     if let Some(init) = m.init {
@@ -1133,12 +1136,19 @@ impl Transform {
                         // references can be rewritten to runtime property
                         // accesses. Implicit Flow enum members do not have an
                         // initializer, so keep the semantic value as-is.
+                        let enum_computer = EnumValueComputer {
+                            enum_id: &enum_id,
+                            unresolved_ctxt: self.unresolved_ctxt,
+                            record: &self.semantic.enum_record,
+                            enum_member_names: &self.semantic.enum_member_names,
+                            current_member_name: &name,
+                        };
                         let mut recomputed = enum_computer.compute(init);
                         if let TsEnumRecordValue::Opaque(expr) = &mut recomputed {
                             expr.visit_mut_with(&mut RefRewriter {
                                 query: EnumMemberRefQuery {
                                     enum_id: &id.to_id(),
-                                    member_names: &member_names,
+                                    member_names,
                                     unresolved_ctxt: self.unresolved_ctxt,
                                 },
                             });

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{wtf8::Wtf8Buf, Atom, Wtf8Atom};
 use swc_common::{SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
@@ -97,6 +97,8 @@ pub(crate) struct EnumValueComputer<'a> {
     pub enum_id: &'a Id,
     pub unresolved_ctxt: SyntaxContext,
     pub record: &'a TsEnumRecord,
+    pub enum_member_names: &'a FxHashMap<Id, FxHashSet<Wtf8Atom>>,
+    pub current_member_name: &'a Wtf8Atom,
 }
 
 /// Returns a statically known enum member key without discarding lone
@@ -128,9 +130,10 @@ impl EnumValueComputer<'_> {
             Expr::Lit(Lit::Str(s)) => TsEnumRecordValue::String(s.value),
             Expr::Lit(Lit::Num(n)) => TsEnumRecordValue::Number(n),
             Expr::Ident(ref ident) if ident.ctxt == self.unresolved_ctxt => {
+                let member_name: Wtf8Atom = ident.sym.clone().into();
                 if let Some(value) = self.record.get(&TsEnumRecordKey {
                     enum_id: self.enum_id.clone(),
-                    member_name: ident.sym.clone().into(),
+                    member_name: member_name.clone(),
                 }) {
                     if value.is_const() {
                         value.clone()
@@ -141,6 +144,14 @@ impl EnumValueComputer<'_> {
                                 .make_member(ident.clone().into())
                                 .into(),
                         )
+                    }
+                } else if self.is_known_member(self.enum_id, &member_name) {
+                    if member_name == *self.current_member_name {
+                        TsEnumRecordValue::Opaque(expr)
+                    } else {
+                        // TypeScript reports a use-before-declaration error and
+                        // uses zero as the enum evaluator's recovery value.
+                        TsEnumRecordValue::number(0)
                     }
                 } else {
                     match ident.sym.as_ref() {
@@ -170,6 +181,12 @@ impl EnumValueComputer<'_> {
             | Expr::TsSatisfies(TsSatisfiesExpr { expr, .. }) => self.compute_rec(expr),
             _ => TsEnumRecordValue::Opaque(expr),
         }
+    }
+
+    fn is_known_member(&self, enum_id: &Id, member_name: &Wtf8Atom) -> bool {
+        self.enum_member_names
+            .get(enum_id)
+            .is_some_and(|member_names| member_names.contains(member_name))
     }
 
     fn compute_unary(&self, expr: UnaryExpr) -> TsEnumRecordValue {
@@ -278,14 +295,29 @@ impl EnumValueComputer<'_> {
             return opaque_expr;
         };
 
-        self.record
-            .get(&TsEnumRecordKey {
-                enum_id: ident.to_id(),
-                member_name,
-            })
-            .cloned()
-            .filter(TsEnumRecordValue::has_value)
-            .unwrap_or(opaque_expr)
+        let enum_id = ident.to_id();
+        let key = TsEnumRecordKey {
+            enum_id: enum_id.clone(),
+            member_name: member_name.clone(),
+        };
+
+        if let Some(value) = self.record.get(&key) {
+            return if value.is_const() {
+                value.clone()
+            } else {
+                opaque_expr
+            };
+        }
+
+        if self.is_known_member(&enum_id, &member_name)
+            && !(enum_id == *self.enum_id && member_name == *self.current_member_name)
+        {
+            // See the corresponding recovery behavior for unqualified member
+            // references above.
+            return TsEnumRecordValue::number(0);
+        }
+
+        opaque_expr
     }
 
     fn compute_tpl(&self, expr: Tpl) -> TsEnumRecordValue {

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -1,5 +1,5 @@
 use rustc_hash::FxHashMap;
-use swc_atoms::{Atom, Wtf8Atom};
+use swc_atoms::{wtf8::Wtf8Buf, Atom, Wtf8Atom};
 use swc_common::{SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_utils::{
@@ -7,25 +7,17 @@ use swc_ecma_utils::{
     ExprFactory,
 };
 
-#[inline]
-fn atom_from_wtf8_atom(value: &Wtf8Atom) -> Atom {
-    value
-        .as_str()
-        .map(Atom::from)
-        .unwrap_or_else(|| Atom::from(value.to_string_lossy()))
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub(crate) struct TsEnumRecordKey {
     pub enum_id: Id,
-    pub member_name: Atom,
+    pub member_name: Wtf8Atom,
 }
 
 pub(crate) type TsEnumRecord = FxHashMap<TsEnumRecordKey, TsEnumRecordValue>;
 
 #[derive(Debug, Clone)]
 pub(crate) enum TsEnumRecordValue {
-    String(Atom),
+    String(Wtf8Atom),
     Number(Number),
     Opaque(Box<Expr>),
     Void,
@@ -72,6 +64,16 @@ impl TsEnumRecordValue {
     pub fn has_value(&self) -> bool {
         !matches!(self, TsEnumRecordValue::Void)
     }
+
+    fn push_to_string(&self, output: &mut Wtf8Buf) -> bool {
+        match self {
+            Self::String(value) => output.push_wtf8(value),
+            Self::Number(value) => output.push_str(&value.value.to_js_string()),
+            Self::Opaque(_) | Self::Void => return false,
+        }
+
+        true
+    }
 }
 
 impl From<TsEnumRecordValue> for Expr {
@@ -97,6 +99,24 @@ pub(crate) struct EnumValueComputer<'a> {
     pub record: &'a TsEnumRecord,
 }
 
+/// Returns a statically known enum member key without discarding lone
+/// surrogates.
+pub(crate) fn static_enum_member_name(property: &MemberProp) -> Option<Wtf8Atom> {
+    match property {
+        MemberProp::Ident(ident) => Some(ident.sym.clone().into()),
+        MemberProp::Computed(ComputedPropName { expr, .. }) => match &**expr {
+            Expr::Lit(Lit::Str(string)) => Some(string.value.clone()),
+            Expr::Tpl(template) if template.exprs.is_empty() && template.quasis.len() == 1 => {
+                template.quasis[0].cooked.clone()
+            }
+            _ => None,
+        },
+        MemberProp::PrivateName(_) => None,
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unable to access unknown nodes"),
+    }
+}
+
 /// https://github.com/microsoft/TypeScript/pull/50528
 impl EnumValueComputer<'_> {
     pub fn compute(&self, expr: Box<Expr>) -> TsEnumRecordValue {
@@ -105,12 +125,12 @@ impl EnumValueComputer<'_> {
 
     fn compute_rec(&self, expr: Box<Expr>) -> TsEnumRecordValue {
         match *expr {
-            Expr::Lit(Lit::Str(s)) => TsEnumRecordValue::String(atom_from_wtf8_atom(&s.value)),
+            Expr::Lit(Lit::Str(s)) => TsEnumRecordValue::String(s.value),
             Expr::Lit(Lit::Num(n)) => TsEnumRecordValue::Number(n),
             Expr::Ident(ref ident) if ident.ctxt == self.unresolved_ctxt => {
                 if let Some(value) = self.record.get(&TsEnumRecordKey {
                     enum_id: self.enum_id.clone(),
-                    member_name: ident.sym.clone(),
+                    member_name: ident.sym.clone().into(),
                 }) {
                     if value.is_const() {
                         value.clone()
@@ -201,6 +221,14 @@ impl EnumValueComputer<'_> {
         let left = self.compute_rec(expr.left);
         let right = self.compute_rec(expr.right);
 
+        if expr.op == BinaryOp::Add && (left.is_string() || right.is_string()) {
+            let mut value = Wtf8Buf::new();
+
+            if left.push_to_string(&mut value) && right.push_to_string(&mut value) {
+                return TsEnumRecordValue::String(Wtf8Atom::from(&*value));
+            }
+        }
+
         match (left, right, expr.op) {
             (TsEnumRecordValue::Number(left), TsEnumRecordValue::Number(right), op) => {
                 let left = JsNumber::from(left.value);
@@ -223,19 +251,6 @@ impl EnumValueComputer<'_> {
 
                 TsEnumRecordValue::number(value)
             }
-            (TsEnumRecordValue::String(left), TsEnumRecordValue::String(right), op!(bin, "+")) => {
-                TsEnumRecordValue::String(format!("{left}{right}").into())
-            }
-            (TsEnumRecordValue::Number(left), TsEnumRecordValue::String(right), op!(bin, "+")) => {
-                let left = left.value.to_js_string();
-
-                TsEnumRecordValue::String(format!("{left}{right}").into())
-            }
-            (TsEnumRecordValue::String(left), TsEnumRecordValue::Number(right), op!(bin, "+")) => {
-                let right = right.value.to_js_string();
-
-                TsEnumRecordValue::String(format!("{left}{right}").into())
-            }
             (left, right, _) => {
                 let mut origin_expr = origin_expr;
 
@@ -253,22 +268,10 @@ impl EnumValueComputer<'_> {
     }
 
     fn compute_member(&self, expr: MemberExpr) -> TsEnumRecordValue {
-        if matches!(expr.prop, MemberProp::PrivateName(..)) {
-            return TsEnumRecordValue::Opaque(expr.into());
-        }
-
         let opaque_expr = TsEnumRecordValue::Opaque(expr.clone().into());
 
-        let member_name = match expr.prop {
-            MemberProp::Ident(ident) => ident.sym,
-            MemberProp::Computed(ComputedPropName { expr, .. }) => {
-                let Expr::Lit(Lit::Str(s)) = *expr else {
-                    return opaque_expr;
-                };
-
-                atom_from_wtf8_atom(&s.value)
-            }
-            _ => return opaque_expr,
+        let Some(member_name) = static_enum_member_name(&expr.prop) else {
+            return opaque_expr;
         };
 
         let Expr::Ident(ident) = *expr.obj else {
@@ -292,23 +295,27 @@ impl EnumValueComputer<'_> {
 
         let mut quasis_iter = quasis.into_iter();
 
-        let Some(mut string) = quasis_iter.next().map(|q| q.raw.to_string()) else {
+        let Some(first_quasi) = quasis_iter.next() else {
             return opaque_expr;
         };
+        let Some(first_cooked) = first_quasi.cooked.as_ref() else {
+            return opaque_expr;
+        };
+        let mut string = Wtf8Buf::from(first_cooked);
 
         for (q, expr) in quasis_iter.zip(exprs) {
             let expr = self.compute_rec(expr);
 
-            let expr = match expr {
-                TsEnumRecordValue::String(s) => s.to_string(),
-                TsEnumRecordValue::Number(n) => n.value.to_js_string(),
-                _ => return opaque_expr,
+            if !expr.push_to_string(&mut string) {
+                return opaque_expr;
+            }
+            let Some(cooked) = q.cooked.as_ref() else {
+                return opaque_expr;
             };
 
-            string.push_str(&expr);
-            string.push_str(&q.raw);
+            string.push_wtf8(cooked);
         }
 
-        TsEnumRecordValue::String(string.into())
+        TsEnumRecordValue::String(Wtf8Atom::from(&*string))
     }
 }

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/enum-evaluation-context/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/enum-evaluation-context/input.ts
@@ -1,0 +1,49 @@
+enum DuplicateMembers {
+    A = 1,
+    A = 5,
+    B,
+    C = A + 1,
+}
+
+enum MergedMembers {
+    A = 1,
+}
+
+enum MergedMembers {
+    B = A + 1,
+    C = MergedMembers.A + 2,
+}
+
+enum ForwardReference {
+    A = Later + 1,
+    Later = 1,
+}
+
+enum QualifiedForwardReference {
+    A = QualifiedForwardReference.Later + 1,
+    Later = 1,
+}
+
+enum SelfReference {
+    A = SelfReference.A,
+    B = B,
+}
+
+declare function getValue(): number;
+enum OpaqueMembers {
+    A = getValue(),
+    B = A,
+    C = OpaqueMembers.A,
+}
+
+enum ShadowedGlobals {
+    Positive = Infinity,
+    Infinity = 1,
+    NotANumber = NaN,
+    NaN = 2,
+}
+
+enum Globals {
+    Positive = Infinity,
+    NotANumber = NaN,
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/enum-evaluation-context/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/enum-evaluation-context/output.js
@@ -1,0 +1,48 @@
+var DuplicateMembers = /*#__PURE__*/ function(DuplicateMembers) {
+    DuplicateMembers[DuplicateMembers["A"] = 1] = "A";
+    DuplicateMembers[DuplicateMembers["A"] = 5] = "A";
+    DuplicateMembers[DuplicateMembers["B"] = 6] = "B";
+    DuplicateMembers[DuplicateMembers["C"] = 2] = "C";
+    return DuplicateMembers;
+}(DuplicateMembers || {});
+var MergedMembers = /*#__PURE__*/ function(MergedMembers) {
+    MergedMembers[MergedMembers["A"] = 1] = "A";
+    return MergedMembers;
+}(MergedMembers || {});
+(function(MergedMembers) {
+    MergedMembers[MergedMembers["B"] = 2] = "B";
+    MergedMembers[MergedMembers["C"] = 3] = "C";
+})(MergedMembers);
+var ForwardReference = /*#__PURE__*/ function(ForwardReference) {
+    ForwardReference[ForwardReference["A"] = 1] = "A";
+    ForwardReference[ForwardReference["Later"] = 1] = "Later";
+    return ForwardReference;
+}(ForwardReference || {});
+var QualifiedForwardReference = /*#__PURE__*/ function(QualifiedForwardReference) {
+    QualifiedForwardReference[QualifiedForwardReference["A"] = 1] = "A";
+    QualifiedForwardReference[QualifiedForwardReference["Later"] = 1] = "Later";
+    return QualifiedForwardReference;
+}(QualifiedForwardReference || {});
+var SelfReference = function(SelfReference) {
+    SelfReference[SelfReference["A"] = SelfReference.A] = "A";
+    SelfReference[SelfReference["B"] = SelfReference.B] = "B";
+    return SelfReference;
+}(SelfReference || {});
+var OpaqueMembers = function(OpaqueMembers) {
+    OpaqueMembers[OpaqueMembers["A"] = getValue()] = "A";
+    OpaqueMembers[OpaqueMembers["B"] = OpaqueMembers.A] = "B";
+    OpaqueMembers[OpaqueMembers["C"] = OpaqueMembers.A] = "C";
+    return OpaqueMembers;
+}(OpaqueMembers || {});
+var ShadowedGlobals = /*#__PURE__*/ function(ShadowedGlobals) {
+    ShadowedGlobals[ShadowedGlobals["Positive"] = 0] = "Positive";
+    ShadowedGlobals[ShadowedGlobals["Infinity"] = 1] = "Infinity";
+    ShadowedGlobals[ShadowedGlobals["NotANumber"] = 0] = "NotANumber";
+    ShadowedGlobals[ShadowedGlobals["NaN"] = 2] = "NaN";
+    return ShadowedGlobals;
+}(ShadowedGlobals || {});
+var Globals = /*#__PURE__*/ function(Globals) {
+    Globals[Globals["Positive"] = Infinity] = "Positive";
+    Globals[Globals["NotANumber"] = NaN] = "NotANumber";
+    return Globals;
+}(Globals || {});

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/enum-template-cooked/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/enum-template-cooked/input.ts
@@ -1,0 +1,10 @@
+enum TemplateCooked {
+    "\uD800" = 1,
+    FromString = TemplateCooked["\uD800"] + 1,
+    FromTemplate = TemplateCooked[`\uD800`] + 2,
+    Escaped = `line\n`,
+    Interpolated = `value:\x20${1}\u0021`,
+    LoneSurrogate = `\uD800`,
+    InterpolatedSurrogate = `x${"\uD800"}y`,
+    ConcatenatedSurrogate = "\uD800" + "x",
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/enum-template-cooked/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/enum-template-cooked/output.js
@@ -1,0 +1,11 @@
+var TemplateCooked = /*#__PURE__*/ function(TemplateCooked) {
+    TemplateCooked[TemplateCooked["\uD800"] = 1] = "\uD800";
+    TemplateCooked[TemplateCooked["FromString"] = 2] = "FromString";
+    TemplateCooked[TemplateCooked["FromTemplate"] = 3] = "FromTemplate";
+    TemplateCooked["Escaped"] = "line\n";
+    TemplateCooked["Interpolated"] = "value: 1!";
+    TemplateCooked["LoneSurrogate"] = "\uD800";
+    TemplateCooked["InterpolatedSurrogate"] = "x\uD800y";
+    TemplateCooked["ConcatenatedSurrogate"] = "\uD800x";
+    return TemplateCooked;
+}(TemplateCooked || {});

--- a/crates/swc_typescript/src/fast_dts/decl.rs
+++ b/crates/swc_typescript/src/fast_dts/decl.rs
@@ -40,6 +40,8 @@ impl FastDts {
                 self.transform_fn(&mut fn_decl.function, Some(fn_decl.ident.span));
             }
             Decl::Var(var) => {
+                self.register_enum_external_constants(var);
+
                 if var.declare {
                     return;
                 }

--- a/crates/swc_typescript/src/fast_dts/enum.rs
+++ b/crates/swc_typescript/src/fast_dts/enum.rs
@@ -1,13 +1,14 @@
 use core::f64;
-use std::borrow::Borrow;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{wtf8::Wtf8Buf, Atom, Wtf8Atom};
-use swc_common::{Spanned, DUMMY_SP};
+use swc_common::{Mark, DUMMY_SP};
 use swc_ecma_ast::{
-    BinExpr, BinaryOp, Expr, Lit, Number, Str, TsEnumDecl, TsEnumMemberId, UnaryExpr, UnaryOp,
+    BinExpr, BinaryOp, Expr, Id, Lit, MemberExpr, Number, Pat, Program, Str, TsEnumDecl,
+    TsEnumMemberId, UnaryExpr, UnaryOp, VarDecl, VarDeclKind,
 };
 use swc_ecma_utils::number::{JsNumber, ToJsString};
+use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 
 use super::{util::ast_ext::MemberPropExt, FastDts};
 
@@ -45,172 +46,420 @@ impl ConstantValue {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+struct Evaluation {
+    value: Option<ConstantValue>,
+    has_external_references: bool,
+}
+
+impl Evaluation {
+    fn constant(value: ConstantValue) -> Self {
+        Self {
+            value: Some(value),
+            has_external_references: false,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct EnumMemberKey {
+    enum_id: Id,
+    member_name: Wtf8Atom,
+}
+
+#[derive(Debug, Clone)]
+struct EnumMemberBinding {
+    evaluation: Evaluation,
+    declaration_id: u32,
+}
+
+#[derive(Debug, Clone)]
+struct ExternalConstant {
+    init: Box<Expr>,
+    source_order: u32,
+}
+
+/// Source-order state shared by enum declarations in one FastDts transform.
+///
+/// TypeScript stores the value of each enum member declaration separately,
+/// while references resolve through the member symbol's first value
+/// declaration. Keeping those concerns separate is required for duplicate and
+/// merged enum declarations.
+#[derive(Debug, Default)]
+pub(super) struct EnumEvaluationContext {
+    member_names: FxHashMap<Id, FxHashSet<Wtf8Atom>>,
+    member_bindings: FxHashMap<EnumMemberKey, EnumMemberBinding>,
+    external_constants: FxHashMap<Id, ExternalConstant>,
+    next_declaration_id: u32,
+    next_source_order: u32,
+}
+
+impl EnumEvaluationContext {
+    fn take_declaration_id(&mut self) -> u32 {
+        let declaration_id = self.next_declaration_id;
+        self.next_declaration_id += 1;
+        declaration_id
+    }
+
+    fn take_source_order(&mut self) -> u32 {
+        let source_order = self.next_source_order;
+        self.next_source_order += 1;
+        source_order
+    }
+}
+
+#[derive(Default)]
+struct EnumMemberNameCollector {
+    names: FxHashMap<Id, FxHashSet<Wtf8Atom>>,
+}
+
+impl Visit for EnumMemberNameCollector {
+    noop_visit_type!();
+
+    fn visit_ts_enum_decl(&mut self, decl: &TsEnumDecl) {
+        let member_names = self.names.entry(decl.id.to_id()).or_default();
+        member_names.extend(
+            decl.members
+                .iter()
+                .map(|member| enum_member_name(&member.id)),
+        );
+
+        decl.visit_children_with(self);
+    }
+}
+
 impl FastDts {
-    pub(crate) fn transform_enum(&mut self, decl: &mut TsEnumDecl) {
-        let mut prev_init_value = Some(ConstantValue::number(-1.0));
-        let mut prev_members = FxHashMap::default();
-        for member in &mut decl.members {
-            let value = if let Some(init_expr) = &member.init {
-                let computed_value = self.evaluate(init_expr, &decl.id.sym, &prev_members);
-                if computed_value.is_none() {
-                    self.enum_member_initializers(member.id.span());
-                }
-                computed_value
-            } else if let Some(ConstantValue::Number(v)) = prev_init_value {
-                Some(ConstantValue::number(v.value + 1.0))
-            } else {
-                None
+    pub(crate) fn collect_enum_member_names(&mut self, program: &Program) {
+        let mut collector = EnumMemberNameCollector::default();
+        program.visit_with(&mut collector);
+        self.enum_evaluation_context.member_names = collector.names;
+    }
+
+    pub(crate) fn register_enum_external_constants(&mut self, decl: &VarDecl) {
+        if decl.kind != VarDeclKind::Const {
+            return;
+        }
+
+        for declarator in &decl.decls {
+            let Pat::Ident(binding) = &declarator.name else {
+                continue;
+            };
+            if binding.type_ann.is_some() {
+                continue;
+            }
+            let Some(init) = &declarator.init else {
+                continue;
             };
 
-            prev_init_value = value.clone();
-            if let Some(value) = &value {
-                prev_members.insert(enum_member_name(&member.id), value.clone());
-            }
-
-            member.init = value.map(|value| {
-                Box::new(match value {
-                    ConstantValue::Number(number) => Expr::Lit(Lit::Num(number)),
-                    ConstantValue::String(value) => Expr::Lit(Lit::Str(Str {
-                        span: DUMMY_SP,
-                        value,
-                        raw: None,
-                    })),
-                })
-            });
+            let source_order = self.enum_evaluation_context.take_source_order();
+            self.enum_evaluation_context
+                .external_constants
+                .entry(binding.id.to_id())
+                .or_insert_with(|| ExternalConstant {
+                    init: init.clone(),
+                    source_order,
+                });
         }
     }
 
+    pub(crate) fn transform_enum(&mut self, decl: &mut TsEnumDecl) {
+        let enum_id = decl.id.to_id();
+        let declaration_id = self.enum_evaluation_context.take_declaration_id();
+        let unresolved_mark = self.unresolved_mark;
+        let mut previous_value = Some(ConstantValue::number(-1.0));
+
+        for member in &mut decl.members {
+            let source_order = self.enum_evaluation_context.take_source_order();
+            let member_name = enum_member_name(&member.id);
+            let member_key = EnumMemberKey {
+                enum_id: enum_id.clone(),
+                member_name: member_name.clone(),
+            };
+
+            let evaluation = if let Some(init) = &member.init {
+                let mut evaluator = EnumEvaluator {
+                    context: &self.enum_evaluation_context,
+                    unresolved_mark,
+                    current_member: &member_key,
+                    current_declaration_id: declaration_id,
+                    constant_stack: FxHashSet::default(),
+                };
+                evaluator.evaluate(init, source_order, true)
+            } else {
+                match &previous_value {
+                    Some(ConstantValue::Number(number)) => {
+                        Evaluation::constant(ConstantValue::number(number.value + 1.0))
+                    }
+                    Some(ConstantValue::String(_)) | None => Evaluation::default(),
+                }
+            };
+
+            if member.init.is_some() && evaluation.has_external_references {
+                self.enum_member_initializers(member.span);
+            }
+
+            previous_value = evaluation.value.clone();
+            self.enum_evaluation_context
+                .member_bindings
+                .entry(member_key)
+                .or_insert_with(|| EnumMemberBinding {
+                    evaluation: evaluation.clone(),
+                    declaration_id,
+                });
+
+            member.init = evaluation.value.map(constant_value_to_expr);
+        }
+    }
+}
+
+struct EnumEvaluator<'a> {
+    context: &'a EnumEvaluationContext,
+    unresolved_mark: Mark,
+    current_member: &'a EnumMemberKey,
+    current_declaration_id: u32,
+    constant_stack: FxHashSet<Id>,
+}
+
+impl EnumEvaluator<'_> {
     fn evaluate(
-        &self,
+        &mut self,
         expr: &Expr,
-        enum_name: &Atom,
-        prev_members: &FxHashMap<Wtf8Atom, ConstantValue>,
-    ) -> Option<ConstantValue> {
+        source_order: u32,
+        in_enum_member_scope: bool,
+    ) -> Evaluation {
         match expr {
             Expr::Lit(lit) => match lit {
-                Lit::Str(string) => Some(ConstantValue::String(string.value.clone())),
-                Lit::Num(number) => Some(ConstantValue::Number(number.clone())),
+                Lit::Str(string) => {
+                    Evaluation::constant(ConstantValue::String(string.value.clone()))
+                }
+                Lit::Num(number) => Evaluation::constant(ConstantValue::Number(number.clone())),
                 Lit::Null(_) | Lit::BigInt(_) | Lit::Bool(_) | Lit::Regex(_) | Lit::JSXText(_) => {
-                    None
+                    Evaluation::default()
                 }
                 #[cfg(swc_ast_unknown)]
                 _ => panic!("unable to access unknown nodes"),
             },
             Expr::Tpl(template) => {
                 let mut quasis = template.quasis.iter();
-                let first = quasis.next()?.cooked.as_ref()?;
+                let Some(first) = quasis.next().and_then(|quasi| quasi.cooked.as_ref()) else {
+                    return Evaluation::default();
+                };
                 let mut value = Wtf8Buf::from(first);
+                let mut has_external_references = false;
 
                 for (expr, quasi) in template.exprs.iter().zip(quasis) {
-                    self.evaluate(expr, enum_name, prev_members)?
-                        .push_to(&mut value);
-                    value.push_wtf8(quasi.cooked.as_ref()?);
+                    let evaluation = self.evaluate(expr, source_order, in_enum_member_scope);
+                    let Some(constant) = evaluation.value else {
+                        // TypeScript discards external-reference state when a
+                        // template expression is not fully constant.
+                        return Evaluation::default();
+                    };
+                    constant.push_to(&mut value);
+                    let Some(cooked) = quasi.cooked.as_ref() else {
+                        return Evaluation::default();
+                    };
+                    value.push_wtf8(cooked);
+                    has_external_references |= evaluation.has_external_references;
                 }
 
-                Some(ConstantValue::String(Wtf8Atom::from(&*value)))
+                Evaluation {
+                    value: Some(ConstantValue::String(Wtf8Atom::from(&*value))),
+                    has_external_references,
+                }
             }
-            Expr::Paren(expr) => self.evaluate(&expr.expr, enum_name, prev_members),
-            Expr::Bin(bin_expr) => self.evaluate_binary_expr(bin_expr, enum_name, prev_members),
-            Expr::Unary(unary_expr) => {
-                self.evaluate_unary_expr(unary_expr, enum_name, prev_members)
-            }
+            Expr::Paren(expr) => self.evaluate(&expr.expr, source_order, in_enum_member_scope),
+            Expr::Bin(expr) => self.evaluate_binary(expr, source_order, in_enum_member_scope),
+            Expr::Unary(expr) => self.evaluate_unary(expr, source_order, in_enum_member_scope),
             Expr::Ident(ident) => {
-                if ident.sym == "Infinity" {
-                    Some(ConstantValue::converted_number(
+                self.evaluate_identifier(ident, source_order, in_enum_member_scope)
+            }
+            Expr::Member(member) => self.evaluate_member(member, in_enum_member_scope),
+            Expr::OptChain(chain) => chain
+                .base
+                .as_member()
+                .map_or_else(Evaluation::default, |member| {
+                    self.evaluate_member(member, in_enum_member_scope)
+                }),
+            _ => Evaluation::default(),
+        }
+    }
+
+    fn evaluate_identifier(
+        &mut self,
+        ident: &swc_ecma_ast::Ident,
+        source_order: u32,
+        in_enum_member_scope: bool,
+    ) -> Evaluation {
+        let is_unresolved = ident.ctxt.has_mark(self.unresolved_mark);
+        let member_name: Wtf8Atom = ident.sym.clone().into();
+
+        if in_enum_member_scope
+            && is_unresolved
+            && self.is_known_member(&self.current_member.enum_id, &member_name)
+        {
+            let key = EnumMemberKey {
+                enum_id: self.current_member.enum_id.clone(),
+                member_name,
+            };
+            return self.evaluate_enum_member(&key, true);
+        }
+
+        if is_unresolved {
+            match ident.sym.as_ref() {
+                "Infinity" => {
+                    return Evaluation::constant(ConstantValue::converted_number(
                         f64::INFINITY,
                         Some(ident.sym.clone()),
-                    ))
-                } else if ident.sym == "NaN" {
-                    Some(ConstantValue::converted_number(
+                    ));
+                }
+                "NaN" => {
+                    return Evaluation::constant(ConstantValue::converted_number(
                         f64::NAN,
                         Some(ident.sym.clone()),
-                    ))
-                } else {
-                    prev_members.get(ident.sym.borrow()).cloned()
+                    ));
                 }
+                _ => {}
             }
-            Expr::Member(member) => {
-                let ident = member.obj.as_ident()?;
-                if &ident.sym == enum_name {
-                    let name = member.prop.static_name()?;
-                    prev_members.get(name).cloned()
-                } else {
-                    None
-                }
-            }
-            Expr::OptChain(opt_chain) => {
-                let member = opt_chain.base.as_member()?;
-                let ident = member.obj.as_ident()?;
-                if &ident.sym == enum_name {
-                    let name = member.prop.static_name()?;
-                    prev_members.get(name).cloned()
-                } else {
-                    None
-                }
-            }
-            _ => None,
         }
+
+        self.evaluate_external_constant(&ident.to_id(), source_order)
     }
 
-    fn evaluate_unary_expr(
-        &self,
-        expr: &UnaryExpr,
-        enum_name: &Atom,
-        prev_members: &FxHashMap<Wtf8Atom, ConstantValue>,
-    ) -> Option<ConstantValue> {
-        let value = self.evaluate(&expr.arg, enum_name, prev_members)?;
-        let value = match value {
-            ConstantValue::Number(number) => number.value,
-            ConstantValue::String(_) => {
-                let value = if expr.op == UnaryOp::Minus {
-                    ConstantValue::number(f64::NAN)
-                } else if expr.op == UnaryOp::Tilde {
-                    ConstantValue::number(-1.0)
-                } else {
-                    value
-                };
-                return Some(value);
-            }
+    fn evaluate_external_constant(&mut self, id: &Id, source_order: u32) -> Evaluation {
+        let Some(constant) = self.context.external_constants.get(id) else {
+            return Evaluation::default();
+        };
+        if constant.source_order >= source_order || !self.constant_stack.insert(id.clone()) {
+            return Evaluation::default();
+        }
+
+        let mut evaluation = self.evaluate(&constant.init, constant.source_order, false);
+        self.constant_stack.remove(id);
+        evaluation.has_external_references = true;
+        evaluation
+    }
+
+    fn evaluate_member(&mut self, member: &MemberExpr, in_enum_member_scope: bool) -> Evaluation {
+        let Some(ident) = member.obj.as_ident() else {
+            return Evaluation::default();
+        };
+        let Some(member_name) = member.prop.static_name() else {
+            return Evaluation::default();
+        };
+        let key = EnumMemberKey {
+            enum_id: ident.to_id(),
+            member_name: member_name.clone(),
         };
 
-        match expr.op {
-            UnaryOp::Minus => Some(ConstantValue::number(-value)),
-            UnaryOp::Plus => Some(ConstantValue::number(value)),
-            UnaryOp::Tilde => Some(ConstantValue::number((!JsNumber::from(value)).into())),
+        self.evaluate_enum_member(&key, in_enum_member_scope)
+    }
+
+    fn evaluate_enum_member(&self, key: &EnumMemberKey, in_enum_member_scope: bool) -> Evaluation {
+        if let Some(binding) = self.context.member_bindings.get(key) {
+            let mut evaluation = binding.evaluation.clone();
+            if !in_enum_member_scope || binding.declaration_id != self.current_declaration_id {
+                evaluation.has_external_references = true;
+            }
+            return evaluation;
+        }
+
+        if !self.is_known_member(&key.enum_id, &key.member_name) {
+            return Evaluation::default();
+        }
+
+        if in_enum_member_scope && key == self.current_member {
+            return Evaluation::default();
+        }
+
+        // TypeScript reports the forward reference separately and uses zero as
+        // the enum evaluator's recovery value.
+        Evaluation::constant(ConstantValue::number(0.0))
+    }
+
+    fn is_known_member(&self, enum_id: &Id, member_name: &Wtf8Atom) -> bool {
+        self.context
+            .member_names
+            .get(enum_id)
+            .is_some_and(|member_names| member_names.contains(member_name))
+    }
+
+    fn evaluate_unary(
+        &mut self,
+        expr: &UnaryExpr,
+        source_order: u32,
+        in_enum_member_scope: bool,
+    ) -> Evaluation {
+        let evaluation = self.evaluate(&expr.arg, source_order, in_enum_member_scope);
+        let has_external_references = evaluation.has_external_references;
+        let Some(ConstantValue::Number(number)) = evaluation.value else {
+            return Evaluation {
+                value: None,
+                has_external_references,
+            };
+        };
+
+        let value = match expr.op {
+            UnaryOp::Minus => Some(-number.value),
+            UnaryOp::Plus => Some(number.value),
+            UnaryOp::Tilde => Some((!JsNumber::from(number.value)).into()),
             _ => None,
+        };
+
+        Evaluation {
+            value: value.map(ConstantValue::number),
+            has_external_references,
         }
     }
 
-    fn evaluate_binary_expr(
-        &self,
+    fn evaluate_binary(
+        &mut self,
         expr: &BinExpr,
-        enum_name: &Atom,
-        prev_members: &FxHashMap<Wtf8Atom, ConstantValue>,
-    ) -> Option<ConstantValue> {
-        let left = self.evaluate(&expr.left, enum_name, prev_members)?;
-        let right = self.evaluate(&expr.right, enum_name, prev_members)?;
+        source_order: u32,
+        in_enum_member_scope: bool,
+    ) -> Evaluation {
+        let left = self.evaluate(&expr.left, source_order, in_enum_member_scope);
+        let right = self.evaluate(&expr.right, source_order, in_enum_member_scope);
+        let has_external_references = left.has_external_references || right.has_external_references;
+        let (Some(left), Some(right)) = (left.value, right.value) else {
+            return Evaluation {
+                value: None,
+                has_external_references,
+            };
+        };
 
         if expr.op == BinaryOp::Add
-            && (matches!(left, ConstantValue::String(_))
-                || matches!(right, ConstantValue::String(_)))
+            && (matches!(&left, ConstantValue::String(_))
+                || matches!(&right, ConstantValue::String(_)))
         {
             let mut value = Wtf8Buf::new();
             left.push_to(&mut value);
             right.push_to(&mut value);
-            return Some(ConstantValue::String(Wtf8Atom::from(&*value)));
+            return Evaluation {
+                value: Some(ConstantValue::String(Wtf8Atom::from(&*value))),
+                has_external_references,
+            };
         }
 
         let left = JsNumber::from(match left {
             ConstantValue::Number(number) => number.value,
-            ConstantValue::String(_) => return None,
+            ConstantValue::String(_) => {
+                return Evaluation {
+                    value: None,
+                    has_external_references,
+                };
+            }
         });
-
         let right = JsNumber::from(match right {
             ConstantValue::Number(number) => number.value,
-            ConstantValue::String(_) => return None,
+            ConstantValue::String(_) => {
+                return Evaluation {
+                    value: None,
+                    has_external_references,
+                };
+            }
         });
 
-        match expr.op {
+        let value = match expr.op {
             BinaryOp::LShift => Some(left << right),
             BinaryOp::RShift => Some(left >> right),
             BinaryOp::ZeroFillRShift => Some(left.unsigned_shr(right)),
@@ -224,9 +473,24 @@ impl FastDts {
             BinaryOp::BitAnd => Some(left & right),
             BinaryOp::Exp => Some(left.pow(right)),
             _ => None,
+        };
+
+        Evaluation {
+            value: value.map(|number| ConstantValue::number(number.into())),
+            has_external_references,
         }
-        .map(|number| ConstantValue::number(number.into()))
     }
+}
+
+fn constant_value_to_expr(value: ConstantValue) -> Box<Expr> {
+    Box::new(match value {
+        ConstantValue::Number(number) => Expr::Lit(Lit::Num(number)),
+        ConstantValue::String(value) => Expr::Lit(Lit::Str(Str {
+            span: DUMMY_SP,
+            value,
+            raw: None,
+        })),
+    })
 }
 
 fn enum_member_name(member: &TsEnumMemberId) -> Wtf8Atom {

--- a/crates/swc_typescript/src/fast_dts/enum.rs
+++ b/crates/swc_typescript/src/fast_dts/enum.rs
@@ -1,7 +1,8 @@
 use core::f64;
+use std::borrow::Borrow;
 
 use rustc_hash::FxHashMap;
-use swc_atoms::Atom;
+use swc_atoms::{wtf8::Wtf8Buf, Atom, Wtf8Atom};
 use swc_common::{Spanned, DUMMY_SP};
 use swc_ecma_ast::{
     BinExpr, BinaryOp, Expr, Lit, Number, Str, TsEnumDecl, TsEnumMemberId, UnaryExpr, UnaryOp,
@@ -13,7 +14,7 @@ use super::{util::ast_ext::MemberPropExt, FastDts};
 #[derive(Debug, Clone)]
 enum ConstantValue {
     Number(Number),
-    String(String),
+    String(Wtf8Atom),
 }
 
 impl ConstantValue {
@@ -34,6 +35,13 @@ impl ConstantValue {
             value,
             raw,
         })
+    }
+
+    fn push_to(self, output: &mut Wtf8Buf) {
+        match self {
+            Self::Number(number) => output.push_str(&number.value.to_js_string()),
+            Self::String(string) => output.push_wtf8(&string),
+        }
     }
 }
 
@@ -56,25 +64,15 @@ impl FastDts {
 
             prev_init_value = value.clone();
             if let Some(value) = &value {
-                let member_name = match &member.id {
-                    TsEnumMemberId::Ident(ident) => ident.sym.clone(),
-                    TsEnumMemberId::Str(s) => s
-                        .value
-                        .clone()
-                        .try_into_atom()
-                        .unwrap_or_else(|wtf8| Atom::from(&*wtf8.to_string_lossy())),
-                    #[cfg(swc_ast_unknown)]
-                    _ => panic!("unable to access unknown nodes"),
-                };
-                prev_members.insert(member_name.clone(), value.clone());
+                prev_members.insert(enum_member_name(&member.id), value.clone());
             }
 
             member.init = value.map(|value| {
                 Box::new(match value {
                     ConstantValue::Number(number) => Expr::Lit(Lit::Num(number)),
-                    ConstantValue::String(s) => Expr::Lit(Lit::Str(Str {
+                    ConstantValue::String(value) => Expr::Lit(Lit::Str(Str {
                         span: DUMMY_SP,
-                        value: s.clone().into(),
+                        value,
                         raw: None,
                     })),
                 })
@@ -86,11 +84,11 @@ impl FastDts {
         &self,
         expr: &Expr,
         enum_name: &Atom,
-        prev_members: &FxHashMap<Atom, ConstantValue>,
+        prev_members: &FxHashMap<Wtf8Atom, ConstantValue>,
     ) -> Option<ConstantValue> {
         match expr {
             Expr::Lit(lit) => match lit {
-                Lit::Str(s) => Some(ConstantValue::String(s.value.to_string_lossy().to_string())),
+                Lit::Str(string) => Some(ConstantValue::String(string.value.clone())),
                 Lit::Num(number) => Some(ConstantValue::Number(number.clone())),
                 Lit::Null(_) | Lit::BigInt(_) | Lit::Bool(_) | Lit::Regex(_) | Lit::JSXText(_) => {
                     None
@@ -98,12 +96,18 @@ impl FastDts {
                 #[cfg(swc_ast_unknown)]
                 _ => panic!("unable to access unknown nodes"),
             },
-            Expr::Tpl(tpl) => {
-                let mut value = String::new();
-                for part in &tpl.quasis {
-                    value.push_str(&part.raw);
+            Expr::Tpl(template) => {
+                let mut quasis = template.quasis.iter();
+                let first = quasis.next()?.cooked.as_ref()?;
+                let mut value = Wtf8Buf::from(first);
+
+                for (expr, quasi) in template.exprs.iter().zip(quasis) {
+                    self.evaluate(expr, enum_name, prev_members)?
+                        .push_to(&mut value);
+                    value.push_wtf8(quasi.cooked.as_ref()?);
                 }
-                Some(ConstantValue::String(value))
+
+                Some(ConstantValue::String(Wtf8Atom::from(&*value)))
             }
             Expr::Paren(expr) => self.evaluate(&expr.expr, enum_name, prev_members),
             Expr::Bin(bin_expr) => self.evaluate_binary_expr(bin_expr, enum_name, prev_members),
@@ -122,7 +126,7 @@ impl FastDts {
                         Some(ident.sym.clone()),
                     ))
                 } else {
-                    prev_members.get(&ident.sym).cloned()
+                    prev_members.get(ident.sym.borrow()).cloned()
                 }
             }
             Expr::Member(member) => {
@@ -152,11 +156,11 @@ impl FastDts {
         &self,
         expr: &UnaryExpr,
         enum_name: &Atom,
-        prev_members: &FxHashMap<Atom, ConstantValue>,
+        prev_members: &FxHashMap<Wtf8Atom, ConstantValue>,
     ) -> Option<ConstantValue> {
         let value = self.evaluate(&expr.arg, enum_name, prev_members)?;
         let value = match value {
-            ConstantValue::Number(n) => n.value,
+            ConstantValue::Number(number) => number.value,
             ConstantValue::String(_) => {
                 let value = if expr.op == UnaryOp::Minus {
                     ConstantValue::number(f64::NAN)
@@ -181,7 +185,7 @@ impl FastDts {
         &self,
         expr: &BinExpr,
         enum_name: &Atom,
-        prev_members: &FxHashMap<Atom, ConstantValue>,
+        prev_members: &FxHashMap<Wtf8Atom, ConstantValue>,
     ) -> Option<ConstantValue> {
         let left = self.evaluate(&expr.left, enum_name, prev_members)?;
         let right = self.evaluate(&expr.right, enum_name, prev_members)?;
@@ -190,28 +194,19 @@ impl FastDts {
             && (matches!(left, ConstantValue::String(_))
                 || matches!(right, ConstantValue::String(_)))
         {
-            let left_string = match left {
-                ConstantValue::Number(number) => number.value.to_js_string(),
-                ConstantValue::String(s) => s,
-            };
-
-            let right_string = match right {
-                ConstantValue::Number(number) => number.value.to_js_string(),
-                ConstantValue::String(s) => s,
-            };
-
-            return Some(ConstantValue::String(format!(
-                "{left_string}{right_string}"
-            )));
+            let mut value = Wtf8Buf::new();
+            left.push_to(&mut value);
+            right.push_to(&mut value);
+            return Some(ConstantValue::String(Wtf8Atom::from(&*value)));
         }
 
         let left = JsNumber::from(match left {
-            ConstantValue::Number(n) => n.value,
+            ConstantValue::Number(number) => number.value,
             ConstantValue::String(_) => return None,
         });
 
         let right = JsNumber::from(match right {
-            ConstantValue::Number(n) => n.value,
+            ConstantValue::Number(number) => number.value,
             ConstantValue::String(_) => return None,
         });
 
@@ -231,5 +226,14 @@ impl FastDts {
             _ => None,
         }
         .map(|number| ConstantValue::number(number.into()))
+    }
+}
+
+fn enum_member_name(member: &TsEnumMemberId) -> Wtf8Atom {
+    match member {
+        TsEnumMemberId::Ident(ident) => ident.sym.clone().into(),
+        TsEnumMemberId::Str(string) => string.value.clone(),
+        #[cfg(swc_ast_unknown)]
+        _ => panic!("unable to access unknown nodes"),
     }
 }

--- a/crates/swc_typescript/src/fast_dts/mod.rs
+++ b/crates/swc_typescript/src/fast_dts/mod.rs
@@ -46,6 +46,7 @@ pub struct FastDts {
     is_top_level: bool,
     used_refs: UsedRefs,
     internal_annotations: Option<FxHashSet<BytePos>>,
+    enum_evaluation_context: r#enum::EnumEvaluationContext,
 }
 
 #[derive(Debug, Default)]
@@ -65,6 +66,7 @@ impl FastDts {
             is_top_level: true,
             used_refs: UsedRefs::default(),
             internal_annotations,
+            enum_evaluation_context: Default::default(),
         }
     }
 
@@ -81,6 +83,8 @@ impl FastDts {
 
 impl FastDts {
     pub fn transform(&mut self, program: &mut Program) -> Vec<DtsIssue> {
+        self.enum_evaluation_context = Default::default();
+        self.collect_enum_member_names(program);
         match program {
             Program::Module(module) => self.transform_module_body(&mut module.body, false),
             Program::Script(script) => self.transform_script(script),

--- a/crates/swc_typescript/src/fast_dts/util/ast_ext.rs
+++ b/crates/swc_typescript/src/fast_dts/util/ast_ext.rs
@@ -1,6 +1,6 @@
-use std::borrow::Cow;
+use std::borrow::{Borrow, Cow};
 
-use swc_atoms::Atom;
+use swc_atoms::{Atom, Wtf8Atom};
 use swc_common::Mark;
 use swc_ecma_ast::{
     BindingIdent, ComputedPropName, Expr, Ident, Lit, MemberProp, ObjectPatProp, Pat, Prop,
@@ -234,17 +234,17 @@ impl PropNameExit for Prop {
 }
 
 pub trait MemberPropExt {
-    fn static_name(&self) -> Option<&Atom>;
+    fn static_name(&self) -> Option<&Wtf8Atom>;
 }
 
 impl MemberPropExt for MemberProp {
-    fn static_name(&self) -> Option<&Atom> {
+    fn static_name(&self) -> Option<&Wtf8Atom> {
         match self {
-            MemberProp::Ident(ident_name) => Some(&ident_name.sym),
+            MemberProp::Ident(ident_name) => Some(ident_name.sym.borrow()),
             MemberProp::Computed(computed_prop_name) => match computed_prop_name.expr.as_ref() {
-                Expr::Lit(Lit::Str(s)) => s.value.as_atom(),
+                Expr::Lit(Lit::Str(s)) => Some(&s.value),
                 Expr::Tpl(tpl) if tpl.quasis.len() == 1 && tpl.exprs.is_empty() => {
-                    Some(&tpl.quasis[0].raw)
+                    tpl.quasis[0].cooked.as_ref()
                 }
                 _ => None,
             },

--- a/crates/swc_typescript/tests/fixture/enum-evaluation-context.snap
+++ b/crates/swc_typescript/tests/fixture/enum-evaluation-context.snap
@@ -1,0 +1,183 @@
+```==================== .D.TS ====================
+
+export declare enum Direct {
+    Known = 1,
+    Unknown,
+    Typed,
+    Imported,
+    Mutable,
+    Function,
+    Class
+}
+export declare enum Binary {
+    KnownUnknown,
+    UnknownKnown,
+    KnownMutable,
+    MutableKnown,
+    KnownMember = 2,
+    UnknownMember
+}
+export declare enum Template {
+    Known = "1",
+    Unknown,
+    KnownUnknown,
+    UnknownKnown,
+    KnownPlusUnknown,
+    UnknownPlusKnown
+}
+export declare enum Propagation {
+    External = 1,
+    FromExternal = 2,
+    Implicit = 3,
+    FromImplicit = 4,
+    Reset = 10,
+    FromReset = 11
+}
+export declare enum DuplicateMembers {
+    A = 1,
+    A = 5,
+    B = 6,
+    C = 2
+}
+export declare enum MergedMembers {
+    A = 1
+}
+export declare enum MergedMembers {
+    B = 2,
+    C = 3
+}
+export declare enum ForwardReference {
+    A = 1,
+    Later = 1
+}
+export declare enum QualifiedForwardReference {
+    A = 1,
+    Later = 1
+}
+export declare enum SelfReference {
+    A,
+    B
+}
+export declare enum OpaqueMembers {
+    A,
+    B,
+    C
+}
+export declare enum UnsupportedEvaluation {
+    UnaryString,
+    OptionalMember = 1
+}
+export declare enum ShadowedGlobals {
+    Positive = 0,
+    Infinity = 1,
+    NotANumber = 0,
+    NaN = 2
+}
+export declare enum Globals {
+    Positive = Infinity,
+    NotANumber = NaN
+}
+
+
+==================== Errors ====================
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:15:1]
+ 14 | export enum Direct {
+ 15 |     Known = known,
+    :     ^^^^^^^^^^^^^
+ 16 |     Unknown = unknown,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:16:1]
+ 15 |     Known = known,
+ 16 |     Unknown = unknown,
+    :     ^^^^^^^^^^^^^^^^^
+ 17 |     Typed = typed,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:25:1]
+ 24 | export enum Binary {
+ 25 |     KnownUnknown = known + Missing,
+    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 26 |     UnknownKnown = Missing + known,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:26:1]
+ 25 |     KnownUnknown = known + Missing,
+ 26 |     UnknownKnown = Missing + known,
+    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 27 |     KnownMutable = known + mutable,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:27:1]
+ 26 |     UnknownKnown = Missing + known,
+ 27 |     KnownMutable = known + mutable,
+    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 28 |     MutableKnown = mutable + known,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:28:1]
+ 27 |     KnownMutable = known + mutable,
+ 28 |     MutableKnown = mutable + known,
+    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 29 |     KnownMember = Direct.Known + 1,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:29:1]
+ 28 |     MutableKnown = mutable + known,
+ 29 |     KnownMember = Direct.Known + 1,
+    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 30 |     UnknownMember = Direct.Unknown + 1,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:30:1]
+ 29 |     KnownMember = Direct.Known + 1,
+ 30 |     UnknownMember = Direct.Unknown + 1,
+    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 31 | }
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:34:1]
+ 33 | export enum Template {
+ 34 |     Known = `${known}`,
+    :     ^^^^^^^^^^^^^^^^^^
+ 35 |     Unknown = `${unknown}`,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:43:1]
+ 42 | export enum Propagation {
+ 43 |     External = known,
+    :     ^^^^^^^^^^^^^^^^
+ 44 |     FromExternal = External + 1,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:44:1]
+ 43 |     External = known,
+ 44 |     FromExternal = External + 1,
+    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 45 |     Implicit,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:63:1]
+ 62 | export enum MergedMembers {
+ 63 |     B = A + 1,
+    :     ^^^^^^^^^
+ 64 |     C = MergedMembers.A + 2,
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:64:1]
+ 63 |     B = A + 1,
+ 64 |     C = MergedMembers.A + 2,
+    :     ^^^^^^^^^^^^^^^^^^^^^^^
+ 65 | }
+    `----
+  x TS9020: Enum member initializers must be computable without references to external symbols with --isolatedDeclarations.
+    ,-[$DIR/tests/fixture/enum-evaluation-context.ts:90:1]
+ 89 |     UnaryString = -"1",
+ 90 |     OptionalMember = Direct?.Known,
+    :     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+ 91 | }
+    `----
+
+
+```

--- a/crates/swc_typescript/tests/fixture/enum-evaluation-context.ts
+++ b/crates/swc_typescript/tests/fixture/enum-evaluation-context.ts
@@ -1,0 +1,103 @@
+import { importedValue } from "pkg";
+
+const known = 1;
+const unknown = makeValue();
+const typed: number = 1;
+let mutable = 1;
+function makeValue(): number {
+    return 1;
+}
+class Holder {
+    static value = 1;
+}
+
+export enum Direct {
+    Known = known,
+    Unknown = unknown,
+    Typed = typed,
+    Imported = importedValue,
+    Mutable = mutable,
+    Function = makeValue(),
+    Class = Holder.value,
+}
+
+export enum Binary {
+    KnownUnknown = known + Missing,
+    UnknownKnown = Missing + known,
+    KnownMutable = known + mutable,
+    MutableKnown = mutable + known,
+    KnownMember = Direct.Known + 1,
+    UnknownMember = Direct.Unknown + 1,
+}
+
+export enum Template {
+    Known = `${known}`,
+    Unknown = `${unknown}`,
+    KnownUnknown = `${known}${Missing}`,
+    UnknownKnown = `${Missing}${known}`,
+    KnownPlusUnknown = `${known + Missing}`,
+    UnknownPlusKnown = `${Missing + known}`,
+}
+
+export enum Propagation {
+    External = known,
+    FromExternal = External + 1,
+    Implicit,
+    FromImplicit = Implicit + 1,
+    Reset = 10,
+    FromReset = Reset + 1,
+}
+
+export enum DuplicateMembers {
+    A = 1,
+    A = 5,
+    B,
+    C = A + 1,
+}
+
+export enum MergedMembers {
+    A = 1,
+}
+
+export enum MergedMembers {
+    B = A + 1,
+    C = MergedMembers.A + 2,
+}
+
+export enum ForwardReference {
+    A = Later + 1,
+    Later = 1,
+}
+
+export enum QualifiedForwardReference {
+    A = QualifiedForwardReference.Later + 1,
+    Later = 1,
+}
+
+export enum SelfReference {
+    A = SelfReference.A,
+    B = B,
+}
+
+export enum OpaqueMembers {
+    A = makeValue(),
+    B = A,
+    C = OpaqueMembers.A,
+}
+
+export enum UnsupportedEvaluation {
+    UnaryString = -"1",
+    OptionalMember = Direct?.Known,
+}
+
+export enum ShadowedGlobals {
+    Positive = Infinity,
+    Infinity = 1,
+    NotANumber = NaN,
+    NaN = 2,
+}
+
+export enum Globals {
+    Positive = Infinity,
+    NotANumber = NaN,
+}

--- a/crates/swc_typescript/tests/fixture/enum-template-cooked.snap
+++ b/crates/swc_typescript/tests/fixture/enum-template-cooked.snap
@@ -1,0 +1,13 @@
+```==================== .D.TS ====================
+
+export declare enum TemplateMemberKeys {
+    "A" = 1,
+    FromCooked = 2,
+    "\uD800" = 1,
+    FromString = 2,
+    FromTemplate = 3,
+    LoneSurrogate = "\uD800",
+    InterpolatedSurrogate = "x\uD800y"
+}
+
+

--- a/crates/swc_typescript/tests/fixture/enum-template-cooked.ts
+++ b/crates/swc_typescript/tests/fixture/enum-template-cooked.ts
@@ -1,0 +1,9 @@
+export enum TemplateMemberKeys {
+    "A" = 1,
+    FromCooked = TemplateMemberKeys[`\x41`] + 1,
+    "\uD800" = 1,
+    FromString = TemplateMemberKeys["\uD800"] + 1,
+    FromTemplate = TemplateMemberKeys[`\uD800`] + 2,
+    LoneSurrogate = `\uD800`,
+    InterpolatedSurrogate = `x${"\uD800"}y`,
+}


### PR DESCRIPTION
**Description:**

The existing enum evaluator keeps only a per-declaration map of previously evaluated members. That state is too narrow to match TypeScript behavior for duplicate or merged declarations, forward and self references, external constants, and references that shadow global names.

This PR introduces source-order-aware enum evaluation state in both the transform and fast-DTS paths. It records member names, bindings, external constants, and reference provenance across declarations, while the transform-side name collection uses the same stack-safe expression traversal as the main analyzer.

**Related issue (if exists):**

- #12043
  - #12047
    - #12050
      - #12048
        - #12051
      - #12052
        - #12053
      - #12054
      - #12055
      - #12056
      - #12057
    - #12058
    - #12049
      - #12059
        - **#12060** (current)