### PR TITLE
fix(es/react-compiler): preserve compiled body source maps

### DIFF
--- a/.changeset/preserve-react-compiler-source-maps.md
+++ b/.changeset/preserve-react-compiler-source-maps.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_react_compiler: patch
+---
+
+fix(es/react-compiler): Preserve source maps for compiled function bodies

--- a/crates/swc_ecma_react_compiler/Cargo.toml
+++ b/crates/swc_ecma_react_compiler/Cargo.toml
@@ -30,7 +30,7 @@ swc_ecma_parser    = { version = "45.1.0", path = "../swc_ecma_parser", default-
 swc_ecma_visit     = { version = "29.0.0", path = "../swc_ecma_visit" }
 
 [dev-dependencies]
-swc_common      = { version = "26.0.0", path = "../swc_common" }
+swc_common      = { version = "26.0.0", path = "../swc_common", features = ["sourcemap"] }
 swc_ecma_parser = { version = "45.1.0", path = "../swc_ecma_parser", default-features = false, features = [
   "typescript",
 ] }

--- a/crates/swc_ecma_react_compiler/src/convert_ast.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_ast.rs
@@ -19,7 +19,7 @@ use react_compiler_ast::{
 use swc_common::{
     comments::{Comment as SwcComment, CommentKind, SingleThreadedComments},
     util::take::Take,
-    Span, Spanned,
+    BytePos, Span, Spanned,
 };
 use swc_ecma_ast as swc;
 
@@ -28,6 +28,7 @@ use crate::preserved_ast::PreservedAst;
 pub struct ConvertResult {
     pub file: File,
     pub preserved_ast: PreservedAst,
+    pub source_start: BytePos,
 }
 
 /// Converts an SWC AST to the React compiler's Babel-compatible AST.
@@ -36,7 +37,8 @@ pub fn convert_program(
     source_text: &str,
     comments: Option<&SingleThreadedComments>,
 ) -> ConvertResult {
-    let ctx = ConvertCtx::new(source_text);
+    let source_start = BytePos(program.span().lo.0.max(1));
+    let ctx = ConvertCtx::new(source_text, source_start);
     let comments = convert_swc_comments(&ctx, comments);
     let mut ctx = ctx.with_comments(comments);
     let file = ctx.convert_program(program);
@@ -44,18 +46,20 @@ pub fn convert_program(
     ConvertResult {
         file,
         preserved_ast: ctx.preserved_ast.into_inner(),
+        source_start,
     }
 }
 
 struct ConvertCtx<'a> {
     source_text: &'a str,
+    source_start: BytePos,
     line_offsets: Vec<u32>,
     comments: Vec<Comment>,
     preserved_ast: RefCell<PreservedAst>,
 }
 
 impl<'a> ConvertCtx<'a> {
-    fn new(source_text: &'a str) -> Self {
+    fn new(source_text: &'a str, source_start: BytePos) -> Self {
         let mut line_offsets = vec![0u32];
         for (i, ch) in source_text.char_indices() {
             let next = i + ch.len_utf8();
@@ -65,6 +69,7 @@ impl<'a> ConvertCtx<'a> {
         }
         Self {
             source_text,
+            source_start,
             line_offsets,
             comments: Default::default(),
             preserved_ast: Default::default(),
@@ -93,15 +98,17 @@ impl<'a> ConvertCtx<'a> {
 
     /// Converts a SWC span to a Babel-compatible position.
     ///
-    /// SWC `BytePos` values are byte offsets and 1-based. Base node offsets
-    /// stay 1-based so scope keys can use `span.lo` directly, while `loc`
-    /// follows Babel's 1-based lines and 0-based columns/indices.
+    /// SWC `BytePos` values are global offsets within a `SourceMap`. Base node
+    /// offsets stay global so scope keys can use `span.lo` directly, while
+    /// `loc` follows Babel's file-relative, 0-based columns and indices.
     ///
     /// Assumption: the React Compiler does not receive the original source text
     /// from this bridge, so UTF-8 byte offsets are enough for `column` and
     /// `index`. If that changes, switch these offsets to UTF-16 code units.
     fn position(&self, offset: u32) -> Position {
-        let offset = offset.saturating_sub(1).min(self.source_text.len() as u32);
+        let offset = offset
+            .saturating_sub(self.source_start.0)
+            .min(self.source_text.len() as u32);
         let line_idx = match self.line_offsets.binary_search(&offset) {
             Ok(idx) => idx,
             Err(idx) => idx.saturating_sub(1),
@@ -151,7 +158,8 @@ impl<'a> ConvertCtx<'a> {
                     .source_text
                     .find('\n')
                     .unwrap_or(self.source_text.len()) as u32;
-                let span = Span::new(swc_common::BytePos(1), swc_common::BytePos(1 + end));
+                let start = self.source_start;
+                let span = Span::new(start, BytePos(start.0 + end));
                 InterpreterDirective {
                     base: self.make_base_node(span),
                     value: shebang.to_string(),

--- a/crates/swc_ecma_react_compiler/src/convert_ast_reverse.rs
+++ b/crates/swc_ecma_react_compiler/src/convert_ast_reverse.rs
@@ -26,19 +26,25 @@ use swc_ecma_ast as swc;
 use crate::preserved_ast::PreservedAst;
 
 /// Convert with source text and preserved SWC nodes from the forward pass.
-pub fn convert_program_to_swc(file: &File, preserved_ast: PreservedAst) -> swc::Program {
-    let ctx = ReverseCtx::new(preserved_ast);
+pub fn convert_program_to_swc(
+    file: &File,
+    preserved_ast: PreservedAst,
+    source_start: BytePos,
+) -> swc::Program {
+    let ctx = ReverseCtx::new(preserved_ast, source_start);
     ctx.convert_program(&file.program)
 }
 
 struct ReverseCtx {
     preserved_ast: RefCell<PreservedAst>,
+    source_start: BytePos,
 }
 
 impl ReverseCtx {
-    fn new(preserved_ast: PreservedAst) -> Self {
+    fn new(preserved_ast: PreservedAst, source_start: BytePos) -> Self {
         Self {
             preserved_ast: RefCell::new(preserved_ast),
+            source_start,
         }
     }
 
@@ -106,6 +112,26 @@ impl ReverseCtx {
         match (base.start, base.end) {
             (Some(start), Some(end)) => Span::new(BytePos(start), BytePos(end)),
             (Some(start), None) => Span::new(BytePos(start), BytePos(start)),
+            _ => self.span_from_loc(base),
+        }
+    }
+
+    fn span_from_loc(&self, base: &BaseNode) -> Span {
+        let Some(loc) = &base.loc else {
+            return DUMMY_SP;
+        };
+
+        // The React Compiler preserves `loc` for rebuilt source nodes but does
+        // not preserve Babel's `start` and `end` offsets. `loc.index` is a
+        // file-relative byte offset, while SWC's `BytePos` is global.
+        let byte_pos = |index: Option<u32>| {
+            index
+                .and_then(|index| self.source_start.0.checked_add(index))
+                .map(BytePos)
+        };
+        match (byte_pos(loc.start.index), byte_pos(loc.end.index)) {
+            (Some(start), Some(end)) => Span::new(start, end),
+            (Some(start), None) => Span::new(start, start),
             _ => DUMMY_SP,
         }
     }
@@ -262,11 +288,20 @@ impl ReverseCtx {
                     .map(|arg| Box::new(self.convert_expression(arg))),
             })
             .into(),
-            Statement::ExpressionStatement(expr) => swc::Stmt::Expr(swc::ExprStmt {
-                span: self.span_from_base(&expr.base),
-                expr: Box::new(self.convert_expression(&expr.expression)),
-            })
-            .into(),
+            Statement::ExpressionStatement(expr) => {
+                let span = self.span_from_base(&expr.base);
+                let mut expression = self.convert_expression(&expr.expression);
+                // Codegen emits this mapping from the expression span. The
+                // compiler may only retain a location on the rebuilt statement.
+                if expression.span().is_dummy() {
+                    expression.set_span(span);
+                }
+                swc::Stmt::Expr(swc::ExprStmt {
+                    span,
+                    expr: Box::new(expression),
+                })
+                .into()
+            }
             Statement::IfStatement(if_stmt) => swc::Stmt::If(swc::IfStmt {
                 span: self.span_from_base(&if_stmt.base),
                 test: Box::new(self.convert_expression(&if_stmt.test)),

--- a/crates/swc_ecma_react_compiler/src/lib.rs
+++ b/crates/swc_ecma_react_compiler/src/lib.rs
@@ -97,6 +97,7 @@ pub fn transform(
     let ConvertResult {
         file,
         preserved_ast,
+        source_start,
     } = convert_program(program, source_text, comments);
     let emit_success_error_diagnostics = options.no_emit;
     let result =
@@ -117,7 +118,7 @@ pub fn transform(
 
     let rename_plan = build_rename_plan(&scope_info, &renames);
     let program = file.map(|file: react_compiler_ast::File| {
-        let mut compiled = convert_program_to_swc(&file, preserved_ast);
+        let mut compiled = convert_program_to_swc(&file, preserved_ast, source_start);
         apply_renames(&mut compiled, &rename_plan);
         compiled
     });

--- a/crates/swc_ecma_react_compiler/src/tests/integration.rs
+++ b/crates/swc_ecma_react_compiler/src/tests/integration.rs
@@ -9,7 +9,7 @@ use react_compiler_ast::{
     statements::Statement,
     File,
 };
-use swc_common::{sync::Lrc, FileName, SourceMap};
+use swc_common::{sync::Lrc, BytePos, FileName, SourceMap};
 use swc_ecma_ast::{DefaultDecl, EsVersion, ModuleDecl, ModuleItem};
 use swc_ecma_codegen::Node;
 use swc_ecma_parser::{parse_file_as_module, parse_file_as_program, EsSyntax, Syntax};
@@ -22,7 +22,7 @@ use crate::{
 };
 
 fn convert_program_to_swc(file: &File) -> swc_ecma_ast::Program {
-    convert_program_to_swc_with_preserved_ast(file, Default::default())
+    convert_program_to_swc_with_preserved_ast(file, Default::default(), BytePos(1))
 }
 
 fn convert_module(module: &swc_ecma_ast::Module, source_text: &str) -> File {
@@ -1808,7 +1808,11 @@ fn convert_ts_source(source: &str) -> crate::convert_ast::ConvertResult {
 fn round_trip_convert_result(result: crate::convert_ast::ConvertResult) -> swc_ecma_ast::Program {
     assert_file_serializes_to_json(&result.file);
 
-    convert_program_to_swc_with_preserved_ast(&result.file, result.preserved_ast)
+    convert_program_to_swc_with_preserved_ast(
+        &result.file,
+        result.preserved_ast,
+        result.source_start,
+    )
 }
 
 /// TS module-interop statements (`import x = require(...)`, `export = x`,

--- a/crates/swc_ecma_react_compiler/tests/fixture.rs
+++ b/crates/swc_ecma_react_compiler/tests/fixture.rs
@@ -4,7 +4,10 @@ use std::{
 };
 
 use serde::Deserialize;
-use swc_common::{comments::SingleThreadedComments, sync::Lrc, SourceMap};
+use swc_common::{
+    comments::SingleThreadedComments, source_map::DefaultSourceMapGenConfig, sync::Lrc, BytePos,
+    FileName, LineCol, SourceMap,
+};
 use swc_ecma_ast::{EsVersion, Program};
 use swc_ecma_codegen::{
     text_writer::{JsWriter, WriteJs},
@@ -100,10 +103,14 @@ fn parse_program(
     (program, comments, source_type)
 }
 
-fn emit_program(program: &Program, cm: Lrc<SourceMap>) -> String {
+fn emit_program(
+    program: &Program,
+    cm: Lrc<SourceMap>,
+    mappings: Option<&mut Vec<(BytePos, LineCol)>>,
+) -> String {
     let mut buf = Vec::new();
     {
-        let wr = Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, None)) as Box<dyn WriteJs>;
+        let wr = Box::new(JsWriter::new(cm.clone(), "\n", &mut buf, mappings)) as Box<dyn WriteJs>;
         let mut emitter = Emitter {
             cfg: swc_ecma_codegen::Config::default(),
             cm,
@@ -152,7 +159,7 @@ fn run_compile_pass(input: PathBuf) {
                 result.diagnostics
             )
         });
-        let code = emit_program(&transformed, cm);
+        let code = emit_program(&transformed, cm, None);
 
         NormalizedOutput::from(code)
             .compare_to_file(&output)
@@ -173,6 +180,65 @@ fn run_build_pass(input: PathBuf) {
     .unwrap();
 }
 
+fn position_of(text: &str, needle: &str) -> LineCol {
+    let offset = text
+        .find(needle)
+        .unwrap_or_else(|| panic!("failed to find `{needle}`"));
+    let prefix = &text[..offset];
+    LineCol {
+        line: prefix.bytes().filter(|byte| *byte == b'\n').count() as u32,
+        col: prefix
+            .rsplit_once('\n')
+            .map_or(prefix, |(_, line)| line)
+            .encode_utf16()
+            .count() as u32,
+    }
+}
+
+fn run_source_map(input: PathBuf) {
+    run_test2(false, |cm, _| {
+        let source = read_to_string(&input)
+            .unwrap_or_else(|err| panic!("failed to read {}: {err}", input.display()));
+        cm.new_source_file(
+            Lrc::new(FileName::Custom("preloaded.js".into())),
+            " ".repeat(source.len() + 1),
+        );
+        let transformed = transform_fixture(&input, cm.clone())
+            .program
+            .expect("React Compiler should transform source-map fixture");
+        let mut mappings = Vec::new();
+        let code = emit_program(&transformed, cm.clone(), Some(&mut mappings));
+        let source_map = cm.build_source_map(&mappings, None, DefaultSourceMapGenConfig);
+
+        for needle in ["Promise.resolve", "setValue(next)", "Count:"] {
+            let original = position_of(&source, needle);
+            let generated = position_of(&code, needle);
+            let token = source_map
+                .lookup_token(generated.line, generated.col)
+                .unwrap_or_else(|| panic!("missing source-map entry for `{needle}`"));
+
+            assert_eq!(
+                token.get_dst_line(),
+                generated.line,
+                "wrong generated line for `{needle}`"
+            );
+            assert_eq!(
+                token.get_source().map(|source| &**source),
+                Some(input.to_string_lossy().as_ref()),
+                "wrong source file for `{needle}`"
+            );
+            assert_eq!(
+                token.get_src_line(),
+                original.line,
+                "wrong original line for `{needle}`"
+            );
+        }
+
+        Ok(())
+    })
+    .unwrap();
+}
+
 #[testing::fixture("tests/fixture/compile-pass/**/input/*")]
 fn compile_pass(input: PathBuf) {
     run_compile_pass(input);
@@ -181,4 +247,9 @@ fn compile_pass(input: PathBuf) {
 #[testing::fixture("tests/fixture/build-pass/*")]
 fn build_pass(input: PathBuf) {
     run_build_pass(input);
+}
+
+#[testing::fixture("tests/fixture/source-map/**/input.*")]
+fn source_map(input: PathBuf) {
+    run_source_map(input);
 }

--- a/crates/swc_ecma_react_compiler/tests/fixture/compile-pass/ast-roundtrip/output/jsx.tsx
+++ b/crates/swc_ecma_react_compiler/tests/fixture/compile-pass/ast-roundtrip/output/jsx.tsx
@@ -31,7 +31,7 @@ export function App<T extends string = "on">(x: T): React.ReactElement {
     }
     let t4;
     if ($[4] !== x) {
-        t4 = <section data-id={dashboard.id} {...panelProps}><UI.Panel x={x} title={`Status: ${Status.Ready}`}>{t1}{t2}{t3}{dashboard.actions}</UI.Panel></section>;
+        t4 = <section data-id={dashboard.id} {...panelProps}><UI.Panel<T> x={x} title={`Status: ${Status.Ready}`}>{t1}{t2}{t3}{dashboard.actions}</UI.Panel></section>;
         $[4] = x;
         $[5] = t4;
     } else {

--- a/crates/swc_ecma_react_compiler/tests/fixture/source-map/compiled-body/input.tsx
+++ b/crates/swc_ecma_react_compiler/tests/fixture/source-map/compiled-body/input.tsx
@@ -1,0 +1,18 @@
+import { useState } from "react";
+
+export function useCounter() {
+    const [value, setValue] = useState(0);
+    const increment = async () => {
+        const next = await Promise.resolve(value + 1);
+        setValue(next);
+        return next;
+    };
+
+    return { value, increment };
+}
+
+export function App() {
+    const { value, increment } = useCounter();
+
+    return <button onClick={increment}>Count: {value}</button>;
+}


### PR DESCRIPTION
**Description:**

React Compiler rebuilt nodes retain Babel `loc` information but often omit `start` and `end`. The reverse AST converter previously turned those nodes into `DUMMY_SP`, so codegen omitted source-map mappings for compiled component and hook bodies.

This change preserves the source file start position across the AST round trip, converts file-relative `loc.index` values back to global SWC `BytePos` values, and lets rebuilt expression statements inherit their retained statement location when the root expression has no span. Recovered spans also allow preserved TypeScript JSX type arguments to be restored.

The source-map fixture preloads another source file to cover non-initial `SourceMap` ranges, then verifies that `Promise.resolve`, `setValue(next)`, and JSX body output resolve to the correct generated line, source file, and original line.


**Related issue (if exists):**

- https://github.com/web-infra-dev/rspack/issues/15350