### PR TITLE
fix(es/parser): allow ambient rest trailing commas

### DIFF
--- a/.changeset/ambient-rest-trailing-comma.md
+++ b/.changeset/ambient-rest-trailing-comma.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_parser: patch
+---
+
+fix(es/parser): allow ambient rest trailing commas

--- a/crates/swc_ecma_parser/src/parser/pat.rs
+++ b/crates/swc_ecma_parser/src/parser/pat.rs
@@ -824,7 +824,10 @@ impl<I: Tokens> Parser<I> {
 
             if !self.input().is(Token::RParen) {
                 expect!(self, Token::Comma);
-                if self.input().is(Token::RParen) && is_rest {
+                if self.input().is(Token::RParen)
+                    && is_rest
+                    && (!self.ctx().contains(Context::InDeclare) || self.syntax().flow())
+                {
                     self.emit_err(self.input().prev_span(), SyntaxError::CommaAfterRestElement);
                 }
             }
@@ -904,7 +907,11 @@ impl<I: Tokens> Parser<I> {
 
             if !self.input().is(Token::RParen) {
                 expect!(self, Token::Comma);
-                if is_rest && self.input().is(Token::RParen) {
+                // Ambient TypeScript signatures allow a trailing comma after rest.
+                if is_rest
+                    && self.input().is(Token::RParen)
+                    && (!self.ctx().contains(Context::InDeclare) || self.syntax().flow())
+                {
                     self.emit_err(self.input().prev_span(), SyntaxError::CommaAfterRestElement);
                 }
             }

--- a/crates/swc_ecma_parser/tests/typescript.rs
+++ b/crates/swc_ecma_parser/tests/typescript.rs
@@ -2,11 +2,12 @@
 
 use std::{
     fs::File,
-    io::Read,
+    io::{self, Read},
     path::{Path, PathBuf},
 };
 
 use pretty_assertions::assert_eq;
+use serde::Deserialize;
 use swc_common::{comments::SingleThreadedComments, FileName};
 use swc_ecma_ast::*;
 use swc_ecma_parser::{lexer::Lexer, PResult, Parser, Syntax, TsSyntax};
@@ -17,6 +18,12 @@ use crate::common::Normalizer;
 
 #[path = "common/mod.rs"]
 mod common;
+
+#[derive(Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TestConfig {
+    no_early_errors: Option<bool>,
+}
 
 #[testing::fixture("tests/shifted/**/*.ts")]
 fn shifted(file: PathBuf) {
@@ -182,7 +189,16 @@ fn run_spec(file: &Path, output_json: &Path) {
         eprintln!("\n\n========== Running reference test {file_name}\nSource:\n{input}\n");
     }
 
-    with_parser(false, file, true, false, |p, _| {
+    // AST fixtures normally suppress early errors; regression fixtures can opt in.
+    let config_path = file.with_file_name("config.json");
+    let config: TestConfig = match File::open(&config_path) {
+        Ok(file) => serde_json::from_reader(file).expect("failed to parse fixture config"),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => TestConfig::default(),
+        Err(err) => panic!("failed to read {}: {err}", config_path.display()),
+    };
+    let no_early_errors = config.no_early_errors.unwrap_or(true);
+
+    with_parser(false, file, no_early_errors, false, |p, _| {
         let program = p.parse_program()?.fold_with(&mut Normalizer {
             drop_span: false,
             is_test262: false,

--- a/crates/swc_ecma_parser/tests/typescript/ambient-rest-trailing-comma/config.json
+++ b/crates/swc_ecma_parser/tests/typescript/ambient-rest-trailing-comma/config.json
@@ -1,0 +1,3 @@
+{
+  "noEarlyErrors": false
+}

--- a/crates/swc_ecma_parser/tests/typescript/ambient-rest-trailing-comma/declare.ts
+++ b/crates/swc_ecma_parser/tests/typescript/ambient-rest-trailing-comma/declare.ts
@@ -1,0 +1,5 @@
+declare function f(...args: string[],): void;
+declare class C {
+    constructor(...args: string[],);
+    method(...args: string[],): void;
+}

--- a/crates/swc_ecma_parser/tests/typescript/ambient-rest-trailing-comma/declare.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/ambient-rest-trailing-comma/declare.ts.json
@@ -1,0 +1,305 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 141
+  },
+  "body": [
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 18,
+          "end": 19
+        },
+        "ctxt": 0,
+        "value": "f",
+        "optional": false
+      },
+      "declare": true,
+      "params": [
+        {
+          "type": "Parameter",
+          "span": {
+            "start": 20,
+            "end": 37
+          },
+          "decorators": [],
+          "pat": {
+            "type": "RestElement",
+            "span": {
+              "start": 20,
+              "end": 37
+            },
+            "rest": {
+              "start": 20,
+              "end": 23
+            },
+            "argument": {
+              "type": "Identifier",
+              "span": {
+                "start": 23,
+                "end": 27
+              },
+              "ctxt": 0,
+              "value": "args",
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 27,
+                "end": 37
+              },
+              "typeAnnotation": {
+                "type": "TsArrayType",
+                "span": {
+                  "start": 29,
+                  "end": 37
+                },
+                "elemType": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 29,
+                    "end": 35
+                  },
+                  "kind": "string"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 1,
+        "end": 46
+      },
+      "ctxt": 0,
+      "body": null,
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 39,
+          "end": 45
+        },
+        "typeAnnotation": {
+          "type": "TsKeywordType",
+          "span": {
+            "start": 41,
+            "end": 45
+          },
+          "kind": "void"
+        }
+      }
+    },
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 61,
+          "end": 62
+        },
+        "ctxt": 0,
+        "value": "C",
+        "optional": false
+      },
+      "declare": true,
+      "span": {
+        "start": 47,
+        "end": 141
+      },
+      "ctxt": 0,
+      "decorators": [],
+      "body": [
+        {
+          "type": "Constructor",
+          "span": {
+            "start": 69,
+            "end": 101
+          },
+          "ctxt": 0,
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 69,
+              "end": 80
+            },
+            "value": "constructor"
+          },
+          "params": [
+            {
+              "type": "Parameter",
+              "span": {
+                "start": 81,
+                "end": 98
+              },
+              "decorators": [],
+              "pat": {
+                "type": "RestElement",
+                "span": {
+                  "start": 81,
+                  "end": 98
+                },
+                "rest": {
+                  "start": 81,
+                  "end": 84
+                },
+                "argument": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 84,
+                    "end": 88
+                  },
+                  "ctxt": 0,
+                  "value": "args",
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 88,
+                    "end": 98
+                  },
+                  "typeAnnotation": {
+                    "type": "TsArrayType",
+                    "span": {
+                      "start": 90,
+                      "end": 98
+                    },
+                    "elemType": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 90,
+                        "end": 96
+                      },
+                      "kind": "string"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "body": null,
+          "accessibility": null,
+          "isOptional": false
+        },
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 106,
+            "end": 139
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 106,
+              "end": 112
+            },
+            "value": "method"
+          },
+          "function": {
+            "params": [
+              {
+                "type": "Parameter",
+                "span": {
+                  "start": 113,
+                  "end": 130
+                },
+                "decorators": [],
+                "pat": {
+                  "type": "RestElement",
+                  "span": {
+                    "start": 113,
+                    "end": 130
+                  },
+                  "rest": {
+                    "start": 113,
+                    "end": 116
+                  },
+                  "argument": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 116,
+                      "end": 120
+                    },
+                    "ctxt": 0,
+                    "value": "args",
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 120,
+                      "end": 130
+                    },
+                    "typeAnnotation": {
+                      "type": "TsArrayType",
+                      "span": {
+                        "start": 122,
+                        "end": 130
+                      },
+                      "elemType": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 122,
+                          "end": 128
+                        },
+                        "kind": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "decorators": [],
+            "span": {
+              "start": 106,
+              "end": 139
+            },
+            "ctxt": 0,
+            "body": null,
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 132,
+                "end": 138
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 134,
+                  "end": 138
+                },
+                "kind": "void"
+              }
+            }
+          },
+          "kind": "method",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false
+        }
+      ],
+      "superClass": null,
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    }
+  ],
+  "interpreter": null
+}

