### PR TITLE
fix(html/minifier): Preserve JSON script boundaries

### DIFF
--- a/.changeset/preserve-json-script-boundaries.md
+++ b/.changeset/preserve-json-script-boundaries.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_html_minifier: patch
+---
+
+fix(html/minifier): Preserve JSON script boundaries

--- a/crates/swc_html_minifier/src/lib.rs
+++ b/crates/swc_html_minifier/src/lib.rs
@@ -1789,6 +1789,20 @@ impl<C: MinifyCss> Minifier<'_, C> {
         result.ok()
     }
 
+    /// Escapes serialized JSON so it cannot terminate its containing HTML
+    /// `script` element.
+    ///
+    /// HTML tokenization recognizes `</script` before the JSON is parsed.
+    /// Serializing an escaped `<` as a literal character can therefore turn
+    /// inert JSON data into active HTML.
+    fn escape_json_for_html_script(json: String) -> String {
+        if json.contains('<') {
+            json.replace('<', "\\u003C")
+        } else {
+            json
+        }
+    }
+
     fn need_minify_js(&self) -> bool {
         match self.options.minify_js {
             MinifyJsOption::Bool(value) => value,
@@ -2742,7 +2756,7 @@ impl<C: MinifyCss> VisitMut for Minifier<'_, C> {
                     None => return,
                 };
 
-                n.data = minified.into();
+                n.data = Self::escape_json_for_html_script(minified).into();
             }
             Some(MinifierType::Css) => {
                 let minified =

--- a/crates/swc_html_minifier/src/lib.rs
+++ b/crates/swc_html_minifier/src/lib.rs
@@ -1794,7 +1794,7 @@ impl<C: MinifyCss> Minifier<'_, C> {
     ///
     /// HTML tokenization recognizes `</script` before the JSON is parsed.
     /// Serializing an escaped `<` as a literal character can therefore turn
-    /// inert JSON data into active HTML.
+    /// JSON data into a different HTML element structure.
     fn escape_json_for_html_script(json: String) -> String {
         if json.contains('<') {
             json.replace('<', "\\u003C")

--- a/crates/swc_html_minifier/tests/fixture/element/script-json-escaping/input.html
+++ b/crates/swc_html_minifier/tests/fixture/element/script-json-escaping/input.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <script type="application/json">
     {
-        "payload": "\u003C\u002Fscript>\u003Cscript>globalThis.pwned=true\u003C\u002Fscript>"
+        "content": "\u003C\u002Fscript>\u003Cdiv>content\u003C\u002Fdiv>"
     }
 </script>
 <p>after</p>

--- a/crates/swc_html_minifier/tests/fixture/element/script-json-escaping/input.html
+++ b/crates/swc_html_minifier/tests/fixture/element/script-json-escaping/input.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<script type="application/json">
+    {
+        "payload": "\u003C\u002Fscript>\u003Cscript>globalThis.pwned=true\u003C\u002Fscript>"
+    }
+</script>
+<p>after</p>

--- a/crates/swc_html_minifier/tests/fixture/element/script-json-escaping/output.min.html
+++ b/crates/swc_html_minifier/tests/fixture/element/script-json-escaping/output.min.html
@@ -1,0 +1,1 @@
+<!doctype html><script type=application/json>{"payload":"\u003C/script>\u003Cscript>globalThis.pwned=true\u003C/script>"}</script><p>after

--- a/crates/swc_html_minifier/tests/fixture/element/script-json-escaping/output.min.html
+++ b/crates/swc_html_minifier/tests/fixture/element/script-json-escaping/output.min.html
@@ -1,1 +1,1 @@
-<!doctype html><script type=application/json>{"payload":"\u003C/script>\u003Cscript>globalThis.pwned=true\u003C/script>"}</script><p>after
+<!doctype html><script type=application/json>{"content":"\u003C/script>\u003Cdiv>content\u003C/div>"}</script><p>after


### PR DESCRIPTION
**Description:**

Preserve JSON `script` element boundaries during HTML minification.

The JSON serializer normalizes Unicode escapes, which can turn escaped less-than signs into literal characters and change how the HTML parser delimits the containing element. Re-escape less-than signs after serialization so the minified document retains the same element structure. Add fixture coverage for encoded element-like content.

**Related issue (if exists):**

None.

**Verification:**

- `cargo test -p swc_html_minifier`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
