### PR TITLE
feat(es/minifier): expand support for trivial spreads

### DIFF
--- a/.changeset/drop-trivial-object-spread.md
+++ b/.changeset/drop-trivial-object-spread.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+feat(es/minifier): drop trivial object spread of primitives

--- a/crates/swc_ecma_minifier/src/compress/pure/misc.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/misc.rs
@@ -292,13 +292,32 @@ impl Pure<'_> {
             }
         }
 
+        // Spreading a primitive of these types copies zero own enumerable
+        // properties (`ToObject` on them yields a wrapper whose properties are
+        // all non-enumerable), so `{ ...x }` where `x` is one of them
+        // contributes nothing.
+        //
+        // Strings are intentionally EXCLUDED: they expose indexed own
+        // enumerable properties (`{ ..."ab" }` === `{ 0: "a", 1: "b" }`).
+        // Objects, arrays, functions, etc. are also excluded as they carry
+        // real properties.
+        fn spreads_no_props(expr: &Expr, expr_ctx: ExprCtx) -> bool {
+            matches!(
+                expr.get_type(expr_ctx),
+                Value::Known(Type::Undefined | Type::Null | Type::Bool | Type::Num | Type::Symbol)
+            )
+        }
+
         fn can_flatten_spread_expr(expr: &Expr, expr_ctx: ExprCtx) -> bool {
             match expr {
                 Expr::Object(ObjectLit { props, .. }) => {
                     props.iter().all(|p| can_flatten_spread_prop(p, expr_ctx))
                 }
-                Expr::Lit(Lit::Null(_)) => true,
-                _ => false,
+                // Spreading a side-effect-free expression that has no own
+                // enumerable properties contributes nothing. We require purity
+                // so that we never discard observable side effects
+                // (e.g. `{ ...void foo() }`).
+                _ => spreads_no_props(expr, expr_ctx) && !expr.may_have_side_effects(expr_ctx),
             }
         }
 
