### PR TITLE
fix(es/parser): allow line breaks before enum names

### DIFF
--- a/.changeset/enum-name-line-break.md
+++ b/.changeset/enum-name-line-break.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+fix(es/parser): allow line breaks before enum names

--- a/crates/swc_ecma_parser/src/parser/stmt.rs
+++ b/crates/swc_ecma_parser/src/parser/stmt.rs
@@ -2085,8 +2085,8 @@ impl<I: Tokens> Parser<I> {
             && is_typescript
             && self.input().syntax().typescript_allows_enum()
             && peek!(self).is_some_and(|peek| peek.is_word())
-            && !self.input_mut().has_linebreak_between_cur_and_peeked()
         {
+            // A line break before an enum name does not terminate the declaration.
             let start = self.input().cur_pos();
             self.bump();
             return Ok(self.parse_ts_enum_decl(start, false)?.into());

--- a/crates/swc_ecma_parser/tests/typescript/enum-line-break/input.ts
+++ b/crates/swc_ecma_parser/tests/typescript/enum-line-break/input.ts
@@ -1,0 +1,13 @@
+enum
+E { A }
+
+export enum
+Exported { A }
+
+namespace N {
+    enum /*
+    */ Nested { B }
+
+    export enum /*
+    */ ExportedNested { B }
+}

--- a/crates/swc_ecma_parser/tests/typescript/enum-line-break/input.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/enum-line-break/input.ts.json
@@ -1,0 +1,209 @@
+{
+  "type": "Module",
+  "span": {
+    "start": 1,
+    "end": 138
+  },
+  "body": [
+    {
+      "type": "TsEnumDeclaration",
+      "span": {
+        "start": 1,
+        "end": 13
+      },
+      "declare": false,
+      "isConst": false,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 6,
+          "end": 7
+        },
+        "ctxt": 0,
+        "value": "E",
+        "optional": false
+      },
+      "members": [
+        {
+          "type": "TsEnumMember",
+          "span": {
+            "start": 10,
+            "end": 11
+          },
+          "id": {
+            "type": "Identifier",
+            "span": {
+              "start": 10,
+              "end": 11
+            },
+            "ctxt": 0,
+            "value": "A",
+            "optional": false
+          },
+          "init": null
+        }
+      ]
+    },
+    {
+      "type": "ExportDeclaration",
+      "span": {
+        "start": 15,
+        "end": 41
+      },
+      "declaration": {
+        "type": "TsEnumDeclaration",
+        "span": {
+          "start": 22,
+          "end": 41
+        },
+        "declare": false,
+        "isConst": false,
+        "id": {
+          "type": "Identifier",
+          "span": {
+            "start": 27,
+            "end": 35
+          },
+          "ctxt": 0,
+          "value": "Exported",
+          "optional": false
+        },
+        "members": [
+          {
+            "type": "TsEnumMember",
+            "span": {
+              "start": 38,
+              "end": 39
+            },
+            "id": {
+              "type": "Identifier",
+              "span": {
+                "start": 38,
+                "end": 39
+              },
+              "ctxt": 0,
+              "value": "A",
+              "optional": false
+            },
+            "init": null
+          }
+        ]
+      }
+    },
+    {
+      "type": "TsModuleDeclaration",
+      "span": {
+        "start": 43,
+        "end": 138
+      },
+      "declare": false,
+      "global": false,
+      "namespace": true,
+      "id": {
+        "type": "Identifier",
+        "span": {
+          "start": 53,
+          "end": 54
+        },
+        "ctxt": 0,
+        "value": "N",
+        "optional": false
+      },
+      "body": {
+        "type": "TsModuleBlock",
+        "span": {
+          "start": 55,
+          "end": 138
+        },
+        "body": [
+          {
+            "type": "TsEnumDeclaration",
+            "span": {
+              "start": 61,
+              "end": 88
+            },
+            "declare": false,
+            "isConst": false,
+            "id": {
+              "type": "Identifier",
+              "span": {
+                "start": 76,
+                "end": 82
+              },
+              "ctxt": 0,
+              "value": "Nested",
+              "optional": false
+            },
+            "members": [
+              {
+                "type": "TsEnumMember",
+                "span": {
+                  "start": 85,
+                  "end": 86
+                },
+                "id": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 85,
+                    "end": 86
+                  },
+                  "ctxt": 0,
+                  "value": "B",
+                  "optional": false
+                },
+                "init": null
+              }
+            ]
+          },
+          {
+            "type": "ExportDeclaration",
+            "span": {
+              "start": 94,
+              "end": 136
+            },
+            "declaration": {
+              "type": "TsEnumDeclaration",
+              "span": {
+                "start": 101,
+                "end": 136
+              },
+              "declare": false,
+              "isConst": false,
+              "id": {
+                "type": "Identifier",
+                "span": {
+                  "start": 116,
+                  "end": 130
+                },
+                "ctxt": 0,
+                "value": "ExportedNested",
+                "optional": false
+              },
+              "members": [
+                {
+                  "type": "TsEnumMember",
+                  "span": {
+                    "start": 133,
+                    "end": 134
+                  },
+                  "id": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 133,
+                      "end": 134
+                    },
+                    "ctxt": 0,
+                    "value": "B",
+                    "optional": false
+                  },
+                  "init": null
+                }
+              ]
+            }
+          }
+        ]
+      }
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
Recognize TypeScript enum declarations when a line break separates `enum` from its name. Valid input such as the following currently fails to parse:

```ts
enum
E { A }
```

Remove the no-line-break condition from enum statement dispatch. A newline, including one inside a block comment, does not terminate an enum declaration. Add a fixture covering a direct newline and a multiline comment inside a namespace.
