### PR TITLE
chore: require add-changeset skill for pull requests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,7 @@
 -   Run `git commit` only after `git add`.
 -   Once changes are staged, commit without unnecessary delay so staged history is preserved.
 -   When creating or updating a pull request, follow the repository pull request template.
+-   When creating a pull request, use the `add-changeset` skill to create the required changeset.
 -   After addressing pull request review comments and pushing updates, resolve the corresponding review threads.
 
 ## Testing


### PR DESCRIPTION
**Description:**

Require pull request creation workflows to use the `add-changeset` skill.

This keeps future SWC pull requests consistent when identifying changed publishable Rust crates, selecting version bumps, and including `swc_core` where required. This pull request changes repository guidance only; it does not modify a publishable Rust crate, so no release changeset is needed.

**Related issue (if exists):**

None.

**Validation:**

- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
