### PR TITLE
fix(bindings): preserve wasm fallback after native validation failure

### DIFF
--- a/.changeset/preserve-wasm-fallback.md
+++ b/.changeset/preserve-wasm-fallback.md
@@ -1,0 +1,5 @@
+---
+swc_core: patch
+---
+
+fix(bindings): preserve wasm fallback when native binding validation fails

--- a/packages/core/__tests__/binding_fallback_test.mjs
+++ b/packages/core/__tests__/binding_fallback_test.mjs
@@ -1,0 +1,36 @@
+import { loadBindings } from "../src/load-bindings";
+
+it("uses wasm when native binding validation fails", () => {
+    const wasmBinding = {};
+
+    const result = loadBindings(
+        undefined,
+        () => ({
+            getTargetTriple() {
+                throw new Error("native binding is invalid");
+            },
+        }),
+        () => wasmBinding
+    );
+
+    expect(result.binding).toBeUndefined();
+    expect(result.fallbackBindings).toBe(wasmBinding);
+});
+
+it("preserves errors thrown while loading wasm fallback", () => {
+    const wasmError = new Error("wasm binding failed to load");
+
+    expect(() =>
+        loadBindings(
+            undefined,
+            () => ({
+                getTargetTriple() {
+                    throw new Error("native binding is invalid");
+                },
+            }),
+            () => {
+                throw wasmError;
+            }
+        )
+    ).toThrow(wasmError);
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -85,6 +85,7 @@
         "index.js",
         "types.d.ts",
         "util.js",
+        "load-bindings.js",
         "README.md",
         "binding.js",
         "package.json",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,3 @@
-import { resolve } from "path";
 import type {
     Plugin,
     ParseOptions,
@@ -14,33 +13,18 @@ export type * from "@swc/types";
 // @ts-ignore
 export { newMangleNameCache as experimental_newMangleNameCache } from "./binding";
 import { BundleInput, compileBundleOptions } from "./spack";
-import * as assert from "assert";
 // @ts-ignore
 import type { NapiMinifyExtra } from "./binding";
+import { loadBindings } from "./load-bindings";
 
 // Allow overrides to the location of the .node binding file
 const bindingsOverride = process.env["SWC_BINARY_PATH"];
 // `@swc/core` includes d.ts for the `@swc/wasm` to provide typed fallback bindings
 // todo: fix package.json scripts
 let fallbackBindings: any;
-const bindings: typeof import("../binding") = (() => {
-    let binding;
-    try {
-        binding = !!bindingsOverride
-            ? require(resolve(bindingsOverride))
-            : require("./binding.js");
-
-        // If native binding loaded successfully, it should return proper target triple constant.
-        const triple = binding.getTargetTriple();
-        assert.ok(triple, "Failed to read target triple from native binary.");
-        return binding;
-    } catch (_) {
-        // postinstall supposed to install `@swc/wasm` already
-        fallbackBindings = require("@swc/wasm");
-    } finally {
-        return binding;
-    }
-})();
+const loadedBindings = loadBindings(bindingsOverride);
+const bindings: typeof import("../binding") = loadedBindings.binding;
+fallbackBindings = loadedBindings.fallbackBindings;
 
 type ProgramSourceContext = {
     realFilename?: string | null;

--- a/packages/core/src/load-bindings.ts
+++ b/packages/core/src/load-bindings.ts
@@ -1,0 +1,29 @@
+import { resolve } from "path";
+import * as assert from "assert";
+
+type LoadModule = (path: string) => any;
+
+type BindingLoadResult = {
+    binding?: any;
+    fallbackBindings?: any;
+};
+
+export function loadBindings(
+    bindingsOverride: string | undefined,
+    loadNative: LoadModule = (path) => require(path),
+    loadWasm: () => any = () => require("@swc/wasm")
+): BindingLoadResult {
+    try {
+        const binding = loadNative(
+            bindingsOverride ? resolve(bindingsOverride) : "./binding.js"
+        );
+
+        // If native binding loaded successfully, it should return proper target triple constant.
+        const triple = binding.getTargetTriple();
+        assert.ok(triple, "Failed to read target triple from native binary.");
+        return { binding };
+    } catch (_) {
+        // postinstall supposed to install `@swc/wasm` already
+        return { fallbackBindings: loadWasm() };
+    }
+}


### PR DESCRIPTION
<!-- Note: CI script will automatically rebase your PR so please do not rebase unless required -->

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. -->

**Description:**

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


`packages/core/src/index.ts` returned `binding` from a `finally` block after attempting to load the native binding and falling back to `@swc/wasm`.

When the native binding loaded successfully but `getTargetTriple()` validation failed, the `finally` return overrode the fallback result and returned the invalid native binding instead.

The `finally` return has been removed by moving binding initialization into a dedicated loader. The change also preserves the original error when loading `@swc/wasm` fails.

Added tests covering:

- native binding validation failure uses the WASM fallback;
- WASM fallback loading errors are not swallowed.


**BREAKING CHANGE:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG. Add description or remove entirely if not breaking.

You may need to update `MIGRATION.md` for the breaking changes.
-->

None.

**Related issue (if exists):**

None.