### PR TITLE
fix(es/minifier): Check eval and arguments usage in var define scope

### DIFF
--- a/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/inline.rs
@@ -17,7 +17,10 @@ use crate::{
         util::contains_super,
     },
     program_data::{ScopeData, VarUsageInfo, VarUsageInfoFlags},
-    usage_analyzer::alias::{collect_infects_from, AliasConfig},
+    usage_analyzer::{
+        alias::{collect_infects_from, AliasConfig},
+        analyzer::storage::Storage,
+    },
     util::{
         idents_captured_by, idents_used_by, idents_used_by_ignoring_nested, size::SizeWithCtxt,
     },
@@ -41,7 +44,7 @@ impl Optimizer<'_> {
             self.may_remove_ident(ident)
         );
 
-        if let Some(scope) = self.data.get_scope(self.ctx.var_scope) {
+        if let Some(scope) = self.data.get_scope(ident.ctxt) {
             if scope.intersects(ScopeData::HAS_EVAL_CALL.union(ScopeData::HAS_WITH_STMT)) {
                 return;
             }
@@ -67,18 +70,14 @@ impl Optimizer<'_> {
                 return;
             }
 
-            let used_arguments = self
-                .data
-                .get_scope(self.ctx.var_scope)
-                .unwrap()
-                .contains(ScopeData::USED_ARGUMENTS);
-
-            if used_arguments
-                && usage
-                    .flags
-                    .contains(VarUsageInfoFlags::DECLARED_AS_FN_PARAM)
-            {
-                return;
+            if let Some(scope) = self.data.get_scope(ident.ctxt) {
+                if scope.contains(ScopeData::USED_ARGUMENTS)
+                    && usage
+                        .flags
+                        .contains(VarUsageInfoFlags::DECLARED_AS_FN_PARAM)
+                {
+                    return;
+                }
             }
 
             if usage
@@ -675,7 +674,7 @@ impl Optimizer<'_> {
 
         let id = i.to_id();
 
-        if let Some(scope) = self.data.get_scope(self.ctx.var_scope) {
+        if let Some(scope) = self.data.get_scope(id.1) {
             if scope.intersects(ScopeData::HAS_EVAL_CALL.union(ScopeData::HAS_WITH_STMT)) {
                 return;
             }
@@ -722,6 +721,14 @@ impl Optimizer<'_> {
                                 usage,
                             )
                         {
+                            if let Some(scope) = self.data.get_scope(f.function.ctxt) {
+                                if scope
+                                    .intersects(ScopeData::HAS_EVAL_CALL.union(ScopeData::IS_ARROW))
+                                {
+                                    return;
+                                }
+                            }
+
                             for (idx, param) in f.function.params.iter().enumerate() {
                                 match &param.pat {
                                     Pat::Rest(..) => return,
@@ -955,6 +962,12 @@ impl Optimizer<'_> {
                 }
 
                 remap.insert(id, new_ctxt);
+            }
+
+            for (from, to) in cache.into_iter() {
+                if let Some(scope) = self.data.get_scope(from) {
+                    *self.data.scope(to) = *scope
+                }
             }
 
             let mut value = value.clone();

--- a/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/mod.rs
@@ -80,7 +80,6 @@ pub(super) fn optimizer<'a>(
             remaining_depth: 6,
         },
         scope: marks.top_level_ctxt,
-        var_scope: marks.top_level_ctxt,
         bit_ctx: BitCtx::default(),
     };
 
@@ -111,9 +110,6 @@ struct Ctx {
 
     /// Current scope.
     scope: SyntaxContext,
-
-    /// fn or top level scope
-    var_scope: SyntaxContext,
 
     bit_ctx: BitCtx,
 }
@@ -392,7 +388,7 @@ impl Optimizer<'_> {
 
         if self
             .data
-            .get_scope(self.ctx.var_scope)
+            .get_scope(self.ctx.scope)
             .unwrap()
             .contains(ScopeData::HAS_EVAL_CALL)
         {
@@ -1486,7 +1482,6 @@ impl Optimizer<'_> {
                 .with(BitCtx::TopLevel, false)
                 .with(BitCtx::InParam, false),
             scope,
-            var_scope: scope,
             ..self.ctx.clone()
         }
     }
@@ -1822,7 +1817,6 @@ impl VisitMut for Optimizer<'_> {
                         .with(BitCtx::InBlock, true)
                         .with(BitCtx::InParam, false),
                     scope: s.body.ctxt,
-                    var_scope: s.body.ctxt,
                     ..self.ctx.clone()
                 };
                 n.visit_mut_children_with(&mut *self.with_ctx(ctx));

