### PR TITLE
fix(es/minifier): preserve do-while control-flow targets

### DIFF
--- a/.changeset/preserve-do-while-control-flow.md
+++ b/.changeset/preserve-do-while-control-flow.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+fix(es/minifier): Preserve do-while control-flow targets

--- a/crates/swc_ecma_minifier/src/compress/pure/loops.rs
+++ b/crates/swc_ecma_minifier/src/compress/pure/loops.rs
@@ -264,7 +264,9 @@ impl Pure<'_> {
             Stmt::DoWhile(stmt) => {
                 let val = stmt.test.as_pure_bool(self.expr_ctx);
                 if let Value::Known(false) = val {
-                    if should_not_inline_loop_body(&stmt.body, true) {
+                    // A direct break or continue targets this loop and cannot survive
+                    // unwrapping.
+                    if should_not_inline_loop_body(&stmt.body, false) {
                         return;
                     }
 

--- a/crates/swc_ecma_minifier/tests/fixture/issues/do-while-false-control-flow/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/do-while-false-control-flow/config.json
@@ -1,0 +1,6 @@
+{
+    "dead_code": true,
+    "evaluate": true,
+    "loops": true,
+    "passes": 2
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/do-while-false-control-flow/expected.stdout
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/do-while-false-control-flow/expected.stdout
@@ -1,0 +1,5 @@
+unlabeled break body0,tail0,body1,tail1
+labeled break body0,tail0,body1,tail1
+unlabeled continue body0,tail0,body1,tail1
+labeled continue body0,tail0,body1,tail1
+hoist after break undefined

--- a/crates/swc_ecma_minifier/tests/fixture/issues/do-while-false-control-flow/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/do-while-false-control-flow/input.js
@@ -1,0 +1,61 @@
+function unlabeledBreak() {
+    var result = [];
+    for (var i = 0; i < 2; i++) {
+        do {
+            result.push("body" + i);
+            break;
+        } while (false);
+        result.push("tail" + i);
+    }
+    return result.join(",");
+}
+
+function labeledBreak() {
+    var result = [];
+    for (var i = 0; i < 2; i++) {
+        inner: do {
+            result.push("body" + i);
+            break inner;
+        } while (false);
+        result.push("tail" + i);
+    }
+    return result.join(",");
+}
+
+function unlabeledContinue() {
+    var result = [];
+    for (var i = 0; i < 2; i++) {
+        do {
+            result.push("body" + i);
+            continue;
+        } while (false);
+        result.push("tail" + i);
+    }
+    return result.join(",");
+}
+
+function labeledContinue() {
+    var result = [];
+    for (var i = 0; i < 2; i++) {
+        inner: do {
+            result.push("body" + i);
+            continue inner;
+        } while (false);
+        result.push("tail" + i);
+    }
+    return result.join(",");
+}
+
+function hoistAfterBreak() {
+    do {
+        break;
+        var hoisted = 1;
+    } while (false);
+    return typeof hoisted;
+}
+
+console.log("unlabeled break", unlabeledBreak());
+console.log("labeled break", labeledBreak());
+console.log("unlabeled continue", unlabeledContinue());
+console.log("labeled continue", labeledContinue());
+console.log("hoist after break", hoistAfterBreak());

--- a/crates/swc_ecma_minifier/tests/fixture/issues/do-while-false-control-flow/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/do-while-false-control-flow/output.js
@@ -1,0 +1,56 @@
+function unlabeledBreak() {
+    var result = [];
+    for(var i = 0; i < 2; i++){
+        do {
+            result.push("body" + i);
+            break;
+        }while (false)
+        result.push("tail" + i);
+    }
+    return result.join(",");
+}
+function labeledBreak() {
+    var result = [];
+    for(var i = 0; i < 2; i++){
+        do {
+            result.push("body" + i);
+            break;
+        }while (false)
+        result.push("tail" + i);
+    }
+    return result.join(",");
+}
+function unlabeledContinue() {
+    var result = [];
+    for(var i = 0; i < 2; i++){
+        do {
+            result.push("body" + i);
+            continue;
+        }while (false)
+        result.push("tail" + i);
+    }
+    return result.join(",");
+}
+function labeledContinue() {
+    var result = [];
+    for(var i = 0; i < 2; i++){
+        do {
+            result.push("body" + i);
+            continue;
+        }while (false)
+        result.push("tail" + i);
+    }
+    return result.join(",");
+}
+function hoistAfterBreak() {
+    do {
+        var hoisted;
+        break;
+    }while (false)
+    return typeof hoisted;
+}
+console.log("unlabeled break", unlabeledBreak());
+console.log("labeled break", labeledBreak());
+console.log("unlabeled continue", unlabeledContinue());
+console.log("labeled continue", labeledContinue());
+console.log("hoist after break", hoistAfterBreak());


### PR DESCRIPTION
**Description:**

The minifier's `loops` optimization replaces a constant-false `do...while` statement with its body. It previously allowed a direct `break` or `continue` while doing so, even though those statements target the loop being removed.

After unwrapping, the abrupt completion could target a surrounding loop and silently change program behavior, or become an illegal statement when no enclosing target existed.

This change passes `false` for `allow_break_continue` when checking a constant-false `do...while` body. SWC now retains the loop when a direct `break` or `continue` depends on it, while other safe constant-false loop bodies remain eligible for unwrapping.

The regression fixture covers:

- unlabeled and labeled `break` statements nested in an outer loop;
- unlabeled and labeled `continue` statements nested in an outer loop;
- declaration hoisting after an early `break`.

Labels are not required to reproduce the bug. The labeled cases are included because they match the Kotlin/JS output reported in web-infra-dev/rspack#15335; after label normalization they expose the same direct control-flow dependency.

A similar semantic guard exists in the separate `simplify` transform following #1618. This change applies that constraint to the minifier compressor's independent constant-loop optimization.

**Testing:**

- `UPDATE=1 cargo test -p swc_ecma_minifier --test compress --features concurrent do_while_false_control_flow -- --nocapture`
- `cargo test -p swc_ecma_minifier --test compress --features concurrent do_while_false_control_flow -- --nocapture`
- `(cd crates/swc_ecma_minifier && ./scripts/exec.sh)`
- `cargo test -p swc_ecma_minifier`
- `cargo fmt --all`
- `cargo clippy -p swc_ecma_minifier --all-targets --features concurrent -- -D warnings`

**BREAKING CHANGE:**

None.

**Related issue (if exists):**

Fixes #12159.

Related to web-infra-dev/rspack#15335.

See also #1618.
