### PR TITLE
fix(es/react): handle apos JSX entities

### DIFF
--- a/.changeset/fix-react-handle-apos.md
+++ b/.changeset/fix-react-handle-apos.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_react: patch
+---
+
+fix(es/react): Handle `apos` JSX character references.

--- a/crates/swc_ecma_transforms_react/src/jsx/mod.rs
+++ b/crates/swc_ecma_transforms_react/src/jsx/mod.rs
@@ -1964,6 +1964,7 @@ fn is_known_html_entity(name: &str) -> bool {
             | "diams"
             | "quot"
             | "amp"
+            | "apos"
             | "lt"
             | "gt"
     )

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/input.js
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/input.js
@@ -1,0 +1,1 @@
+const a = <p>&apos;&amp;</p>;

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/options.json
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/options.json
@@ -1,0 +1,1 @@
+{ "runtime": "automatic" }

--- a/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/output.mjs
+++ b/crates/swc_ecma_transforms_react/tests/jsx/fixture/issue-12123/output.mjs
@@ -1,0 +1,4 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+const a = /*#__PURE__*/ _jsx("p", {
+    children: "'&"
+});


### PR DESCRIPTION
**Description:**

Fixes a panic when JSX text contains `&apos;` followed by another supported
character reference, for example:

```jsx
const a = <p>&apos;&amp;</p>;
```

SWC's JSX lexer already decodes `&apos;`, but the React transform maintains an
independent entity list for correlating decoded JSX text with its raw source.
Because that list did not include `apos`, the decoded and raw character offsets
could diverge and cause entity mask construction to panic.

This change recognizes `apos` in the transform's entity list, restoring
consistency with SWC's existing parser behavior.

Although the [JSX specification](https://react.github.io/jsx/#sec-HTMLCharacterReference)
text limits named references to HTML4's 252 entities, Babel and TypeScript also
decode `apos`. This option preserves that de-facto compatibility behavior.

**BREAKING CHANGE:**

No.

**Related issue (if exists):**

- Close: #12123
