### PR TITLE
docs(es/minifier): clarify decorator input and test boundaries

### DIFF
--- a/.changeset/minifier-decorator-guidance.md
+++ b/.changeset/minifier-decorator-guidance.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_minifier: patch
+---
+
+docs(es/minifier): Clarify that decorators are lowered before minification and keep decorator-specific handling and tests in the appropriate parser or transform suites.

--- a/crates/swc_ecma_minifier/AGENTS.md
+++ b/crates/swc_ecma_minifier/AGENTS.md
@@ -5,6 +5,12 @@
 - Always run execution tests after making changes.
 - You can run fixture tests by doing ./scripts/test.sh, and you can do UPDATE=1 ./scripts/test.sh to update fixtures.
 
+### Decorators
+
+- Decorators are lowered before minification and are never present in minifier input.
+- Do not add decorator-specific handling or defensive code to the minifier.
+- Do not add tests for decorator syntax or decorator transform behavior to minifier test suites. Place these tests in the parser or decorator transform suites instead.
+
 ### Minifier Semantic Assumptions
 
 The ECMAScript minifier may rely on the documented assumptions from the SWC


### PR DESCRIPTION
**Description:**

Document that decorators are lowered before minification and never reach minifier input. Instruct AI agents not to add decorator-specific handling or defensive code to the minifier, and to place decorator syntax and transform tests in the parser or decorator transform suites.

Includes the required patch changeset for `swc_ecma_minifier` and `swc_core`. No implementation or existing tests changed.

Validation: reviewed the documentation diff and passed `git diff --check`. Runtime tests were not run for this documentation-only change.

**Related issue (if exists):**

None.
