### PR TITLE
fix(es): Decode template raw values when cooked is missing

### DIFF
--- a/.changeset/fast-dts-template-missing-cooked.md
+++ b/.changeset/fast-dts-template-missing-cooked.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_typescript: patch
+---
+
+fix(typescript): Decode raw-only templates in Fast DTS values, computed property names, accessor matching, and enum evaluation.

--- a/.changeset/template-literal-missing-cooked.md
+++ b/.changeset/template-literal-missing-cooked.md
@@ -1,0 +1,7 @@
+---
+swc_core: patch
+swc_ecma_compat_es2015: patch
+swc_ecma_transforms_compat: patch
+---
+
+fix(es/compat): Decode raw escapes when lowering ordinary templates whose cooked values are missing.

--- a/.changeset/template-raw-decoding-boundaries.md
+++ b/.changeset/template-raw-decoding-boundaries.md
@@ -1,0 +1,6 @@
+---
+swc_core: patch
+swc_ecma_ast: patch
+---
+
+fix(es/ast): Preserve line endings, Unicode escapes, and unpaired surrogates when decoding template raw values.

--- a/crates/swc_ecma_ast/src/lit.rs
+++ b/crates/swc_ecma_ast/src/lit.rs
@@ -212,15 +212,16 @@ impl Str {
         self.value.is_empty()
     }
 
