### PR TITLE
chore: Fix stale helper path in add-changeset skill

### DIFF
--- a/.agents/skills/add-changeset/SKILL.md
+++ b/.agents/skills/add-changeset/SKILL.md
@@ -67,15 +67,15 @@ perf: Optimize es parser comment finalization
 Run this helper from the repository root:
 
 ```bash
-node .codex/skills/add-changeset/scripts/changed-rust-crates.mjs
+node .agents/skills/add-changeset/scripts/changed-rust-crates.mjs
 ```
 
 Useful options:
 
 ```bash
-node .codex/skills/add-changeset/scripts/changed-rust-crates.mjs --base origin/main
-node .codex/skills/add-changeset/scripts/changed-rust-crates.mjs --json
-node .codex/skills/add-changeset/scripts/changed-rust-crates.mjs --include-private
+node .agents/skills/add-changeset/scripts/changed-rust-crates.mjs --base origin/main
+node .agents/skills/add-changeset/scripts/changed-rust-crates.mjs --json
+node .agents/skills/add-changeset/scripts/changed-rust-crates.mjs --include-private
 ```
 
 Treat the helper as an inventory aid. It does not decide breaking changes, does not understand public API exposure, and cannot fully interpret workspace-level changes.


### PR DESCRIPTION
**Description:**

`.agents/skills/add-changeset/SKILL.md` tells agents to run the helper from
`.codex/skills/...`, which no longer exists. Following the skill as written fails
on its first command:

    $ node .codex/skills/add-changeset/scripts/changed-rust-crates.mjs
    Error: Cannot find module '.../swc/.codex/skills/add-changeset/scripts/changed-rust-crates.mjs'

Root cause: the rename in 753b222f (`chore: Move skill`) moved the skill from
`.codex/` to `.agents/` with similarity index 100%, so the four references inside
the document travelled along unchanged.

Two reasons it went unnoticed for three months: `.codex/` is still in the tree
(it holds `config.toml` for the CodSpeed MCP), so the directory looks alive; and
#12072 edited this same file without touching those lines.

`.agents/skills/repair-pr/SKILL.md` already points at
`.agents/skills/repair-pr/scripts/repair-pr.mjs`. This only brings `add-changeset`
in line with it.

Four lines, one file. `git grep "\.codex"` matches nothing else outside a
`#[cfg(test)]` tempdir string in `crates/testing_macros/src/fixture.rs`. No
changeset: no publishable crate is affected.

After the change, `node .agents/skills/add-changeset/scripts/changed-rust-crates.mjs --help`
prints the usage.

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

N/A
