### PR TITLE
fix(es/minifier): shorten loose undefined comparisons to null

### DIFF
--- a/crates/swc/tests/tsc-references/parserindenter.2.minified.js
+++ b/crates/swc/tests/tsc-references/parserindenter.2.minified.js
@@ -34,7 +34,7 @@ import { _ as _class_call_check } from "@swc/helpers/_/_class_call_check";
         var commentLastLineNumber = this.snapshot.GetLineNumberFromPosition(token.Span.endPosition());
         if (token.lineNumber() == commentLastLineNumber) return result;
         var commentFirstLineIndentationDelta = this.GetIndentationDelta(token.Span.startPosition(), null);
-        if (void 0 != commentFirstLineIndentationDelta) for(var line = token.lineNumber() + 1; line <= commentLastLineNumber; line++){
+        if (null != commentFirstLineIndentationDelta) for(var line = token.lineNumber() + 1; line <= commentLastLineNumber; line++){
             var lineStartPosition = this.snapshot.GetLineFromLineNumber(line).startPosition(), lineIndent = this.GetLineIndentationForOffset(lineStartPosition), commentIndentationInfo = this.ApplyIndentationDelta2(lineIndent, commentFirstLineIndentationDelta);
             if (null != commentIndentationInfo) {
                 var tokenStartPosition = lineStartPosition + lineIndent.length, commentIndentationEdit = this.GetIndentEdit(commentIndentationInfo, tokenStartPosition, !1);

--- a/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
@@ -4,11 +4,15 @@ use swc_ecma_utils::{ExprExt, Type, Value};
 use Value::Known;
 
 use super::{BitCtx, Optimizer};
-use crate::{compress::util::negate, util::make_bool};
+use crate::{
+    compress::util::{is_pure_undefined, negate},
+    util::make_bool,
+};
 
 impl Optimizer<'_> {
     ///
     /// - `'12' === `foo` => '12' == 'foo'`
+    /// - `x == undefined` => `x == null` (also for `!=`)
     pub(super) fn optimize_bin_equal(&mut self, e: &mut BinExpr) {
         if !self.options.comparisons {
             return;
@@ -66,6 +70,21 @@ impl Optimizer<'_> {
                             "Reduced `===` to `==` because types of operands are identical"
                         )
                     }
+                }
+            }
+        }
+
+        if matches!(e.op, op!("==") | op!("!=")) {
+            // Loose equality treats null and undefined identically. Only replace
+            // pure undefined expressions so effects in `void expr` are preserved.
+            for operand in [&mut e.left, &mut e.right] {
+                if is_pure_undefined(self.ctx.expr_ctx, operand) {
+                    self.changed = true;
+                    report_change!("comparisons: Replacing undefined with null in loose equality");
+                    **operand = Lit::Null(Null {
+                        span: operand.span(),
+                    })
+                    .into();
                 }
             }
         }

--- a/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
+++ b/crates/swc_ecma_minifier/src/compress/optimize/ops.rs
@@ -74,7 +74,8 @@ impl Optimizer<'_> {
             }
         }
 
