### PR TITLE
fix(es/jsx): preserve unsupported apos entity

### DIFF
--- a/.changeset/fix-jsx-preserve-apos.md
+++ b/.changeset/fix-jsx-preserve-apos.md
@@ -1,0 +1,8 @@
+---
+swc_core: major
+swc_ecma_lexer: major
+swc_ecma_parser: major
+swc_ecma_transforms_react: patch
+---
+
+fix(es/jsx): Preserve unsupported `apos` character references.

--- a/crates/swc_ecma_lexer/src/common/lexer/jsx.rs
+++ b/crates/swc_ecma_lexer/src/common/lexer/jsx.rs
@@ -16,7 +16,6 @@ macro_rules! xhtml {
 xhtml!(
   quot: '\u{0022}',
   amp: '&',
-  apos: '\u{0027}',
   lt: '<',
   gt: '>',
   nbsp: '\u{00A0}',

--- a/crates/swc_ecma_parser/src/lexer/jsx.rs
+++ b/crates/swc_ecma_parser/src/lexer/jsx.rs
@@ -16,7 +16,6 @@ macro_rules! xhtml {
 xhtml!(
   quot: '\u{0022}',
   amp: '&',
-  apos: '\u{0027}',
   lt: '<',
   gt: '>',
   nbsp: '\u{00A0}',

--- a/crates/swc_ecma_parser/tests/jsx/basic/issue-12123/input.js
+++ b/crates/swc_ecma_parser/tests/jsx/basic/issue-12123/input.js
@@ -1,0 +1,1 @@
+const a = <p>&apos;&amp;</p>;

--- a/crates/swc_ecma_parser/tests/jsx/basic/issue-12123/input.js.json
+++ b/crates/swc_ecma_parser/tests/jsx/basic/issue-12123/input.js.json
@@ -1,0 +1,96 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 30
+  },
+  "body": [
+    {
+      "type": "VariableDeclaration",
+      "span": {
+        "start": 1,
+        "end": 30
+      },
+      "ctxt": 0,
+      "kind": "const",
+      "declare": false,
+      "declarations": [
+        {
+          "type": "VariableDeclarator",
+          "span": {
+            "start": 7,
+            "end": 29
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 7,
+              "end": 8
+            },
+            "ctxt": 0,
+            "value": "a",
+            "optional": false,
+            "typeAnnotation": null
+          },
+          "init": {
+            "type": "JSXElement",
+            "span": {
+              "start": 11,
+              "end": 29
+            },
+            "opening": {
+              "type": "JSXOpeningElement",
+              "name": {
+                "type": "Identifier",
+                "span": {
+                  "start": 12,
+                  "end": 13
+                },
+                "ctxt": 0,
+                "value": "p",
+                "optional": false
+              },
+              "span": {
+                "start": 11,
+                "end": 14
+              },
+              "attributes": [],
+              "selfClosing": false,
+              "typeArguments": null
+            },
+            "children": [
+              {
+                "type": "JSXText",
+                "span": {
+                  "start": 14,
+                  "end": 25
+                },
+                "value": "&apos;&",
+                "raw": "&apos;&amp;"
+              }
+            ],
+            "closing": {
+              "type": "JSXClosingElement",
+              "span": {
+                "start": 25,
+                "end": 29
+              },
+              "name": {
+                "type": "Identifier",
+                "span": {
+                  "start": 27,
+                  "end": 28
+                },
+                "ctxt": 0,
+                "value": "p",
+                "optional": false
+              }
+            }
+          },
+          "definite": false
+        }
+      ]
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/input.js
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/input.js
@@ -1,0 +1,1 @@
+const a = <p>&apos;&amp;</p>;

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/options.json
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/options.json
@@ -1,0 +1,1 @@
+{ "runtime": "automatic" }

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/output.mjs
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+const a = /*#__PURE__*/ _jsx("p", {
+    children: "&apos;&"
+});


### PR DESCRIPTION
**Description:**

Fixes a panic when JSX text contains `&apos;` followed by a supported character
reference, for example:

```jsx
const a = <p>&apos;&amp;</p>;
```

The [JSX specification](https://react.github.io/jsx/#sec-HTMLCharacterReference)
limits named character references to HTML4's 252 entities. `apos` is not
included in that set.

SWC previously decoded `&apos;` in the JSX lexer, while the React transform
treated it as unsupported. This made decoded JSX text inconsistent with its raw
source and could cause entity mask construction to panic.

This change removes `apos` from the JSX lexer entity tables. It is preserved
verbatim, while supported entities such as `&amp;` continue to decode:

```js
children: "&apos;&"
```

This follows the JSX specification's written HTML4 entity set.

**BREAKING CHANGE:**

JSX source containing `&apos;` is no longer compiled as an apostrophe. It is
preserved as the literal text `&apos;`.

**Related issue (if exists):**

- Close: #12123
