### PR TITLE
fix(es/decorators): Avoid class state leakage for nested undecorated classes

### DIFF
--- a/.changeset/fix-decorator-nested-class-state.md
+++ b/.changeset/fix-decorator-nested-class-state.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_proposal: patch
+---
+
+fix(es/decorators): Avoid class state leakage for nested undecorated classes

--- a/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
@@ -3392,7 +3392,7 @@ impl VisitMut for DecoratorPass {
                 private_id_index,
                 ..Default::default()
             };
-            c.visit_mut_with(self);
+            maybe_grow_default(|| c.visit_mut_with(self));
             let nested_state = take(&mut self.state);
             old_state.private_id_index = nested_state.private_id_index;
             self.state = old_state;

--- a/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
@@ -3385,6 +3385,19 @@ impl VisitMut for DecoratorPass {
 
                 return;
             }
+
+            let mut old_state = take(&mut self.state);
+            let private_id_index = old_state.private_id_index;
+            self.state = ClassState {
+                private_id_index,
+                ..Default::default()
+            };
+            c.visit_mut_with(self);
+            let nested_state = take(&mut self.state);
+            old_state.private_id_index = nested_state.private_id_index;
+            self.state = old_state;
+
+            return;
         }
 
         maybe_grow_default(|| e.visit_mut_children_with(self));

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-12074/exec.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-12074/exec.js
@@ -1,0 +1,20 @@
+const fields = Symbol.for("fields");
+const track = () => (_value, ctx) => {
+  if (ctx.kind === "field") {
+    ctx.addInitializer(function () {
+      (this[fields] ??= new Set()).add(ctx.name);
+    });
+  }
+};
+
+class Foo {
+  @track() a;
+  @track() b;
+  static X = class {}; // <-- remove this line and the decorators run
+  constructor() {
+    this.a = 1;
+    this.b = 2;
+  }
+}
+
+expect([...(new Foo()[fields] ?? [])]).toStrictEqual(["a", "b"]);

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-12074/input.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-12074/input.js
@@ -1,0 +1,20 @@
+const fields = Symbol.for("fields");
+const track = () => (_value, ctx) => {
+  if (ctx.kind === "field") {
+    ctx.addInitializer(function () {
+      (this[fields] ??= new Set()).add(ctx.name);
+    });
+  }
+};
+
+class Foo {
+  @track() a;
+  @track() b;
+  static X = class {}; // <-- remove this line and the decorators run
+  constructor() {
+    this.a = 1;
+    this.b = 2;
+  }
+}
+
+console.log([...(new Foo()[fields] ?? [])]); // expected ["a","b"], actual []

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-12074/options.json
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-12074/options.json
@@ -1,0 +1,3 @@
+{
+  "plugins": [["proposal-decorators", { "version": "2022-03" }]]
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/issue-12074/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/issue-12074/output.js
@@ -1,0 +1,37 @@
+var _dec, _dec1, _init_a, _init_b, _initProto;
+const fields = Symbol.for("fields");
+const track = ()=>(_value, ctx)=>{
+        if (ctx.kind === "field") {
+            ctx.addInitializer(function() {
+                (this[fields] ??= new Set()).add(ctx.name);
+            });
+        }
+    };
+_dec = track(), _dec1 = track();
+class Foo {
+    static{
+        ({ e: [_init_a, _init_b, _initProto] } = _apply_decs_2203_r(this, [
+            [
+                _dec,
+                0,
+                "a"
+            ],
+            [
+                _dec1,
+                0,
+                "b"
+            ]
+        ], []));
+    }
+    a = (_initProto(this), _init_a(this));
+    b = _init_b(this);
+    static X = class {
+    };
+    constructor(){
+        this.a = 1;
+        this.b = 2;
+    }
+}
+console.log([
+    ...new Foo()[fields] ?? []
+]); // expected ["a","b"], actual []


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
- Closes: #12074 