### PR TITLE
ci: Gate jobs with detected changes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,6 +55,9 @@ jobs:
         with:
           node-version: "24"
 
+      - name: Test change detection
+        run: node --test ./scripts/github/change-detection.test.mjs
+
       - name: Install cargo-mono
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
           persist-credentials: false
 
       # We explicitly do this to cache properly.
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: nightly-2026-04-10
           components: rustfmt
@@ -100,7 +100,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: nightly-2026-04-10
           components: rustfmt
@@ -121,7 +121,7 @@ jobs:
           persist-credentials: false
           submodules: true
 
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: nightly-2026-04-10
           components: clippy
@@ -142,7 +142,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Install cargo-deny
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
@@ -167,7 +167,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Install cargo-shear
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
@@ -200,7 +200,7 @@ jobs:
 
       # We explicitly do this to cache properly.
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         # MSRV is current stable for ES crates and nightly for other languages.
 
       - uses: ./.github/actions/setup-node
@@ -228,7 +228,7 @@ jobs:
           persist-credentials: false
 
       # We explicitly do this to cache properly.
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -304,7 +304,7 @@ jobs:
 
       # We explicitly do this to cache properly.
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         if: matrix.settings.crate != '__noop__'
         with:
           toolchain: nightly-2026-04-10
@@ -466,7 +466,7 @@ jobs:
 
       # We explicitly do this to cache properly.
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - uses: ./.github/actions/setup-node
         id: setup-node
@@ -526,7 +526,7 @@ jobs:
 
       # We explicitly do this to cache properly.
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - uses: ./.github/actions/setup-node
         id: setup-node

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -111,8 +111,7 @@ jobs:
     name: Cargo clippy
     needs:
       - detect-changes
