### PR TITLE
fix(es/typescript): Treat const variable references as enum constants

### DIFF
--- a/.changeset/fix-ts-enum-const-var-folding.md
+++ b/.changeset/fix-ts-enum-const-var-folding.md
@@ -1,0 +1,5 @@
+---
+swc_core: patch
+swc_ecma_transforms_typescript: patch
+---
+fix(es/typescript): Treat const variable references as enum constants

--- a/crates/swc/tests/tsc-references/constEnum2.1.normal.js
+++ b/crates/swc/tests/tsc-references/constEnum2.1.normal.js
@@ -7,6 +7,5 @@ var CONST = 9000 % 2;
 var D = function(D) {
     D[D["e"] = 199 * Math.floor(Math.random() * 1000)] = "e";
     D[D["f"] = 10 - 100 * Math.floor(Math.random() % 8)] = "f";
-    D[D["g"] = CONST] = "g";
     return D;
 }(D || {});

--- a/crates/swc/tests/tsc-references/constEnum2.2.minified.js
+++ b/crates/swc/tests/tsc-references/constEnum2.2.minified.js
@@ -1,2 +1,2 @@
 //// [constEnum2.ts]
-var D, D1 = ((D = D1 || {})[D.e = 199 * Math.floor(1000 * Math.random())] = "e", D[D.f = 10 - 100 * Math.floor(Math.random() % 8)] = "f", D[D.g = 0] = "g", D);
+var D, D1 = ((D = D1 || {})[D.e = 199 * Math.floor(1000 * Math.random())] = "e", D[D.f = 10 - 100 * Math.floor(Math.random() % 8)] = "f", D);

--- a/crates/swc_ecma_transforms_typescript/src/semantic.rs
+++ b/crates/swc_ecma_transforms_typescript/src/semantic.rs
@@ -264,6 +264,7 @@ impl SemanticAnalyzer {
         default_init: &TsEnumRecordValue,
         record: &TsEnumRecord,
         ambient_record: &TsEnumRecord,
+        ambient_const_enum_only: Option<&FxHashSet<Id>>,
         const_vars: &FxHashMap<Id, TsEnumRecordValue>,
         unresolved_ctxt: SyntaxContext,
         flow_syntax: bool,
@@ -278,6 +279,7 @@ impl SemanticAnalyzer {
                     const_vars,
                     const_enum_only: None,
                     ambient_record,
+                    ambient_const_enum_only,
                 }
                 .compute(expr, EvalCtx::MEMBER)
             })
