### PR TITLE
perf(es/minifier): reuse ProgramData across compress iterations

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/mod.rs
@@ -25,7 +25,7 @@ use crate::{
     compress::hoist_decls::decl_hoister,
     mode::Mode,
     option::{CompressOptions, MangleOptions},
-    program_data::analyze,
+    program_data::ProgramData,
     usage_analyzer::marks::Marks,
     util::force_dump_program,
 };
@@ -52,6 +52,7 @@ where
         pass: 1,
         mode,
         static_alias_state: Default::default(),
+        program_data: ProgramData::default(),
     }
 }
 
@@ -66,6 +67,9 @@ struct Compressor<'a> {
 
     /// State for static alias optimization, shared across passes.
     static_alias_state: StaticAliasState,
+
+    /// Reused across hoist + compress iterations.
+    program_data: ProgramData,
 }
 
 impl CompilerPass for Compressor<'_> {
@@ -88,7 +92,7 @@ impl Compressor<'_> {
         );
 
         if self.options.hoist_vars || self.options.hoist_fns {
-            let data = analyze(&*n, Some(self.marks), false);
+            self.program_data.analyze(n, Some(self.marks), false);
 
             let mut v = decl_hoister(
                 DeclHoisterConfig {
@@ -96,7 +100,7 @@ impl Compressor<'_> {
                     hoist_vars: self.options.hoist_vars,
                     _top_level: self.options.top_level(),
                 },
-                &data,
+                &self.program_data,
             );
             n.visit_mut_with(&mut v);
             self.changed |= v.changed();
@@ -179,7 +183,7 @@ impl Compressor<'_> {
         }
 
         {
-            let mut data = analyze(&*n, Some(self.marks), false);
+            self.program_data.analyze(n, Some(self.marks), false);
 
             // TODO: reset_opt_flags
             //
@@ -189,7 +193,7 @@ impl Compressor<'_> {
                 self.marks,
                 self.options,
                 self.mangle_options,
-                &mut data,
+                &mut self.program_data,
                 self.mode,
                 &mut self.static_alias_state,
             );

--- a/crates/swc_ecma_minifier/src/program_data.rs
+++ b/crates/swc_ecma_minifier/src/program_data.rs
@@ -1,4 +1,4 @@
-use std::collections::hash_map::Entry;
+use std::{collections::hash_map::Entry, mem::take};
 
 use indexmap::IndexSet;
 use rustc_hash::{FxBuildHasher, FxHashMap};
@@ -23,16 +23,9 @@ pub(crate) fn analyze<N>(n: &N, marks: Option<Marks>, collect_property_atoms: bo
 where
     N: VisitWith<UsageAnalyzer<ProgramData>>,
 {
-    let data = if collect_property_atoms {
-        ProgramData {
-            property_atoms: Some(Vec::with_capacity(128)),
-            ..Default::default()
-        }
-    } else {
-        ProgramData::default()
-    };
-
-    analyze_with_custom_storage(data, n, marks)
+    let mut data = ProgramData::default();
+    data.analyze(n, marks, collect_property_atoms);
+    data
 }
 
 /// Analyzed info of a whole program we are working on.
@@ -45,6 +38,38 @@ pub(crate) struct ProgramData {
     scopes: Vec<ScopeData>,
 
     pub(crate) property_atoms: Option<Vec<Wtf8Atom>>,
+}
+
+impl ProgramData {
+    /// Re-analyze `n`, retaining top-level collection capacities.
+    pub(crate) fn analyze<N>(&mut self, n: &N, marks: Option<Marks>, collect_property_atoms: bool)
+    where
+        N: VisitWith<UsageAnalyzer<ProgramData>>,
+    {
+        self.clear_retaining_capacity(collect_property_atoms);
+        // `analyze_with_custom_storage` takes ownership; put the result back.
+        let storage = take(self);
+        *self = analyze_with_custom_storage(storage, n, marks);
+    }
+
+    /// Drop analyzed facts while keeping backing allocation capacity.
+    ///
+    /// `scopes` must be cleared (not zeroed in place): [`Storage::scopes`]
+    /// merges every slot, so leftover high ctxt entries from a prior run
+    /// would be observed again.
+    fn clear_retaining_capacity(&mut self, collect_property_atoms: bool) {
+        self.vars.clear();
+        self.initialized_vars.clear();
+        self.scopes.clear();
+
+        if collect_property_atoms {
+            self.property_atoms
+                .get_or_insert_with(|| Vec::with_capacity(128))
+                .clear();
+        } else {
+            self.property_atoms = None;
+        }
+    }
 }
 
 bitflags::bitflags! {


### PR DESCRIPTION
## Summary
- Reuse a single `ProgramData` on the compressor across hoist and fixed-point iterations instead of allocating a fresh analysis every pass.
- Add `ProgramData::analyze` / `clear_retaining_capacity` so top-level `vars`, `initialized_vars`, and `scopes` capacity is retained while facts are cleared correctly (scopes must be cleared, not zeroed in place).

This is a low-risk foundation for later coarse re-analyze gating. Local wall-clock gains on CodSpeed-style lib benches were small / within noise; peak RSS was essentially unchanged.

## Test plan
- [x] `cargo fmt --check`
- [x] `cargo check --all --all-targets`
- [x] `cargo test -p swc_ecma_minifier --features concurrent --features par-core/chili`
- [ ] CodSpeed CI on this PR


Made with [Cursor](https://cursor.com)