--- a/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/unused.rs
@@ -705,15 +705,6 @@ impl Optimizer<'_> {
             return;
         }
 
-        if self
-            .data
-            .get_scope(self.ctx.var_scope)
-            .unwrap()
-            .intersects(ScopeData::HAS_EVAL_CALL.union(ScopeData::HAS_WITH_STMT))
-        {
-            return;
-        }
-
         let assign = match e {
             Expr::Assign(AssignExpr { op: op!("="), .. }) => return,
             // RHS may not be evaluated
@@ -723,6 +714,12 @@ impl Optimizer<'_> {
         };
 
         if let AssignTarget::Simple(SimpleAssignTarget::Ident(left)) = &assign.left {
+            if let Some(scope) = self.data.get_scope(left.id.ctxt) {
+                if scope.intersects(ScopeData::HAS_EVAL_CALL.union(ScopeData::HAS_WITH_STMT)) {
+                    return;
+                }
+            }
+
             if let Some(var) = self.data.vars.get(&left.to_id()) {
                 // TODO: We don't need fn_local check
                 if var
@@ -752,15 +749,6 @@ impl Optimizer<'_> {
             return;
         }
 
-        if self
-            .data
-            .get_scope(self.ctx.var_scope)
-            .unwrap()
-            .intersects(ScopeData::HAS_EVAL_CALL.union(ScopeData::HAS_WITH_STMT))
-        {
-            return;
-        }
-
         let assign = match e {
             Expr::Assign(e) => e,
             _ => return,
@@ -780,6 +768,12 @@ impl Optimizer<'_> {
                 return;
             }
 
+            if let Some(scope) = self.data.get_scope(i.ctxt) {
+                if scope.intersects(ScopeData::HAS_EVAL_CALL.union(ScopeData::HAS_WITH_STMT)) {
+                    return;
+                }
+            }
+
             if let Some(var) = self.data.vars.get(&i.to_id()) {
                 // technically this is inline
                 if !var.flags.intersects(
@@ -787,7 +781,7 @@ impl Optimizer<'_> {
                 ) && var.usage_count == 0
                     && var.flags.contains(VarUsageInfoFlags::DECLARED)
                     && (!var.flags.contains(VarUsageInfoFlags::DECLARED_AS_FN_PARAM)
-                        || !self.data.used_arguments(self.ctx.scope)
+                        || !self.data.used_arguments(i.ctxt)
                         || self.ctx.expr_ctx.in_strict)
                 {
                     report_change!(

--- a/crates/swc_ecma_minifier/tests/fixture/issues/12032/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/12032/input.js
@@ -1,0 +1,13 @@
+function run(f) {
+    f();
+}
+
+function foo(b) {
+    run(() => {
+        b = 2;
+    });
+
+    console.log(arguments[0]);
+}
+
+foo(1);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/12032/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/12032/output.js
@@ -1,0 +1,3 @@
+!function(b) {
+    b = 2, console.log(arguments[0]);
+}(1);


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**
It still may raise problems in case of inlining idents into other scopes, or passes like invoke IIFE, where the defining scope maybe eliminated but the syntax context attached to the ident is preserved. However one may also argue that in such cases eval/arguments usage couldn't read those moved idents so this won't have visible effects aside from var shadowing.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
Closes #12032