@@ -319,6 +321,9 @@ impl SemanticAnalyzer {
                     const_vars: &self.info.const_vars,
                     const_enum_only: self.ts_enum_is_mutable.then_some(&self.info.const_enum),
                     ambient_record: &self.info.ambient_enum_record,
+                    ambient_const_enum_only: self
+                        .ts_enum_is_mutable
+                        .then_some(&self.info.const_enum),
                 }
                 .compute(
                     init.clone(),
@@ -623,6 +628,7 @@ impl Visit for SemanticAnalyzer {
                 const_vars: &self.info.const_vars,
                 const_enum_only: self.ts_enum_is_mutable.then_some(&self.info.const_enum),
                 ambient_record: &self.info.ambient_enum_record,
+                ambient_const_enum_only: self.ts_enum_is_mutable.then_some(&self.info.const_enum),
             }
             .compute(init.clone(), EvalCtx::CONST_INIT);
 
@@ -664,6 +670,7 @@ impl Visit for SemanticAnalyzer {
                 &default_init,
                 &self.info.enum_record,
                 &self.info.ambient_enum_record,
+                self.ts_enum_is_mutable.then_some(&self.info.const_enum),
                 &self.info.const_vars,
                 self.unresolved_ctxt,
                 self.flow_syntax,
@@ -755,6 +762,7 @@ mod tests {
             &TsEnumRecordValue::Void,
             &Default::default(),
             &Default::default(),
+            None,
             &Default::default(),
             SyntaxContext::empty(),
             true,
@@ -774,6 +782,7 @@ mod tests {
             &TsEnumRecordValue::from(2.0),
             &Default::default(),
             &Default::default(),
+            None,
             &Default::default(),
             SyntaxContext::empty(),
             false,

--- a/crates/swc_ecma_transforms_typescript/src/semantic.rs
+++ b/crates/swc_ecma_transforms_typescript/src/semantic.rs
@@ -540,23 +540,24 @@ impl Visit for SemanticAnalyzer {
     }
 
     fn visit_var_decl(&mut self, node: &VarDecl) {
-        node.visit_children_with(self);
-
-        if self.skip_transform_info || node.declare || node.kind != VarDeclKind::Const {
-            return;
-        }
+        let track = !self.skip_transform_info && !node.declare && node.kind == VarDeclKind::Const;
 
         for decl in &node.decls {
+            decl.visit_with(self);
+
+            if !track {
+                continue;
+            }
+
             let Pat::Ident(BindingIdent { id, type_ann: None }) = &decl.name else {
                 continue;
             };
             let Some(init) = &decl.init else { continue };
 
-            let empty = TsEnumRecord::default();
             let value = EnumValueComputer {
                 enum_id: &id.to_id(),
                 unresolved_ctxt: self.unresolved_ctxt,
-                record: &empty,
+                record: &self.info.enum_record,
                 const_vars: &self.info.const_vars,
             }
             .compute(init.clone(), EvalCtx::CONST_INIT);

--- a/crates/swc_ecma_transforms_typescript/src/semantic.rs
+++ b/crates/swc_ecma_transforms_typescript/src/semantic.rs
@@ -554,6 +554,10 @@ impl Visit for SemanticAnalyzer {
             };
             let Some(init) = &decl.init else { continue };
 
+            if !EnumValueComputer::can_fold_shape(init) {
+                continue;
+            }
+
             let value = EnumValueComputer {
                 enum_id: &id.to_id(),
                 unresolved_ctxt: self.unresolved_ctxt,

--- a/crates/swc_ecma_transforms_typescript/src/semantic.rs
+++ b/crates/swc_ecma_transforms_typescript/src/semantic.rs
@@ -7,7 +7,7 @@ use swc_ecma_visit::{noop_visit_type, Visit, VisitWith};
 use crate::{
     retain::{should_retain_decl, IsConcrete},
     shared::{enum_member_name, get_module_ident},
-    ts_enum::{EnumValueComputer, TsEnumRecord, TsEnumRecordKey, TsEnumRecordValue},
+    ts_enum::{EnumValueComputer, EvalCtx, TsEnumRecord, TsEnumRecordKey, TsEnumRecordValue},
 };
 
 #[derive(Debug, Default)]
@@ -19,6 +19,7 @@ pub(crate) struct SemanticInfo {
     pub enum_record: TsEnumRecord,
     pub const_enum: FxHashSet<Id>,
     pub namespace_import_equals_usage: FxHashSet<Span>,
+    pub const_vars: FxHashMap<Id, TsEnumRecordValue>,
 }
 
 impl SemanticInfo {
@@ -257,6 +258,7 @@ impl SemanticAnalyzer {
         enum_id: &Id,
         default_init: &TsEnumRecordValue,
         record: &TsEnumRecord,
+        const_vars: &FxHashMap<Id, TsEnumRecordValue>,
         unresolved_ctxt: SyntaxContext,
         flow_syntax: bool,
     ) -> TsEnumRecordValue {
@@ -267,8 +269,9 @@ impl SemanticAnalyzer {
                     enum_id,
                     unresolved_ctxt,
                     record,
+                    const_vars,
                 }
-                .compute(expr)
+                .compute(expr, EvalCtx::MEMBER)
             })
             .filter(TsEnumRecordValue::has_value)
             .unwrap_or_else(|| {
@@ -536,6 +539,34 @@ impl Visit for SemanticAnalyzer {
         }
     }
 
+    fn visit_var_decl(&mut self, node: &VarDecl) {
+        node.visit_children_with(self);
+
+        if self.skip_transform_info || node.declare || node.kind != VarDeclKind::Const {
+            return;
+        }
+
+        for decl in &node.decls {
+            let Pat::Ident(BindingIdent { id, type_ann: None }) = &decl.name else {
+                continue;
+            };
+            let Some(init) = &decl.init else { continue };
+
+            let empty = TsEnumRecord::default();
+            let value = EnumValueComputer {
+                enum_id: &id.to_id(),
+                unresolved_ctxt: self.unresolved_ctxt,
+                record: &empty,
+                const_vars: &self.info.const_vars,
+            }
+            .compute(init.clone(), EvalCtx::CONST_INIT);
+
+            if value.is_const() {
+                self.info.const_vars.insert(id.to_id(), value);
+            }
+        }
+    }
+
     fn visit_ts_enum_decl(&mut self, node: &TsEnumDecl) {
         node.visit_children_with(self);
 
@@ -566,6 +597,7 @@ impl Visit for SemanticAnalyzer {
                 &id.to_id(),
                 &default_init,
                 &self.info.enum_record,
+                &self.info.const_vars,
                 self.unresolved_ctxt,
                 self.flow_syntax,
             );
@@ -655,6 +687,7 @@ mod tests {
             &id("E"),
             &TsEnumRecordValue::Void,
             &Default::default(),
+            &Default::default(),
             SyntaxContext::empty(),
             true,
         );
@@ -671,6 +704,7 @@ mod tests {
             enum_member("A"),
             &id("E"),
             &TsEnumRecordValue::from(2.0),
+            &Default::default(),
             &Default::default(),
             SyntaxContext::empty(),
             false,

--- a/crates/swc_ecma_transforms_typescript/src/semantic.rs
+++ b/crates/swc_ecma_transforms_typescript/src/semantic.rs
@@ -17,6 +17,7 @@ pub(crate) struct SemanticInfo {
     pub id_value: FxHashSet<Id>,
     pub exported_binding: FxHashMap<Id, Option<Id>>,
     pub enum_record: TsEnumRecord,
+    pub ambient_enum_record: TsEnumRecord,
     pub const_enum: FxHashSet<Id>,
     pub namespace_import_equals_usage: FxHashSet<Span>,
     pub const_vars: FxHashMap<Id, TsEnumRecordValue>,
@@ -256,11 +257,13 @@ impl SemanticAnalyzer {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn transform_ts_enum_member(
         member: TsEnumMember,
         enum_id: &Id,
         default_init: &TsEnumRecordValue,
         record: &TsEnumRecord,
+        ambient_record: &TsEnumRecord,
         const_vars: &FxHashMap<Id, TsEnumRecordValue>,
         unresolved_ctxt: SyntaxContext,
         flow_syntax: bool,
@@ -274,6 +277,7 @@ impl SemanticAnalyzer {
                     record,
                     const_vars,
                     const_enum_only: None,
+                    ambient_record,
                 }
                 .compute(expr, EvalCtx::MEMBER)
             })
@@ -289,6 +293,56 @@ impl SemanticAnalyzer {
                     default_init.clone()
                 }
             })
+    }
+}
+
+impl SemanticAnalyzer {
+    /// Ambient enums are erased from the output, but `tsc` still treats their
+    /// members with constant initializers as constant enum expressions inside
+    /// enum and const initializers. In an ambient `const enum` every member is
+    /// constant, so the usual auto-increment applies; in a plain ambient enum
+    /// a member without an initializer stays opaque. Kept out of `enum_record`
+    /// so the inliner never rewrites runtime reads of the ambient object.
+    fn record_ambient_enum(&mut self, node: &TsEnumDecl) {
+        if node.is_const {
+            self.info.const_enum.insert(node.id.to_id());
+        }
+
+        let mut default_init: TsEnumRecordValue = 0.0.into();
+
+        for member in &node.members {
+            let value = match (&member.init, node.is_const) {
+                (Some(init), _) => EnumValueComputer {
+                    enum_id: &node.id.to_id(),
+                    unresolved_ctxt: self.unresolved_ctxt,
+                    record: &self.info.enum_record,
+                    const_vars: &self.info.const_vars,
+                    const_enum_only: self.ts_enum_is_mutable.then_some(&self.info.const_enum),
+                    ambient_record: &self.info.ambient_enum_record,
+                }
+                .compute(
+                    init.clone(),
+                    // Type syntax inside an ambient initializer removes
+                    // constness, like in a const initializer: `tsc` leaves
+                    // `declare enum A { X = 1 as number }` opaque.
+                    EvalCtx::CONST_INIT,
+                ),
+                (None, true) => default_init.clone(),
+                (None, false) => continue,
+            };
+
+            default_init = value.inc();
+
+            if value.is_const() {
+                self.info.ambient_enum_record.insert(
+                    TsEnumRecordKey {
+                        enum_id: node.id.to_id(),
+                        member_name: enum_member_name(&member.id),
+                    },
+                    value,
+                );
+            }
+        }
     }
 }
 
@@ -544,7 +598,7 @@ impl Visit for SemanticAnalyzer {
     }
 
     fn visit_var_decl(&mut self, node: &VarDecl) {
-        let track = !self.skip_transform_info && !node.declare && node.kind == VarDeclKind::Const;
+        let track = node.kind == VarDeclKind::Const;
 
         for decl in &node.decls {
             decl.visit_with(self);
@@ -568,6 +622,7 @@ impl Visit for SemanticAnalyzer {
                 record: &self.info.enum_record,
                 const_vars: &self.info.const_vars,
                 const_enum_only: self.ts_enum_is_mutable.then_some(&self.info.const_enum),
+                ambient_record: &self.info.ambient_enum_record,
             }
             .compute(init.clone(), EvalCtx::CONST_INIT);
 
@@ -581,6 +636,7 @@ impl Visit for SemanticAnalyzer {
         node.visit_children_with(self);
 
         if self.skip_transform_info {
+            self.record_ambient_enum(node);
             return;
         }
 
@@ -607,6 +663,7 @@ impl Visit for SemanticAnalyzer {
                 &id.to_id(),
                 &default_init,
                 &self.info.enum_record,
+                &self.info.ambient_enum_record,
                 &self.info.const_vars,
                 self.unresolved_ctxt,
                 self.flow_syntax,
@@ -698,6 +755,7 @@ mod tests {
             &TsEnumRecordValue::Void,
             &Default::default(),
             &Default::default(),
+            &Default::default(),
             SyntaxContext::empty(),
             true,
         );
@@ -714,6 +772,7 @@ mod tests {
             enum_member("A"),
             &id("E"),
             &TsEnumRecordValue::from(2.0),
+            &Default::default(),
             &Default::default(),
             &Default::default(),
             SyntaxContext::empty(),

--- a/crates/swc_ecma_transforms_typescript/src/semantic.rs
+++ b/crates/swc_ecma_transforms_typescript/src/semantic.rs
@@ -49,6 +49,7 @@ pub(crate) fn analyze_program(
     unresolved_mark: Mark,
     seed_usage: FxHashSet<Id>,
     flow_syntax: bool,
+    ts_enum_is_mutable: bool,
 ) -> SemanticInfo {
     let mut analyzer = SemanticAnalyzer {
         unresolved_ctxt: SyntaxContext::empty().apply_mark(unresolved_mark),
@@ -61,6 +62,7 @@ pub(crate) fn analyze_program(
         namespace_id: None,
         skip_transform_info: false,
         flow_syntax,
+        ts_enum_is_mutable,
     };
 
     program.visit_with(&mut analyzer);
@@ -76,6 +78,7 @@ struct SemanticAnalyzer {
     namespace_id: Option<Id>,
     skip_transform_info: bool,
     flow_syntax: bool,
+    ts_enum_is_mutable: bool,
 }
 
 #[derive(Default)]
@@ -270,6 +273,7 @@ impl SemanticAnalyzer {
                     unresolved_ctxt,
                     record,
                     const_vars,
+                    const_enum_only: None,
                 }
                 .compute(expr, EvalCtx::MEMBER)
             })
@@ -563,6 +567,7 @@ impl Visit for SemanticAnalyzer {
                 unresolved_ctxt: self.unresolved_ctxt,
                 record: &self.info.enum_record,
                 const_vars: &self.info.const_vars,
+                const_enum_only: self.ts_enum_is_mutable.then_some(&self.info.const_enum),
             }
             .compute(init.clone(), EvalCtx::CONST_INIT);
 

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -1115,6 +1115,7 @@ impl Transform {
             unresolved_ctxt: self.unresolved_ctxt,
             record: &self.semantic.enum_record,
             const_vars: &self.semantic.const_vars,
+            const_enum_only: None,
         };
 
         let member_list: Vec<_> = members

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -1117,6 +1117,7 @@ impl Transform {
             const_vars: &self.semantic.const_vars,
             const_enum_only: None,
             ambient_record: &self.semantic.ambient_enum_record,
+            ambient_const_enum_only: None,
         };
 
         let member_list: Vec<_> = members

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -1116,6 +1116,7 @@ impl Transform {
             record: &self.semantic.enum_record,
             const_vars: &self.semantic.const_vars,
             const_enum_only: None,
+            ambient_record: &self.semantic.ambient_enum_record,
         };
 
         let member_list: Vec<_> = members

--- a/crates/swc_ecma_transforms_typescript/src/transform.rs
+++ b/crates/swc_ecma_transforms_typescript/src/transform.rs
@@ -22,7 +22,9 @@ use crate::{
     retain::{should_retain_module_item, should_retain_stmt},
     semantic::SemanticInfo,
     shared::enum_member_name,
-    ts_enum::{static_enum_member_name, EnumValueComputer, TsEnumRecordKey, TsEnumRecordValue},
+    ts_enum::{
+        static_enum_member_name, EnumValueComputer, EvalCtx, TsEnumRecordKey, TsEnumRecordValue,
+    },
     utils::{assign_value_to_this_private_prop, assign_value_to_this_prop, Factory},
 };
 
@@ -1112,6 +1114,7 @@ impl Transform {
             enum_id: &id.to_id(),
             unresolved_ctxt: self.unresolved_ctxt,
             record: &self.semantic.enum_record,
+            const_vars: &self.semantic.const_vars,
         };
 
         let member_list: Vec<_> = members
@@ -1133,7 +1136,7 @@ impl Transform {
                         // references can be rewritten to runtime property
                         // accesses. Implicit Flow enum members do not have an
                         // initializer, so keep the semantic value as-is.
-                        let mut recomputed = enum_computer.compute(init);
+                        let mut recomputed = enum_computer.compute(init, EvalCtx::RECOMPUTE);
                         if let TsEnumRecordValue::Opaque(expr) = &mut recomputed {
                             expr.visit_mut_with(&mut RefRewriter {
                                 query: EnumMemberRefQuery {

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -159,6 +159,36 @@ impl EvalCtx {
 
 /// https://github.com/microsoft/TypeScript/pull/50528
 impl EnumValueComputer<'_> {
+    /// Whether [`Self::compute`] could fold this expression at all, decided
+    /// from its outermost form alone.
+    ///
+    /// `compute` takes the expression by value, so evaluating an initializer
+    /// means cloning it. Every form not listed here hits the `Opaque`
+    /// catch-all immediately, and `const` initializers in real TypeScript are
+    /// mostly arrow functions, object literals and calls — cloning those to
+    /// discard the result dominated the cost of the collection pass.
+    ///
+    /// Kept in sync with the arms of `compute_rec`. An omission here can only
+    /// under-fold; it can never produce a wrong value.
+    pub fn can_fold_shape(expr: &Expr) -> bool {
+        matches!(
+            expr,
+            Expr::Lit(..)
+                | Expr::Ident(..)
+                | Expr::Paren(..)
+                | Expr::Unary(..)
+                | Expr::Bin(..)
+                | Expr::Member(..)
+                | Expr::Tpl(..)
+                | Expr::TsAs(..)
+                | Expr::TsNonNull(..)
+                | Expr::TsTypeAssertion(..)
+                | Expr::TsConstAssertion(..)
+                | Expr::TsInstantiation(..)
+                | Expr::TsSatisfies(..)
+        )
+    }
+
     pub fn compute(&self, expr: Box<Expr>, ctx: EvalCtx) -> TsEnumRecordValue {
         self.compute_rec(expr, ctx)
     }

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -105,6 +105,11 @@ pub(crate) struct EnumValueComputer<'a> {
     /// enum can be reassigned at runtime, so reads of its members are not
     /// compile-time constants and must stay opaque.
     pub const_enum_only: Option<&'a FxHashSet<Id>>,
+    /// Members of ambient (`declare`) enums. Kept separate from `record` so
+    /// only the evaluator sees them: `tsc` folds them inside enum and const
+    /// initializers but never rewrites runtime reads of the ambient object,
+    /// and the inliner keys on `record` membership.
+    pub ambient_record: &'a TsEnumRecord,
 }
 
 /// Returns a statically known enum member key without discarding lone
@@ -205,9 +210,18 @@ impl EnumValueComputer<'_> {
             Expr::Lit(Lit::Str(s)) => TsEnumRecordValue::String(s.value),
             Expr::Lit(Lit::Num(n)) => TsEnumRecordValue::Number(n),
             Expr::Ident(ref ident) if ident.ctxt == self.unresolved_ctxt => {
-                if let Some(value) = self.record.get(&TsEnumRecordKey {
+                let key = TsEnumRecordKey {
                     enum_id: self.enum_id.clone(),
                     member_name: ident.sym.clone().into(),
+                };
+
+                if let Some(value) = self.record.get(&key).or_else(|| {
+                    // Same rule as `compute_member`: crossing type syntax
+                    // clears `allow_const_var`, and an ambient sibling reached
+                    // that way is not a constant enum expression.
+                    ctx.allow_const_var
+                        .then(|| self.ambient_record.get(&key))
+                        .flatten()
                 }) {
                     if value.is_const() {
                         value.clone()
@@ -366,7 +380,7 @@ impl EnumValueComputer<'_> {
         }
     }
 
-    fn compute_member(&self, expr: MemberExpr, _ctx: EvalCtx) -> TsEnumRecordValue {
+    fn compute_member(&self, expr: MemberExpr, ctx: EvalCtx) -> TsEnumRecordValue {
         let opaque_expr = TsEnumRecordValue::Opaque(expr.clone().into());
 
         let Some(member_name) = static_enum_member_name(&expr.prop) else {
@@ -386,10 +400,22 @@ impl EnumValueComputer<'_> {
             return opaque_expr;
         }
 
+        let key = TsEnumRecordKey {
+            enum_id,
+            member_name,
+        };
+
+        // `allow_const_var` is cleared when evaluation crosses type syntax, so
+        // an ambient member reached through an assertion is not a constant
+        // enum expression. Only the ambient lookup is guarded: the concrete
+        // path folds these today (swc-project/swc#12150) and changing it here
+        // would revert #11769.
         self.record
-            .get(&TsEnumRecordKey {
-                enum_id,
-                member_name,
+            .get(&key)
+            .or_else(|| {
+                ctx.allow_const_var
+                    .then(|| self.ambient_record.get(&key))
+                    .flatten()
             })
             .cloned()
             .filter(TsEnumRecordValue::has_value)

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -110,6 +110,13 @@ pub(crate) struct EnumValueComputer<'a> {
     /// initializers but never rewrites runtime reads of the ambient object,
     /// and the inliner keys on `record` membership.
     pub ambient_record: &'a TsEnumRecord,
+    /// Applied to the ambient fallback only: under `tsEnumIsMutable` a plain
+    /// ambient enum is a runtime object that can be reassigned like any other
+    /// non-const enum, so only ambient `const enum` members may resolve.
+    /// Unlike `const_enum_only`, this does not touch the primary record — how
+    /// concrete enum reads behave under the option predates the ambient
+    /// support (see swc-project/swc#12151).
+    pub ambient_const_enum_only: Option<&'a FxHashSet<Id>>,
 }
 
 /// Returns a statically known enum member key without discarding lone
@@ -216,10 +223,10 @@ impl EnumValueComputer<'_> {
                 };
 
                 if let Some(value) = self.record.get(&key).or_else(|| {
-                    // Same rule as `compute_member`: crossing type syntax
-                    // clears `allow_const_var`, and an ambient sibling reached
-                    // that way is not a constant enum expression.
-                    ctx.allow_const_var
+                    // Same rules as `compute_member`: crossing type syntax
+                    // clears `allow_const_var`, and under mutable enums only
+                    // ambient `const enum` siblings may resolve.
+                    (ctx.allow_const_var && self.ambient_is_resolvable(&key.enum_id))
                         .then(|| self.ambient_record.get(&key))
                         .flatten()
                 }) {
@@ -380,6 +387,11 @@ impl EnumValueComputer<'_> {
         }
     }
 
+    fn ambient_is_resolvable(&self, enum_id: &Id) -> bool {
+        self.ambient_const_enum_only
+            .map_or(true, |set| set.contains(enum_id))
+    }
+
     fn compute_member(&self, expr: MemberExpr, ctx: EvalCtx) -> TsEnumRecordValue {
         let opaque_expr = TsEnumRecordValue::Opaque(expr.clone().into());
 
@@ -413,7 +425,7 @@ impl EnumValueComputer<'_> {
         self.record
             .get(&key)
             .or_else(|| {
-                ctx.allow_const_var
+                (ctx.allow_const_var && self.ambient_is_resolvable(&key.enum_id))
                     .then(|| self.ambient_record.get(&key))
                     .flatten()
             })

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -97,6 +97,7 @@ pub(crate) struct EnumValueComputer<'a> {
     pub enum_id: &'a Id,
     pub unresolved_ctxt: SyntaxContext,
     pub record: &'a TsEnumRecord,
+    pub const_vars: &'a FxHashMap<Id, TsEnumRecordValue>,
 }
 
 /// Returns a statically known enum member key without discarding lone
@@ -117,13 +118,52 @@ pub(crate) fn static_enum_member_name(property: &MemberProp) -> Option<Wtf8Atom>
     }
 }
 
+/// Evaluation context for [`EnumValueComputer::compute_rec`].
+///
+/// TypeScript decides enum member constness from the *syntactic* form of the
+/// initializer, without type resolution. See
+/// https://github.com/microsoft/TypeScript/pull/50528 and the constraints
+/// described in https://github.com/evanw/esbuild/issues/4387.
+#[derive(Clone, Copy)]
+pub(crate) struct EvalCtx {
+    /// Whether a reference to a `const` binding may be resolved to its value.
+    /// Disabled under type syntax: `enum E { A = foo as string }` is not a
+    /// constant for TypeScript even when `foo` is.
+    allow_const_var: bool,
+    /// Whether type syntax makes the whole expression non-constant instead of
+    /// being stripped. Used when evaluating a `const` initializer, where any
+    /// annotation or assertion removes constness.
+    ts_is_opaque: bool,
+}
+
+impl EvalCtx {
+    /// Context for a `const` variable initializer.
+    pub(crate) const CONST_INIT: Self = Self {
+        allow_const_var: true,
+        ts_is_opaque: true,
+    };
+    /// Context for an enum member initializer.
+    pub(crate) const MEMBER: Self = Self {
+        allow_const_var: true,
+        ts_is_opaque: false,
+    };
+    /// Context for re-computing a member whose value the pre-pass already
+    /// classified as non-constant. Resolving `const` bindings here would
+    /// override that verdict: the binding map is complete by this point, and
+    /// type assertions have already been stripped from the initializer.
+    pub(crate) const RECOMPUTE: Self = Self {
+        allow_const_var: false,
+        ts_is_opaque: false,
+    };
+}
+
 /// https://github.com/microsoft/TypeScript/pull/50528
 impl EnumValueComputer<'_> {
-    pub fn compute(&self, expr: Box<Expr>) -> TsEnumRecordValue {
-        self.compute_rec(expr)
+    pub fn compute(&self, expr: Box<Expr>, ctx: EvalCtx) -> TsEnumRecordValue {
+        self.compute_rec(expr, ctx)
     }
 
-    fn compute_rec(&self, expr: Box<Expr>) -> TsEnumRecordValue {
+    fn compute_rec(&self, expr: Box<Expr>, ctx: EvalCtx) -> TsEnumRecordValue {
         match *expr {
             Expr::Lit(Lit::Str(s)) => TsEnumRecordValue::String(s.value),
             Expr::Lit(Lit::Num(n)) => TsEnumRecordValue::Number(n),
@@ -155,29 +195,51 @@ impl EnumValueComputer<'_> {
                     }
                 }
             }
-            Expr::Paren(e) => self.compute_rec(e.expr),
-            Expr::Unary(e) => self.compute_unary(e),
-            Expr::Bin(e) => self.compute_bin(e),
-            Expr::Member(e) => self.compute_member(e),
-            Expr::Tpl(e) => self.compute_tpl(e),
+            // A reference to a `const` binding whose initializer is a constant
+            // expression. TypeScript treats it as a compile-time constant, so
+            // the member is emitted as a string enum instead of a reverse
+            // mapping. Only reachable when not under type syntax.
+            Expr::Ident(ref ident) if ctx.allow_const_var => self
+                .const_vars
+                .get(&ident.to_id())
+                .cloned()
+                .unwrap_or_else(|| TsEnumRecordValue::Opaque(expr)),
+            Expr::Paren(e) => self.compute_rec(e.expr, ctx),
+            Expr::Unary(e) => self.compute_unary(e, ctx),
+            Expr::Bin(e) => self.compute_bin(e, ctx),
+            Expr::Member(e) => self.compute_member(e, ctx),
+            Expr::Tpl(e) => self.compute_tpl(e, ctx),
             // Handle TypeScript type expressions by stripping them
             // and computing the inner expression
-            Expr::TsAs(TsAsExpr { expr, .. })
-            | Expr::TsNonNull(TsNonNullExpr { expr, .. })
-            | Expr::TsTypeAssertion(TsTypeAssertion { expr, .. })
-            | Expr::TsConstAssertion(TsConstAssertion { expr, .. })
-            | Expr::TsInstantiation(TsInstantiation { expr, .. })
-            | Expr::TsSatisfies(TsSatisfiesExpr { expr, .. }) => self.compute_rec(expr),
+            Expr::TsAs(TsAsExpr { expr: inner, .. })
+            | Expr::TsNonNull(TsNonNullExpr { expr: inner, .. })
+            | Expr::TsTypeAssertion(TsTypeAssertion { expr: inner, .. })
+            | Expr::TsConstAssertion(TsConstAssertion { expr: inner, .. })
+            | Expr::TsInstantiation(TsInstantiation { expr: inner, .. })
+            | Expr::TsSatisfies(TsSatisfiesExpr { expr: inner, .. }) => {
+                if ctx.ts_is_opaque {
+                    // Any annotation or assertion removes constness from a
+                    // `const` initializer.
+                    return TsEnumRecordValue::Opaque(inner);
+                }
+                self.compute_rec(
+                    inner,
+                    EvalCtx {
+                        allow_const_var: false,
+                        ..ctx
+                    },
+                )
+            }
             _ => TsEnumRecordValue::Opaque(expr),
         }
     }
 
-    fn compute_unary(&self, expr: UnaryExpr) -> TsEnumRecordValue {
+    fn compute_unary(&self, expr: UnaryExpr, ctx: EvalCtx) -> TsEnumRecordValue {
         if !matches!(expr.op, op!(unary, "+") | op!(unary, "-") | op!("~")) {
             return TsEnumRecordValue::Opaque(expr.into());
         }
 
-        let inner = self.compute_rec(expr.arg);
+        let inner = self.compute_rec(expr.arg, ctx);
 
         let TsEnumRecordValue::Number(num) = inner else {
             return TsEnumRecordValue::Opaque(
@@ -198,7 +260,7 @@ impl EnumValueComputer<'_> {
         }
     }
 
-    fn compute_bin(&self, expr: BinExpr) -> TsEnumRecordValue {
+    fn compute_bin(&self, expr: BinExpr, ctx: EvalCtx) -> TsEnumRecordValue {
         let origin_expr = expr.clone();
         if !matches!(
             expr.op,
@@ -218,8 +280,8 @@ impl EnumValueComputer<'_> {
             return TsEnumRecordValue::Opaque(origin_expr.into());
         }
 
-        let left = self.compute_rec(expr.left);
-        let right = self.compute_rec(expr.right);
+        let left = self.compute_rec(expr.left, ctx);
+        let right = self.compute_rec(expr.right, ctx);
 
         if expr.op == BinaryOp::Add && (left.is_string() || right.is_string()) {
             let mut value = Wtf8Buf::new();
@@ -267,7 +329,7 @@ impl EnumValueComputer<'_> {
         }
     }
 
-    fn compute_member(&self, expr: MemberExpr) -> TsEnumRecordValue {
+    fn compute_member(&self, expr: MemberExpr, _ctx: EvalCtx) -> TsEnumRecordValue {
         let opaque_expr = TsEnumRecordValue::Opaque(expr.clone().into());
 
         let Some(member_name) = static_enum_member_name(&expr.prop) else {
@@ -288,7 +350,7 @@ impl EnumValueComputer<'_> {
             .unwrap_or(opaque_expr)
     }
 
-    fn compute_tpl(&self, expr: Tpl) -> TsEnumRecordValue {
+    fn compute_tpl(&self, expr: Tpl, ctx: EvalCtx) -> TsEnumRecordValue {
         let opaque_expr = TsEnumRecordValue::Opaque(expr.clone().into());
 
         let Tpl { exprs, quasis, .. } = expr;
@@ -304,7 +366,7 @@ impl EnumValueComputer<'_> {
         let mut string = Wtf8Buf::from(first_cooked);
 
         for (q, expr) in quasis_iter.zip(exprs) {
-            let expr = self.compute_rec(expr);
+            let expr = self.compute_rec(expr, ctx);
 
             if !expr.push_to_string(&mut string) {
                 return opaque_expr;

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -1,4 +1,4 @@
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use swc_atoms::{wtf8::Wtf8Buf, Atom, Wtf8Atom};
 use swc_common::{SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
@@ -98,6 +98,13 @@ pub(crate) struct EnumValueComputer<'a> {
     pub unresolved_ctxt: SyntaxContext,
     pub record: &'a TsEnumRecord,
     pub const_vars: &'a FxHashMap<Id, TsEnumRecordValue>,
+    /// When `Some`, only enums in this set may be resolved through a member
+    /// expression.
+    ///
+    /// Mirrors the `ts_enum_is_mutable` guard in `transform.rs`: a non-const
+    /// enum can be reassigned at runtime, so reads of its members are not
+    /// compile-time constants and must stay opaque.
+    pub const_enum_only: Option<&'a FxHashSet<Id>>,
 }
 
 /// Returns a statically known enum member key without discarding lone
@@ -370,9 +377,18 @@ impl EnumValueComputer<'_> {
             return opaque_expr;
         };
 
+        let enum_id = ident.to_id();
+
+        if self
+            .const_enum_only
+            .is_some_and(|set| !set.contains(&enum_id))
+        {
+            return opaque_expr;
+        }
+
         self.record
             .get(&TsEnumRecordKey {
-                enum_id: ident.to_id(),
+                enum_id,
                 member_name,
             })
             .cloned()

--- a/crates/swc_ecma_transforms_typescript/src/typescript.rs
+++ b/crates/swc_ecma_transforms_typescript/src/typescript.rs
@@ -52,6 +52,7 @@ impl Pass for TypeScript {
             self.unresolved_mark,
             mem::take(&mut self.id_usage),
             self.config.flow_syntax,
+            self.config.ts_enum_is_mutable,
         );
 
         n.mutate(transform(

--- a/crates/swc_ecma_transforms_typescript/tests/__swc_snapshots__/tests/strip.rs/ts_enum_is_mutable_true.js
+++ b/crates/swc_ecma_transforms_typescript/tests/__swc_snapshots__/tests/strip.rs/ts_enum_is_mutable_true.js
@@ -28,3 +28,9 @@ var L = /*#__PURE__*/ function(L) {
     return L;
 }(L || {});
 console.log(L.A);
+const m = M.A;
+var N = /*#__PURE__*/ function(N) {
+    N[N["A"] = 7] = "A";
+    N[N["B"] = 8] = "B";
+    return N;
+}(N || {});

--- a/crates/swc_ecma_transforms_typescript/tests/__swc_snapshots__/tests/strip.rs/ts_enum_is_mutable_true.js
+++ b/crates/swc_ecma_transforms_typescript/tests/__swc_snapshots__/tests/strip.rs/ts_enum_is_mutable_true.js
@@ -34,3 +34,9 @@ var N = /*#__PURE__*/ function(N) {
     N[N["B"] = 8] = "B";
     return N;
 }(N || {});
+O.A = 5;
+var P = function(P) {
+    P[P["A"] = O.A] = "A";
+    return P;
+}(P || {});
+console.log(P.A);

--- a/crates/swc_ecma_transforms_typescript/tests/__swc_snapshots__/tests/strip.rs/ts_enum_is_mutable_true.js
+++ b/crates/swc_ecma_transforms_typescript/tests/__swc_snapshots__/tests/strip.rs/ts_enum_is_mutable_true.js
@@ -16,3 +16,15 @@ var H = /*#__PURE__*/ function(H) {
     return H;
 }(H || {});
 console.log(2);
+const j = H.A;
+var J = function(J) {
+    J[J["A"] = j] = "A";
+    return J;
+}(J || {});
+console.log(J.A);
+const l = 3;
+var L = /*#__PURE__*/ function(L) {
+    L[L["A"] = 3] = "A";
+    return L;
+}(L || {});
+console.log(L.A);

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-ambient/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-ambient/input.ts
@@ -1,0 +1,113 @@
+declare const fromAmbientConst = 1;
+enum AmbientConstNum {
+    A = fromAmbientConst,
+    B
+}
+
+declare const fromAmbientStr = "v";
+enum AmbientConstStr {
+    A = fromAmbientStr
+}
+
+declare enum Ambient {
+    X = 1,
+    Y = X + 1,
+    S = "s",
+    NoInit
+}
+
+const viaConst = Ambient.X;
+enum ViaConst {
+    P = viaConst,
+    Q
+}
+
+enum Direct {
+    P = Ambient.Y,
+    Q
+}
+
+const stillRuntime = Ambient.NoInit;
+enum StaysRuntime {
+    P = stillRuntime,
+    Q
+}
+
+console.log(Ambient.X);
+
+declare const enum AmbientConst {
+    X,
+    Y = 5,
+    Z
+}
+
+const fromConstEnum = AmbientConst.Z;
+enum FromAmbientConstEnum {
+    P = fromConstEnum,
+    Q
+}
+
+enum Concrete {
+    K = 40
+}
+
+declare enum AmbientFromConcrete {
+    Y = Concrete.K + 2
+}
+
+enum ResultChain {
+    A = AmbientFromConcrete.Y,
+    B
+}
+
+enum Merged {
+    X = 1
+}
+declare enum Merged {
+    Y = 5
+}
+enum FromMerged {
+    P = Merged.Y,
+    Q
+}
+console.log(Merged.Y);
+
+const seed = 1;
+declare enum AmbientFromConst {
+    Y = seed
+}
+enum ChainBack {
+    P = AmbientFromConst.Y,
+    Q
+}
+
+declare enum AmbientAsserted {
+    X = 1
+}
+enum AssertedRead {
+    A = AmbientAsserted.X as number,
+    B
+}
+const assertedVia = AmbientAsserted.X as number;
+enum AssertedViaConst {
+    A = assertedVia,
+    B
+}
+
+declare enum AssertedSibling {
+    X = 1,
+    Y = X as number
+}
+const viaAssertedSibling = AssertedSibling.Y;
+enum FromAssertedSibling {
+    P = viaAssertedSibling,
+    Q
+}
+
+declare enum AssertedInit {
+    X = 1 as number
+}
+enum FromAssertedInit {
+    Y = AssertedInit.X,
+    Z
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-ambient/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-ambient/output.js
@@ -1,0 +1,80 @@
+var AmbientConstNum = /*#__PURE__*/ function(AmbientConstNum) {
+    AmbientConstNum[AmbientConstNum["A"] = 1] = "A";
+    AmbientConstNum[AmbientConstNum["B"] = 2] = "B";
+    return AmbientConstNum;
+}(AmbientConstNum || {});
+var AmbientConstStr = /*#__PURE__*/ function(AmbientConstStr) {
+    AmbientConstStr["A"] = "v";
+    return AmbientConstStr;
+}(AmbientConstStr || {});
+const viaConst = Ambient.X;
+var ViaConst = /*#__PURE__*/ function(ViaConst) {
+    ViaConst[ViaConst["P"] = 1] = "P";
+    ViaConst[ViaConst["Q"] = 2] = "Q";
+    return ViaConst;
+}(ViaConst || {});
+var Direct = /*#__PURE__*/ function(Direct) {
+    Direct[Direct["P"] = 2] = "P";
+    Direct[Direct["Q"] = 3] = "Q";
+    return Direct;
+}(Direct || {});
+const stillRuntime = Ambient.NoInit;
+var StaysRuntime = function(StaysRuntime) {
+    StaysRuntime[StaysRuntime["P"] = stillRuntime] = "P";
+    StaysRuntime[StaysRuntime["Q"] = void 0] = "Q";
+    return StaysRuntime;
+}(StaysRuntime || {});
+console.log(Ambient.X);
+const fromConstEnum = AmbientConst.Z;
+var FromAmbientConstEnum = /*#__PURE__*/ function(FromAmbientConstEnum) {
+    FromAmbientConstEnum[FromAmbientConstEnum["P"] = 6] = "P";
+    FromAmbientConstEnum[FromAmbientConstEnum["Q"] = 7] = "Q";
+    return FromAmbientConstEnum;
+}(FromAmbientConstEnum || {});
+var Concrete = /*#__PURE__*/ function(Concrete) {
+    Concrete[Concrete["K"] = 40] = "K";
+    return Concrete;
+}(Concrete || {});
+var ResultChain = /*#__PURE__*/ function(ResultChain) {
+    ResultChain[ResultChain["A"] = 42] = "A";
+    ResultChain[ResultChain["B"] = 43] = "B";
+    return ResultChain;
+}(ResultChain || {});
+var Merged = /*#__PURE__*/ function(Merged) {
+    Merged[Merged["X"] = 1] = "X";
+    return Merged;
+}(Merged || {});
+var FromMerged = /*#__PURE__*/ function(FromMerged) {
+    FromMerged[FromMerged["P"] = 5] = "P";
+    FromMerged[FromMerged["Q"] = 6] = "Q";
+    return FromMerged;
+}(FromMerged || {});
+console.log(Merged.Y);
+const seed = 1;
+var ChainBack = /*#__PURE__*/ function(ChainBack) {
+    ChainBack[ChainBack["P"] = 1] = "P";
+    ChainBack[ChainBack["Q"] = 2] = "Q";
+    return ChainBack;
+}(ChainBack || {});
+var AssertedRead = function(AssertedRead) {
+    AssertedRead[AssertedRead["A"] = AmbientAsserted.X] = "A";
+    AssertedRead[AssertedRead["B"] = void 0] = "B";
+    return AssertedRead;
+}(AssertedRead || {});
+const assertedVia = AmbientAsserted.X;
+var AssertedViaConst = function(AssertedViaConst) {
+    AssertedViaConst[AssertedViaConst["A"] = assertedVia] = "A";
+    AssertedViaConst[AssertedViaConst["B"] = void 0] = "B";
+    return AssertedViaConst;
+}(AssertedViaConst || {});
+const viaAssertedSibling = AssertedSibling.Y;
+var FromAssertedSibling = function(FromAssertedSibling) {
+    FromAssertedSibling[FromAssertedSibling["P"] = viaAssertedSibling] = "P";
+    FromAssertedSibling[FromAssertedSibling["Q"] = void 0] = "Q";
+    return FromAssertedSibling;
+}(FromAssertedSibling || {});
+var FromAssertedInit = function(FromAssertedInit) {
+    FromAssertedInit[FromAssertedInit["Y"] = AssertedInit.X] = "Y";
+    FromAssertedInit[FromAssertedInit["Z"] = void 0] = "Z";
+    return FromAssertedInit;
+}(FromAssertedInit || {});

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-const-var/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-const-var/input.ts
@@ -1,0 +1,20 @@
+const s = "aThisIs";
+const n = 1;
+const concat = "a" + "b";
+const chain = s;
+
+enum StringEnum {
+    A = s,
+    B = "bThisIs",
+}
+
+enum NumericAutoIncrement {
+    A = n,
+    B,
+    C,
+}
+
+enum ConstantExpr {
+    A = concat,
+    B = chain,
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-const-var/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-const-var/output.js
@@ -1,0 +1,20 @@
+const s = "aThisIs";
+const n = 1;
+const concat = "a" + "b";
+const chain = s;
+var StringEnum = /*#__PURE__*/ function(StringEnum) {
+    StringEnum["A"] = "aThisIs";
+    StringEnum["B"] = "bThisIs";
+    return StringEnum;
+}(StringEnum || {});
+var NumericAutoIncrement = /*#__PURE__*/ function(NumericAutoIncrement) {
+    NumericAutoIncrement[NumericAutoIncrement["A"] = 1] = "A";
+    NumericAutoIncrement[NumericAutoIncrement["B"] = 2] = "B";
+    NumericAutoIncrement[NumericAutoIncrement["C"] = 3] = "C";
+    return NumericAutoIncrement;
+}(NumericAutoIncrement || {});
+var ConstantExpr = /*#__PURE__*/ function(ConstantExpr) {
+    ConstantExpr["A"] = "ab";
+    ConstantExpr["B"] = "aThisIs";
+    return ConstantExpr;
+}(ConstantExpr || {});

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-declarator-order/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-declarator-order/input.ts
@@ -1,0 +1,7 @@
+const first = 1, second = (()=>{
+    enum Nested {
+        A = first,
+        B
+    }
+    return Nested;
+})();

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-declarator-order/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-declarator-order/output.js
@@ -1,0 +1,8 @@
+const first = 1, second = (()=>{
+    let Nested = /*#__PURE__*/ function(Nested) {
+        Nested[Nested["A"] = 1] = "A";
+        Nested[Nested["B"] = 2] = "B";
+        return Nested;
+    }({});
+    return Nested;
+})();

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-enum-member-init/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-enum-member-init/input.ts
@@ -1,0 +1,17 @@
+enum Str {
+    A = "a"
+}
+const fromStr = Str.A;
+enum FromEnumMemberStr {
+    X = fromStr,
+    Y = "y"
+}
+
+enum Num {
+    A = 1
+}
+const fromNum = Num.A;
+enum FromEnumMemberNum {
+    X = fromNum,
+    Y
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-enum-member-init/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-enum-member-init/output.js
@@ -1,0 +1,20 @@
+var Str = /*#__PURE__*/ function(Str) {
+    Str["A"] = "a";
+    return Str;
+}(Str || {});
+const fromStr = "a";
+var FromEnumMemberStr = /*#__PURE__*/ function(FromEnumMemberStr) {
+    FromEnumMemberStr["X"] = "a";
+    FromEnumMemberStr["Y"] = "y";
+    return FromEnumMemberStr;
+}(FromEnumMemberStr || {});
+var Num = /*#__PURE__*/ function(Num) {
+    Num[Num["A"] = 1] = "A";
+    return Num;
+}(Num || {});
+const fromNum = 1;
+var FromEnumMemberNum = /*#__PURE__*/ function(FromEnumMemberNum) {
+    FromEnumMemberNum[FromEnumMemberNum["X"] = 1] = "X";
+    FromEnumMemberNum[FromEnumMemberNum["Y"] = 2] = "Y";
+    return FromEnumMemberNum;
+}(FromEnumMemberNum || {});

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-not-const/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-not-const/input.ts
@@ -1,0 +1,35 @@
+const annotated: string = "s";
+const asserted = "s" as string;
+const constAsserted = "s" as const;
+let mutable = "s";
+var hoisted = "s";
+const { destructured } = { destructured: "s" };
+const poisoned = "s";
+
+enum TypeAnnotation {
+    A = annotated,
+    B = "b",
+}
+
+enum TypeAssertion {
+    A = asserted,
+    B = constAsserted,
+}
+
+enum NotConstBinding {
+    A = mutable,
+    B = hoisted,
+    C = destructured,
+}
+
+enum AssertionOnReference {
+    A = poisoned as string,
+    B = "b",
+}
+
+enum ForwardReference {
+    A = declaredLater,
+    B = "b",
+}
+
+const declaredLater = "s";

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-not-const/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-not-const/output.js
@@ -1,0 +1,36 @@
+const annotated = "s";
+const asserted = "s";
+const constAsserted = "s";
+let mutable = "s";
+var hoisted = "s";
+const { destructured } = {
+    destructured: "s"
+};
+const poisoned = "s";
+var TypeAnnotation = function(TypeAnnotation) {
+    TypeAnnotation[TypeAnnotation["A"] = annotated] = "A";
+    TypeAnnotation["B"] = "b";
+    return TypeAnnotation;
+}(TypeAnnotation || {});
+var TypeAssertion = function(TypeAssertion) {
+    TypeAssertion[TypeAssertion["A"] = asserted] = "A";
+    TypeAssertion[TypeAssertion["B"] = constAsserted] = "B";
+    return TypeAssertion;
+}(TypeAssertion || {});
+var NotConstBinding = function(NotConstBinding) {
+    NotConstBinding[NotConstBinding["A"] = mutable] = "A";
+    NotConstBinding[NotConstBinding["B"] = hoisted] = "B";
+    NotConstBinding[NotConstBinding["C"] = destructured] = "C";
+    return NotConstBinding;
+}(NotConstBinding || {});
+var AssertionOnReference = function(AssertionOnReference) {
+    AssertionOnReference[AssertionOnReference["A"] = poisoned] = "A";
+    AssertionOnReference["B"] = "b";
+    return AssertionOnReference;
+}(AssertionOnReference || {});
+var ForwardReference = function(ForwardReference) {
+    ForwardReference[ForwardReference["A"] = declaredLater] = "A";
+    ForwardReference["B"] = "b";
+    return ForwardReference;
+}(ForwardReference || {});
+const declaredLater = "s";

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-scope/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-scope/input.ts
@@ -1,0 +1,30 @@
+declare const ambient: string;
+
+const outer = "outer";
+
+enum Ambient {
+    A = ambient,
+    B = "b",
+}
+
+function inFunction() {
+    const inner = "inner";
+    enum Local {
+        A = inner,
+        B = "b",
+    }
+    return Local;
+}
+
+namespace NS {
+    const scoped = "scoped";
+    export enum InNamespace {
+        A = scoped,
+        B = "b",
+    }
+}
+
+enum ShadowedOuter {
+    A = outer,
+    B = "b",
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-scope/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-11715-scope/output.js
@@ -1,0 +1,28 @@
+const outer = "outer";
+var Ambient = function(Ambient) {
+    Ambient[Ambient["A"] = ambient] = "A";
+    Ambient["B"] = "b";
+    return Ambient;
+}(Ambient || {});
+function inFunction() {
+    const inner = "inner";
+    let Local = /*#__PURE__*/ function(Local) {
+        Local["A"] = "inner";
+        Local["B"] = "b";
+        return Local;
+    }({});
+    return Local;
+}
+(function(NS) {
+    const scoped = "scoped";
+    (function(InNamespace) {
+        InNamespace["A"] = "scoped";
+        InNamespace["B"] = "b";
+    })(NS.InNamespace || (NS.InNamespace = {}));
+})(NS || (NS = {}));
+var ShadowedOuter = /*#__PURE__*/ function(ShadowedOuter) {
+    ShadowedOuter["A"] = "outer";
+    ShadowedOuter["B"] = "b";
+    return ShadowedOuter;
+}(ShadowedOuter || {});
+var NS;

--- a/crates/swc_ecma_transforms_typescript/tests/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip.rs
@@ -2843,6 +2843,19 @@ test!(
       A = H.A
     }
     console.log(I.A);
+    const j = H.A;
+    enum J {
+      A = j
+    }
+    console.log(J.A);
+    const enum K {
+      A = 3,
+    }
+    const l = K.A;
+    enum L {
+      A = l
+    }
+    console.log(L.A);
     "#
 );
 

--- a/crates/swc_ecma_transforms_typescript/tests/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip.rs
@@ -2864,6 +2864,14 @@ test!(
       A = m,
       B
     }
+    declare enum O {
+      A = 1,
+    }
+    (O as any).A = 5;
+    enum P {
+      A = O.A
+    }
+    console.log(P.A);
     "#
 );
 

--- a/crates/swc_ecma_transforms_typescript/tests/strip.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip.rs
@@ -2856,6 +2856,14 @@ test!(
       A = l
     }
     console.log(L.A);
+    declare const enum M {
+      A = 7,
+    }
+    const m = M.A;
+    enum N {
+      A = m,
+      B
+    }
     "#
 );
 


### PR DESCRIPTION
**Description:**

`EnumValueComputer::compute_rec` gates its identifier arm on `ctxt == unresolved_ctxt`, which only matches references to sibling enum members. A reference to a real `const` binding is a resolved binding, so it fell through to the `Opaque` catch-all.

Two consequences. The reported one is emit shape:

```ts
const foo = "aThisIs";
enum E { A = foo, B = "bThisIs" }
```

```js
// before — three properties, because the reverse mapping assigns twice
E[E["A"] = foo] = "A";
// after, and what tsc emits
E["A"] = "aThisIs";
```

The second is not in the issue and is worse — numeric members silently become `undefined`:

```ts
const foo = 1;
enum E { A = foo, B, C }
```

```
before -> { A: 1, "1": "A", "undefined": "C" }
after  -> { A: 1, B: 2, C: 3, "1": "A", "2": "B", "3": "C" }
```

`TsEnumRecordValue::inc()` returns `Void` for an opaque value, so every following auto-incremented member collapses.

This restores an existing code path rather than adding a rule: `compute_rec` already implements the constant folding from microsoft/TypeScript#50528 for literals, parens, unary and binary operators, template literals and enum member references. Const-variable references are the one production that was never wired in.

**What qualifies as a constant**

TypeScript decides this from the syntactic form alone, with no type resolution — confirmed as intentional and required for third-party transpilers in microsoft/TypeScript#63275, and described in evanw/esbuild#4387. A binding qualifies when it is a simple `const` with no type annotation, whose initializer is itself a constant expression, transitively — including ambient ones: `declare const x = 1` folds, since ambient contexts only allow initializers that are literals. Members of `declare enum` with constant initializers fold the same way — with the usual auto-increment inside an ambient `const enum`, none in a plain ambient enum, and runtime reads of the ambient object left untouched, all matching `tsc`. Two rules fall out of that and both are covered by fixtures:

- Type syntax removes constness. `const foo = "s" as string`, `const foo: "s" = "s"`, `foo satisfies T`, `<T>foo`, `foo!` and `as const` all stay reverse-mapped, and so does `enum E { A = foo as string }` — an assertion on the reference is enough.
- Within the same scope, a binding declared after the enum is not visible to it. The collection pass runs in source order, so a forward reference is simply not in the map yet — and it would be a TDZ error at runtime anyway. Across a function boundary `tsc` is more permissive; that case is listed under known limitations.

**Verified against `tsc` 5.9.3**

Every fixture case was diffed against `transpileModule` output. Folded: plain `const`, transitive chains, `"a" + "b"`, template literals, numeric bindings, and `const` bindings in function or namespace scope. Not folded: type annotations and assertions, `let`, `var`, annotated or uninitialized `declare const`, ambient enum members without initializers, destructured bindings, and forward references.

**Known limitations**

- Namespace member access (`N.foo`, `N.M.foo`) still produces a reverse mapping, and an auto-incremented member following it collapses to `undefined`. `compute_member` bails on any non-`Ident` object. Additive and independent; opened as #12102.
- An enum nested in a function-like body does not see outer `const` bindings declared later in the file. `tsc` folds those, since the body does not run at the declaration point: `function f() { enum E { A = x, B } } const x = 1` gives `A = 1`, `B = 2`. Matching it needs deferred evaluation of nested enums, which is a different rule from the syntactic one implemented here. Left as-is — it only ever under-folds, which is the behavior on `main` today.
- An ambient enum member referencing a `const` declared later in the file stays opaque — the collection pass runs in source order, while `tsc` folds it since ambient declarations are erased. Same deferred-evaluation family as the function-boundary case above.
- Cross-file constants are not folded. `tsc`'s own `transpileModule` does not fold them either — only `createProgram` does — so matching single-file semantics looks like the right contract here.
- Where `tsc` needs the checker, this stays conservative. `const foo: string = "s"` makes `tsc` emit a string enum without folding the value; a syntactic transpiler cannot know the type, so the member stays reverse-mapped.

`enum E { A = "s" as any }` still diverges from `tsc`, which reverse-maps it. That behavior predates this PR — it was introduced by #11769 for #11761 — so it is out of scope here; reported as #12150. `ts_enum_with_type_assertion` is unchanged.

**Tests:** six fixtures under `tests/fixture/`, plus two cases added to `ts_enum_is_mutable_true`. Each fails without the change — verified by copying them into a worktree checked out at `main`. Full crate suite green (203 fixture tests, 5039 identity), plus `swc --test tsc` (4579), `swc_ts_fast_strip` (4458), `swc --test projects` (889, including the `issues-11xxx/11761` fixture from #11769) and `swc --test exec` (451). One tsc conformance reference moved: in `constEnum2.ts`, `g = CONST` now resolves to a constant, so the member is inlined rather than emitted — the same treatment `d = 10` already gets in that same `const enum`. The members that call `Math.random()` stay opaque and are still emitted. Also checked with `RUSTFLAGS="--cfg swc_ast_unknown"` since this touches a `match` over `Expr`.

**Mutable enums**

Under `tsEnumIsMutable`, `enter_expr_for_inline_enum` deliberately leaves reads of non-const enums as runtime reads. The collection pass mirrors that guard: `const x = D.A` only resolves when `D` is a `const enum`. This diverges from `tsc`, which folds it — but matching `tsc` here would contradict the option's own contract, and would emit `const x = D.A` while using the folded value for the enum member that reads it. Both sides are covered by `ts_enum_is_mutable_true`: a const from a mutable enum member stays a runtime read, one from a `const enum` member still folds.

**Performance**

The first version of the collection pass evaluated every `const` initializer in the program. `compute` takes the expression by value, so each one was cloned, and in real TypeScript most `const` initializers — arrow functions, object literals, calls — hit the `Opaque` catch-all immediately, so the clone was discarded. That showed up as a CodSpeed regression on the TypeScript benchmarks.

Checking the outermost form before cloning removes it: `es/transform/baseline/common_typescript` goes from 59.6 us back to 53.3 us, against 53.3 us on `main`. Measured with `cargo bench` on both. No test output changes.

**BREAKING CHANGE:** None.

**Related issue (if exists):**
- Closes: #11715