--- a/crates/swc_ecma_parser/tests/typescript/ambient-rest-trailing-comma/input.d.ts
+++ b/crates/swc_ecma_parser/tests/typescript/ambient-rest-trailing-comma/input.d.ts
@@ -1,0 +1,5 @@
+function f(...args: string[],): void;
+class C {
+    constructor(...args: string[],);
+    method(...args: string[],): void;
+}

--- a/crates/swc_ecma_parser/tests/typescript/ambient-rest-trailing-comma/input.d.ts.json
+++ b/crates/swc_ecma_parser/tests/typescript/ambient-rest-trailing-comma/input.d.ts.json
@@ -1,0 +1,305 @@
+{
+  "type": "Script",
+  "span": {
+    "start": 1,
+    "end": 125
+  },
+  "body": [
+    {
+      "type": "FunctionDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 10,
+          "end": 11
+        },
+        "ctxt": 0,
+        "value": "f",
+        "optional": false
+      },
+      "declare": false,
+      "params": [
+        {
+          "type": "Parameter",
+          "span": {
+            "start": 12,
+            "end": 29
+          },
+          "decorators": [],
+          "pat": {
+            "type": "RestElement",
+            "span": {
+              "start": 12,
+              "end": 29
+            },
+            "rest": {
+              "start": 12,
+              "end": 15
+            },
+            "argument": {
+              "type": "Identifier",
+              "span": {
+                "start": 15,
+                "end": 19
+              },
+              "ctxt": 0,
+              "value": "args",
+              "optional": false,
+              "typeAnnotation": null
+            },
+            "typeAnnotation": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 19,
+                "end": 29
+              },
+              "typeAnnotation": {
+                "type": "TsArrayType",
+                "span": {
+                  "start": 21,
+                  "end": 29
+                },
+                "elemType": {
+                  "type": "TsKeywordType",
+                  "span": {
+                    "start": 21,
+                    "end": 27
+                  },
+                  "kind": "string"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "decorators": [],
+      "span": {
+        "start": 1,
+        "end": 38
+      },
+      "ctxt": 0,
+      "body": null,
+      "generator": false,
+      "async": false,
+      "typeParameters": null,
+      "returnType": {
+        "type": "TsTypeAnnotation",
+        "span": {
+          "start": 31,
+          "end": 37
+        },
+        "typeAnnotation": {
+          "type": "TsKeywordType",
+          "span": {
+            "start": 33,
+            "end": 37
+          },
+          "kind": "void"
+        }
+      }
+    },
+    {
+      "type": "ClassDeclaration",
+      "identifier": {
+        "type": "Identifier",
+        "span": {
+          "start": 45,
+          "end": 46
+        },
+        "ctxt": 0,
+        "value": "C",
+        "optional": false
+      },
+      "declare": false,
+      "span": {
+        "start": 39,
+        "end": 125
+      },
+      "ctxt": 0,
+      "decorators": [],
+      "body": [
+        {
+          "type": "Constructor",
+          "span": {
+            "start": 53,
+            "end": 85
+          },
+          "ctxt": 0,
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 53,
+              "end": 64
+            },
+            "value": "constructor"
+          },
+          "params": [
+            {
+              "type": "Parameter",
+              "span": {
+                "start": 65,
+                "end": 82
+              },
+              "decorators": [],
+              "pat": {
+                "type": "RestElement",
+                "span": {
+                  "start": 65,
+                  "end": 82
+                },
+                "rest": {
+                  "start": 65,
+                  "end": 68
+                },
+                "argument": {
+                  "type": "Identifier",
+                  "span": {
+                    "start": 68,
+                    "end": 72
+                  },
+                  "ctxt": 0,
+                  "value": "args",
+                  "optional": false,
+                  "typeAnnotation": null
+                },
+                "typeAnnotation": {
+                  "type": "TsTypeAnnotation",
+                  "span": {
+                    "start": 72,
+                    "end": 82
+                  },
+                  "typeAnnotation": {
+                    "type": "TsArrayType",
+                    "span": {
+                      "start": 74,
+                      "end": 82
+                    },
+                    "elemType": {
+                      "type": "TsKeywordType",
+                      "span": {
+                        "start": 74,
+                        "end": 80
+                      },
+                      "kind": "string"
+                    }
+                  }
+                }
+              }
+            }
+          ],
+          "body": null,
+          "accessibility": null,
+          "isOptional": false
+        },
+        {
+          "type": "ClassMethod",
+          "span": {
+            "start": 90,
+            "end": 123
+          },
+          "key": {
+            "type": "Identifier",
+            "span": {
+              "start": 90,
+              "end": 96
+            },
+            "value": "method"
+          },
+          "function": {
+            "params": [
+              {
+                "type": "Parameter",
+                "span": {
+                  "start": 97,
+                  "end": 114
+                },
+                "decorators": [],
+                "pat": {
+                  "type": "RestElement",
+                  "span": {
+                    "start": 97,
+                    "end": 114
+                  },
+                  "rest": {
+                    "start": 97,
+                    "end": 100
+                  },
+                  "argument": {
+                    "type": "Identifier",
+                    "span": {
+                      "start": 100,
+                      "end": 104
+                    },
+                    "ctxt": 0,
+                    "value": "args",
+                    "optional": false,
+                    "typeAnnotation": null
+                  },
+                  "typeAnnotation": {
+                    "type": "TsTypeAnnotation",
+                    "span": {
+                      "start": 104,
+                      "end": 114
+                    },
+                    "typeAnnotation": {
+                      "type": "TsArrayType",
+                      "span": {
+                        "start": 106,
+                        "end": 114
+                      },
+                      "elemType": {
+                        "type": "TsKeywordType",
+                        "span": {
+                          "start": 106,
+                          "end": 112
+                        },
+                        "kind": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            ],
+            "decorators": [],
+            "span": {
+              "start": 90,
+              "end": 123
+            },
+            "ctxt": 0,
+            "body": null,
+            "generator": false,
+            "async": false,
+            "typeParameters": null,
+            "returnType": {
+              "type": "TsTypeAnnotation",
+              "span": {
+                "start": 116,
+                "end": 122
+              },
+              "typeAnnotation": {
+                "type": "TsKeywordType",
+                "span": {
+                  "start": 118,
+                  "end": 122
+                },
+                "kind": "void"
+              }
+            }
+          },
+          "kind": "method",
+          "isStatic": false,
+          "accessibility": null,
+          "isAbstract": false,
+          "isOptional": false,
+          "isOverride": false
+        }
+      ],
+      "superClass": null,
+      "isAbstract": false,
+      "typeParams": null,
+      "superTypeParams": null,
+      "implements": []
+    }
+  ],
+  "interpreter": null
+}


### PR DESCRIPTION
Accept trailing commas after rest parameters in ambient TypeScript declarations. Valid signatures such as the following currently produce `CommaAfterRestElement` when early-error diagnostics are enabled:

```ts
declare function f(...args: string[],): void;
declare class C {
    constructor(...args: string[],);
    method(...args: string[],): void;
}
```

Apply the ambient TypeScript exception to both formal and constructor parameter parsing. JavaScript, non-ambient signatures, and Flow retain their existing diagnostics.

Add fixtures for explicit `declare` declarations and implicit ambient declarations in `.d.ts` files. The TypeScript fixture harness now accepts an optional `noEarlyErrors` setting so these fixtures exercise the diagnostic that previously rejected them. Existing fixtures keep their current default. Existing non-ambient error coverage is reused.