-        if matches!(e.op, op!("==") | op!("!=")) {
+        // Inside `with`, even unresolved identifiers can refer to object properties.
+        if matches!(e.op, op!("==") | op!("!=")) && !self.ctx.bit_ctx.contains(BitCtx::InWithStmt) {
             // Loose equality treats null and undefined identically. Only replace
             // pure undefined expressions so effects in `void expr` are preserved.
             for operand in [&mut e.left, &mut e.right] {

--- a/crates/swc_ecma_minifier/tests/fixture/issues/2257/full/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/2257/full/output.js
@@ -3107,7 +3107,7 @@
     /***/ },
     /***/ 23140: /***/ function(module, __unused_webpack_exports, __webpack_require__) {
         var wellKnownSymbol = __webpack_require__(81019), create = __webpack_require__(18255), definePropertyModule = __webpack_require__(94770), UNSCOPABLES = wellKnownSymbol("unscopables"), ArrayPrototype = Array.prototype;
-        void 0 == ArrayPrototype[UNSCOPABLES] && definePropertyModule.f(ArrayPrototype, UNSCOPABLES, {
+        null == ArrayPrototype[UNSCOPABLES] && definePropertyModule.f(ArrayPrototype, UNSCOPABLES, {
             configurable: !0,
             value: create(null)
         }), // add a key to Array.prototype[@@unscopables]
@@ -3687,7 +3687,7 @@
                         first: void 0,
                         last: void 0,
                         size: 0
-                    }), DESCRIPTORS || (that.size = 0), void 0 != iterable && iterate(iterable, that[ADDER], {
+                    }), DESCRIPTORS || (that.size = 0), null != iterable && iterate(iterable, that[ADDER], {
                         that: that,
                         AS_ENTRIES: IS_MAP
                     });
@@ -3849,7 +3849,7 @@
                         type: CONSTRUCTOR_NAME,
                         id: id++,
                         frozen: void 0
-                    }), void 0 != iterable && iterate(iterable, that[ADDER], {
+                    }), null != iterable && iterate(iterable, that[ADDER], {
                         that: that,
                         AS_ENTRIES: IS_MAP
                     });
@@ -3936,7 +3936,7 @@
                 ACCEPT_ITERABLES || ((Constructor = wrapper(function(dummy, iterable) {
                     anInstance(dummy, Constructor, CONSTRUCTOR_NAME);
                     var that = inheritIfRequired(new NativeConstructor(), dummy, Constructor);
-                    return void 0 != iterable && iterate(iterable, that[ADDER], {
+                    return null != iterable && iterate(iterable, that[ADDER], {
                         that: that,
                         AS_ENTRIES: IS_MAP
                     }), that;
@@ -4384,7 +4384,7 @@
     /***/ 99422: /***/ function(module, __unused_webpack_exports, __webpack_require__) {
         var classof = __webpack_require__(85983), getMethod = __webpack_require__(84316), Iterators = __webpack_require__(25463), ITERATOR = __webpack_require__(81019)("iterator");
         module.exports = function(it) {
-            if (void 0 != it) return getMethod(it, ITERATOR) || getMethod(it, "@@iterator") || Iterators[classof(it)];
+            if (null != it) return getMethod(it, ITERATOR) || getMethod(it, "@@iterator") || Iterators[classof(it)];
         };
     /***/ },
     /***/ 11661: /***/ function(module, __unused_webpack_exports, __webpack_require__) {
@@ -4787,7 +4787,7 @@
     /***/ 65400: /***/ function(module, __unused_webpack_exports, __webpack_require__) {
         "use strict";
         var IteratorPrototype, PrototypeOfArrayIteratorPrototype, arrayIterator, fails = __webpack_require__(60232), isCallable = __webpack_require__(67106), create = __webpack_require__(18255), getPrototypeOf = __webpack_require__(39311), redefine = __webpack_require__(78109), wellKnownSymbol = __webpack_require__(81019), IS_PURE = __webpack_require__(80627), ITERATOR = wellKnownSymbol("iterator"), BUGGY_SAFARI_ITERATORS = !1;
-        [].keys && ("next" in (arrayIterator = [].keys()) ? (PrototypeOfArrayIteratorPrototype = getPrototypeOf(getPrototypeOf(arrayIterator))) !== Object.prototype && (IteratorPrototype = PrototypeOfArrayIteratorPrototype) : BUGGY_SAFARI_ITERATORS = !0), void 0 == IteratorPrototype || fails(function() {
+        [].keys && ("next" in (arrayIterator = [].keys()) ? (PrototypeOfArrayIteratorPrototype = getPrototypeOf(getPrototypeOf(arrayIterator))) !== Object.prototype && (IteratorPrototype = PrototypeOfArrayIteratorPrototype) : BUGGY_SAFARI_ITERATORS = !0), null == IteratorPrototype || fails(function() {
             var test = {};
             // FF44- legacy iterators case
             return IteratorPrototype[ITERATOR].call(test) !== test;
@@ -5323,7 +5323,7 @@
         // `RequireObjectCoercible` abstract operation
         // https://tc39.es/ecma262/#sec-requireobjectcoercible
         module.exports = function(it) {
-            if (void 0 == it) throw TypeError("Can't call method on " + it);
+            if (null == it) throw TypeError("Can't call method on " + it);
             return it;
         };
     /***/ },
@@ -5400,7 +5400,7 @@
         // https://tc39.es/ecma262/#sec-speciesconstructor
         module.exports = function(O, defaultConstructor) {
             var S, C = anObject(O).constructor;
-            return void 0 === C || void 0 == (S = anObject(C)[SPECIES]) ? defaultConstructor : aConstructor(S);
+            return void 0 === C || null == (S = anObject(C)[SPECIES]) ? defaultConstructor : aConstructor(S);
         };
     /***/ },
     /***/ 49324: /***/ function(module, __unused_webpack_exports, __webpack_require__) {
@@ -8596,7 +8596,7 @@
                 // `String.prototype.match` method
                 // https://tc39.es/ecma262/#sec-string.prototype.match
                 function(regexp) {
-                    var O = requireObjectCoercible(this), matcher = void 0 == regexp ? void 0 : getMethod(regexp, MATCH);
+                    var O = requireObjectCoercible(this), matcher = null == regexp ? void 0 : getMethod(regexp, MATCH);
                     return matcher ? matcher.call(regexp, O) : new RegExp(regexp)[MATCH](toString1(O));
                 },
                 // `RegExp.prototype[@@match]` method
@@ -8703,7 +8703,7 @@
                 // `String.prototype.replace` method
                 // https://tc39.es/ecma262/#sec-string.prototype.replace
                 function(searchValue, replaceValue) {
-                    var O = requireObjectCoercible(this), replacer = void 0 == searchValue ? void 0 : getMethod(searchValue, REPLACE);
+                    var O = requireObjectCoercible(this), replacer = null == searchValue ? void 0 : getMethod(searchValue, REPLACE);
                     return replacer ? replacer.call(searchValue, O, replaceValue) : nativeReplace.call(toString1(O), searchValue, replaceValue);
                 },
                 // `RegExp.prototype[@@replace]` method
@@ -8766,7 +8766,7 @@
                 // `String.prototype.search` method
                 // https://tc39.es/ecma262/#sec-string.prototype.search
                 function(regexp) {
-                    var O = requireObjectCoercible(this), searcher = void 0 == regexp ? void 0 : getMethod(regexp, SEARCH);
+                    var O = requireObjectCoercible(this), searcher = null == regexp ? void 0 : getMethod(regexp, SEARCH);
                     return searcher ? searcher.call(regexp, O) : new RegExp(regexp)[SEARCH](toString1(O));
                 },
                 // `RegExp.prototype[@@search]` method
@@ -8822,7 +8822,7 @@
                 // `String.prototype.split` method
                 // https://tc39.es/ecma262/#sec-string.prototype.split
                 function(separator, limit) {
-                    var O = requireObjectCoercible(this), splitter = void 0 == separator ? void 0 : getMethod(separator, SPLIT);
+                    var O = requireObjectCoercible(this), splitter = null == separator ? void 0 : getMethod(separator, SPLIT);
                     return splitter ? splitter.call(separator, O, limit) : internalSplit.call(toString1(O), separator, limit);
                 },
                 // `RegExp.prototype[@@split]` method

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-disabled/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-disabled/config.json
@@ -1,0 +1,4 @@
+{
+    "defaults": true,
+    "comparisons": false
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-disabled/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-disabled/input.js
@@ -1,0 +1,2 @@
+console.log(it == undefined, undefined == it);
+console.log(it != void 0, void 0 != it);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-disabled/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-disabled/output.js
@@ -1,0 +1,1 @@
+console.log(void 0 == it, void 0 == it), console.log(void 0 != it, void 0 != it);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-only/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-only/config.json
@@ -1,0 +1,4 @@
+{
+    "defaults": false,
+    "comparisons": true
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-only/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-only/input.js
@@ -1,0 +1,12 @@
+console.log(it == undefined, undefined == it);
+console.log(it != undefined, undefined != it);
+console.log(it == void 0, void 0 == it);
+console.log(it != void 1, void 1 != it);
+console.log(it === undefined, undefined === it);
+console.log(it !== void 0, void 0 !== it);
+console.log(it < undefined, undefined > it);
+function shadowed(undefined, it) {
+    console.log(it == undefined, undefined == it);
+    console.log(it != undefined, undefined != it);
+}
+shadowed(1, 1);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-only/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/comparisons-only/output.js
@@ -1,0 +1,12 @@
+console.log(null == it, null == it);
+console.log(null != it, null != it);
+console.log(null == it, null == it);
+console.log(null != it, null != it);
+console.log(void 0 === it, void 0 === it);
+console.log(void 0 !== it, void 0 !== it);
+console.log((void 0) > it, (void 0) > it);
+function shadowed(undefined, it1) {
+    console.log(undefined == it1, undefined == it1);
+    console.log(undefined != it1, undefined != it1);
+}
+shadowed(1, 1);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/config.json
@@ -1,0 +1,3 @@
+{
+    "defaults": true
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/default/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/default/input.js
@@ -1,0 +1,1 @@
+console.log(it == undefined);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/default/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/default/output.js
@@ -1,0 +1,1 @@
+console.log(null == it);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/side-effects/expected.stdout
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/side-effects/expected.stdout
@@ -1,0 +1,15 @@
+value
+effect
+true
+effect
+value
+true
+value
+effect
+false
+effect
+value
+false
+value
+ReferenceError
+ReferenceError

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/side-effects/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/side-effects/input.js
@@ -1,0 +1,21 @@
+function value() {
+    console.log("value");
+    return null;
+}
+function effect() {
+    console.log("effect");
+}
+console.log(value() == void effect());
+console.log(void effect() == value());
+console.log(value() != void effect());
+console.log(void effect() != value());
+try {
+    console.log(value() == void missing);
+} catch (error) {
+    console.log(error.name);
+}
+try {
+    console.log(void missing == value());
+} catch (error) {
+    console.log(error.name);
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/side-effects/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/side-effects/output.js
@@ -1,0 +1,17 @@
+function value() {
+    return console.log("value"), null;
+}
+function effect() {
+    console.log("effect");
+}
+console.log(value() == void effect()), console.log(void effect() == value()), console.log(value() != void effect()), console.log(void effect() != value());
+try {
+    console.log(value() == void missing);
+} catch (error) {
+    console.log(error.name);
+}
+try {
+    console.log(void missing == value());
+} catch (error) {
+    console.log(error.name);
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/values/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/values/config.json
@@ -1,0 +1,4 @@
+{
+    "defaults": false,
+    "comparisons": true
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/values/expected.stdout
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/values/expected.stdout
@@ -1,0 +1,9 @@
+false false
+true true
+true true
+false false
+true true
+false false
+false false
+true true
+PASS

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/values/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/values/input.js
@@ -1,0 +1,32 @@
+function check(it, expected) {
+    if ((it == undefined) !== expected || (undefined == it) !== expected) {
+        throw new Error("loose equality");
+    }
+    if ((it != undefined) === expected || (undefined != it) === expected) {
+        throw new Error("loose inequality");
+    }
+    if ((it == void 0) !== expected || (void 1 == it) !== expected) {
+        throw new Error("void equality");
+    }
+    if ((it != void 1) === expected || (void 0 != it) === expected) {
+        throw new Error("void inequality");
+    }
+}
+check(undefined, true);
+check(null, true);
+for (const value of [false, 0, NaN, "", 1, "undefined", {}, [], 0n, Symbol()]) {
+    check(value, false);
+}
+function strict(it) {
+    console.log(it === undefined, undefined === it);
+    console.log(it !== void 0, void 0 !== it);
+}
+strict(null);
+strict(undefined);
+function shadowed(undefined, it) {
+    console.log(it == undefined, undefined == it);
+    console.log(it != undefined, undefined != it);
+}
+shadowed(1, 1);
+shadowed(1, null);
+console.log("PASS");

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/values/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/values/output.js
@@ -1,0 +1,33 @@
+function check(it, expected) {
+    if (null == it !== expected || null == it !== expected) throw Error("loose equality");
+    if (null != it === expected || null != it === expected) throw Error("loose inequality");
+    if (null == it !== expected || null == it !== expected) throw Error("void equality");
+    if (null != it === expected || null != it === expected) throw Error("void inequality");
+}
+check(void 0, true);
+check(null, true);
+for (const value of [
+    false,
+    0,
+    0 / 0,
+    "",
+    1,
+    "undefined",
+    {},
+    [],
+    0n,
+    Symbol()
+])check(value, false);
+function strict(it) {
+    console.log(void 0 === it, void 0 === it);
+    console.log(void 0 !== it, void 0 !== it);
+}
+strict(null);
+strict(void 0);
+function shadowed(undefined, it) {
+    console.log(undefined == it, undefined == it);
+    console.log(undefined != it, undefined != it);
+}
+shadowed(1, 1);
+shadowed(1, null);
+console.log("PASS");

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-default/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-default/config.json
@@ -1,0 +1,4 @@
+{
+    "defaults": true,
+    "module": false
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-default/expected.stdout
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-default/expected.stdout
@@ -1,0 +1,2 @@
+true true
+false false

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-default/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-default/input.js
@@ -1,0 +1,4 @@
+with ({ undefined: 1 }) {
+    console.log(1 == undefined, undefined == 1);
+    console.log(1 != undefined, undefined != 1);
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-default/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-default/output.js
@@ -1,0 +1,3 @@
+with ({
+    undefined: 1
+})console.log(1 == undefined, undefined == 1), console.log(1 != undefined, undefined != 1);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-scope/config.json
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-scope/config.json
@@ -1,0 +1,5 @@
+{
+    "defaults": false,
+    "comparisons": true,
+    "module": false
+}

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-scope/expected.stdout
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-scope/expected.stdout
@@ -1,0 +1,6 @@
+true true
+false false
+false false
+true true
+true false
+true false

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-scope/input.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-scope/input.js
@@ -1,0 +1,10 @@
+with ({ undefined: 1 }) {
+    console.log(1 == undefined, undefined == 1);
+    console.log(1 != undefined, undefined != 1);
+    console.log(null == undefined, undefined == null);
+    console.log(null != undefined, undefined != null);
+    (function () {
+        console.log(1 == undefined, undefined != 1);
+    })();
+}
+console.log(null == undefined, undefined != null);

--- a/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-scope/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/issues/undefined-equality/with-scope/output.js
@@ -1,0 +1,12 @@
+with ({
+    undefined: 1
+}){
+    console.log(1 == undefined, undefined == 1);
+    console.log(1 != undefined, undefined != 1);
+    console.log(null == undefined, undefined == null);
+    console.log(null != undefined, undefined != null);
+    (function() {
+        console.log(1 == undefined, undefined != 1);
+    })();
+}
+console.log(true, false);

--- a/crates/swc_ecma_minifier/tests/fixture/next/react-ace/chunks/8a28b14e.d8fbda268ed281a1/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/next/react-ace/chunks/8a28b14e.d8fbda268ed281a1/output.js
@@ -12,18 +12,18 @@
             }).modules = {}, define.payloads = {}, _require = function(parentId, module, callback) {
                 if ("string" == typeof module) {
                     var payload = lookup(parentId, module);
-                    if (void 0 != payload) return callback && callback(), payload;
+                    if (null != payload) return callback && callback(), payload;
                 } else if ("[object Array]" === Object.prototype.toString.call(module)) {
                     for(var params = [], i = 0, l = module.length; i < l; ++i){
                         var dep = lookup(parentId, module[i]);
-                        if (void 0 == dep && require.original) return;
+                        if (null == dep && require.original) return;
                         params.push(dep);
                     }
                     return callback && callback.apply(null, params) || !0;
                 }
             }, require = function(module, callback) {
                 var packagedModule = _require("", module, callback);
-                return void 0 == packagedModule && require.original ? require.original.apply(this, arguments) : packagedModule;
+                return null == packagedModule && require.original ? require.original.apply(this, arguments) : packagedModule;
             }, normalizeModule = function(parentId, moduleName) {
                 // normalize plugin requires
                 if (-1 !== moduleName.indexOf("!")) {
@@ -389,7 +389,7 @@
                 "use strict";
                 var activeListenerOptions, keys = require("./keys"), useragent = require("./useragent"), pressedKeys = null, ts = 0;
                 function getListenerOptions() {
-                    return void 0 == activeListenerOptions && function() {
+                    return null == activeListenerOptions && function() {
                         activeListenerOptions = !1;
                         try {
                             document.createComment("").addEventListener("test", function() {}, {
@@ -1986,7 +1986,7 @@
                         if (kb) {
                             "function" != typeof kb || kb.handleKeyboard || (kb.handleKeyboard = kb);
                             var i = this.$handlers.indexOf(kb);
-                            -1 != i && this.$handlers.splice(i, 1), void 0 == pos ? this.$handlers.push(kb) : this.$handlers.splice(pos, 0, kb), -1 == i && kb.attach && kb.attach(this.$editor);
+                            -1 != i && this.$handlers.splice(i, 1), null == pos ? this.$handlers.push(kb) : this.$handlers.splice(pos, 0, kb), -1 == i && kb.attach && kb.attach(this.$editor);
                         }
                     }, this.removeKeyboardHandler = function(kb) {
                         var i = this.$handlers.indexOf(kb);
@@ -2571,7 +2571,7 @@
                     }, this.setContentWidth = function(width) {
                         this.contentWidth = width;
                     }, this.isRtlLine = function(row) {
-                        return !!this.$isRtl || (void 0 != row ? this.session.getLine(row).charAt(0) == this.RLE : this.isRtlDir);
+                        return !!this.$isRtl || (null != row ? this.session.getLine(row).charAt(0) == this.RLE : this.isRtlDir);
                     }, this.setRtlDirection = function(editor, isRtlDir) {
                         for(var cursor = editor.getCursorPosition(), row = editor.selection.getSelectionAnchor().row; row <= cursor.row; row++)isRtlDir || editor.session.getLine(row).charAt(0) !== editor.session.$bidiHandler.RLE ? isRtlDir && editor.session.getLine(row).charAt(0) !== editor.session.$bidiHandler.RLE && editor.session.doc.insert({
                             column: 0,
@@ -2860,7 +2860,7 @@
                         }
                         return data;
                     }, this.fromJSON = function(data) {
-                        if (void 0 == data.start) if (this.rangeList && data.length > 1) {
+                        if (null == data.start) if (this.rangeList && data.length > 1) {
                             this.toSingleRange(data[0]);
                             for(var i = data.length; i--;){
                                 var r = Range.fromPoints(data[i].start, data[i].end);
@@ -4643,7 +4643,7 @@
                         var length = this.getLength();
                         void 0 === row ? row = length : row < 0 ? row = 0 : row >= length && (row = length - 1, column = void 0);
                         var line = this.getLine(row);
-                        return void 0 == column && (column = line.length), {
+                        return null == column && (column = line.length), {
                             row: row,
                             column: column = Math.min(Math.max(column, 0), line.length)
                         };
@@ -5347,7 +5347,7 @@
                             return range.end.row = iterator.getCurrentTokenRow(), range.end.column = iterator.getCurrentTokenColumn() + token.value.length - 2, range;
                         }
                     }, this.foldAll = function(startRow, endRow, depth, test) {
-                        void 0 == depth && (depth = 100000); // JSON.stringify doesn't hanle Infinity
+                        null == depth && (depth = 100000); // JSON.stringify doesn't hanle Infinity
                         var foldWidgets = this.foldWidgets;
                         if (foldWidgets) {
                             endRow = endRow || this.getLength(), startRow = startRow || 0;
@@ -6494,7 +6494,7 @@
                             }
                         }
                     }, this.bindKey = function(key, command, position) {
-                        if ("object" == typeof key && key && (void 0 == position && (position = key.position), key = key[this.platform]), key) {
+                        if ("object" == typeof key && key && (null == position && (position = key.position), key = key[this.platform]), key) {
                             if ("function" == typeof command) return this.addCommand({
                                 exec: command,
                                 bindKey: key,
@@ -7904,7 +7904,7 @@
                                         return;
                                     }
                                     var row = iterator.getCurrentTokenRow(), column = iterator.getCurrentTokenColumn(), range = new Range(row, column, row, column + token.value.length), sbm = session.$backMarkers[session.$tagHighlight];
-                                    session.$tagHighlight && void 0 != sbm && 0 !== range.compareRange(sbm.range) && (session.removeMarker(session.$tagHighlight), session.$tagHighlight = null), session.$tagHighlight || (session.$tagHighlight = session.addMarker(range, "ace_bracket", "text"));
+                                    session.$tagHighlight && null != sbm && 0 !== range.compareRange(sbm.range) && (session.removeMarker(session.$tagHighlight), session.$tagHighlight = null), session.$tagHighlight || (session.$tagHighlight = session.addMarker(range, "ace_bracket", "text"));
                                 }
                             }, 50);
                         }
@@ -8978,7 +8978,7 @@
                     }, this.canRedo = function() {
                         return this.$redoStack.length > 0;
                     }, this.bookmark = function(rev) {
-                        void 0 == rev && (rev = this.$rev), this.mark = rev;
+                        null == rev && (rev = this.$rev), this.mark = rev;
                     }, this.isAtBookmark = function() {
                         return this.$rev === this.mark;
                     }, this.toJSON = function() {}, this.fromJSON = function() {}, this.hasUndo = this.canUndo, this.hasRedo = this.canRedo, this.isClean = this.isAtBookmark, this.markClean = this.bookmark, this.$prettyPrint = function(delta) {
@@ -10772,7 +10772,7 @@ margin: 0 10px;\
                     }, this.visualizeBlur = function() {
                         dom.removeCssClass(this.container, "ace_focus");
                     }, this.showComposition = function(composition) {
-                        this.$composition = composition, composition.cssText || (composition.cssText = this.textarea.style.cssText), void 0 == composition.useTextareaForIME && (composition.useTextareaForIME = this.$useTextareaForIME), this.$useTextareaForIME ? (dom.addCssClass(this.textarea, "ace_composition"), this.textarea.style.cssText = "", this.$moveTextAreaToCursor(), this.$cursorLayer.element.style.display = "none") : composition.markerId = this.session.addMarker(composition.markerRange, "ace_composition_marker", "text");
+                        this.$composition = composition, composition.cssText || (composition.cssText = this.textarea.style.cssText), null == composition.useTextareaForIME && (composition.useTextareaForIME = this.$useTextareaForIME), this.$useTextareaForIME ? (dom.addCssClass(this.textarea, "ace_composition"), this.textarea.style.cssText = "", this.$moveTextAreaToCursor(), this.$cursorLayer.element.style.display = "none") : composition.markerId = this.session.addMarker(composition.markerRange, "ace_composition_marker", "text");
                     }, this.setCompositionText = function(text) {
                         var cursor = this.session.selection.cursor;
                         this.addToken(text, "composition_placeholder", cursor.row, cursor.column), this.$moveTextAreaToCursor();
@@ -11656,7 +11656,7 @@ margin: 0 10px;\
                             }
                         }
                     }, this.findAll = function(needle, options, additive) {
-                        if ((options = options || {}).needle = needle || options.needle, void 0 == options.needle) {
+                        if ((options = options || {}).needle = needle || options.needle, null == options.needle) {
                             var range = this.selection.isEmpty() ? this.selection.getWordRange() : this.selection.getRange();
                             options.needle = this.session.getTextRange(range);
                         }

--- a/crates/swc_ecma_minifier/tests/fixture/next/react-pdf-renderer/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/next/react-pdf-renderer/output.js
@@ -8787,7 +8787,7 @@
                              *     var wordArray = CryptoJS.lib.WordArray.create([0x00010203, 0x04050607]);
                              *     var wordArray = CryptoJS.lib.WordArray.create([0x00010203, 0x04050607], 6);
                              */ init: function(t, e) {
-                        t = this.words = t || [], void 0 != e ? this.sigBytes = e : this.sigBytes = 4 * t.length;
+                        t = this.words = t || [], null != e ? this.sigBytes = e : this.sigBytes = 4 * t.length;
                     },
                     /**
                              * Converts this word array to a string.
@@ -9800,7 +9800,7 @@
         /***/ 7507: /***/ function(t) {
             t.exports = function(t, e, r) {
                 // based on algorithm from http://en.wikipedia.org/wiki/HSL_and_HSV#Converting_to_RGB
-                if (void 0 == t) return [
+                if (null == t) return [
                     0,
                     0,
                     0

--- a/crates/swc_ecma_minifier/tests/fixture/next/syncfusion/933-e9f9a6bf671b96fc/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/next/syncfusion/933-e9f9a6bf671b96fc/output.js
@@ -7720,7 +7720,7 @@
                 }
                 // eslint-disable-next-line @typescript-eslint/no-unused-vars
                 function wireClearBtnEvents(element, button, container) {
-                    (void 0 == isBindClearAction || isBindClearAction) && button.addEventListener('click', function(event) {
+                    (null == isBindClearAction || isBindClearAction) && button.addEventListener('click', function(event) {
                         element.classList.contains(CLASSNAMES_DISABLE) || element.readOnly || (event.preventDefault(), element !== document.activeElement && element.focus(), element.value = '', (0, _syncfusion_ej2_base__WEBPACK_IMPORTED_MODULE_0__ /* .addClass */ .cn)([
                             button
                         ], CLASSNAMES_CLEARICONHIDE));

--- a/crates/swc_ecma_minifier/tests/fixture/next/wrap-contracts/output.js
+++ b/crates/swc_ecma_minifier/tests/fixture/next/wrap-contracts/output.js
@@ -2617,8 +2617,8 @@
                 async createTransaction(attributes, jwk) {
                     let transaction = {};
                     if (Object.assign(transaction, attributes), !attributes.data && !(attributes.target && attributes.quantity)) throw Error("A new Arweave transaction must have a 'data' value, or 'target' and 'quantity' values.");
-                    if (void 0 == attributes.owner && jwk && "use_wallet" !== jwk && (transaction.owner = jwk.n), void 0 == attributes.last_tx && (transaction.last_tx = await this.transactions.getTransactionAnchor()), "string" == typeof attributes.data && (attributes.data = ArweaveUtils.stringToBuffer(attributes.data)), attributes.data instanceof ArrayBuffer && (attributes.data = new Uint8Array(attributes.data)), attributes.data && !(attributes.data instanceof Uint8Array)) throw Error("Expected data to be a string, Uint8Array or ArrayBuffer");
-                    if (void 0 == attributes.reward) {
+                    if (null == attributes.owner && jwk && "use_wallet" !== jwk && (transaction.owner = jwk.n), null == attributes.last_tx && (transaction.last_tx = await this.transactions.getTransactionAnchor()), "string" == typeof attributes.data && (attributes.data = ArweaveUtils.stringToBuffer(attributes.data)), attributes.data instanceof ArrayBuffer && (attributes.data = new Uint8Array(attributes.data)), attributes.data && !(attributes.data instanceof Uint8Array)) throw Error("Expected data to be a string, Uint8Array or ArrayBuffer");
+                    if (null == attributes.reward) {
                         let length = attributes.data ? attributes.data.byteLength : 0;
                         transaction.reward = await this.transactions.getPrice(length, transaction.target);
                     }
@@ -2632,11 +2632,11 @@
                     if (Object.assign(transaction, attributes), !attributes.data) throw Error("Silo transactions must have a 'data' value");
                     if (!siloUri) throw Error("No Silo URI specified.");
                     if (attributes.target || attributes.quantity) throw Error("Silo transactions can only be used for storing data, sending AR to other wallets isn't supported.");
-                    if (void 0 == attributes.owner) {
+                    if (null == attributes.owner) {
                         if (!jwk || !jwk.n) throw Error("A new Arweave transaction must either have an 'owner' attribute, or you must provide the jwk parameter.");
                         transaction.owner = jwk.n;
                     }
-                    void 0 == attributes.last_tx && (transaction.last_tx = await this.transactions.getTransactionAnchor());
+                    null == attributes.last_tx && (transaction.last_tx = await this.transactions.getTransactionAnchor());
                     let siloResource = await this.silo.parseUri(siloUri);
                     if ("string" == typeof attributes.data) {
                         let encrypted = await this.crypto.encrypt(ArweaveUtils.stringToBuffer(attributes.data), siloResource.getEncryptionKey());
@@ -4278,8 +4278,8 @@
                 async createTransaction(attributes, jwk) {
                     let transaction = {};
                     if (Object.assign(transaction, attributes), !attributes.data && !(attributes.target && attributes.quantity)) throw Error("A new Arweave transaction must have a 'data' value, or 'target' and 'quantity' values.");
-                    if (void 0 == attributes.owner && jwk && "use_wallet" !== jwk && (transaction.owner = jwk.n), void 0 == attributes.last_tx && (transaction.last_tx = await this.transactions.getTransactionAnchor()), "string" == typeof attributes.data && (attributes.data = ArweaveUtils.stringToBuffer(attributes.data)), attributes.data instanceof ArrayBuffer && (attributes.data = new Uint8Array(attributes.data)), attributes.data && !(attributes.data instanceof Uint8Array)) throw Error("Expected data to be a string, Uint8Array or ArrayBuffer");
-                    if (void 0 == attributes.reward) {
+                    if (null == attributes.owner && jwk && "use_wallet" !== jwk && (transaction.owner = jwk.n), null == attributes.last_tx && (transaction.last_tx = await this.transactions.getTransactionAnchor()), "string" == typeof attributes.data && (attributes.data = ArweaveUtils.stringToBuffer(attributes.data)), attributes.data instanceof ArrayBuffer && (attributes.data = new Uint8Array(attributes.data)), attributes.data && !(attributes.data instanceof Uint8Array)) throw Error("Expected data to be a string, Uint8Array or ArrayBuffer");
+                    if (null == attributes.reward) {
                         let length = attributes.data ? attributes.data.byteLength : 0;
                         transaction.reward = await this.transactions.getPrice(length, transaction.target);
                     }
@@ -4293,11 +4293,11 @@
                     if (Object.assign(transaction, attributes), !attributes.data) throw Error("Silo transactions must have a 'data' value");
                     if (!siloUri) throw Error("No Silo URI specified.");
                     if (attributes.target || attributes.quantity) throw Error("Silo transactions can only be used for storing data, sending AR to other wallets isn't supported.");
-                    if (void 0 == attributes.owner) {
+                    if (null == attributes.owner) {
                         if (!jwk || !jwk.n) throw Error("A new Arweave transaction must either have an 'owner' attribute, or you must provide the jwk parameter.");
                         transaction.owner = jwk.n;
                     }
-                    void 0 == attributes.last_tx && (transaction.last_tx = await this.transactions.getTransactionAnchor());
+                    null == attributes.last_tx && (transaction.last_tx = await this.transactions.getTransactionAnchor());
                     let siloResource = await this.silo.parseUri(siloUri);
                     if ("string" == typeof attributes.data) {
                         let encrypted = await this.crypto.encrypt(ArweaveUtils.stringToBuffer(attributes.data), siloResource.getEncryptionKey());
@@ -24288,7 +24288,7 @@ function _get9(dt, pos) {
                     this.arweave = arweave, this.warp = warp, this.logger = LoggerFactory_1.LoggerFactory.INST.create('DefaultCreateContract'), this.deployFromSourceTx = this.deployFromSourceTx.bind(this);
                 }
                 async deploy(contractData, disableBundling) {
-                    let { wallet, initState, tags, transfer, data } = contractData, effectiveUseBundler = void 0 == disableBundling ? 'warp' == this.warp.definitionLoader.type() : !disableBundling, source = new SourceImpl_1.SourceImpl(this.arweave), srcTx = await source.save(contractData, wallet, effectiveUseBundler);
+                    let { wallet, initState, tags, transfer, data } = contractData, effectiveUseBundler = null == disableBundling ? 'warp' == this.warp.definitionLoader.type() : !disableBundling, source = new SourceImpl_1.SourceImpl(this.arweave), srcTx = await source.save(contractData, wallet, effectiveUseBundler);
                     return this.logger.debug('Creating new contract'), await this.deployFromSourceTx({
                         srcTxId: srcTx.id,
                         wallet,
@@ -24301,7 +24301,7 @@ function _get9(dt, pos) {
                 async deployFromSourceTx(contractData, disableBundling, srcTx = null) {
                     let responseOk, response;
                     this.logger.debug('Creating new contract from src tx');
-                    let { wallet, srcTxId, initState, tags, transfer, data } = contractData, effectiveUseBundler = void 0 == disableBundling ? 'warp' == this.warp.definitionLoader.type() : !disableBundling, contractTX = await this.arweave.createTransaction({
+                    let { wallet, srcTxId, initState, tags, transfer, data } = contractData, effectiveUseBundler = null == disableBundling ? 'warp' == this.warp.definitionLoader.type() : !disableBundling, contractTX = await this.arweave.createTransaction({
                         data: (null == data ? void 0 : data.body) || initState
                     }, wallet);
                     if (+(null == transfer ? void 0 : transfer.winstonQty) > 0 && transfer.target.length && (this.logger.debug('Creating additional transaction with AR transfer', transfer), contractTX = await this.arweave.createTransaction({

--- a/crates/swc_ecma_minifier/tests/full/size/a83cc6221479cbf2ab203169588b1e39b76a4a61/output.js
+++ b/crates/swc_ecma_minifier/tests/full/size/a83cc6221479cbf2ab203169588b1e39b76a4a61/output.js
@@ -1,1 +1,1 @@
-[]({function(){a(function(){b(function(){for(var f;;)if(void 0==d)for(var f=e;;);})})}});
+[]({function(){a(function(){b(function(){for(var n;;)if(null==d)for(var n=e;;);})})}});

--- a/crates/swc_ecma_minifier/tests/projects/output/angular-1.2.5.js
+++ b/crates/swc_ecma_minifier/tests/projects/output/angular-1.2.5.js
@@ -10579,7 +10579,7 @@
             // We are purposefully using == here rather than === because we want to
             // catch when value is "null or undefined"
             // jshint -W041
-            element.text(void 0 == value ? "" : value);
+            element.text(null == value ? "" : value);
         });
     }), ngBindTemplateDirective = [
         "$interpolate",


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

Optimize loose `==` and `!=` comparisons by replacing side-effect-free `undefined` expressions with `null`, saving two bytes per replacement.

```js
// Input
console.log(it == undefined);

// Before
console.log(void 0==it);

// After
console.log(null==it);
```

Applies to either operand when `comparisons` is enabled. Preserves strict comparisons, shadowed `undefined` bindings, side effects, and exceptions.

Adds five regression fixtures and updates affected output snapshots.

**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

**Related issue (if exists):**
