### PR TITLE
fix(testing): check ignored fixtures relative to crate root

### DIFF
--- a/.changeset/scope-ignored-fixtures.md
+++ b/.changeset/scope-ignored-fixtures.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+testing_macros: patch
+---
+
+fix(testing): Check ignored fixtures relative to the crate root

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7819,6 +7819,7 @@ dependencies = [
  "regex",
  "relative-path",
  "syn 2.0.110",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/testing_macros/Cargo.toml
+++ b/crates/testing_macros/Cargo.toml
@@ -28,3 +28,6 @@ relative-path = { workspace = true }
 [dependencies.syn]
 features  = ["fold", "parsing", "full", "extra-traits"]
 workspace = true
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/testing_macros/src/fixture.rs
+++ b/crates/testing_macros/src/fixture.rs
@@ -1,6 +1,6 @@
 use std::{
     env,
-    path::{Component, PathBuf},
+    path::{Component, Path, PathBuf},
 };
 
 use anyhow::{Context, Error};
@@ -96,7 +96,12 @@ pub fn expand(callee: &Ident, attr: Config) -> Result<Vec<TokenStream>, Error> {
     let base_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR").expect(
         "#[fixture] requires CARGO_MANIFEST_DIR because it's relative to cargo manifest directory",
     ));
-    let resolved_path = RelativePath::new(&attr.pattern).to_path(&base_dir);
+
+    expand_from(callee, attr, &base_dir)
+}
+
+fn expand_from(callee: &Ident, attr: Config, base_dir: &Path) -> Result<Vec<TokenStream>, Error> {
+    let resolved_path = RelativePath::new(&attr.pattern).to_path(base_dir);
     let pattern = resolved_path.to_string_lossy();
 
     let paths =
@@ -111,7 +116,7 @@ pub fn expand(callee: &Ident, attr: Config) -> Result<Vec<TokenStream>, Error> {
             .canonicalize()
             .with_context(|| format!("failed to canonicalize {}", path.display()))?;
 
-        let path_for_name = path.strip_prefix(&base_dir).with_context(|| {
+        let path_for_name = path.strip_prefix(base_dir).with_context(|| {
             format!(
                 "Failed to strip prefix `{}` from `{}`",
                 base_dir.display(),
@@ -130,10 +135,7 @@ pub fn expand(callee: &Ident, attr: Config) -> Result<Vec<TokenStream>, Error> {
             }
         }
 
-        let ignored = path.components().any(|c| match c {
-            Component::Normal(s) => s.to_string_lossy().starts_with('.'),
-            _ => false,
-        });
+        let ignored = is_ignored_fixture(path_for_name);
         let test_name = format!(
             "{}_{}",
             callee,
@@ -174,6 +176,15 @@ pub fn expand(callee: &Ident, attr: Config) -> Result<Vec<TokenStream>, Error> {
     Ok(test_fns)
 }
 
+/// Returns whether a manifest-relative fixture path contains a hidden
+/// component.
+fn is_ignored_fixture(path: &Path) -> bool {
+    path.components().any(|component| match component {
+        Component::Normal(name) => name.to_string_lossy().starts_with('.'),
+        _ => false,
+    })
+}
+
 struct InputParen {
     input: Punctuated<LitStr, Token![,]>,
 }
@@ -183,5 +194,63 @@ impl Parse for InputParen {
         Ok(Self {
             input: input.call(Punctuated::parse_terminated)?,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{create_dir_all, write};
+
+    use proc_macro2::Span;
+    use tempfile::tempdir;
+
+    use super::*;
+
+    #[test]
+    fn ignores_only_hidden_fixture_path_components() {
+        let temp_dir = tempdir().unwrap();
+        let manifest_dir = temp_dir
+            .path()
+            .join(".codex")
+            .join("worktrees")
+            .join("swc")
+            .join("crates")
+            .join("testing_macros");
+        let fixture_dir = manifest_dir.join("tests").join("fixture");
+        let ignored_fixture_dir = fixture_dir.join(".ignored");
+
+        create_dir_all(&ignored_fixture_dir).unwrap();
+        write(fixture_dir.join("normal.ts"), "").unwrap();
+        write(ignored_fixture_dir.join("ignored.ts"), "").unwrap();
+
+        let cases = expand_from(
+            &Ident::new("fixture", Span::call_site()),
+            Config {
+                pattern: "tests/fixture/**/*.ts".into(),
+                exclude_patterns: Vec::new(),
+            },
+            &manifest_dir,
+        )
+        .unwrap();
+
+        let case_count = cases.len();
+        let ignored_count = cases
+            .into_iter()
+            .map(|case| syn::parse2::<syn::ItemFn>(case).unwrap())
+            .filter(|case| case.attrs.iter().any(|attr| attr.path().is_ident("ignore")))
+            .count();
+
+        assert_eq!(case_count, 2);
+        assert_eq!(ignored_count, 1);
+    }
+
+    #[test]
+    fn ignores_hidden_components_in_cross_crate_fixture_paths() {
+        assert!(!is_ignored_fixture(Path::new(
+            "../other-crate/tests/fixture/input.js"
+        )));
+        assert!(is_ignored_fixture(Path::new(
+            "../other-crate/tests/fixture/.case/input.js"
+        )));
     }
 }

--- a/crates/testing_macros/src/lib.rs
+++ b/crates/testing_macros/src/lib.rs
@@ -38,10 +38,11 @@ mod fixture;
 ///
 /// ## Ignoring a test
 ///
-/// If the path to the file contains a component starts with `.` (dot), it will
-/// be ignore. This convention is widely used in many projects (including other
-/// languages), as a file or a directory starting with `.` means hidden file in
-/// unix system.
+/// If the fixture path relative to the crate's `Cargo.toml` contains a
+/// component that starts with `.` (dot), it will be ignored. Ancestors of the
+/// crate are not considered. This convention is widely used in many projects
+/// (including other languages), as a file or a directory starting with `.`
+/// means a hidden file in unix systems.
 ///
 /// Note that they are added as a test `#[ignore]`, so you can use
 /// `cargo test -- --ignored` or `cargo test -- --include-ignored` to run those


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

- Check ignored fixtures relative to `CARGO_MANIFEST_DIR`.
- Prevent hidden ancestor directories, such as `.codex` worktrees, from ignoring all fixtures.
- Add regression coverage and clarify the documented behavior.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
