### PR TITLE
chore(deps): Update lru to 0.18.2 to fix cargo deny

### DIFF
--- a/.changeset/fix-lru-advisory.md
+++ b/.changeset/fix-lru-advisory.md
@@ -1,0 +1,6 @@
+---
+swc_core: major
+swc_ecma_loader: major
+---
+
+chore(deps): Upgrade `lru` to 0.18.2 to address RUSTSEC-2026-0253

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2720,6 +2720,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heapless"
@@ -3655,11 +3660,11 @@ checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "lru"
-version = "0.16.3"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ kstring                   = "2.0.0"
 lazy_static               = "1.4.0"
 lexical                   = "6.1.0"
 lightningcss              = "1.0.0-alpha.68"
-lru                       = "0.16.1"
+lru                       = "0.18.2"
 memchr                    = "2.6.1"
 miette                    = "7.6.0"
 napi                      = { version = "3", default-features = false }

--- a/deny.toml
+++ b/deny.toml
@@ -61,7 +61,6 @@ ignore = [
   "RUSTSEC-2026-0114", # wasmtime 38 has no patched release in this major line (transitive dep via swc_plugin_runner)
   "RUSTSEC-2026-0222", # wasmtime 38 has no patched release in this major line (transitive dep via swc_plugin_runner)
   "RUSTSEC-2026-0186", # memmap2 is constrained by shared-buffer 0.1.4 via wasmer; shared-buffer has no patched release and only uses Mmap::map
-  "RUSTSEC-2026-0222", # wasmtime 38 has no patched release in this major line (transitive dep via swc_plugin_runner)
   "RUSTSEC-2026-0235", # rkyv 0.7.45 is unsupported and transitive via parcel_sourcemap; rkyv 0.8 is upgraded to the patched release
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score


### PR DESCRIPTION
**Description:**

`cargo deny check` started failing on `main` because `lru` 0.16.3 is affected by RUSTSEC-2026-0253, a potential use-after-free in `LruCache::pop()` when dropping a key panics.

This PR:

- updates the workspace `lru` dependency to 0.18.2, which contains the upstream fix;
- updates `Cargo.lock` accordingly;
- removes a duplicate RUSTSEC-2026-0222 entry from `deny.toml`;
- adds release changesets for `swc_ecma_loader` and `swc_core`.

The change restores the dependency advisory check without suppressing RUSTSEC-2026-0253.

Validation:

- `cargo deny check` with cargo-deny 0.18.9
- `cargo test -p swc_ecma_loader`
- `cargo test -p swc_ecma_loader --features cache`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`

**BREAKING CHANGE:**

The `lru` runtime dependency is updated across semver-incompatible releases from 0.16 to 0.18. SWC's public API is unchanged.
