### PR TITLE
docs(agents): Document terser fixture backlog workflow

### DIFF
--- a/.changeset/document-terser-backlog-workflow.md
+++ b/.changeset/document-terser-backlog-workflow.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+docs(es/minifier): Document the Terser fixture backlog workflow

--- a/crates/swc_ecma_minifier/AGENTS.md
+++ b/crates/swc_ecma_minifier/AGENTS.md
@@ -41,3 +41,32 @@ the narrower local invariant.
 - Do not add new regression coverage to tests/terser. Use SWC-owned fixtures such as tests/fixture/issues instead.
 - Update generated fixture outputs with: UPDATE=1 cargo test -p swc_ecma_minifier.
 - Verify without UPDATE before finishing: cargo test -p swc_ecma_minifier.
+
+### Terser Fixture Backlog Workflow
+
+`tests/TODO.txt` and `tests/postponed.txt` are equivalent backlogs of ignored
+Terser compressor fixtures. Work on exactly one entry from either list at a
+time; there is no priority between the lists. An entry such as
+`arrays/constant_join_3/input.js` identifies the fixture at
+`tests/terser/compress/arrays/constant_join_3`:
+
+- `config.json` defines the Terser compression options to reproduce.
+- `input.js` is the source program to minify.
+- `output.js` is the expected Terser-compatible output.
+
+Before changing the minifier, delete only the selected entry from the list
+where it appears. This activates the existing fixture test; leave every other
+backlog entry untouched. Then change the minifier implementation so that the
+fixture passes. Do not make a failing fixture pass by changing its Terser
+fixture input or expected output.
+
+Verify the activated fixture first with:
+
+```sh
+cargo test -p swc_ecma_minifier --test compress fixture_tests__terser__compress__
+```
+
+Then run the full crate fixture suite without `UPDATE`, followed by the
+execution tests required above. Do not use `scripts/update-list.sh` while
+processing an individual entry: it regenerates the lists and can change
+unrelated backlog items.


### PR DESCRIPTION
**Description:**

Documents the one-at-a-time workflow for enabling and implementing ignored Terser minifier fixtures, including focused and full verification expectations.

**Related issue (if exists):**

None.