-    if: >-
-      ${{ needs.detect-changes.outputs.rust_checks == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
+    if: needs.detect-changes.outputs.rust_checks == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -136,8 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: >-
-      ${{ needs.detect-changes.outputs.cargo_deny == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
+    if: needs.detect-changes.outputs.cargo_deny == 'true'
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -186,8 +184,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-    if: >-
-      ${{ needs.detect-changes.outputs.rust_checks == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
+    if: needs.detect-changes.outputs.rust_checks == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -217,8 +214,7 @@ jobs:
     name: Test wasm
     needs:
       - detect-changes
-    if: >-
-      ${{ needs.detect-changes.outputs.test_wasm == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
+    if: needs.detect-changes.outputs.test_wasm == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -248,8 +244,6 @@ jobs:
   list-cargo-tests:
     needs:
       - detect-changes
-    if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') }}
     name: List crates
     runs-on: ubuntu-latest
     permissions:
@@ -454,8 +448,7 @@ jobs:
     name: Test node bindings - ${{ matrix.os }}
     needs:
       - detect-changes
-    if: >-
-      ${{ needs.detect-changes.outputs.node_test == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
+    if: needs.detect-changes.outputs.node_test == 'true'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -515,8 +508,7 @@ jobs:
     name: Test react-compiler bindings - ${{ matrix.os }}
     needs:
       - detect-changes
-    if: >-
-      ${{ needs.detect-changes.outputs.react_compiler_test == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
+    if: needs.detect-changes.outputs.react_compiler_test == 'true'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -567,8 +559,7 @@ jobs:
     name: "Test with @swc/cli"
     needs:
       - detect-changes
-    if: >-
-      ${{ needs.detect-changes.outputs.integration_test == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
+    if: needs.detect-changes.outputs.integration_test == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -674,8 +665,7 @@ jobs:
       - node-test
       - react-compiler-test
       - integration-test
-    if: >-
-      ${{ always() && !contains(github.event.head_commit.message, 'chore: ') }}
+    if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Done
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,10 @@ on:
 
 env:
   CI: 1
-  # Avoid transient HTTP/2 stream resets when the cargo-test matrix fetches the
+  # Tolerate slow or reset HTTP requests when the cargo-test matrix fetches the
   # sparse registry index from many GitHub-hosted runners at once.
   CARGO_HTTP_MULTIPLEXING: "false"
+  CARGO_HTTP_TIMEOUT: 600
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   CARGO_TERM_COLOR: "always"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,8 +27,48 @@ concurrency:
   cancel-in-progress: "${{ github.event_name == 'pull_request' }}"
 
 jobs:
+  detect-changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      force_all: ${{ steps.changes.outputs.force_all }}
+      affected_packages: ${{ steps.changes.outputs.affected_packages }}
+      cargo_fmt: ${{ steps.changes.outputs.cargo_fmt }}
+      rust_checks: ${{ steps.changes.outputs.rust_checks }}
+      helper_codegen: ${{ steps.changes.outputs.helper_codegen }}
+      cargo_deny: ${{ steps.changes.outputs.cargo_deny }}
+      test_wasm: ${{ steps.changes.outputs.test_wasm }}
+      wasm_packages: ${{ steps.changes.outputs.wasm_packages }}
+      node_test: ${{ steps.changes.outputs.node_test }}
+      react_compiler_test: ${{ steps.changes.outputs.react_compiler_test }}
+      integration_test: ${{ steps.changes.outputs.integration_test }}
+      full_cargo_test_matrix: ${{ steps.changes.outputs.full_cargo_test_matrix }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "24"
+
+      - name: Install cargo-mono
+        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
+        with:
+          tool: cargo-mono@0.6.9
+
+      - name: Detect changes
+        id: changes
+        run: node ./scripts/github/detect-changes.mjs >> "$GITHUB_OUTPUT"
+
   cargo-fmt:
     name: Cargo fmt
+    needs:
+      - detect-changes
+    if: needs.detect-changes.outputs.cargo_fmt == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -49,6 +89,9 @@ jobs:
 
   helper-codegen:
     name: Helper codegen
+    needs:
+      - detect-changes
+    if: needs.detect-changes.outputs.helper_codegen == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -66,8 +109,10 @@ jobs:
 
   cargo-clippy:
     name: Cargo clippy
+    needs:
+      - detect-changes
     if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') }}
+      ${{ needs.detect-changes.outputs.rust_checks == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -86,11 +131,13 @@ jobs:
 
   cargo-deny:
     name: Check license of dependencies
+    needs:
+      - detect-changes
     runs-on: ubuntu-latest
     permissions:
       contents: read
     if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') }}
+      ${{ needs.detect-changes.outputs.cargo_deny == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -110,6 +157,9 @@ jobs:
 
   cargo-shear:
     name: Cargo shear
+    needs:
+      - detect-changes
+    if: needs.detect-changes.outputs.rust_checks == 'true'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -131,11 +181,13 @@ jobs:
 
   cargo-check:
     name: Check
+    needs:
+      - detect-changes
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') }}
+      ${{ needs.detect-changes.outputs.rust_checks == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
     strategy:
       fail-fast: false
       matrix:
@@ -163,20 +215,17 @@ jobs:
 
   test-wasm:
     name: Test wasm
+    needs:
+      - detect-changes
     if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') }}
+      ${{ needs.detect-changes.outputs.test_wasm == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
     strategy:
       fail-fast: false
       matrix:
-        pkg:
-          - binding_core_wasm
-          - binding_minifier_wasm
-          - binding_typescript_wasm
-          - binding_nodejs_support_wasm
-          - binding_es_ast_viewer
+        pkg: ${{ fromJson(needs.detect-changes.outputs.wasm_packages) }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
@@ -197,6 +246,8 @@ jobs:
           (cd bindings/${{ matrix.pkg }} && ./scripts/test.sh)
 
   list-cargo-tests:
+    needs:
+      - detect-changes
     if: >-
       ${{ !contains(github.event.head_commit.message, 'chore: ') }}
     name: List crates
@@ -205,18 +256,15 @@ jobs:
       contents: read
     outputs:
       settings: ${{ steps.list-tests.outputs.settings }}
+    env:
+      AFFECTED_PACKAGES: ${{ needs.detect-changes.outputs.affected_packages }}
+      FULL_CARGO_TEST_MATRIX: ${{ needs.detect-changes.outputs.full_cargo_test_matrix }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
-          fetch-depth: 0
 
       - uses: ./.github/actions/setup-node
-
-      - name: Install cargo-mono
-        uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7
-        with:
-          tool: cargo-mono@0.6.9
 
       - name: List crates
         id: list-tests
@@ -404,8 +452,10 @@ jobs:
 
   node-test:
     name: Test node bindings - ${{ matrix.os }}
+    needs:
+      - detect-changes
     if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') }}
+      ${{ needs.detect-changes.outputs.node_test == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -463,8 +513,10 @@ jobs:
 
   react-compiler-test:
     name: Test react-compiler bindings - ${{ matrix.os }}
+    needs:
+      - detect-changes
     if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') }}
+      ${{ needs.detect-changes.outputs.react_compiler_test == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -513,8 +565,10 @@ jobs:
 
   integration-test:
     name: "Test with @swc/cli"
+    needs:
+      - detect-changes
     if: >-
-      ${{ !contains(github.event.head_commit.message, 'chore: ') }}
+      ${{ needs.detect-changes.outputs.integration_test == 'true' && !contains(github.event.head_commit.message, 'chore: ') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -607,14 +661,18 @@ jobs:
 
   done:
     needs:
+      - detect-changes
       - cargo-fmt
+      - helper-codegen
       - cargo-clippy
       - cargo-deny
       - cargo-shear
       - cargo-check
       - test-wasm
+      - list-cargo-tests
       - cargo-test
       - node-test
+      - react-compiler-test
       - integration-test
     if: >-
       ${{ always() && !contains(github.event.head_commit.message, 'chore: ') }}
@@ -622,4 +680,4 @@ jobs:
     name: Done
     steps:
       - run: exit 1
-        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')) }}
+        if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -60,7 +60,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         # Some crates are too slow to build

--- a/.github/workflows/binary-size.yml
+++ b/.github/workflows/binary-size.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Setup Node.js
         uses: ./.github/actions/setup-node

--- a/.github/workflows/devbird.yml
+++ b/.github/workflows/devbird.yml
@@ -80,7 +80,7 @@ jobs:
 
       # We explicitly do this to cache properly.
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           target: wasm32-wasip1
           components: rustfmt

--- a/.github/workflows/publish-crates-manual.yml
+++ b/.github/workflows/publish-crates-manual.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           cache: "false"
 
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         with:
           toolchain: nightly-2025-05-06
 

--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           cache: "false"
 
-      - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
 
       - name: Install cargo-edit
         uses: taiki-e/install-action@3235f8901fd37ffed0052b276cec25a362fb82e9 # v2.77.7

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -326,7 +326,7 @@ jobs:
         shell: bash
         run: echo "version=$(cat ./rust-toolchain)" >> "$GITHUB_OUTPUT"
       - name: Install
-        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
         if: ${{ !matrix.settings.docker }}
         with:
           targets: ${{ matrix.settings.target }}

--- a/scripts/github/change-detection.mjs
+++ b/scripts/github/change-detection.mjs
@@ -1,39 +1,39 @@
 const WASM_PACKAGES = [
-    'binding_core_wasm',
-    'binding_minifier_wasm',
-    'binding_typescript_wasm',
-    'binding_nodejs_support_wasm',
-    'binding_es_ast_viewer',
+  "binding_core_wasm",
+  "binding_minifier_wasm",
+  "binding_typescript_wasm",
+  "binding_nodejs_support_wasm",
+  "binding_es_ast_viewer",
 ];
 
 const DETECTION_INFRA_PATHS = new Set([
-    '.github/workflows/CI.yml',
-    'scripts/github/change-detection.mjs',
-    'scripts/github/change-detection.test.mjs',
-    'scripts/github/detect-changes.mjs',
+  ".github/workflows/CI.yml",
+  "scripts/github/change-detection.mjs",
+  "scripts/github/change-detection.test.mjs",
+  "scripts/github/detect-changes.mjs",
 ]);
 
 const CARGO_TEST_INFRA_PATHS = new Set([
-    'scripts/github/get-test-matrix.mjs',
-    'scripts/github/run-cargo-hack.sh',
-    'scripts/github/test-concurrent.sh',
-    'tests.yml',
+  "scripts/github/get-test-matrix.mjs",
+  "scripts/github/run-cargo-hack.sh",
+  "scripts/github/test-concurrent.sh",
+  "tests.yml",
 ]);
 
 const NODE_SHARED_PATHS = new Set([
-    '.mocha.setup.js',
-    '.mocharc.js',
-    '.node-version',
-    '.npmrc',
-    'package.json',
-    'pnpm-lock.yaml',
-    'pnpm-workspace.yaml',
+  ".mocha.setup.js",
+  ".mocharc.js",
+  ".node-version",
+  ".npmrc",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
 ]);
 
 const RUST_GLOBAL_PATHS = new Set([
-    'Cargo.lock',
-    'Cargo.toml',
-    'rust-toolchain',
+  "Cargo.lock",
+  "Cargo.toml",
+  "rust-toolchain",
 ]);
 
 /**
@@ -43,7 +43,7 @@ const RUST_GLOBAL_PATHS = new Set([
  * default branch remains a complete verification run.
  */
 export function isMainPush(eventName, gitRef) {
-    return eventName === 'push' && gitRef === 'refs/heads/main';
+  return eventName === "push" && gitRef === "refs/heads/main";
 }
 
 /**
@@ -52,109 +52,105 @@ export function isMainPush(eventName, gitRef) {
  * `packages` must contain cargo-mono's default reverse-dependency expansion,
  * not only the packages that directly own changed files.
  */
-export function classifyChanges({ files = [], packages = [], forceAll = false }) {
-    const normalizedFiles = files.map(normalizePath);
-    const affectedPackages = [...new Set(packages)].sort();
-    const affectedPackageSet = new Set(affectedPackages);
+export function classifyChanges({
+  files = [],
+  packages = [],
+  forceAll = false,
+}) {
+  const normalizedFiles = files.map(normalizePath);
+  const affectedPackages = [...new Set(packages)].sort();
+  const affectedPackageSet = new Set(affectedPackages);
 
-    const detectionInfraChanged = normalizedFiles.some((file) =>
-        DETECTION_INFRA_PATHS.has(file),
+  const detectionInfraChanged = normalizedFiles.some((file) =>
+    DETECTION_INFRA_PATHS.has(file)
+  );
+  const runAll = forceAll || detectionInfraChanged;
+  const rustGlobalChanged = normalizedFiles.some((file) =>
+    RUST_GLOBAL_PATHS.has(file)
+  );
+  const rustConfigChanged = normalizedFiles.some(
+    (file) =>
+      file === ".rustfmt.toml" ||
+      file === "clippy.toml" ||
+      file.startsWith(".cargo/")
+  );
+  const nodeSharedChanged = normalizedFiles.some(
+    (file) =>
+      NODE_SHARED_PATHS.has(file) ||
+      file.startsWith(".github/actions/setup-node/")
+  );
+  const cargoTestInfraChanged = normalizedFiles.some(
+    (file) =>
+      CARGO_TEST_INFRA_PATHS.has(file) ||
+      file.startsWith("scripts/cargo/") ||
+      file.startsWith(".cargo/")
+  );
+
+  const cargoFmt =
+    runAll ||
+    normalizedFiles.some(
+      (file) =>
+        file.endsWith(".rs") ||
+        file === ".rustfmt.toml" ||
+        file === "rust-toolchain"
     );
-    const runAll = forceAll || detectionInfraChanged;
-    const rustGlobalChanged = normalizedFiles.some((file) =>
-        RUST_GLOBAL_PATHS.has(file),
+  const rustChecks =
+    runAll ||
+    rustGlobalChanged ||
+    rustConfigChanged ||
+    affectedPackages.length > 0;
+  const helperCodegen =
+    runAll ||
+    normalizedFiles.some(
+      (file) =>
+        file.startsWith("packages/helpers/esm/") ||
+        file.startsWith("tools/generate-code/") ||
+        file.startsWith(
+          "crates/swc_ecma_transforms_base/src/helpers/generated/"
+        )
     );
-    const rustConfigChanged = normalizedFiles.some(
-        (file) =>
-            file === '.rustfmt.toml' ||
-            file === 'clippy.toml' ||
-            file.startsWith('.cargo/'),
-    );
-    const nodeSharedChanged = normalizedFiles.some(
-        (file) =>
-            NODE_SHARED_PATHS.has(file) ||
-            file.startsWith('.github/actions/setup-node/'),
-    );
-    const cargoTestInfraChanged = normalizedFiles.some(
-        (file) =>
-            CARGO_TEST_INFRA_PATHS.has(file) ||
-            file.startsWith('scripts/cargo/') ||
-            file.startsWith('.cargo/'),
+  const cargoDeny =
+    runAll ||
+    normalizedFiles.some(
+      (file) => file === "Cargo.lock" || file === "deny.toml"
     );
 
-    const cargoFmt =
-        runAll ||
-        normalizedFiles.some(
-            (file) =>
-                file.endsWith('.rs') ||
-                file === '.rustfmt.toml' ||
-                file === 'rust-toolchain',
-        );
-    const rustChecks =
-        runAll ||
-        rustGlobalChanged ||
-        rustConfigChanged ||
-        affectedPackages.length > 0;
-    const helperCodegen =
-        runAll ||
-        normalizedFiles.some(
-            (file) =>
-                file.startsWith('packages/helpers/esm/') ||
-                file.startsWith('tools/generate-code/') ||
-                file.startsWith(
-                    'crates/swc_ecma_transforms_base/src/helpers/generated/',
-                ),
-        );
-    const cargoDeny =
-        runAll ||
-        normalizedFiles.some(
-            (file) => file === 'Cargo.lock' || file === 'deny.toml',
-        );
+  const allBindingsAffected = runAll || rustGlobalChanged || nodeSharedChanged;
+  const wasmPackages = allBindingsAffected
+    ? [...WASM_PACKAGES]
+    : WASM_PACKAGES.filter((name) => affectedPackageSet.has(name));
+  const nodeTest =
+    allBindingsAffected ||
+    affectedPackageSet.has("binding_core_node") ||
+    normalizedFiles.some((file) => file.startsWith("packages/core/"));
+  const reactCompilerTest =
+    allBindingsAffected ||
+    affectedPackageSet.has("binding_react_compiler_node") ||
+    normalizedFiles.some((file) => file.startsWith("packages/react-compiler/"));
+  const integrationTest =
+    nodeTest ||
+    affectedPackageSet.has("swc_node_bundler") ||
+    normalizedFiles.some((file) =>
+      file.startsWith("crates/swc_node_bundler/tests/integration/")
+    );
 
-    const allBindingsAffected = runAll || rustGlobalChanged || nodeSharedChanged;
-    const wasmPackages = allBindingsAffected
-        ? [...WASM_PACKAGES]
-        : WASM_PACKAGES.filter((name) => affectedPackageSet.has(name));
-    const nodeTest =
-        allBindingsAffected ||
-        affectedPackageSet.has('binding_core_node') ||
-        normalizedFiles.some((file) => file.startsWith('packages/core/'));
-    const reactCompilerTest =
-        allBindingsAffected ||
-        affectedPackageSet.has('binding_react_compiler_node') ||
-        normalizedFiles.some((file) =>
-            file.startsWith('packages/react-compiler/'),
-        );
-    const integrationTest =
-        nodeTest ||
-        affectedPackageSet.has('swc_node_bundler') ||
-        normalizedFiles.some((file) =>
-            file.startsWith(
-                'crates/swc_node_bundler/tests/integration/',
-            ),
-        );
-
-    return {
-        forceAll: runAll,
-        affectedPackages,
-        cargoFmt,
-        rustChecks,
-        helperCodegen,
-        cargoDeny,
-        testWasm: wasmPackages.length > 0,
-        wasmPackages,
-        nodeTest,
-        reactCompilerTest,
-        integrationTest,
-        fullCargoTestMatrix:
-            runAll ||
-            rustGlobalChanged ||
-            nodeSharedChanged ||
-            cargoTestInfraChanged,
-    };
+  return {
+    forceAll: runAll,
+    affectedPackages,
+    cargoFmt,
+    rustChecks,
+    helperCodegen,
+    cargoDeny,
+    testWasm: wasmPackages.length > 0,
+    wasmPackages,
+    nodeTest,
+    reactCompilerTest,
+    integrationTest,
+    fullCargoTestMatrix:
+      runAll || rustGlobalChanged || nodeSharedChanged || cargoTestInfraChanged,
+  };
 }
 
 function normalizePath(filePath) {
-    return filePath.replaceAll('\\', '/').replace(/^\.\//, '');
+  return filePath.replaceAll("\\", "/").replace(/^\.\//, "");
 }
-

--- a/scripts/github/change-detection.mjs
+++ b/scripts/github/change-detection.mjs
@@ -31,10 +31,13 @@ const NODE_SHARED_PATHS = new Set([
 ]);
 
 const RUST_GLOBAL_PATHS = new Set([
+  ".gitmodules",
   "Cargo.lock",
   "Cargo.toml",
   "rust-toolchain",
 ]);
+
+const TYPES_PACKAGE_PREFIX = "packages/types/";
 
 /**
  * Returns whether an event must run the complete CI suite.
@@ -68,12 +71,14 @@ export function classifyChanges({
   const rustGlobalChanged = normalizedFiles.some((file) =>
     RUST_GLOBAL_PATHS.has(file)
   );
-  const rustConfigChanged = normalizedFiles.some(
-    (file) =>
-      file === ".rustfmt.toml" ||
-      file === "clippy.toml" ||
-      file.startsWith(".cargo/")
+  const cargoConfigChanged = normalizedFiles.some((file) =>
+    file.startsWith(".cargo/")
   );
+  const rustConfigChanged =
+    cargoConfigChanged ||
+    normalizedFiles.some(
+      (file) => file === ".rustfmt.toml" || file === "clippy.toml"
+    );
   const nodeSharedChanged = normalizedFiles.some(
     (file) =>
       NODE_SHARED_PATHS.has(file) ||
@@ -115,17 +120,23 @@ export function classifyChanges({
       (file) => file === "Cargo.lock" || file === "deny.toml"
     );
 
-  const allBindingsAffected = runAll || rustGlobalChanged || nodeSharedChanged;
+  const allBindingsAffected =
+    runAll || rustGlobalChanged || cargoConfigChanged || nodeSharedChanged;
+  const typesPackageChanged = normalizedFiles.some((file) =>
+    file.startsWith(TYPES_PACKAGE_PREFIX)
+  );
   const wasmPackages = allBindingsAffected
     ? [...WASM_PACKAGES]
     : WASM_PACKAGES.filter((name) => affectedPackageSet.has(name));
   const nodeTest =
     allBindingsAffected ||
     affectedPackageSet.has("binding_core_node") ||
+    typesPackageChanged ||
     normalizedFiles.some((file) => file.startsWith("packages/core/"));
   const reactCompilerTest =
     allBindingsAffected ||
     affectedPackageSet.has("binding_react_compiler_node") ||
+    typesPackageChanged ||
     normalizedFiles.some((file) => file.startsWith("packages/react-compiler/"));
   const integrationTest =
     nodeTest ||

--- a/scripts/github/change-detection.mjs
+++ b/scripts/github/change-detection.mjs
@@ -1,0 +1,160 @@
+const WASM_PACKAGES = [
+    'binding_core_wasm',
+    'binding_minifier_wasm',
+    'binding_typescript_wasm',
+    'binding_nodejs_support_wasm',
+    'binding_es_ast_viewer',
+];
+
+const DETECTION_INFRA_PATHS = new Set([
+    '.github/workflows/CI.yml',
+    'scripts/github/change-detection.mjs',
+    'scripts/github/change-detection.test.mjs',
+    'scripts/github/detect-changes.mjs',
+]);
+
+const CARGO_TEST_INFRA_PATHS = new Set([
+    'scripts/github/get-test-matrix.mjs',
+    'scripts/github/run-cargo-hack.sh',
+    'scripts/github/test-concurrent.sh',
+    'tests.yml',
+]);
+
+const NODE_SHARED_PATHS = new Set([
+    '.mocha.setup.js',
+    '.mocharc.js',
+    '.node-version',
+    '.npmrc',
+    'package.json',
+    'pnpm-lock.yaml',
+    'pnpm-workspace.yaml',
+]);
+
+const RUST_GLOBAL_PATHS = new Set([
+    'Cargo.lock',
+    'Cargo.toml',
+    'rust-toolchain',
+]);
+
+/**
+ * Returns whether an event must run the complete CI suite.
+ *
+ * Pull requests and merge groups are intentionally selective. A push to the
+ * default branch remains a complete verification run.
+ */
+export function isMainPush(eventName, gitRef) {
+    return eventName === 'push' && gitRef === 'refs/heads/main';
+}
+
+/**
+ * Classifies changed files and affected Cargo packages into CI job inputs.
+ *
+ * `packages` must contain cargo-mono's default reverse-dependency expansion,
+ * not only the packages that directly own changed files.
+ */
+export function classifyChanges({ files = [], packages = [], forceAll = false }) {
+    const normalizedFiles = files.map(normalizePath);
+    const affectedPackages = [...new Set(packages)].sort();
+    const affectedPackageSet = new Set(affectedPackages);
+
+    const detectionInfraChanged = normalizedFiles.some((file) =>
+        DETECTION_INFRA_PATHS.has(file),
+    );
+    const runAll = forceAll || detectionInfraChanged;
+    const rustGlobalChanged = normalizedFiles.some((file) =>
+        RUST_GLOBAL_PATHS.has(file),
+    );
+    const rustConfigChanged = normalizedFiles.some(
+        (file) =>
+            file === '.rustfmt.toml' ||
+            file === 'clippy.toml' ||
+            file.startsWith('.cargo/'),
+    );
+    const nodeSharedChanged = normalizedFiles.some(
+        (file) =>
+            NODE_SHARED_PATHS.has(file) ||
+            file.startsWith('.github/actions/setup-node/'),
+    );
+    const cargoTestInfraChanged = normalizedFiles.some(
+        (file) =>
+            CARGO_TEST_INFRA_PATHS.has(file) ||
+            file.startsWith('scripts/cargo/') ||
+            file.startsWith('.cargo/'),
+    );
+
+    const cargoFmt =
+        runAll ||
+        normalizedFiles.some(
+            (file) =>
+                file.endsWith('.rs') ||
+                file === '.rustfmt.toml' ||
+                file === 'rust-toolchain',
+        );
+    const rustChecks =
+        runAll ||
+        rustGlobalChanged ||
+        rustConfigChanged ||
+        affectedPackages.length > 0;
+    const helperCodegen =
+        runAll ||
+        normalizedFiles.some(
+            (file) =>
+                file.startsWith('packages/helpers/esm/') ||
+                file.startsWith('tools/generate-code/') ||
+                file.startsWith(
+                    'crates/swc_ecma_transforms_base/src/helpers/generated/',
+                ),
+        );
+    const cargoDeny =
+        runAll ||
+        normalizedFiles.some(
+            (file) => file === 'Cargo.lock' || file === 'deny.toml',
+        );
+
+    const allBindingsAffected = runAll || rustGlobalChanged || nodeSharedChanged;
+    const wasmPackages = allBindingsAffected
+        ? [...WASM_PACKAGES]
+        : WASM_PACKAGES.filter((name) => affectedPackageSet.has(name));
+    const nodeTest =
+        allBindingsAffected ||
+        affectedPackageSet.has('binding_core_node') ||
+        normalizedFiles.some((file) => file.startsWith('packages/core/'));
+    const reactCompilerTest =
+        allBindingsAffected ||
+        affectedPackageSet.has('binding_react_compiler_node') ||
+        normalizedFiles.some((file) =>
+            file.startsWith('packages/react-compiler/'),
+        );
+    const integrationTest =
+        nodeTest ||
+        affectedPackageSet.has('swc_node_bundler') ||
+        normalizedFiles.some((file) =>
+            file.startsWith(
+                'crates/swc_node_bundler/tests/integration/',
+            ),
+        );
+
+    return {
+        forceAll: runAll,
+        affectedPackages,
+        cargoFmt,
+        rustChecks,
+        helperCodegen,
+        cargoDeny,
+        testWasm: wasmPackages.length > 0,
+        wasmPackages,
+        nodeTest,
+        reactCompilerTest,
+        integrationTest,
+        fullCargoTestMatrix:
+            runAll ||
+            rustGlobalChanged ||
+            nodeSharedChanged ||
+            cargoTestInfraChanged,
+    };
+}
+
+function normalizePath(filePath) {
+    return filePath.replaceAll('\\', '/').replace(/^\.\//, '');
+}
+

--- a/scripts/github/change-detection.mjs
+++ b/scripts/github/change-detection.mjs
@@ -82,6 +82,7 @@ export function classifyChanges({
   const nodeSharedChanged = normalizedFiles.some(
     (file) =>
       NODE_SHARED_PATHS.has(file) ||
+      file.endsWith("/package.json") ||
       file.startsWith(".github/actions/setup-node/")
   );
   const cargoTestInfraChanged = normalizedFiles.some(

--- a/scripts/github/change-detection.test.mjs
+++ b/scripts/github/change-detection.test.mjs
@@ -1,0 +1,147 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { classifyChanges, isMainPush } from './change-detection.mjs';
+
+test('a root Cargo.lock change runs Rust, binding, deny, and cargo tests', () => {
+    const result = classifyChanges({ files: ['Cargo.lock'] });
+
+    assert.equal(result.cargoDeny, true);
+    assert.equal(result.rustChecks, true);
+    assert.equal(result.testWasm, true);
+    assert.equal(result.nodeTest, true);
+    assert.equal(result.reactCompilerTest, true);
+    assert.equal(result.integrationTest, true);
+    assert.equal(result.fullCargoTestMatrix, true);
+});
+
+test('a nested fixture Cargo.lock does not run cargo-deny', () => {
+    const result = classifyChanges({
+        files: ['packages/core/e2e/fixtures/plugin_analyze/Cargo.lock'],
+        packages: ['binding_core_node'],
+    });
+
+    assert.equal(result.cargoDeny, false);
+    assert.equal(result.nodeTest, true);
+});
+
+test('a deny policy change only runs cargo-deny', () => {
+    const result = classifyChanges({ files: ['deny.toml'] });
+
+    assert.equal(result.cargoDeny, true);
+    assert.equal(result.cargoFmt, false);
+    assert.equal(result.rustChecks, false);
+    assert.equal(result.testWasm, false);
+    assert.equal(result.nodeTest, false);
+    assert.equal(result.fullCargoTestMatrix, false);
+});
+
+test('a Rust change uses cargo-mono reverse dependents for related jobs', () => {
+    const result = classifyChanges({
+        files: ['crates/swc_ecma_parser/src/lib.rs'],
+        packages: [
+            'swc_ecma_parser',
+            'binding_core_node',
+            'binding_core_wasm',
+        ],
+    });
+
+    assert.equal(result.cargoFmt, true);
+    assert.equal(result.rustChecks, true);
+    assert.equal(result.cargoDeny, false);
+    assert.deepEqual(result.wasmPackages, ['binding_core_wasm']);
+    assert.equal(result.nodeTest, true);
+    assert.equal(result.reactCompilerTest, false);
+});
+
+test('helper sources only run helper codegen', () => {
+    const result = classifyChanges({
+        files: ['packages/helpers/esm/_define_property.js'],
+    });
+
+    assert.equal(result.helperCodegen, true);
+    assert.equal(result.cargoFmt, false);
+    assert.equal(result.rustChecks, false);
+    assert.equal(result.nodeTest, false);
+});
+
+test('an individual wasm binding produces a focused matrix', () => {
+    const result = classifyChanges({
+        files: ['bindings/binding_typescript_wasm/src/lib.rs'],
+        packages: ['binding_typescript_wasm'],
+    });
+
+    assert.deepEqual(result.wasmPackages, ['binding_typescript_wasm']);
+    assert.equal(result.testWasm, true);
+    assert.equal(result.nodeTest, false);
+});
+
+test('node and react compiler packages select their own binding jobs', () => {
+    const nodeResult = classifyChanges({
+        files: ['packages/core/index.ts'],
+    });
+    const reactResult = classifyChanges({
+        files: ['packages/react-compiler/index.ts'],
+    });
+
+    assert.equal(nodeResult.nodeTest, true);
+    assert.equal(nodeResult.integrationTest, true);
+    assert.equal(nodeResult.reactCompilerTest, false);
+    assert.equal(reactResult.reactCompilerTest, true);
+    assert.equal(reactResult.nodeTest, false);
+});
+
+test('shared pnpm configuration runs all JavaScript and binding tests', () => {
+    const result = classifyChanges({ files: ['pnpm-lock.yaml'] });
+
+    assert.equal(result.testWasm, true);
+    assert.equal(result.nodeTest, true);
+    assert.equal(result.reactCompilerTest, true);
+    assert.equal(result.integrationTest, true);
+    assert.equal(result.fullCargoTestMatrix, true);
+    assert.equal(result.cargoDeny, false);
+});
+
+test('documentation-only changes do not select expensive jobs', () => {
+    const result = classifyChanges({ files: ['docs/usage.md'] });
+
+    assert.deepEqual(result.affectedPackages, []);
+    assert.equal(result.cargoFmt, false);
+    assert.equal(result.rustChecks, false);
+    assert.equal(result.helperCodegen, false);
+    assert.equal(result.cargoDeny, false);
+    assert.equal(result.testWasm, false);
+    assert.equal(result.nodeTest, false);
+    assert.equal(result.reactCompilerTest, false);
+    assert.equal(result.integrationTest, false);
+    assert.equal(result.fullCargoTestMatrix, false);
+});
+
+test('CI detection infrastructure changes force a complete run', () => {
+    const result = classifyChanges({ files: ['.github/workflows/CI.yml'] });
+
+    assert.equal(result.forceAll, true);
+    assert.equal(result.cargoFmt, true);
+    assert.equal(result.rustChecks, true);
+    assert.equal(result.helperCodegen, true);
+    assert.equal(result.cargoDeny, true);
+    assert.equal(result.testWasm, true);
+    assert.equal(result.nodeTest, true);
+    assert.equal(result.reactCompilerTest, true);
+    assert.equal(result.integrationTest, true);
+    assert.equal(result.fullCargoTestMatrix, true);
+});
+
+test('detection failures force a complete run', () => {
+    const result = classifyChanges({ forceAll: true });
+
+    assert.equal(result.forceAll, true);
+    assert.equal(result.fullCargoTestMatrix, true);
+    assert.equal(result.cargoDeny, true);
+});
+
+test('only pushes to main force a complete event run', () => {
+    assert.equal(isMainPush('push', 'refs/heads/main'), true);
+    assert.equal(isMainPush('pull_request', 'refs/pull/1/merge'), false);
+    assert.equal(isMainPush('merge_group', 'refs/heads/gh-readonly-queue/main'), false);
+});

--- a/scripts/github/change-detection.test.mjs
+++ b/scripts/github/change-detection.test.mjs
@@ -1,147 +1,146 @@
-import assert from 'node:assert/strict';
-import test from 'node:test';
+import assert from "node:assert/strict";
+import test from "node:test";
 
-import { classifyChanges, isMainPush } from './change-detection.mjs';
+import { classifyChanges, isMainPush } from "./change-detection.mjs";
 
-test('a root Cargo.lock change runs Rust, binding, deny, and cargo tests', () => {
-    const result = classifyChanges({ files: ['Cargo.lock'] });
+test("a root Cargo.lock change runs Rust, binding, deny, and cargo tests", () => {
+  const result = classifyChanges({ files: ["Cargo.lock"] });
 
-    assert.equal(result.cargoDeny, true);
-    assert.equal(result.rustChecks, true);
-    assert.equal(result.testWasm, true);
-    assert.equal(result.nodeTest, true);
-    assert.equal(result.reactCompilerTest, true);
-    assert.equal(result.integrationTest, true);
-    assert.equal(result.fullCargoTestMatrix, true);
+  assert.equal(result.cargoDeny, true);
+  assert.equal(result.rustChecks, true);
+  assert.equal(result.testWasm, true);
+  assert.equal(result.nodeTest, true);
+  assert.equal(result.reactCompilerTest, true);
+  assert.equal(result.integrationTest, true);
+  assert.equal(result.fullCargoTestMatrix, true);
 });
 
-test('a nested fixture Cargo.lock does not run cargo-deny', () => {
-    const result = classifyChanges({
-        files: ['packages/core/e2e/fixtures/plugin_analyze/Cargo.lock'],
-        packages: ['binding_core_node'],
-    });
+test("a nested fixture Cargo.lock does not run cargo-deny", () => {
+  const result = classifyChanges({
+    files: ["packages/core/e2e/fixtures/plugin_analyze/Cargo.lock"],
+    packages: ["binding_core_node"],
+  });
 
-    assert.equal(result.cargoDeny, false);
-    assert.equal(result.nodeTest, true);
+  assert.equal(result.cargoDeny, false);
+  assert.equal(result.nodeTest, true);
 });
 
-test('a deny policy change only runs cargo-deny', () => {
-    const result = classifyChanges({ files: ['deny.toml'] });
+test("a deny policy change only runs cargo-deny", () => {
+  const result = classifyChanges({ files: ["deny.toml"] });
 
-    assert.equal(result.cargoDeny, true);
-    assert.equal(result.cargoFmt, false);
-    assert.equal(result.rustChecks, false);
-    assert.equal(result.testWasm, false);
-    assert.equal(result.nodeTest, false);
-    assert.equal(result.fullCargoTestMatrix, false);
+  assert.equal(result.cargoDeny, true);
+  assert.equal(result.cargoFmt, false);
+  assert.equal(result.rustChecks, false);
+  assert.equal(result.testWasm, false);
+  assert.equal(result.nodeTest, false);
+  assert.equal(result.fullCargoTestMatrix, false);
 });
 
-test('a Rust change uses cargo-mono reverse dependents for related jobs', () => {
-    const result = classifyChanges({
-        files: ['crates/swc_ecma_parser/src/lib.rs'],
-        packages: [
-            'swc_ecma_parser',
-            'binding_core_node',
-            'binding_core_wasm',
-        ],
-    });
+test("a Rust change uses cargo-mono reverse dependents for related jobs", () => {
+  const result = classifyChanges({
+    files: ["crates/swc_ecma_parser/src/lib.rs"],
+    packages: ["swc_ecma_parser", "binding_core_node", "binding_core_wasm"],
+  });
 
-    assert.equal(result.cargoFmt, true);
-    assert.equal(result.rustChecks, true);
-    assert.equal(result.cargoDeny, false);
-    assert.deepEqual(result.wasmPackages, ['binding_core_wasm']);
-    assert.equal(result.nodeTest, true);
-    assert.equal(result.reactCompilerTest, false);
+  assert.equal(result.cargoFmt, true);
+  assert.equal(result.rustChecks, true);
+  assert.equal(result.cargoDeny, false);
+  assert.deepEqual(result.wasmPackages, ["binding_core_wasm"]);
+  assert.equal(result.nodeTest, true);
+  assert.equal(result.reactCompilerTest, false);
 });
 
-test('helper sources only run helper codegen', () => {
-    const result = classifyChanges({
-        files: ['packages/helpers/esm/_define_property.js'],
-    });
+test("helper sources only run helper codegen", () => {
+  const result = classifyChanges({
+    files: ["packages/helpers/esm/_define_property.js"],
+  });
 
-    assert.equal(result.helperCodegen, true);
-    assert.equal(result.cargoFmt, false);
-    assert.equal(result.rustChecks, false);
-    assert.equal(result.nodeTest, false);
+  assert.equal(result.helperCodegen, true);
+  assert.equal(result.cargoFmt, false);
+  assert.equal(result.rustChecks, false);
+  assert.equal(result.nodeTest, false);
 });
 
-test('an individual wasm binding produces a focused matrix', () => {
-    const result = classifyChanges({
-        files: ['bindings/binding_typescript_wasm/src/lib.rs'],
-        packages: ['binding_typescript_wasm'],
-    });
+test("an individual wasm binding produces a focused matrix", () => {
+  const result = classifyChanges({
+    files: ["bindings/binding_typescript_wasm/src/lib.rs"],
+    packages: ["binding_typescript_wasm"],
+  });
 
-    assert.deepEqual(result.wasmPackages, ['binding_typescript_wasm']);
-    assert.equal(result.testWasm, true);
-    assert.equal(result.nodeTest, false);
+  assert.deepEqual(result.wasmPackages, ["binding_typescript_wasm"]);
+  assert.equal(result.testWasm, true);
+  assert.equal(result.nodeTest, false);
 });
 
-test('node and react compiler packages select their own binding jobs', () => {
-    const nodeResult = classifyChanges({
-        files: ['packages/core/index.ts'],
-    });
-    const reactResult = classifyChanges({
-        files: ['packages/react-compiler/index.ts'],
-    });
+test("node and react compiler packages select their own binding jobs", () => {
+  const nodeResult = classifyChanges({
+    files: ["packages/core/index.ts"],
+  });
+  const reactResult = classifyChanges({
+    files: ["packages/react-compiler/index.ts"],
+  });
 
-    assert.equal(nodeResult.nodeTest, true);
-    assert.equal(nodeResult.integrationTest, true);
-    assert.equal(nodeResult.reactCompilerTest, false);
-    assert.equal(reactResult.reactCompilerTest, true);
-    assert.equal(reactResult.nodeTest, false);
+  assert.equal(nodeResult.nodeTest, true);
+  assert.equal(nodeResult.integrationTest, true);
+  assert.equal(nodeResult.reactCompilerTest, false);
+  assert.equal(reactResult.reactCompilerTest, true);
+  assert.equal(reactResult.nodeTest, false);
 });
 
-test('shared pnpm configuration runs all JavaScript and binding tests', () => {
-    const result = classifyChanges({ files: ['pnpm-lock.yaml'] });
+test("shared pnpm configuration runs all JavaScript and binding tests", () => {
+  const result = classifyChanges({ files: ["pnpm-lock.yaml"] });
 
-    assert.equal(result.testWasm, true);
-    assert.equal(result.nodeTest, true);
-    assert.equal(result.reactCompilerTest, true);
-    assert.equal(result.integrationTest, true);
-    assert.equal(result.fullCargoTestMatrix, true);
-    assert.equal(result.cargoDeny, false);
+  assert.equal(result.testWasm, true);
+  assert.equal(result.nodeTest, true);
+  assert.equal(result.reactCompilerTest, true);
+  assert.equal(result.integrationTest, true);
+  assert.equal(result.fullCargoTestMatrix, true);
+  assert.equal(result.cargoDeny, false);
 });
 
-test('documentation-only changes do not select expensive jobs', () => {
-    const result = classifyChanges({ files: ['docs/usage.md'] });
+test("documentation-only changes do not select expensive jobs", () => {
+  const result = classifyChanges({ files: ["docs/usage.md"] });
 
-    assert.deepEqual(result.affectedPackages, []);
-    assert.equal(result.cargoFmt, false);
-    assert.equal(result.rustChecks, false);
-    assert.equal(result.helperCodegen, false);
-    assert.equal(result.cargoDeny, false);
-    assert.equal(result.testWasm, false);
-    assert.equal(result.nodeTest, false);
-    assert.equal(result.reactCompilerTest, false);
-    assert.equal(result.integrationTest, false);
-    assert.equal(result.fullCargoTestMatrix, false);
+  assert.deepEqual(result.affectedPackages, []);
+  assert.equal(result.cargoFmt, false);
+  assert.equal(result.rustChecks, false);
+  assert.equal(result.helperCodegen, false);
+  assert.equal(result.cargoDeny, false);
+  assert.equal(result.testWasm, false);
+  assert.equal(result.nodeTest, false);
+  assert.equal(result.reactCompilerTest, false);
+  assert.equal(result.integrationTest, false);
+  assert.equal(result.fullCargoTestMatrix, false);
 });
 
-test('CI detection infrastructure changes force a complete run', () => {
-    const result = classifyChanges({ files: ['.github/workflows/CI.yml'] });
+test("CI detection infrastructure changes force a complete run", () => {
+  const result = classifyChanges({ files: [".github/workflows/CI.yml"] });
 
-    assert.equal(result.forceAll, true);
-    assert.equal(result.cargoFmt, true);
-    assert.equal(result.rustChecks, true);
-    assert.equal(result.helperCodegen, true);
-    assert.equal(result.cargoDeny, true);
-    assert.equal(result.testWasm, true);
-    assert.equal(result.nodeTest, true);
-    assert.equal(result.reactCompilerTest, true);
-    assert.equal(result.integrationTest, true);
-    assert.equal(result.fullCargoTestMatrix, true);
+  assert.equal(result.forceAll, true);
+  assert.equal(result.cargoFmt, true);
+  assert.equal(result.rustChecks, true);
+  assert.equal(result.helperCodegen, true);
+  assert.equal(result.cargoDeny, true);
+  assert.equal(result.testWasm, true);
+  assert.equal(result.nodeTest, true);
+  assert.equal(result.reactCompilerTest, true);
+  assert.equal(result.integrationTest, true);
+  assert.equal(result.fullCargoTestMatrix, true);
 });
 
-test('detection failures force a complete run', () => {
-    const result = classifyChanges({ forceAll: true });
+test("detection failures force a complete run", () => {
+  const result = classifyChanges({ forceAll: true });
 
-    assert.equal(result.forceAll, true);
-    assert.equal(result.fullCargoTestMatrix, true);
-    assert.equal(result.cargoDeny, true);
+  assert.equal(result.forceAll, true);
+  assert.equal(result.fullCargoTestMatrix, true);
+  assert.equal(result.cargoDeny, true);
 });
 
-test('only pushes to main force a complete event run', () => {
-    assert.equal(isMainPush('push', 'refs/heads/main'), true);
-    assert.equal(isMainPush('pull_request', 'refs/pull/1/merge'), false);
-    assert.equal(isMainPush('merge_group', 'refs/heads/gh-readonly-queue/main'), false);
+test("only pushes to main force a complete event run", () => {
+  assert.equal(isMainPush("push", "refs/heads/main"), true);
+  assert.equal(isMainPush("pull_request", "refs/pull/1/merge"), false);
+  assert.equal(
+    isMainPush("merge_group", "refs/heads/gh-readonly-queue/main"),
+    false
+  );
 });

--- a/scripts/github/change-detection.test.mjs
+++ b/scripts/github/change-detection.test.mjs
@@ -87,6 +87,39 @@ test("node and react compiler packages select their own binding jobs", () => {
   assert.equal(reactResult.nodeTest, false);
 });
 
+test("shared types changes run all pnpm workspace dependents", () => {
+  const result = classifyChanges({
+    files: ["packages/types/index.ts"],
+  });
+
+  assert.equal(result.nodeTest, true);
+  assert.equal(result.reactCompilerTest, true);
+  assert.equal(result.integrationTest, true);
+  assert.equal(result.testWasm, false);
+});
+
+test("Cargo configuration changes run all Rust and binding checks", () => {
+  const result = classifyChanges({ files: [".cargo/config.toml"] });
+
+  assert.equal(result.rustChecks, true);
+  assert.equal(result.testWasm, true);
+  assert.equal(result.nodeTest, true);
+  assert.equal(result.reactCompilerTest, true);
+  assert.equal(result.integrationTest, true);
+  assert.equal(result.fullCargoTestMatrix, true);
+});
+
+test("submodule configuration changes run submodule consumers", () => {
+  const result = classifyChanges({ files: [".gitmodules"] });
+
+  assert.equal(result.rustChecks, true);
+  assert.equal(result.testWasm, true);
+  assert.equal(result.nodeTest, true);
+  assert.equal(result.reactCompilerTest, true);
+  assert.equal(result.integrationTest, true);
+  assert.equal(result.fullCargoTestMatrix, true);
+});
+
 test("shared pnpm configuration runs all JavaScript and binding tests", () => {
   const result = classifyChanges({ files: ["pnpm-lock.yaml"] });
 

--- a/scripts/github/change-detection.test.mjs
+++ b/scripts/github/change-detection.test.mjs
@@ -131,6 +131,17 @@ test("shared pnpm configuration runs all JavaScript and binding tests", () => {
   assert.equal(result.cargoDeny, false);
 });
 
+test("workspace package manifests run pnpm-installing jobs", () => {
+  const result = classifyChanges({ files: ["packages/helpers/package.json"] });
+
+  assert.equal(result.testWasm, true);
+  assert.equal(result.nodeTest, true);
+  assert.equal(result.reactCompilerTest, true);
+  assert.equal(result.integrationTest, true);
+  assert.equal(result.fullCargoTestMatrix, true);
+  assert.equal(result.cargoDeny, false);
+});
+
 test("documentation-only changes do not select expensive jobs", () => {
   const result = classifyChanges({ files: ["docs/usage.md"] });
 

--- a/scripts/github/detect-changes.mjs
+++ b/scripts/github/detect-changes.mjs
@@ -1,70 +1,71 @@
 #!/usr/bin/env node
-import { execFile } from 'node:child_process';
-import { promisify } from 'node:util';
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 
-import { classifyChanges, isMainPush } from './change-detection.mjs';
+import { classifyChanges, isMainPush } from "./change-detection.mjs";
 
 const execFileAsync = promisify(execFile);
-const DEFAULT_BASE_BRANCH = 'main';
+const DEFAULT_BASE_BRANCH = "main";
 
-const eventName = process.env.GITHUB_EVENT_NAME ?? '';
-const gitRef = process.env.GITHUB_REF ?? '';
+const eventName = process.env.GITHUB_EVENT_NAME ?? "";
+const gitRef = process.env.GITHUB_REF ?? "";
 const baseBranch = process.env.GITHUB_BASE_REF || DEFAULT_BASE_BRANCH;
 const changedBaseRef = `origin/${baseBranch}`;
 
 try {
-    if (isMainPush(eventName, gitRef)) {
-        process.stderr.write('Running the complete CI suite for a push to main.\n');
-        printOutputs(classifyChanges({ forceAll: true }));
-    } else {
-        process.stderr.write(
-            `Detecting changes for event=${eventName}, ref=${gitRef}, base=${changedBaseRef}.\n`,
-        );
-        const { stdout } = await execFileAsync(
-            'cargo',
-            ['mono', '--output', 'json', 'changed', '--base', changedBaseRef],
-            { maxBuffer: 10 * 1024 * 1024 },
-        );
-        const changed = JSON.parse(stdout);
-        const outputs = classifyChanges({
-            files: changed.files ?? [],
-            packages: changed.packages ?? [],
-        });
-
-        process.stderr.write(
-            `Detected ${changed.files?.length ?? 0} changed files and ${outputs.affectedPackages.length} affected packages.\n`,
-        );
-        printOutputs(outputs);
-    }
-} catch (error) {
-    process.stderr.write(
-        `Failed to detect changes; running the complete CI suite: ${error}\n`,
-    );
+  if (isMainPush(eventName, gitRef)) {
+    process.stderr.write("Running the complete CI suite for a push to main.\n");
     printOutputs(classifyChanges({ forceAll: true }));
+  } else {
+    process.stderr.write(
+      `Detecting changes for event=${eventName}, ref=${gitRef}, base=${changedBaseRef}.\n`
+    );
+    const { stdout } = await execFileAsync(
+      "cargo",
+      ["mono", "--output", "json", "changed", "--base", changedBaseRef],
+      { maxBuffer: 10 * 1024 * 1024 }
+    );
+    const changed = JSON.parse(stdout);
+    const outputs = classifyChanges({
+      files: changed.files ?? [],
+      packages: changed.packages ?? [],
+    });
+
+    process.stderr.write(
+      `Detected ${changed.files?.length ?? 0} changed files and ${
+        outputs.affectedPackages.length
+      } affected packages.\n`
+    );
+    printOutputs(outputs);
+  }
+} catch (error) {
+  process.stderr.write(
+    `Failed to detect changes; running the complete CI suite: ${error}\n`
+  );
+  printOutputs(classifyChanges({ forceAll: true }));
 }
 
 function printOutputs(outputs) {
-    const values = {
-        force_all: outputs.forceAll,
-        affected_packages: outputs.affectedPackages,
-        cargo_fmt: outputs.cargoFmt,
-        rust_checks: outputs.rustChecks,
-        helper_codegen: outputs.helperCodegen,
-        cargo_deny: outputs.cargoDeny,
-        test_wasm: outputs.testWasm,
-        wasm_packages: outputs.wasmPackages,
-        node_test: outputs.nodeTest,
-        react_compiler_test: outputs.reactCompilerTest,
-        integration_test: outputs.integrationTest,
-        full_cargo_test_matrix: outputs.fullCargoTestMatrix,
-    };
+  const values = {
+    force_all: outputs.forceAll,
+    affected_packages: outputs.affectedPackages,
+    cargo_fmt: outputs.cargoFmt,
+    rust_checks: outputs.rustChecks,
+    helper_codegen: outputs.helperCodegen,
+    cargo_deny: outputs.cargoDeny,
+    test_wasm: outputs.testWasm,
+    wasm_packages: outputs.wasmPackages,
+    node_test: outputs.nodeTest,
+    react_compiler_test: outputs.reactCompilerTest,
+    integration_test: outputs.integrationTest,
+    full_cargo_test_matrix: outputs.fullCargoTestMatrix,
+  };
 
-    for (const [name, value] of Object.entries(values)) {
-        console.log(`${name}=${formatOutput(value)}`);
-    }
+  for (const [name, value] of Object.entries(values)) {
+    console.log(`${name}=${formatOutput(value)}`);
+  }
 }
 
 function formatOutput(value) {
-    return Array.isArray(value) ? JSON.stringify(value) : String(value);
+  return Array.isArray(value) ? JSON.stringify(value) : String(value);
 }
-

--- a/scripts/github/detect-changes.mjs
+++ b/scripts/github/detect-changes.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { classifyChanges, isMainPush } from './change-detection.mjs';
+
+const execFileAsync = promisify(execFile);
+const DEFAULT_BASE_BRANCH = 'main';
+
+const eventName = process.env.GITHUB_EVENT_NAME ?? '';
+const gitRef = process.env.GITHUB_REF ?? '';
+const baseBranch = process.env.GITHUB_BASE_REF || DEFAULT_BASE_BRANCH;
+const changedBaseRef = `origin/${baseBranch}`;
+
+try {
+    if (isMainPush(eventName, gitRef)) {
+        process.stderr.write('Running the complete CI suite for a push to main.\n');
+        printOutputs(classifyChanges({ forceAll: true }));
+    } else {
+        process.stderr.write(
+            `Detecting changes for event=${eventName}, ref=${gitRef}, base=${changedBaseRef}.\n`,
+        );
+        const { stdout } = await execFileAsync(
+            'cargo',
+            ['mono', '--output', 'json', 'changed', '--base', changedBaseRef],
+            { maxBuffer: 10 * 1024 * 1024 },
+        );
+        const changed = JSON.parse(stdout);
+        const outputs = classifyChanges({
+            files: changed.files ?? [],
+            packages: changed.packages ?? [],
+        });
+
+        process.stderr.write(
+            `Detected ${changed.files?.length ?? 0} changed files and ${outputs.affectedPackages.length} affected packages.\n`,
+        );
+        printOutputs(outputs);
+    }
+} catch (error) {
+    process.stderr.write(
+        `Failed to detect changes; running the complete CI suite: ${error}\n`,
+    );
+    printOutputs(classifyChanges({ forceAll: true }));
+}
+
+function printOutputs(outputs) {
+    const values = {
+        force_all: outputs.forceAll,
+        affected_packages: outputs.affectedPackages,
+        cargo_fmt: outputs.cargoFmt,
+        rust_checks: outputs.rustChecks,
+        helper_codegen: outputs.helperCodegen,
+        cargo_deny: outputs.cargoDeny,
+        test_wasm: outputs.testWasm,
+        wasm_packages: outputs.wasmPackages,
+        node_test: outputs.nodeTest,
+        react_compiler_test: outputs.reactCompilerTest,
+        integration_test: outputs.integrationTest,
+        full_cargo_test_matrix: outputs.fullCargoTestMatrix,
+    };
+
+    for (const [name, value] of Object.entries(values)) {
+        console.log(`${name}=${formatOutput(value)}`);
+    }
+}
+
+function formatOutput(value) {
+    return Array.isArray(value) ? JSON.stringify(value) : String(value);
+}
+

--- a/scripts/github/get-test-matrix.mjs
+++ b/scripts/github/get-test-matrix.mjs
@@ -1,124 +1,92 @@
 #!/usr/bin/env zx
-import * as path from 'node:path';
-import * as fs from 'node:fs/promises';
-import { parse } from 'yaml';
+import * as path from "node:path";
+import * as fs from "node:fs/promises";
+import { parse } from "yaml";
 
-const NOOP_CRATE = '__noop__';
-const DEFAULT_BASE_BRANCH = 'main';
-const INFRA_PATH_PREFIXES = ['.github/', 'scripts/github/', 'scripts/cargo/', '.cargo/'];
-const INFRA_PATH_EXACT = new Set(['tests.yml']);
+const NOOP_CRATE = "__noop__";
 
 const scriptDir = __dirname;
-const repoRootDir = path.resolve(scriptDir, '../../');
-const testsYmlPath = path.resolve(repoRootDir, 'tests.yml');
-const testsYml = parse(await fs.readFile(testsYmlPath, 'utf8'));
+const repoRootDir = path.resolve(scriptDir, "../../");
+const testsYmlPath = path.resolve(repoRootDir, "tests.yml");
+const testsYml = parse(await fs.readFile(testsYmlPath, "utf8"));
+const affectedPackages = parseAffectedPackages(
+  process.env.AFFECTED_PACKAGES ?? "[]"
+);
+const fullCargoTestMatrix = process.env.FULL_CARGO_TEST_MATRIX === "true";
 
 process.stderr.write(`Script dir: ${scriptDir}\n`);
 process.stderr.write(`Using tests.yml at ${testsYmlPath}\n`);
-
-const eventName = process.env.GITHUB_EVENT_NAME ?? '';
-const gitRef = process.env.GITHUB_REF ?? '';
-const baseBranch = process.env.GITHUB_BASE_REF ?? DEFAULT_BASE_BRANCH;
-const changedBaseRef = `origin/${baseBranch}`;
-
-process.stderr.write(`Event: ${eventName}, ref: ${gitRef}, base: ${changedBaseRef}\n`);
+process.stderr.write(
+  `Affected packages: ${affectedPackages.length}, full matrix: ${fullCargoTestMatrix}\n`
+);
 
 const allPackages = await getAllWorkspacePackageNames();
 const allPackageSet = new Set(allPackages);
 const allSettings = toMatrixSettings(allPackages, testsYml);
 
-if (eventName === 'push' && gitRef === 'refs/heads/main') {
-    process.stderr.write('Running full matrix for push to main.\n');
-    printSettings(allSettings);
-    process.exit(0);
+if (fullCargoTestMatrix) {
+  process.stderr.write("Running the complete cargo-test matrix.\n");
+  printSettings(allSettings);
+  process.exit(0);
 }
 
-try {
-    const changedResult = await getChangedPackages(changedBaseRef);
-    const changedSet = new Set(
-        changedResult.packages.filter((name) => allPackageSet.has(name)),
-    );
-    const selectedPackages = allPackages.filter((name) => changedSet.has(name));
+const affectedPackageSet = new Set(
+  affectedPackages.filter((name) => allPackageSet.has(name))
+);
+const selectedPackages = allPackages.filter((name) =>
+  affectedPackageSet.has(name)
+);
 
-    process.stderr.write(
-        `Changed packages resolved: ${selectedPackages.length}, changed files: ${changedResult.files.length}\n`,
-    );
+if (selectedPackages.length > 0) {
+  printSettings(toMatrixSettings(selectedPackages, testsYml));
+  process.exit(0);
+}
 
-    if (selectedPackages.length > 0) {
-        printSettings(toMatrixSettings(selectedPackages, testsYml));
-        process.exit(0);
-    }
+process.stderr.write("No affected crates; returning noop matrix entry.\n");
+printSettings([{ crate: NOOP_CRATE, os: "ubuntu-latest" }]);
 
-    if (hasInfrastructureChanges(changedResult.files)) {
-        process.stderr.write(
-            'No crate changes but infrastructure paths changed; falling back to full matrix.\n',
-        );
-        printSettings(allSettings);
-        process.exit(0);
-    }
+function parseAffectedPackages(rawValue) {
+  const parsed = JSON.parse(rawValue);
+  if (
+    !Array.isArray(parsed) ||
+    parsed.some((name) => typeof name !== "string")
+  ) {
+    throw new TypeError("AFFECTED_PACKAGES must be a JSON array of strings");
+  }
 
-    process.stderr.write('No affected crates; returning noop matrix entry.\n');
-    printSettings([{ crate: NOOP_CRATE, os: 'ubuntu-latest' }]);
-} catch (error) {
-    process.stderr.write(
-        `Failed to resolve changed crates, falling back to full matrix: ${error}\n`,
-    );
-    printSettings(allSettings);
+  return parsed;
 }
 
 async function getAllWorkspacePackageNames() {
-    const rawMetadata = await $`cargo metadata --format-version=1 --all-features --no-deps`;
-    const metadata = JSON.parse(rawMetadata.stdout);
-    return metadata.packages
-        .map((pkg) => pkg.name)
-        .filter((name) => name !== 'xtask')
-        .sort();
+  const rawMetadata =
+    await $`cargo metadata --format-version=1 --all-features --no-deps`;
+  const metadata = JSON.parse(rawMetadata.stdout);
+  return metadata.packages
+    .map((pkg) => pkg.name)
+    .filter((name) => name !== "xtask")
+    .sort();
 }
 
 function toMatrixSettings(packages, config) {
-    const windowsPackages = new Set(config.os?.windows ?? []);
-    const macosPackages = new Set(config.os?.macos ?? []);
-    const settings = [];
+  const windowsPackages = new Set(config.os?.windows ?? []);
+  const macosPackages = new Set(config.os?.macos ?? []);
+  const settings = [];
 
-    for (const pkg of packages) {
-        settings.push({ crate: pkg, os: 'ubuntu-latest' });
+  for (const pkg of packages) {
+    settings.push({ crate: pkg, os: "ubuntu-latest" });
 
-        if (windowsPackages.has(pkg)) {
-            settings.push({ crate: pkg, os: 'windows-latest' });
-        }
-
-        if (macosPackages.has(pkg)) {
-            settings.push({ crate: pkg, os: 'macos-latest' });
-        }
+    if (windowsPackages.has(pkg)) {
+      settings.push({ crate: pkg, os: "windows-latest" });
     }
 
-    return settings;
-}
+    if (macosPackages.has(pkg)) {
+      settings.push({ crate: pkg, os: "macos-latest" });
+    }
+  }
 
-async function getChangedPackages(baseRef) {
-    const changedOutput = await $`cargo mono --output json changed --base ${baseRef}`;
-    const changedResult = JSON.parse(changedOutput.stdout);
-    return {
-        files: changedResult.files ?? [],
-        packages: changedResult.packages ?? [],
-    };
-}
-
-function hasInfrastructureChanges(files) {
-    return files.some((rawPath) => {
-        const normalizedPath = normalizePath(rawPath);
-        if (INFRA_PATH_EXACT.has(normalizedPath)) {
-            return true;
-        }
-
-        return INFRA_PATH_PREFIXES.some((prefix) => normalizedPath.startsWith(prefix));
-    });
-}
-
-function normalizePath(filePath) {
-    return filePath.replaceAll('\\', '/').replace(/^\.\//, '');
+  return settings;
 }
 
 function printSettings(settings) {
-    console.log(JSON.stringify(settings));
+  console.log(JSON.stringify(settings));
 }


### PR DESCRIPTION
**Description:**

Use `cargo mono changed` as the shared source of truth for CI job selection. This prevents unrelated dependency advisories from blocking PRs that do not modify the root `Cargo.lock`, while preserving complete runs on pushes to `main`, CI infrastructure changes, and change-detection failures.

- run `cargo-deny` only for root `Cargo.lock` or `deny.toml` changes
- gate Rust, helper, Node, React Compiler, and integration jobs on affected inputs
- restrict the wasm matrix to affected bindings
- reuse detected packages when building the cargo-test matrix
- allow intentional skips in the required `Done` check while preserving failures and cancellations
- add focused Node tests for change classification and fallback behavior

**Validation:**

- `node --test scripts/github/change-detection.test.mjs`
- selective, noop, full-matrix, and detection-failure simulations
- `actionlint -color -shellcheck= .github/workflows/CI.yml`
- `pnpm exec prettier --check ...`
- `cargo fmt --all`
- `cargo clippy --all --all-targets -- -D warnings`
- `cargo deny check`