### PR TITLE
fix(es/typescript): Fold optional-chained enum member reads

### DIFF
--- a/.changeset/fold-optchain-enum-member.md
+++ b/.changeset/fold-optchain-enum-member.md
@@ -3,4 +3,4 @@ swc_core: patch
 swc_ecma_transforms_typescript: patch
 ---
 
-fix(es/typescript): Fold optional-chained enum member reads in enum evaluation
+fix(es/typescript): Fold optional-chained enum member reads

--- a/.changeset/fold-optchain-enum-member.md
+++ b/.changeset/fold-optchain-enum-member.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_transforms_typescript: patch
+---
+
+fix(es/typescript): Fold optional-chained enum member reads in enum evaluation

--- a/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
+++ b/crates/swc_ecma_transforms_typescript/src/ts_enum.rs
@@ -198,6 +198,7 @@ impl EnumValueComputer<'_> {
                 | Expr::Unary(..)
                 | Expr::Bin(..)
                 | Expr::Member(..)
+                | Expr::OptChain(..)
                 | Expr::Tpl(..)
                 | Expr::TsAs(..)
                 | Expr::TsNonNull(..)
@@ -266,6 +267,19 @@ impl EnumValueComputer<'_> {
             Expr::Unary(e) => self.compute_unary(e, ctx),
             Expr::Bin(e) => self.compute_bin(e, ctx),
             Expr::Member(e) => self.compute_member(e, ctx),
+            Expr::OptChain(e) => {
+                let opaque_expr = TsEnumRecordValue::Opaque(e.clone().into());
+                let OptChainBase::Member(member) = *e.base else {
+                    return opaque_expr;
+                };
+                // `compute_member` builds its own fallback from the
+                // `MemberExpr` alone, which would drop the `?.` and turn a
+                // guarded read into an unguarded one.
+                match self.compute_member(member, ctx) {
+                    TsEnumRecordValue::Opaque(..) => opaque_expr,
+                    value => value,
+                }
+            }
             Expr::Tpl(e) => self.compute_tpl(e, ctx),
             // Handle TypeScript type expressions by stripping them
             // and computing the inner expression

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-12152-optchain/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-12152-optchain/input.ts
@@ -1,0 +1,18 @@
+enum E {
+    A = 1,
+}
+const direct = E?.A;
+enum FromDirect {
+    X = direct,
+    Y,
+}
+const computed = E?.["A"];
+enum FromComputed {
+    X = computed,
+    Y,
+}
+const nested = E?.A?.valueOf;
+enum FromNested {
+    X = nested,
+    Y,
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-12152-optchain/input.ts
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-12152-optchain/input.ts
@@ -16,3 +16,11 @@ enum FromNested {
     X = nested,
     Y,
 }
+enum InMember {
+    X = E?.A,
+    Y,
+}
+const obj = { foo: 1 } as const;
+enum NotEnum {
+    X = obj?.foo,
+}

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-12152-optchain/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-12152-optchain/output.js
@@ -1,0 +1,22 @@
+var E = /*#__PURE__*/ function(E) {
+    E[E["A"] = 1] = "A";
+    return E;
+}(E || {});
+const direct = E?.A;
+var FromDirect = /*#__PURE__*/ function(FromDirect) {
+    FromDirect[FromDirect["X"] = 1] = "X";
+    FromDirect[FromDirect["Y"] = 2] = "Y";
+    return FromDirect;
+}(FromDirect || {});
+const computed = E?.["A"];
+var FromComputed = /*#__PURE__*/ function(FromComputed) {
+    FromComputed[FromComputed["X"] = 1] = "X";
+    FromComputed[FromComputed["Y"] = 2] = "Y";
+    return FromComputed;
+}(FromComputed || {});
+const nested = E?.A?.valueOf;
+var FromNested = function(FromNested) {
+    FromNested[FromNested["X"] = nested] = "X";
+    FromNested[FromNested["Y"] = void 0] = "Y";
+    return FromNested;
+}(FromNested || {});

--- a/crates/swc_ecma_transforms_typescript/tests/fixture/issue-12152-optchain/output.js
+++ b/crates/swc_ecma_transforms_typescript/tests/fixture/issue-12152-optchain/output.js
@@ -20,3 +20,15 @@ var FromNested = function(FromNested) {
     FromNested[FromNested["Y"] = void 0] = "Y";
     return FromNested;
 }(FromNested || {});
+var InMember = /*#__PURE__*/ function(InMember) {
+    InMember[InMember["X"] = 1] = "X";
+    InMember[InMember["Y"] = 2] = "Y";
+    return InMember;
+}(InMember || {});
+const obj = {
+    foo: 1
+};
+var NotEnum = function(NotEnum) {
+    NotEnum[NotEnum["X"] = obj?.foo] = "X";
+    return NotEnum;
+}(NotEnum || {});


### PR DESCRIPTION
**Description:**

Closes #12152.

`compute_rec` had no arm for `Expr::OptChain`, and `can_fold_shape` didn't admit it either, so an optional-chained enum member read stayed opaque. In a `const` initializer that also corrupts the enum it feeds: the member after it auto-increments from an opaque value and collapses to `undefined`.

```ts
enum E { A = 1 }
const value = E?.A;
enum F { X = value, Y }   // before: X = value, Y = void 0
```

`tsc` 5.9.3 `transpileModule` treats these as constant enum expressions, verified by executing the emitted output rather than diffing it:

| initializer | tsc 5.9.3 | swc before | swc after |
|---|---|---|---|
| `const v = E?.A;` then `X = v, Y` | X=1 Y=2 | X=v Y=undefined | X=1 Y=2 |
| `const v = E?.["A"];` then `X = v, Y` | X=1 Y=2 | X=v Y=undefined | X=1 Y=2 |
| `enum G { X = E?.A, Y }` | X=1 Y=2 | X=E?.A Y=undefined | X=1 Y=2 |
| `enum H { X = obj?.foo }` | `obj?.foo` | `obj?.foo` | `obj?.foo` |

The last two rows are why the change is slightly wider than the issue title: `tsc` folds these in member position too, with no diagnostic, so gating the arm to `const` initializers would have left a divergence the issue didn't name. The `obj?.foo` row is the negative control — `compute_member` builds its fallback from the `MemberExpr` alone, which would drop the `?.` and turn a guarded read into an unguarded one, so the arm keeps its own `Opaque` from the original expression.

Known limitation, unchanged: `E?.A?.B` stays opaque, because `compute_member` requires the object to be an `Ident`. Same emit as today's `main`.

**Performance:** `es/transform/baseline/common_typescript`, same session: `main` 51.858 µs and 52.621 µs across two runs, branch 52.299 µs. The change sits inside the run-to-run spread on this machine, so no measurable regression.

**Related issue:** #12152
