### PR TITLE
fix(es/minifier): remove unused variable initializer cycles

### DIFF
--- a/.changeset/fix-minifier-unused-initializer-cycles.md
+++ b/.changeset/fix-minifier-unused-initializer-cycles.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+swc_ecma_transforms_optimization: patch
+---
+
+fix(es/minifier): Remove unused variable initializer cycles

--- a/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
+++ b/crates/swc_ecma_minifier/tests/libs-size.snapshot.md
@@ -2,7 +2,7 @@
 | --- | --- | --- | --- |
 | antd.js | 6.38 MiB | 2.06 MiB | 445.44 KiB |
 | d3.js | 542.74 KiB | 261.26 KiB | 85.54 KiB |
-| echarts.js | 3.41 MiB | 977.04 KiB | 314.10 KiB |
+| echarts.js | 3.41 MiB | 977.04 KiB | 314.09 KiB |
 | jquery.js | 280.89 KiB | 87.79 KiB | 30.20 KiB |
 | lodash.js | 531.35 KiB | 68.92 KiB | 24.63 KiB |
 | moment.js | 169.83 KiB | 57.33 KiB | 18.25 KiB |

--- a/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
+++ b/crates/swc_ecma_transforms_optimization/src/simplify/dce/mod.rs
@@ -545,6 +545,25 @@ fn class_def_is_side_effect_free(class: &Class, expr_ctx: ExprCtx) -> bool {
         })
 }
 
+/// Returns true if references in an initializer can be attributed to the
+/// initialized binding instead of being treated as eager top-level references.
+fn can_attribute_initializer_refs_to_binding(expr: &Expr, expr_ctx: ExprCtx) -> bool {
+    match expr {
+        Expr::Fn(_) | Expr::Arrow(_) => true,
+        Expr::Class(c) => {
+            // Class heritage is evaluated while defining the class and can throw
+            // even when evaluating the heritage expression itself is pure. The
+            // remaining checks reject decorators, computed keys, and static
+            // initialization, leaving only dependencies evaluated after the class
+            // value is used (for example, method and constructor bodies).
+            c.class.super_class.is_none()
+                && class_def_is_trivial(&c.class)
+                && class_def_is_side_effect_free(&c.class, expr_ctx)
+        }
+        _ => false,
+    }
+}
+
 impl Visit for Analyzer<'_> {
     noop_visit_type!();
 
