### PR TITLE
chore: Publish `@swc/types@v0.1.28`

### DIFF
--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@swc/types",
-    "version": "0.1.27",
+    "version": "0.1.28",
     "description": "Typings for the swc project.",
     "types": "./index.d.ts",
     "sideEffects": false,


### PR DESCRIPTION
**Description:**

Bumps `@swc/types` to `0.1.28` so that `reactCompiler.environment` can actually reach consumers.

`@swc/types@0.1.27` was published on 2026-06-16, from the version bump in b182fbd5bc (#11917). `reactCompiler.environment.enableFunctionOutlining` was added to `packages/types/index.ts` afterwards, in 52b78aa1d7 (#12030, 2026-07-23), without a version bump. `0.1.27` is still the latest version on npm, so the published tarball predates that change and the field is absent from every version consumers can install.

The result is that `jsc.transform.reactCompiler.environment` is accepted by the Rust config (`crates/swc/src/config/mod.rs`, applied via `ReactCompilerEnvironmentConfig::apply_to`) and works at runtime in `@swc/core` 1.15.47, but fails to type-check:

```ts
import type { Config } from "@swc/core";

const config: Config = {
  jsc: {
    transform: {
      reactCompiler: {
        // Object literal may only specify known properties,
        // and 'environment' does not exist in type 'ReactCompilerOptions'.
        environment: { enableFunctionOutlining: false },
      },
    },
  },
};
```

`@swc/core` has no `Config` of its own — `packages/core/src/index.ts` is `export type * from "@swc/types"` — so the typings consumers get are entirely determined by the resolved `@swc/types`.

Root cause of the drift: `@swc/types` is not part of the `@swc/core` release pipeline (`publish.yml` / `publish-npm-package.yml` don't reference it). It is published only by `publish-misc-packages.yml`, which is `workflow_dispatch`-only. So a normal `@swc/core` release republishes the native bindings while leaving the typings on whatever tarball was last manually published.

:warning: **Merging this does not publish anything.** Since `publish-misc-packages.yml` is manual, a maintainer needs to dispatch "Publish misc packages" (`npmTag: latest`) from `main` after this lands. Without that step the version bump has no effect for consumers.

Once published, propagation is automatic for existing installs: `@swc/core@1.15.47` declares `"@swc/types": "^0.1.27"`, which `0.1.28` satisfies, so a lockfile refresh is enough — no `@swc/core` bump required.

**BREAKING CHANGE:**

None. Version bump only; no changes to the type definitions themselves.

**Related issue (if exists):**

Follow-up to #12030.