### PR TITLE
fix(es/parser): Preserve await grammar boundaries

### DIFF
--- a/.changeset/preserve-await-grammar-boundaries.md
+++ b/.changeset/preserve-await-grammar-boundaries.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+fix(es/parser): Preserve await grammar boundaries in unambiguous parsing

--- a/crates/swc_ecma_parser/src/parser/expr.rs
+++ b/crates/swc_ecma_parser/src/parser/expr.rs
@@ -392,11 +392,11 @@ impl<I: Tokens> Parser<I> {
                 }
                 .into());
             } else if cur == Token::Await {
-                let parses_await = self
-                    .ctx()
-                    .intersects(Context::InAsync.union(Context::Module))
-                    || self.can_classify_module()
-                    || !self.can_continue_await_as_script_identifier();
+                let parses_await = self.ctx().intersects(
+                    Context::InAsync
+                        .union(Context::Module)
+                        .union(Context::InStaticBlock),
+                ) || self.is_unambiguous_module();
 
                 if parses_await {
                     return self.parse_await_expr(None);
@@ -2342,8 +2342,8 @@ impl<I: Tokens> Parser<I> {
                 )
             })
         {
-            if ctx.contains(Context::Module) {
-                self.emit_err(span, SyntaxError::InvalidIdentInAsync);
+            if ctx.intersects(Context::Module.union(Context::CanBeModule)) {
+                self.emit_module_mode_err(span, SyntaxError::InvalidIdentInAsync);
             }
 
             return Ok(Ident::new_no_ctxt(atom!("await"), span).into());
@@ -2351,14 +2351,6 @@ impl<I: Tokens> Parser<I> {
 
         let ambiguous_script_different_ast =
             self.can_classify_module() && self.is_ambiguous_await_prefix();
-
-        if start_of_await_token.is_none() && self.can_classify_module() {
-            if ambiguous_script_different_ast {
-                self.ambiguous_script_different_ast = true;
-            } else {
-                self.mark_found_module_item();
-            }
-        }
 
         if ctx.contains(Context::InFunction) && !ctx.contains(Context::InAsync) {
             self.emit_err(await_token, SyntaxError::AwaitInFunction);
@@ -2369,6 +2361,13 @@ impl<I: Tokens> Parser<I> {
         }
 
         let arg = self.parse_unary_expr()?;
+        if start_of_await_token.is_none() && self.can_classify_module() {
+            if ambiguous_script_different_ast {
+                self.ambiguous_script_different_ast = true;
+            } else {
+                self.mark_found_module_item();
+            }
+        }
         Ok(AwaitExpr {
             span: self.span(start),
             arg,
@@ -2384,82 +2383,29 @@ impl<I: Tokens> Parser<I> {
         }
 
         let cur = self.input().cur();
-        cur.is_bin_op()
-            || cur.is_assign_op()
-            || matches!(
-                cur,
-                Token::Asterisk
-                    | Token::PlusPlus
-                    | Token::MinusMinus
-                    | Token::Dot
-                    | Token::LParen
-                    | Token::LBracket
-                    | Token::Arrow
-                    | Token::QuestionMark
-                    | Token::NoSubstitutionTemplateLiteral
-                    | Token::TemplateHead
-                    | Token::Regex
-                    | Token::Slash
-                    | Token::DivEq
-                    | Token::In
-                    | Token::InstanceOf
-                    | Token::OptionalChain
-            )
-            || (self.input().syntax().typescript()
-                && matches!(cur, Token::As | Token::Satisfies | Token::Bang))
-            || (cur == Token::Of
-                && !self
-                    .input()
-                    .token_flags()
-                    .contains(crate::lexer::TokenFlags::UNICODE))
-    }
-
-    /// Returns whether the next token can continue an `await`
-    /// IdentifierReference under Script grammar.
-    fn can_continue_await_as_script_identifier(&mut self) -> bool {
-        if self.input_mut().has_linebreak_between_cur_and_peeked() {
-            return true;
+        let is_escaped = self
+            .input()
+            .token_flags()
+            .contains(crate::lexer::TokenFlags::UNICODE);
+        match cur {
+            Token::Plus
+            | Token::Minus
+            | Token::LParen
+            | Token::LBracket
+            | Token::NoSubstitutionTemplateLiteral
+            | Token::TemplateHead
+            | Token::Slash
+            | Token::DivEq
+            | Token::Bang
+            | Token::Lt => true,
+            Token::Of | Token::InstanceOf if !is_escaped => true,
+            Token::In if !is_escaped => self.ctx().contains(Context::IncludeInExpr),
+            Token::As | Token::Satisfies if !is_escaped => self.input().syntax().typescript(),
+            Token::Regex => {
+                unreachable!("regular expressions are initially scanned as '/' or '/='")
+            }
+            _ => false,
         }
-
-        let Some(next) = peek!(self) else {
-            return true;
-        };
-
-        next.is_bin_op()
-            || next.is_assign_op()
-            || matches!(
-                next,
-                Token::Asterisk
-                    | Token::PlusPlus
-                    | Token::MinusMinus
-                    | Token::Dot
-                    | Token::LParen
-                    | Token::LBracket
-                    | Token::Arrow
-                    | Token::QuestionMark
-                    | Token::NoSubstitutionTemplateLiteral
-                    | Token::TemplateHead
-                    | Token::Regex
-                    | Token::Slash
-                    | Token::DivEq
-                    | Token::In
-                    | Token::InstanceOf
-                    | Token::OptionalChain
-                    | Token::Semi
-                    | Token::RBrace
-                    | Token::RParen
-                    | Token::RBracket
-                    | Token::Comma
-                    | Token::Colon
-                    | Token::Eof
-            )
-            || (self.input().syntax().typescript()
-                && matches!(next, Token::As | Token::Satisfies | Token::Bang))
-            || (next == Token::Of
-                && !self
-                    .input()
-                    .token_flags()
-                    .contains(crate::lexer::TokenFlags::UNICODE))
     }
 
     pub(crate) fn parse_for_head_prefix(&mut self) -> PResult<Box<Expr>> {
@@ -3221,31 +3167,6 @@ impl<I: Tokens> Parser<I> {
                 !ctx.contains(Context::InGenerator),
                 !ctx.contains(Context::InAsync),
             )?;
-
-            let is_for_of_head = ctx.contains(Context::ForLoopInit)
-                && self.input().is(Token::Of)
-                && !self
-                    .input()
-                    .token_flags()
-                    .contains(crate::lexer::TokenFlags::UNICODE);
-            let continues_script_expression = (self.input().is(Token::In)
-                && ctx.contains(Context::IncludeInExpr))
-                || self.input().is(Token::InstanceOf)
-                || (self.input().syntax().typescript()
-                    && matches!(self.input().cur(), Token::As | Token::Satisfies));
-            if cur == Token::Await
-                && !is_for_of_head
-                && !continues_script_expression
-                && !self.input().had_line_break_before_cur()
-                && self.input().cur().is_word()
-            {
-                let error = if ctx.contains(Context::InFunction) {
-                    SyntaxError::AwaitInFunction
-                } else {
-                    SyntaxError::TopLevelAwaitInScript
-                };
-                self.emit_err(id.span, error);
-            }
 
             if !can_be_arrow {
                 return Ok(id.into());

--- a/crates/swc_ecma_parser/src/parser/mod.rs
+++ b/crates/swc_ecma_parser/src/parser/mod.rs
@@ -96,6 +96,12 @@ enum UnambiguousParseAction {
     RetryAsScript,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ProgramGrammar {
+    Module,
+    Script,
+}
+
 /// EcmaScript parser.
 #[derive(Clone)]
 pub struct Parser<I: self::input::Tokens> {
@@ -408,34 +414,51 @@ impl<I: Tokens> Parser<I> {
         let module_checkpoint = self.program_checkpoint_save();
         self.enter_unambiguous_module_context();
 
-        if let Ok(parsed) = self.parse_program_once() {
-            match self.unambiguous_parse_action(&parsed.body) {
-                UnambiguousParseAction::KeepModule => {
-                    return Ok(self.finish_program(parsed, true));
-                }
-                UnambiguousParseAction::RelabelAsScript => {
-                    return Ok(self.finish_program(parsed, false));
-                }
-                UnambiguousParseAction::RetryAsScript => {}
+        let module_result = self.parse_program_once();
+        let preserve_module_result_on_script_error =
+            module_result.is_err() || self.ambiguous_script_different_ast;
+        let action = match &module_result {
+            Ok(parsed) => self.unambiguous_parse_action(&parsed.body),
+            Err(_) => UnambiguousParseAction::RetryAsScript,
+        };
+
+        match action {
+            UnambiguousParseAction::KeepModule => {
+                let Ok(parsed) = module_result else {
+                    unreachable!("a failed Module probe always retries as Script")
+                };
+                return Ok(self.finish_program(parsed, ProgramGrammar::Module));
+            }
+            UnambiguousParseAction::RelabelAsScript => {
+                let Ok(parsed) = module_result else {
+                    unreachable!("a failed Module probe always retries as Script")
+                };
+                return Ok(self.finish_program(parsed, ProgramGrammar::Script));
+            }
+            UnambiguousParseAction::RetryAsScript => {}
+        }
+
+        // Keep the first Module result and its diagnostics intact while probing
+        // Script. If both probes report errors, preserve Module only for a fatal
+        // Module failure or a known grammar ambiguity; otherwise the absence of
+        // module syntax still classifies the recoverable program as Script.
+        let mut script_parser = self.clone();
+        script_parser.program_checkpoint_load(module_checkpoint);
+        script_parser.enter_unambiguous_script_context();
+
+        if let Ok(parsed) = script_parser.parse_program_once() {
+            let script_has_errors = script_parser.input.iter.has_errors();
+            let has_module_syntax = script_parser.has_module_syntax(&parsed.body);
+            let can_commit_script = !has_module_syntax
+                && (!script_has_errors || !preserve_module_result_on_script_error);
+            if can_commit_script {
+                let program = script_parser.finish_program(parsed, ProgramGrammar::Script);
+                *self = script_parser;
+                return Ok(program);
             }
         }
 
-        self.program_checkpoint_load(module_checkpoint);
-        let retry_checkpoint = self.program_checkpoint_save();
-        self.enter_unambiguous_script_context();
-
-        if let Ok(parsed) = self.parse_program_once() {
-            let is_valid_script = !self.input.iter.has_errors();
-            let has_module_syntax = self.has_module_syntax(&parsed.body);
-            if is_valid_script && !has_module_syntax {
-                return Ok(self.finish_program(parsed, false));
-            }
-        }
-
-        self.program_checkpoint_load(retry_checkpoint);
-        self.enter_unambiguous_module_context();
-        let parsed = self.parse_program_once()?;
-        Ok(self.finish_program(parsed, true))
+        module_result.map(|parsed| self.finish_program(parsed, ProgramGrammar::Module))
     }
 
     fn parse_program_once(&mut self) -> PResult<ParsedProgram> {
@@ -451,46 +474,63 @@ impl<I: Tokens> Parser<I> {
         })
     }
 
-    fn finish_program(&mut self, parsed: ParsedProgram, is_module: bool) -> Program {
+    fn finish_program(&mut self, parsed: ParsedProgram, grammar: ProgramGrammar) -> Program {
         let ParsedProgram {
             start,
             shebang,
             body,
         } = parsed;
 
-        let ret = if is_module {
-            let ctx = self.ctx()
-                | Context::Module
-                | Context::CanBeModule
-                | Context::TopLevel
-                | Context::Strict;
-            // Emit buffered strict mode / module code violations.
-            self.input.set_ctx(ctx);
-            if self.syntax().flow() {
-                self.report_duplicate_exports(&body);
-            }
-            Program::Module(Module {
-                span: self.span(start),
-                body,
-                shebang,
-            })
-        } else {
-            let ctx = self.ctx() & !Context::Module & !Context::CanBeModule & !Context::InAsync;
-            self.input.set_ctx(ctx | Context::TopLevel);
-            let body = body
-                .into_iter()
-                .map(|item| match item {
-                    ModuleItem::ModuleDecl(_) => unreachable!("Module is handled above"),
-                    ModuleItem::Stmt(stmt) => stmt,
-                    #[cfg(swc_ast_unknown)]
-                    _ => unreachable!(),
+        let ret = match grammar {
+            ProgramGrammar::Module => {
+                let ctx = self.ctx()
+                    | Context::Module
+                    | Context::CanBeModule
+                    | Context::TopLevel
+                    | Context::Strict;
+                // Emit buffered strict mode / module code violations.
+                self.input.set_ctx(ctx);
+                if self.syntax().flow() {
+                    self.report_duplicate_exports(&body);
+                }
+                Program::Module(Module {
+                    span: self.span(start),
+                    body,
+                    shebang,
                 })
-                .collect();
-            Program::Script(Script {
-                span: self.span(start),
-                body,
-                shebang,
-            })
+            }
+            ProgramGrammar::Script => {
+                let ctx = self.ctx() & !Context::Module & !Context::CanBeModule & !Context::InAsync;
+                self.input.set_ctx(ctx | Context::TopLevel);
+
+                let requires_module_ast = body
+                    .iter()
+                    .any(|item| matches!(item, ModuleItem::ModuleDecl(..)));
+                if requires_module_ast {
+                    // TypeScript internal import aliases use Script grammar, but the AST can
+                    // only represent them as module declarations.
+                    Program::Module(Module {
+                        span: self.span(start),
+                        body,
+                        shebang,
+                    })
+                } else {
+                    let body = body
+                        .into_iter()
+                        .map(|item| match item {
+                            ModuleItem::ModuleDecl(_) => unreachable!("handled above"),
+                            ModuleItem::Stmt(stmt) => stmt,
+                            #[cfg(swc_ast_unknown)]
+                            _ => unreachable!(),
+                        })
+                        .collect();
+                    Program::Script(Script {
+                        span: self.span(start),
+                        body,
+                        shebang,
+                    })
+                }
+            }
         };
 
         debug_assert!(self.input().cur() == Token::Eof);
@@ -517,7 +557,7 @@ impl<I: Tokens> Parser<I> {
     fn unambiguous_parse_action(&self, body: &[ModuleItem]) -> UnambiguousParseAction {
         if self.has_module_syntax(body) {
             UnambiguousParseAction::KeepModule
-        } else if self.ambiguous_script_different_ast {
+        } else if self.input.iter.has_errors() || self.ambiguous_script_different_ast {
             UnambiguousParseAction::RetryAsScript
         } else {
             UnambiguousParseAction::RelabelAsScript
@@ -526,17 +566,23 @@ impl<I: Tokens> Parser<I> {
 
     fn has_module_syntax(&self, body: &[ModuleItem]) -> bool {
         self.found_module_item
-            || body
-                .iter()
-                .any(|item| matches!(item, ModuleItem::ModuleDecl(..)))
+            || body.iter().any(|item| {
+                let ModuleItem::ModuleDecl(module_decl) = item else {
+                    return false;
+                };
+
+                match module_decl {
+                    ModuleDecl::TsImportEquals(import) => {
+                        import.is_export
+                            || matches!(&import.module_ref, TsModuleRef::TsExternalModuleRef(..))
+                    }
+                    _ => true,
+                }
+            })
     }
 
     fn is_unambiguous_module(&self) -> bool {
         self.program_parse_mode == ProgramParseMode::Module
-    }
-
-    fn is_unambiguous_script(&self) -> bool {
-        self.program_parse_mode == ProgramParseMode::Script
     }
 
     fn can_classify_module(&self) -> bool {

--- a/crates/swc_ecma_parser/src/parser/module_item.rs
+++ b/crates/swc_ecma_parser/src/parser/module_item.rs
@@ -864,6 +864,14 @@ impl<I: Tokens> Parser<I> {
         .into())
     }
 
+    #[inline]
+    fn enter_import_module_context(&mut self) {
+        if !self.ctx().contains(Context::Module) {
+            let ctx = self.ctx() | Context::Module | Context::Strict;
+            self.set_ctx(ctx);
+        }
+    }
+
     pub(crate) fn parse_import(&mut self) -> PResult<ModuleItem> {
         let start = self.cur_pos();
 
@@ -891,18 +899,11 @@ impl<I: Tokens> Parser<I> {
             .into());
         }
 
-        // It's now import statement
-
-        if !self.ctx().contains(Context::Module) {
-            // Switch to module mode
-            let ctx = self.ctx() | Context::Module | Context::Strict;
-            self.set_ctx(ctx);
-        }
-
         expect!(self, Token::Import);
 
         // Handle import 'mod.js'
         if self.input().cur() == Token::Str {
+            self.enter_import_module_context();
             let src = Box::new(self.parse_str_lit());
             let with = if self.input().syntax().import_attributes()
                 && !self.input().had_line_break_before_cur()
@@ -986,10 +987,11 @@ impl<I: Tokens> Parser<I> {
                 }
 
                 if self.input().syntax().typescript() && self.input().is(Token::Eq) {
-                    return self
-                        .parse_ts_import_equals_decl(start, local, false, type_only)
-                        .map(ModuleDecl::from)
-                        .map(ModuleItem::from);
+                    let decl = self.parse_ts_import_equals_decl(start, local, false, type_only)?;
+                    if matches!(&decl.module_ref, TsModuleRef::TsExternalModuleRef(..)) {
+                        self.enter_import_module_context();
+                    }
+                    return Ok(ModuleDecl::TsImportEquals(decl).into());
                 }
 
                 if matches!(&*local.sym, "source" | "defer") {
@@ -1028,6 +1030,8 @@ impl<I: Tokens> Parser<I> {
                 }));
             }
         }
+
+        self.enter_import_module_context();
 
         {
             let import_spec_start = self.cur_pos();

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -1915,17 +1915,33 @@ impl<I: Tokens> Parser<I> {
         }
 
         if cur == Token::Await && (include_decl || top_level) {
-            if top_level && !self.is_unambiguous_module() && !self.is_unambiguous_script() {
+            let handled_by_explicit_program =
+                top_level && self.program_parse_mode == ProgramParseMode::None;
+            if handled_by_explicit_program {
                 self.mark_found_module_item();
                 if !self.ctx().contains(Context::CanBeModule) {
                     self.emit_err(self.input().cur_span(), SyntaxError::TopLevelAwaitInScript);
                 }
             }
 
-            if peek!(self).is_some_and(|peek| peek == Token::Using) {
+            let is_await_using = peek!(self).is_some_and(|peek| peek == Token::Using)
+                && !self.input_mut().has_linebreak_between_cur_and_peeked();
+
+            if is_await_using {
                 let eaten_await = Some(self.input().cur_pos());
                 if self.can_classify_module() {
                     self.mark_found_module_item();
+                } else if !self
+                    .ctx()
+                    .intersects(Context::InAsync.union(Context::Module))
+                    && !handled_by_explicit_program
+                {
+                    let error = if self.ctx().contains(Context::InFunction) {
+                        SyntaxError::AwaitInFunction
+                    } else {
+                        SyntaxError::TopLevelAwaitInScript
+                    };
+                    self.emit_err(self.input().cur_span(), error);
                 }
                 self.assert_and_bump(Token::Await);
                 let v = self.parse_using_decl(start, true)?;
@@ -2924,7 +2940,7 @@ export default function waitUntil(callback, options = {}) {
     }
 
     #[test]
-    #[should_panic(expected = "top level await is only allowed in module")]
+    #[should_panic(expected = "Expected ';', '}' or <eof>")]
     fn top_level_await_in_script() {
         let src = "await promise";
         test_parser(src, Syntax::Es(Default::default()), |p| p.parse_script());
@@ -2956,7 +2972,7 @@ export default function waitUntil(callback, options = {}) {
     }
 
     #[test]
-    #[should_panic(expected = "await isn't allowed in non-async function")]
+    #[should_panic(expected = "Expected ';', '}' or <eof>")]
     fn await_in_function_in_script() {
         let src = "function foo (p) { await p; }";
         test_parser(src, Syntax::Es(Default::default()), |p| p.parse_script());

--- a/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
+++ b/crates/swc_ecma_transforms_typescript/tests/strip_correctness.rs
@@ -150,17 +150,9 @@ fn identity(entry: PathBuf) {
             None,
         );
 
-        // It's very unscientific.
-        // TODO: Change this with visitor
-        if js_content.contains("import") || js_content.contains("export") {
-            parser
-                .parse_module()
-                .unwrap_or_else(|err| panic!("{js_content} is invalid module\n{err:?}"));
-        } else {
-            parser
-                .parse_script()
-                .unwrap_or_else(|err| panic!("{js_content} is invalid script\n{err:?}"));
-        }
+        parser
+            .parse_program()
+            .unwrap_or_else(|err| panic!("{js_content} is invalid program\n{err:?}"));
 
         Ok(())
     })


### PR DESCRIPTION
**Description:**

Follow-up to #12142. Compared with `main`, this PR:

- refines Script/Module retry decisions around ambiguous `await` expressions;
- handles line breaks, escaped contextual keywords, `!`, and `in` correctly;
- fixes `await` handling in class fields, static blocks, and `await using`;
- preserves the original Module result and diagnostics when both parses fail;

Some edge cases were identified during the code review of #12142, including `await!`, static-block `await`, and the line break in `await\nusing`.

**Related issue:**

- #12142