### PR TITLE
fix(es2015): preserve const reassignment errors in block scoping

### DIFF
--- a/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
+++ b/crates/swc_ecma_compat_es2015/src/block_scoping/mod.rs
@@ -4,7 +4,7 @@ use indexmap::IndexMap;
 use rustc_hash::{FxHashMap, FxHashSet};
 use smallvec::SmallVec;
 use swc_atoms::{atom, Atom};
-use swc_common::{util::take::Take, Mark, Spanned, SyntaxContext, DUMMY_SP};
+use swc_common::{util::take::Take, Mark, Span, Spanned, SyntaxContext, DUMMY_SP};
 use swc_ecma_ast::*;
 use swc_ecma_transforms_base::helper;
 use swc_ecma_utils::{
@@ -12,7 +12,8 @@ use swc_ecma_utils::{
     ExprFactory, StmtLike,
 };
 use swc_ecma_visit::{
-    noop_visit_mut_type, visit_mut_obj_and_computed, visit_mut_pass, VisitMut, VisitMutWith,
+    noop_visit_mut_type, noop_visit_type, visit_mut_obj_and_computed, visit_mut_pass, Visit,
+    VisitMut, VisitMutWith, VisitWith,
 };
 
 mod vars;
@@ -38,6 +39,8 @@ pub fn block_scoping(unresolved_mark: Mark) -> impl Pass {
             scope: Default::default(),
             vars: Vec::new(),
             var_decl_kind: VarDeclKind::Var,
+            const_vars: Default::default(),
+            const_vars_collected: false,
         }),
     )
 }
@@ -74,6 +77,8 @@ struct BlockScoping {
     scope: ScopeStack,
     vars: Vec<VarDeclarator>,
     var_decl_kind: VarDeclKind,
+    const_vars: FxHashSet<Id>,
+    const_vars_collected: bool,
 }
 
 impl BlockScoping {
@@ -127,6 +132,83 @@ impl BlockScoping {
                 }
             }
         }
+    }
+
+    fn collect_const_vars<T>(&mut self, node: &T)
+    where
+        T: VisitWith<ConstCollector>,
+    {
+        if self.const_vars_collected {
+            return;
+        }
+
+        let mut visitor = ConstCollector::default();
+        node.visit_with(&mut visitor);
+        self.const_vars = visitor.ids;
+        self.const_vars_collected = true;
+    }
+
+    fn make_read_only_error(&self, ident: &Ident) -> Expr {
+        CallExpr {
+            span: DUMMY_SP,
+            callee: helper!(read_only_error),
+            args: vec![quote_str!(ident.span, ident.sym.clone()).as_arg()],
+            ..Default::default()
+        }
+        .into()
+    }
+
+    fn const_assignment_to_expr(
+        &self,
+        span: Span,
+        ident: &Ident,
+        assign_op: AssignOp,
+        right: Box<Expr>,
+    ) -> Expr {
+        let err = Box::new(self.make_read_only_error(ident));
+
+        if assign_op == op!("=") {
+            return SeqExpr {
+                span,
+                exprs: vec![right, err],
+            }
+            .into();
+        }
+
+        let op = assign_op.to_update().unwrap();
+
+        if assign_op.may_short_circuit() {
+            return BinExpr {
+                span,
+                left: Box::new(ident.clone().into()),
+                op,
+                right: Box::new(
+                    SeqExpr {
+                        span,
+                        exprs: vec![right, err],
+                    }
+                    .into(),
+                ),
+            }
+            .into();
+        }
+
+        SeqExpr {
+            span,
+            exprs: vec![
+                Box::new(
+                    BinExpr {
+                        span,
+                        left: Box::new(ident.clone().into()),
+                        op,
+                        right,
+                    }
+                    .into(),
+                ),
+                err,
+            ],
+        }
+        .into()
     }
 
     fn in_loop_body(&self) -> bool {
@@ -553,15 +635,34 @@ impl VisitMut for BlockScoping {
         self.visit_mut_with_scope(ScopeKind::Fn, &mut f.body);
     }
 
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        expr.visit_mut_children_with(self);
+
+        if let Expr::Assign(assign) = expr {
+            if let AssignTarget::Simple(SimpleAssignTarget::Ident(ident)) = &assign.left {
+                if self.const_vars.contains(&ident.to_id()) {
+                    *expr = self.const_assignment_to_expr(
+                        assign.span,
+                        ident,
+                        assign.op,
+                        assign.right.take(),
+                    );
+                }
+            }
+        }
+    }
+
     fn visit_mut_ident(&mut self, node: &mut Ident) {
         self.mark_as_used(node);
     }
 
     fn visit_mut_module_items(&mut self, stmts: &mut Vec<ModuleItem>) {
+        self.collect_const_vars(stmts);
         self.visit_mut_stmt_like(stmts);
     }
 
     fn visit_mut_stmts(&mut self, n: &mut Vec<Stmt>) {
+        self.collect_const_vars(n);
         self.visit_mut_stmt_like(n);
     }
 
