### PR TITLE
fix(es/module): strip import attributes from CJS dynamic import

### DIFF
--- a/.changeset/cjs-dynamic-import-attributes.md
+++ b/.changeset/cjs-dynamic-import-attributes.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_module: patch
+---
+
+fix(es/module): strip import attributes from CommonJS dynamic import

--- a/crates/swc_ecma_transforms_module/src/common_js.rs
+++ b/crates/swc_ecma_transforms_module/src/common_js.rs
@@ -584,18 +584,29 @@ impl Cjs {
 
 /// ```javascript
 /// Promise.resolve(args).then(p => require(p))
-/// // for literial dynamic import:
+/// // for literal dynamic import:
 /// Promise.resolve().then(() => require(args))
 /// ```
+///
+/// Import attributes / assertions (`import(x, { with: { type: "json" } })`)
+/// are not expressible via `require`, so only the module specifier is kept.
 pub(crate) fn cjs_dynamic_import(
     span: Span,
-    args: Vec<ExprOrSpread>,
+    mut args: Vec<ExprOrSpread>,
     require: Ident,
     import_interop: ImportInterop,
     support_arrow: bool,
     is_lit_path: bool,
 ) -> Expr {
     let p = private_ident!("p");
+
+    // Keep only the specifier. Extra arguments (import attributes / assert)
+    // cannot be forwarded to `require` and must not be passed to
+    // `Promise.resolve` either (`Promise.resolve(path, opts)` ignores `opts`
+    // and would silently drop attributes today).
+    if args.len() > 1 {
+        args.truncate(1);
+    }
 
     let (resolve_args, callback_params, require_args) = if is_lit_path {
         (Vec::new(), Vec::new(), args)
@@ -604,7 +615,6 @@ pub(crate) fn cjs_dynamic_import(
     };
 
     let then = member_expr!(Default::default(), Default::default(), Promise.resolve)
-        // TODO: handle import assert
         .as_call(DUMMY_SP, resolve_args)
         .make_member(quote_ident!("then"));
 

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/assert-keyword/input.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/assert-keyword/input.js
@@ -1,0 +1,2 @@
+import("./data.json", { assert: { type: "json" } });
+import(path, { assert: { type: "json" } });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/assert-keyword/output.amd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/assert-keyword/output.amd.js
@@ -1,0 +1,11 @@
+define([
+    "require"
+], function(require) {
+    "use strict";
+    new Promise((resolve, reject)=>require([
+            "./data.json"
+        ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard(m)), reject));
+    new Promise((resolve, reject)=>require([
+            path
+        ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard(m)), reject));
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/assert-keyword/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/assert-keyword/output.cjs
@@ -1,0 +1,3 @@
+"use strict";
+Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard(require("./data.json")));
+Promise.resolve(path).then((p)=>/*#__PURE__*/ _interop_require_wildcard(require(p)));

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/assert-keyword/output.umd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/assert-keyword/output.umd.js
@@ -1,0 +1,17 @@
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory();
+    else if (typeof define === "function" && define.amd) define([], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
+})(this, function() {
+    "use strict";
+    import("./data.json", {
+        assert: {
+            type: "json"
+        }
+    });
+    import(path, {
+        assert: {
+            type: "json"
+        }
+    });
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/computed/input.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/computed/input.js
@@ -1,0 +1,2 @@
+import(path, { with: { type: "json" } });
+import(getPath(), { with: { type: "json" } });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/computed/output.amd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/computed/output.amd.js
@@ -1,0 +1,11 @@
+define([
+    "require"
+], function(require) {
+    "use strict";
+    new Promise((resolve, reject)=>require([
+            path
+        ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard(m)), reject));
+    new Promise((resolve, reject)=>require([
+            getPath()
+        ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard(m)), reject));
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/computed/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/computed/output.cjs
@@ -1,0 +1,3 @@
+"use strict";
+Promise.resolve(path).then((p)=>/*#__PURE__*/ _interop_require_wildcard(require(p)));
+Promise.resolve(getPath()).then((p)=>/*#__PURE__*/ _interop_require_wildcard(require(p)));

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/computed/output.umd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/computed/output.umd.js
@@ -1,0 +1,17 @@
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory();
+    else if (typeof define === "function" && define.amd) define([], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
+})(this, function() {
+    "use strict";
+    import(path, {
+        with: {
+            type: "json"
+        }
+    });
+    import(getPath(), {
+        with: {
+            type: "json"
+        }
+    });
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/literal/input.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/literal/input.js
@@ -1,0 +1,2 @@
+import("./data.json", { with: { type: "json" } });
+import('./config.json', { with: { type: 'json' } });

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/literal/output.amd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/literal/output.amd.js
@@ -1,0 +1,11 @@
+define([
+    "require"
+], function(require) {
+    "use strict";
+    new Promise((resolve, reject)=>require([
+            "./data.json"
+        ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard(m)), reject));
+    new Promise((resolve, reject)=>require([
+            "./config.json"
+        ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard(m)), reject));
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/literal/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/literal/output.cjs
@@ -1,0 +1,3 @@
+"use strict";
+Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard(require("./data.json")));
+Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard(require("./config.json")));

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/literal/output.umd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/literal/output.umd.js
@@ -1,0 +1,17 @@
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory();
+    else if (typeof define === "function" && define.amd) define([], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
+})(this, function() {
+    "use strict";
+    import("./data.json", {
+        with: {
+            type: "json"
+        }
+    });
+    import('./config.json', {
+        with: {
+            type: 'json'
+        }
+    });
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/mixed/input.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/mixed/input.js
@@ -1,0 +1,4 @@
+import("plain.js");
+import("./data.json", { with: { type: "json" } });
+import(dynamicPath, { with: { type: "json" } });
+import("also-plain.js");

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/mixed/output.amd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/mixed/output.amd.js
@@ -1,0 +1,17 @@
+define([
+    "require"
+], function(require) {
+    "use strict";
+    new Promise((resolve, reject)=>require([
+            "plain.js"
+        ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard(m)), reject));
+    new Promise((resolve, reject)=>require([
+            "./data.json"
+        ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard(m)), reject));
+    new Promise((resolve, reject)=>require([
+            dynamicPath
+        ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard(m)), reject));
+    new Promise((resolve, reject)=>require([
+            "also-plain.js"
+        ], (m)=>resolve(/*#__PURE__*/ _interop_require_wildcard(m)), reject));
+});

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/mixed/output.cjs
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/mixed/output.cjs
@@ -1,0 +1,5 @@
+"use strict";
+Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard(require("plain.js")));
+Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard(require("./data.json")));
+Promise.resolve(dynamicPath).then((p)=>/*#__PURE__*/ _interop_require_wildcard(require(p)));
+Promise.resolve().then(()=>/*#__PURE__*/ _interop_require_wildcard(require("also-plain.js")));

--- a/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/mixed/output.umd.js
+++ b/crates/swc_ecma_transforms_module/tests/fixture/common/dynamic-import-attributes/mixed/output.umd.js
@@ -1,0 +1,19 @@
+(function(global, factory) {
+    if (typeof module === "object" && typeof module.exports === "object") factory();
+    else if (typeof define === "function" && define.amd) define([], factory);
+    else if (global = typeof globalThis !== "undefined" ? globalThis : global || self) factory();
+})(this, function() {
+    "use strict";
+    import("plain.js");
+    import("./data.json", {
+        with: {
+            type: "json"
+        }
+    });
+    import(dynamicPath, {
+        with: {
+            type: "json"
+        }
+    });
+    import("also-plain.js");
+});


### PR DESCRIPTION
**Description:**

`cjs_dynamic_import` had a `TODO: handle import assert`. With import attributes, CommonJS lowering was incorrect:

- `import("./data.json", { with: { type: "json" } })` became `require("./data.json", { with: ... })` — invalid `require` arity/options
- `import(path, { with: ... })` became `Promise.resolve(path, opts).then(...)` — attributes silently discarded by `Promise.resolve`

`require` cannot express import attributes, so this change truncates dynamic import arguments to the module specifier only (matching the existing AMD path that already used `args[..1]`).

Fixtures cover literal paths, computed paths, legacy `assert`, and mixed cases under `tests/fixture/common/dynamic-import-attributes/**`.

**Related issue (if exists):**

N/A (direct PR; no existing tracked issue)