@@ -374,16 +393,12 @@ impl Pure<'_> {
                 PropOrSpread::Spread(SpreadElement { expr, .. })
                     if can_flatten_spread_expr(&expr, self.expr_ctx) =>
                 {
-                    match *expr {
-                        Expr::Object(ObjectLit { props, .. }) => {
-                            for p in props {
-                                new_props.push(p);
-                            }
-                        }
-
-                        Expr::Lit(Lit::Null(_)) => {}
-
-                        _ => {}
+                    // A plain object literal is flattened into the target; any
+                    // other flattenable spread is a no-property primitive
+                    // (including `null`) that contributes nothing, so it is
+                    // simply dropped.
+                    if let Expr::Object(ObjectLit { props, .. }) = *expr {
+                        new_props.extend(props);
                     }
                 }
 

--- a/crates/swc_ecma_minifier/tests/fixture/issues/spread-primitives-void-call/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/spread-primitives-void-call/input.js
@@ -1,0 +1,6 @@
+// The motivating case: a pure call inside `void` is reduced to `void 0` by
+// earlier passes, and the resulting trivial spread is then dropped.
+function foo() {
+    return 1 + 1;
+}
+console.log({ a: 1, ...(void foo()) });

--- a/crates/swc_ecma_minifier/tests/fixture/issues/spread-primitives-void-call/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/spread-primitives-void-call/output.js
@@ -1,0 +1,5 @@
+// The motivating case: a pure call inside `void` is reduced to `void 0` by
+// earlier passes, and the resulting trivial spread is then dropped.
+console.log({
+    a: 1
+});

--- a/crates/swc_ecma_minifier/tests/fixture/issues/spread-primitives/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/spread-primitives/input.js
@@ -1,0 +1,22 @@
+// Object spread of a primitive with no own enumerable properties contributes
+// nothing and should be dropped entirely.
+console.log({ a: 1, ...(void 0) });
+console.log({ a: 1, ...void 0 });
+console.log({ a: 1, ...null });
+console.log({ a: 1, ...undefined });
+console.log({ a: 1, ...true });
+console.log({ a: 1, ...false });
+console.log({ a: 1, ...42 });
+console.log({ a: 1, ...(1 + 1) });
+console.log({ ...(void 0), a: 1 });
+console.log({ a: 1, ...(void 0), b: 2 });
+
+// Strings expose indexed own enumerable properties, so they must NOT be dropped.
+console.log({ a: 1, ..."ab" });
+
+// A real object literal still flattens (existing behavior, must not regress).
+console.log({ a: 1, ...{ b: 2 } });
+
+// Array spread requires an iterable; spreading these primitives throws at
+// runtime, so array spread must never be folded away.
+console.log([1, ...[2, 3]]);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/spread-primitives/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/spread-primitives/output.js
@@ -1,0 +1,38 @@
+// Object spread of a primitive with no own enumerable properties contributes
+// nothing and should be dropped entirely.
+console.log({
+    a: 1
+}), console.log({
+    a: 1
+}), console.log({
+    a: 1
+}), console.log({
+    a: 1
+}), console.log({
+    a: 1
+}), console.log({
+    a: 1
+}), console.log({
+    a: 1
+}), console.log({
+    a: 1
+}), console.log({
+    a: 1
+}), console.log({
+    a: 1,
+    b: 2
+}), // Strings expose indexed own enumerable properties, so they must NOT be dropped.
+console.log({
+    a: 1,
+    ..."ab"
+}), // A real object literal still flattens (existing behavior, must not regress).
+console.log({
+    a: 1,
+    b: 2
+}), // Array spread requires an iterable; spreading these primitives throws at
+// runtime, so array spread must never be folded away.
+console.log([
+    1,
+    2,
+    3
+]);


### PR DESCRIPTION
**Description:**

Support trivial object spreads of pure expression of primitive type

`{...null}` was already supported, this extends that to support `{...undefined}` `{...2}` etc.

[Motivating Example](https://play.swc.rs/?version=1.15.46&code=H4sIAAAAAAAAA0srzUsuyczPU0jLz9fQVKjmUlAoSi0pLcpTMNQ25KrlSs7PK87PSdXLyU%2FXqE60MtRR0NPT0yjLz0yB6NCs1eQCAHICWctEAAAA&config=H4sIAAAAAAAAA41VwW7bMAy99ysCn3focir2AbvtGwTFohxlsmiIlJugyL%2BPVuw0bWhjlyDm4yNF8lH6eNntmhO1za%2Fdh%2FyVj8Fmgnz%2FFgtdEtuzWBpoe0ttDgM3Pxb0RBPkbSSopusNadjmDriyaP%2B638%2BMJiISLIzZ1ocU%2FOUxZ4v9kIHowSZWCVl6SExf%2BTOW8X0COJdH%2BwExgk0biLFkQmLoIGuBW4zRDgRmtFmJMp3U5kCopZjAwuDMkHFQ8eQCB0yS8xl1YJ1p0YEChQwthxE0muQSWiIpT6mnwg4OpevqnL%2BxYbSxWFZywrmORE6rRD1iIDa%2BJK2FN3ClBzdwbu53ZvAmA5ecnnknDGllJn8BpAPREiXbgxa3enjR0xrbbzJD8iJZvii46FurMkEnTTUheKWzU2cgc9CmmcGVFqbOtuvoSvcoODDgvUhF4dJ74Pao5eTLAOgVQMZrvSaqG2DuS7iCT%2FuwAf%2BWIlnX1%2BzRWz6uo3TpDxg3EvTAR3QbDjIJxnU4yyVxHtbxkhyIMsCpLoUq8HwHiP4ZTazX5ZM0ZDskoukiHj5vidnher%2BGe5u6uu4P1yXjEGGEuKbi%2F9iQTVTONk6iXhb7aXnhTROllb0LP1%2B%2FvBpSysvyW4tqenTloaCqyek1EQn1mE7UfHour8fSuibQn4Vdm3X9B%2FL9yjXnBgAA)

Turbopack is adding support for tree shaking CJS exports, it would be convenient to rewrite

`module.exports = {unused: foo() }` as `module.exports = {...(void foo())}` when we determine that the property was unused.  This could then get appropriately folded by SWC.

This pattern presumably comes up in normal code too

`someFunction({prop1, ...(process.env.NODE_ENV == "development" ? {extra debugging props} : undefined)})`

and similar patterns involving null safe access `someFunction({...do?.you?.exist()})` if SWC can fold the condition it should also be able to drop the spread.


**BREAKING CHANGE:**

None.