+    /// Decodes an ordinary template element's raw text into its string value.
+    ///
+    /// Normalizes line endings and preserves unpaired UTF-16 surrogates.
+    /// Invalid escapes emit diagnostics; tagged templates must preserve
+    /// their optional cooked value instead of using this conversion.
     pub fn from_tpl_raw(tpl: &TplElement) -> Wtf8Atom {
         let tpl_raw = &tpl.raw;
         let span = tpl.span;
         let mut buf: Wtf8Buf = Wtf8Buf::with_capacity(tpl_raw.len());
         let mut iter = tpl_raw.chars();
-        // prev_result can only be less than 0xdc00
-        // so init with 0xdc00 as no prev result
-        const NO_PREV_RESULT: u32 = 0xdc00;
-        let mut prev_result: u32 = NO_PREV_RESULT;
         while let Some(c) = iter.next() {
             match c {
                 '\\' => {
@@ -255,94 +256,44 @@ impl Str {
                             }
                             '\n' | '\u{2028}' | '\u{2029}' => {}
                             'u' | 'x' => {
-                                let mut count: u8 = 0;
-                                // result is a 4 digit hex value
-                                let mut result: u32 = 0;
-                                let mut max_len = if c == 'u' { 4 } else { 2 };
+                                let braced = c == 'u' && iter.clone().next() == Some('{');
+                                if braced {
+                                    iter.next();
+                                }
+                                let digits = if c == 'u' { 4 } else { 2 };
+                                let mut count = 0;
+                                let mut result = 0u32;
+                                let mut terminated = !braced;
                                 for c in &mut iter {
-                                    match c {
-                                        '{' if max_len == 4 && count == 0 => {
-                                            max_len = 6;
-                                            continue;
-                                        }
-                                        '}' if max_len == 6 => {
-                                            break;
-                                        }
-                                        '0'..='9' => {
-                                            result = (result << 4) | (c as u32 - '0' as u32);
-                                            count += 1;
-                                        }
-                                        'a'..='f' => {
-                                            result = (result << 4) | (c as u32 - 'a' as u32 + 10);
-                                            count += 1;
-                                        }
-                                        'A'..='F' => {
-                                            result = (result << 4) | (c as u32 - 'A' as u32 + 10);
-                                            count += 1;
-                                        }
-                                        _ => emit_span_error(
+                                    if braced && c == '}' {
+                                        terminated = true;
+                                        break;
+                                    }
+                                    let Some(digit) = c.to_digit(16) else {
+                                        emit_span_error(
                                             span,
                                             "Uncaught SyntaxError: Invalid Unicode escape sequence",
-                                        ),
-                                    }
-                                    if count >= max_len {
-                                        if result > 0x10ffff {
-                                            emit_span_error(
-                                                span,
-                                                "Uncaught SyntaxError: Undefined Unicode \
-                                                 code-point",
-                                            )
-                                        } else {
-                                            break;
-                                        }
+                                        );
+                                        break;
+                                    };
+                                    // Saturation keeps arbitrarily long invalid escapes from
+                                    // overflowing while allowing leading zeroes in valid ones.
+                                    result = result.saturating_mul(16).saturating_add(digit);
+                                    count += 1;
+                                    if !braced && count == digits {
+                                        break;
                                     }
                                 }
-                                if max_len == 2 && max_len != count {
+                                if !terminated || count == 0 || (!braced && count != digits) {
                                     emit_span_error(
                                         span,
                                         "Uncaught SyntaxError: Invalid hexadecimal escape sequence",
                                     );
                                 }
-                                if (0xd800..=0xdfff).contains(&result) {
-                                    // Handle UTF-16 surrogate pair
-                                    if result < 0xdc00 {
-                                        // High surrogate pair
-                                        if prev_result != NO_PREV_RESULT {
-                                            // If the previous result is a high surrogate
-                                            // We can be sure `prev_result` is less than 0xdc00
-                                            buf.push(unsafe {
-                                                CodePoint::from_u32_unchecked(prev_result)
-                                            });
-                                        }
-                                        let mut iter = iter.clone();
-                                        if let Some('\\') = iter.next() {
-                                            if let Some('u') = iter.next() {
-                                                // less than 0xdc00
-                                                prev_result = result;
-                                                continue;
-                                            }
-                                        }
-                                    } else if prev_result != NO_PREV_RESULT {
-                                        // Low surrogate pair
-                                        // Decode to supplementary plane code point
-                                        // (0x10000-0x10FFFF)
-                                        result = 0x10000
-                                            + ((result & 0x3ff) | ((prev_result & 0x3ff) << 10));
-                                        // We can be sure result is a valid code point here
-                                        buf.push(unsafe { CodePoint::from_u32_unchecked(result) });
-                                        prev_result = NO_PREV_RESULT;
-                                        continue;
-                                    }
-                                }
-                                if prev_result != NO_PREV_RESULT {
-                                    // Could not find a valid low surrogate pair
-                                    // We can be sure `prev_result` is less than 0xdc00
-                                    buf.push(unsafe { CodePoint::from_u32_unchecked(prev_result) });
-                                    prev_result = NO_PREV_RESULT;
-                                }
-                                if result <= 0x10ffff {
-                                    // We can be sure result is a valid code point here
-                                    buf.push(unsafe { CodePoint::from_u32_unchecked(result) });
+                                if let Some(code_point) = CodePoint::from_u32(result) {
+                                    // Wtf8Buf joins adjacent surrogate pairs and preserves
+                                    // unpaired surrogates without lookahead or buffering.
+                                    buf.push(code_point);
                                 } else {
                                     emit_span_error(
                                         span,
@@ -379,6 +330,13 @@ impl Str {
                             }
                         }
                     }
+                }
+
+                '\r' => {
+                    if iter.clone().next() == Some('\n') {
+                        iter.next();
+                    }
+                    buf.push_char('\n');
                 }
 
                 c => {

--- a/crates/swc_ecma_ast/tests/lit.rs
+++ b/crates/swc_ecma_ast/tests/lit.rs
@@ -172,3 +172,23 @@ fn should_panic_octal_2() {
 fn should_panic_octal_7() {
     test_from_tpl_raw("\\7", "");
 }
+
+#[test]
+fn template_line_endings() {
+    test_from_tpl_raw("a\rb\r\nc\n", "a\nb\nc\n");
+    test_from_tpl_raw("a\\\rb\\\r\nc\\\nd", "abcd");
+    test_from_tpl_raw("\\r\\n", "\r\n");
+}
+
+#[test]
+fn braced_unicode_boundaries() {
+    test_from_tpl_raw("\\u{10FFFF}", "\u{10FFFF}");
+    test_from_tpl_raw("\\u{000000000041}", "A");
+}
+
+#[test]
+fn consecutive_unpaired_surrogates() {
+    test_from_tpl_raw("\\uD800\\uD801", "\\uD800\\uD801");
+    test_from_tpl_raw("\\uD800\\uD801x", "\\uD800\\uD801x");
+    test_from_tpl_raw("\\uD800\\uD801\\uDC00", "\\uD800\u{10400}");
+}

--- a/crates/swc_ecma_compat_es2015/src/template_literal.rs
+++ b/crates/swc_ecma_compat_es2015/src/template_literal.rs
@@ -61,7 +61,7 @@ impl VisitMut for TemplateLiteral {
                         let s = quasis[0]
                             .cooked
                             .clone()
-                            .unwrap_or_else(|| quasis[0].raw.clone().into());
+                            .unwrap_or_else(|| Str::from_tpl_raw(&quasis[0]));
 
                         Str {
                             span: quasis[0].span,
@@ -92,14 +92,15 @@ impl VisitMut for TemplateLiteral {
                     let expr = if i % 2 == 0 {
                         // Quasis
                         match quasis.next() {
-                            Some(TplElement {
-                                span, cooked, raw, ..
-                            }) => {
-                                let s = cooked.clone().unwrap_or_else(|| raw.clone().into());
+                            Some(quasi) => {
+                                let s = quasi
+                                    .cooked
+                                    .clone()
+                                    .unwrap_or_else(|| Str::from_tpl_raw(quasi));
 
                                 Box::new(
                                     Lit::Str(Str {
-                                        span: *span,
+                                        span: quasi.span,
                                         value: s,
                                         raw: None,
                                     })

--- a/crates/swc_ecma_transforms_compat/tests/es2015_template_literals.rs
+++ b/crates/swc_ecma_transforms_compat/tests/es2015_template_literals.rs
@@ -1,7 +1,10 @@
-use swc_ecma_ast::Pass;
+use std::path::PathBuf;
+
+use swc_ecma_ast::{Expr, Pass};
 use swc_ecma_parser::Syntax;
 use swc_ecma_transforms_compat::es2015::template_literal;
-use swc_ecma_transforms_testing::{test, test_exec};
+use swc_ecma_transforms_testing::{test, test_exec, test_fixture};
+use swc_ecma_visit::{visit_mut_pass, VisitMut, VisitMutWith};
 
 fn syntax() -> Syntax {
     Default::default()
@@ -839,3 +842,29 @@ var undefined = 4;
 tag`\01`;
 }"
 );
+
+/// Models plugins that synthesize ordinary templates with only raw text.
+struct ClearCooked;
+
+impl VisitMut for ClearCooked {
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        expr.visit_mut_children_with(self);
+        if let Expr::Tpl(tpl) = expr {
+            for quasi in &mut tpl.quasis {
+                quasi.cooked = None;
+            }
+        }
+    }
+}
+
+#[testing::fixture("tests/template-literals/missing-cooked/**/input.js")]
+fn missing_cooked(input: PathBuf) {
+    let output = input.with_file_name("output.js");
+    test_fixture(
+        syntax(),
+        &|_| (visit_mut_pass(ClearCooked), tr(Default::default())),
+        &input,
+        &output,
+        Default::default(),
+    );
+}

--- a/crates/swc_ecma_transforms_compat/tests/template-literals/missing-cooked/escapes/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/template-literals/missing-cooked/escapes/input.js
@@ -1,0 +1,7 @@
+consume(`\n`, `\\2b`, `\x41`, `\u0041`, `\u{1F600}`, `\u{10FFFF}`);
+consume(`\u{000000000041}`, `\uD800`, `\uDC00`, `\uD800\uD801`, `\uD800\uDC00`);
+consume(`\n${value}\\2b${other}\t`);
+consume(`\0\b\f\r\t\v`, `\`\$\\`, `\q`);
+consume(`first\
+second`);
+tag`\unicode`;

--- a/crates/swc_ecma_transforms_compat/tests/template-literals/missing-cooked/escapes/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/template-literals/missing-cooked/escapes/output.js
@@ -1,0 +1,17 @@
+function _templateObject() {
+    const data = _tagged_template_literal([
+        void 0
+    ], [
+        "\\unicode"
+    ]);
+    _templateObject = function() {
+        return data;
+    };
+    return data;
+}
+consume("\n", "\\2b", "A", "A", "😀", "􏿿");
+consume("A", "\uD800", "\uDC00", "\uD800\uD801", "𐀀");
+consume("\n".concat(value, "\\2b").concat(other, "	"));
+consume("\0\b\f\r	\v", "`$\\", "q");
+consume("firstsecond");
+tag(_templateObject());

--- a/crates/swc_ecma_transforms_compat/tests/template-literals/missing-cooked/line-endings/.gitattributes
+++ b/crates/swc_ecma_transforms_compat/tests/template-literals/missing-cooked/line-endings/.gitattributes
@@ -1,0 +1,2 @@
+# Preserve the exact CR and CRLF bytes exercised by this fixture.
+input.js -text

--- a/crates/swc_ecma_transforms_compat/tests/template-literals/missing-cooked/line-endings/input.js
+++ b/crates/swc_ecma_transforms_compat/tests/template-literals/missing-cooked/line-endings/input.js
@@ -1,0 +1,8 @@
+consume(`ab
+c
+`);
+consume(`a\b\
+c\
+d`);
+consume(`a${value}b
+`);

--- a/crates/swc_ecma_transforms_compat/tests/template-literals/missing-cooked/line-endings/output.js
+++ b/crates/swc_ecma_transforms_compat/tests/template-literals/missing-cooked/line-endings/output.js
@@ -1,0 +1,3 @@
+consume("a\nb\nc\n");
+consume("abcd");
+consume("a\n".concat(value, "b\n"));

--- a/crates/swc_typescript/src/fast_dts/enum.rs
+++ b/crates/swc_typescript/src/fast_dts/enum.rs
@@ -9,7 +9,10 @@ use swc_ecma_ast::{
 };
 use swc_ecma_utils::number::{JsNumber, ToJsString};
 
-use super::{util::ast_ext::MemberPropExt, FastDts};
+use super::{
+    util::ast_ext::{tpl_element_value, MemberPropExt},
+    FastDts,
+};
 
 #[derive(Debug, Clone)]
 enum ConstantValue {
@@ -98,13 +101,13 @@ impl FastDts {
             },
             Expr::Tpl(template) => {
                 let mut quasis = template.quasis.iter();
-                let first = quasis.next()?.cooked.as_ref()?;
-                let mut value = Wtf8Buf::from(first);
+                let first = tpl_element_value(quasis.next()?);
+                let mut value = Wtf8Buf::from(first.as_ref());
 
                 for (expr, quasi) in template.exprs.iter().zip(quasis) {
                     self.evaluate(expr, enum_name, prev_members)?
                         .push_to(&mut value);
-                    value.push_wtf8(quasi.cooked.as_ref()?);
+                    value.push_wtf8(&tpl_element_value(quasi));
                 }
 
                 Some(ConstantValue::String(Wtf8Atom::from(&*value)))
@@ -133,7 +136,7 @@ impl FastDts {
                 let ident = member.obj.as_ident()?;
                 if &ident.sym == enum_name {
                     let name = member.prop.static_name()?;
-                    prev_members.get(name).cloned()
+                    prev_members.get(name.as_ref()).cloned()
                 } else {
                     None
                 }
@@ -143,7 +146,7 @@ impl FastDts {
                 let ident = member.obj.as_ident()?;
                 if &ident.sym == enum_name {
                     let name = member.prop.static_name()?;
-                    prev_members.get(name).cloned()
+                    prev_members.get(name.as_ref()).cloned()
                 } else {
                     None
                 }

--- a/crates/swc_typescript/src/fast_dts/mod.rs
+++ b/crates/swc_typescript/src/fast_dts/mod.rs
@@ -408,7 +408,7 @@ impl FastDts {
                                     member_expr
                                         .prop
                                         .static_name()
-                                        .is_some_and(|name| properties.contains(name))
+                                        .is_some_and(|name| properties.contains(name.as_ref()))
                                 })
                         {
                             self.function_with_assigning_properties(member_expr.span);

--- a/crates/swc_typescript/src/fast_dts/types.rs
+++ b/crates/swc_typescript/src/fast_dts/types.rs
@@ -13,7 +13,7 @@ use super::{
     inferrer::ReturnTypeInferrer,
     type_ann,
     util::{
-        ast_ext::{ExprExit, PatExt, StaticProp},
+        ast_ext::{tpl_element_value, ExprExit, PatExt, StaticProp},
         types::{ts_keyword_type, ts_lit_type},
     },
     FastDts,
@@ -401,25 +401,9 @@ impl FastDts {
                     .into();
                 }
 
-                if let Expr::Tpl(Tpl {
-                    span,
-                    exprs,
-                    quasis,
-                }) = computed.expr.as_ref()
-                {
-                    if exprs.is_empty() {
-                        let str_prop = quasis
-                            .first()
-                            .and_then(|el| el.cooked.as_ref())
-                            .unwrap()
-                            .clone();
-
-                        let str_prop = Str {
-                            span: *span,
-                            value: str_prop,
-                            raw: None,
-                        };
-
+                if let Expr::Tpl(tpl) = computed.expr.as_ref() {
+                    if let Some(mut str_prop) = self.tpl_to_string(tpl) {
+                        str_prop.span = tpl.span;
                         return str_prop.into();
                     }
                 }
@@ -483,10 +467,7 @@ impl FastDts {
 
         tpl.quasis.first().map(|element| Str {
             span: DUMMY_SP,
-            value: element
-                .cooked
-                .clone()
-                .unwrap_or_else(|| element.raw.clone().into()),
+            value: tpl_element_value(element).into_owned(),
             raw: None,
         })
     }

--- a/crates/swc_typescript/src/fast_dts/util/ast_ext.rs
+++ b/crates/swc_typescript/src/fast_dts/util/ast_ext.rs
@@ -4,9 +4,18 @@ use swc_atoms::{Atom, Wtf8Atom};
 use swc_common::Mark;
 use swc_ecma_ast::{
     BindingIdent, ComputedPropName, Expr, Ident, Lit, MemberProp, ObjectPatProp, Pat, Prop,
-    PropName, TsTypeAnn,
+    PropName, Str, TplElement, TsTypeAnn,
 };
 use swc_ecma_utils::number::ToJsString;
+
+/// Borrows parsed template values and decodes raw-only elements synthesized by
+/// transforms. Only ordinary templates should use this fallback.
+pub fn tpl_element_value(element: &TplElement) -> Cow<'_, Wtf8Atom> {
+    match &element.cooked {
+        Some(cooked) => Cow::Borrowed(cooked),
+        None => Cow::Owned(Str::from_tpl_raw(element)),
+    }
+}
 
 pub trait ExprExit {
     fn get_root_ident(&self) -> Option<&Ident>;
@@ -175,11 +184,12 @@ impl PropNameExit for ComputedPropName {
                 #[cfg(swc_ast_unknown)]
                 _ => panic!("unable to access unknown nodes"),
             },
-            Expr::Tpl(tpl) if tpl.exprs.is_empty() => tpl
-                .quasis
-                .first()
-                .and_then(|e| e.cooked.as_ref())
-                .and_then(|atom| atom.as_str().map(Cow::Borrowed)),
+            Expr::Tpl(tpl) if tpl.exprs.is_empty() => {
+                match tpl_element_value(tpl.quasis.first()?) {
+                    Cow::Borrowed(value) => value.as_str().map(Cow::Borrowed),
+                    Cow::Owned(value) => value.as_str().map(|value| Cow::Owned(value.to_owned())),
+                }
+            }
             _ => None,
         }
     }
@@ -234,17 +244,17 @@ impl PropNameExit for Prop {
 }
 
 pub trait MemberPropExt {
-    fn static_name(&self) -> Option<&Wtf8Atom>;
+    fn static_name(&self) -> Option<Cow<'_, Wtf8Atom>>;
 }
 
 impl MemberPropExt for MemberProp {
-    fn static_name(&self) -> Option<&Wtf8Atom> {
+    fn static_name(&self) -> Option<Cow<'_, Wtf8Atom>> {
         match self {
-            MemberProp::Ident(ident_name) => Some(ident_name.sym.borrow()),
+            MemberProp::Ident(ident_name) => Some(Cow::Borrowed(ident_name.sym.borrow())),
             MemberProp::Computed(computed_prop_name) => match computed_prop_name.expr.as_ref() {
-                Expr::Lit(Lit::Str(s)) => Some(&s.value),
+                Expr::Lit(Lit::Str(s)) => Some(Cow::Borrowed(&s.value)),
                 Expr::Tpl(tpl) if tpl.quasis.len() == 1 && tpl.exprs.is_empty() => {
-                    tpl.quasis[0].cooked.as_ref()
+                    Some(tpl_element_value(&tpl.quasis[0]))
                 }
                 _ => None,
             },

--- a/crates/swc_typescript/tests/fixture/template-raw/accessors.snap
+++ b/crates/swc_typescript/tests/fixture/template-raw/accessors.snap
@@ -1,0 +1,8 @@
+```==================== .D.TS ====================
+
+export declare const accessors: {
+    ["A"]: number;
+    readonly ["read\nonly"]: string;
+};
+
+

--- a/crates/swc_typescript/tests/fixture/template-raw/accessors.ts
+++ b/crates/swc_typescript/tests/fixture/template-raw/accessors.ts
@@ -1,0 +1,5 @@
+export const accessors = {
+    get [`\x41`](): number { return 1; },
+    set [`\u0041`](value: number) {},
+    get [`read\nonly`](): string { return "value"; },
+} as const;

--- a/crates/swc_typescript/tests/fixture/template-raw/computed-keys.snap
+++ b/crates/swc_typescript/tests/fixture/template-raw/computed-keys.snap
@@ -1,0 +1,10 @@
+```==================== .D.TS ====================
+
+export declare const keys: {
+    readonly ["A"]: 1;
+    readonly ["line\nbreak"]: 2;
+    readonly ["😀"]: 3;
+    readonly ["\uD800"]: 4;
+};
+
+

--- a/crates/swc_typescript/tests/fixture/template-raw/computed-keys.ts
+++ b/crates/swc_typescript/tests/fixture/template-raw/computed-keys.ts
@@ -1,0 +1,6 @@
+export const keys = {
+    [`\x41`]: 1,
+    [`line\nbreak`]: 2,
+    [`\u{1F600}`]: 3,
+    [`\uD800`]: 4,
+} as const;

--- a/crates/swc_typescript/tests/fixture/template-raw/enum-members.snap
+++ b/crates/swc_typescript/tests/fixture/template-raw/enum-members.snap
@@ -1,0 +1,9 @@
+```==================== .D.TS ====================
+
+export declare enum Members {
+    A = 1,
+    Direct = 1,
+    Optional = 1
+}
+
+

--- a/crates/swc_typescript/tests/fixture/template-raw/enum-members.ts
+++ b/crates/swc_typescript/tests/fixture/template-raw/enum-members.ts
@@ -1,0 +1,5 @@
+export enum Members {
+    A = 1,
+    Direct = Members[`\x41`],
+    Optional = Members?.[`\u0041`],
+}

--- a/crates/swc_typescript/tests/fixture/template-raw/enum-values.snap
+++ b/crates/swc_typescript/tests/fixture/template-raw/enum-values.snap
@@ -1,0 +1,9 @@
+```==================== .D.TS ====================
+
+export declare enum Values {
+    Plain = "A",
+    Interpolated = "\nA\\",
+    Number = "😀42\uD800"
+}
+
+

--- a/crates/swc_typescript/tests/fixture/template-raw/enum-values.ts
+++ b/crates/swc_typescript/tests/fixture/template-raw/enum-values.ts
@@ -1,0 +1,5 @@
+export enum Values {
+    Plain = `\x41`,
+    Interpolated = `\n${Plain}\\`,
+    Number = `\u{1F600}${42}\uD800`,
+}

--- a/crates/swc_typescript/tests/fixture/template-raw/escapes.snap
+++ b/crates/swc_typescript/tests/fixture/template-raw/escapes.snap
@@ -1,0 +1,15 @@
+```==================== .D.TS ====================
+
+export declare const newline = "\n";
+export declare const css = "\\2b";
+export declare const hex = "A";
+export declare const unicode = "􏿿";
+export declare const surrogates = "\uD800\uD801";
+export declare const continuation = "firstsecond";
+export declare class Values {
+    readonly newline = "\n";
+    readonly css = "\\2b";
+    readonly surrogate = "\uD800";
+}
+
+

--- a/crates/swc_typescript/tests/fixture/template-raw/escapes.ts
+++ b/crates/swc_typescript/tests/fixture/template-raw/escapes.ts
@@ -1,0 +1,12 @@
+export const newline = `\n`;
+export const css = `\\2b`;
+export const hex = `\x41`;
+export const unicode = `\u{10FFFF}`;
+export const surrogates = `\uD800\uD801`;
+export const continuation = `first\
+second`;
+export class Values {
+    readonly newline = `\n`;
+    readonly css = `\\2b`;
+    readonly surrogate = `\uD800`;
+}

--- a/crates/swc_typescript/tests/typescript.rs
+++ b/crates/swc_typescript/tests/typescript.rs
@@ -1,15 +1,40 @@
 use std::path::PathBuf;
 
 use swc_common::{comments::SingleThreadedComments, Mark};
+use swc_ecma_ast::Expr;
 use swc_ecma_codegen::to_code_with_comments;
 use swc_ecma_parser::{parse_file_as_program, Syntax, TsSyntax};
 use swc_ecma_transforms_base::{fixer::paren_remover, resolver};
+use swc_ecma_visit::{VisitMut, VisitMutWith};
 use swc_typescript::fast_dts::{FastDts, FastDtsOptions};
 use testing::NormalizedOutput;
 
 #[testing::fixture("tests/**/*.ts")]
 #[testing::fixture("tests/**/*.tsx")]
 fn fixture(input: PathBuf) {
+    run_fixture(input, false);
+}
+
+#[testing::fixture("tests/fixture/template-raw/*.ts")]
+fn missing_cooked(input: PathBuf) {
+    // The same declarations must be emitted for parsed and synthesized templates.
+    run_fixture(input, true);
+}
+
+struct ClearCooked;
+
+impl VisitMut for ClearCooked {
+    fn visit_mut_expr(&mut self, expr: &mut Expr) {
+        expr.visit_mut_children_with(self);
+        if let Expr::Tpl(tpl) = expr {
+            for quasi in &mut tpl.quasis {
+                quasi.cooked = None;
+            }
+        }
+    }
+}
+
+fn run_fixture(input: PathBuf, clear_cooked: bool) {
     let mut dts_code = String::new();
     let res = testing::run_test2(false, |cm, handler| {
         let fm = cm.load_file(&input).expect("failed to load test case");
@@ -31,6 +56,10 @@ fn fixture(input: PathBuf) {
         .map(|program| program.apply(resolver(unresolved_mark, top_level_mark, true)))
         .map(|program| program.apply(paren_remover(None)))
         .unwrap();
+
+        if clear_cooked {
+            program.visit_mut_with(&mut ClearCooked);
+        }
 
         let internal_annotations = FastDts::get_internal_annotations(&comments);
         let mut checker = FastDts::new(


### PR DESCRIPTION
**Description:**

Use `Str::from_tpl_raw` when `cooked` is missing in template literal lowering and Fast DTS, preserving escape sequences' string values. This fixes doubled backslashes in CSS produced by the styled-components plugin.

Also correct line-ending normalization and Unicode escape handling in the decoder, with regression tests for lowering and declaration generation.

**Related issue (if exists):**

- Closes #12346.
