### PR TITLE
fix(plugin/runner): write Wasmer cache atomically

### DIFF
--- a/.changeset/fix-wasmer-cache-atomic-write.md
+++ b/.changeset/fix-wasmer-cache-atomic-write.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_plugin_backend_wasmer: patch
+---
+
+fix(plugin/runner): Write Wasmer plugin cache atomically

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7423,6 +7423,7 @@ dependencies = [
  "parking_lot",
  "swc_common",
  "swc_plugin_runner",
+ "tempfile",
  "wasmer",
  "wasmer-compiler-cranelift",
  "wasmer-wasix",

--- a/crates/swc_plugin_backend_wasmer/Cargo.toml
+++ b/crates/swc_plugin_backend_wasmer/Cargo.toml
@@ -40,3 +40,6 @@ swc_plugin_runner = { version = "32.0.0", path = "../swc_plugin_runner" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 wasmer-compiler-cranelift = { version = "6.1.0-rc.3", default-features = false }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/crates/swc_plugin_backend_wasmer/src/filesystem_cache.rs
+++ b/crates/swc_plugin_backend_wasmer/src/filesystem_cache.rs
@@ -1,0 +1,106 @@
+use std::{
+    fs::{File, OpenOptions},
+    io::{self, ErrorKind, Write},
+    path::{Path, PathBuf},
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+static TEMP_FILE_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Writes a serialized module without exposing a partially-written cache file.
+///
+/// Jest and other parallel runners can load the same plugin from multiple
+/// processes. Writing directly to the final path allows one process to observe
+/// another process's incomplete Wasmer artifact. A temporary file in the same
+/// directory keeps the final rename atomic.
+pub(crate) fn write_atomic(path: &Path, data: &[u8]) -> io::Result<()> {
+    let (temporary_path, mut file) = create_temporary_file(path)?;
+
+    if let Err(err) = file.write_all(data) {
+        drop(file);
+        let _ = std::fs::remove_file(&temporary_path);
+        return Err(err);
+    }
+    drop(file);
+
+    match std::fs::rename(&temporary_path, path) {
+        Ok(()) => Ok(()),
+        // Windows does not replace an existing file with rename. Another process
+        // publishing the same content first is a successful cache write for us.
+        Err(_) if path.is_file() => {
+            let _ = std::fs::remove_file(&temporary_path);
+            Ok(())
+        }
+        Err(err) => {
+            let _ = std::fs::remove_file(&temporary_path);
+            Err(err)
+        }
+    }
+}
+
+fn create_temporary_file(path: &Path) -> io::Result<(PathBuf, File)> {
+    loop {
+        let id = TEMP_FILE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let mut temporary_path = path.as_os_str().to_os_string();
+        temporary_path.push(format!(".{}.{}.tmp", std::process::id(), id));
+        let temporary_path = PathBuf::from(temporary_path);
+
+        match OpenOptions::new()
+            .create_new(true)
+            .write(true)
+            .open(&temporary_path)
+        {
+            Ok(file) => return Ok((temporary_path, file)),
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => continue,
+            Err(err) => return Err(err),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Barrier};
+
+    use super::*;
+
+    #[test]
+    fn concurrent_writers_only_publish_complete_cache_files() {
+        const WRITER_COUNT: usize = 8;
+        const PAYLOAD_SIZE: usize = 2 * 1024 * 1024;
+
+        let directory = tempfile::tempdir().unwrap();
+        let cache_path = directory.path().join("plugin.wasmer");
+        let barrier = Arc::new(Barrier::new(WRITER_COUNT + 1));
+        let payloads: Vec<_> = (0..WRITER_COUNT)
+            .map(|index| Arc::new(vec![index as u8; PAYLOAD_SIZE]))
+            .collect();
+
+        let handles: Vec<_> = payloads
+            .iter()
+            .map(|payload| {
+                let barrier = barrier.clone();
+                let cache_path = cache_path.clone();
+                let payload = payload.clone();
+                std::thread::spawn(move || {
+                    barrier.wait();
+                    write_atomic(&cache_path, &payload)
+                })
+            })
+            .collect();
+
+        barrier.wait();
+        while handles.iter().any(|handle| !handle.is_finished()) {
+            if let Ok(data) = std::fs::read(&cache_path) {
+                assert!(payloads.iter().any(|payload| payload.as_slice() == data));
+            }
+        }
+
+        for handle in handles {
+            handle.join().unwrap().unwrap();
+        }
+
+        let data = std::fs::read(&cache_path).unwrap();
+        assert!(payloads.iter().any(|payload| payload.as_slice() == data));
+        assert_eq!(std::fs::read_dir(directory.path()).unwrap().count(), 1);
+    }
+}

--- a/crates/swc_plugin_backend_wasmer/src/lib.rs
+++ b/crates/swc_plugin_backend_wasmer/src/lib.rs
@@ -9,6 +9,9 @@ use swc_plugin_runner::runtime;
 use wasmer::{AsStoreMut, Store};
 use wasmer_wasix::{default_fs_backing, Runtime};
 
+#[cfg(not(target_arch = "wasm32"))]
+mod filesystem_cache;
+
 /// Identifier for bytecode cache stored in local filesystem.
 ///
 /// This MUST be updated when bump up wasmer.
@@ -304,7 +307,16 @@ impl runtime::Runtime for WasmerRuntime {
 
     fn store_cache(&self, path: &Path, cache: &runtime::ModuleCache) -> anyhow::Result<()> {
         let cache = cache.0.downcast_ref::<WasmerCache>().unwrap();
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let data = cache.module.serialize()?;
+            filesystem_cache::write_atomic(path, &data)?;
+        }
+
+        #[cfg(target_arch = "wasm32")]
         cache.module.serialize_to_file(path)?;
+
         Ok(())
     }
 }


### PR DESCRIPTION
**Description:**

This fixes intermittent Wasmer plugin cache corruption when multiple processes compile the same plugin concurrently.

The Wasmer backend previously serialized modules directly to the final cache path. Parallel Jest, Turbo, or Nx workers could observe the file after its metadata header was written but before the complete artifact was available, producing `metadata_len` slice-bound failures. The backend now serializes the module in memory, writes it to a unique temporary file in the cache directory, and atomically renames the completed file into place.

A concurrent-writer regression test verifies that readers only observe complete cache artifacts.

**Related issue (if exists):**

Fixes #6467

**Validation:**

- `cargo test -p swc_plugin_backend_wasmer`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