@@ -643,7 +662,15 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_class_expr(&mut self, n: &ClassExpr) {
-        n.visit_children_with(self);
+        if let Some(ident) = &n.ident {
+            // ClassDefinitionEvaluation creates a lexical binding for a named
+            // class expression that is visible only inside the class definition.
+            let old = self.cur_class_id.replace(ident.to_id());
+            n.visit_children_with(self);
+            self.cur_class_id = old;
+        } else {
+            n.visit_children_with(self);
+        }
 
         if !n.class.decorators.is_empty() {
             if let Some(i) = &n.ident {
@@ -769,7 +796,17 @@ impl Visit for Analyzer<'_> {
     }
 
     fn visit_fn_expr(&mut self, n: &FnExpr) {
-        n.visit_children_with(self);
+        if let Some(ident) = &n.ident {
+            // `InstantiateOrdinaryFunctionExpression` creates a binding for a named
+            // function expression in an environment local to the function. It is
+            // therefore a self-reference, not a reference to an outer declaration
+            // with the same symbol.
+            let old = self.cur_fn_id.replace(ident.to_id());
+            n.visit_children_with(self);
+            self.cur_fn_id = old;
+        } else {
+            n.visit_children_with(self);
+        }
 
         if !n.function.decorators.is_empty() {
             if let Some(i) = &n.ident {
@@ -805,7 +842,19 @@ impl Visit for Analyzer<'_> {
         n.name.visit_with(self);
 
         self.in_var_decl = false;
-        n.init.visit_with(self);
+        match (&n.name, n.init.as_deref()) {
+            // When a function or a side-effect-free class directly initializes a
+            // variable, its deferred references are dependencies of that variable
+            // rather than top-level entries. Keep this limited to direct values:
+            // attributing an arbitrary initializer to the binding could hide its
+            // eager side effects or TDZ errors.
+            (Pat::Ident(binding), Some(init))
+                if can_attribute_initializer_refs_to_binding(init, self.expr_ctx) =>
+            {
+                self.with_ast_path(vec![binding.to_id()], |v| n.init.visit_with(v));
+            }
+            _ => n.init.visit_with(self),
+        }
 
         self.in_var_decl = old;
     }

--- a/crates/swc_ecma_transforms_optimization/tests/dce/expression-cycles-declarations/input.js
+++ b/crates/swc_ecma_transforms_optimization/tests/dce/expression-cycles-declarations/input.js
@@ -1,0 +1,101 @@
+var varA = function () {
+    varB();
+};
+var varB = function () {
+    varA();
+};
+
+let letA = function () {
+    letB();
+};
+let letB = function () {
+    letA();
+};
+
+const constA = () => {
+    constB();
+};
+const constB = () => {
+    constA();
+};
+
+let LetClass = class {
+    method() {
+        return LetFactory();
+    }
+};
+let LetFactory = function () {
+    return new LetClass();
+};
+
+const ConstClass = class {
+    method() {
+        return ConstFactory();
+    }
+};
+const ConstFactory = () => new ConstClass();
+
+var usedFunctionA = function () {
+    usedFunctionB();
+};
+var usedFunctionB = function () {
+    usedFunctionA();
+};
+use(usedFunctionA);
+
+var usedClass = class {
+    method(value) {
+        return usedClassFactory(value);
+    }
+};
+async function usedClassFactory() {
+    return new usedClass();
+}
+use(usedClass);
+
+var namedFunction = function localFunctionName() {
+    localFunctionName();
+};
+var localFunctionName = function () {
+    namedFunction();
+};
+use(namedFunction);
+
+var namedClass = class LocalClassName {
+    method() {
+        return new LocalClassName();
+    }
+};
+var LocalClassName = class {
+    method() {
+        return new namedClass();
+    }
+};
+use(namedClass);
+
+var heritageClass = class extends heritageBase {
+    method() {
+        return heritageFactory();
+    }
+};
+var heritageBase = class {};
+function heritageFactory() {
+    return new heritageClass();
+}
+
+var effectfulClass = class {
+    static value = effect();
+
+    method() {
+        return effectfulFactory();
+    }
+};
+function effectfulFactory() {
+    return new effectfulClass();
+}
+
+let tdzLetA = tdzLetB;
+let tdzLetB = tdzLetA;
+
+const tdzConstA = tdzConstB;
+const tdzConstB = tdzConstA;

--- a/crates/swc_ecma_transforms_optimization/tests/dce/expression-cycles-declarations/output.full.js
+++ b/crates/swc_ecma_transforms_optimization/tests/dce/expression-cycles-declarations/output.full.js
@@ -1,0 +1,49 @@
+var usedFunctionA = function() {
+    usedFunctionB();
+};
+var usedFunctionB = function() {
+    usedFunctionA();
+};
+use(usedFunctionA);
+var usedClass = class {
+    method(value) {
+        return usedClassFactory(value);
+    }
+};
+async function usedClassFactory() {
+    return new usedClass();
+}
+use(usedClass);
+var namedFunction = function localFunctionName() {
+    localFunctionName();
+};
+use(namedFunction);
+var namedClass = class LocalClassName {
+    method() {
+        return new LocalClassName();
+    }
+};
+use(namedClass);
+var heritageClass = class extends heritageBase {
+    method() {
+        return heritageFactory();
+    }
+};
+var heritageBase = class {
+};
+function heritageFactory() {
+    return new heritageClass();
+}
+var effectfulClass = class {
+    static value = effect();
+    method() {
+        return effectfulFactory();
+    }
+};
+function effectfulFactory() {
+    return new effectfulClass();
+}
+let tdzLetA = tdzLetB;
+let tdzLetB = tdzLetA;
+const tdzConstA = tdzConstB;
+const tdzConstB = tdzConstA;

--- a/crates/swc_ecma_transforms_optimization/tests/dce/expression-cycles-declarations/output.js
+++ b/crates/swc_ecma_transforms_optimization/tests/dce/expression-cycles-declarations/output.js
@@ -1,0 +1,49 @@
+var usedFunctionA = function() {
+    usedFunctionB();
+};
+var usedFunctionB = function() {
+    usedFunctionA();
+};
+use(usedFunctionA);
+var usedClass = class {
+    method(value) {
+        return usedClassFactory(value);
+    }
+};
+async function usedClassFactory() {
+    return new usedClass();
+}
+use(usedClass);
+var namedFunction = function localFunctionName() {
+    localFunctionName();
+};
+use(namedFunction);
+var namedClass = class LocalClassName {
+    method() {
+        return new LocalClassName();
+    }
+};
+use(namedClass);
+var heritageClass = class extends heritageBase {
+    method() {
+        return heritageFactory();
+    }
+};
+var heritageBase = class {
+};
+function heritageFactory() {
+    return new heritageClass();
+}
+var effectfulClass = class {
+    static value = effect();
+    method() {
+        return effectfulFactory();
+    }
+};
+function effectfulFactory() {
+    return new effectfulClass();
+}
+let tdzLetA = tdzLetB;
+let tdzLetB = tdzLetA;
+const tdzConstA = tdzConstB;
+const tdzConstB = tdzConstA;


### PR DESCRIPTION
**Description:**

DCE previously visited variable initializers without associating deferred references with the initialized binding. References inside function, arrow, and eligible class expressions were therefore treated as top-level graph entries, which prevented otherwise unreachable dependency cycles from being removed.

For example:

```js
var AsyncParsePluginContext = class {
    parse(current) {
        return parseAsync(current);
    }
};

async function parseAsync() {
    return new AsyncParsePluginContext();
}
```

The reference to `parseAsync` was incorrectly treated as an entry:

```text
entry -> parseAsync -> AsyncParsePluginContext
```

This PR attributes references from direct deferred-value initializers to their variable binding:

```text
AsyncParsePluginContext <-> parseAsync
```

With no external entry into this strongly connected component, DCE can remove the entire unused cycle.

The optimization applies to identifier bindings initialized directly with:

- Function expressions
- Arrow functions
- Class expressions without heritage, decorators, computed keys, static initialization, or other observable definition-time work

Named function and class expressions are also handled using their local expression bindings, preventing self-references from being mistaken for references to outer declarations with the same symbol.

The conservative behavior is preserved for eager or potentially observable initializers, including:

- Destructuring bindings
- Class heritage
- Effectful class definitions
- Static initialization
- Eager `let` and `const` dependency cycles

The new DCE fixture covers:

- Removable `var`, `let`, and `const` function and class expression cycles
- Cycles retained through an external reference
- Named function and class expression bindings
- Class heritage and effectful static initialization
- Eager `let` and `const` cycles

The minifier size snapshot is also updated to reflect the resulting `echarts.js` gzip reduction from `314.10 KiB` to `314.09 KiB`.

**Testing:**

- `cargo test -p swc_ecma_transforms_optimization`
- `cargo test -p swc_ecma_minifier`
- `crates/swc_ecma_minifier/scripts/exec.sh`
- `crates/swc_ecma_minifier/scripts/test.sh`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