@@ -639,6 +740,23 @@ fn find_lexical_vars(node: &VarDecl) -> Vec<Id> {
     }
 
     find_pat_ids(&node.decls)
+}
+
+#[derive(Default)]
+struct ConstCollector {
+    ids: FxHashSet<Id>,
+}
+
+impl Visit for ConstCollector {
+    noop_visit_type!(fail);
+
+    fn visit_var_decl(&mut self, node: &VarDecl) {
+        if node.kind == VarDeclKind::Const {
+            self.ids.extend(find_pat_ids(&node.decls));
+        }
+
+        node.visit_children_with(self);
+    }
 }
 
 struct FlowHelper<'a> {

--- a/crates/swc_ecma_transforms_compat/tests/__swc_snapshots__/tests/es2015_block_scoping.rs/issue_12130.js
+++ b/crates/swc_ecma_transforms_compat/tests/__swc_snapshots__/tests/es2015_block_scoping.rs/issue_12130.js
@@ -1,0 +1,2 @@
+var x = 0;
+42, _read_only_error("x");

--- a/crates/swc_ecma_transforms_compat/tests/es2015_block_scoping.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_block_scoping.rs
@@ -562,6 +562,16 @@ test!(
 
 test!(
     ::swc_ecma_parser::Syntax::default(),
+    |_| block_scoping(Mark::new()),
+    issue_12130,
+    "
+    const x = 0;
+    x = 42;
+    "
+);
+
+test!(
+    ::swc_ecma_parser::Syntax::default(),
     |_| tr(),
     issue_2998_1,
     "


### PR DESCRIPTION
## Summary
- preserve read-only errors when `const` bindings are lowered by the ES2015 block scoping transform
- add a regression snapshot for `const x = 0; x = 42;`

## Details
`block_scoping` converted `const` declarations to `var`, but did not remember that the original binding was read-only. That meant reassignments like `x = 42` were emitted unchanged instead of calling `_read_only_error("x")`.

This patch collects `const` bindings before mutation and rewrites simple identifier assignments targeting those bindings so the RHS is still evaluated, but the transformed output ends with `_read_only_error(...)` instead of performing the write.

## Testing
- `cargo test -p swc_ecma_transforms_compat --test es2015_block_scoping issue_12130 -- --exact`
- `cargo test -p swc_ecma_transforms_compat --test es2015_block_scoping issue_2027_1 -- --exact`
- `cargo test -p swc_ecma_transforms_compat --test es2015_block_scoping for_loop -- --exact`

A broader run of `cargo test -p swc_ecma_transforms_compat --test es2015_block_scoping` still hits pre-existing local environment failures for mocha-backed exec tests, so I kept verification focused on the changed contract.

## AI disclosure
This patch was drafted with AI assistance and then manually reviewed and verified with the targeted SWC tests above.
