### PR TITLE
fix(es/compat): preserve for-of var binding scope

### DIFF
--- a/.changeset/preserve-for-of-var-scope.md
+++ b/.changeset/preserve-for-of-var-scope.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_transformer: patch
+swc_ecma_transforms_compat: patch
+---
+
+fix(es/compat): preserve for-of object-rest binding scope

--- a/crates/swc_ecma_transformer/src/es2018/object_rest_spread.rs
+++ b/crates/swc_ecma_transformer/src/es2018/object_rest_spread.rs
@@ -519,6 +519,10 @@ impl ObjectRestSpreadPass {
 
         match left {
             ForHead::VarDecl(var_decl) => {
+                // Keep the original declaration kind: `var` bindings are
+                // function-scoped, while `let` and `const` need per-iteration
+                // lexical bindings.
+                let kind = var_decl.kind;
                 let ref_ident = private_ident!("_ref");
                 let pat = var_decl.decls[0].name.take();
                 var_decl.decls[0].name = ref_ident.clone().into();
@@ -527,7 +531,7 @@ impl ObjectRestSpreadPass {
                 lowerer.visit(pat, Box::new(ref_ident.into()));
 
                 let stmt: Stmt = VarDecl {
-                    kind: VarDeclKind::Let,
+                    kind,
                     decls: lowerer.out.into_decls(),
                     ..Default::default()
                 }

--- a/crates/swc_ecma_transforms_compat/tests/__swc_snapshots__/tests/es2018_object_rest_spread.rs/rest_for_x.js
+++ b/crates/swc_ecma_transforms_compat/tests/__swc_snapshots__/tests/es2018_object_rest_spread.rs/rest_for_x.js
@@ -1,7 +1,7 @@
 var _ref;
 // ForXStatement
 for (var _ref1 of []){
-    let { a } = _ref1, b = _object_without_properties(_ref1, [
+    var { a } = _ref1, b = _object_without_properties(_ref1, [
         "a"
     ]);
 }

--- a/crates/swc_ecma_transforms_compat/tests/es2018_object_rest_spread.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2018_object_rest_spread.rs
@@ -2502,6 +2502,33 @@ compare_stdout!(
     "###
 );
 
+compare_stdout!(
+    syntax(),
+    |_| tr(Default::default()),
+    issue_12153_var_and_lexical_scope,
+    r###"
+    const values = [
+      { a: 1, extra: 2 },
+      { a: 3, extra: 4 },
+    ];
+
+    for (var { a, ...b } of values) {}
+    console.log(typeof a, a, b.extra);
+
+    const letClosures = [];
+    for (let { a, ...b } of values) {
+      letClosures.push(() => [a, b.extra]);
+    }
+    console.log(JSON.stringify(letClosures.map((f) => f())));
+
+    const constClosures = [];
+    for (const { a, ...b } of values) {
+      constClosures.push(() => [a, b.extra]);
+    }
+    console.log(JSON.stringify(constClosures.map((f) => f())));
+    "###
+);
+
 #[testing::fixture("tests/object-rest-spread/**/input.js")]
 fn fixture(input: PathBuf) {
     let parent = input.parent().unwrap();

--- a/crates/swc_ecma_transforms_compat/tests/object-rest-spread/12153/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/object-rest-spread/12153/input.js
@@ -1,0 +1,5 @@
+const values = [{ a: 1, extra: 2 }];
+
+for (var { a, ...b } of values) {}
+for (let { a, ...b } of values) {}
+for (const { a, ...b } of values) {}

--- a/crates/swc_ecma_transforms_compat/tests/object-rest-spread/12153/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/object-rest-spread/12153/output.js
@@ -1,0 +1,21 @@
+const values = [
+    {
+        a: 1,
+        extra: 2
+    }
+];
+for (var _ref of values){
+    var { a } = _ref, b = _object_without_properties(_ref, [
+        "a"
+    ]);
+}
+for (let _ref of values){
+    let { a } = _ref, b = _object_without_properties(_ref, [
+        "a"
+    ]);
+}
+for (const _ref of values){
+    const { a } = _ref, b = _object_without_properties(_ref, [
+        "a"
+    ]);
+}


### PR DESCRIPTION
**Description:**

The object-rest transform always emitted `let` for declarations moved from a `for-of` head into the loop body. That preserves lexical bindings, but changes an original `var` binding from function scope to block scope and makes it unavailable after the loop.

This preserves the original declaration kind, adds fixture coverage for `var`/`let`/`const`, and adds a runtime regression that checks both post-loop `var` access and per-iteration lexical bindings.

Verified with the focused object-rest fixture and runtime tests, `cargo fmt`, and Clippy for the affected crates.

**Related issue (if exists):**

Fixes #12153
