### PR TITLE
perf(es/minifier): Apply pending substitutions in batch for if-dense statement lists

### DIFF
--- a/.changeset/batch-substitutions-if-dense.md
+++ b/.changeset/batch-substitutions-if-dense.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+perf(es/minifier): Apply pending substitutions in batch for if-dense statement lists

--- a/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/conditionals.rs
@@ -251,13 +251,10 @@ impl Optimizer<'_> {
             return;
         }
 
-        // we must inline first to avoid https://github.com/swc-project/swc/issues/11517
-        stmts
-            .iter_mut()
-            .filter_map(|s| s.as_stmt_mut().and_then(|s| s.as_mut_if_stmt()))
-            .for_each(|s| {
-                self.changed |= self.vars.inline_with_multi_replacer(s);
-            });
+        // NOTE: The caller is responsible for applying pending substitutions
+        // to the statement list (see `handle_stmt_likes`, which does it in a
+        // single batch walk for `if`-dense lists) before merging. This is
+        // required to avoid https://github.com/swc-project/swc/issues/11517
 
         let has_work =
             stmts

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -463,6 +463,8 @@ impl Optimizer<'_> {
     where
         T: StmtLike + ModuleItemLike + ModuleItemExt + VisitMutWith<Self> + VisitWith<AssertValid>,
         Vec<T>: VisitMutWith<Self> + VisitWith<UsageAnalyzer<ProgramData>> + VisitWith<AssertValid>,
+        Vec<T>:
+            for<'aa> VisitMutWith<NormalMultiReplacer<'aa>> + for<'aa> VisitMutWith<Finalizer<'aa>>,
     {
         let mut use_asm = false;
         let prepend_stmts = self.prepend_stmts.take();
@@ -544,6 +546,33 @@ impl Optimizer<'_> {
         #[cfg(debug_assertions)]
         {
             stmts.visit_with(&mut AssertValid);
+        }
+
+        // Apply pending substitutions (required before `merge_similar_ifs` to
+        // avoid https://github.com/swc-project/swc/issues/11517). Strategy
+        // depends on `if` density: for `if`-dense lists a single batch walk
+        // beats two walks per `if`; for `if`-sparse lists the per-`if` walks
+        // stay cheaper than walking the whole list twice. Both are
+        // semantically equivalent: the substitution maps do not change during
+        // application except for consumption of applied entries, which happens
+        // in the same statement order either way.
+        let if_count = stmts
+            .iter()
+            .filter(|s| {
+                s.as_stmt()
+                    .map(|s| matches!(s, Stmt::If(_)))
+                    .unwrap_or(false)
+            })
+            .count();
+        if if_count >= 16 {
+            self.changed |= self.vars.inline_with_multi_replacer(stmts);
+        } else {
+            stmts
+                .iter_mut()
+                .filter_map(|s| s.as_stmt_mut().and_then(|s| s.as_mut_if_stmt()))
+                .for_each(|s| {
+                    self.changed |= self.vars.inline_with_multi_replacer(s);
+                });
         }
 
         self.merge_similar_ifs(stmts);


### PR DESCRIPTION
**Description:**

Profiling the minifier on large inputs showed that `inline_with_multi_replacer` is invoked tens of thousands of times per `optimize()` call (each call = one `Finalizer` walk + one `NormalMultiReplacer` walk over a small subtree), with hit rates of only 0.4–1.7% (replacer) and 0.006–0.04% (finalizer) — i.e. ~99% of the walks change nothing. About half of them came from `merge_similar_ifs`, which flushed pending substitutions into **each `if` statement individually** before merging (34k double walks per run on typescript.js alone).

This PR applies pending substitutions to the whole statement list in a **single batch walk** when the list is `if`-dense (`>= 16` ifs), and keeps the per-`if` loop for sparse lists. The two forms are semantically equivalent: the substitution maps do not change during application except for consumption of applied entries, which happens in the same statement order either way. The density gate preserves the win where batching pays off (Σ(if subtrees) ≈ Σ(list)) without regressing `if`-sparse inputs, where per-`if` walks are already the cheaper strategy.

**Output:** byte-identical on the entire fixture corpus — the full suite passes with **zero fixture updates required** (including the big projects/bench lib fixtures).

**Test plan:**
- [x] `cargo fmt --all`
- [x] `cargo clippy --all --all-targets -- -D warnings`
- [x] `cargo test -p swc_ecma_minifier` (fully green, no fixture updates)
- [x] `./scripts/exec.sh` (2128/2128 pass)

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

https://github.com/swc-project/swc/issues/11517 (the pre-existing workaround this change preserves, but cheaper)