### PR TITLE
chore: Fix changeset for React compiler package switch

### DIFF
--- a/.changeset/use-maintained-react-compiler-fork.md
+++ b/.changeset/use-maintained-react-compiler-fork.md
@@ -1,6 +1,6 @@
 ---
-swc_core: patch
-swc_ecma_react_compiler: patch
+swc_core: major
+swc_ecma_react_compiler: major
 ---
 
 fix(es/react-compiler): Use the official React compiler package


### PR DESCRIPTION
**Description:**

Correct the changeset added in #12168 to use major bumps for `swc_ecma_react_compiler` and `swc_core`. The runtime dependency package identity changed, and `swc_ecma_react_compiler` publicly re-exports upstream compiler types; `swc_core` exposes that crate through its `ecma_react_compiler` feature.

**BREAKING CHANGE:**

The React compiler runtime dependency moved from the forked packages to the official packages, changing the identity of publicly re-exported upstream types.

**Related issue (if exists):**

#12168