### PR TITLE
fix: Use Rust changeset package names

### DIFF
--- a/.changeset/fix-string-import-names.md
+++ b/.changeset/fix-string-import-names.md
@@ -1,5 +1,5 @@
 ---
-"swc_ecma_minifier": patch
+swc_ecma_minifier: patch
 ---
 
 Preserve string-named module imports when merging import declarations.

--- a/.changeset/preserve-string-method-arguments.md
+++ b/.changeset/preserve-string-method-arguments.md
@@ -1,6 +1,6 @@
 ---
-"swc_core": patch
-"swc_ecma_minifier": patch
+swc_core: patch
+swc_ecma_minifier: patch
 ---
 
 Preserve argument evaluation when folding literal string case-conversion calls.


### PR DESCRIPTION
**Description:**

Correct two changesets that used npm-style quoted package keys. The Rust changeset parser treated the quotes as part of each crate name, preventing the release bump from resolving those crates.

**Related issue (if exists):**

N/A