### PR TITLE
fix(es/decorators): drop params from getter replacing decorated private method

### DIFF
--- a/.changeset/drop-getter-params-decorated-private-method.md
+++ b/.changeset/drop-getter-params-decorated-private-method.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_proposal: patch
+---
+
+fix(es/decorators): Drop params from getter replacing decorated private method

--- a/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
+++ b/crates/swc_ecma_transforms_proposal/src/decorator_impl.rs
@@ -2555,6 +2555,7 @@ impl VisitMut for DecoratorPass {
                     p.kind = MethodKind::Getter;
                     p.function.is_async = false;
                     p.function.is_generator = false;
+                    p.function.params = Vec::new();
                     p.function.body = Some(FunctionBody {
                         span: DUMMY_SP,
                         stmts: vec![call_stmt],

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods/private-with-params/input.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods/private-with-params/input.js
@@ -1,0 +1,28 @@
+const dec = () => {};
+class Foo {
+  value = 1;
+
+  @dec
+  #a(x, y) {
+    return this.value + x + y;
+  }
+
+  @dec
+  #b(x = 1, ...rest) {
+    return [x, rest];
+  }
+
+  @dec
+  #c({ x }, [y]) {
+    return x + y;
+  }
+
+  @dec
+  static #s(x) {
+    return x;
+  }
+
+  call() {
+    return [this.#a(1, 2), this.#b(), this.#c({ x: 1 }, [2])];
+  }
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods/private-with-params/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2022-03-methods/private-with-params/output.js
@@ -1,0 +1,68 @@
+var _call_a, _call_b, _call_c, _call_s, _initProto, _initStatic;
+const dec = ()=>{};
+class Foo {
+    static{
+        ({ e: [_call_s, _call_a, _call_b, _call_c, _initProto, _initStatic] } = _apply_decs_2203_r(this, [
+            [
+                dec,
+                7,
+                "s",
+                function(x) {
+                    return x;
+                }
+            ],
+            [
+                dec,
+                2,
+                "a",
+                function(x, y) {
+                    return this.value + x + y;
+                }
+            ],
+            [
+                dec,
+                2,
+                "b",
+                function(x = 1, ...rest) {
+                    return [
+                        x,
+                        rest
+                    ];
+                }
+            ],
+            [
+                dec,
+                2,
+                "c",
+                function({ x }, [y]) {
+                    return x + y;
+                }
+            ]
+        ], []));
+        _initStatic(this);
+    }
+    value = (_initProto(this), 1);
+    get #a() {
+        return _call_a;
+    }
+    get #b() {
+        return _call_b;
+    }
+    get #c() {
+        return _call_c;
+    }
+    static get #s() {
+        return _call_s;
+    }
+    call() {
+        return [
+            this.#a(1, 2),
+            this.#b(),
+            this.#c({
+                x: 1
+            }, [
+                2
+            ])
+        ];
+    }
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-methods/private-with-params/exec.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-methods/private-with-params/exec.js
@@ -1,0 +1,26 @@
+const dec = (fn) => fn;
+
+class Foo {
+  value = 10;
+
+  @dec
+  #a(x, y) {
+    return this.value + x + y;
+  }
+
+  @dec
+  #b(x = 1, ...rest) {
+    return [x, rest.length];
+  }
+
+  @dec
+  #c({ x }, [y]) {
+    return x + y;
+  }
+
+  call() {
+    return [this.#a(2, 3), this.#b(), this.#b(5, 6, 7), this.#c({ x: 1 }, [2])];
+  }
+}
+
+expect(new Foo().call()).toEqual([15, [1, 0], [5, 2], 3]);

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-methods/private-with-params/input.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-methods/private-with-params/input.js
@@ -1,0 +1,28 @@
+const dec = () => {};
+class Foo {
+  value = 1;
+
+  @dec
+  #a(x, y) {
+    return this.value + x + y;
+  }
+
+  @dec
+  #b(x = 1, ...rest) {
+    return [x, rest];
+  }
+
+  @dec
+  #c({ x }, [y]) {
+    return x + y;
+  }
+
+  @dec
+  static #s(x) {
+    return x;
+  }
+
+  call() {
+    return [this.#a(1, 2), this.#b(), this.#c({ x: 1 }, [2])];
+  }
+}

--- a/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-methods/private-with-params/output.js
+++ b/crates/swc_ecma_transforms_proposal/tests/decorators/2023-11-methods/private-with-params/output.js
@@ -1,0 +1,68 @@
+let _call_a, _call_b, _call_c, _call_s, _initProto, _initStatic;
+const dec = ()=>{};
+class Foo {
+    static{
+        ({ e: [_call_s, _call_a, _call_b, _call_c, _initProto, _initStatic] } = _apply_decs_2311(this, [], [
+            [
+                dec,
+                10,
+                "s",
+                function(x) {
+                    return x;
+                }
+            ],
+            [
+                dec,
+                2,
+                "a",
+                function(x, y) {
+                    return this.value + x + y;
+                }
+            ],
+            [
+                dec,
+                2,
+                "b",
+                function(x = 1, ...rest) {
+                    return [
+                        x,
+                        rest
+                    ];
+                }
+            ],
+            [
+                dec,
+                2,
+                "c",
+                function({ x }, [y]) {
+                    return x + y;
+                }
+            ]
+        ], 0, (o)=>#a in o));
+        _initStatic(this);
+    }
+    value = (_initProto(this), 1);
+    get #a() {
+        return _call_a;
+    }
+    get #b() {
+        return _call_b;
+    }
+    get #c() {
+        return _call_c;
+    }
+    static get #s() {
+        return _call_s;
+    }
+    call() {
+        return [
+            this.#a(1, 2),
+            this.#b(),
+            this.#c({
+                x: 1
+            }, [
+                2
+            ])
+        ];
+    }
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Decorating a private method rewrites it into a private getter returning the extracted call target. The rewrite reset `is_async` and `is_generator` but not `params`, so a method with parameters produced an invalid getter:

```js
class Foo {
  @dec
  #a(x, y) {
    return x + y;
  }
}
```

```js
get #a(x, y) {  // SyntaxError: Getter must not have any formal parameters
    return _call_a;
}
```

Clearing `params` on the switch to `MethodKind::Getter` fixes it. The parameters remain on the extracted function.

No existing test caught this: codegen emits `Function::params` regardless of `MethodKind`, and the parser's `GetterParam` check is a recoverable error the fixture harness discards. Only running the output surfaces it, so the 2023-11 fixture includes an `exec` case.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

**Related issue (if exists):**

None