### PR TITLE
fix(swc): key optimizer env cache by configured values

### DIFF
--- a/.changeset/fix-optimizer-env-cache-key.md
+++ b/.changeset/fix-optimizer-env-cache-key.md
@@ -1,0 +1,6 @@
+---
+swc: patch
+swc_core: patch
+---
+
+fix(swc): Key cached optimizer environment values by their configured map

--- a/crates/swc/src/config/mod.rs
+++ b/crates/swc/src/config/mod.rs
@@ -2291,11 +2291,11 @@ impl GlobalPassOption {
                     static CACHE: Lazy<DashMap<Vec<(Atom, Atom)>, ValuesMap, FxBuildHasher>> =
                         Lazy::new(Default::default);
 
-                    let cache_key = self
-                        .vars
+                    let mut cache_key = map
                         .iter()
                         .map(|(k, v)| (k.clone(), v.clone()))
                         .collect::<Vec<_>>();
+                    cache_key.sort_unstable();
                     if let Some(v) = CACHE.get(&cache_key) {
                         (*v).clone()
                     } else {

--- a/crates/swc/tests/simple.rs
+++ b/crates/swc/tests/simple.rs
@@ -1,7 +1,9 @@
 #[cfg(feature = "react-compiler")]
-use swc::{config::TransformConfig, BoolOrDataConfig};
+use swc::BoolOrDataConfig;
 use swc::{
-    config::{Config, IsModule, JscConfig, Options},
+    config::{
+        Config, GlobalPassOption, IsModule, JscConfig, OptimizerConfig, Options, TransformConfig,
+    },
     Compiler,
 };
 use swc_common::FileName;
@@ -29,6 +31,44 @@ fn compile(src: &str, options: Options) -> String {
             }
         })
         .unwrap()
+}
+
+fn compile_with_optimizer_globals(src: &str, globals: &str) -> String {
+    let globals: GlobalPassOption = serde_json::from_str(globals).expect("invalid globals");
+
+    compile(
+        src,
+        Options {
+            swcrc: false,
+            config: Config {
+                jsc: JscConfig {
+                    transform: Some(TransformConfig {
+                        optimizer: Some(OptimizerConfig {
+                            globals: Some(globals),
+                            ..Default::default()
+                        }),
+                        ..Default::default()
+                    })
+                    .into(),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )
+}
+
+#[test]
+fn optimizer_globals_env_map_cache_key_includes_env_values() {
+    const SRC: &str = "console.log(process.env.REPRO_VALUE);";
+
+    let first = compile_with_optimizer_globals(SRC, r#"{ "envs": { "REPRO_VALUE": "'first'" } }"#);
+    let second =
+        compile_with_optimizer_globals(SRC, r#"{ "envs": { "REPRO_VALUE": "'second'" } }"#);
+
+    assert!(first.contains("first"));
+    assert!(second.contains("second"));
 }
 
 #[test]

--- a/crates/swc/tests/simple.rs
+++ b/crates/swc/tests/simple.rs
@@ -67,8 +67,8 @@ fn optimizer_globals_env_map_cache_key_includes_env_values() {
     let second =
         compile_with_optimizer_globals(SRC, r#"{ "envs": { "REPRO_VALUE": "'second'" } }"#);
 
-    assert!(first.contains("first"));
-    assert!(second.contains("second"));
+    assert_eq!(first, "console.log('first');\n");
+    assert_eq!(second, "console.log('second');\n");
 }
 
 #[test]


### PR DESCRIPTION
**Description:**

`GlobalPassOption::build` stores parsed `jsc.transform.optimizer.globals.envs` maps in a process-wide cache, but the cache key is currently built from `globals.vars`. Two compilations with the same `vars` and different explicit `envs` maps therefore collide, causing the later compilation to reuse stale environment replacements from the earlier one.

Build the cache key from the configured environment map instead, and sort its entries so equivalent maps produce the same key regardless of iteration order.

This was discovered while investigating the cached-span source-map issue fixed by #12129, but it is a separate cache-key bug.

The regression test compiles the same source twice in one process with different explicit environment values. Before the fix, the second compilation incorrectly emits the first value.

Tests:

- `cargo fmt --all -- --check`
- `cargo clippy -p swc --all-targets -- -D warnings`
- `cargo test -p swc --lib`
- `cargo test -p swc --test simple`
- `cargo test -p swc --test simple --features react-compiler`
- `cargo test -p swc --test rust_api`
- `cargo test -p swc --test source_map define_source_map_is_stable_across_compilations -- --exact`

**Related issue (if exists):**

Follow-up to #12129.
